### PR TITLE
added observability domain to duckdb

### DIFF
--- a/.changeset/quick-llamas-accept.md
+++ b/.changeset/quick-llamas-accept.md
@@ -2,14 +2,14 @@
 '@mastra/duckdb': minor
 ---
 
-Added observability storage domain to DuckDB adapter. Provides OLAP-based storage for traces, metrics, logs, scores, and feedback using DuckDB's analytical engine. New exports: `DuckDBStore`, `ObservabilityStorageDuckDB`, and `DuckDBConnection` connection manager.
+Adds observability storage using DuckDB for traces, metrics, logs, scores, and feedback. Exports `DuckDBStore`, `ObservabilityStorageDuckDB`, and `DuckDBConnection`.
 
-Migration note: this adapter depends on `@mastra/core >=1.13.0-0` for observability storage. Upgrade `@mastra/core` to 1.13.0 or newer before using the DuckDB observability store.
+Older `@mastra/core` versions show an upgrade error when you use the DuckDB observability store.
 
 ```typescript
 import { Mastra } from '@mastra/core/mastra';
 import { DefaultExporter, Observability } from '@mastra/observability';
-import { MastraCompositeStore } from '@mastra/core/storage'
+import { MastraCompositeStore } from '@mastra/core/storage';
 import { LibSQLStore } from '@mastra/libsql';
 import { DuckDBStore } from '@mastra/duckdb';
 
@@ -22,7 +22,7 @@ const storage = new MastraCompositeStore({
     ...libSqlStore.stores,
     observability: duckDBStore.observability,
   }
-})
+});
 
 export const mastra = new Mastra({
   agents: { /* your agents here */ },

--- a/.changeset/quick-llamas-accept.md
+++ b/.changeset/quick-llamas-accept.md
@@ -1,0 +1,41 @@
+---
+'@mastra/duckdb': minor
+---
+
+Added observability storage domain to DuckDB adapter. Provides OLAP-based storage for traces, metrics, logs, scores, and feedback using DuckDB's analytical engine. New exports: `DuckDBStore`, `ObservabilityStorageDuckDB`, and `DuckDBConnection` connection manager.
+
+Migration note: this adapter depends on `@mastra/core >=1.13.0-0` for observability storage. Upgrade `@mastra/core` to 1.13.0 or newer before using the DuckDB observability store.
+
+```typescript
+import { Mastra } from '@mastra/core/mastra';
+import { DefaultExporter, Observability } from '@mastra/observability';
+import { MastraCompositeStore } from '@mastra/core/storage'
+import { LibSQLStore } from '@mastra/libsql';
+import { DuckDBStore } from '@mastra/duckdb';
+
+const duckDBStore = new DuckDBStore();
+const libSqlStore = new LibSQLStore();
+
+const storage = new MastraCompositeStore({
+  id: "composite",
+  domains: {
+    ...libSqlStore.stores,
+    observability: duckDBStore.observability,
+  }
+})
+
+export const mastra = new Mastra({
+  agents: { /* your agents here */ },
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'obs-test',
+        exporters: [
+          new DefaultExporter(),
+        ],
+      },
+    },
+  }),
+  storage,
+});
+```

--- a/stores/duckdb/package.json
+++ b/stores/duckdb/package.json
@@ -45,7 +45,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.13.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/duckdb/package.json
+++ b/stores/duckdb/package.json
@@ -45,7 +45,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.13.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/duckdb/src/__tests__/duckdb-vector.test.ts
+++ b/stores/duckdb/src/__tests__/duckdb-vector.test.ts
@@ -13,7 +13,7 @@
 
 import { createVectorTestSuite } from '@internal/storage-test-utils';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { DuckDBVector } from '../vector/index.js';
+import { DuckDBVector } from '../vector/index';
 
 describe('DuckDBVector', () => {
   let vectorDB: DuckDBVector;

--- a/stores/duckdb/src/index.ts
+++ b/stores/duckdb/src/index.ts
@@ -1,9 +1,12 @@
 /**
- * @mastra/duckdb - DuckDB vector store provider for Mastra
+ * @mastra/duckdb - DuckDB vector and observability storage provider for Mastra
  *
- * Provides embedded high-performance vector storage with HNSW indexing.
+ * Provides embedded high-performance vector storage with HNSW indexing
+ * and OLAP-based observability storage for metrics, traces, logs, scores, and feedback.
  * No external server required - runs in-process.
  */
 
-export { DuckDBVector } from './vector/index.js';
-export type { DuckDBVectorConfig, DuckDBVectorFilter } from './vector/types.js';
+export { DuckDBVector } from './vector/index';
+export type { DuckDBVectorConfig, DuckDBVectorFilter } from './vector/types';
+export { DuckDBConnection, DuckDBStore, ObservabilityStorageDuckDB } from './storage/index';
+export type { DuckDBStorageConfig, DuckDBStoreConfig, ObservabilityDuckDBConfig } from './storage/index';

--- a/stores/duckdb/src/storage/db/index.ts
+++ b/stores/duckdb/src/storage/db/index.ts
@@ -1,0 +1,197 @@
+import { DuckDBInstance, DuckDBTimestampValue } from '@duckdb/node-api';
+import type { DuckDBValue } from '@duckdb/node-api';
+import { MastraBase } from '@mastra/core/base';
+
+/** Convert DuckDB-specific return types to plain JS types */
+function toJsValue(val: unknown): unknown {
+  if (val === null || val === undefined) return val;
+  // DuckDBTimestampValue → Date (micros since epoch)
+  if (val instanceof DuckDBTimestampValue) {
+    return new Date(Number(val.micros / 1000n));
+  }
+  // BigInt → Number (safe for values we care about)
+  if (typeof val === 'bigint') {
+    return Number(val);
+  }
+  return val;
+}
+
+/** Configuration for the DuckDB database connection. */
+export interface DuckDBStorageConfig {
+  /** Path to the DuckDB file. Defaults to 'mastra.duckdb'. Use ':memory:' for ephemeral. */
+  path?: string;
+}
+
+/**
+ * Shared DuckDB connection management for Mastra storage.
+ * Defaults to a local file (`mastra.duckdb`) when no path is provided.
+ * Pass `path: ':memory:'` for an ephemeral in-memory database.
+ */
+export class DuckDBConnection extends MastraBase {
+  private instance: DuckDBInstance | null = null;
+  private initialized = false;
+  private initPromise: Promise<void> | null = null;
+  private path: string;
+
+  constructor(config: DuckDBStorageConfig = {}) {
+    super({ component: 'STORAGE', name: 'DUCKDB' });
+    this.path = config.path ?? 'mastra.duckdb';
+  }
+
+  private async initialize(): Promise<void> {
+    if (this.initialized && this.instance) return;
+
+    if (this.initPromise) {
+      await this.initPromise;
+      if (this.instance) return;
+      this.initPromise = null;
+      this.initialized = false;
+    }
+
+    this.initPromise = (async () => {
+      try {
+        this.instance = await DuckDBInstance.create(this.path);
+        this.initialized = true;
+      } catch (error) {
+        this.instance = null;
+        this.initialized = false;
+        this.initPromise = null;
+        throw error;
+      }
+    })();
+
+    return this.initPromise;
+  }
+
+  /** Create a new connection to the DuckDB instance, initializing if needed. */
+  async getConnection() {
+    await this.initialize();
+    if (!this.instance) {
+      throw new Error('DuckDB instance not initialized');
+    }
+    return this.instance.connect();
+  }
+
+  private closeConnection(connection: unknown): void {
+    const conn = connection as {
+      closeSync?: () => void;
+      disconnectSync?: () => void;
+      close?: () => void;
+      disconnect?: () => void;
+    };
+    try {
+      if (typeof conn?.closeSync === 'function') {
+        conn.closeSync();
+        return;
+      }
+      if (typeof conn?.disconnectSync === 'function') {
+        conn.disconnectSync();
+        return;
+      }
+      if (typeof conn?.close === 'function') {
+        conn.close();
+        return;
+      }
+      if (typeof conn?.disconnect === 'function') {
+        conn.disconnect();
+      }
+    } catch {
+      // Ignore close failures to avoid masking query/execute errors.
+    }
+  }
+
+  /**
+   * Execute a SQL query and return results as objects.
+   */
+  async query<T = Record<string, unknown>>(sql: string, params: unknown[] = []): Promise<T[]> {
+    const connection = await this.getConnection();
+    try {
+      if (params.length === 0) {
+        const result = await connection.run(sql);
+        const rows = await result.getRows();
+        const columns = result.columnNames();
+        return rows.map(row => {
+          const obj: Record<string, unknown> = {};
+          columns.forEach((col, i) => {
+            obj[col] = toJsValue(row[i]);
+          });
+          return obj as T;
+        });
+      }
+
+      let paramIndex = 0;
+      const preparedSql = sql.replace(/\?/g, () => `$${++paramIndex}`);
+      const stmt = await connection.prepare(preparedSql);
+      stmt.bind(params as DuckDBValue[]);
+      const result = await stmt.run();
+      const rows = await result.getRows();
+      const columns = result.columnNames();
+      return rows.map(row => {
+        const obj: Record<string, unknown> = {};
+        columns.forEach((col, i) => {
+          obj[col] = toJsValue(row[i]);
+        });
+        return obj as T;
+      });
+    } finally {
+      this.closeConnection(connection);
+    }
+  }
+
+  /**
+   * Execute a SQL statement without returning results.
+   */
+  async execute(sql: string, params: unknown[] = []): Promise<void> {
+    const connection = await this.getConnection();
+    try {
+      if (params.length === 0) {
+        await connection.run(sql);
+        return;
+      }
+      let paramIndex = 0;
+      const preparedSql = sql.replace(/\?/g, () => `$${++paramIndex}`);
+      const stmt = await connection.prepare(preparedSql);
+      stmt.bind(params as DuckDBValue[]);
+      await stmt.run();
+    } finally {
+      this.closeConnection(connection);
+    }
+  }
+
+  /**
+   * Escape a value for safe inline SQL use.
+   * DuckDB prepared statements can't handle NULL for parameters typed as ANY,
+   * so for complex INSERT/UPDATE operations we inline values safely.
+   */
+  static sqlValue(value: unknown): string {
+    if (value === null || value === undefined) return 'NULL';
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) return 'NULL';
+      return String(value);
+    }
+    if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
+    if (value instanceof Date) return `'${value.toISOString()}'::TIMESTAMP`;
+    if (typeof value === 'string') return `'${value.replace(/'/g, "''")}'`;
+    // Objects/arrays → JSON string
+    return `'${JSON.stringify(value).replace(/'/g, "''")}'`;
+  }
+
+  /** Release the DuckDB instance, allowing garbage collection. */
+  async close(): Promise<void> {
+    if (this.instance) {
+      try {
+        const instance = this.instance as unknown as { closeSync?: () => void; close?: () => void };
+        if (typeof instance.closeSync === 'function') {
+          instance.closeSync();
+        } else if (typeof instance.close === 'function') {
+          instance.close();
+        }
+      } catch {
+        // Ignore close failures to allow cleanup of references.
+      }
+      this.instance = null;
+      this.initialized = false;
+      this.initPromise = null;
+    }
+  }
+}

--- a/stores/duckdb/src/storage/domains/observability/ddl.ts
+++ b/stores/duckdb/src/storage/domains/observability/ddl.ts
@@ -1,0 +1,196 @@
+/**
+ * DDL statements for DuckDB observability tables.
+ * All tables use append-only patterns with a single `timestamp` column.
+ *
+ * Column ordering convention:
+ *   1. Event metadata (eventType, timestamp)
+ *   2. IDs (trace, span, experiment, resource, run, session, etc.)
+ *   3. Entity hierarchy (entity, parent, root)
+ *   4. Context (user, org, environment, service, source)
+ *   5. Domain-specific scalar fields
+ *   6. JSON fields (attributes, metadata, tags, input/output, etc.)
+ */
+
+/** DDL for the span_events append-only table. */
+export const SPAN_EVENTS_DDL = `
+CREATE TABLE IF NOT EXISTS span_events (
+  -- Event metadata
+  eventType VARCHAR NOT NULL,
+  timestamp TIMESTAMP NOT NULL,
+
+  -- IDs
+  traceId VARCHAR NOT NULL,
+  spanId VARCHAR NOT NULL,
+  parentSpanId VARCHAR,
+  experimentId VARCHAR,
+
+  -- Entity
+  entityType VARCHAR,
+  entityId VARCHAR,
+  entityName VARCHAR,
+
+  -- Context
+  userId VARCHAR,
+  organizationId VARCHAR,
+  resourceId VARCHAR,
+  runId VARCHAR,
+  sessionId VARCHAR,
+  threadId VARCHAR,
+  requestId VARCHAR,
+  environment VARCHAR,
+  source VARCHAR,
+  serviceName VARCHAR,
+  requestContext JSON,
+
+  -- Span-specific scalars
+  name VARCHAR,
+  spanType VARCHAR,
+  isEvent BOOLEAN,
+  endedAt TIMESTAMP,
+
+  -- JSON fields
+  attributes JSON,
+  metadata JSON,
+  tags JSON,
+  scope JSON,
+  links JSON,
+  input JSON,
+  output JSON,
+  error JSON
+)`;
+
+/** DDL for the metric_events append-only table. */
+export const METRIC_EVENTS_DDL = `
+CREATE TABLE IF NOT EXISTS metric_events (
+  -- Event metadata
+  timestamp TIMESTAMP NOT NULL,
+
+  -- IDs
+  traceId VARCHAR,
+  spanId VARCHAR,
+  experimentId VARCHAR,
+
+  -- Entity hierarchy
+  entityType VARCHAR,
+  entityId VARCHAR,
+  entityName VARCHAR,
+  parentEntityType VARCHAR,
+  parentEntityId VARCHAR,
+  parentEntityName VARCHAR,
+  rootEntityType VARCHAR,
+  rootEntityId VARCHAR,
+  rootEntityName VARCHAR,
+
+  -- Context
+  userId VARCHAR,
+  organizationId VARCHAR,
+  resourceId VARCHAR,
+  runId VARCHAR,
+  sessionId VARCHAR,
+  threadId VARCHAR,
+  requestId VARCHAR,
+  environment VARCHAR,
+  source VARCHAR,
+  serviceName VARCHAR,
+
+  -- Metric-specific scalars
+  name VARCHAR NOT NULL,
+  value DOUBLE NOT NULL,
+
+  -- JSON fields
+  labels JSON,
+  metadata JSON,
+  scope JSON
+)`;
+
+/** DDL for the log_events append-only table. */
+export const LOG_EVENTS_DDL = `
+CREATE TABLE IF NOT EXISTS log_events (
+  -- Event metadata
+  timestamp TIMESTAMP NOT NULL,
+
+  -- IDs
+  traceId VARCHAR,
+  spanId VARCHAR,
+  experimentId VARCHAR,
+
+  -- Entity hierarchy
+  entityType VARCHAR,
+  entityId VARCHAR,
+  entityName VARCHAR,
+  parentEntityType VARCHAR,
+  parentEntityId VARCHAR,
+  parentEntityName VARCHAR,
+  rootEntityType VARCHAR,
+  rootEntityId VARCHAR,
+  rootEntityName VARCHAR,
+
+  -- Context
+  userId VARCHAR,
+  organizationId VARCHAR,
+  resourceId VARCHAR,
+  runId VARCHAR,
+  sessionId VARCHAR,
+  threadId VARCHAR,
+  requestId VARCHAR,
+  environment VARCHAR,
+  source VARCHAR,
+  serviceName VARCHAR,
+
+  -- Log-specific scalars
+  level VARCHAR NOT NULL,
+  message VARCHAR NOT NULL,
+
+  -- JSON fields
+  data JSON,
+  tags JSON,
+  metadata JSON,
+  scope JSON
+)`;
+
+/** DDL for the score_events append-only table. */
+export const SCORE_EVENTS_DDL = `
+CREATE TABLE IF NOT EXISTS score_events (
+  -- Event metadata
+  timestamp TIMESTAMP NOT NULL,
+
+  -- IDs
+  traceId VARCHAR NOT NULL,
+  spanId VARCHAR,
+  experimentId VARCHAR,
+  scoreTraceId VARCHAR,
+
+  -- Score-specific scalars
+  scorerId VARCHAR NOT NULL,
+  scorerVersion VARCHAR,
+  source VARCHAR,
+  score DOUBLE NOT NULL,
+  reason VARCHAR,
+
+  -- JSON fields
+  metadata JSON
+)`;
+
+/** DDL for the feedback_events append-only table. */
+export const FEEDBACK_EVENTS_DDL = `
+CREATE TABLE IF NOT EXISTS feedback_events (
+  -- Event metadata
+  timestamp TIMESTAMP NOT NULL,
+
+  -- IDs
+  traceId VARCHAR NOT NULL,
+  spanId VARCHAR,
+  experimentId VARCHAR,
+
+  -- Feedback-specific scalars
+  source VARCHAR NOT NULL,
+  feedbackType VARCHAR NOT NULL,
+  value VARCHAR NOT NULL,
+  comment VARCHAR,
+
+  -- JSON fields
+  metadata JSON
+)`;
+
+/** All observability DDL statements, in creation order. */
+export const ALL_DDL = [SPAN_EVENTS_DDL, METRIC_EVENTS_DDL, LOG_EVENTS_DDL, SCORE_EVENTS_DDL, FEEDBACK_EVENTS_DDL];

--- a/stores/duckdb/src/storage/domains/observability/ddl.ts
+++ b/stores/duckdb/src/storage/domains/observability/ddl.ts
@@ -96,9 +96,15 @@ CREATE TABLE IF NOT EXISTS metric_events (
   -- Metric-specific scalars
   name VARCHAR NOT NULL,
   value DOUBLE NOT NULL,
+  provider VARCHAR,
+  model VARCHAR,
+  estimatedCost DOUBLE,
+  costUnit VARCHAR,
 
   -- JSON fields
+  tags JSON,
   labels JSON,
+  costMetadata JSON,
   metadata JSON,
   scope JSON
 )`;
@@ -181,6 +187,8 @@ CREATE TABLE IF NOT EXISTS feedback_events (
   traceId VARCHAR NOT NULL,
   spanId VARCHAR,
   experimentId VARCHAR,
+  userId VARCHAR,
+  sourceId VARCHAR,
 
   -- Feedback-specific scalars
   source VARCHAR NOT NULL,

--- a/stores/duckdb/src/storage/domains/observability/discovery.ts
+++ b/stores/duckdb/src/storage/domains/observability/discovery.ts
@@ -1,0 +1,85 @@
+import { EntityType } from '@mastra/core/observability';
+import type {
+  GetEntityTypesArgs,
+  GetEntityTypesResponse,
+  GetEntityNamesArgs,
+  GetEntityNamesResponse,
+  GetServiceNamesArgs,
+  GetServiceNamesResponse,
+  GetEnvironmentsArgs,
+  GetEnvironmentsResponse,
+  GetTagsArgs,
+  GetTagsResponse,
+} from '@mastra/core/storage';
+import type { DuckDBConnection } from '../../db/index';
+
+/** Return distinct entity types from span_events. */
+export async function getEntityTypes(db: DuckDBConnection, _args: GetEntityTypesArgs): Promise<GetEntityTypesResponse> {
+  const rows = await db.query<{ entityType: string }>(
+    `SELECT DISTINCT entityType FROM span_events WHERE entityType IS NOT NULL ORDER BY entityType`,
+  );
+  const validTypes = new Set(Object.values(EntityType));
+  const typeSet = new Set<EntityType>();
+  for (const row of rows) {
+    if (row.entityType && validTypes.has(row.entityType as EntityType)) {
+      typeSet.add(row.entityType as EntityType);
+    }
+  }
+  return { entityTypes: Array.from(typeSet).sort() };
+}
+
+/** Return distinct entity names, optionally filtered by entity type. */
+export async function getEntityNames(db: DuckDBConnection, args: GetEntityNamesArgs): Promise<GetEntityNamesResponse> {
+  const conditions = [`entityName IS NOT NULL`];
+  const params: unknown[] = [];
+
+  if (args.entityType) {
+    conditions.push(`entityType = ?`);
+    params.push(args.entityType);
+  }
+
+  const rows = await db.query<{ entityName: string }>(
+    `SELECT DISTINCT entityName FROM span_events WHERE ${conditions.join(' AND ')} ORDER BY entityName`,
+    params,
+  );
+  return { names: rows.map(r => r.entityName) };
+}
+
+/** Return distinct service names from span_events. */
+export async function getServiceNames(
+  db: DuckDBConnection,
+  _args: GetServiceNamesArgs,
+): Promise<GetServiceNamesResponse> {
+  const rows = await db.query<{ serviceName: string }>(
+    `SELECT DISTINCT serviceName FROM span_events WHERE serviceName IS NOT NULL ORDER BY serviceName`,
+  );
+  return { serviceNames: rows.map(r => r.serviceName) };
+}
+
+/** Return distinct environment values from span_events. */
+export async function getEnvironments(
+  db: DuckDBConnection,
+  _args: GetEnvironmentsArgs,
+): Promise<GetEnvironmentsResponse> {
+  const rows = await db.query<{ environment: string }>(
+    `SELECT DISTINCT environment FROM span_events WHERE environment IS NOT NULL ORDER BY environment`,
+  );
+  return { environments: rows.map(r => r.environment) };
+}
+
+/** Return distinct tags (unnested from JSON arrays), optionally filtered by entity type. */
+export async function getTags(db: DuckDBConnection, args: GetTagsArgs): Promise<GetTagsResponse> {
+  const conditions = [`tags IS NOT NULL`];
+  const params: unknown[] = [];
+
+  if (args.entityType) {
+    conditions.push(`entityType = ?`);
+    params.push(args.entityType);
+  }
+
+  const rows = await db.query<{ tag: string }>(
+    `SELECT DISTINCT unnest(CAST(tags AS VARCHAR[])) as tag FROM span_events WHERE ${conditions.join(' AND ')} ORDER BY tag`,
+    params,
+  );
+  return { tags: rows.map(r => r.tag) };
+}

--- a/stores/duckdb/src/storage/domains/observability/discovery.ts
+++ b/stores/duckdb/src/storage/domains/observability/discovery.ts
@@ -13,11 +13,23 @@ import type {
 } from '@mastra/core/storage';
 import type { DuckDBConnection } from '../../db/index';
 
-/** Return distinct entity types from span_events. */
+function unionDistinctQueries(selects: string[], orderBy: string): string {
+  return `${selects.join('\nUNION\n')}\nORDER BY ${orderBy}`;
+}
+
+/** Return distinct entity types across observability signals that carry them. */
 export async function getEntityTypes(db: DuckDBConnection, _args: GetEntityTypesArgs): Promise<GetEntityTypesResponse> {
   const rows = await db.query<{ entityType: string }>(
-    `SELECT DISTINCT entityType FROM span_events WHERE entityType IS NOT NULL ORDER BY entityType`,
+    unionDistinctQueries(
+      [
+        `SELECT entityType FROM span_events WHERE entityType IS NOT NULL`,
+        `SELECT entityType FROM metric_events WHERE entityType IS NOT NULL`,
+        `SELECT entityType FROM log_events WHERE entityType IS NOT NULL`,
+      ],
+      'entityType',
+    ),
   );
+
   const validTypes = new Set(Object.values(EntityType));
   const typeSet = new Set<EntityType>();
   for (const row of rows) {
@@ -28,57 +40,76 @@ export async function getEntityTypes(db: DuckDBConnection, _args: GetEntityTypes
   return { entityTypes: Array.from(typeSet).sort() };
 }
 
-/** Return distinct entity names, optionally filtered by entity type. */
+/** Return distinct entity names across observability signals, optionally filtered by entity type. */
 export async function getEntityNames(db: DuckDBConnection, args: GetEntityNamesArgs): Promise<GetEntityNamesResponse> {
-  const conditions = [`entityName IS NOT NULL`];
-  const params: unknown[] = [];
+  const buildSelect = (table: 'span_events' | 'metric_events' | 'log_events') => {
+    const conditions = [`entityName IS NOT NULL`];
+    if (args.entityType) {
+      conditions.push(`entityType = ?`);
+    }
+    return `SELECT entityName FROM ${table} WHERE ${conditions.join(' AND ')}`;
+  };
 
-  if (args.entityType) {
-    conditions.push(`entityType = ?`);
-    params.push(args.entityType);
-  }
-
+  const params = args.entityType ? [args.entityType, args.entityType, args.entityType] : [];
   const rows = await db.query<{ entityName: string }>(
-    `SELECT DISTINCT entityName FROM span_events WHERE ${conditions.join(' AND ')} ORDER BY entityName`,
+    unionDistinctQueries(
+      [buildSelect('span_events'), buildSelect('metric_events'), buildSelect('log_events')],
+      'entityName',
+    ),
     params,
   );
   return { names: rows.map(r => r.entityName) };
 }
 
-/** Return distinct service names from span_events. */
+/** Return distinct service names across observability signals. */
 export async function getServiceNames(
   db: DuckDBConnection,
   _args: GetServiceNamesArgs,
 ): Promise<GetServiceNamesResponse> {
   const rows = await db.query<{ serviceName: string }>(
-    `SELECT DISTINCT serviceName FROM span_events WHERE serviceName IS NOT NULL ORDER BY serviceName`,
+    unionDistinctQueries(
+      [
+        `SELECT serviceName FROM span_events WHERE serviceName IS NOT NULL`,
+        `SELECT serviceName FROM metric_events WHERE serviceName IS NOT NULL`,
+        `SELECT serviceName FROM log_events WHERE serviceName IS NOT NULL`,
+      ],
+      'serviceName',
+    ),
   );
   return { serviceNames: rows.map(r => r.serviceName) };
 }
 
-/** Return distinct environment values from span_events. */
+/** Return distinct environment values across observability signals. */
 export async function getEnvironments(
   db: DuckDBConnection,
   _args: GetEnvironmentsArgs,
 ): Promise<GetEnvironmentsResponse> {
   const rows = await db.query<{ environment: string }>(
-    `SELECT DISTINCT environment FROM span_events WHERE environment IS NOT NULL ORDER BY environment`,
+    unionDistinctQueries(
+      [
+        `SELECT environment FROM span_events WHERE environment IS NOT NULL`,
+        `SELECT environment FROM metric_events WHERE environment IS NOT NULL`,
+        `SELECT environment FROM log_events WHERE environment IS NOT NULL`,
+      ],
+      'environment',
+    ),
   );
   return { environments: rows.map(r => r.environment) };
 }
 
-/** Return distinct tags (unnested from JSON arrays), optionally filtered by entity type. */
+/** Return distinct tags across observability signals, optionally filtered by entity type. */
 export async function getTags(db: DuckDBConnection, args: GetTagsArgs): Promise<GetTagsResponse> {
-  const conditions = [`tags IS NOT NULL`];
-  const params: unknown[] = [];
+  const buildSelect = (table: 'span_events' | 'metric_events' | 'log_events') => {
+    const conditions = [`tags IS NOT NULL`];
+    if (args.entityType) {
+      conditions.push(`entityType = ?`);
+    }
+    return `SELECT unnest(CAST(tags AS VARCHAR[])) AS tag FROM ${table} WHERE ${conditions.join(' AND ')}`;
+  };
 
-  if (args.entityType) {
-    conditions.push(`entityType = ?`);
-    params.push(args.entityType);
-  }
-
+  const params = args.entityType ? [args.entityType, args.entityType, args.entityType] : [];
   const rows = await db.query<{ tag: string }>(
-    `SELECT DISTINCT unnest(CAST(tags AS VARCHAR[])) as tag FROM span_events WHERE ${conditions.join(' AND ')} ORDER BY tag`,
+    unionDistinctQueries([buildSelect('span_events'), buildSelect('metric_events'), buildSelect('log_events')], 'tag'),
     params,
   );
   return { tags: rows.map(r => r.tag) };

--- a/stores/duckdb/src/storage/domains/observability/feedback.ts
+++ b/stores/duckdb/src/storage/domains/observability/feedback.ts
@@ -12,16 +12,18 @@ import { v, jsonV, toDate, parseJson } from './helpers';
 export async function createFeedback(db: DuckDBConnection, args: CreateFeedbackArgs): Promise<void> {
   const f = args.feedback;
   await db.execute(
-    `INSERT INTO feedback_events (timestamp, traceId, spanId, source, feedbackType, value, comment, experimentId, metadata)
+    `INSERT INTO feedback_events (timestamp, traceId, spanId, experimentId, userId, sourceId, source, feedbackType, value, comment, metadata)
      VALUES (${[
        v(f.timestamp),
        v(f.traceId),
        v(f.spanId ?? null),
+       v(f.experimentId ?? null),
+       v(f.userId ?? null),
+       v(f.sourceId ?? null),
        v(f.source),
        v(f.feedbackType),
        v(String(f.value)),
        v(f.comment ?? null),
-       v(f.experimentId ?? null),
        jsonV(f.metadata),
      ].join(', ')})`,
   );
