### PR TITLE
fix(schema-compat): resolve type inference regression in InferPublicSchema for createTool

### DIFF
--- a/.changeset/odd-cobras-camp.md
+++ b/.changeset/odd-cobras-camp.md
@@ -2,4 +2,4 @@
 '@mastra/schema-compat': patch
 ---
 
-Fixed type inference for `createTool` execute callback. After the standard schema migration, `inputData` in the `execute` function lost its type information and became `unknown`. Now TypeScript correctly infers the type from your `inputSchema`, restoring autocomplete and type checking. See [#14252](https://github.com/mastra-ai/mastra/issues/14252)
+Fixed TypeScript inference for the `createTool` `execute` callback's `inputData` parameter. When using a typed `inputSchema`, `inputData` is now correctly inferred instead of falling back to `unknown`. See [#14252](https://github.com/mastra-ai/mastra/issues/14252)

--- a/.changeset/odd-cobras-camp.md
+++ b/.changeset/odd-cobras-camp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed type inference for `createTool` execute callback. After the standard schema migration, `inputData` in the `execute` function lost its type information and became `unknown`. Now TypeScript correctly infers the type from your `inputSchema`, restoring autocomplete and type checking. See [#14252](https://github.com/mastra-ai/mastra/issues/14252)

--- a/packages/schema-compat/src/schema.types.ts
+++ b/packages/schema-compat/src/schema.types.ts
@@ -38,4 +38,4 @@ export type InferPublicSchema<T extends PublicSchema> =
             ? O
             : T extends StandardSchemaWithJSON<any, infer O>
               ? O
-              : unknown;
+              : never;

--- a/packages/schema-compat/src/schema.types.ts
+++ b/packages/schema-compat/src/schema.types.ts
@@ -25,4 +25,17 @@ export type PublicSchema<Output = unknown, Input = Output> =
   | JSONSchema7
   | StandardSchemaWithJSON<Input, Output>;
 
-export type InferPublicSchema<T extends PublicSchema> = T extends PublicSchema<infer Output> ? Output : never;
+export type InferPublicSchema<T extends PublicSchema> =
+  T extends z4.ZodType<infer O, any>
+    ? O
+    : T extends z3.Schema<infer O, any, any>
+      ? O
+      : T extends SchemaV4<infer O>
+        ? O
+        : T extends SchemaV5<infer O>
+          ? O
+          : T extends SchemaV6<infer O>
+            ? O
+            : T extends StandardSchemaWithJSON<any, infer O>
+              ? O
+              : unknown;


### PR DESCRIPTION
## Description
  <!-- Provide a brief description of the changes in this PR -->

After the standard schema migration in 1.10.0, `InferPublicSchema` used a single `infer` across a 7-member `PublicSchema` union, causing TypeScript to fail type inference and return `unknown` for the `execute` callback's `inputData` parameter in `createTool`. This broke type safety for all tool authors using zod schemas.

  Replaced the single union-based inference with a chained conditional type that checks each schema type individually (zod v4,       zod v3, AI SDK v4/v5/v6, StandardSchemaWithJSON), giving TypeScript a clear inference path per schema type.

  ## Related Issue(s)
  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
  Fixes #14252

  ## Type of Change
  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist
  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored correct TypeScript inference for the createTool execute callback's inputData parameter. After schema processing, inputData now inherits the type from your inputSchema (instead of becoming unknown), bringing back accurate autocomplete and type checking for inputs and improving developer ergonomics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->