### PR TITLE
 fix: add PublicSchemaWorkingMemory to WorkingMemory union type

### DIFF
--- a/.changeset/fix-working-memory-public-schema.md
+++ b/.changeset/fix-working-memory-public-schema.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix WorkingMemory type to accept Zod schemas in workingMemory.schema configuration

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -204,7 +204,7 @@ type WorkingMemoryNone = BaseWorkingMemory & {
   schema?: never;
 };
 
-export type WorkingMemory = TemplateWorkingMemory | SchemaWorkingMemory | WorkingMemoryNone;
+export type WorkingMemory = TemplateWorkingMemory | SchemaWorkingMemory | PublicSchemaWorkingMemory | WorkingMemoryNone;
 
 /**
  * Vector index configuration for optimizing semantic recall performance.


### PR DESCRIPTION
## Description
  <!-- Provide a brief description of the changes in this PR -->

Add `PublicSchemaWorkingMemory` to the `WorkingMemory` union type in `packages/core/src/memory/types.ts`. The type was defined but not included in the union, causing TypeScript errors when users pass Zod schemas to `workingMemory.schema`. The runtime already handles Zod schemas via `toStandardSchema()` conversion - this fix aligns the type system with the existing runtime behavior.

  ## Related Issue(s)
  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
  Fixes #14259

  ## Type of Change
  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist
  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed WorkingMemory to properly accept Zod schemas in memory configuration, expanding support for different schema-based memory setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->