@@ -37,17 +39,19 @@ export async function batchCreateFeedback(db: DuckDBConnection, args: BatchCreat
         v(f.timestamp),
         v(f.traceId),
         v(f.spanId ?? null),
+        v(f.experimentId ?? null),
+        v(f.userId ?? null),
+        v(f.sourceId ?? null),
         v(f.source),
         v(f.feedbackType),
         v(String(f.value)),
         v(f.comment ?? null),
-        v(f.experimentId ?? null),
         jsonV(f.metadata),
       ].join(', ')})`,
   );
 
   await db.execute(
-    `INSERT INTO feedback_events (timestamp, traceId, spanId, source, feedbackType, value, comment, experimentId, metadata)
+    `INSERT INTO feedback_events (timestamp, traceId, spanId, experimentId, userId, sourceId, source, feedbackType, value, comment, metadata)
      VALUES ${tuples.join(',\n       ')}`,
   );
 }
@@ -85,14 +89,14 @@ export async function listFeedback(db: DuckDBConnection, args: ListFeedbackArgs)
       timestamp: toDate(r.timestamp),
       traceId: r.traceId as string,
       spanId: (r.spanId as string) ?? null,
+      experimentId: (r.experimentId as string) ?? null,
+      userId: (r.userId as string) ?? null,
+      sourceId: (r.sourceId as string) ?? null,
       source: r.source as string,
       feedbackType: r.feedbackType as string,
       value,
       comment: (r.comment as string) ?? null,
-      experimentId: (r.experimentId as string) ?? null,
       metadata: parseJson(r.metadata) as Record<string, unknown> | null,
-      createdAt: toDate(r.timestamp),
-      updatedAt: null,
     };
   });
 

--- a/stores/duckdb/src/storage/domains/observability/feedback.ts
+++ b/stores/duckdb/src/storage/domains/observability/feedback.ts
@@ -1,0 +1,103 @@
+import type {
+  BatchCreateFeedbackArgs,
+  CreateFeedbackArgs,
+  ListFeedbackArgs,
+  ListFeedbackResponse,
+} from '@mastra/core/storage';
+import type { DuckDBConnection } from '../../db/index';
+import { buildWhereClause, buildOrderByClause, buildPaginationClause } from './filters';
+import { v, jsonV, toDate, parseJson } from './helpers';
+
+/** Insert a single feedback event. */
+export async function createFeedback(db: DuckDBConnection, args: CreateFeedbackArgs): Promise<void> {
+  const f = args.feedback;
+  await db.execute(
+    `INSERT INTO feedback_events (timestamp, traceId, spanId, source, feedbackType, value, comment, experimentId, metadata)
+     VALUES (${[
+       v(f.timestamp),
+       v(f.traceId),
+       v(f.spanId ?? null),
+       v(f.source),
+       v(f.feedbackType),
+       v(String(f.value)),
+       v(f.comment ?? null),
+       v(f.experimentId ?? null),
+       jsonV(f.metadata),
+     ].join(', ')})`,
+  );
+}
+
+/** Insert multiple feedback events in a single statement. */
+export async function batchCreateFeedback(db: DuckDBConnection, args: BatchCreateFeedbackArgs): Promise<void> {
+  if (args.feedbacks.length === 0) return;
+
+  const tuples = args.feedbacks.map(
+    f =>
+      `(${[
+        v(f.timestamp),
+        v(f.traceId),
+        v(f.spanId ?? null),
+        v(f.source),
+        v(f.feedbackType),
+        v(String(f.value)),
+        v(f.comment ?? null),
+        v(f.experimentId ?? null),
+        jsonV(f.metadata),
+      ].join(', ')})`,
+  );
+
+  await db.execute(
+    `INSERT INTO feedback_events (timestamp, traceId, spanId, source, feedbackType, value, comment, experimentId, metadata)
+     VALUES ${tuples.join(',\n       ')}`,
+  );
+}
+
+/** Query feedback events with filtering, ordering, and pagination. */
+export async function listFeedback(db: DuckDBConnection, args: ListFeedbackArgs): Promise<ListFeedbackResponse> {
+  const filters = args.filters ?? {};
+  const page = Number(args.pagination?.page ?? 0);
+  const perPage = Number(args.pagination?.perPage ?? 10);
+  const orderBy = { field: args.orderBy?.field ?? 'timestamp', direction: args.orderBy?.direction ?? 'DESC' } as const;
+
+  const { clause: filterClause, params: filterParams } = buildWhereClause(filters as Record<string, unknown>);
+  const orderByClause = buildOrderByClause(orderBy);
+  const { clause: paginationClause, params: paginationParams } = buildPaginationClause({ page, perPage });
+
+  const countResult = await db.query<{ total: number }>(
+    `SELECT COUNT(*) as total FROM feedback_events ${filterClause}`,
+    filterParams,
+  );
+  const total = Number(countResult[0]?.total ?? 0);
+
+  const rows = await db.query(`SELECT * FROM feedback_events ${filterClause} ${orderByClause} ${paginationClause}`, [
+    ...filterParams,
+    ...paginationParams,
+  ]);
+
+  const feedback = rows.map(row => {
+    const r = row as Record<string, unknown>;
+    const rawValue = r.value;
+    let value: number | string = rawValue as string;
+    const numValue = Number(rawValue);
+    if (!isNaN(numValue)) value = numValue;
+
+    return {
+      timestamp: toDate(r.timestamp),
+      traceId: r.traceId as string,
+      spanId: (r.spanId as string) ?? null,
+      source: r.source as string,
+      feedbackType: r.feedbackType as string,
+      value,
+      comment: (r.comment as string) ?? null,
+      experimentId: (r.experimentId as string) ?? null,
+      metadata: parseJson(r.metadata) as Record<string, unknown> | null,
+      createdAt: toDate(r.timestamp),
+      updatedAt: null,
+    };
+  });
+
+  return {
+    pagination: { total, page, perPage, hasMore: (page + 1) * perPage < total },
+    feedback,
+  };
+}

--- a/stores/duckdb/src/storage/domains/observability/filters.ts
+++ b/stores/duckdb/src/storage/domains/observability/filters.ts
@@ -72,21 +72,6 @@ export function buildWhereClause(
       continue;
     }
 
-    if (key === 'search') {
-      conditions.push(`message ILIKE ?`);
-      params.push(`%${value}%`);
-      continue;
-    }
-
-    if (key === 'dataKeys') {
-      const keys = value as string[];
-      for (const k of keys) {
-        conditions.push(`json_extract(data, ?) IS NOT NULL`);
-        params.push(buildJsonPath(k));
-      }
-      continue;
-    }
-
     if (key === 'status') {
       // Derived field for traces
       const status = value as string;

--- a/stores/duckdb/src/storage/domains/observability/filters.ts
+++ b/stores/duckdb/src/storage/domains/observability/filters.ts
@@ -1,0 +1,169 @@
+import type { DateRange } from '@mastra/core/storage';
+import { parseFieldKey } from '@mastra/core/utils';
+
+export function buildJsonPath(key: string): string {
+  try {
+    return `$.${parseFieldKey(key)}`;
+  } catch {
+    const escaped = key.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    return `$["${escaped}"]`;
+  }
+}
+
+function normalizeJsonFilterValue(value: unknown): string | null {
+  if (value === undefined) return null;
+  if (typeof value === 'string') return value;
+  const json = JSON.stringify(value);
+  return json ?? null;
+}
+
+function sanitizeColumn(column: string): string {
+  return parseFieldKey(column);
+}
+
+/**
+ * Build a WHERE clause from a filter object.
+ * Returns { clause, params } for parameterized queries.
+ */
+export function buildWhereClause(
+  filters: Record<string, unknown> | undefined,
+  fieldMappings?: Record<string, string>,
+): { clause: string; params: unknown[] } {
+  if (!filters) return { clause: '', params: [] };
+
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  for (const [key, value] of Object.entries(filters)) {
+    if (value === undefined || value === null) continue;
+
+    const column = sanitizeColumn(fieldMappings?.[key] ?? key);
+
+    if (key === 'timestamp' || key === 'startedAt' || key === 'endedAt') {
+      const dateRange = value as DateRange;
+      if (dateRange.start) {
+        const op = dateRange.startExclusive ? '>' : '>=';
+        conditions.push(`${column} ${op} ?`);
+        params.push(dateRange.start);
+      }
+      if (dateRange.end) {
+        const op = dateRange.endExclusive ? '<' : '<=';
+        conditions.push(`${column} ${op} ?`);
+        params.push(dateRange.end);
+      }
+      continue;
+    }
+
+    if (key === 'labels') {
+      const labelsObj = value as Record<string, string>;
+      for (const [labelKey, labelValue] of Object.entries(labelsObj)) {
+        conditions.push(`json_extract_string(${column}, ?) = ?`);
+        params.push(buildJsonPath(labelKey), labelValue);
+      }
+      continue;
+    }
+
+    if (key === 'tags') {
+      const tags = value as string[];
+      for (const tag of tags) {
+        conditions.push(`list_contains(CAST(${column} AS VARCHAR[]), ?)`);
+        params.push(tag);
+      }
+      continue;
+    }
+
+    if (key === 'search') {
+      conditions.push(`message ILIKE ?`);
+      params.push(`%${value}%`);
+      continue;
+    }
+
+    if (key === 'dataKeys') {
+      const keys = value as string[];
+      for (const k of keys) {
+        conditions.push(`json_extract(data, ?) IS NOT NULL`);
+        params.push(buildJsonPath(k));
+      }
+      continue;
+    }
+
+    if (key === 'status') {
+      // Derived field for traces
+      const status = value as string;
+      if (status === 'error') {
+        conditions.push(`error IS NOT NULL`);
+      } else if (status === 'running') {
+        conditions.push(`endedAt IS NULL AND error IS NULL`);
+      } else if (status === 'success') {
+        conditions.push(`endedAt IS NOT NULL AND error IS NULL`);
+      }
+      continue;
+    }
+
+    if (key === 'hasChildError') {
+      // Handled at query level, skip for now
+      continue;
+    }
+
+    if (key === 'metadata' || key === 'scope') {
+      const jsonObj = value as Record<string, unknown>;
+      for (const [jsonKey, jsonValue] of Object.entries(jsonObj)) {
+        const normalized = normalizeJsonFilterValue(jsonValue);
+        if (normalized === null) continue;
+        conditions.push(`json_extract_string(${column}, ?) = ?`);
+        params.push(buildJsonPath(jsonKey), normalized);
+      }
+      continue;
+    }
+
+    // Array values => IN clause
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      const placeholders = value.map(() => '?').join(', ');
+      conditions.push(`${column} IN (${placeholders})`);
+      params.push(...value);
+      continue;
+    }
+
+    // Simple equality
+    conditions.push(`${column} = ?`);
+    params.push(value);
+  }
+
+  const clause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  return { clause, params };
+}
+
+/**
+ * Build an ORDER BY clause from orderBy config.
+ */
+export function buildOrderByClause(orderBy?: { field: string; direction: string }): string {
+  if (!orderBy) return '';
+  const dir = orderBy.direction.toUpperCase();
+  if (dir !== 'ASC' && dir !== 'DESC') {
+    throw new Error(`Invalid sort direction: ${orderBy.direction}`);
+  }
+  const field = parseFieldKey(orderBy.field);
+  return `ORDER BY ${field} ${dir}`;
+}
+
+/**
+ * Build a LIMIT/OFFSET clause from pagination config.
+ */
+export function buildPaginationClause(pagination?: { page: number; perPage: number }): {
+  clause: string;
+  params: unknown[];
+} {
+  if (!pagination) return { clause: '', params: [] };
+  if (!Number.isInteger(pagination.page) || pagination.page < 0) {
+    throw new Error(`Invalid page: ${pagination.page}`);
+  }
+  if (!Number.isInteger(pagination.perPage) || pagination.perPage <= 0) {
+    throw new Error(`Invalid perPage: ${pagination.perPage}`);
+  }
+  const offset = pagination.page * pagination.perPage;
+  return {
+    clause: `LIMIT ? OFFSET ?`,
+    params: [pagination.perPage, offset],
+  };
+}

--- a/stores/duckdb/src/storage/domains/observability/filters.ts
+++ b/stores/duckdb/src/storage/domains/observability/filters.ts
@@ -6,7 +6,7 @@ export function buildJsonPath(key: string): string {
     return `$.${parseFieldKey(key)}`;
   } catch {
     const escaped = key.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    return `$["${escaped}"]`;
+    return `$."${escaped}"`;
   }
 }
 

--- a/stores/duckdb/src/storage/domains/observability/helpers.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/helpers.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { toDate } from './helpers';
+
+describe('observability helpers', () => {
+  it('toDate throws for invalid dates', () => {
+    expect(() => toDate('not-a-date')).toThrow('Expected valid date but received invalid date');
+  });
+});

--- a/stores/duckdb/src/storage/domains/observability/helpers.ts
+++ b/stores/duckdb/src/storage/domains/observability/helpers.ts
@@ -1,4 +1,3 @@
-import type { SpanRecord } from '@mastra/core/storage';
 import { DuckDBConnection } from '../../db/index';
 
 /** Shorthand for {@link DuckDBConnection.sqlValue}. */
@@ -43,43 +42,4 @@ export function parseJsonArray(value: unknown): unknown[] | null {
   if (value === null || value === undefined) return null;
   const parsed = parseJson(value);
   return Array.isArray(parsed) ? parsed : null;
-}
-
-/** Map a raw DuckDB row to a typed SpanRecord, parsing JSON fields. */
-export function rowToSpanRecord(row: Record<string, unknown>): SpanRecord {
-  return {
-    traceId: row.traceId as string,
-    spanId: row.spanId as string,
-    name: row.name as string,
-    spanType: row.spanType as SpanRecord['spanType'],
-    parentSpanId: (row.parentSpanId as string) ?? null,
-    isEvent: row.isEvent as boolean,
-    startedAt: toDate(row.startedAt),
-    endedAt: toDateOrNull(row.endedAt),
-    experimentId: (row.experimentId as string) ?? null,
-    entityType: (row.entityType as SpanRecord['entityType']) ?? null,
-    entityId: (row.entityId as string) ?? null,
-    entityName: (row.entityName as string) ?? null,
-    userId: (row.userId as string) ?? null,
-    organizationId: (row.organizationId as string) ?? null,
-    resourceId: (row.resourceId as string) ?? null,
-    runId: (row.runId as string) ?? null,
-    sessionId: (row.sessionId as string) ?? null,
-    threadId: (row.threadId as string) ?? null,
-    requestId: (row.requestId as string) ?? null,
-    environment: (row.environment as string) ?? null,
-    source: (row.source as string) ?? null,
-    serviceName: (row.serviceName as string) ?? null,
-    attributes: parseJson(row.attributes) as Record<string, unknown> | null,
-    metadata: parseJson(row.metadata) as Record<string, unknown> | null,
-    tags: parseJsonArray(row.tags) as string[] | null,
-    scope: parseJson(row.scope) as Record<string, unknown> | null,
-    links: parseJsonArray(row.links),
-    input: parseJson(row.input) as Record<string, unknown> | null,
-    output: parseJson(row.output) as Record<string, unknown> | null,
-    error: parseJson(row.error) as Record<string, unknown> | null,
-    requestContext: parseJson(row.requestContext) as Record<string, unknown> | null,
-    createdAt: toDate(row.startedAt),
-    updatedAt: null,
-  };
 }

--- a/stores/duckdb/src/storage/domains/observability/helpers.ts
+++ b/stores/duckdb/src/storage/domains/observability/helpers.ts
@@ -1,0 +1,85 @@
+import type { SpanRecord } from '@mastra/core/storage';
+import { DuckDBConnection } from '../../db/index';
+
+/** Shorthand for {@link DuckDBConnection.sqlValue}. */
+export const v = DuckDBConnection.sqlValue;
+
+/** Serialize a value to JSON then SQL-escape it, or return 'NULL'. */
+export function jsonV(val: unknown): string {
+  if (val === null || val === undefined) return 'NULL';
+  return DuckDBConnection.sqlValue(JSON.stringify(val));
+}
+
+/** Coerce a value to a Date. Throws if value is nullish. */
+export function toDate(val: unknown): Date {
+  if (val === null || val === undefined) {
+    throw new Error('Expected date value but received null/undefined');
+  }
+  if (val instanceof Date) return val;
+  return new Date(String(val));
+}
+
+/** Coerce a value to a Date, returning null for nullish values. */
+export function toDateOrNull(val: unknown): Date | null {
+  if (val === null || val === undefined) return null;
+  return val instanceof Date ? val : new Date(String(val));
+}
+
+/** Parse a JSON string, returning the original value if parsing fails. */
+export function parseJson(value: unknown): unknown {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}
+
+/** Parse a JSON string and return the result only if it is an array. */
+export function parseJsonArray(value: unknown): unknown[] | null {
+  if (value === null || value === undefined) return null;
+  const parsed = parseJson(value);
+  return Array.isArray(parsed) ? parsed : null;
+}
+
+/** Map a raw DuckDB row to a typed SpanRecord, parsing JSON fields. */
+export function rowToSpanRecord(row: Record<string, unknown>): SpanRecord {
+  return {
+    traceId: row.traceId as string,
+    spanId: row.spanId as string,
+    name: row.name as string,
+    spanType: row.spanType as SpanRecord['spanType'],
+    parentSpanId: (row.parentSpanId as string) ?? null,
+    isEvent: row.isEvent as boolean,
+    startedAt: toDate(row.startedAt),
+    endedAt: toDateOrNull(row.endedAt),
+    experimentId: (row.experimentId as string) ?? null,
+    entityType: (row.entityType as SpanRecord['entityType']) ?? null,
+    entityId: (row.entityId as string) ?? null,
+    entityName: (row.entityName as string) ?? null,
+    userId: (row.userId as string) ?? null,
+    organizationId: (row.organizationId as string) ?? null,
+    resourceId: (row.resourceId as string) ?? null,
+    runId: (row.runId as string) ?? null,
+    sessionId: (row.sessionId as string) ?? null,
+    threadId: (row.threadId as string) ?? null,
+    requestId: (row.requestId as string) ?? null,
+    environment: (row.environment as string) ?? null,
+    source: (row.source as string) ?? null,
+    serviceName: (row.serviceName as string) ?? null,
+    attributes: parseJson(row.attributes) as Record<string, unknown> | null,
+    metadata: parseJson(row.metadata) as Record<string, unknown> | null,
+    tags: parseJsonArray(row.tags) as string[] | null,
+    scope: parseJson(row.scope) as Record<string, unknown> | null,
+    links: parseJsonArray(row.links),
+    input: parseJson(row.input) as Record<string, unknown> | null,
+    output: parseJson(row.output) as Record<string, unknown> | null,
+    error: parseJson(row.error) as Record<string, unknown> | null,
+    requestContext: parseJson(row.requestContext) as Record<string, unknown> | null,
+    createdAt: toDate(row.startedAt),
+    updatedAt: null,
+  };
+}

