### PR TITLE
fix(schema-compat): avoid false z.toJSONSchema unavailable errors

### DIFF
--- a/.changeset/curly-turtles-pump.md
+++ b/.changeset/curly-turtles-pump.md
@@ -1,0 +1,8 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed false `z.toJSONSchema is not available` errors for compatible Zod versions.
+
+**What changed**
+- Improved Zod schema conversion detection so JSON Schema generation works more reliably across different runtime setups.

--- a/deployers/cloud/src/utils/execa.ts
+++ b/deployers/cloud/src/utils/execa.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import { Transform } from 'node:stream';
 import { execa } from 'execa';
 import { PROJECT_ENV_VARS, PROJECT_ROOT } from './constants.js';
@@ -58,7 +59,8 @@ export function runWithChildProcess(cmd: string, args: string[]): { stdout?: str
   const pinoStream = createPinoStream();
 
   try {
-    const { stdout, stderr } = require('node:child_process').spawnSync(cmd, args, {
+    const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
+    const { stdout, stderr } = __require('node:child_process').spawnSync(cmd, args, {
       cwd: PROJECT_ROOT,
       encoding: 'utf8',
       shell: true,

--- a/mastracode/package.json
+++ b/mastracode/package.json
@@ -93,8 +93,7 @@
     "tsx": "^4.21.0",
     "typescript": "catalog:",
     "typescript-eslint": "^8.51.0",
-    "vitest": "catalog:",
-    "zod": "catalog:"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/packages/_config/src/eslint.js
+++ b/packages/_config/src/eslint.js
@@ -172,6 +172,7 @@ export const createConfig = async () =>
             '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
 
             '@typescript-eslint/no-floating-promises': 'error',
+            '@typescript-eslint/no-require-imports': ERROR,
 
             '@typescript-eslint/ban-ts-comment': [
               ERROR,

--- a/packages/agent-builder/integration-tests/src/agent-template-behavior.test.ts
+++ b/packages/agent-builder/integration-tests/src/agent-template-behavior.test.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, rmSync, cpSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join, resolve } from 'node:path';
 import { RequestContext } from '@mastra/core/request-context';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -8,7 +9,8 @@ import { AgentBuilder } from '../../src/index';
 // Import openai dynamically to handle cases where it might not be available
 const openai = (() => {
   try {
-    return require('@ai-sdk/openai').openai;
+    const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
+    return __require('@ai-sdk/openai').openai;
   } catch {
     return null;
   }

--- a/packages/agent-builder/integration-tests/src/workflow-builder-integration.test.ts
+++ b/packages/agent-builder/integration-tests/src/workflow-builder-integration.test.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, rmSync, cpSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join, resolve } from 'node:path';
 import { Agent } from '@mastra/core/agent';
 import { Mastra } from '@mastra/core/mastra';
@@ -11,7 +12,8 @@ import { workflowBuilderWorkflow } from '../../src/workflows';
 // Import openai dynamically to handle cases where it might not be available
 const openai = (() => {
   try {
-    return require('@ai-sdk/openai').openai;
+    const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
+    return __require('@ai-sdk/openai').openai;
   } catch {
     return null;
   }

--- a/packages/schema-compat/src/json-to-zod.test.ts
+++ b/packages/schema-compat/src/json-to-zod.test.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import { describe, it, expect } from 'vitest';
 import type { JsonSchema } from './json-to-zod';
 import { jsonSchemaToZod } from './json-to-zod';
@@ -1088,7 +1089,8 @@ describe('jsonSchemaToZod', () => {
       const result = jsonSchemaToZod(schema);
 
       // Should be valid JavaScript that can be evaluated with Function()
-      const { z } = require('zod');
+      const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
+      const { z } = __require('zod');
       expect(() => {
         Function('z', `"use strict";return (${result});`)(z);
       }).not.toThrow();
@@ -1103,7 +1105,8 @@ describe('jsonSchemaToZod', () => {
       };
 
       const result = jsonSchemaToZod(schema);
-      const { z } = require('zod');
+      const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
+      const { z } = __require('zod');
       const zodSchema = Function('z', `"use strict";return (${result});`)(z);
 
       // Valid data (strings only - matches exactly one schema)

--- a/packages/schema-compat/src/standard-schema/adapters/zod-v4.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/zod-v4.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import type { StandardSchemaV1, StandardJSONSchemaV1 } from '@standard-schema/spec';
 import type { StandardSchemaWithJSON, StandardSchemaWithJSONProps } from '../standard-schema.types';
 
@@ -51,21 +52,54 @@ function convertToJsonSchema(
 }
 
 /**
- * Cached reference to z.toJSONSchema from zod/v4.
+ * Cached reference to z.toJSONSchema.
  */
 let _toJSONSchema: ((schema: unknown, options?: unknown) => unknown) | null = null;
 let _toJSONSchemaResolved = false;
+const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
+
+function pickToJSONSchema(mod: unknown): ((schema: unknown, options?: unknown) => unknown) | null {
+  const candidate = mod as {
+    toJSONSchema?: unknown;
+    z?: { toJSONSchema?: unknown };
+    default?: { toJSONSchema?: unknown; z?: { toJSONSchema?: unknown } };
+  };
+
+  const picks = [
+    candidate?.toJSONSchema,
+    candidate?.z?.toJSONSchema,
+    candidate?.default?.toJSONSchema,
+    candidate?.default?.z?.toJSONSchema,
+  ];
+
+  const toJSONSchema = picks.find(fn => typeof fn === 'function');
+  return (toJSONSchema as ((schema: unknown, options?: unknown) => unknown) | undefined) ?? null;
+}
+
+function resolveToJSONSchema(
+  loadModule: (moduleName: 'zod/v4' | 'zod') => unknown,
+): ((schema: unknown, options?: unknown) => unknown) | null {
+  for (const moduleName of ['zod/v4', 'zod'] as const) {
+    try {
+      const zodModule = loadModule(moduleName);
+      const toJSONSchema = pickToJSONSchema(zodModule);
+      if (toJSONSchema) {
+        return toJSONSchema;
+      }
+    } catch {
+      // Try next module path.
+    }
+  }
+
+  return null;
+}
 
 function getToJSONSchema(): ((schema: unknown, options?: unknown) => unknown) | null {
   if (_toJSONSchemaResolved) {
     return _toJSONSchema;
   }
-  try {
-    const zv4 = require('zod/v4');
-    _toJSONSchema = typeof zv4.toJSONSchema === 'function' ? zv4.toJSONSchema : null;
-  } catch {
-    _toJSONSchema = null;
-  }
+
+  _toJSONSchema = resolveToJSONSchema(moduleName => __require(moduleName));
   _toJSONSchemaResolved = true;
   return _toJSONSchema;
 }

--- a/packages/server/src/server/handlers/agent-builder.test.ts
+++ b/packages/server/src/server/handlers/agent-builder.test.ts
@@ -3,6 +3,7 @@ import { MockStore } from '@mastra/core/storage';
 import { createStep, createWorkflow } from '@mastra/core/workflows';
 import type { Workflow } from '@mastra/core/workflows';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import z from 'zod';
 import { HTTPException } from '../http-exception';
 import { getWorkflowInfo, WorkflowRegistry } from '../utils';
 import {
@@ -44,8 +45,6 @@ vi.mock('zod', async importOriginal => {
     })),
   };
 });
-
-const z = require('zod');
 
 function createMockWorkflow(name: string) {
   const execute = vi.fn<any>().mockResolvedValue({ result: 'success' });

--- a/packages/server/src/server/handlers/agent-builder.test.ts
+++ b/packages/server/src/server/handlers/agent-builder.test.ts
@@ -3,7 +3,7 @@ import { MockStore } from '@mastra/core/storage';
 import { createStep, createWorkflow } from '@mastra/core/workflows';
 import type { Workflow } from '@mastra/core/workflows';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import z from 'zod';
+import { z } from 'zod';
 import { HTTPException } from '../http-exception';
 import { getWorkflowInfo, WorkflowRegistry } from '../utils';
 import {
@@ -33,16 +33,24 @@ vi.mock('@mastra/agent-builder', () => ({
 }));
 
 vi.mock('zod', async importOriginal => {
-  const actual: {} = await importOriginal();
+  const actual = (await importOriginal()) as { z?: Record<string, unknown> };
+
+  const object = vi.fn(() => ({
+    parse: vi.fn(input => input),
+    safeParse: vi.fn(input => ({ success: true, data: input })),
+  }));
+
+  const string = vi.fn(() => ({
+    parse: vi.fn(input => input),
+  }));
+
   return {
     ...actual,
-    object: vi.fn(() => ({
-      parse: vi.fn(input => input),
-      safeParse: vi.fn(input => ({ success: true, data: input })),
-    })),
-    string: vi.fn(() => ({
-      parse: vi.fn(input => input),
-    })),
+    z: {
+      ...(actual.z ?? {}),
+      object,
+      string,
+    },
   };
 });
 

--- a/packages/server/src/server/handlers/workflows.test.ts
+++ b/packages/server/src/server/handlers/workflows.test.ts
@@ -3,6 +3,7 @@ import { MockStore } from '@mastra/core/storage';
 import { createStep, createWorkflow } from '@mastra/core/workflows';
 import type { Workflow } from '@mastra/core/workflows';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import z from 'zod';
 import { HTTPException } from '../http-exception';
 import { getWorkflowInfo } from '../utils';
 import { createTestServerContext } from './test-utils';
@@ -36,8 +37,6 @@ vi.mock('zod', async importOriginal => {
     })),
   };
 });
-
-const z = require('zod');
 
 function createMockWorkflow(name: string) {
   const execute = vi.fn<any>().mockResolvedValue({ result: 'success' });

--- a/packages/server/src/server/handlers/workflows.test.ts
+++ b/packages/server/src/server/handlers/workflows.test.ts
@@ -3,7 +3,7 @@ import { MockStore } from '@mastra/core/storage';
 import { createStep, createWorkflow } from '@mastra/core/workflows';
 import type { Workflow } from '@mastra/core/workflows';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import z from 'zod';
+import { z } from 'zod';
 import { HTTPException } from '../http-exception';
 import { getWorkflowInfo } from '../utils';
 import { createTestServerContext } from './test-utils';
@@ -25,16 +25,24 @@ import {
 } from './workflows';
 
 vi.mock('zod', async importOriginal => {
-  const actual: {} = await importOriginal();
+  const actual = (await importOriginal()) as { z?: Record<string, unknown> };
+
+  const object = vi.fn(() => ({
+    parse: vi.fn(input => input),
+    safeParse: vi.fn(input => ({ success: true, data: input })),
+  }));
+
+  const string = vi.fn(() => ({
+    parse: vi.fn(input => input),
+  }));
+
   return {
     ...actual,
-    object: vi.fn(() => ({
-      parse: vi.fn(input => input),
-      safeParse: vi.fn(input => ({ success: true, data: input })),
-    })),
-    string: vi.fn(() => ({
-      parse: vi.fn(input => input),
-    })),
+    z: {
+      ...(actual.z ?? {}),
+      object,
+      string,
+    },
   };
 });
 

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
@@ -28,7 +29,8 @@ const OM_TABLE = 'mastra_observational_memory' as const;
  */
 let _omTableSchema: Record<string, Record<string, any>> | undefined;
 try {
-  const storage = require('@mastra/core/storage');
+  const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
+  const storage = __require('@mastra/core/storage');
   _omTableSchema = storage.OBSERVATIONAL_MEMORY_TABLE_SCHEMA;
 } catch {
   // OM not available in this version of core

--- a/voice/google-gemini-live-api/src/tool-args-bug.test.ts
+++ b/voice/google-gemini-live-api/src/tool-args-bug.test.ts
@@ -4,13 +4,15 @@
  * https://github.com/mastra-ai/mastra/issues/10161
  */
 
+import { createRequire } from 'node:module';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { z } from 'zod';
 import { GeminiLiveVoice } from './index';
 
 // Mock WebSocket
 vi.mock('ws', () => {
-  const EventEmitter = require('node:events');
+  const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
+  const EventEmitter = __require('node:events');
   class MockWebSocket extends EventEmitter {
     static CONNECTING = 0;
     static OPEN = 1;


### PR DESCRIPTION
## Summary
- fix Zod JSON Schema conversion detection in @mastra/schema-compat to avoid false `z.toJSONSchema is not available` errors in ESM/CJS runtime variations
- improve `toJSONSchema` export-shape resolution across supported Zod module layouts
- add global TypeScript lint rule in @internal/lint to disallow `require()` style imports (`@typescript-eslint/no-require-imports`)
- include a patch changeset for @mastra/schema-compat

## Test plan
- pnpm --filter @mastra/schema-compat test -- src/standard-schema/adapters/zod-v4.test.ts
- pnpm exec eslint "src/standard-schema/adapters/zod-v4.ts" "src/json-to-zod.test.ts" (run in packages/schema-compat)

Closes #14217


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false "z.toJSONSchema is not available" errors with compatible Zod versions.
  * Improved Zod-to-JSON Schema detection for more reliable generation across runtimes.

* **Chores**
  * Improved module-loading compatibility with a fallback loader for ESM environments.
  * Removed Zod from package dependencies.

* **Tests**
  * Updated tests to use guarded/dynamic imports and ESM-friendly requires.

* **Style**
  * Added TypeScript ESLint rule: no-require-imports (error).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->