--- a/stores/duckdb/src/storage/domains/observability/helpers.ts
+++ b/stores/duckdb/src/storage/domains/observability/helpers.ts
@@ -14,8 +14,11 @@ export function toDate(val: unknown): Date {
   if (val === null || val === undefined) {
     throw new Error('Expected date value but received null/undefined');
   }
-  if (val instanceof Date) return val;
-  return new Date(String(val));
+  const date = val instanceof Date ? val : new Date(String(val));
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Expected valid date but received invalid date');
+  }
+  return date;
 }
 
 /** Coerce a value to a Date, returning null for nullish values. */

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -1,0 +1,620 @@
+import { EntityType, SpanType } from '@mastra/core/observability';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { DuckDBStore } from '../../index';
+import type { ObservabilityStorageDuckDB } from './index';
+
+describe('ObservabilityStorageDuckDB', () => {
+  let store: DuckDBStore;
+  let storage: ObservabilityStorageDuckDB;
+
+  beforeAll(async () => {
+    store = new DuckDBStore({ path: ':memory:' });
+    storage = store.observability;
+    await store.init();
+  });
+
+  beforeEach(async () => {
+    await storage.dangerouslyClearAll();
+  });
+
+  afterAll(async () => {
+    await store.db.close();
+  });
+
+  // ==========================================================================
+  // Tracing Strategy
+  // ==========================================================================
+
+  it('reports event-sourced as preferred strategy', () => {
+    expect(storage.tracingStrategy).toEqual({
+      preferred: 'event-sourced',
+      supported: ['event-sourced'],
+    });
+  });
+
+  // ==========================================================================
+  // Span Event Insertion + Reconstruction
+  // ==========================================================================
+
+  describe('span events', () => {
+    const now = new Date();
+
+    it('creates and reconstructs a span from start event', async () => {
+      await storage.createSpan({
+        span: {
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          parentSpanId: null,
+          name: 'agent-run',
+          spanType: SpanType.AGENT_RUN,
+          isEvent: false,
+          entityType: EntityType.AGENT,
+          entityId: 'agent-1',
+          entityName: 'myAgent',
+          userId: null,
+          organizationId: null,
+          resourceId: null,
+          runId: null,
+          sessionId: null,
+          threadId: null,
+          requestId: null,
+          environment: 'test',
+          source: null,
+          serviceName: 'test-service',
+          scope: null,
+          attributes: { model: 'gpt-4' },
+          metadata: { foo: 'bar' },
+          tags: ['tag1', 'tag2'],
+          links: null,
+          input: { prompt: 'hello' },
+          output: null,
+          error: null,
+          startedAt: now,
+          endedAt: null,
+        },
+      });
+
+      const result = await storage.getSpan({ traceId: 'trace-1', spanId: 'span-1' });
+      expect(result).not.toBeNull();
+      const span = result!.span;
+      expect(span.name).toBe('agent-run');
+      expect(span.traceId).toBe('trace-1');
+      expect(span.spanId).toBe('span-1');
+      expect(span.spanType).toBe('agent_run');
+      expect(span.entityType).toBe('agent');
+      expect(span.entityName).toBe('myAgent');
+      expect(span.environment).toBe('test');
+      expect(span.endedAt).toBeNull();
+    });
+
+    it('reconstructs span with update and end events', async () => {
+      // Start
+      await storage.createSpan({
+        span: {
+          traceId: 'trace-2',
+          spanId: 'span-2',
+          parentSpanId: null,
+          name: 'tool-call',
+          spanType: SpanType.TOOL_CALL,
+          isEvent: false,
+          entityType: EntityType.TOOL,
+          entityId: 'tool-1',
+          entityName: 'weather',
+          userId: null,
+          organizationId: null,
+          resourceId: null,
+          runId: null,
+          sessionId: null,
+          threadId: null,
+          requestId: null,
+          environment: null,
+          source: null,
+          serviceName: null,
+          scope: null,
+          attributes: null,
+          metadata: null,
+          tags: null,
+          links: null,
+          input: { city: 'NYC' },
+          output: null,
+          error: null,
+          startedAt: new Date('2026-01-01T00:00:00Z'),
+          endedAt: null,
+        },
+      });
+
+      // Update with output
+      await storage.updateSpan({
+        traceId: 'trace-2',
+        spanId: 'span-2',
+        updates: {
+          output: { temp: 72 },
+          endedAt: new Date('2026-01-01T00:00:01Z'),
+        },
+      });
+
+      const result = await storage.getSpan({ traceId: 'trace-2', spanId: 'span-2' });
+      expect(result).not.toBeNull();
+      const span = result!.span;
+      expect(span.name).toBe('tool-call');
+      expect(span.output).toEqual({ temp: 72 });
+      expect(span.endedAt).toBeInstanceOf(Date);
+    });
+
+    it('batch creates and lists traces', async () => {
+      await storage.batchCreateSpans({
+        records: [
+          {
+            traceId: 'trace-3',
+            spanId: 'root-span',
+            parentSpanId: null,
+            name: 'workflow-run',
+            spanType: SpanType.WORKFLOW_RUN,
+            isEvent: false,
+            entityType: EntityType.WORKFLOW_RUN,
+            entityId: 'wf-1',
+            entityName: 'myWorkflow',
+            userId: null,
+            organizationId: null,
+            resourceId: null,
+            runId: null,
+            sessionId: null,
+            threadId: null,
+            requestId: null,
+            environment: 'production',
+            source: null,
+            serviceName: 'svc',
+            scope: null,
+            attributes: null,
+            metadata: null,
+            tags: ['v1'],
+            links: null,
+            input: null,
+            output: null,
+            error: null,
+            startedAt: new Date('2026-01-01T00:00:00Z'),
+            endedAt: null,
+          },
+          {
+            traceId: 'trace-3',
+            spanId: 'child-span',
+            parentSpanId: 'root-span',
+            name: 'agent-step',
+            spanType: SpanType.AGENT_RUN,
+            isEvent: false,
+            entityType: EntityType.AGENT,
+            entityId: 'agent-1',
+            entityName: 'myAgent',
+            userId: null,
+            organizationId: null,
+            resourceId: null,
+            runId: null,
+            sessionId: null,
+            threadId: null,
+            requestId: null,
+            environment: 'production',
+            source: null,
+            serviceName: 'svc',
+            scope: null,
+            attributes: null,
+            metadata: null,
+            tags: null,
+            links: null,
+            input: null,
+            output: null,
+            error: null,
+            startedAt: new Date('2026-01-01T00:00:01Z'),
+            endedAt: null,
+          },
+        ],
+      });
+
+      const trace = await storage.getTrace({ traceId: 'trace-3' });
+      expect(trace).not.toBeNull();
+      expect(trace!.spans).toHaveLength(2);
+
+      const rootResult = await storage.getRootSpan({ traceId: 'trace-3' });
+      expect(rootResult).not.toBeNull();
+      expect(rootResult!.span.name).toBe('workflow-run');
+      expect(rootResult!.span.parentSpanId).toBeNull();
+
+      const traces = await storage.listTraces({});
+      expect(traces.spans.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('batch deletes traces', async () => {
+      await storage.createSpan({
+        span: {
+          traceId: 'trace-del',
+          spanId: 'span-del',
+          parentSpanId: null,
+          name: 'delete-me',
+          spanType: SpanType.AGENT_RUN,
+          isEvent: false,
+          entityType: null,
+          entityId: null,
+          entityName: null,
+          userId: null,
+          organizationId: null,
+          resourceId: null,
+          runId: null,
+          sessionId: null,
+          threadId: null,
+          requestId: null,
+          environment: null,
+          source: null,
+          serviceName: null,
+          scope: null,
+          attributes: null,
+          metadata: null,
+          tags: null,
+          links: null,
+          input: null,
+          output: null,
+          error: null,
+          startedAt: now,
+          endedAt: null,
+        },
+      });
+
+      await storage.batchDeleteTraces({ traceIds: ['trace-del'] });
+      const result = await storage.getSpan({ traceId: 'trace-del', spanId: 'span-del' });
+      expect(result).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // Logs
+  // ==========================================================================
+
+  describe('logs', () => {
+    it('creates and lists logs', async () => {
+      await storage.batchCreateLogs({
+        logs: [
+          {
+            timestamp: new Date(),
+            level: 'info',
+            message: 'Test log message',
+            data: { key: 'value' },
+            traceId: 'trace-1',
+            spanId: 'span-1',
+            tags: ['test'],
+            entityType: EntityType.AGENT,
+            entityId: 'agent-1',
+            entityName: 'myAgent',
+            metadata: null,
+          },
+          {
+            timestamp: new Date(),
+            level: 'error',
+            message: 'Error occurred',
+            data: null,
+            traceId: 'trace-1',
+            spanId: null,
+            tags: null,
+            metadata: null,
+          },
+        ],
+      });
+
+      const result = await storage.listLogs({});
+      expect(result.logs).toHaveLength(2);
+
+      const filtered = await storage.listLogs({
+        filters: { level: 'error' },
+      });
+      expect(filtered.logs).toHaveLength(1);
+      expect(filtered.logs[0]!.message).toBe('Error occurred');
+    });
+  });
+
+  // ==========================================================================
+  // Metrics + OLAP Queries
+  // ==========================================================================
+
+  describe('metrics', () => {
+    beforeEach(async () => {
+      // Insert sample metrics
+      await storage.batchCreateMetrics({
+        metrics: [
+          {
+            timestamp: new Date('2026-01-01T00:00:00Z'),
+            name: 'mastra_agent_duration_ms',
+            value: 100,
+            labels: { status: 'ok' },
+            entityType: EntityType.AGENT,
+            entityName: 'weatherAgent',
+          },
+          {
+            timestamp: new Date('2026-01-01T00:00:05Z'),
+            name: 'mastra_agent_duration_ms',
+            value: 200,
+            labels: { status: 'ok' },
+            entityType: EntityType.AGENT,
+            entityName: 'weatherAgent',
+          },
+          {
+            timestamp: new Date('2026-01-01T00:00:10Z'),
+            name: 'mastra_agent_duration_ms',
+            value: 500,
+            labels: { status: 'error' },
+            entityType: EntityType.AGENT,
+            entityName: 'codeAgent',
+          },
+          {
+            timestamp: new Date('2026-01-01T01:00:00Z'),
+            name: 'mastra_tool_calls_started',
+            value: 1,
+            labels: {},
+            entityType: EntityType.TOOL,
+            entityName: 'search',
+          },
+        ],
+      });
+    });
+
+    it('getMetricAggregate returns sum', async () => {
+      const result = await storage.getMetricAggregate({
+        name: ['mastra_agent_duration_ms'],
+        aggregation: 'sum',
+      });
+      expect(result.value).toBe(800); // 100 + 200 + 500
+    });
+
+    it('getMetricAggregate returns avg', async () => {
+      const result = await storage.getMetricAggregate({
+        name: ['mastra_agent_duration_ms'],
+        aggregation: 'avg',
+      });
+      expect(result.value).toBeCloseTo(266.67, 0);
+    });
+
+    it('getMetricAggregate returns count', async () => {
+      const result = await storage.getMetricAggregate({
+        name: ['mastra_agent_duration_ms'],
+        aggregation: 'count',
+      });
+      expect(result.value).toBe(3);
+    });
+
+    it('getMetricBreakdown groups by entityName', async () => {
+      const result = await storage.getMetricBreakdown({
+        name: ['mastra_agent_duration_ms'],
+        groupBy: ['entityName'],
+        aggregation: 'avg',
+      });
+      expect(result.groups).toHaveLength(2);
+      const weather = result.groups.find(g => g.dimensions.entityName === 'weatherAgent');
+      const code = result.groups.find(g => g.dimensions.entityName === 'codeAgent');
+      expect(weather).toBeDefined();
+      expect(weather!.value).toBe(150); // (100+200)/2
+      expect(code).toBeDefined();
+      expect(code!.value).toBe(500);
+    });
+
+    it('getMetricTimeSeries returns bucketed data', async () => {
+      const result = await storage.getMetricTimeSeries({
+        name: ['mastra_agent_duration_ms'],
+        interval: '1h',
+        aggregation: 'sum',
+      });
+      expect(result.series.length).toBeGreaterThanOrEqual(1);
+      const mainSeries = result.series[0]!;
+      expect(mainSeries.points.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('getMetricPercentiles returns percentile series', async () => {
+      const result = await storage.getMetricPercentiles({
+        name: 'mastra_agent_duration_ms',
+        percentiles: [0.5, 0.99],
+        interval: '1h',
+      });
+      expect(result.series).toHaveLength(2);
+      const p50 = result.series.find(s => s.percentile === 0.5);
+      expect(p50).toBeDefined();
+    });
+  });
+
+  // ==========================================================================
+  // Discovery Methods
+  // ==========================================================================
+
+  describe('discovery', () => {
+    beforeEach(async () => {
+      await storage.batchCreateMetrics({
+        metrics: [
+          {
+            timestamp: new Date(),
+            name: 'mastra_agent_duration_ms',
+            value: 100,
+            labels: { agent: 'weatherAgent', status: 'ok' },
+            entityType: EntityType.AGENT,
+            entityName: 'weatherAgent',
+          },
+          {
+            timestamp: new Date(),
+            name: 'mastra_tool_calls_started',
+            value: 1,
+            labels: { tool: 'search' },
+          },
+        ],
+      });
+
+      await storage.batchCreateSpans({
+        records: [
+          {
+            traceId: 'disc-trace',
+            spanId: 'disc-span',
+            parentSpanId: null,
+            name: 'test',
+            spanType: SpanType.AGENT_RUN,
+            isEvent: false,
+            entityType: EntityType.AGENT,
+            entityId: 'a-1',
+            entityName: 'weatherAgent',
+            userId: null,
+            organizationId: null,
+            resourceId: null,
+            runId: null,
+            sessionId: null,
+            threadId: null,
+            requestId: null,
+            environment: 'production',
+            source: null,
+            serviceName: 'my-service',
+            scope: null,
+            attributes: null,
+            metadata: null,
+            tags: ['v1', 'experiment'],
+            links: null,
+            input: null,
+            output: null,
+            error: null,
+            startedAt: new Date(),
+            endedAt: null,
+          },
+        ],
+      });
+    });
+
+    it('getMetricNames returns distinct names', async () => {
+      const result = await storage.getMetricNames({});
+      expect(result.names).toContain('mastra_agent_duration_ms');
+      expect(result.names).toContain('mastra_tool_calls_started');
+    });
+
+    it('getMetricNames filters by prefix', async () => {
+      const result = await storage.getMetricNames({ prefix: 'mastra_agent' });
+      expect(result.names).toContain('mastra_agent_duration_ms');
+      expect(result.names).not.toContain('mastra_tool_calls_started');
+    });
+
+    it('getMetricLabelKeys returns label keys', async () => {
+      const result = await storage.getMetricLabelKeys({ metricName: 'mastra_agent_duration_ms' });
+      expect(result.keys).toContain('agent');
+      expect(result.keys).toContain('status');
+    });
+
+    it('getMetricLabelValues returns values for a label key', async () => {
+      const result = await storage.getMetricLabelValues({
+        metricName: 'mastra_agent_duration_ms',
+        labelKey: 'status',
+      });
+      expect(result.values).toContain('ok');
+    });
+
+    it('getEntityTypes returns distinct entity types', async () => {
+      const result = await storage.getEntityTypes({});
+      expect(result.entityTypes).toContain('agent');
+    });
+
+    it('getEntityNames returns entity names', async () => {
+      const result = await storage.getEntityNames({ entityType: EntityType.AGENT });
+      expect(result.names).toContain('weatherAgent');
+    });
+
+    it('getServiceNames returns service names', async () => {
+      const result = await storage.getServiceNames({});
+      expect(result.serviceNames).toContain('my-service');
+    });
+
+    it('getEnvironments returns environments', async () => {
+      const result = await storage.getEnvironments({});
+      expect(result.environments).toContain('production');
+    });
+
+    it('getTags returns distinct tags', async () => {
+      const result = await storage.getTags({});
+      expect(result.tags).toContain('v1');
+      expect(result.tags).toContain('experiment');
+    });
+  });
+
+  // ==========================================================================
+  // Scores
+  // ==========================================================================
+
+  describe('scores', () => {
+    it('creates and lists scores', async () => {
+      await storage.createScore({
+        score: {
+          timestamp: new Date(),
+          traceId: 'trace-1',
+          spanId: null,
+          scorerId: 'relevance',
+          score: 0.85,
+          reason: 'Good answer',
+          experimentId: 'exp-1',
+          metadata: { entityType: 'agent' },
+        },
+      });
+
+      await storage.createScore({
+        score: {
+          timestamp: new Date(),
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          scorerId: 'factuality',
+          score: 0.9,
+          reason: null,
+          experimentId: null,
+          metadata: null,
+        },
+      });
+
+      const result = await storage.listScores({});
+      expect(result.scores).toHaveLength(2);
+
+      const filtered = await storage.listScores({
+        filters: { scorerId: 'relevance' },
+      });
+      expect(filtered.scores).toHaveLength(1);
+      expect(filtered.scores[0]!.score).toBe(0.85);
+    });
+  });
+
+  // ==========================================================================
+  // Feedback
+  // ==========================================================================
+
+  describe('feedback', () => {
+    it('creates and lists feedback', async () => {
+      await storage.createFeedback({
+        feedback: {
+          timestamp: new Date(),
+          traceId: 'trace-1',
+          spanId: null,
+          source: 'user',
+          feedbackType: 'thumbs',
+          value: 1,
+          comment: 'Great!',
+          experimentId: null,
+          metadata: null,
+        },
+      });
+
+      await storage.createFeedback({
+        feedback: {
+          timestamp: new Date(),
+          traceId: 'trace-2',
+          spanId: null,
+          source: 'reviewer',
+          feedbackType: 'rating',
+          value: 4,
+          comment: null,
+          experimentId: 'exp-1',
+          metadata: null,
+        },
+      });
+
+      const result = await storage.listFeedback({});
+      expect(result.feedback).toHaveLength(2);
+
+      const filtered = await storage.listFeedback({
+        filters: { source: 'user' },
+      });
+      expect(filtered.feedback).toHaveLength(1);
+      expect(filtered.feedback[0]!.value).toBe(1);
+    });
+  });
+});

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -87,8 +87,7 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(span.endedAt).toBeNull();
     });
 
-    it('reconstructs span with update and end events', async () => {
-      // Start
+    it('reconstructs a completed span from start and end rows only', async () => {
       await storage.createSpan({
         span: {
           traceId: 'trace-2',
@@ -116,19 +115,9 @@ describe('ObservabilityStorageDuckDB', () => {
           tags: null,
           links: null,
           input: { city: 'NYC' },
-          output: null,
+          output: { temp: 72 },
           error: null,
           startedAt: new Date('2026-01-01T00:00:00Z'),
-          endedAt: null,
-        },
-      });
-
-      // Update with output
-      await storage.updateSpan({
-        traceId: 'trace-2',
-        spanId: 'span-2',
-        updates: {
-          output: { temp: 72 },
           endedAt: new Date('2026-01-01T00:00:01Z'),
         },
       });
@@ -139,6 +128,19 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(span.name).toBe('tool-call');
       expect(span.output).toEqual({ temp: 72 });
       expect(span.endedAt).toBeInstanceOf(Date);
+    });
+
+    it('does not support span updates for event-sourced tracing', async () => {
+      await expect(
+        storage.updateSpan({
+          traceId: 'trace-2',
+          spanId: 'span-2',
+          updates: {
+            output: { temp: 72 },
+            endedAt: new Date('2026-01-01T00:00:01Z'),
+          },
+        }),
+      ).rejects.toThrow('does not support updating spans');
     });
 
     it('batch creates and lists traces', async () => {
@@ -322,6 +324,11 @@ describe('ObservabilityStorageDuckDB', () => {
             name: 'mastra_agent_duration_ms',
             value: 100,
             labels: { status: 'ok' },
+            provider: 'openai',
+            model: 'gpt-4o-mini',
+            estimatedCost: 0.1,
+            costUnit: 'usd',
+            tags: ['prod'],
             entityType: EntityType.AGENT,
             entityName: 'weatherAgent',
           },
@@ -330,6 +337,11 @@ describe('ObservabilityStorageDuckDB', () => {
             name: 'mastra_agent_duration_ms',
             value: 200,
             labels: { status: 'ok' },
+            provider: 'openai',
+            model: 'gpt-4o-mini',
+            estimatedCost: 0.2,
+            costUnit: 'usd',
+            tags: ['prod'],
             entityType: EntityType.AGENT,
             entityName: 'weatherAgent',
           },
@@ -338,6 +350,11 @@ describe('ObservabilityStorageDuckDB', () => {
             name: 'mastra_agent_duration_ms',
             value: 500,
             labels: { status: 'error' },
+            provider: 'anthropic',
+            model: 'claude-3-7-sonnet',
+            estimatedCost: 0.5,
+            costUnit: 'usd',
+            tags: ['prod'],
             entityType: EntityType.AGENT,
             entityName: 'codeAgent',
           },
@@ -346,6 +363,7 @@ describe('ObservabilityStorageDuckDB', () => {
             name: 'mastra_tool_calls_started',
             value: 1,
             labels: {},
+            tags: ['prod'],
             entityType: EntityType.TOOL,
             entityName: 'search',
           },
@@ -359,6 +377,30 @@ describe('ObservabilityStorageDuckDB', () => {
         aggregation: 'sum',
       });
       expect(result.value).toBe(800); // 100 + 200 + 500
+      expect(result.estimatedCost).toBeCloseTo(0.8);
+      expect(result.costUnit).toBe('usd');
+    });
+
+    it('listMetrics returns paginated metric records with shared filters', async () => {
+      const result = await storage.listMetrics({
+        filters: {
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          tags: ['prod'],
+        },
+        pagination: { page: 0, perPage: 1 },
+        orderBy: { field: 'timestamp', direction: 'ASC' },
+      });
+
+      expect(result.pagination.total).toBe(2);
+      expect(result.pagination.hasMore).toBe(true);
+      expect(result.metrics).toHaveLength(1);
+      expect(result.metrics[0]!.provider).toBe('openai');
+      expect(result.metrics[0]!.model).toBe('gpt-4o-mini');
+      expect(result.metrics[0]!.estimatedCost).toBeCloseTo(0.1);
+      expect(result.metrics[0]!.costUnit).toBe('usd');
+      expect(result.metrics[0]!.tags).toEqual(['prod']);
+      expect(result.metrics[0]!.labels).toEqual({ status: 'ok' });
     });
 
     it('getMetricAggregate returns avg', async () => {
@@ -388,8 +430,29 @@ describe('ObservabilityStorageDuckDB', () => {
       const code = result.groups.find(g => g.dimensions.entityName === 'codeAgent');
       expect(weather).toBeDefined();
       expect(weather!.value).toBe(150); // (100+200)/2
+      expect(weather!.estimatedCost).toBeCloseTo(0.3);
+      expect(weather!.costUnit).toBe('usd');
       expect(code).toBeDefined();
       expect(code!.value).toBe(500);
+      expect(code!.estimatedCost).toBeCloseTo(0.5);
+      expect(code!.costUnit).toBe('usd');
+    });
+
+    it('getMetricBreakdown groups by label keys', async () => {
+      const result = await storage.getMetricBreakdown({
+        name: ['mastra_agent_duration_ms'],
+        groupBy: ['status'],
+        aggregation: 'count',
+      });
+
+      expect(result.groups).toHaveLength(2);
+      const ok = result.groups.find(g => g.dimensions.status === 'ok');
+      const error = result.groups.find(g => g.dimensions.status === 'error');
+
+      expect(ok?.value).toBe(2);
+      expect(ok?.estimatedCost).toBeCloseTo(0.3);
+      expect(error?.value).toBe(1);
+      expect(error?.estimatedCost).toBeCloseTo(0.5);
     });
 
     it('getMetricTimeSeries returns bucketed data', async () => {
@@ -401,6 +464,23 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(result.series.length).toBeGreaterThanOrEqual(1);
       const mainSeries = result.series[0]!;
       expect(mainSeries.points.length).toBeGreaterThanOrEqual(1);
+      expect(mainSeries.costUnit).toBe('usd');
+      expect(mainSeries.points[0]!.estimatedCost).toBeCloseTo(0.8);
+    });
+
+    it('filters metrics by canonical cost fields', async () => {
+      const result = await storage.getMetricAggregate({
+        name: ['mastra_agent_duration_ms'],
+        aggregation: 'sum',
+        filters: {
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          costUnit: 'usd',
+        },
+      });
+
+      expect(result.value).toBe(300);
+      expect(result.estimatedCost).toBeCloseTo(0.3);
     });
 
     it('getMetricPercentiles returns percentile series', async () => {
@@ -430,12 +510,37 @@ describe('ObservabilityStorageDuckDB', () => {
             labels: { agent: 'weatherAgent', status: 'ok' },
             entityType: EntityType.AGENT,
             entityName: 'weatherAgent',
+            serviceName: 'metric-service',
+            environment: 'metric-env',
+            tags: ['metric-tag'],
           },
           {
             timestamp: new Date(),
             name: 'mastra_tool_calls_started',
             value: 1,
             labels: { tool: 'search' },
+            entityType: EntityType.TOOL,
+            entityName: 'metricTool',
+            serviceName: 'metric-service',
+            environment: 'metric-env',
+            tags: ['metric-tag'],
+          },
+        ],
+      });
+
+      await storage.batchCreateLogs({
+        logs: [
+          {
+            timestamp: new Date(),
+            level: 'info',
+            message: 'discovery-log',
+            data: null,
+            entityType: EntityType.INPUT_PROCESSOR,
+            entityName: 'logProcessor',
+            serviceName: 'log-service',
+            environment: 'log-env',
+            tags: ['log-tag'],
+            metadata: null,
           },
         ],
       });
@@ -506,27 +611,41 @@ describe('ObservabilityStorageDuckDB', () => {
     it('getEntityTypes returns distinct entity types', async () => {
       const result = await storage.getEntityTypes({});
       expect(result.entityTypes).toContain('agent');
+      expect(result.entityTypes).toContain('tool');
+      expect(result.entityTypes).toContain('input_processor');
     });
 
     it('getEntityNames returns entity names', async () => {
       const result = await storage.getEntityNames({ entityType: EntityType.AGENT });
       expect(result.names).toContain('weatherAgent');
+
+      const toolNames = await storage.getEntityNames({ entityType: EntityType.TOOL });
+      expect(toolNames.names).toContain('metricTool');
+
+      const processorNames = await storage.getEntityNames({ entityType: EntityType.INPUT_PROCESSOR });
+      expect(processorNames.names).toContain('logProcessor');
     });
 
     it('getServiceNames returns service names', async () => {
       const result = await storage.getServiceNames({});
       expect(result.serviceNames).toContain('my-service');
+      expect(result.serviceNames).toContain('metric-service');
+      expect(result.serviceNames).toContain('log-service');
     });
 
     it('getEnvironments returns environments', async () => {
       const result = await storage.getEnvironments({});
       expect(result.environments).toContain('production');
+      expect(result.environments).toContain('metric-env');
+      expect(result.environments).toContain('log-env');
     });
 
     it('getTags returns distinct tags', async () => {
       const result = await storage.getTags({});
       expect(result.tags).toContain('v1');
       expect(result.tags).toContain('experiment');
+      expect(result.tags).toContain('metric-tag');
+      expect(result.tags).toContain('log-tag');
     });
   });
 
@@ -589,6 +708,8 @@ describe('ObservabilityStorageDuckDB', () => {
           value: 1,
           comment: 'Great!',
           experimentId: null,
+          userId: 'user-1',
+          sourceId: 'source-1',
           metadata: null,
         },
       });
@@ -603,6 +724,8 @@ describe('ObservabilityStorageDuckDB', () => {
           value: 4,
           comment: null,
           experimentId: 'exp-1',
+          userId: 'user-2',
+          sourceId: 'source-2',
           metadata: null,
         },
       });
@@ -615,6 +738,8 @@ describe('ObservabilityStorageDuckDB', () => {
       });
       expect(filtered.feedback).toHaveLength(1);
       expect(filtered.feedback[0]!.value).toBe(1);
+      expect(filtered.feedback[0]!.userId).toBe('user-1');
+      expect(filtered.feedback[0]!.sourceId).toBe('source-1');
     });
   });
 });

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -455,6 +455,46 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(error?.estimatedCost).toBeCloseTo(0.5);
     });
 
+    it('getMetricBreakdown accepts discovered label keys with non-identifier characters', async () => {
+      await storage.batchCreateMetrics({
+        metrics: [
+          {
+            timestamp: new Date('2026-01-01T00:00:20Z'),
+            name: 'mastra_agent_duration_ms',
+            value: 300,
+            labels: { 'foo-bar': 'alpha' },
+            entityType: EntityType.AGENT,
+            entityName: 'weatherAgent',
+          },
+          {
+            timestamp: new Date('2026-01-01T00:00:25Z'),
+            name: 'mastra_agent_duration_ms',
+            value: 400,
+            labels: { 'foo-bar': 'beta' },
+            entityType: EntityType.AGENT,
+            entityName: 'codeAgent',
+          },
+        ],
+      });
+
+      const keys = await storage.getMetricLabelKeys({ metricName: 'mastra_agent_duration_ms' });
+      expect(keys.keys).toContain('foo-bar');
+
+      const result = await storage.getMetricBreakdown({
+        name: ['mastra_agent_duration_ms'],
+        groupBy: ['foo-bar'],
+        aggregation: 'count',
+      });
+
+      const alpha = result.groups.find(group => group.dimensions['foo-bar'] === 'alpha');
+      const beta = result.groups.find(group => group.dimensions['foo-bar'] === 'beta');
+      const missing = result.groups.find(group => group.dimensions['foo-bar'] === null);
+
+      expect(alpha?.value).toBe(1);
+      expect(beta?.value).toBe(1);
+      expect(missing?.value).toBe(3);
+    });
+
     it('getMetricTimeSeries returns bucketed data', async () => {
       const result = await storage.getMetricTimeSeries({
         name: ['mastra_agent_duration_ms'],
@@ -466,6 +506,43 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(mainSeries.points.length).toBeGreaterThanOrEqual(1);
       expect(mainSeries.costUnit).toBe('usd');
       expect(mainSeries.points[0]!.estimatedCost).toBeCloseTo(0.8);
+    });
+
+    it('getMetricTimeSeries keeps colliding display names as separate grouped series', async () => {
+      await storage.batchCreateMetrics({
+        metrics: [
+          {
+            timestamp: new Date('2026-01-01T02:00:00Z'),
+            name: 'mastra_collision_metric',
+            value: 10,
+            labels: { segmentA: 'a', segmentB: 'b|c' },
+            entityType: EntityType.TOOL,
+            entityName: 'search',
+          },
+          {
+            timestamp: new Date('2026-01-01T02:00:00Z'),
+            name: 'mastra_collision_metric',
+            value: 20,
+            labels: { segmentA: 'a|b', segmentB: 'c' },
+            entityType: EntityType.TOOL,
+            entityName: 'search',
+          },
+        ],
+      });
+
+      const result = await storage.getMetricTimeSeries({
+        name: ['mastra_collision_metric'],
+        interval: '1h',
+        aggregation: 'sum',
+        groupBy: ['segmentA', 'segmentB'],
+      });
+
+      expect(result.series).toHaveLength(2);
+      expect(result.series.every(series => series.name === 'a|b|c')).toBe(true);
+      expect(result.series.map(series => series.points.length)).toEqual([1, 1]);
+      expect(result.series.map(series => series.points[0]!.value).sort((left, right) => left - right)).toEqual([
+        10, 20,
+      ]);
     });
 
     it('filters metrics by canonical cost fields', async () => {
@@ -740,6 +817,87 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(filtered.feedback[0]!.value).toBe(1);
       expect(filtered.feedback[0]!.userId).toBe('user-1');
       expect(filtered.feedback[0]!.sourceId).toBe('source-1');
+    });
+
+    it('batch creates and lists feedback', async () => {
+      await storage.batchCreateFeedback({
+        feedbacks: [
+          {
+            timestamp: new Date('2026-01-01T00:00:00Z'),
+            traceId: 'batch-trace-1',
+            spanId: null,
+            source: 'user',
+            feedbackType: 'thumbs',
+            value: 1,
+            comment: 'Helpful',
+            experimentId: null,
+            userId: 'user-1',
+            sourceId: 'source-1',
+            metadata: null,
+          },
+          {
+            timestamp: new Date('2026-01-01T00:00:01Z'),
+            traceId: 'batch-trace-2',
+            spanId: 'span-2',
+            source: 'reviewer',
+            feedbackType: 'rating',
+            value: 4,
+            comment: null,
+            experimentId: 'exp-1',
+            userId: 'user-2',
+            sourceId: 'source-2',
+            metadata: { category: 'quality' },
+          },
+          {
+            timestamp: new Date('2026-01-01T00:00:02Z'),
+            traceId: 'batch-trace-3',
+            spanId: null,
+            source: 'system',
+            feedbackType: 'flag',
+            value: 'needs-review',
+            comment: 'Escalated',
+            experimentId: null,
+            userId: null,
+            sourceId: 'source-3',
+            metadata: { severity: 'high' },
+          },
+        ],
+      });
+
+      const result = await storage.listFeedback({
+        orderBy: { field: 'timestamp', direction: 'ASC' },
+      });
+
+      expect(result.feedback).toHaveLength(3);
+      expect(result.feedback).toEqual([
+        expect.objectContaining({
+          traceId: 'batch-trace-1',
+          spanId: null,
+          source: 'user',
+          feedbackType: 'thumbs',
+          value: 1,
+          comment: 'Helpful',
+          metadata: null,
+        }),
+        expect.objectContaining({
+          traceId: 'batch-trace-2',
+          spanId: 'span-2',
+          source: 'reviewer',
+          feedbackType: 'rating',
+          value: 4,
+          comment: null,
+          metadata: { category: 'quality' },
+        }),
+        expect.objectContaining({
+          traceId: 'batch-trace-3',
+          spanId: null,
+          source: 'system',
+          feedbackType: 'flag',
+          value: 'needs-review',
+          comment: 'Escalated',
+          metadata: { severity: 'high' },
+        }),
+      ]);
     });
   });
 });

--- a/stores/duckdb/src/storage/domains/observability/index.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.ts
@@ -1,7 +1,6 @@
 import { ObservabilityStorage } from '@mastra/core/storage';
 import type {
   CreateSpanArgs,
-  UpdateSpanArgs,
   GetSpanArgs,
   GetSpanResponse,
   GetRootSpanArgs,
@@ -11,12 +10,13 @@ import type {
   ListTracesArgs,
   ListTracesResponse,
   BatchCreateSpansArgs,
-  BatchUpdateSpansArgs,
   BatchDeleteTracesArgs,
   BatchCreateLogsArgs,
   ListLogsArgs,
   ListLogsResponse,
   BatchCreateMetricsArgs,
+  ListMetricsArgs,
+  ListMetricsResponse,
   CreateScoreArgs,
   BatchCreateScoresArgs,
   ListScoresArgs,
@@ -49,7 +49,7 @@ import type {
   GetEnvironmentsResponse,
   GetTagsArgs,
   GetTagsResponse,
-  TracingStorageStrategy,
+  ObservabilityStorageStrategy,
 } from '@mastra/core/storage';
 import type { DuckDBConnection } from '../../db/index';
 import { ALL_DDL } from './ddl';
@@ -92,9 +92,9 @@ export class ObservabilityStorageDuckDB extends ObservabilityStorage {
     }
   }
 
-  public override get tracingStrategy(): {
-    preferred: TracingStorageStrategy;
-    supported: TracingStorageStrategy[];
+  public override get observabilityStrategy(): {
+    preferred: ObservabilityStorageStrategy;
+    supported: ObservabilityStorageStrategy[];
   } {
     return {
       preferred: 'event-sourced' as const,
@@ -106,14 +106,8 @@ export class ObservabilityStorageDuckDB extends ObservabilityStorage {
   async createSpan(args: CreateSpanArgs): Promise<void> {
     return tracingOps.createSpan(this.db, args);
   }
-  async updateSpan(args: UpdateSpanArgs): Promise<void> {
-    return tracingOps.updateSpan(this.db, args);
-  }
   async batchCreateSpans(args: BatchCreateSpansArgs): Promise<void> {
     return tracingOps.batchCreateSpans(this.db, args);
-  }
-  async batchUpdateSpans(args: BatchUpdateSpansArgs): Promise<void> {
-    return tracingOps.batchUpdateSpans(this.db, args);
   }
   async batchDeleteTraces(args: BatchDeleteTracesArgs): Promise<void> {
     return tracingOps.batchDeleteTraces(this.db, args);
@@ -142,6 +136,9 @@ export class ObservabilityStorageDuckDB extends ObservabilityStorage {
   // Metrics
   async batchCreateMetrics(args: BatchCreateMetricsArgs): Promise<void> {
     return metricOps.batchCreateMetrics(this.db, args);
+  }
+  async listMetrics(args: ListMetricsArgs): Promise<ListMetricsResponse> {
+    return metricOps.listMetrics(this.db, args);
   }
   async getMetricAggregate(args: GetMetricAggregateArgs): Promise<GetMetricAggregateResponse> {
     return metricOps.getMetricAggregate(this.db, args);

--- a/stores/duckdb/src/storage/domains/observability/index.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.ts
@@ -1,0 +1,207 @@
+import { ObservabilityStorage } from '@mastra/core/storage';
+import type {
+  CreateSpanArgs,
+  UpdateSpanArgs,
+  GetSpanArgs,
+  GetSpanResponse,
+  GetRootSpanArgs,
+  GetRootSpanResponse,
+  GetTraceArgs,
+  GetTraceResponse,
+  ListTracesArgs,
+  ListTracesResponse,
+  BatchCreateSpansArgs,
+  BatchUpdateSpansArgs,
+  BatchDeleteTracesArgs,
+  BatchCreateLogsArgs,
+  ListLogsArgs,
+  ListLogsResponse,
+  BatchCreateMetricsArgs,
+  CreateScoreArgs,
+  BatchCreateScoresArgs,
+  ListScoresArgs,
+  ListScoresResponse,
+  CreateFeedbackArgs,
+  BatchCreateFeedbackArgs,
+  ListFeedbackArgs,
+  ListFeedbackResponse,
+  GetMetricAggregateArgs,
+  GetMetricAggregateResponse,
+  GetMetricBreakdownArgs,
+  GetMetricBreakdownResponse,
+  GetMetricTimeSeriesArgs,
+  GetMetricTimeSeriesResponse,
+  GetMetricPercentilesArgs,
+  GetMetricPercentilesResponse,
+  GetMetricNamesArgs,
+  GetMetricNamesResponse,
+  GetMetricLabelKeysArgs,
+  GetMetricLabelKeysResponse,
+  GetMetricLabelValuesArgs,
+  GetMetricLabelValuesResponse,
+  GetEntityTypesArgs,
+  GetEntityTypesResponse,
+  GetEntityNamesArgs,
+  GetEntityNamesResponse,
+  GetServiceNamesArgs,
+  GetServiceNamesResponse,
+  GetEnvironmentsArgs,
+  GetEnvironmentsResponse,
+  GetTagsArgs,
+  GetTagsResponse,
+  TracingStorageStrategy,
+} from '@mastra/core/storage';
+import type { DuckDBConnection } from '../../db/index';
+import { ALL_DDL } from './ddl';
+import * as discoveryOps from './discovery';
+import * as feedbackOps from './feedback';
+import * as logOps from './logs';
+import * as metricOps from './metrics';
+import * as scoreOps from './scores';
+import * as tracingOps from './tracing';
+
+/** Configuration for the DuckDB observability storage domain. */
+export interface ObservabilityDuckDBConfig {
+  /** Shared DuckDB instance to use for all observability queries. */
+  db: DuckDBConnection;
+}
+
+/**
+ * DuckDB-backed observability storage for traces, metrics, logs, scores, and feedback.
+ * Uses an append-only event-sourced model with SQL-based reconstruction for spans.
+ */
+export class ObservabilityStorageDuckDB extends ObservabilityStorage {
+  private db: DuckDBConnection;
+
+  constructor(config: ObservabilityDuckDBConfig) {
+    super();
+    this.db = config.db;
+  }
+
+  /** Create all observability tables if they don't exist. */
+  async init(): Promise<void> {
+    for (const ddl of ALL_DDL) {
+      await this.db.execute(ddl);
+    }
+  }
+
+  /** Delete all rows from every observability table. Use with caution. */
+  async dangerouslyClearAll(): Promise<void> {
+    for (const table of ['span_events', 'metric_events', 'log_events', 'score_events', 'feedback_events']) {
+      await this.db.execute(`TRUNCATE TABLE ${table}`);
+    }
+  }
+
+  public override get tracingStrategy(): {
+    preferred: TracingStorageStrategy;
+    supported: TracingStorageStrategy[];
+  } {
+    return {
+      preferred: 'event-sourced' as const,
+      supported: ['event-sourced' as const],
+    };
+  }
+
+  // Tracing
+  async createSpan(args: CreateSpanArgs): Promise<void> {
+    return tracingOps.createSpan(this.db, args);
+  }
+  async updateSpan(args: UpdateSpanArgs): Promise<void> {
+    return tracingOps.updateSpan(this.db, args);
+  }
+  async batchCreateSpans(args: BatchCreateSpansArgs): Promise<void> {
+    return tracingOps.batchCreateSpans(this.db, args);
+  }
+  async batchUpdateSpans(args: BatchUpdateSpansArgs): Promise<void> {
+    return tracingOps.batchUpdateSpans(this.db, args);
+  }
+  async batchDeleteTraces(args: BatchDeleteTracesArgs): Promise<void> {
+    return tracingOps.batchDeleteTraces(this.db, args);
+  }
+  async getSpan(args: GetSpanArgs): Promise<GetSpanResponse | null> {
+    return tracingOps.getSpan(this.db, args);
+  }
+  async getRootSpan(args: GetRootSpanArgs): Promise<GetRootSpanResponse | null> {
+    return tracingOps.getRootSpan(this.db, args);
+  }
+  async getTrace(args: GetTraceArgs): Promise<GetTraceResponse | null> {
+    return tracingOps.getTrace(this.db, args);
+  }
+  async listTraces(args: ListTracesArgs): Promise<ListTracesResponse> {
+    return tracingOps.listTraces(this.db, args);
+  }
+
+  // Logs
+  async batchCreateLogs(args: BatchCreateLogsArgs): Promise<void> {
+    return logOps.batchCreateLogs(this.db, args);
+  }
+  async listLogs(args: ListLogsArgs): Promise<ListLogsResponse> {
+    return logOps.listLogs(this.db, args);
+  }
+
+  // Metrics
+  async batchCreateMetrics(args: BatchCreateMetricsArgs): Promise<void> {
+    return metricOps.batchCreateMetrics(this.db, args);
+  }
+  async getMetricAggregate(args: GetMetricAggregateArgs): Promise<GetMetricAggregateResponse> {
+    return metricOps.getMetricAggregate(this.db, args);
+  }
+  async getMetricBreakdown(args: GetMetricBreakdownArgs): Promise<GetMetricBreakdownResponse> {
+    return metricOps.getMetricBreakdown(this.db, args);
+  }
+  async getMetricTimeSeries(args: GetMetricTimeSeriesArgs): Promise<GetMetricTimeSeriesResponse> {
+    return metricOps.getMetricTimeSeries(this.db, args);
+  }
+  async getMetricPercentiles(args: GetMetricPercentilesArgs): Promise<GetMetricPercentilesResponse> {
+    return metricOps.getMetricPercentiles(this.db, args);
+  }
+  // Metric Discovery
+  async getMetricNames(args: GetMetricNamesArgs): Promise<GetMetricNamesResponse> {
+    return metricOps.getMetricNames(this.db, args);
+  }
+  async getMetricLabelKeys(args: GetMetricLabelKeysArgs): Promise<GetMetricLabelKeysResponse> {
+    return metricOps.getMetricLabelKeys(this.db, args);
+  }
+  async getMetricLabelValues(args: GetMetricLabelValuesArgs): Promise<GetMetricLabelValuesResponse> {
+    return metricOps.getMetricLabelValues(this.db, args);
+  }
+
+  // Span Discovery
+  async getEntityTypes(args: GetEntityTypesArgs): Promise<GetEntityTypesResponse> {
+    return discoveryOps.getEntityTypes(this.db, args);
+  }
+  async getEntityNames(args: GetEntityNamesArgs): Promise<GetEntityNamesResponse> {
+    return discoveryOps.getEntityNames(this.db, args);
+  }
+  async getServiceNames(args: GetServiceNamesArgs): Promise<GetServiceNamesResponse> {
+    return discoveryOps.getServiceNames(this.db, args);
+  }
+  async getEnvironments(args: GetEnvironmentsArgs): Promise<GetEnvironmentsResponse> {
+    return discoveryOps.getEnvironments(this.db, args);
+  }
+  async getTags(args: GetTagsArgs): Promise<GetTagsResponse> {
+    return discoveryOps.getTags(this.db, args);
+  }
+
+  // Scores
+  async createScore(args: CreateScoreArgs): Promise<void> {
+    return scoreOps.createScore(this.db, args);
+  }
+  async batchCreateScores(args: BatchCreateScoresArgs): Promise<void> {
+    return scoreOps.batchCreateScores(this.db, args);
+  }
+  async listScores(args: ListScoresArgs): Promise<ListScoresResponse> {
+    return scoreOps.listScores(this.db, args);
+  }
+
+  // Feedback
+  async createFeedback(args: CreateFeedbackArgs): Promise<void> {
+    return feedbackOps.createFeedback(this.db, args);
+  }
+  async batchCreateFeedback(args: BatchCreateFeedbackArgs): Promise<void> {
+    return feedbackOps.batchCreateFeedback(this.db, args);
+  }
+  async listFeedback(args: ListFeedbackArgs): Promise<ListFeedbackResponse> {
+    return feedbackOps.listFeedback(this.db, args);
+  }
+}

--- a/stores/duckdb/src/storage/domains/observability/logs.ts
+++ b/stores/duckdb/src/storage/domains/observability/logs.ts
@@ -1,0 +1,145 @@
+import type { BatchCreateLogsArgs, ListLogsArgs, ListLogsResponse } from '@mastra/core/storage';
+import type { DuckDBConnection } from '../../db/index';
+import { buildWhereClause, buildOrderByClause, buildPaginationClause } from './filters';
+import { v, jsonV, toDate, parseJson, parseJsonArray } from './helpers';
+
+const COLUMNS = [
+  'timestamp',
+  'level',
+  'message',
+  'data',
+  'traceId',
+  'spanId',
+  'entityType',
+  'entityId',
+  'entityName',
+  'parentEntityType',
+  'parentEntityId',
+  'parentEntityName',
+  'rootEntityType',
+  'rootEntityId',
+  'rootEntityName',
+  'userId',
+  'organizationId',
+  'resourceId',
+  'runId',
+  'sessionId',
+  'threadId',
+  'requestId',
+  'environment',
+  'source',
+  'serviceName',
+  'experimentId',
+  'tags',
+  'metadata',
+  'scope',
+] as const;
+
+const COLUMNS_SQL = COLUMNS.join(', ');
+
+function rowToLogRecord(row: Record<string, unknown>): Record<string, unknown> {
+  return {
+    timestamp: toDate(row.timestamp),
+    level: row.level as string,
+    message: row.message as string,
+    data: parseJson(row.data),
+    traceId: (row.traceId as string) ?? null,
+    spanId: (row.spanId as string) ?? null,
+    entityType: (row.entityType as string) ?? null,
+    entityId: (row.entityId as string) ?? null,
+    entityName: (row.entityName as string) ?? null,
+    parentEntityType: (row.parentEntityType as string) ?? null,
+    parentEntityId: (row.parentEntityId as string) ?? null,
+    parentEntityName: (row.parentEntityName as string) ?? null,
+    rootEntityType: (row.rootEntityType as string) ?? null,
+    rootEntityId: (row.rootEntityId as string) ?? null,
+    rootEntityName: (row.rootEntityName as string) ?? null,
+    userId: (row.userId as string) ?? null,
+    organizationId: (row.organizationId as string) ?? null,
+    resourceId: (row.resourceId as string) ?? null,
+    runId: (row.runId as string) ?? null,
+    sessionId: (row.sessionId as string) ?? null,
+    threadId: (row.threadId as string) ?? null,
+    requestId: (row.requestId as string) ?? null,
+    environment: (row.environment as string) ?? null,
+    source: (row.source as string) ?? null,
+    serviceName: (row.serviceName as string) ?? null,
+    experimentId: (row.experimentId as string) ?? null,
+    tags: parseJsonArray(row.tags),
+    metadata: parseJson(row.metadata),
+    scope: parseJson(row.scope),
+    createdAt: toDate(row.timestamp),
+    updatedAt: null,
+  };
+}
+
+/** Insert multiple log events in a single statement. */
+export async function batchCreateLogs(db: DuckDBConnection, args: BatchCreateLogsArgs): Promise<void> {
+  if (args.logs.length === 0) return;
+
+  const tuples = args.logs.map(log => {
+    return `(${[
+      v(log.timestamp),
+      v(log.level),
+      v(log.message),
+      jsonV(log.data),
+      v(log.traceId ?? null),
+      v(log.spanId ?? null),
+      v(log.entityType ?? null),
+      v(log.entityId ?? null),
+      v(log.entityName ?? null),
+      v(log.parentEntityType ?? null),
+      v(log.parentEntityId ?? null),
+      v(log.parentEntityName ?? null),
+      v(log.rootEntityType ?? null),
+      v(log.rootEntityId ?? null),
+      v(log.rootEntityName ?? null),
+      v(log.userId ?? null),
+      v(log.organizationId ?? null),
+      v(log.resourceId ?? null),
+      v(log.runId ?? null),
+      v(log.sessionId ?? null),
+      v(log.threadId ?? null),
+      v(log.requestId ?? null),
+      v(log.environment ?? null),
+      v(log.source ?? null),
+      v(log.serviceName ?? null),
+      v(log.experimentId ?? null),
+      jsonV(log.tags),
+      jsonV(log.metadata),
+      jsonV(log.scope),
+    ].join(', ')})`;
+  });
+
+  await db.execute(`INSERT INTO log_events (${COLUMNS_SQL}) VALUES ${tuples.join(',\n')}`);
+}
+
+/** Query log events with filtering, ordering, and pagination. */
+export async function listLogs(db: DuckDBConnection, args: ListLogsArgs): Promise<ListLogsResponse> {
+  const filters = args.filters ?? {};
+  const page = Number(args.pagination?.page ?? 0);
+  const perPage = Number(args.pagination?.perPage ?? 10);
+  const orderBy = { field: args.orderBy?.field ?? 'timestamp', direction: args.orderBy?.direction ?? 'DESC' } as const;
+
+  const { clause: filterClause, params: filterParams } = buildWhereClause(filters as Record<string, unknown>);
+  const orderByClause = buildOrderByClause(orderBy);
+  const { clause: paginationClause, params: paginationParams } = buildPaginationClause({ page, perPage });
+
+  const countResult = await db.query<{ total: number }>(
+    `SELECT COUNT(*) as total FROM log_events ${filterClause}`,
+    filterParams,
+  );
+  const total = Number(countResult[0]?.total ?? 0);
+
+  const rows = await db.query(`SELECT * FROM log_events ${filterClause} ${orderByClause} ${paginationClause}`, [
+    ...filterParams,
+    ...paginationParams,
+  ]);
+
+  const logs = rows.map(row => rowToLogRecord(row as Record<string, unknown>)) as ListLogsResponse['logs'];
+
+  return {
+    pagination: { total, page, perPage, hasMore: (page + 1) * perPage < total },
+    logs,
+  };
+}

--- a/stores/duckdb/src/storage/domains/observability/logs.ts
+++ b/stores/duckdb/src/storage/domains/observability/logs.ts
@@ -68,8 +68,6 @@ function rowToLogRecord(row: Record<string, unknown>): Record<string, unknown> {
     tags: parseJsonArray(row.tags),
     metadata: parseJson(row.metadata),
     scope: parseJson(row.scope),
-    createdAt: toDate(row.timestamp),
-    updatedAt: null,
   };
 }
 

--- a/stores/duckdb/src/storage/domains/observability/metrics.ts
+++ b/stores/duckdb/src/storage/domains/observability/metrics.ts
@@ -1,5 +1,7 @@
 import type {
   BatchCreateMetricsArgs,
+  ListMetricsArgs,
+  ListMetricsResponse,
   GetMetricAggregateArgs,
   GetMetricAggregateResponse,
   GetMetricBreakdownArgs,
@@ -17,30 +19,31 @@ import type {
   AggregationType,
   AggregationInterval,
 } from '@mastra/core/storage';
+import { parseFieldKey } from '@mastra/core/utils';
 import type { DuckDBConnection } from '../../db/index';
-import { buildJsonPath, buildWhereClause } from './filters';
-import { v, jsonV } from './helpers';
+import { buildJsonPath, buildOrderByClause, buildPaginationClause, buildWhereClause } from './filters';
+import { parseJson, parseJsonArray, toDate, v, jsonV } from './helpers';
 
 // ============================================================================
 // Helpers
 // ============================================================================
 
-function getAggregationSql(aggregation: AggregationType): string {
+function getAggregationSql(aggregation: AggregationType, measure = 'value'): string {
   switch (aggregation) {
     case 'sum':
-      return 'SUM(value)';
+      return `SUM(${measure})`;
     case 'avg':
-      return 'AVG(value)';
+      return `AVG(${measure})`;
     case 'min':
-      return 'MIN(value)';
+      return `MIN(${measure})`;
     case 'max':
-      return 'MAX(value)';
+      return `MAX(${measure})`;
     case 'count':
-      return 'CAST(COUNT(value) AS DOUBLE)';
+      return `CAST(COUNT(${measure}) AS DOUBLE)`;
     case 'last':
-      return 'arg_max(value, timestamp)';
+      return `arg_max(${measure}, timestamp)`;
     default:
-      return 'SUM(value)';
+      return `SUM(${measure})`;
   }
 }
 
@@ -69,15 +72,10 @@ function buildMetricNameFilter(name: string | string[]): { clause: string; param
   return { clause: `name = ?`, params: [name] };
 }
 
-// ============================================================================
-// Write
-// ============================================================================
-
 const METRIC_COLUMNS = [
   'timestamp',
   'name',
   'value',
-  'labels',
   'traceId',
   'spanId',
   'entityType',
@@ -100,23 +98,50 @@ const METRIC_COLUMNS = [
   'source',
   'serviceName',
   'experimentId',
+  'provider',
+  'model',
+  'estimatedCost',
+  'costUnit',
+  'tags',
+  'labels',
+  'costMetadata',
   'metadata',
   'scope',
 ] as const;
 
 type MetricColumn = (typeof METRIC_COLUMNS)[number];
 
-const METRIC_GROUP_BY_EXCLUDED: MetricColumn[] = ['value', 'labels', 'metadata', 'scope'];
-
 const METRIC_COLUMNS_SQL = METRIC_COLUMNS.join(', ');
-const METRIC_GROUP_BY_COLUMNS = new Set(METRIC_COLUMNS.filter(col => !METRIC_GROUP_BY_EXCLUDED.includes(col)));
+const METRIC_COLUMN_SET = new Set<string>(METRIC_COLUMNS);
+const METRIC_LABEL_ONLY_GROUP_BY_EXCLUDED = new Set<MetricColumn>(['metadata', 'scope', 'costMetadata', 'tags']);
 
-function normalizeGroupByColumns(groupBy: string[]): MetricColumn[] {
-  const invalid = groupBy.filter(col => !METRIC_GROUP_BY_COLUMNS.has(col as MetricColumn));
-  if (invalid.length > 0) {
-    throw new Error(`Invalid groupBy column(s): ${invalid.join(', ')}`);
-  }
-  return groupBy as MetricColumn[];
+type ResolvedGroupBy =
+  | { kind: 'column'; key: string; selectSql: string; groupSql: string; resultKey: string }
+  | { kind: 'label'; key: string; selectSql: string; groupSql: string; resultKey: string };
+
+type CostSummary = {
+  estimatedCost: number | null;
+  costUnit: string | null;
+};
+
+function getCostSummarySelect(prefix = ''): string {
+  const ref = (column: string) => `${prefix}${column}`;
+  return [
+    `SUM(${ref('estimatedCost')}) FILTER (WHERE ${ref('estimatedCost')} IS NOT NULL) AS estimatedCost`,
+    `,`,
+    `CASE`,
+    `  WHEN COUNT(DISTINCT ${ref('costUnit')}) FILTER (WHERE ${ref('costUnit')} IS NOT NULL) = 1`,
+    `  THEN MIN(${ref('costUnit')}) FILTER (WHERE ${ref('costUnit')} IS NOT NULL)`,
+    `  ELSE NULL`,
+    `END AS costUnit`,
+  ].join(' ');
+}
+
+function normalizeCostSummaryRow(row: Record<string, unknown>): CostSummary {
+  return {
+    estimatedCost: row.estimatedCost === null || row.estimatedCost === undefined ? null : Number(row.estimatedCost),
+    costUnit: row.costUnit === null || row.costUnit === undefined ? null : String(row.costUnit),
+  };
 }
 
 function buildCombinedWhereClause(
@@ -136,6 +161,79 @@ function buildCombinedWhereClause(
   return { clause: `WHERE ${conditions.join(' AND ')}`, params };
 }
 
+function resolveGroupBy(groupBy: string[]): ResolvedGroupBy[] {
+  return groupBy.map(key => {
+    const parsed = parseFieldKey(key);
+
+    if (METRIC_COLUMN_SET.has(parsed)) {
+      if (METRIC_LABEL_ONLY_GROUP_BY_EXCLUDED.has(parsed as MetricColumn)) {
+        throw new Error(`Invalid groupBy column(s): ${key}`);
+      }
+
+      return {
+        kind: 'column',
+        key,
+        selectSql: `${parsed} AS "${key}"`,
+        groupSql: parsed,
+        resultKey: key,
+      };
+    }
+
+    const labelPath = buildJsonPath(key).replace(/'/g, "''");
+    const labelExpr = `json_extract_string(labels, '${labelPath}')`;
+    return {
+      kind: 'label',
+      key,
+      selectSql: `${labelExpr} AS "${key}"`,
+      groupSql: labelExpr,
+      resultKey: key,
+    };
+  });
+}
+
+function rowToMetricRecord(row: Record<string, unknown>): Record<string, unknown> {
+  return {
+    timestamp: toDate(row.timestamp),
+    name: row.name as string,
+    value: Number(row.value),
+    traceId: (row.traceId as string) ?? null,
+    spanId: (row.spanId as string) ?? null,
+    entityType: (row.entityType as string) ?? null,
+    entityId: (row.entityId as string) ?? null,
+    entityName: (row.entityName as string) ?? null,
+    parentEntityType: (row.parentEntityType as string) ?? null,
+    parentEntityId: (row.parentEntityId as string) ?? null,
+    parentEntityName: (row.parentEntityName as string) ?? null,
+    rootEntityType: (row.rootEntityType as string) ?? null,
+    rootEntityId: (row.rootEntityId as string) ?? null,
+    rootEntityName: (row.rootEntityName as string) ?? null,
+    userId: (row.userId as string) ?? null,
+    organizationId: (row.organizationId as string) ?? null,
+    resourceId: (row.resourceId as string) ?? null,
+    runId: (row.runId as string) ?? null,
+    sessionId: (row.sessionId as string) ?? null,
+    threadId: (row.threadId as string) ?? null,
+    requestId: (row.requestId as string) ?? null,
+    environment: (row.environment as string) ?? null,
+    source: (row.source as string) ?? null,
+    serviceName: (row.serviceName as string) ?? null,
+    experimentId: (row.experimentId as string) ?? null,
+    provider: (row.provider as string) ?? null,
+    model: (row.model as string) ?? null,
+    estimatedCost: row.estimatedCost === null || row.estimatedCost === undefined ? null : Number(row.estimatedCost),
+    costUnit: (row.costUnit as string) ?? null,
+    costMetadata: parseJson(row.costMetadata) as Record<string, unknown> | null,
+    tags: parseJsonArray(row.tags) as string[] | null,
+    labels: (parseJson(row.labels) as Record<string, string> | null) ?? {},
+    metadata: parseJson(row.metadata) as Record<string, unknown> | null,
+    scope: parseJson(row.scope) as Record<string, unknown> | null,
+  };
+}
+
+// ============================================================================
+// Write
+// ============================================================================
+
 /** Insert multiple metric events in a single statement. */
 export async function batchCreateMetrics(db: DuckDBConnection, args: BatchCreateMetricsArgs): Promise<void> {
   if (args.metrics.length === 0) return;
@@ -145,7 +243,6 @@ export async function batchCreateMetrics(db: DuckDBConnection, args: BatchCreate
       v(m.timestamp),
       v(m.name),
       v(m.value),
-      v(JSON.stringify(m.labels ?? {})),
       v(m.traceId ?? null),
       v(m.spanId ?? null),
       v(m.entityType ?? null),
@@ -168,12 +265,47 @@ export async function batchCreateMetrics(db: DuckDBConnection, args: BatchCreate
       v(m.source ?? null),
       v(m.serviceName ?? null),
       v(m.experimentId ?? null),
-      jsonV(m.metadata),
-      jsonV(m.scope),
+      v(m.provider ?? null),
+      v(m.model ?? null),
+      v(m.estimatedCost ?? null),
+      v(m.costUnit ?? null),
+      jsonV(m.tags ?? null),
+      v(JSON.stringify(m.labels ?? {})),
+      jsonV(m.costMetadata ?? null),
+      jsonV(m.metadata ?? null),
+      jsonV(m.scope ?? null),
     ].join(', ')})`;
   });
 
   await db.execute(`INSERT INTO metric_events (${METRIC_COLUMNS_SQL}) VALUES ${tuples.join(',\n')}`);
+}
+
+/** Query metric events with filtering, ordering, and pagination. */
+export async function listMetrics(db: DuckDBConnection, args: ListMetricsArgs): Promise<ListMetricsResponse> {
+  const filters = args.filters ?? {};
+  const page = Number(args.pagination?.page ?? 0);
+  const perPage = Number(args.pagination?.perPage ?? 10);
+  const orderBy = { field: args.orderBy?.field ?? 'timestamp', direction: args.orderBy?.direction ?? 'DESC' } as const;
+
+  const { clause: filterClause, params: filterParams } = buildWhereClause(filters as Record<string, unknown>);
+  const orderByClause = buildOrderByClause(orderBy);
+  const { clause: paginationClause, params: paginationParams } = buildPaginationClause({ page, perPage });
+
+  const countResult = await db.query<{ total: number }>(
+    `SELECT COUNT(*) AS total FROM metric_events ${filterClause}`,
+    filterParams,
+  );
+  const total = Number(countResult[0]?.total ?? 0);
+
+  const rows = await db.query<Record<string, unknown>>(
+    `SELECT * FROM metric_events ${filterClause} ${orderByClause} ${paginationClause}`,
+    [...filterParams, ...paginationParams],
+  );
+
+  return {
+    pagination: { total, page, perPage, hasMore: (page + 1) * perPage < total },
+    metrics: rows.map(row => rowToMetricRecord(row)) as ListMetricsResponse['metrics'],
+  };
 }
 
 // ============================================================================
@@ -196,9 +328,12 @@ export async function getMetricAggregate(
     filterClause,
     filterParams,
   );
-  const sql = `SELECT ${aggSql} as value FROM metric_events ${whereClause}`;
-  const result = await db.query<{ value: number | null }>(sql, allParams);
-  const value = result[0]?.value ?? null;
+
+  const sql = `SELECT ${aggSql} AS value, ${getCostSummarySelect()} FROM metric_events ${whereClause}`;
+  const result = await db.query<Record<string, unknown>>(sql, allParams);
+  const row = result[0] ?? {};
+  const value = row.value === null || row.value === undefined ? null : Number(row.value);
+  const costSummary = normalizeCostSummaryRow(row);
 
   if (args.comparePeriod && args.filters?.timestamp) {
     const ts = args.filters.timestamp;
@@ -224,6 +359,7 @@ export async function getMetricAggregate(
           prevStart = new Date(ts.start.getTime() - duration);
           prevEnd = new Date(ts.end.getTime() - duration);
       }
+
       const prevFilters = {
         ...(args.filters ?? {}),
         timestamp: {
@@ -242,20 +378,43 @@ export async function getMetricAggregate(
         prevFilterClause,
         prevFilterParams,
       );
-      const prevSql = `SELECT ${aggSql} as value FROM metric_events ${prevWhereClause}`;
-      const prevResult = await db.query<{ value: number | null }>(prevSql, prevParams);
-      const previousValue = prevResult[0]?.value ?? null;
+
+      const prevSql = `SELECT ${aggSql} AS value, ${getCostSummarySelect()} FROM metric_events ${prevWhereClause}`;
+      const prevResult = await db.query<Record<string, unknown>>(prevSql, prevParams);
+      const prevRow = prevResult[0] ?? {};
+      const previousValue = prevRow.value === null || prevRow.value === undefined ? null : Number(prevRow.value);
+      const previousCostSummary = normalizeCostSummaryRow(prevRow);
 
       let changePercent: number | null = null;
       if (previousValue !== null && previousValue !== 0 && value !== null) {
         changePercent = ((value - previousValue) / Math.abs(previousValue)) * 100;
       }
 
-      return { value, previousValue, changePercent };
+      let costChangePercent: number | null = null;
+      if (
+        previousCostSummary.estimatedCost !== null &&
+        previousCostSummary.estimatedCost !== 0 &&
+        costSummary.estimatedCost !== null
+      ) {
+        costChangePercent =
+          ((costSummary.estimatedCost - previousCostSummary.estimatedCost) /
+            Math.abs(previousCostSummary.estimatedCost)) *
+          100;
+      }
+
+      return {
+        value,
+        estimatedCost: costSummary.estimatedCost,
+        costUnit: costSummary.costUnit,
+        previousValue,
+        previousEstimatedCost: previousCostSummary.estimatedCost,
+        changePercent,
+        costChangePercent,
+      };
     }
   }
 
-  return { value };
+  return { value, estimatedCost: costSummary.estimatedCost, costUnit: costSummary.costUnit };
 }
 
 /** Aggregate a metric grouped by one or more dimensions. */
@@ -268,28 +427,33 @@ export async function getMetricBreakdown(
   const { clause: filterClause, params: filterParams } = buildWhereClause(
     args.filters as Record<string, unknown> | undefined,
   );
+  const { clause: whereClause, params: allParams } = buildCombinedWhereClause(
+    nameClause,
+    nameParams,
+    filterClause,
+    filterParams,
+  );
 
-  const allConditions = [nameClause];
-  const allParams = [...nameParams];
-  if (filterClause) {
-    allConditions.push(filterClause.replace('WHERE ', ''));
-    allParams.push(...filterParams);
-  }
-
-  const whereClause = `WHERE ${allConditions.join(' AND ')}`;
-  const groupBy = normalizeGroupByColumns(args.groupBy);
-  const groupByCols = groupBy.join(', ');
-
-  const sql = `SELECT ${groupByCols}, ${aggSql} as value FROM metric_events ${whereClause} GROUP BY ${groupByCols} ORDER BY value DESC`;
-  const rows = await db.query(sql, allParams);
+  const resolvedGroupBy = resolveGroupBy(args.groupBy);
+  const selectGroupBy = resolvedGroupBy.map(entry => entry.selectSql).join(', ');
+  const groupByCols = resolvedGroupBy.map(entry => entry.groupSql).join(', ');
+  const sql = `SELECT ${selectGroupBy}, ${aggSql} AS value, ${getCostSummarySelect()} FROM metric_events ${whereClause} GROUP BY ${groupByCols} ORDER BY value DESC`;
+  const rows = await db.query<Record<string, unknown>>(sql, allParams);
 
   const groups = rows.map(row => {
-    const r = row as Record<string, unknown>;
-    const dimensions: Record<string, string> = {};
-    for (const col of groupBy) {
-      dimensions[col] = String(r[col] ?? '');
+    const dimensions: Record<string, string | null> = {};
+    for (const entry of resolvedGroupBy) {
+      const value = row[entry.resultKey];
+      dimensions[entry.key] = value === null || value === undefined ? null : String(value);
     }
-    return { dimensions, value: Number(r.value ?? 0) };
+
+    const costSummary = normalizeCostSummaryRow(row);
+    return {
+      dimensions,
+      value: Number(row.value ?? 0),
+      estimatedCost: costSummary.estimatedCost,
+      costUnit: costSummary.costUnit,
+    };
   });
 
   return { groups };
@@ -306,63 +470,99 @@ export async function getMetricTimeSeries(
   const { clause: filterClause, params: filterParams } = buildWhereClause(
     args.filters as Record<string, unknown> | undefined,
   );
-
-  const allConditions = [nameClause];
-  const allParams = [...nameParams];
-  if (filterClause) {
-    allConditions.push(filterClause.replace('WHERE ', ''));
-    allParams.push(...filterParams);
-  }
-
-  const whereClause = `WHERE ${allConditions.join(' AND ')}`;
+  const { clause: whereClause, params: allParams } = buildCombinedWhereClause(
+    nameClause,
+    nameParams,
+    filterClause,
+    filterParams,
+  );
 
   if (args.groupBy && args.groupBy.length > 0) {
-    const groupBy = normalizeGroupByColumns(args.groupBy);
-    const groupByCols = groupBy.join(', ');
+    const resolvedGroupBy = resolveGroupBy(args.groupBy);
+    const selectGroupBy = resolvedGroupBy.map(entry => entry.selectSql).join(', ');
+    const groupByCols = resolvedGroupBy.map(entry => entry.groupSql).join(', ');
     const sql = `
-      SELECT time_bucket(INTERVAL '${intervalSql}', timestamp) as bucket,
-             ${groupByCols}, ${aggSql} as value
+      SELECT time_bucket(INTERVAL '${intervalSql}', timestamp) AS bucket,
+             ${selectGroupBy},
+             ${aggSql} AS value,
+             ${getCostSummarySelect()}
       FROM metric_events ${whereClause}
       GROUP BY bucket, ${groupByCols}
       ORDER BY bucket
     `;
-    const rows = await db.query(sql, allParams);
+    const rows = await db.query<Record<string, unknown>>(sql, allParams);
 
-    const seriesMap = new Map<string, { timestamp: Date; value: number }[]>();
+    const seriesMap = new Map<
+      string,
+      {
+        name: string;
+        costUnits: Set<string>;
+        points: { timestamp: Date; value: number; estimatedCost: number | null }[];
+      }
+    >();
+
     for (const row of rows) {
-      const r = row as Record<string, unknown>;
-      const key = groupBy.map(col => String(r[col] ?? '')).join('|');
-      if (!seriesMap.has(key)) seriesMap.set(key, []);
-      seriesMap.get(key)!.push({
-        timestamp: new Date(r.bucket as string),
-        value: Number(r.value ?? 0),
+      const name = resolvedGroupBy
+        .map(entry => {
+          const value = row[entry.resultKey];
+          return value === null || value === undefined ? '' : String(value);
+        })
+        .join('|');
+      const costSummary = normalizeCostSummaryRow(row);
+
+      if (!seriesMap.has(name)) {
+        seriesMap.set(name, {
+          name,
+          costUnits: new Set(),
+          points: [],
+        });
+      }
+
+      if (costSummary.costUnit) {
+        seriesMap.get(name)!.costUnits.add(costSummary.costUnit);
+      }
+
+      seriesMap.get(name)!.points.push({
+        timestamp: row.bucket instanceof Date ? row.bucket : new Date(String(row.bucket)),
+        value: Number(row.value ?? 0),
+        estimatedCost: costSummary.estimatedCost,
       });
     }
 
     return {
-      series: Array.from(seriesMap.entries()).map(([name, points]) => ({ name, points })),
+      series: Array.from(seriesMap.values()).map(series => ({
+        name: series.name,
+        costUnit: series.costUnits.size === 1 ? Array.from(series.costUnits)[0]! : null,
+        points: series.points,
+      })),
     };
   }
 
   const sql = `
-    SELECT time_bucket(INTERVAL '${intervalSql}', timestamp) as bucket,
-           ${aggSql} as value
+    SELECT time_bucket(INTERVAL '${intervalSql}', timestamp) AS bucket,
+           ${aggSql} AS value,
+           ${getCostSummarySelect()}
     FROM metric_events ${whereClause}
     GROUP BY bucket
     ORDER BY bucket
   `;
-  const rows = await db.query(sql, allParams);
-
+  const rows = await db.query<Record<string, unknown>>(sql, allParams);
   const metricName = Array.isArray(args.name) ? args.name.join(',') : args.name;
+  const overallCostUnits = new Set(
+    rows.map(row => row.costUnit).filter((value): value is string => typeof value === 'string'),
+  );
+
   return {
     series: [
       {
         name: metricName,
+        costUnit: overallCostUnits.size === 1 ? Array.from(overallCostUnits)[0]! : null,
         points: rows.map(row => {
-          const r = row as Record<string, unknown>;
+          const costSummary = normalizeCostSummaryRow(row);
           return {
-            timestamp: r.bucket instanceof Date ? r.bucket : new Date(String(r.bucket)),
-            value: Number(r.value ?? 0),
+            timestamp: row.bucket instanceof Date ? row.bucket : new Date(String(row.bucket)),
+            value: Number(row.value ?? 0),
+            estimatedCost: costSummary.estimatedCost,
           };
         }),
       },
@@ -392,23 +592,20 @@ export async function getMetricPercentiles(
   const series = [];
   for (const p of args.percentiles) {
     const sql = `
-      SELECT time_bucket(INTERVAL '${intervalSql}', timestamp) as bucket,
-             percentile_cont(${p}) WITHIN GROUP (ORDER BY value) as pvalue
+      SELECT time_bucket(INTERVAL '${intervalSql}', timestamp) AS bucket,
+             percentile_cont(${p}) WITHIN GROUP (ORDER BY value) AS pvalue
       FROM metric_events ${whereClause}
       GROUP BY bucket
       ORDER BY bucket
     `;
-    const rows = await db.query(sql, allParams);
+    const rows = await db.query<Record<string, unknown>>(sql, allParams);
 
     series.push({
       percentile: p,
-      points: rows.map(row => {
-        const r = row as Record<string, unknown>;
-        return {
-          timestamp: new Date(r.bucket as string),
-          value: Number(r.pvalue ?? 0),
-        };
-      }),
+      points: rows.map(row => ({
+        timestamp: row.bucket instanceof Date ? row.bucket : new Date(String(row.bucket)),
+        value: Number(row.pvalue ?? 0),
+      })),
     });
   }
 
@@ -447,7 +644,7 @@ export async function getMetricLabelKeys(
   args: GetMetricLabelKeysArgs,
 ): Promise<GetMetricLabelKeysResponse> {
   const rows = await db.query<{ key: string }>(
-    `SELECT DISTINCT unnest(json_keys(labels)) as key FROM metric_events WHERE name = ? AND labels IS NOT NULL`,
+    `SELECT DISTINCT unnest(json_keys(labels)) AS key FROM metric_events WHERE name = ? AND labels IS NOT NULL`,
     [args.metricName],
   );
   return { keys: rows.map(r => r.key) };
@@ -460,7 +657,7 @@ export async function getMetricLabelValues(
 ): Promise<GetMetricLabelValuesResponse> {
   const labelPath = buildJsonPath(args.labelKey);
   const conditions = [`name = ?`, `json_extract_string(labels, ?) IS NOT NULL`];
-  const params: unknown[] = [labelPath, args.metricName, labelPath];
+  const params: unknown[] = [args.metricName, labelPath];
 
   if (args.prefix) {
     conditions.push(`json_extract_string(labels, ?) LIKE ?`);
@@ -471,8 +668,8 @@ export async function getMetricLabelValues(
   if (args.limit) params.push(args.limit);
 
   const rows = await db.query<{ val: string }>(
-    `SELECT DISTINCT json_extract_string(labels, ?) as val FROM metric_events WHERE ${conditions.join(' AND ')} ORDER BY val ${limitClause}`,
-    params,
+    `SELECT DISTINCT json_extract_string(labels, ?) AS val FROM metric_events WHERE ${conditions.join(' AND ')} ORDER BY val ${limitClause}`,
+    [labelPath, ...params],
   );
 
   return { values: rows.map(r => r.val) };

--- a/stores/duckdb/src/storage/domains/observability/metrics.ts
+++ b/stores/duckdb/src/storage/domains/observability/metrics.ts
@@ -124,6 +124,14 @@ type CostSummary = {
   costUnit: string | null;
 };
 
+function buildGroupByAlias(index: number): string {
+  return `group_by_${index}`;
+}
+
+function toSeriesDisplayValue(value: unknown): string {
+  return value === null || value === undefined ? '' : String(value);
+}
+
 function getCostSummarySelect(prefix = ''): string {
   const ref = (column: string) => `${prefix}${column}`;
   return [
@@ -162,10 +170,9 @@ function buildCombinedWhereClause(
 }
 
 function resolveGroupBy(groupBy: string[]): ResolvedGroupBy[] {
-  return groupBy.map(key => {
-    const parsed = parseFieldKey(key);
-
-    if (METRIC_COLUMN_SET.has(parsed)) {
+  return groupBy.map((key, index) => {
+    if (METRIC_COLUMN_SET.has(key)) {
+      const parsed = parseFieldKey(key);
       if (METRIC_LABEL_ONLY_GROUP_BY_EXCLUDED.has(parsed as MetricColumn)) {
         throw new Error(`Invalid groupBy column(s): ${key}`);
       }
@@ -181,12 +188,13 @@ function resolveGroupBy(groupBy: string[]): ResolvedGroupBy[] {
 
     const labelPath = buildJsonPath(key).replace(/'/g, "''");
     const labelExpr = `json_extract_string(labels, '${labelPath}')`;
+    const alias = buildGroupByAlias(index);
     return {
       kind: 'label',
       key,
-      selectSql: `${labelExpr} AS "${key}"`,
-      groupSql: labelExpr,
-      resultKey: key,
+      selectSql: `${labelExpr} AS ${alias}`,
+      groupSql: alias,
+      resultKey: alias,
     };
   });
 }
@@ -502,16 +510,13 @@ export async function getMetricTimeSeries(
     >();
 
     for (const row of rows) {
-      const name = resolvedGroupBy
-        .map(entry => {
-          const value = row[entry.resultKey];
-          return value === null || value === undefined ? '' : String(value);
-        })
-        .join('|');
+      const dimensionValues = resolvedGroupBy.map(entry => row[entry.resultKey]);
+      const seriesKey = JSON.stringify(dimensionValues);
+      const name = dimensionValues.map(toSeriesDisplayValue).join('|');
       const costSummary = normalizeCostSummaryRow(row);
 
-      if (!seriesMap.has(name)) {
-        seriesMap.set(name, {
+      if (!seriesMap.has(seriesKey)) {
+        seriesMap.set(seriesKey, {
           name,
           costUnits: new Set(),
           points: [],
@@ -519,10 +524,10 @@ export async function getMetricTimeSeries(
       }
 
       if (costSummary.costUnit) {
-        seriesMap.get(name)!.costUnits.add(costSummary.costUnit);
+        seriesMap.get(seriesKey)!.costUnits.add(costSummary.costUnit);
       }
 
-      seriesMap.get(name)!.points.push({
+      seriesMap.get(seriesKey)!.points.push({
         timestamp: row.bucket instanceof Date ? row.bucket : new Date(String(row.bucket)),
         value: Number(row.value ?? 0),
         estimatedCost: costSummary.estimatedCost,

--- a/stores/duckdb/src/storage/domains/observability/metrics.ts
+++ b/stores/duckdb/src/storage/domains/observability/metrics.ts
@@ -1,0 +1,479 @@
+import type {
+  BatchCreateMetricsArgs,
+  GetMetricAggregateArgs,
+  GetMetricAggregateResponse,
+  GetMetricBreakdownArgs,
+  GetMetricBreakdownResponse,
+  GetMetricTimeSeriesArgs,
+  GetMetricTimeSeriesResponse,
+  GetMetricPercentilesArgs,
+  GetMetricPercentilesResponse,
+  GetMetricNamesArgs,
+  GetMetricNamesResponse,
+  GetMetricLabelKeysArgs,
+  GetMetricLabelKeysResponse,
+  GetMetricLabelValuesArgs,
+  GetMetricLabelValuesResponse,
+  AggregationType,
+  AggregationInterval,
+} from '@mastra/core/storage';
+import type { DuckDBConnection } from '../../db/index';
+import { buildJsonPath, buildWhereClause } from './filters';
+import { v, jsonV } from './helpers';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function getAggregationSql(aggregation: AggregationType): string {
+  switch (aggregation) {
+    case 'sum':
+      return 'SUM(value)';
+    case 'avg':
+      return 'AVG(value)';
+    case 'min':
+      return 'MIN(value)';
+    case 'max':
+      return 'MAX(value)';
+    case 'count':
+      return 'CAST(COUNT(value) AS DOUBLE)';
+    case 'last':
+      return 'arg_max(value, timestamp)';
+    default:
+      return 'SUM(value)';
+  }
+}
+
+function getIntervalSql(interval: AggregationInterval): string {
+  switch (interval) {
+    case '1m':
+      return '1 minute';
+    case '5m':
+      return '5 minutes';
+    case '15m':
+      return '15 minutes';
+    case '1h':
+      return '1 hour';
+    case '1d':
+      return '1 day';
+    default:
+      return '1 hour';
+  }
+}
+
+function buildMetricNameFilter(name: string | string[]): { clause: string; params: unknown[] } {
+  if (Array.isArray(name)) {
+    const placeholders = name.map(() => '?').join(', ');
+    return { clause: `name IN (${placeholders})`, params: name };
+  }
+  return { clause: `name = ?`, params: [name] };
+}
+
+// ============================================================================
+// Write
+// ============================================================================
+
+const METRIC_COLUMNS = [
+  'timestamp',
+  'name',
+  'value',
+  'labels',
+  'traceId',
+  'spanId',
+  'entityType',
+  'entityId',
+  'entityName',
+  'parentEntityType',
+  'parentEntityId',
+  'parentEntityName',
+  'rootEntityType',
+  'rootEntityId',
+  'rootEntityName',
+  'userId',
+  'organizationId',
+  'resourceId',
+  'runId',
+  'sessionId',
+  'threadId',
+  'requestId',
+  'environment',
+  'source',
+  'serviceName',
+  'experimentId',
+  'metadata',
+  'scope',
+] as const;
+
+type MetricColumn = (typeof METRIC_COLUMNS)[number];
+
+const METRIC_GROUP_BY_EXCLUDED: MetricColumn[] = ['value', 'labels', 'metadata', 'scope'];
+
+const METRIC_COLUMNS_SQL = METRIC_COLUMNS.join(', ');
+const METRIC_GROUP_BY_COLUMNS = new Set(METRIC_COLUMNS.filter(col => !METRIC_GROUP_BY_EXCLUDED.includes(col)));
+
+function normalizeGroupByColumns(groupBy: string[]): MetricColumn[] {
+  const invalid = groupBy.filter(col => !METRIC_GROUP_BY_COLUMNS.has(col as MetricColumn));
+  if (invalid.length > 0) {
+    throw new Error(`Invalid groupBy column(s): ${invalid.join(', ')}`);
+  }
+  return groupBy as MetricColumn[];
+}
+
+function buildCombinedWhereClause(
+  nameClause: string,
+  nameParams: unknown[],
+  filterClause: string,
+  filterParams: unknown[],
+): { clause: string; params: unknown[] } {
+  const conditions = [nameClause];
+  const params: unknown[] = [...nameParams];
+
+  if (filterClause) {
+    conditions.push(filterClause.replace('WHERE ', ''));
+    params.push(...filterParams);
+  }
+
+  return { clause: `WHERE ${conditions.join(' AND ')}`, params };
+}
+
+/** Insert multiple metric events in a single statement. */
+export async function batchCreateMetrics(db: DuckDBConnection, args: BatchCreateMetricsArgs): Promise<void> {
+  if (args.metrics.length === 0) return;
+
+  const tuples = args.metrics.map(m => {
+    return `(${[
+      v(m.timestamp),
+      v(m.name),
+      v(m.value),
+      v(JSON.stringify(m.labels ?? {})),
+      v(m.traceId ?? null),
+      v(m.spanId ?? null),
+      v(m.entityType ?? null),
+      v(m.entityId ?? null),
+      v(m.entityName ?? null),
+      v(m.parentEntityType ?? null),
+      v(m.parentEntityId ?? null),
+      v(m.parentEntityName ?? null),
+      v(m.rootEntityType ?? null),
+      v(m.rootEntityId ?? null),
+      v(m.rootEntityName ?? null),
+      v(m.userId ?? null),
+      v(m.organizationId ?? null),
+      v(m.resourceId ?? null),
+      v(m.runId ?? null),
+      v(m.sessionId ?? null),
+      v(m.threadId ?? null),
+      v(m.requestId ?? null),
+      v(m.environment ?? null),
+      v(m.source ?? null),
+      v(m.serviceName ?? null),
+      v(m.experimentId ?? null),
+      jsonV(m.metadata),
+      jsonV(m.scope),
+    ].join(', ')})`;
+  });
+
+  await db.execute(`INSERT INTO metric_events (${METRIC_COLUMNS_SQL}) VALUES ${tuples.join(',\n')}`);
+}
+
+// ============================================================================
+// OLAP Queries
+// ============================================================================
+
+/** Compute an aggregate value (sum, avg, min, max, etc.) for a metric, with optional period comparison. */
+export async function getMetricAggregate(
+  db: DuckDBConnection,
+  args: GetMetricAggregateArgs,
+): Promise<GetMetricAggregateResponse> {
+  const aggSql = getAggregationSql(args.aggregation);
+  const { clause: nameClause, params: nameParams } = buildMetricNameFilter(args.name);
+  const { clause: filterClause, params: filterParams } = buildWhereClause(
+    args.filters as Record<string, unknown> | undefined,
+  );
+  const { clause: whereClause, params: allParams } = buildCombinedWhereClause(
+    nameClause,
+    nameParams,
+    filterClause,
+    filterParams,
+  );
+  const sql = `SELECT ${aggSql} as value FROM metric_events ${whereClause}`;
+  const result = await db.query<{ value: number | null }>(sql, allParams);
+  const value = result[0]?.value ?? null;
+
+  if (args.comparePeriod && args.filters?.timestamp) {
+    const ts = args.filters.timestamp;
+    if (ts.start && ts.end) {
+      const duration = ts.end.getTime() - ts.start.getTime();
+      let prevStart: Date;
+      let prevEnd: Date;
+
+      switch (args.comparePeriod) {
+        case 'previous_period':
+          prevStart = new Date(ts.start.getTime() - duration);
+          prevEnd = new Date(ts.end.getTime() - duration);
+          break;
+        case 'previous_day':
+          prevStart = new Date(ts.start.getTime() - 86400000);
+          prevEnd = new Date(ts.end.getTime() - 86400000);
+          break;
+        case 'previous_week':
+          prevStart = new Date(ts.start.getTime() - 604800000);
+          prevEnd = new Date(ts.end.getTime() - 604800000);
+          break;
+        default:
+          prevStart = new Date(ts.start.getTime() - duration);
+          prevEnd = new Date(ts.end.getTime() - duration);
+      }
+      const prevFilters = {
+        ...(args.filters ?? {}),
+        timestamp: {
+          start: prevStart,
+          end: prevEnd,
+          startExclusive: ts.startExclusive,
+          endExclusive: ts.endExclusive,
+        },
+      };
+      const { clause: prevFilterClause, params: prevFilterParams } = buildWhereClause(
+        prevFilters as Record<string, unknown>,
+      );
+      const { clause: prevWhereClause, params: prevParams } = buildCombinedWhereClause(
+        nameClause,
+        nameParams,
+        prevFilterClause,
+        prevFilterParams,
+      );
+      const prevSql = `SELECT ${aggSql} as value FROM metric_events ${prevWhereClause}`;
+      const prevResult = await db.query<{ value: number | null }>(prevSql, prevParams);
+      const previousValue = prevResult[0]?.value ?? null;
+
+      let changePercent: number | null = null;
+      if (previousValue !== null && previousValue !== 0 && value !== null) {
+        changePercent = ((value - previousValue) / Math.abs(previousValue)) * 100;
+      }
+
+      return { value, previousValue, changePercent };
+    }
+  }
+
+  return { value };
+}
+
+/** Aggregate a metric grouped by one or more dimensions. */
+export async function getMetricBreakdown(
+  db: DuckDBConnection,
+  args: GetMetricBreakdownArgs,
+): Promise<GetMetricBreakdownResponse> {
+  const aggSql = getAggregationSql(args.aggregation);
+  const { clause: nameClause, params: nameParams } = buildMetricNameFilter(args.name);
+  const { clause: filterClause, params: filterParams } = buildWhereClause(
+    args.filters as Record<string, unknown> | undefined,
+  );
+
+  const allConditions = [nameClause];
+  const allParams = [...nameParams];
+  if (filterClause) {
+    allConditions.push(filterClause.replace('WHERE ', ''));
+    allParams.push(...filterParams);
+  }
+
+  const whereClause = `WHERE ${allConditions.join(' AND ')}`;
+  const groupBy = normalizeGroupByColumns(args.groupBy);
+  const groupByCols = groupBy.join(', ');
+
+  const sql = `SELECT ${groupByCols}, ${aggSql} as value FROM metric_events ${whereClause} GROUP BY ${groupByCols} ORDER BY value DESC`;
+  const rows = await db.query(sql, allParams);
+
+  const groups = rows.map(row => {
+    const r = row as Record<string, unknown>;
+    const dimensions: Record<string, string> = {};
+    for (const col of groupBy) {
+      dimensions[col] = String(r[col] ?? '');
+    }
+    return { dimensions, value: Number(r.value ?? 0) };
+  });
+
+  return { groups };
+}
+
+/** Aggregate a metric into time-bucketed series, with optional group-by dimensions. */
+export async function getMetricTimeSeries(
+  db: DuckDBConnection,
+  args: GetMetricTimeSeriesArgs,
+): Promise<GetMetricTimeSeriesResponse> {
+  const aggSql = getAggregationSql(args.aggregation);
+  const intervalSql = getIntervalSql(args.interval);
+  const { clause: nameClause, params: nameParams } = buildMetricNameFilter(args.name);
+  const { clause: filterClause, params: filterParams } = buildWhereClause(
+    args.filters as Record<string, unknown> | undefined,
+  );
+
+  const allConditions = [nameClause];
+  const allParams = [...nameParams];
+  if (filterClause) {
+    allConditions.push(filterClause.replace('WHERE ', ''));
+    allParams.push(...filterParams);
+  }
+
+  const whereClause = `WHERE ${allConditions.join(' AND ')}`;
+
+  if (args.groupBy && args.groupBy.length > 0) {
+    const groupBy = normalizeGroupByColumns(args.groupBy);
+    const groupByCols = groupBy.join(', ');
+    const sql = `
+      SELECT time_bucket(INTERVAL '${intervalSql}', timestamp) as bucket,
+             ${groupByCols}, ${aggSql} as value
+      FROM metric_events ${whereClause}
+      GROUP BY bucket, ${groupByCols}
+      ORDER BY bucket
+    `;
+    const rows = await db.query(sql, allParams);
+
+    const seriesMap = new Map<string, { timestamp: Date; value: number }[]>();
+    for (const row of rows) {
+      const r = row as Record<string, unknown>;
+      const key = groupBy.map(col => String(r[col] ?? '')).join('|');
+      if (!seriesMap.has(key)) seriesMap.set(key, []);
+      seriesMap.get(key)!.push({
+        timestamp: new Date(r.bucket as string),
+        value: Number(r.value ?? 0),
+      });
+    }
+
+    return {
+      series: Array.from(seriesMap.entries()).map(([name, points]) => ({ name, points })),
+    };
+  }
+
+  const sql = `
+    SELECT time_bucket(INTERVAL '${intervalSql}', timestamp) as bucket,
+           ${aggSql} as value
+    FROM metric_events ${whereClause}
+    GROUP BY bucket
+    ORDER BY bucket
+  `;
+  const rows = await db.query(sql, allParams);
+
+  const metricName = Array.isArray(args.name) ? args.name.join(',') : args.name;
+  return {
+    series: [
+      {
+        name: metricName,
+        points: rows.map(row => {
+          const r = row as Record<string, unknown>;
+          return {
+            timestamp: r.bucket instanceof Date ? r.bucket : new Date(String(r.bucket)),
+            value: Number(r.value ?? 0),
+          };
+        }),
+      },
+    ],
+  };
+}
+
+/** Compute percentile time series for a metric using `percentile_cont`. */
+export async function getMetricPercentiles(
+  db: DuckDBConnection,
+  args: GetMetricPercentilesArgs,
+): Promise<GetMetricPercentilesResponse> {
+  const intervalSql = getIntervalSql(args.interval);
+  const { clause: filterClause, params: filterParams } = buildWhereClause(
+    args.filters as Record<string, unknown> | undefined,
+  );
+
+  const allConditions = [`name = ?`];
+  const allParams: unknown[] = [args.name];
+  if (filterClause) {
+    allConditions.push(filterClause.replace('WHERE ', ''));
+    allParams.push(...filterParams);
+  }
+
+  const whereClause = `WHERE ${allConditions.join(' AND ')}`;
+
+  const series = [];
+  for (const p of args.percentiles) {
+    const sql = `
+      SELECT time_bucket(INTERVAL '${intervalSql}', timestamp) as bucket,
+             percentile_cont(${p}) WITHIN GROUP (ORDER BY value) as pvalue
+      FROM metric_events ${whereClause}
+      GROUP BY bucket
+      ORDER BY bucket
+    `;
+    const rows = await db.query(sql, allParams);
+
+    series.push({
+      percentile: p,
+      points: rows.map(row => {
+        const r = row as Record<string, unknown>;
+        return {
+          timestamp: new Date(r.bucket as string),
+          value: Number(r.pvalue ?? 0),
+        };
+      }),
+    });
+  }
+
+  return { series };
+}
+
+// ============================================================================
+// Discovery / Metadata
+// ============================================================================
+
+/** Return distinct metric names, optionally filtered by prefix. */
+export async function getMetricNames(db: DuckDBConnection, args: GetMetricNamesArgs): Promise<GetMetricNamesResponse> {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (args.prefix) {
+    conditions.push(`name LIKE ?`);
+    params.push(`${args.prefix}%`);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  const limitClause = args.limit ? `LIMIT ?` : '';
+  if (args.limit) params.push(args.limit);
+
+  const rows = await db.query<{ name: string }>(
+    `SELECT DISTINCT name FROM metric_events ${whereClause} ORDER BY name ${limitClause}`,
+    params,
+  );
+
+  return { names: rows.map(r => r.name) };
+}
+
+/** Return distinct label keys for a given metric name. */
+export async function getMetricLabelKeys(
+  db: DuckDBConnection,
+  args: GetMetricLabelKeysArgs,
+): Promise<GetMetricLabelKeysResponse> {
+  const rows = await db.query<{ key: string }>(
+    `SELECT DISTINCT unnest(json_keys(labels)) as key FROM metric_events WHERE name = ? AND labels IS NOT NULL`,
+    [args.metricName],
+  );
+  return { keys: rows.map(r => r.key) };
+}
+
+/** Return distinct values for a specific label key on a metric. */
+export async function getMetricLabelValues(
+  db: DuckDBConnection,
+  args: GetMetricLabelValuesArgs,
+): Promise<GetMetricLabelValuesResponse> {
+  const labelPath = buildJsonPath(args.labelKey);
+  const conditions = [`name = ?`, `json_extract_string(labels, ?) IS NOT NULL`];
+  const params: unknown[] = [labelPath, args.metricName, labelPath];
+
+  if (args.prefix) {
+    conditions.push(`json_extract_string(labels, ?) LIKE ?`);
+    params.push(labelPath, `${args.prefix}%`);
+  }
+
+  const limitClause = args.limit ? `LIMIT ?` : '';
+  if (args.limit) params.push(args.limit);
+
+  const rows = await db.query<{ val: string }>(
+    `SELECT DISTINCT json_extract_string(labels, ?) as val FROM metric_events WHERE ${conditions.join(' AND ')} ORDER BY val ${limitClause}`,
+    params,
+  );
+
+  return { values: rows.map(r => r.val) };
+}

--- a/stores/duckdb/src/storage/domains/observability/scores.ts
+++ b/stores/duckdb/src/storage/domains/observability/scores.ts
@@ -1,0 +1,99 @@
+import type { BatchCreateScoresArgs, CreateScoreArgs, ListScoresArgs, ListScoresResponse } from '@mastra/core/storage';
+import type { DuckDBConnection } from '../../db/index';
+import { buildWhereClause, buildOrderByClause, buildPaginationClause } from './filters';
+import { v, jsonV, toDate, parseJson } from './helpers';
+
+/** Insert a single score event. */
+export async function createScore(db: DuckDBConnection, args: CreateScoreArgs): Promise<void> {
+  const s = args.score;
+  await db.execute(
+    `INSERT INTO score_events (timestamp, traceId, spanId, scorerId, scorerVersion, source, score, reason, experimentId, scoreTraceId, metadata)
+     VALUES (${[
+       v(s.timestamp),
+       v(s.traceId),
+       v(s.spanId ?? null),
+       v(s.scorerId),
+       v(s.scorerVersion ?? null),
+       v(s.source ?? null),
+       v(s.score),
+       v(s.reason ?? null),
+       v(s.experimentId ?? null),
+       v(s.scoreTraceId ?? null),
+       jsonV(s.metadata),
+     ].join(', ')})`,
+  );
+}
+
+/** Insert multiple score events in a single statement. */
+export async function batchCreateScores(db: DuckDBConnection, args: BatchCreateScoresArgs): Promise<void> {
+  if (args.scores.length === 0) return;
+
+  const tuples = args.scores.map(
+    s =>
+      `(${[
+        v(s.timestamp),
+        v(s.traceId),
+        v(s.spanId ?? null),
+        v(s.scorerId),
+        v(s.scorerVersion ?? null),
+        v(s.source ?? null),
+        v(s.score),
+        v(s.reason ?? null),
+        v(s.experimentId ?? null),
+        v(s.scoreTraceId ?? null),
+        jsonV(s.metadata),
+      ].join(', ')})`,
+  );
+
+  await db.execute(
+    `INSERT INTO score_events (timestamp, traceId, spanId, scorerId, scorerVersion, source, score, reason, experimentId, scoreTraceId, metadata)
+     VALUES ${tuples.join(',\n       ')}`,
+  );
+}
+
+/** Query score events with filtering, ordering, and pagination. */
+export async function listScores(db: DuckDBConnection, args: ListScoresArgs): Promise<ListScoresResponse> {
+  const filters = args.filters ?? {};
+  const page = Number(args.pagination?.page ?? 0);
+  const perPage = Number(args.pagination?.perPage ?? 10);
+  const orderBy = { field: args.orderBy?.field ?? 'timestamp', direction: args.orderBy?.direction ?? 'DESC' } as const;
+
+  const { clause: filterClause, params: filterParams } = buildWhereClause(filters as Record<string, unknown>);
+  const orderByClause = buildOrderByClause(orderBy);
+  const { clause: paginationClause, params: paginationParams } = buildPaginationClause({ page, perPage });
+
+  const countResult = await db.query<{ total: number }>(
+    `SELECT COUNT(*) as total FROM score_events ${filterClause}`,
+    filterParams,
+  );
+  const total = Number(countResult[0]?.total ?? 0);
+
+  const rows = await db.query(`SELECT * FROM score_events ${filterClause} ${orderByClause} ${paginationClause}`, [
+    ...filterParams,
+    ...paginationParams,
+  ]);
+
+  const scores = rows.map(row => {
+    const r = row as Record<string, unknown>;
+    return {
+      timestamp: toDate(r.timestamp),
+      traceId: r.traceId as string,
+      spanId: (r.spanId as string) ?? null,
+      scorerId: r.scorerId as string,
+      scorerVersion: (r.scorerVersion as string) ?? null,
+      source: (r.source as string) ?? null,
+      score: Number(r.score),
+      reason: (r.reason as string) ?? null,
+      experimentId: (r.experimentId as string) ?? null,
+      scoreTraceId: (r.scoreTraceId as string) ?? null,
+      metadata: parseJson(r.metadata) as Record<string, unknown> | null,
+      createdAt: toDate(r.timestamp),
+      updatedAt: null,
+    };
+  });
+
+  return {
+    pagination: { total, page, perPage, hasMore: (page + 1) * perPage < total },
+    scores,
+  };
+}

--- a/stores/duckdb/src/storage/domains/observability/scores.ts
+++ b/stores/duckdb/src/storage/domains/observability/scores.ts
@@ -87,8 +87,6 @@ export async function listScores(db: DuckDBConnection, args: ListScoresArgs): Pr
       experimentId: (r.experimentId as string) ?? null,
       scoreTraceId: (r.scoreTraceId as string) ?? null,
       metadata: parseJson(r.metadata) as Record<string, unknown> | null,
-      createdAt: toDate(r.timestamp),
-      updatedAt: null,
     };
   });
 

--- a/stores/duckdb/src/storage/domains/observability/tracing.ts
+++ b/stores/duckdb/src/storage/domains/observability/tracing.ts
@@ -1,6 +1,5 @@
 import type {
   CreateSpanArgs,
-  UpdateSpanArgs,
   GetSpanArgs,
   GetSpanResponse,
   GetRootSpanArgs,
@@ -10,13 +9,13 @@ import type {
   ListTracesArgs,
   ListTracesResponse,
   BatchCreateSpansArgs,
-  BatchUpdateSpansArgs,
   BatchDeleteTracesArgs,
+  SpanRecord,
 } from '@mastra/core/storage';
 import { toTraceSpans } from '@mastra/core/storage';
 import type { DuckDBConnection } from '../../db/index';
 import { buildWhereClause, buildOrderByClause, buildPaginationClause } from './filters';
-import { v, jsonV, rowToSpanRecord } from './helpers';
+import { v, jsonV, parseJson, parseJsonArray, toDate, toDateOrNull } from './helpers';
 
 // ============================================================================
 // Columns & Reconstruction
@@ -61,8 +60,8 @@ const COLUMNS_SQL = COLUMNS.join(', ');
 
 /**
  * Reconstruction query uses `arg_max(field, timestamp) FILTER (WHERE field IS NOT NULL)`
- * so that partial update events (with NULLs for unchanged fields) don't overwrite
- * values set by earlier events.
+ * so that the final end event supplies the terminal span fields without wiping
+ * stable values emitted on the start event.
  */
 function argMaxNonNull(col: string): string {
   return `arg_max(${col}, timestamp) FILTER (WHERE ${col} IS NOT NULL) as ${col}`;
@@ -103,6 +102,44 @@ const SPAN_RECONSTRUCT_SELECT = `
   FROM span_events
 `;
 
+function rowToSpanRecord(row: Record<string, unknown>): SpanRecord {
+  return {
+    traceId: row.traceId as string,
+    spanId: row.spanId as string,
+    name: row.name as string,
+    spanType: row.spanType as SpanRecord['spanType'],
+    parentSpanId: (row.parentSpanId as string) ?? null,
+    isEvent: row.isEvent as boolean,
+    startedAt: toDate(row.startedAt),
+    endedAt: toDateOrNull(row.endedAt),
+    experimentId: (row.experimentId as string) ?? null,
+    entityType: (row.entityType as SpanRecord['entityType']) ?? null,
+    entityId: (row.entityId as string) ?? null,
+    entityName: (row.entityName as string) ?? null,
+    userId: (row.userId as string) ?? null,
+    organizationId: (row.organizationId as string) ?? null,
+    resourceId: (row.resourceId as string) ?? null,
+    runId: (row.runId as string) ?? null,
+    sessionId: (row.sessionId as string) ?? null,
+    threadId: (row.threadId as string) ?? null,
+    requestId: (row.requestId as string) ?? null,
+    environment: (row.environment as string) ?? null,
+    source: (row.source as string) ?? null,
+    serviceName: (row.serviceName as string) ?? null,
+    attributes: parseJson(row.attributes) as Record<string, unknown> | null,
+    metadata: parseJson(row.metadata) as Record<string, unknown> | null,
+    tags: parseJsonArray(row.tags) as string[] | null,
+    scope: parseJson(row.scope) as Record<string, unknown> | null,
+    links: parseJsonArray(row.links),
+    input: parseJson(row.input) as Record<string, unknown> | null,
+    output: parseJson(row.output) as Record<string, unknown> | null,
+    error: parseJson(row.error) as Record<string, unknown> | null,
+    requestContext: parseJson(row.requestContext) as Record<string, unknown> | null,
+    createdAt: toDate(row.startedAt),
+    updatedAt: null,
+  };
+}
+
 function buildHasChildErrorClause(hasChildError: boolean | undefined): string {
   if (hasChildError === undefined) return '';
   const base = `SELECT 1 FROM reconstructed_spans c WHERE c.traceId = root_spans.traceId AND c.spanId != root_spans.spanId AND c.error IS NOT NULL`;
@@ -116,16 +153,15 @@ function buildHasChildErrorClause(hasChildError: boolean | undefined): string {
 /**
  * A span event row to be inserted into the span_events table.
  *
- * `timestamp` is the event ordering key, computed internally from the eventType:
- *   - 'start'  → the span's actual start time
- *   - 'update' → now (wall-clock time the update was recorded)
- *   - 'end'    → now (wall-clock time the end was recorded)
+ * `timestamp` is the event ordering key:
+ *   - 'start' → the span's actual start time
+ *   - 'end'   → the span's actual end time
  *
  * The reconstruction query derives `startedAt` from
  * `min(timestamp) FILTER (WHERE eventType = 'start')`.
  */
 interface SpanEventRow {
-  eventType: 'start' | 'update' | 'end';
+  eventType: 'start' | 'end';
   timestamp: Date;
   traceId: string;
   spanId: string;
@@ -206,10 +242,47 @@ async function insertSpanEvents(db: DuckDBConnection, rows: SpanEventRow[]): Pro
 // Public API
 // ============================================================================
 
-function createSpanRow(s: CreateSpanArgs['span']): SpanEventRow {
+function createStartSpanRow(s: CreateSpanArgs['span']): SpanEventRow {
   return {
     eventType: 'start',
     timestamp: s.startedAt,
+    traceId: s.traceId,
+    spanId: s.spanId,
+    parentSpanId: s.parentSpanId ?? null,
+    name: s.name,
+    spanType: s.spanType,
+    isEvent: s.isEvent,
+    endedAt: null,
+    experimentId: s.experimentId ?? null,
+    entityType: s.entityType ?? null,
+    entityId: s.entityId ?? null,
+    entityName: s.entityName ?? null,
+    userId: s.userId ?? null,
+    organizationId: s.organizationId ?? null,
+    resourceId: s.resourceId ?? null,
+    runId: s.runId ?? null,
+    sessionId: s.sessionId ?? null,
+    threadId: s.threadId ?? null,
+    requestId: s.requestId ?? null,
+    environment: s.environment ?? null,
+    source: s.source ?? null,
+    serviceName: s.serviceName ?? null,
+    attributes: (s.attributes as Record<string, unknown>) ?? null,
+    metadata: (s.metadata as Record<string, unknown>) ?? null,
+    tags: s.tags ?? null,
+    scope: (s.scope as Record<string, unknown>) ?? null,
+    links: null,
+    input: (s.input as Record<string, unknown>) ?? null,
+    output: null,
+    error: null,
+    requestContext: (s.requestContext as Record<string, unknown>) ?? null,
+  };
+}
+
+function createEndSpanRow(s: CreateSpanArgs['span']): SpanEventRow {
+  return {
+    eventType: 'end',
+    timestamp: s.endedAt!,
     traceId: s.traceId,
     spanId: s.spanId,
     parentSpanId: s.parentSpanId ?? null,
@@ -243,66 +316,25 @@ function createSpanRow(s: CreateSpanArgs['span']): SpanEventRow {
   };
 }
 
-function updateSpanRow(args: UpdateSpanArgs): SpanEventRow {
-  const u = args.updates;
-  return {
-    eventType: u.endedAt ? 'end' : 'update',
-    timestamp: new Date(),
-    traceId: args.traceId,
-    spanId: args.spanId,
-    parentSpanId: null,
-    name: u.name ?? null,
-    spanType: u.spanType ?? null,
-    isEvent: u.isEvent ?? null,
-    endedAt: u.endedAt ?? null,
-    experimentId: null,
-    entityType: null,
-    entityId: null,
-    entityName: null,
-    userId: null,
-    organizationId: null,
-    resourceId: null,
-    runId: null,
-    sessionId: null,
-    threadId: null,
-    requestId: null,
-    environment: null,
-    source: null,
-    serviceName: null,
-    attributes: (u.attributes as Record<string, unknown>) ?? null,
-    metadata: (u.metadata as Record<string, unknown>) ?? null,
-    tags: null,
-    scope: (u.scope as Record<string, unknown>) ?? null,
-    links: u.links ?? null,
-    input: (u.input as Record<string, unknown>) ?? null,
-    output: (u.output as Record<string, unknown>) ?? null,
-    error: (u.error as Record<string, unknown>) ?? null,
-    requestContext: null,
-  };
-}
-
 /** Insert a 'start' event for a new span. */
 export async function createSpan(db: DuckDBConnection, args: CreateSpanArgs): Promise<void> {
-  await insertSpanEvents(db, [createSpanRow(args.span)]);
-}
-
-/** Insert an 'update' or 'end' event for an existing span. */
-export async function updateSpan(db: DuckDBConnection, args: UpdateSpanArgs): Promise<void> {
-  await insertSpanEvents(db, [updateSpanRow(args)]);
+  const rows = [createStartSpanRow(args.span)];
+  if (args.span.endedAt) {
+    rows.push(createEndSpanRow(args.span));
+  }
+  await insertSpanEvents(db, rows);
 }
 
 /** Insert 'start' events for multiple spans in a single statement. */
 export async function batchCreateSpans(db: DuckDBConnection, args: BatchCreateSpansArgs): Promise<void> {
   if (args.records.length === 0) return;
-  await insertSpanEvents(db, args.records.map(createSpanRow));
-}
-
-/** Insert 'update'/'end' events for multiple spans in a single statement. */
-export async function batchUpdateSpans(db: DuckDBConnection, args: BatchUpdateSpansArgs): Promise<void> {
-  if (args.records.length === 0) return;
-  const rows = args.records.map(record =>
-    updateSpanRow({ traceId: record.traceId, spanId: record.spanId, updates: record.updates }),
-  );
+  const rows = args.records.flatMap(record => {
+    const events = [createStartSpanRow(record)];
+    if (record.endedAt) {
+      events.push(createEndSpanRow(record));
+    }
+    return events;
+  });
   await insertSpanEvents(db, rows);
 }
 

--- a/stores/duckdb/src/storage/domains/observability/tracing.ts
+++ b/stores/duckdb/src/storage/domains/observability/tracing.ts
@@ -1,0 +1,403 @@
+import type {
+  CreateSpanArgs,
+  UpdateSpanArgs,
+  GetSpanArgs,
+  GetSpanResponse,
+  GetRootSpanArgs,
+  GetRootSpanResponse,
+  GetTraceArgs,
+  GetTraceResponse,
+  ListTracesArgs,
+  ListTracesResponse,
+  BatchCreateSpansArgs,
+  BatchUpdateSpansArgs,
+  BatchDeleteTracesArgs,
+} from '@mastra/core/storage';
+import { toTraceSpans } from '@mastra/core/storage';
+import type { DuckDBConnection } from '../../db/index';
+import { buildWhereClause, buildOrderByClause, buildPaginationClause } from './filters';
+import { v, jsonV, rowToSpanRecord } from './helpers';
+
+// ============================================================================
+// Columns & Reconstruction
+// ============================================================================
+
+const COLUMNS = [
+  'eventType',
+  'timestamp',
+  'traceId',
+  'spanId',
+  'parentSpanId',
+  'name',
+  'spanType',
+  'isEvent',
+  'endedAt',
+  'experimentId',
+  'entityType',
+  'entityId',
+  'entityName',
+  'userId',
+  'organizationId',
+  'resourceId',
+  'runId',
+  'sessionId',
+  'threadId',
+  'requestId',
+  'environment',
+  'source',
+  'serviceName',
+  'attributes',
+  'metadata',
+  'tags',
+  'scope',
+  'links',
+  'input',
+  'output',
+  'error',
+  'requestContext',
+] as const;
+
+const COLUMNS_SQL = COLUMNS.join(', ');
+
+/**
+ * Reconstruction query uses `arg_max(field, timestamp) FILTER (WHERE field IS NOT NULL)`
+ * so that partial update events (with NULLs for unchanged fields) don't overwrite
+ * values set by earlier events.
+ */
+function argMaxNonNull(col: string): string {
+  return `arg_max(${col}, timestamp) FILTER (WHERE ${col} IS NOT NULL) as ${col}`;
+}
+
+const SPAN_RECONSTRUCT_SELECT = `
+  SELECT
+    traceId, spanId,
+    ${argMaxNonNull('name')},
+    ${argMaxNonNull('spanType')},
+    ${argMaxNonNull('parentSpanId')},
+    ${argMaxNonNull('isEvent')},
+    coalesce(min(timestamp) FILTER (WHERE eventType = 'start'), min(timestamp)) as startedAt,
+    ${argMaxNonNull('endedAt')},
+    ${argMaxNonNull('experimentId')},
+    ${argMaxNonNull('entityType')},
+    ${argMaxNonNull('entityId')},
+    ${argMaxNonNull('entityName')},
+    ${argMaxNonNull('userId')},
+    ${argMaxNonNull('organizationId')},
+    ${argMaxNonNull('resourceId')},
+    ${argMaxNonNull('runId')},
+    ${argMaxNonNull('sessionId')},
+    ${argMaxNonNull('threadId')},
+    ${argMaxNonNull('requestId')},
+    ${argMaxNonNull('environment')},
+    ${argMaxNonNull('source')},
+    ${argMaxNonNull('serviceName')},
+    ${argMaxNonNull('attributes')},
+    ${argMaxNonNull('metadata')},
+    ${argMaxNonNull('tags')},
+    ${argMaxNonNull('scope')},
+    ${argMaxNonNull('links')},
+    ${argMaxNonNull('input')},
+    ${argMaxNonNull('output')},
+    ${argMaxNonNull('error')},
+    ${argMaxNonNull('requestContext')}
+  FROM span_events
+`;
+
+function buildHasChildErrorClause(hasChildError: boolean | undefined): string {
+  if (hasChildError === undefined) return '';
+  const base = `SELECT 1 FROM reconstructed_spans c WHERE c.traceId = root_spans.traceId AND c.spanId != root_spans.spanId AND c.error IS NOT NULL`;
+  return hasChildError ? `EXISTS (${base})` : `NOT EXISTS (${base})`;
+}
+
+// ============================================================================
+// Row builder — used by both create and update
+// ============================================================================
+
+/**
+ * A span event row to be inserted into the span_events table.
+ *
+ * `timestamp` is the event ordering key, computed internally from the eventType:
+ *   - 'start'  → the span's actual start time
+ *   - 'update' → now (wall-clock time the update was recorded)
+ *   - 'end'    → now (wall-clock time the end was recorded)
+ *
+ * The reconstruction query derives `startedAt` from
+ * `min(timestamp) FILTER (WHERE eventType = 'start')`.
+ */
+interface SpanEventRow {
+  eventType: 'start' | 'update' | 'end';
+  timestamp: Date;
+  traceId: string;
+  spanId: string;
+  parentSpanId: string | null;
+  name: string | null;
+  spanType: string | null;
+  isEvent: boolean | null;
+  endedAt: Date | null;
+  experimentId: string | null;
+  entityType: string | null;
+  entityId: string | null;
+  entityName: string | null;
+  userId: string | null;
+  organizationId: string | null;
+  resourceId: string | null;
+  runId: string | null;
+  sessionId: string | null;
+  threadId: string | null;
+  requestId: string | null;
+  environment: string | null;
+  source: string | null;
+  serviceName: string | null;
+  attributes: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
+  tags: string[] | null;
+  scope: Record<string, unknown> | null;
+  links: unknown[] | null;
+  input: Record<string, unknown> | null;
+  output: Record<string, unknown> | null;
+  error: Record<string, unknown> | null;
+  requestContext: Record<string, unknown> | null;
+}
+
+function toValuesTuple(row: SpanEventRow): string {
+  return [
+    v(row.eventType),
+    v(row.timestamp),
+    v(row.traceId),
+    v(row.spanId),
+    v(row.parentSpanId),
+    v(row.name),
+    v(row.spanType),
+    v(row.isEvent),
+    v(row.endedAt),
+    v(row.experimentId),
+    v(row.entityType),
+    v(row.entityId),
+    v(row.entityName),
+    v(row.userId),
+    v(row.organizationId),
+    v(row.resourceId),
+    v(row.runId),
+    v(row.sessionId),
+    v(row.threadId),
+    v(row.requestId),
+    v(row.environment),
+    v(row.source),
+    v(row.serviceName),
+    jsonV(row.attributes),
+    jsonV(row.metadata),
+    jsonV(row.tags),
+    jsonV(row.scope),
+    jsonV(row.links),
+    jsonV(row.input),
+    jsonV(row.output),
+    jsonV(row.error),
+    jsonV(row.requestContext),
+  ].join(', ');
+}
+
+async function insertSpanEvents(db: DuckDBConnection, rows: SpanEventRow[]): Promise<void> {
+  if (rows.length === 0) return;
+  const tuples = rows.map(row => `(${toValuesTuple(row)})`).join(',\n');
+  await db.execute(`INSERT INTO span_events (${COLUMNS_SQL}) VALUES ${tuples}`);
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+function createSpanRow(s: CreateSpanArgs['span']): SpanEventRow {
+  return {
+    eventType: 'start',
+    timestamp: s.startedAt,
+    traceId: s.traceId,
+    spanId: s.spanId,
+    parentSpanId: s.parentSpanId ?? null,
+    name: s.name,
+    spanType: s.spanType,
+    isEvent: s.isEvent,
+    endedAt: s.endedAt ?? null,
+    experimentId: s.experimentId ?? null,
+    entityType: s.entityType ?? null,
+    entityId: s.entityId ?? null,
+    entityName: s.entityName ?? null,
+    userId: s.userId ?? null,
+    organizationId: s.organizationId ?? null,
+    resourceId: s.resourceId ?? null,
+    runId: s.runId ?? null,
+    sessionId: s.sessionId ?? null,
+    threadId: s.threadId ?? null,
+    requestId: s.requestId ?? null,
+    environment: s.environment ?? null,
+    source: s.source ?? null,
+    serviceName: s.serviceName ?? null,
+    attributes: (s.attributes as Record<string, unknown>) ?? null,
+    metadata: (s.metadata as Record<string, unknown>) ?? null,
+    tags: s.tags ?? null,
+    scope: (s.scope as Record<string, unknown>) ?? null,
+    links: s.links ?? null,
+    input: (s.input as Record<string, unknown>) ?? null,
+    output: (s.output as Record<string, unknown>) ?? null,
+    error: (s.error as Record<string, unknown>) ?? null,
+    requestContext: (s.requestContext as Record<string, unknown>) ?? null,
+  };
+}
+
+function updateSpanRow(args: UpdateSpanArgs): SpanEventRow {
+  const u = args.updates;
+  return {
+    eventType: u.endedAt ? 'end' : 'update',
+    timestamp: new Date(),
+    traceId: args.traceId,
+    spanId: args.spanId,
+    parentSpanId: null,
+    name: u.name ?? null,
+    spanType: u.spanType ?? null,
+    isEvent: u.isEvent ?? null,
+    endedAt: u.endedAt ?? null,
+    experimentId: null,
+    entityType: null,
+    entityId: null,
+    entityName: null,
+    userId: null,
+    organizationId: null,
+    resourceId: null,
+    runId: null,
+    sessionId: null,
+    threadId: null,
+    requestId: null,
+    environment: null,
+    source: null,
+    serviceName: null,
+    attributes: (u.attributes as Record<string, unknown>) ?? null,
+    metadata: (u.metadata as Record<string, unknown>) ?? null,
+    tags: null,
+    scope: (u.scope as Record<string, unknown>) ?? null,
+    links: u.links ?? null,
+    input: (u.input as Record<string, unknown>) ?? null,
+    output: (u.output as Record<string, unknown>) ?? null,
+    error: (u.error as Record<string, unknown>) ?? null,
+    requestContext: null,
+  };
+}
+
+/** Insert a 'start' event for a new span. */
+export async function createSpan(db: DuckDBConnection, args: CreateSpanArgs): Promise<void> {
+  await insertSpanEvents(db, [createSpanRow(args.span)]);
+}
+
+/** Insert an 'update' or 'end' event for an existing span. */
+export async function updateSpan(db: DuckDBConnection, args: UpdateSpanArgs): Promise<void> {
+  await insertSpanEvents(db, [updateSpanRow(args)]);
+}
+
+/** Insert 'start' events for multiple spans in a single statement. */
+export async function batchCreateSpans(db: DuckDBConnection, args: BatchCreateSpansArgs): Promise<void> {
+  if (args.records.length === 0) return;
+  await insertSpanEvents(db, args.records.map(createSpanRow));
+}
+
+/** Insert 'update'/'end' events for multiple spans in a single statement. */
+export async function batchUpdateSpans(db: DuckDBConnection, args: BatchUpdateSpansArgs): Promise<void> {
+  if (args.records.length === 0) return;
+  const rows = args.records.map(record =>
+    updateSpanRow({ traceId: record.traceId, spanId: record.spanId, updates: record.updates }),
+  );
+  await insertSpanEvents(db, rows);
+}
+
+/** Delete all span events for the given trace IDs. */
+export async function batchDeleteTraces(db: DuckDBConnection, args: BatchDeleteTracesArgs): Promise<void> {
+  if (args.traceIds.length === 0) return;
+  const placeholders = args.traceIds.map(() => '?').join(', ');
+  await db.execute(`DELETE FROM span_events WHERE traceId IN (${placeholders})`, args.traceIds);
+}
+
+// ============================================================================
+// Read / Reconstruction
+// ============================================================================
+
+/** Reconstruct a single span from its event history. */
+export async function getSpan(db: DuckDBConnection, args: GetSpanArgs): Promise<GetSpanResponse | null> {
+  const rows = await db.query(`${SPAN_RECONSTRUCT_SELECT} WHERE traceId = ? AND spanId = ? GROUP BY traceId, spanId`, [
+    args.traceId,
+    args.spanId,
+  ]);
+  if (rows.length === 0) return null;
+  return { span: rowToSpanRecord(rows[0]!) };
+}
+
+/** Reconstruct the root span (no parent) for a trace. */
+export async function getRootSpan(db: DuckDBConnection, args: GetRootSpanArgs): Promise<GetRootSpanResponse | null> {
+  const rows = await db.query(
+    `${SPAN_RECONSTRUCT_SELECT} WHERE traceId = ? GROUP BY traceId, spanId HAVING arg_max(parentSpanId, timestamp) IS NULL LIMIT 1`,
+    [args.traceId],
+  );
+  if (rows.length === 0) return null;
+  return { span: rowToSpanRecord(rows[0]!) };
+}
+
+/** Reconstruct all spans belonging to a trace. */
+export async function getTrace(db: DuckDBConnection, args: GetTraceArgs): Promise<GetTraceResponse | null> {
+  const rows = await db.query(`${SPAN_RECONSTRUCT_SELECT} WHERE traceId = ? GROUP BY traceId, spanId`, [args.traceId]);
+  if (rows.length === 0) return null;
+  return {
+    traceId: args.traceId,
+    spans: rows.map(row => rowToSpanRecord(row as Record<string, unknown>)),
+  };
+}
+
+/** List root spans (traces) with filtering, ordering, and pagination. */
+export async function listTraces(db: DuckDBConnection, args: ListTracesArgs): Promise<ListTracesResponse> {
+  const filters = args.filters ?? {};
+  const page = Number(args.pagination?.page ?? 0);
+  const perPage = Number(args.pagination?.perPage ?? 10);
+  const orderBy = { field: args.orderBy?.field ?? 'startedAt', direction: args.orderBy?.direction ?? 'DESC' } as const;
+
+  const { clause: filterClause, params: filterParams } = buildWhereClause(filters as Record<string, unknown>);
+  const orderByClause = buildOrderByClause(orderBy);
+  const { clause: paginationClause, params: paginationParams } = buildPaginationClause({ page, perPage });
+
+  const filterParts = [];
+  if (filterClause) filterParts.push(filterClause.replace(/^WHERE\s+/i, ''));
+  const hasChildError = typeof filters.hasChildError === 'boolean' ? filters.hasChildError : undefined;
+  const childErrorClause = buildHasChildErrorClause(hasChildError);
+  if (childErrorClause) filterParts.push(childErrorClause);
+  const combinedFilterClause = filterParts.length > 0 ? `WHERE ${filterParts.join(' AND ')}` : '';
+
+  const cteSql = `
+    WITH reconstructed_spans AS (
+      ${SPAN_RECONSTRUCT_SELECT}
+      GROUP BY traceId, spanId
+    ),
+    root_spans AS (
+      SELECT * FROM reconstructed_spans
+      WHERE parentSpanId IS NULL
+    )
+  `;
+
+  const countSql = `
+    ${cteSql}
+    SELECT COUNT(*) as total FROM root_spans ${combinedFilterClause}
+  `;
+  const countResult = await db.query<{ total: number }>(countSql, filterParams);
+  const total = Number(countResult[0]?.total ?? 0);
+
+  const dataSql = `
+    ${cteSql}
+    SELECT * FROM root_spans ${combinedFilterClause} ${orderByClause} ${paginationClause}
+  `;
+  const rows = await db.query(dataSql, [...filterParams, ...paginationParams]);
+
+  const spans = rows.map(row => rowToSpanRecord(row as Record<string, unknown>));
+
+  return {
+    pagination: {
+      total,
+      page,
+      perPage,
+      hasMore: (page + 1) * perPage < total,
+    },
+    spans: toTraceSpans(spans),
+  };
+}

--- a/stores/duckdb/src/storage/index.ts
+++ b/stores/duckdb/src/storage/index.ts
@@ -1,0 +1,69 @@
+import type { StorageDomains } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
+
+import { DuckDBConnection } from './db/index';
+import { ObservabilityStorageDuckDB } from './domains/observability/index';
+
+// Re-export lower-level pieces for direct use / composition
+export { DuckDBConnection } from './db/index';
+export type { DuckDBStorageConfig } from './db/index';
+export { ObservabilityStorageDuckDB } from './domains/observability/index';
+export type { ObservabilityDuckDBConfig } from './domains/observability/index';
+
+/** Configuration for the top-level DuckDBStore composite. */
+export interface DuckDBStoreConfig {
+  /** Store identifier. Defaults to 'duckdb'. */
+  id?: string;
+  /**
+   * Path to the DuckDB database file.
+   * @default 'mastra.duckdb'
+   * Use ':memory:' for an ephemeral in-memory database.
+   */
+  path?: string;
+}
+
+/**
+ * DuckDB storage adapter for Mastra.
+ *
+ * Currently provides observability storage (traces, metrics, logs, scores, feedback).
+ * Use via composition with another store for domains DuckDB doesn't yet cover.
+ *
+ * @example
+ * ```typescript
+ * // As the observability backend in a composed store
+ * const storage = new MastraCompositeStore({
+ *   id: 'my-store',
+ *   default: new LibSQLStore({ id: 'my-store', url: 'file:./dev.db' }),
+ *   domains: {
+ *     observability: new DuckDBStore().observability,
+ *   },
+ * });
+ *
+ * // Or standalone (only observability domain available)
+ * const duckdb = new DuckDBStore();
+ * const obs = await duckdb.getStore('observability');
+ * ```
+ */
+export class DuckDBStore extends MastraCompositeStore {
+  readonly db: DuckDBConnection;
+
+  stores: StorageDomains;
+
+  constructor(config: DuckDBStoreConfig = {}) {
+    const id = config.id ?? 'duckdb';
+    super({ id, name: 'DuckDBStore' });
+
+    this.db = new DuckDBConnection({ path: config.path });
+
+    const observability = new ObservabilityStorageDuckDB({ db: this.db });
+
+    this.stores = {
+      observability,
+    };
+  }
+
+  /** Convenience accessor for the observability domain. */
+  get observability(): ObservabilityStorageDuckDB {
+    return this.stores.observability as ObservabilityStorageDuckDB;
+  }
+}

--- a/stores/duckdb/src/storage/index.ts
+++ b/stores/duckdb/src/storage/index.ts
@@ -1,6 +1,6 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { StorageDomains } from '@mastra/core/storage';
-import { MastraCompositeStore } from '@mastra/core/storage';
+import { MastraCompositeStore, ObservabilityStorage as CoreObservabilityStorage } from '@mastra/core/storage';
 
 import { DuckDBConnection } from './db/index';
 import type {
@@ -38,13 +38,14 @@ type ObservabilityStoreImpl = ObservabilityStorageDuckDBImpl;
  * This avoids loading the concrete observability implementation until init or first use,
  * which lets DuckDBStore degrade cleanly when paired with an older @mastra/core runtime.
  */
-export class ObservabilityStorageDuckDB {
+export class ObservabilityStorageDuckDB extends CoreObservabilityStorage {
   private db: DuckDBConnection;
   private delegate: ObservabilityStoreImpl | null = null;
   private loadPromise: Promise<ObservabilityStoreImpl | null> | null = null;
   private unavailableError: MastraError | null = null;
 
   constructor(config: ObservabilityDuckDBConfig) {
+    super();
     this.db = config.db;
   }
 
@@ -389,7 +390,7 @@ export class DuckDBStore extends MastraCompositeStore {
     this.observabilityStore = new ObservabilityStorageDuckDB({ db: this.db });
 
     this.stores = {
-      observability: this.observabilityStore as unknown as StorageDomains['observability'],
+      observability: this.observabilityStore,
     };
   }
 

--- a/stores/duckdb/src/storage/index.ts
+++ b/stores/duckdb/src/storage/index.ts
@@ -1,14 +1,345 @@
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { StorageDomains } from '@mastra/core/storage';
 import { MastraCompositeStore } from '@mastra/core/storage';
 
 import { DuckDBConnection } from './db/index';
-import { ObservabilityStorageDuckDB } from './domains/observability/index';
+import type {
+  ObservabilityDuckDBConfig,
+  ObservabilityStorageDuckDB as ObservabilityStorageDuckDBImpl,
+} from './domains/observability/index';
+
+const OBSERVABILITY_UPGRADE_MESSAGE =
+  'DuckDB observability storage requires `@mastra/core` with observability storage support. Upgrade `@mastra/core` to use this store.';
+
+function isObservabilityCompatibilityError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    error.message.includes('@mastra/core') &&
+    (error.message.includes('does not provide an export named') ||
+      error.message.includes('No matching export') ||
+      error.message.includes('Cannot find module') ||
+      error.message.includes('Cannot find package'))
+  );
+}
 
 // Re-export lower-level pieces for direct use / composition
 export { DuckDBConnection } from './db/index';
 export type { DuckDBStorageConfig } from './db/index';
-export { ObservabilityStorageDuckDB } from './domains/observability/index';
 export type { ObservabilityDuckDBConfig } from './domains/observability/index';
+
+type ObservabilityStoreImpl = ObservabilityStorageDuckDBImpl;
+
+/**
+ * Lazy DuckDB observability facade.
+ *
+ * This avoids loading the concrete observability implementation until init or first use,
+ * which lets DuckDBStore degrade cleanly when paired with an older @mastra/core runtime.
+ */
+export class ObservabilityStorageDuckDB {
+  private db: DuckDBConnection;
+  private delegate: ObservabilityStoreImpl | null = null;
+  private loadPromise: Promise<ObservabilityStoreImpl | null> | null = null;
+  private unavailableError: MastraError | null = null;
+
+  constructor(config: ObservabilityDuckDBConfig) {
+    this.db = config.db;
+  }
+
+  private createUnavailableError(cause?: unknown): MastraError {
+    return new MastraError(
+      {
+        id: 'OBSERVABILITY_STORAGE_DUCKDB_CORE_UPGRADE_NOT_IMPLEMENTED',
+        domain: ErrorDomain.MASTRA_OBSERVABILITY,
+        category: ErrorCategory.SYSTEM,
+        text: OBSERVABILITY_UPGRADE_MESSAGE,
+      },
+      cause,
+    );
+  }
+
+  private async loadDelegate(): Promise<ObservabilityStoreImpl | null> {
+    if (this.delegate) {
+      return this.delegate;
+    }
+
+    if (this.unavailableError) {
+      return null;
+    }
+
+    if (!this.loadPromise) {
+      this.loadPromise = import('./domains/observability/index')
+        .then(({ ObservabilityStorageDuckDB }) => {
+          const delegate = new ObservabilityStorageDuckDB({ db: this.db });
+          this.delegate = delegate;
+          return delegate;
+        })
+        .catch(error => {
+          if (isObservabilityCompatibilityError(error)) {
+            this.unavailableError = this.createUnavailableError(error);
+            return null;
+          }
+
+          throw error;
+        });
+    }
+
+    return this.loadPromise;
+  }
+
+  private async requireDelegate(): Promise<ObservabilityStoreImpl> {
+    const delegate = await this.loadDelegate();
+    if (!delegate) {
+      throw this.unavailableError ?? this.createUnavailableError();
+    }
+
+    return delegate;
+  }
+
+  get observabilityStrategy(): ObservabilityStoreImpl['observabilityStrategy'] {
+    return (
+      this.delegate?.observabilityStrategy ?? {
+        preferred: 'event-sourced',
+        supported: ['event-sourced'],
+      }
+    );
+  }
+
+  get tracingStrategy(): ObservabilityStoreImpl['tracingStrategy'] {
+    return this.delegate?.tracingStrategy ?? this.observabilityStrategy;
+  }
+
+  async init(...args: Parameters<ObservabilityStoreImpl['init']>): ReturnType<ObservabilityStoreImpl['init']> {
+    const delegate = await this.loadDelegate();
+    if (!delegate) {
+      return;
+    }
+
+    return delegate.init(...args);
+  }
+
+  async dangerouslyClearAll(
+    ...args: Parameters<ObservabilityStoreImpl['dangerouslyClearAll']>
+  ): ReturnType<ObservabilityStoreImpl['dangerouslyClearAll']> {
+    const delegate = await this.requireDelegate();
+    return delegate.dangerouslyClearAll(...args);
+  }
+
+  async createSpan(
+    ...args: Parameters<ObservabilityStoreImpl['createSpan']>
+  ): ReturnType<ObservabilityStoreImpl['createSpan']> {
+    const delegate = await this.requireDelegate();
+    return delegate.createSpan(...args);
+  }
+
+  async updateSpan(
+    ...args: Parameters<ObservabilityStoreImpl['updateSpan']>
+  ): ReturnType<ObservabilityStoreImpl['updateSpan']> {
+    const delegate = await this.requireDelegate();
+    return delegate.updateSpan(...args);
+  }
+
+  async getSpan(...args: Parameters<ObservabilityStoreImpl['getSpan']>): ReturnType<ObservabilityStoreImpl['getSpan']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getSpan(...args);
+  }
+
+  async getRootSpan(
+    ...args: Parameters<ObservabilityStoreImpl['getRootSpan']>
+  ): ReturnType<ObservabilityStoreImpl['getRootSpan']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getRootSpan(...args);
+  }
+
+  async getTrace(
+    ...args: Parameters<ObservabilityStoreImpl['getTrace']>
+  ): ReturnType<ObservabilityStoreImpl['getTrace']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getTrace(...args);
+  }
+
+  async listTraces(
+    ...args: Parameters<ObservabilityStoreImpl['listTraces']>
+  ): ReturnType<ObservabilityStoreImpl['listTraces']> {
+    const delegate = await this.requireDelegate();
+    return delegate.listTraces(...args);
+  }
+
+  async batchCreateSpans(
+    ...args: Parameters<ObservabilityStoreImpl['batchCreateSpans']>
+  ): ReturnType<ObservabilityStoreImpl['batchCreateSpans']> {
+    const delegate = await this.requireDelegate();
+    return delegate.batchCreateSpans(...args);
+  }
+
+  async batchUpdateSpans(
+    ...args: Parameters<ObservabilityStoreImpl['batchUpdateSpans']>
+  ): ReturnType<ObservabilityStoreImpl['batchUpdateSpans']> {
+    const delegate = await this.requireDelegate();
+    return delegate.batchUpdateSpans(...args);
+  }
+
+  async batchDeleteTraces(
+    ...args: Parameters<ObservabilityStoreImpl['batchDeleteTraces']>
+  ): ReturnType<ObservabilityStoreImpl['batchDeleteTraces']> {
+    const delegate = await this.requireDelegate();
+    return delegate.batchDeleteTraces(...args);
+  }
+
+  async batchCreateLogs(
+    ...args: Parameters<ObservabilityStoreImpl['batchCreateLogs']>
+  ): ReturnType<ObservabilityStoreImpl['batchCreateLogs']> {
+    const delegate = await this.requireDelegate();
+    return delegate.batchCreateLogs(...args);
+  }
+
+  async listLogs(
+    ...args: Parameters<ObservabilityStoreImpl['listLogs']>
+  ): ReturnType<ObservabilityStoreImpl['listLogs']> {
+    const delegate = await this.requireDelegate();
+    return delegate.listLogs(...args);
+  }
+
+  async batchCreateMetrics(
+    ...args: Parameters<ObservabilityStoreImpl['batchCreateMetrics']>
+  ): ReturnType<ObservabilityStoreImpl['batchCreateMetrics']> {
+    const delegate = await this.requireDelegate();
+    return delegate.batchCreateMetrics(...args);
+  }
+
+  async listMetrics(
+    ...args: Parameters<ObservabilityStoreImpl['listMetrics']>
+  ): ReturnType<ObservabilityStoreImpl['listMetrics']> {
+    const delegate = await this.requireDelegate();
+    return delegate.listMetrics(...args);
+  }
+
+  async getMetricAggregate(
+    ...args: Parameters<ObservabilityStoreImpl['getMetricAggregate']>
+  ): ReturnType<ObservabilityStoreImpl['getMetricAggregate']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getMetricAggregate(...args);
+  }
+
+  async getMetricBreakdown(
+    ...args: Parameters<ObservabilityStoreImpl['getMetricBreakdown']>
+  ): ReturnType<ObservabilityStoreImpl['getMetricBreakdown']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getMetricBreakdown(...args);
+  }
+
+  async getMetricTimeSeries(
+    ...args: Parameters<ObservabilityStoreImpl['getMetricTimeSeries']>
+  ): ReturnType<ObservabilityStoreImpl['getMetricTimeSeries']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getMetricTimeSeries(...args);
+  }
+
+  async getMetricPercentiles(
+    ...args: Parameters<ObservabilityStoreImpl['getMetricPercentiles']>
+  ): ReturnType<ObservabilityStoreImpl['getMetricPercentiles']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getMetricPercentiles(...args);
+  }
+
+  async getMetricNames(
+    ...args: Parameters<ObservabilityStoreImpl['getMetricNames']>
+  ): ReturnType<ObservabilityStoreImpl['getMetricNames']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getMetricNames(...args);
+  }
+
+  async getMetricLabelKeys(
+    ...args: Parameters<ObservabilityStoreImpl['getMetricLabelKeys']>
+  ): ReturnType<ObservabilityStoreImpl['getMetricLabelKeys']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getMetricLabelKeys(...args);
+  }
+
+  async getMetricLabelValues(
+    ...args: Parameters<ObservabilityStoreImpl['getMetricLabelValues']>
+  ): ReturnType<ObservabilityStoreImpl['getMetricLabelValues']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getMetricLabelValues(...args);
+  }
+
+  async getEntityTypes(
+    ...args: Parameters<ObservabilityStoreImpl['getEntityTypes']>
+  ): ReturnType<ObservabilityStoreImpl['getEntityTypes']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getEntityTypes(...args);
+  }
+
+  async getEntityNames(
+    ...args: Parameters<ObservabilityStoreImpl['getEntityNames']>
+  ): ReturnType<ObservabilityStoreImpl['getEntityNames']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getEntityNames(...args);
+  }
+
+  async getServiceNames(
+    ...args: Parameters<ObservabilityStoreImpl['getServiceNames']>
+  ): ReturnType<ObservabilityStoreImpl['getServiceNames']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getServiceNames(...args);
+  }
+
+  async getEnvironments(
+    ...args: Parameters<ObservabilityStoreImpl['getEnvironments']>
+  ): ReturnType<ObservabilityStoreImpl['getEnvironments']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getEnvironments(...args);
+  }
+
+  async getTags(...args: Parameters<ObservabilityStoreImpl['getTags']>): ReturnType<ObservabilityStoreImpl['getTags']> {
+    const delegate = await this.requireDelegate();
+    return delegate.getTags(...args);
+  }
+
+  async createScore(
+    ...args: Parameters<ObservabilityStoreImpl['createScore']>
+  ): ReturnType<ObservabilityStoreImpl['createScore']> {
+    const delegate = await this.requireDelegate();
+    return delegate.createScore(...args);
+  }
+
+  async batchCreateScores(
+    ...args: Parameters<ObservabilityStoreImpl['batchCreateScores']>
+  ): ReturnType<ObservabilityStoreImpl['batchCreateScores']> {
+    const delegate = await this.requireDelegate();
+    return delegate.batchCreateScores(...args);
+  }
+
+  async listScores(
+    ...args: Parameters<ObservabilityStoreImpl['listScores']>
+  ): ReturnType<ObservabilityStoreImpl['listScores']> {
+    const delegate = await this.requireDelegate();
+    return delegate.listScores(...args);
+  }
+
+  async createFeedback(
+    ...args: Parameters<ObservabilityStoreImpl['createFeedback']>
+  ): ReturnType<ObservabilityStoreImpl['createFeedback']> {
+    const delegate = await this.requireDelegate();
+    return delegate.createFeedback(...args);
+  }
+
+  async batchCreateFeedback(
+    ...args: Parameters<ObservabilityStoreImpl['batchCreateFeedback']>
+  ): ReturnType<ObservabilityStoreImpl['batchCreateFeedback']> {
+    const delegate = await this.requireDelegate();
+    return delegate.batchCreateFeedback(...args);
+  }
+
+  async listFeedback(
+    ...args: Parameters<ObservabilityStoreImpl['listFeedback']>
+  ): ReturnType<ObservabilityStoreImpl['listFeedback']> {
+    const delegate = await this.requireDelegate();
+    return delegate.listFeedback(...args);
+  }
+}
 
 /** Configuration for the top-level DuckDBStore composite. */
 export interface DuckDBStoreConfig {
@@ -46,6 +377,7 @@ export interface DuckDBStoreConfig {
  */
 export class DuckDBStore extends MastraCompositeStore {
   readonly db: DuckDBConnection;
+  private observabilityStore: ObservabilityStorageDuckDB;
 
   stores: StorageDomains;
 
@@ -54,16 +386,15 @@ export class DuckDBStore extends MastraCompositeStore {
     super({ id, name: 'DuckDBStore' });
 
     this.db = new DuckDBConnection({ path: config.path });
-
-    const observability = new ObservabilityStorageDuckDB({ db: this.db });
+    this.observabilityStore = new ObservabilityStorageDuckDB({ db: this.db });
 
     this.stores = {
-      observability,
+      observability: this.observabilityStore as unknown as StorageDomains['observability'],
     };
   }
 
   /** Convenience accessor for the observability domain. */
   get observability(): ObservabilityStorageDuckDB {
-    return this.stores.observability as ObservabilityStorageDuckDB;
+    return this.observabilityStore;
   }
 }

--- a/stores/duckdb/src/vector/filter-builder.ts
+++ b/stores/duckdb/src/vector/filter-builder.ts
@@ -1,5 +1,6 @@
-import type { DuckDBVectorFilter } from './types.js';
+import type { DuckDBVectorFilter } from './types';
 
+/** Result of building a SQL filter: a WHERE clause fragment and bound parameters. */
 export interface FilterResult {
   clause: string;
   params: unknown[];

--- a/stores/duckdb/src/vector/index.ts
+++ b/stores/duckdb/src/vector/index.ts
@@ -15,8 +15,8 @@ import type {
   UpdateVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
-import { buildFilterClause } from './filter-builder.js';
-import type { DuckDBVectorConfig, DuckDBVectorFilter } from './types.js';
+import { buildFilterClause } from './filter-builder';
+import type { DuckDBVectorConfig, DuckDBVectorFilter } from './types';
 
 /**
  * DuckDB vector store implementation for Mastra.
@@ -188,6 +188,7 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
     }
   }
 
+  /** Perform a vector similarity search with optional metadata filtering. */
   async query(params: QueryVectorParams<DuckDBVectorFilter>): Promise<QueryResult[]> {
     await this.initialize();
 
@@ -270,6 +271,7 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
     });
   }
 
+  /** Insert or replace vectors with metadata. Returns the vector IDs. */
   async upsert(params: UpsertVectorParams): Promise<string[]> {
     await this.initialize();
 
@@ -304,6 +306,7 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
     return vectorIds;
   }
 
+  /** Create a vector table with HNSW index for similarity search. */
   async createIndex(params: CreateIndexParams): Promise<void> {
     await this.initialize();
 
@@ -343,6 +346,7 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
     }
   }
 
+  /** List all vector table names in the database. */
   async listIndexes(): Promise<string[]> {
     await this.initialize();
 
@@ -358,6 +362,7 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
     return rows.map(row => row[0] as string);
   }
 
+  /** Return dimension, row count, and metric for a vector index. */
   async describeIndex(params: DescribeIndexParams): Promise<IndexStats> {
     await this.initialize();
 
@@ -396,6 +401,7 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
     };
   }
 
+  /** Drop a vector table and its HNSW index. */
   async deleteIndex(params: DeleteIndexParams): Promise<void> {
     await this.initialize();
 
@@ -406,6 +412,7 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
     await connection.run(`DROP TABLE IF EXISTS ${tableName}`);
   }
 
+  /** Update a vector's embedding and/or metadata by ID or filter. */
   async updateVector(params: UpdateVectorParams<DuckDBVectorFilter>): Promise<void> {
     await this.initialize();
 
@@ -456,6 +463,7 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
     }
   }
 
+  /** Delete a single vector by ID. */
   async deleteVector(params: DeleteVectorParams): Promise<void> {
     await this.initialize();
 
@@ -467,6 +475,7 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
     await this.runStatement(sql, [id]);
   }
 
+  /** Delete multiple vectors by IDs or metadata filter (mutually exclusive). */
   async deleteVectors(params: DeleteVectorsParams<DuckDBVectorFilter>): Promise<void> {
     await this.initialize();
 


### PR DESCRIPTION
## Description

Added observability storage domain to DuckDB adapter. Provides OLAP-based storage for traces, metrics, logs, scores, and feedback using DuckDB's analytical engine. New exports: `DuckDBStore`, `ObservabilityStorageDuckDB`, and `DuckDBConnection` connection manager.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Added DuckDB-backed observability storage supporting traces, metrics, logs, scores, and feedback data persistence
* Introduced `DuckDBStore`, `ObservabilityStorageDuckDB`, and `DuckDBConnection` for composable storage integration
* Enabled metric analytics including aggregates, breakdowns, time-series bucketing, and percentile calculations
* Added discovery methods for entity types, services, environments, and tags

**Tests**
* Added comprehensive test suite for observability operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->