### PR TITLE
test: add LLM recordings to e2e tests for deterministic replay

### DIFF
--- a/packages/core/__recordings__/core-src-agent-__tests__-tool-calls-finish-reason.e2e.json
+++ b/packages/core/__recordings__/core-src-agent-__tests__-tool-calls-finish-reason.e2e.json
@@ -1,0 +1,3057 @@
+{
+  "meta": {
+    "name": "core-src-agent-__tests__-tool-calls-finish-reason.e2e",
+    "testFile": "src/agent/__tests__/tool-calls-finish-reason.e2e.test.ts",
+    "model": "gpt-4o-mini",
+    "createdAt": "2026-03-13T10:55:04.080Z"
+  },
+  "recordings": [
+    {
+      "hash": "8519c2f11710ed59",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            }
+          ],
+          "temperature": 0,
+          "tools": [
+            {
+              "type": "function",
+              "name": "getWeather",
+              "description": "Get the current weather for a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get weather for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getPopulation",
+              "description": "Get the population of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get population for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getTimezone",
+              "description": "Get the timezone of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get timezone for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getLanguage",
+              "description": "Get the primary language spoken in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the language for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getCurrency",
+              "description": "Get the currency used in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the currency for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399263648
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba8016bad7b744-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:54:24 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "73",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_98be2128df6b4806a35d19df32c3cf45"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_033aff9390b0c2470069b3ece034f8819795d8a646bba34aa7\",\"object\":\"response\",\"created_at\":1773399264,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"get",
+          "Timezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_033aff9390b0c2470069b3ece034f8819795d8a646bba34aa7\",\"object\":\"response\",\"created_at\":1773399264,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"na",
+          "me\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\nevent: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"I\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"qkVEknV24acgXXf\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" will\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"o7IrHMfVV2j\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" gather\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"FRWFsiBQS\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" comprehensive\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"pK\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" information\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"FjID\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" about\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"Wbs611LeUM\",\"output_index\":0,\"sequence_number\":9}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"yVZNzxwKST\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" by\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"JQW6B5mGVb04n\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" looking\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"Xq6cw3NO\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" up\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"cfOiS2yXxeVA1\",\"output_index\":0,\"sequence_number\":13}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"aBIl9o5olUbk\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" following\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"EU8vBS\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" details\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"DEPlv53m\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\\n\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"m1tzG2bybeBrL\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"1\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"k7XPuGNQv0pdwN3\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"bkrNo9HMvU91A7f\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"F2dAToEQmKsqV\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Weather\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"HB3olYTM6\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"1eqEPCueczR6GX\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"iKPjUBbOxgIYVGd\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Current\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"ycGLHDpA\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" weather\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"9LxiJEgy\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" conditions\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"A2Oy3\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"6rCNfq3q3ckdQ\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"RkoMRcBINv\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"UwMQaXs8tlP4iW\",\"output_index\":0,\"sequence_number\":29}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"0U5brSEsoWGHmKv\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"fW28mUqi3scdpfb\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"lmHmzFJD70Fu8\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Population\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"L4vNoS\",\"output_index\":0,\"sequence_number\":33}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"rhOEbQFbioRjz2\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"SNpeQiByIjKLGTS\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"BqlKibA9nBzM\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" number\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"AQMiVsS9K\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"rapPvxZF9PYvg\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" people\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"WyL4jUAyH\",\"output_index\":0,\"sequence_number\":39}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" living\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"p47hsnMuo\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"ORk8Gil0e6gH1\",\"output_index\":0,\"sequence_number\":41}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"Y3OPGAS38a\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"DcnbVCgPUb8jZp\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"3\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"J4rMB1YlSf8js5h\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"z6S8NjR8JU39G2k\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"d0zMZn0wRCPy5\",\"output_index\":0,\"sequence_number\":46}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Timezone\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"Jvaoxedz\",\"output_index\":0,\"sequence_number\":47}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"VYXEiqwcQW7Hev\",\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"gDMWczaSZ0kFPwx\",\"output_index\":0,\"sequence_number\":49}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"HeaMnue009dR\",\"output_index\":0,\"sequence_number\":50}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" timezone\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"PMluwa0\",\"output_index\":0,\"sequence_number\":51}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"I9juJw2Zt7Lkx\",\"output_index\":0,\"sequence_number\":52}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" which\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"E0CyuRVkau\",\"output_index\":0,\"sequence_number\":53}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"XPwO19ZVbp\",\"output_index\":0,\"sequence_number\":54}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"0268YGDOIMneD\",\"output_index\":0,\"sequence_number\":55}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" located\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"hQnOkDDa\",\"output_index\":0,\"sequence_number\":56}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"KqvBHD0qavtQVw\",\"output_index\":0,\"sequence_number\":57}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"4\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"yCp9qu2Eevnmocn\",\"output_index\":0,\"sequence_number\":58}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"5uz0wm1LoBRX6ak\",\"output_index\":0,\"sequence_number\":59}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"zjNaxltmi6RFo\",\"output_index\":0,\"sequence_number\":60}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Language\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"TxZBprWo\",\"output_index\":0,\"sequence_number\":61}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"h85LaT44zzllq4\",\"output_index\":0,\"sequence_number\":62}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"OlF5C1DtpthXFtz\",\"output_index\":0,\"sequence_number\":63}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"ZkMii75Pg7Cs\",\"output_index\":0,\"sequence_number\":64}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" primary\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"0uKKeJeA\",\"output_index\":0,\"sequence_number\":65}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" language\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"dWnTCEA\",\"output_index\":0,\"sequence_number\":66}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" spoken\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"jqeCcbiVe\",\"output_index\":0,\"sequence_number\":67}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"DaCRqS7JDhQWJ\",\"output_index\":0,\"sequence_number\":68}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"kzei1SA6N6\",\"output_index\":0,\"sequence_number\":69}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"1wO1insFslkfgC\",\"output_index\":0,\"sequence_number\":70}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"5\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"p5QRyiGjDi6CixT\",\"output_index\":0,\"sequence_number\":71}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"xlFMZUACiGnJhIv\",\"output_index\":0,\"sequence_number\":72}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"emLhTxa3INulL\",\"output_index\":0,\"sequence_number\":73}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Currency\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"zBTiVDSG\",\"output_index\":0,\"sequence_number\":74}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"nXRMwBNzJO4xdx\",\"output_index\":0,\"sequence_number\":75}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"cmIP6hsA9uIr0VW\",\"output_index\":0,\"sequence_number\":76}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"Q8Dp281nSRrh\",\"output_index\":0,\"sequence_number\":77}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" currency\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"HznNVAh\",\"output_index\":0,\"sequence_number\":78}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" used\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"9xKlPvZR6GK\",\"output_index\":0,\"sequence_number\":79}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"aiMblo814XhCM\",\"output_index\":0,\"sequence_number\":80}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"YJMBdKLIQn\",\"output_index\":0,\"sequence_number\":81}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"J1CQbjITarE2p\",\"output_index\":0,\"sequence_number\":82}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"I\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"q2M9OMtQVlm4PG2\",\"output_index\":0,\"sequence_number\":83}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" will\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"hbQrzF3nvnV\",\"output_index\":0,\"sequence_number\":84}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" now\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"qiDHOhXusFGn\",\"output_index\":0,\"sequence_number\":85}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" call\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"34mAcOej5PO\",\"output_index\":0,\"sequence_number\":86}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" all\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"UzPlO94ziw5b\",\"output_index\":0,\"sequence_number\":87}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" five\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"eqvd5KlY7eX\",\"output_index\":0,\"sequence_number\":88}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" tools\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"ps7M5bJRS7\",\"output_index\":0,\"sequence_number\":89}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" simultaneously\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"g\",\"output_index\":0,\"sequence_number\":90}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" to\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"vIF5I5WQJ8LvZ\",\"output_index\":0,\"sequence_number\":91}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" retrieve\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"zI79blS\",\"output_index\":0,\"sequence_number\":92}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" this\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"mYAjdlvSmVX\",\"output_index\":0,\"sequence_number\":93}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" information\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"Fh4R\",\"output_index\":0,\"sequence_number\":94}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"obfuscation\":\"uRvG1bkIXKx7PnS\",\"output_index\":0,\"sequence_number\":95}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":96,\"text\":\"I will gather comprehensive information about Paris by looking up the following details:\\n\\n1. **Weather**: Current weather conditions in Paris.\\n2. **Population**: The number of people living in Paris.\\n3. **Timezone**: The timezone in which Paris is located.\\n4. **Language**: The primary language spoken in Paris.\\n5. **Currency**: The currency used in Paris.\\n\\nI will now call all five tools simultaneously to retrieve this information.\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I will gather comprehensive information about Paris by looking up the following details:\\n\\n1. **Weather**: Current weather conditions in Paris.\\n2. **Population**: The number of people living in Paris.\\n3. **Timezone**: The timezone in which Paris is located.\\n4. **Language**: The primary language spoken in Paris.\\n5. **Currency**: The currency used in Paris.\\n\\nI will now call all five tools simultaneously to retrieve this information.\"},\"sequence_number\":97}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I will gather comprehensive information about Paris by looking up the following details:\\n\\n1. **Weather**: Current weather conditions in Paris.\\n2. **Population**: The number of people living in Paris.\\n3. **Timezone**: The timezone in which Paris is located.\\n4. **Language**: The primary language spoken in Paris.\\n5. **Currency**: The currency used in Paris.\\n\\nI will now call all five tools simultaneously to retrieve this information.\"}],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":98}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_033aff9390b0c2470069b3ece5f99481978f6a01f3d85fdca5\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_AGNsx8aP99PCqkIWIJgEIHCN\",\"name\":\"getWeather\"},\"output_index\":1,\"sequence_number\":99}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_033aff9390b0c2470069b3ece5f99481978f6a01f3d85fdca5\",\"obfuscation\":\"\",\"output_index\":1,\"sequence_number\":100}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_033aff9390b0c2470069b3ece5f99481978f6a01f3d85fdca5\",\"output_index\":1,\"sequence_number\":101}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_033aff9390b0c2470069b3ece5f99481978f6a01f3d85fdca5\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_AGNsx8aP99PCqkIWIJgEIHCN\",\"name\":\"getWeather\"},\"output_index\":1,\"sequence_number\":102}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_033aff9390b0c2470069b3ece5f9a08197bfce962bd4416d1a\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_VFKsGUBb7K7hJOJI6iJHVIiC\",\"name\":\"getPopulation\"},\"output_index\":2,\"sequence_number\":103}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_033aff9390b0c2470069b3ece5f9a08197bfce962bd4416d1a\",\"obfuscation\":\"\",\"output_index\":2,\"sequence_number\":104}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_033aff9390b0c2470069b3ece5f9a08197bfce962bd4416d1a\",\"output_index\":2,\"sequence_number\":105}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_033aff9390b0c2470069b3ece5f9a08197bfce962bd4416d1a\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_VFKsGUBb7K7hJOJI6iJHVIiC\",\"name\":\"getPopulation\"},\"output_index\":2,\"sequence_number\":106}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_033aff9390b0c2470069b3ece5f9a8819787b11ed5f92f80ea\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_jw43V59AtLdgia2aQtM3Sb7F\",\"name\":\"getTimezone\"},\"output_index\":3,\"sequence_number\":107}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_033aff9390b0c2470069b3ece5f9a8819787b11ed5f92f80ea\",\"obfuscation\":\"\",\"output_index\":3,\"sequence_number\":108}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_033aff9390b0c2470069b3ece5f9a8819787b11ed5f92f80ea\",\"output_index\":3,\"sequence_number\":109}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_033aff9390b0c2470069b3ece5f9a8819787b11ed5f92f80ea\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_jw43V59AtLdgia2aQtM3Sb7F\",\"name\":\"getTimezone\"},\"output_index\":3,\"sequence_number\":110}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_033aff9390b0c2470069b3ece5f9ac81979155647de376886b\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_AJ6IIlGNQtnWPsQcZrFiq8Za\",\"name\":\"getLanguage\"},\"output_index\":4,\"sequence_number\":111}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_033aff9390b0c2470069b3ece5f9ac81979155647de376886b\",\"obfuscation\":\"\",\"output_index\":4,\"sequence_number\":112}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_033aff9390b0c2470069b3ece5f9ac81979155647de376886b\",\"output_index\":4,\"sequence_number\":113}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_033aff9390b0c2470069b3ece5f9ac81979155647de376886b\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_AJ6IIlGNQtnWPsQcZrFiq8Za\",\"name\":\"getLanguage\"},\"output_index\":4,\"sequence_number\":114}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_033aff9390b0c2470069b3ece5f9b48197bc116e61cc68eea5\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_KApzy02QwAJEXOcVbRgQHvXK\",\"name\":\"getCurrency\"},\"output_index\":5,\"sequence_number\":115}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_033aff9390b0c2470069b3ece5f9b48197bc116e61cc68eea5\",\"obfuscation\":\"\",\"output_index\":5,\"sequence_number\":116}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_033aff9390b0c2470069b3ece5f9b48197bc116e61cc68eea5\",\"output_index\":5,\"sequence_number\":117}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_033aff9390b0c2470069b3ece5f9b48197bc116e61cc68eea5\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_KApzy02QwAJEXOcVbRgQHvXK\",\"name\":\"getCurrency\"},\"output_index\":5,\"sequence_number\":118}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_033aff9390b0c2470069b3ece034f8819795d8a646bba34aa7\",\"object\":\"response\",\"created_at\":1773399264,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399269,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I will gather comprehensive information about Paris by looking up the following details:\\n\\n1. **Weather**: Current weather conditions in Paris.\\n2. **Population**: The number of people living in Paris.\\n3. **Timezone**: The timezone in which Paris is located.\\n4. **Language**: The primary language spoken in Paris.\\n5. **Currency**: The currency used in Paris.\\n\\nI will now call all five tools simultaneously to retrieve this information.\"}],\"role\":\"assistant\"},{\"id\":\"fc_033aff9390b0c2470069b3ece5f99481978f6a01f3d85fdca5\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_AGNsx8aP99PCqkIWIJgEIHCN\",\"name\":\"getWeather\"},{\"id\":\"fc_033aff9390b0c2470069b3ece5f9a08197bfce962bd4416d1a\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_VFKsGUBb7K7hJOJI6iJHVIiC\",\"name\":\"getPopulation\"},{\"id\":\"fc_033aff9390b0c2470069b3ece5f9a8819787b11ed5f92f80ea\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_jw43V59AtLdgia2aQtM3Sb7F\",\"name\":\"getTimezone\"},{\"id\":\"fc_033aff9390b0c2470069b3ece5f9ac81979155647de376886b\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_AJ6IIlGNQtnWPsQcZrFiq8Za\",\"name\":\"getLanguage\"},{\"id\":\"fc_033aff9390b0c2470069b3ece5f9b48197bc116e61cc68eea5\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_KApzy02QwAJEXOcVbRgQHvXK\",\"name\":\"getCurrency\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":271,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":181,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":452},\"user\":null,\"metadata\":{}},\"sequence_number\":119}\n\n"
+        ],
+        "chunkTimings": [
+          2, 1, 0, 1, 780, 1, 55, 4, 61, 0, 73, 65, 0, 67, 68, 0, 66, 2, 64, 1, 67, 1, 65, 2, 67, 1, 58, 1, 53, 1, 38,
+          1, 34, 0, 41, 1, 47, 0, 49, 99, 1, 47, 0, 51, 1, 8, 1, 45, 1, 57, 0, 53, 52, 31, 2, 70, 64, 0, 44, 1, 36, 0,
+          32, 2, 42, 0, 64, 2, 50, 43, 0, 53, 0, 49, 1, 78, 9, 56, 1, 66, 5, 49, 1, 56, 1, 54, 0, 24, 1, 1, 2459, 1, 2,
+          1, 1, 3, 2, 1, 3, 7, 0, 0, 0, 119
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "1a65b16638a0376c",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            },
+            {
+              "type": "item_reference",
+              "id": "msg_033aff9390b0c2470069b3ece110bc81979c3526d4d49f6508"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_033aff9390b0c2470069b3ece5f99481978f6a01f3d85fdca5"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_033aff9390b0c2470069b3ece5f9a08197bfce962bd4416d1a"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_033aff9390b0c2470069b3ece5f9a8819787b11ed5f92f80ea"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_033aff9390b0c2470069b3ece5f9ac81979155647de376886b"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_033aff9390b0c2470069b3ece5f9b48197bc116e61cc68eea5"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_AGNsx8aP99PCqkIWIJgEIHCN",
+              "output": "{\"city\":\"Paris\",\"temperature\":22,\"condition\":\"sunny\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_VFKsGUBb7K7hJOJI6iJHVIiC",
+              "output": "{\"city\":\"Paris\",\"population\":2161000}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_jw43V59AtLdgia2aQtM3Sb7F",
+              "output": "{\"city\":\"Paris\",\"timezone\":\"CET\",\"utcOffset\":\"+01:00\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_AJ6IIlGNQtnWPsQcZrFiq8Za",
+              "output": "{\"city\":\"Paris\",\"language\":\"French\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_KApzy02QwAJEXOcVbRgQHvXK",
+              "output": "{\"city\":\"Paris\",\"currency\":\"EUR\",\"symbol\":\"€\"}"
+            }
+          ],
+          "temperature": 0,
+          "tools": [
+            {
+              "type": "function",
+              "name": "getWeather",
+              "description": "Get the current weather for a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get weather for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getPopulation",
+              "description": "Get the population of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get population for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getTimezone",
+              "description": "Get the timezone of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get timezone for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getLanguage",
+              "description": "Get the primary language spoken in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the language for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getCurrency",
+              "description": "Get the currency used in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the currency for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399270193
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba803f1c20b744-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:54:30 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "121",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_74a6c4fe31574fd09bfa27b5d5a10abd"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_033aff9390b0c2470069b3ece65be0819782b8bd9d9e06f02b\",\"object\":\"response\",\"created_at\":1773399270,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_033aff9390b0c2470069b3ece65be0819782b8bd9d9e06f02b\",\"object\":\"response\",\"created_at\":1773399270,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Here\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"PxG3BqPS9TG3\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"TaXdYiP5EQuqt\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"Zuoc433MUfRc\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" comprehensive\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"3t\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" city\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"lPnz3Rq2UXt\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" report\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"b3Q22bFMd\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" for\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"oV4cqwCHseTH\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"DTQtboKWw5\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\\n\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"N1jja5bM0AaYW\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"1\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"vLUY2x4HYXi2etn\",\"output_index\":0,\"sequence_number\":13}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"gRCVoDllysX1Fri\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"k6culppDCDeLr\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Weather\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"H2OUpLEx9\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"nOiYd7eQhZogDk\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"RdXaRO62vFNHHyg\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"sIpYKneiYrTW\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" current\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"RsM0Se6c\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" weather\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"7ozJ0zM0\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"EghwgPe5MVTjV\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"0YRDI3cE8W\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"q3v2o5I7J1PaQ\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" sunny\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"nD7mU7RCgq\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" with\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"bkSGbwAkA3f\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"sbIJY4AeFraIy7\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" temperature\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"nZ7j\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"sJ707pteqbwhi\",\"output_index\":0,\"sequence_number\":29}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"ac2CAKHFoa9zV3y\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"22\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"U41AufY7MLJRWj\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"°C\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"Pggu0AAqfqbF2Q\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"IB6k8YJiAcGp6\",\"output_index\":0,\"sequence_number\":33}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"UpcqmtqAdM40Ja2\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"ebBuh3cYtsavs7O\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"cHLMiWTvkw6IF\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Population\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"2ijnt8\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"914hwBqARtFUOP\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"er8ZpdIvUiC7G9y\",\"output_index\":0,\"sequence_number\":39}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"EWK5yUoTok\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" has\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"yWML0iXHFYmV\",\"output_index\":0,\"sequence_number\":41}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"NNK5flnbkpKGtz\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" population\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"1ntgU\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"EXwgEUqxBXUWX\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" approximately\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"2a\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"NtDOIGvzIIpL8FX\",\"output_index\":0,\"sequence_number\":46}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"iZ1fGPFxyPmw4TH\",\"output_index\":0,\"sequence_number\":47}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"1b0FMDIkTUfYuMz\",\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"161\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"ZuHgzsgV4fCPV\",\"output_index\":0,\"sequence_number\":49}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"L0eLDrir7Frpcg2\",\"output_index\":0,\"sequence_number\":50}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"000\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"corcCxKA4YqnG\",\"output_index\":0,\"sequence_number\":51}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" people\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"36AAZ956L\",\"output_index\":0,\"sequence_number\":52}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"vgLePhOiNemem\",\"output_index\":0,\"sequence_number\":53}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"3\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"DFTAkFu8aGJaq7E\",\"output_index\":0,\"sequence_number\":54}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"k5iGfgAxgFbvcj3\",\"output_index\":0,\"sequence_number\":55}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"x8xUtoCemN3jY\",\"output_index\":0,\"sequence_number\":56}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Timezone\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"jfsSBZYh\",\"output_index\":0,\"sequence_number\":57}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"qgR0IAUp4RZPo1\",\"output_index\":0,\"sequence_number\":58}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"vwTtaJ3KfK9TnrW\",\"output_index\":0,\"sequence_number\":59}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"gj54ycVC1d\",\"output_index\":0,\"sequence_number\":60}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"oAfC9BuEZHSSZ\",\"output_index\":0,\"sequence_number\":61}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"ebyiRiA9JFn70\",\"output_index\":0,\"sequence_number\":62}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"N1dEWpvo49gU\",\"output_index\":0,\"sequence_number\":63}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Central\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"wFTnt4ME\",\"output_index\":0,\"sequence_number\":64}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" European\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"88TJJHA\",\"output_index\":0,\"sequence_number\":65}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Time\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"Timj8u9KlYH\",\"output_index\":0,\"sequence_number\":66}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"jMJzM3sceLB9OA\",\"output_index\":0,\"sequence_number\":67}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"C\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"JwTrbb8AVCng2VQ\",\"output_index\":0,\"sequence_number\":68}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"ET\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"kSmKdfyo8dKvZ6\",\"output_index\":0,\"sequence_number\":69}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\")\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"2quJIXOqHyzNBER\",\"output_index\":0,\"sequence_number\":70}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" timezone\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"e7PF53m\",\"output_index\":0,\"sequence_number\":71}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"PXNgFwGUJUlNf6Y\",\"output_index\":0,\"sequence_number\":72}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" with\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"tLqLM4YBygV\",\"output_index\":0,\"sequence_number\":73}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"HIff2KgNxy2AuP\",\"output_index\":0,\"sequence_number\":74}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" UTC\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"zBVtD5oARsk0\",\"output_index\":0,\"sequence_number\":75}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" offset\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"1cVQDR2V8\",\"output_index\":0,\"sequence_number\":76}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"04GDpcIE7lyOb\",\"output_index\":0,\"sequence_number\":77}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" +\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"6xjdrUtPb7Iglt\",\"output_index\":0,\"sequence_number\":78}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"01\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"T0eqJAMLn7x5we\",\"output_index\":0,\"sequence_number\":79}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"zoxSSOX9GOSCRmA\",\"output_index\":0,\"sequence_number\":80}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"00\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"ubb5JbKm6Ev82N\",\"output_index\":0,\"sequence_number\":81}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"91MsiXCCSXpux\",\"output_index\":0,\"sequence_number\":82}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"4\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"YR64vj8zD5JaaqX\",\"output_index\":0,\"sequence_number\":83}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"K2u8quIhgI77SPd\",\"output_index\":0,\"sequence_number\":84}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"crXjifvVHjFz8\",\"output_index\":0,\"sequence_number\":85}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Language\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"spqNGZvV\",\"output_index\":0,\"sequence_number\":86}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"a0oItvWacclg59\",\"output_index\":0,\"sequence_number\":87}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"lyGu0McXbOQaPZq\",\"output_index\":0,\"sequence_number\":88}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"azFNrYp0xlcB\",\"output_index\":0,\"sequence_number\":89}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" primary\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"ctHuUckL\",\"output_index\":0,\"sequence_number\":90}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" language\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"xriISFR\",\"output_index\":0,\"sequence_number\":91}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" spoken\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"zUf5zg0Ox\",\"output_index\":0,\"sequence_number\":92}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"9gwTHdBCdhNjD\",\"output_index\":0,\"sequence_number\":93}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"m1WeFKmkVU\",\"output_index\":0,\"sequence_number\":94}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"XkRSVNtDRhb6B\",\"output_index\":0,\"sequence_number\":95}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" French\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"lisNgdvFm\",\"output_index\":0,\"sequence_number\":96}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"lsZ3gYINudcvn\",\"output_index\":0,\"sequence_number\":97}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"5\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"jFXsFYOfjmyW9Rc\",\"output_index\":0,\"sequence_number\":98}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"Z1hQDOTdO9pPQhG\",\"output_index\":0,\"sequence_number\":99}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"VVz9liYz2DkCO\",\"output_index\":0,\"sequence_number\":100}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Currency\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"QDBKBkO7\",\"output_index\":0,\"sequence_number\":101}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"KSliIZCWn26CUz\",\"output_index\":0,\"sequence_number\":102}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"vPuKt6nBoxhRwBq\",\"output_index\":0,\"sequence_number\":103}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"14jyu85gJ0mh\",\"output_index\":0,\"sequence_number\":104}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" currency\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"Q0UB35x\",\"output_index\":0,\"sequence_number\":105}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" used\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"r7PTUdyu5BD\",\"output_index\":0,\"sequence_number\":106}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"bNU3RPGUNYhxP\",\"output_index\":0,\"sequence_number\":107}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"nTCFPmeWsQ\",\"output_index\":0,\"sequence_number\":108}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"hmMVxNaiZu5iF\",\"output_index\":0,\"sequence_number\":109}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"ircL37gSy0h0\",\"output_index\":0,\"sequence_number\":110}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Euro\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"UakCM41ze1A\",\"output_index\":0,\"sequence_number\":111}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"FtEH2gpuKvJZvy\",\"output_index\":0,\"sequence_number\":112}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"EUR\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"pSryc90mmgVOz\",\"output_index\":0,\"sequence_number\":113}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"),\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"FZPiqqTnakV2b2\",\"output_index\":0,\"sequence_number\":114}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" symbol\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"qfqJZL1xA\",\"output_index\":0,\"sequence_number\":115}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"ized\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"1uIk7R1VSCHu\",\"output_index\":0,\"sequence_number\":116}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" by\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"XUbTfMJCR0XdY\",\"output_index\":0,\"sequence_number\":117}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" €\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"f4fERDnoa4EQqr\",\"output_index\":0,\"sequence_number\":118}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"lQZvejc4nbqpt\",\"output_index\":0,\"sequence_number\":119}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"If\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"nEEVad4u9F46EU\",\"output_index\":0,\"sequence_number\":120}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" you\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"KpE9wpjycFvu\",\"output_index\":0,\"sequence_number\":121}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" need\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"WIvhaewCECX\",\"output_index\":0,\"sequence_number\":122}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" any\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"pQJk6xUJurJG\",\"output_index\":0,\"sequence_number\":123}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" more\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"pOKKWb2ugqN\",\"output_index\":0,\"sequence_number\":124}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" information\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"1iOs\",\"output_index\":0,\"sequence_number\":125}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" or\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"3YYAxwH4zfg98\",\"output_index\":0,\"sequence_number\":126}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" details\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"3M6VFTMH\",\"output_index\":0,\"sequence_number\":127}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"Ok6Lsv8WW5iIKTz\",\"output_index\":0,\"sequence_number\":128}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" feel\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"GpKwe6dPZ2w\",\"output_index\":0,\"sequence_number\":129}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" free\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"7dCfFn7g6dm\",\"output_index\":0,\"sequence_number\":130}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" to\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"bH0j7c8pPOgnd\",\"output_index\":0,\"sequence_number\":131}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" ask\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"tqtQvkYjvhHH\",\"output_index\":0,\"sequence_number\":132}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"!\",\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"obfuscation\":\"iEWtUXMjpHz55F1\",\"output_index\":0,\"sequence_number\":133}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":134,\"text\":\"Here is the comprehensive city report for Paris:\\n\\n1. **Weather**: The current weather in Paris is sunny with a temperature of 22°C.\\n\\n2. **Population**: Paris has a population of approximately 2,161,000 people.\\n\\n3. **Timezone**: Paris is in the Central European Time (CET) timezone, with a UTC offset of +01:00.\\n\\n4. **Language**: The primary language spoken in Paris is French.\\n\\n5. **Currency**: The currency used in Paris is the Euro (EUR), symbolized by €.\\n\\nIf you need any more information or details, feel free to ask!\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here is the comprehensive city report for Paris:\\n\\n1. **Weather**: The current weather in Paris is sunny with a temperature of 22°C.\\n\\n2. **Population**: Paris has a population of approximately 2,161,000 people.\\n\\n3. **Timezone**: Paris is in the Central European Time (CET) timezone, with a UTC offset of +01:00.\\n\\n4. **Language**: The primary language spoken in Paris is French.\\n\\n5. **Currency**: The currency used in Paris is the Euro (EUR), symbolized by €.\\n\\nIf you need any more information or details, feel free to ask!\"},\"sequence_number\":135}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here is the comprehensive city report for Paris:\\n\\n1. **Weather**: The current weather in Paris is sunny with a temperature of 22°C.\\n\\n2. **Population**: Paris has a population of approximately 2,161,000 people.\\n\\n3. **Timezone**: Paris is in the Central European Time (CET) timezone, with a UTC offset of +01:00.\\n\\n4. **Language**: The primary language spoken in Paris is French.\\n\\n5. **Currency**: The currency used in Paris is the Euro (EUR), symbolized by €.\\n\\nIf you need any more information or details, feel free to ask!\"}],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":136}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_033aff9390b0c2470069b3ece65be0819782b8bd9d9e06f02b\",\"object\":\"response\",\"created_at\":1773399270,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399273,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_033aff9390b0c2470069b3ece6d90481979f94b2548b23deaa\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here is the comprehensive city report for Paris:\\n\\n1. **Weather**: The current weather in Paris is sunny with a temperature of 22°C.\\n\\n2. **Population**: Paris has a population of approximately 2,161,000 people.\\n\\n3. **Timezone**: Paris is in the Central European Time (CET) timezone, with a UTC offset of +01:00.\\n\\n4. **Language**: The primary language spoken in Paris is French.\\n\\n5. **Currency**: The currency used in Paris is the Euro (EUR), symbolized by €.\\n\\nIf you need any more information or details, feel free to ask!\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":529,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":132,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":661},\"user\":null,\"metadata\":{}},\"sequence_number\":137}\n\n"
+        ],
+        "chunkTimings": [
+          9, 3, 441, 1, 0, 0, 0, 20, 1, 47, 1, 40, 0, 44, 1, 50, 0, 54, 1, 31, 1, 37, 1, 46, 4, 37, 5, 22, 1, 45, 1, 36,
+          2, 28, 0, 47, 1, 37, 0, 39, 1, 49, 0, 47, 1, 52, 1, 70, 1, 30, 1, 38, 0, 50, 0, 47, 0, 55, 1, 47, 1, 39, 0,
+          55, 1, 65, 11, 33, 2, 57, 0, 47, 0, 55, 117, 5, 0, 57, 0, 68, 0, 54, 0, 59, 0, 52, 2, 46, 2, 59, 0, 64, 3, 24,
+          0, 24, 0, 27, 2, 44, 1, 55, 0, 62, 0, 64, 2, 36, 1, 58, 5, 60, 1, 61, 1, 59, 0, 33, 0, 29, 0, 31, 0, 46, 1,
+          43, 3, 81, 2, 4, 7, 4, 39, 4, 7, 117
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "b3084eece22a7052",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            }
+          ],
+          "temperature": 0,
+          "tools": [
+            {
+              "type": "function",
+              "name": "getWeather",
+              "description": "Get the current weather for a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get weather for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getPopulation",
+              "description": "Get the population of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get population for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getTimezone",
+              "description": "Get the timezone of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get timezone for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getLanguage",
+              "description": "Get the primary language spoken in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the language for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getCurrency",
+              "description": "Get the currency used in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the currency for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399274152
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba80580af9ba5d-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:54:34 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "81",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_62365ccbb77a477baa99bac43f58c079"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0d20550ae04819510069b3ecea5c8c8193b5b1e6c670270c95\",\"object\":\"response\",\"created_at\":1773399274,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTi",
+          "mezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0d20550ae04819510069b3ecea5c8c8193b5b1e6c670270c95\",\"object\":\"response\",\"created_at\":1773399274,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name",
+          "\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"I\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"HDaMWItjKiFBRuW\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" will\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"mbhvsxUGy4w\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" gather\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"KJRpdt7VX\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" comprehensive\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"Gh\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" information\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"3XQT\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" about\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"VgcSlfAqtB\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"Y7GyomyjUX\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" by\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"jKQhHTjzyPmVA\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" looking\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"OaTX7rp5\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" up\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"SsT0Rna9N3zCh\",\"output_index\":0,\"sequence_number\":13}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"IPIw1NMoijbd\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" following\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"SmOgYJ\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" details\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"pEUZ8Arb\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\\n\\n\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"B2oeMX1kN6Ztb\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"1\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"Gay8qY3RKHKq8up\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"BvtSKuF9iDdJwpC\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"65tVMQQE7Eoxg\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Weather\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"VKRvvSpPX\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"XMWyVial6mZOWL\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"WJCnDkHvcK4uEdD\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Current\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"bcIiLVpM\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" weather\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"E1cayxUk\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" conditions\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"cVjZy\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"wwL3BU2DHHiMG\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"LA6kz6aNV6\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"FzNTYew5jL7wf0\",\"output_index\":0,\"sequence_number\":29}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"8q0kAxLVbeDXC2C\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"UHQ26Svp0QHTbXi\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"1OfY8vbpTPOF2\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Population\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"za3g0h\",\"output_index\":0,\"sequence_number\":33}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"vvIvQjnExIOTL7\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"a6xoJ2ohngI8DLa\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"t3b363Ub7u9D\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" number\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"Haw6ahmwa\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"9e6AfljgzPVZ8\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" people\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"cugxy7uUb\",\"output_index\":0,\"sequence_number\":39}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" living\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"8PasU7nBW\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"z6yRA6syXuTNe\",\"output_index\":0,\"sequence_number\":41}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"wBPColOAHH\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"jC2d10KxgvecGO\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"3\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"Tw0kfhFgTM80LnV\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"IkEGgmR28F9TArK\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"GnUpNOi2U9yfg\",\"output_index\":0,\"sequence_number\":46}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Timezone\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"xdlAVpHp\",\"output_index\":0,\"sequence_number\":47}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"5aUGUyW009gvQj\",\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"o8vOs0lVtqxIalB\",\"output_index\":0,\"sequence_number\":49}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"IFe8vFlQHUY0\",\"output_index\":0,\"sequence_number\":50}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" timezone\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"y3WGMDl\",\"output_index\":0,\"sequence_number\":51}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"NlzKhjL0jX7zJ\",\"output_index\":0,\"sequence_number\":52}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" which\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"cxU4HZJX9h\",\"output_index\":0,\"sequence_number\":53}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"FXoIk9Uboe\",\"output_index\":0,\"sequence_number\":54}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"CR01iPEYDG3jk\",\"output_index\":0,\"sequence_number\":55}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" located\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"Qi3gV163\",\"output_index\":0,\"sequence_number\":56}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"wAcLri2I0fyOMr\",\"output_index\":0,\"sequence_number\":57}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"4\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"zo6cNqJM8K59tzk\",\"output_index\":0,\"sequence_number\":58}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"qw6er78w1Kltsrh\",\"output_index\":0,\"sequence_number\":59}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"FLML7vp5Njuil\",\"output_index\":0,\"sequence_number\":60}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Language\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"UuVuOgOP\",\"output_index\":0,\"sequence_number\":61}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"Kz1e5sz9NJNh92\",\"output_index\":0,\"sequence_number\":62}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"zEsj7DW0TYacg3y\",\"output_index\":0,\"sequence_number\":63}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"vUxGYsIzaG2p\",\"output_index\":0,\"sequence_number\":64}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" primary\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"ZyZCEetS\",\"output_index\":0,\"sequence_number\":65}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" language\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"kOFKK69\",\"output_index\":0,\"sequence_number\":66}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" spoken\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"XXqg6qI9A\",\"output_index\":0,\"sequence_number\":67}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"vpWGmlfcaTDTi\",\"output_index\":0,\"sequence_number\":68}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"tsSmQWJFxh\",\"output_index\":0,\"sequence_number\":69}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"DFjxAN0USzkszf\",\"output_index\":0,\"sequence_number\":70}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"5\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"IBusp1RhcXFI9nw\",\"output_index\":0,\"sequence_number\":71}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"QXHiCm66OoJz1n6\",\"output_index\":0,\"sequence_number\":72}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"P12kPiJJtx1zq\",\"output_index\":0,\"sequence_number\":73}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Currency\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"zpCTcHAv\",\"output_index\":0,\"sequence_number\":74}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"Xlr2BvtEkeDlcQ\",\"output_index\":0,\"sequence_number\":75}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"OKG6zz48dcxI0NP\",\"output_index\":0,\"sequence_number\":76}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"mku7oYczUOmE\",\"output_index\":0,\"sequence_number\":77}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" currency\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"ifgI1mc\",\"output_index\":0,\"sequence_number\":78}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" used\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"Q0lGklBLq0Y\",\"output_index\":0,\"sequence_number\":79}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"hDCMYCUGVkJa5\",\"output_index\":0,\"sequence_number\":80}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"RCHt9OJaJY\",\"output_index\":0,\"sequence_number\":81}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"vKnxbbflOI3xC\",\"output_index\":0,\"sequence_number\":82}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"I\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"pp12EYWUIDxyc9J\",\"output_index\":0,\"sequence_number\":83}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" will\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"szFB1Kzz6BH\",\"output_index\":0,\"sequence_number\":84}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" now\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"EHt4e5KXj1iu\",\"output_index\":0,\"sequence_number\":85}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" call\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"hNUOhgh5cMk\",\"output_index\":0,\"sequence_number\":86}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" all\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"NGXJb0rrE5RW\",\"output_index\":0,\"sequence_number\":87}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" five\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"DaCoxMpxulj\",\"output_index\":0,\"sequence_number\":88}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" tools\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"JGRJcdPsqJ\",\"output_index\":0,\"sequence_number\":89}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" simultaneously\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"3\",\"output_index\":0,\"sequence_number\":90}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" to\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"TY5dJi3pg1dXZ\",\"output_index\":0,\"sequence_number\":91}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" retrieve\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"5YmAKj3\",\"output_index\":0,\"sequence_number\":92}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" this\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"Am5RyVwUCQ9\",\"output_index\":0,\"sequence_number\":93}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" information\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"b1xJ\",\"output_index\":0,\"sequence_number\":94}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"obfuscation\":\"SC6ZydPyOaJ2xeA\",\"output_index\":0,\"sequence_number\":95}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":96,\"text\":\"I will gather comprehensive information about Paris by looking up the following details:\\n\\n1. **Weather**: Current weather conditions in Paris.\\n2. **Population**: The number of people living in Paris.\\n3. **Timezone**: The timezone in which Paris is located.\\n4. **Language**: The primary language spoken in Paris.\\n5. **Currency**: The currency used in Paris.\\n\\nI will now call all five tools simultaneously to retrieve this information.\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I will gather comprehensive information about Paris by looking up the following details:\\n\\n1. **Weather**: Current weather conditions in Paris.\\n2. **Population**: The number of people living in Paris.\\n3. **Timezone**: The timezone in which Paris is located.\\n4. **Language**: The primary language spoken in Paris.\\n5. **Currency**: The currency used in Paris.\\n\\nI will now call all five tools simultaneously to retrieve this information.\"},\"sequence_number\":97}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I will gather comprehensive information about Paris by looking up the following details:\\n\\n1. **Weather**: Current weather conditions in Paris.\\n2. **Population**: The number of people living in Paris.\\n3. **Timezone**: The timezone in which Paris is located.\\n4. **Language**: The primary language spoken in Paris.\\n5. **Currency**: The currency used in Paris.\\n\\nI will now call all five tools simultaneously to retrieve this information.\"}],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":98}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0d20550ae04819510069b3ecf2f1bc81938a23a952e3c18436\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_EqATlFl64IP30ZXprtY75a4p\",\"name\":\"getWeather\"},\"output_index\":1,\"sequence_number\":99}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_0d20550ae04819510069b3ecf2f1bc81938a23a952e3c18436\",\"obfuscation\":\"\",\"output_index\":1,\"sequence_number\":100}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_0d20550ae04819510069b3ecf2f1bc81938a23a952e3c18436\",\"output_index\":1,\"sequence_number\":101}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0d20550ae04819510069b3ecf2f1bc81938a23a952e3c18436\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_EqATlFl64IP30ZXprtY75a4p\",\"name\":\"getWeather\"},\"output_index\":1,\"sequence_number\":102}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0d20550ae04819510069b3ecf2f1d08193a572a65fccc6e956\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_RQWInpf7kLnsyBgnEbaMYxEi\",\"name\":\"getPopulation\"},\"output_index\":2,\"sequence_number\":103}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_0d20550ae04819510069b3ecf2f1d08193a572a65fccc6e956\",\"obfuscation\":\"\",\"output_index\":2,\"sequence_number\":104}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_0d20550ae04819510069b3ecf2f1d08193a572a65fccc6e956\",\"output_index\":2,\"sequence_number\":105}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0d20550ae04819510069b3ecf2f1d08193a572a65fccc6e956\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_RQWInpf7kLnsyBgnEbaMYxEi\",\"name\":\"getPopulation\"},\"output_index\":2,\"sequence_number\":106}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0d20550ae04819510069b3ecf2f1d88193bbc38158a8edc4e4\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_rqLPG1Ze0xl1e3WoHTKyOTkr\",\"name\":\"getTimezone\"},\"output_index\":3,\"sequence_number\":107}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_0d20550ae04819510069b3ecf2f1d88193bbc38158a8edc4e4\",\"obfuscation\":\"\",\"output_index\":3,\"sequence_number\":108}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_0d20550ae04819510069b3ecf2f1d88193bbc38158a8edc4e4\",\"output_index\":3,\"sequence_number\":109}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0d20550ae04819510069b3ecf2f1d88193bbc38158a8edc4e4\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_rqLPG1Ze0xl1e3WoHTKyOTkr\",\"name\":\"getTimezone\"},\"output_index\":3,\"sequence_number\":110}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0d20550ae04819510069b3ecf2f1e08193a96c5357ac29139e\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_pYffLAqTENucrSxRoPThhOEX\",\"name\":\"getLanguage\"},\"output_index\":4,\"sequence_number\":111}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_0d20550ae04819510069b3ecf2f1e08193a96c5357ac29139e\",\"obfuscation\":\"\",\"output_index\":4,\"sequence_number\":112}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_0d20550ae04819510069b3ecf2f1e08193a96c5357ac29139e\",\"output_index\":4,\"sequence_number\":113}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0d20550ae04819510069b3ecf2f1e08193a96c5357ac29139e\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_pYffLAqTENucrSxRoPThhOEX\",\"name\":\"getLanguage\"},\"output_index\":4,\"sequence_number\":114}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0d20550ae04819510069b3ecf2f1e88193851349c56332aa6b\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_9TG9E3lU4dsa6zlZS1RpKZAT\",\"name\":\"getCurrency\"},\"output_index\":5,\"sequence_number\":115}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_0d20550ae04819510069b3ecf2f1e88193851349c56332aa6b\",\"obfuscation\":\"\",\"output_index\":5,\"sequence_number\":116}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_0d20550ae04819510069b3ecf2f1e88193851349c56332aa6b\",\"output_index\":5,\"sequence_number\":117}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0d20550ae04819510069b3ecf2f1e88193851349c56332aa6b\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_9TG9E3lU4dsa6zlZS1RpKZAT\",\"name\":\"getCurrency\"},\"output_index\":5,\"sequence_number\":118}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0d20550ae04819510069b3ecea5c8c8193b5b1e6c670270c95\",\"object\":\"response\",\"created_at\":1773399274,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399282,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I will gather comprehensive information about Paris by looking up the following details:\\n\\n1. **Weather**: Current weather conditions in Paris.\\n2. **Population**: The number of people living in Paris.\\n3. **Timezone**: The timezone in which Paris is located.\\n4. **Language**: The primary language spoken in Paris.\\n5. **Currency**: The currency used in Paris.\\n\\nI will now call all five tools simultaneously to retrieve this information.\"}],\"role\":\"assistant\"},{\"id\":\"fc_0d20550ae04819510069b3ecf2f1bc81938a23a952e3c18436\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_EqATlFl64IP30ZXprtY75a4p\",\"name\":\"getWeather\"},{\"id\":\"fc_0d20550ae04819510069b3ecf2f1d08193a572a65fccc6e956\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_RQWInpf7kLnsyBgnEbaMYxEi\",\"name\":\"getPopulation\"},{\"id\":\"fc_0d20550ae04819510069b3ecf2f1d88193bbc38158a8edc4e4\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_rqLPG1Ze0xl1e3WoHTKyOTkr\",\"name\":\"getTimezone\"},{\"id\":\"fc_0d20550ae04819510069b3ecf2f1e08193a96c5357ac29139e\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_pYffLAqTENucrSxRoPThhOEX\",\"name\":\"getLanguage\"},{\"id\":\"fc_0d20550ae04819510069b3ecf2f1e88193851349c56332aa6b\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_9TG9E3lU4dsa6zlZS1RpKZAT\",\"name\":\"getCurrency\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":271,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":181,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":452},\"user\":null,\"metadata\":{}},\"sequence_number\":119}\n\n"
+        ],
+        "chunkTimings": [
+          2, 0, 6, 0, 908, 0, 0, 65, 1, 64, 1, 67, 1, 68, 1, 66, 64, 2, 64, 2, 65, 1, 66, 1, 65, 0, 66, 1, 66, 1, 64, 1,
+          66, 1, 65, 0, 66, 3, 64, 3, 65, 1, 67, 0, 66, 1, 79, 1, 54, 3, 64, 0, 68, 3, 62, 0, 69, 0, 64, 3, 64, 1, 166,
+          1, 74, 1, 68, 0, 65, 1, 68, 1, 114, 1, 68, 1, 64, 1, 297, 0, 64, 0, 71, 1, 71, 0, 75, 1, 79, 0, 85, 0, 81, 1,
+          48, 2, 4, 4167, 1, 1, 2, 1, 3, 4, 0, 1, 4, 98, 2, 24
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "d49adf974ba00600",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            },
+            {
+              "type": "item_reference",
+              "id": "msg_0d20550ae04819510069b3eceb57e88193981f819a258f0c7a"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_0d20550ae04819510069b3ecf2f1bc81938a23a952e3c18436"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_0d20550ae04819510069b3ecf2f1d08193a572a65fccc6e956"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_0d20550ae04819510069b3ecf2f1d88193bbc38158a8edc4e4"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_0d20550ae04819510069b3ecf2f1e08193a96c5357ac29139e"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_0d20550ae04819510069b3ecf2f1e88193851349c56332aa6b"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_EqATlFl64IP30ZXprtY75a4p",
+              "output": "{\"city\":\"Paris\",\"temperature\":22,\"condition\":\"sunny\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_RQWInpf7kLnsyBgnEbaMYxEi",
+              "output": "{\"city\":\"Paris\",\"population\":2161000}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_rqLPG1Ze0xl1e3WoHTKyOTkr",
+              "output": "{\"city\":\"Paris\",\"timezone\":\"CET\",\"utcOffset\":\"+01:00\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_pYffLAqTENucrSxRoPThhOEX",
+              "output": "{\"city\":\"Paris\",\"language\":\"French\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_9TG9E3lU4dsa6zlZS1RpKZAT",
+              "output": "{\"city\":\"Paris\",\"currency\":\"EUR\",\"symbol\":\"€\"}"
+            }
+          ],
+          "temperature": 0,
+          "tools": [
+            {
+              "type": "function",
+              "name": "getWeather",
+              "description": "Get the current weather for a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get weather for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getPopulation",
+              "description": "Get the population of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get population for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getTimezone",
+              "description": "Get the timezone of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get timezone for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getLanguage",
+              "description": "Get the primary language spoken in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the language for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getCurrency",
+              "description": "Get the currency used in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the currency for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399283154
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba80905b58fc93-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:54:43 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "150",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_eb635395ad3d41948ef8cc9ca1874052"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0d20550ae04819510069b3ecf3c784819392924e20aff1fc9a\",\"object\":\"response\",\"created_at\":1773399283,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"promp",
+          "t_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\"",
+          ":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0d20550ae04819510069b3ecf3c784819392924e20aff1fc9a\",\"object\":\"response\",\"created_at\":1773399283,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name",
+          "\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Here\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"5rfSHpa4UjUN\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"XZJfo1k6fNfKj\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"eRZQWyHvqrB7\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" comprehensive\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"Gb\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" city\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"3YfRtUD6MfJ\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" report\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"UE5L7VZLt\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" for\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"KnvZ3QuzQf4I\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"BrZAQvYzx1\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\\n\\n\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"ZtjsO4Np3H3Xe\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"1\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"KufjmY0MVxjYMxt\",\"output_index\":0,\"sequence_number\":13}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"0ChYxFkCLnyQjPX\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"eS7OkME8q3Z6S\",\"output_index\":0,\"sequence_number\":15}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Weather\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"krtSjFMZd\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"sEDaglKcX57x6N\",\"output_index\":0,\"sequence_number\":17}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"7SpW1npK61hBwDl\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"1MfpC7OPYEQx\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" current\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"89nAxpnC\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" weather\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"Pvyaqm3u\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"Tm4K0V0NzLDKi\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"M2ww5e4hxO\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"QEsytPkZoXctJ\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" sunny\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"OBtgLOnXS3\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" with\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"KnWr8AyYBLc\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"1RA6kYPFP7HUoj\",\"output_index\":0,\"sequence_number\":27}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" temperature\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"zHwn\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"Pjg50JBniXiXt\",\"output_index\":0,\"sequence_number\":29}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"5jx6I9itIGOKF14\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"22\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"v5MWwxZ36zT0g9\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"°C\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"Wis1goXutDLdx7\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"lMljtFlcjzSDY\",\"output_index\":0,\"sequence_number\":33}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"8b8LpNBxPef6JUb\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"cpDb75Hw6Qqp2rN\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"AoW4bw2M4poNp\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Population\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"7BkgjE\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"Z6lYRSZ4D2rH4d\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"lZM6iOP9FR7YWqA\",\"output_index\":0,\"sequence_number\":39}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"OibfssNWb9\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" has\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"Z3HAfV7xl4UX\",\"output_index\":0,\"sequence_number\":41}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"xjgaBu8QaawnrG\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" population\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"oroy8\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"aXdsvECGgHwBQ\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" approximately\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"Yl\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"4VE81hC5IbhZKgC\",\"output_index\":0,\"sequence_number\":46}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"ztcEXHKkGdh7ZSx\",\"output_index\":0,\"sequence_number\":47}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"qNoWdrmeMjQ4TC4\",\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"161\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"H3f1eyp0390w7\",\"output_index\":0,\"sequence_number\":49}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"kLg9FBPlufFSIRo\",\"output_index\":0,\"sequence_number\":50}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"000\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"4evoAbH8WRi2M\",\"output_index\":0,\"sequence_number\":51}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" people\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"YS6X6Sred\",\"output_index\":0,\"sequence_number\":52}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"7tsxNw6wKw10K\",\"output_index\":0,\"sequence_number\":53}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"3\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"TFkzOBSK5ZGajul\",\"output_index\":0,\"sequence_number\":54}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"84emXWB7pEhE1Dy\",\"output_index\":0,\"sequence_number\":55}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"aBZHrkBtCIaVg\",\"output_index\":0,\"sequence_number\":56}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Timezone\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"acpegrWm\",\"output_index\":0,\"sequence_number\":57}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"pzh9pHtDNkwiUA\",\"output_index\":0,\"sequence_number\":58}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"k7puXdfDwlpHjHt\",\"output_index\":0,\"sequence_number\":59}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"TTpVzv2q5A\",\"output_index\":0,\"sequence_number\":60}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"X3zsAMz52KHl3\",\"output_index\":0,\"sequence_number\":61}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"ssbMz8VeajaC8\",\"output_index\":0,\"sequence_number\":62}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"VedqO9VfBbVE\",\"output_index\":0,\"sequence_number\":63}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Central\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"eXvZAO8S\",\"output_index\":0,\"sequence_number\":64}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" European\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"D5Klbad\",\"output_index\":0,\"sequence_number\":65}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Time\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"4Hd8OmCKCKc\",\"output_index\":0,\"sequence_number\":66}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"S4AceClFGoKrk3\",\"output_index\":0,\"sequence_number\":67}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"C\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"RT15Lq1ZOBexDXn\",\"output_index\":0,\"sequence_number\":68}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"ET\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"YzcWdxq2BJe2AX\",\"output_index\":0,\"sequence_number\":69}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\")\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"5MoXi54KcIun7ox\",\"output_index\":0,\"sequence_number\":70}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" timezone\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"EL4CTQm\",\"output_index\":0,\"sequence_number\":71}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"HinUsMWQruHJ98J\",\"output_index\":0,\"sequence_number\":72}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" with\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"KMZ5OZztVlw\",\"output_index\":0,\"sequence_number\":73}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"FhrwRCaabnxdNy\",\"output_index\":0,\"sequence_number\":74}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" UTC\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"ObrGDacbj2Lk\",\"output_index\":0,\"sequence_number\":75}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" offset\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"GhdLhD1w4\",\"output_index\":0,\"sequence_number\":76}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"sTbNC9BoVQudR\",\"output_index\":0,\"sequence_number\":77}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" +\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"mZTP7GXxDc9NZT\",\"output_index\":0,\"sequence_number\":78}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"01\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"iu65UJhhXbAJwO\",\"output_index\":0,\"sequence_number\":79}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"2KJeib9trUYFvP1\",\"output_index\":0,\"sequence_number\":80}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"00\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"VzEaowSg5Q947Q\",\"output_index\":0,\"sequence_number\":81}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"3fJvHGSYtQxwH\",\"output_index\":0,\"sequence_number\":82}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"4\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"lG5Ek5mctwKECEQ\",\"output_index\":0,\"sequence_number\":83}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"47q6ecuuxJL9BwW\",\"output_index\":0,\"sequence_number\":84}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"TQ2ga7Qen1CKh\",\"output_index\":0,\"sequence_number\":85}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Language\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"ztYePofA\",\"output_index\":0,\"sequence_number\":86}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"wwAJWZ89xRyiT4\",\"output_index\":0,\"sequence_number\":87}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"0ZnC5unmL9J7J0o\",\"output_index\":0,\"sequence_number\":88}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"YYjHw3WElKkI\",\"output_index\":0,\"sequence_number\":89}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" primary\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"YCbh0o1A\",\"output_index\":0,\"sequence_number\":90}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" language\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"FgW0rpD\",\"output_index\":0,\"sequence_number\":91}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" spoken\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"RyoLyXjmi\",\"output_index\":0,\"sequence_number\":92}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"qmq4QwqOCksaA\",\"output_index\":0,\"sequence_number\":93}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"Pofab83dzk\",\"output_index\":0,\"sequence_number\":94}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"57DQgnVyUiQlW\",\"output_index\":0,\"sequence_number\":95}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" French\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"LdcmPapTo\",\"output_index\":0,\"sequence_number\":96}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"lAoKDrvE4nybk\",\"output_index\":0,\"sequence_number\":97}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"5\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"0eeYdwgy8kihPCP\",\"output_index\":0,\"sequence_number\":98}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"mHoVmVb8w4d09La\",\"output_index\":0,\"sequence_number\":99}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"GnNWwy460q2NA\",\"output_index\":0,\"sequence_number\":100}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Currency\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"aKEyO8Xd\",\"output_index\":0,\"sequence_number\":101}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"ET97Te0oejXoSp\",\"output_index\":0,\"sequence_number\":102}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"2tpWmmOtpztUn82\",\"output_index\":0,\"sequence_number\":103}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"nykx23nIHykx\",\"output_index\":0,\"sequence_number\":104}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" currency\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"JaREbol\",\"output_index\":0,\"sequence_number\":105}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" used\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"GaRLRDb7bBn\",\"output_index\":0,\"sequence_number\":106}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"D4LyIhJd3SSZg\",\"output_index\":0,\"sequence_number\":107}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"86S2Pxatlf\",\"output_index\":0,\"sequence_number\":108}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"0Qj8sveApqzQL\",\"output_index\":0,\"sequence_number\":109}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"l4lUk0e8iSUx\",\"output_index\":0,\"sequence_number\":110}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Euro\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"a5Da13QOeMm\",\"output_index\":0,\"sequence_number\":111}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"63gcfoFElJZoub\",\"output_index\":0,\"sequence_number\":112}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"EUR\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"7G5smndhdHUcC\",\"output_index\":0,\"sequence_number\":113}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"),\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"GC2t7E4bpHUBzW\",\"output_index\":0,\"sequence_number\":114}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" symbol\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"NHzUH6vGy\",\"output_index\":0,\"sequence_number\":115}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"ized\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"5gCS32sbr1Ig\",\"output_index\":0,\"sequence_number\":116}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" by\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"JMh0OKioe3rBr\",\"output_index\":0,\"sequence_number\":117}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" €\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"3C1MF5IUODRXdm\",\"output_index\":0,\"sequence_number\":118}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"k6jweSvS60PRS\",\"output_index\":0,\"sequence_number\":119}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"If\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"H6cVUebM9Bu2Tw\",\"output_index\":0,\"sequence_number\":120}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" you\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"hat7JDCAYiOn\",\"output_index\":0,\"sequence_number\":121}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" need\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"eWp0jIfdo2q\",\"output_index\":0,\"sequence_number\":122}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" any\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"rzvE5KNSsPr6\",\"output_index\":0,\"sequence_number\":123}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" more\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"RGdIENWmcOM\",\"output_index\":0,\"sequence_number\":124}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" information\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"MylR\",\"output_index\":0,\"sequence_number\":125}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" or\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"mWYrYIO9SlrDz\",\"output_index\":0,\"sequence_number\":126}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" details\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"u4apA4r6\",\"output_index\":0,\"sequence_number\":127}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"RZWK7t5I0UYtVmY\",\"output_index\":0,\"sequence_number\":128}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" feel\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"nfYvRUFdqWr\",\"output_index\":0,\"sequence_number\":129}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" free\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"ua1wd8CZ4Ko\",\"output_index\":0,\"sequence_number\":130}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" to\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"JTA969lJq2P6R\",\"output_index\":0,\"sequence_number\":131}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" ask\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"HOCqxv1tAAqs\",\"output_index\":0,\"sequence_number\":132}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"!\",\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"obfuscation\":\"cXqT7n6O81A95OI\",\"output_index\":0,\"sequence_number\":133}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":134,\"text\":\"Here is the comprehensive city report for Paris:\\n\\n1. **Weather**: The current weather in Paris is sunny with a temperature of 22°C.\\n\\n2. **Population**: Paris has a population of approximately 2,161,000 people.\\n\\n3. **Timezone**: Paris is in the Central European Time (CET) timezone, with a UTC offset of +01:00.\\n\\n4. **Language**: The primary language spoken in Paris is French.\\n\\n5. **Currency**: The currency used in Paris is the Euro (EUR), symbolized by €.\\n\\nIf you need any more information or details, feel free to ask!\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here is the comprehensive city report for Paris:\\n\\n1. **Weather**: The current weather in Paris is sunny with a temperature of 22°C.\\n\\n2. **Population**: Paris has a population of approximately 2,161,000 people.\\n\\n3. **Timezone**: Paris is in the Central European Time (CET) timezone, with a UTC offset of +01:00.\\n\\n4. **Language**: The primary language spoken in Paris is French.\\n\\n5. **Currency**: The currency used in Paris is the Euro (EUR), symbolized by €.\\n\\nIf you need any more information or details, feel free to ask!\"},\"sequence_number\":135}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here is the comprehensive city report for Paris:\\n\\n1. **Weather**: The current weather in Paris is sunny with a temperature of 22°C.\\n\\n2. **Population**: Paris has a population of approximately 2,161,000 people.\\n\\n3. **Timezone**: Paris is in the Central European Time (CET) timezone, with a UTC offset of +01:00.\\n\\n4. **Language**: The primary language spoken in Paris is French.\\n\\n5. **Currency**: The currency used in Paris is the Euro (EUR), symbolized by €.\\n\\nIf you need any more information or details, feel free to ask!\"}],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":136}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0d20550ae04819510069b3ecf3c784819392924e20aff1fc9a\",\"object\":\"response\",\"created_at\":1773399283,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399287,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_0d20550ae04819510069b3ecf4991c8193bea8fe7ecf11b5a5\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here is the comprehensive city report for Paris:\\n\\n1. **Weather**: The current weather in Paris is sunny with a temperature of 22°C.\\n\\n2. **Population**: Paris has a population of approximately 2,161,000 people.\\n\\n3. **Timezone**: Paris is in the Central European Time (CET) timezone, with a UTC offset of +01:00.\\n\\n4. **Language**: The primary language spoken in Paris is French.\\n\\n5. **Currency**: The currency used in Paris is the Euro (EUR), symbolized by €.\\n\\nIf you need any more information or details, feel free to ask!\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":529,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":132,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":661},\"user\":null,\"metadata\":{}},\"sequence_number\":137}\n\n"
+        ],
+        "chunkTimings": [
+          0, 0, 0, 7, 1, 674, 1, 20, 1, 36, 0, 24, 0, 40, 1, 29, 52, 29, 33, 1, 33, 2, 18, 3, 22, 2, 34, 26, 33, 2, 20,
+          27, 3, 27, 1, 39, 2, 27, 2, 34, 1, 32, 0, 22, 26, 25, 22, 1, 37, 3, 38, 49, 24, 1, 23, 1, 25, 26, 38, 58, 61,
+          55, 1, 56, 0, 35, 38, 1, 49, 40, 1, 62, 0, 62, 51, 3, 56, 165, 1, 87, 1, 2, 1, 74, 0, 2, 19, 39, 32, 19, 25,
+          2, 26, 1, 30, 0, 19, 32, 44, 0, 27, 2, 26, 43, 1, 26, 0, 3, 37, 2, 2, 78
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "4bac9c325cf09df6",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-5.3-codex",
+          "input": [
+            {
+              "role": "developer",
+              "content": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            }
+          ],
+          "tools": [
+            {
+              "type": "function",
+              "name": "getWeather",
+              "description": "Get the current weather for a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get weather for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getPopulation",
+              "description": "Get the population of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get population for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getTimezone",
+              "description": "Get the timezone of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get timezone for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getLanguage",
+              "description": "Get the primary language spoken in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the language for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getCurrency",
+              "description": "Get the currency used in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the currency for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399287171
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba80a93c11ba5d-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:54:47 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "78",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_a93eb2e1612d4595a01081ea549960eb"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_048dc3e63b812ef30069b3ecf754a08194a746f8802bc0b949\",\"object\":\"response\",\"created_at\":1773399287,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_048dc3e63b812ef30069b3ecf754a08194a746f8802bc0b949\",\"object\":\"response\",\"created_at\":1773399287,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"commentary\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Got\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"zL3aV7wmhreQa\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" it\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"fmjUrC23yOP1L\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" —\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"tmJedzUsSzFhHk\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" I\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"mttJAiLAh3GZ8J\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"’ll\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"2D5t9JyLbBm8U\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" compile\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"OZ5uhOW9\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"Xrmwj1pXPgxsKk\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" full\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"JqJkDgq0Juc\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" city\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"imHKef9zghP\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" report\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"Ztzogxwre\",\"output_index\":0,\"sequence_number\":13}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" for\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"X5k3gKnY4aSx\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"OxVDOMgh9rrFL\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Paris\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"SH0cpf4ls7i\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"ssnRpKGyzftZWy\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" by\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"yjYxymygyI1jV\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" fetching\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"nNvXjht\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" exactly\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"B6vtsKfv\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" these\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"0SGVrMSBhe\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" five\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"M6wdXR0pJAL\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" data\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"KEqFCfGy8X8\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" points\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"HM1suCCCN\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"ePwJTKYVBqSzI\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" one\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"u9DxGET6P47v\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" parallel\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"Eecy7EL\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" step\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"rBm5A6JBCvO\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\\n\\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"o4AQ85v9abBLH\",\"output_index\":0,\"sequence_number\":29}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"1\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"1rZOuW3Ip3l2V9n\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"6WnKcBG5EojZYwq\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Current\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"u36oR6Vu\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" weather\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"QrSEHw4M\",\"output_index\":0,\"sequence_number\":33}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"fIyaPyf8ATgZH\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"tt6LRShyfWhDtun\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"UN4HUS57cIA6WNp\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Population\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"Z9r1Q\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"l2uOnW76g34bi\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"3\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"IaQDtwsfz4aWQI4\",\"output_index\":0,\"sequence_number\":39}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"ZyRjHjuMoe59qNm\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Time\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"Fv1LqrgZkhL\",\"output_index\":0,\"sequence_number\":41}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"zone\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"1rMcioXoATyE\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"WaXiKywT0XC6A\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"4\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"fLuMCZU92TbFU4g\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"4dVJjqbn5ctX7w9\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Primary\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"QjMU24n7\",\"output_index\":0,\"sequence_number\":46}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" language\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"QRPQvBs\",\"output_index\":0,\"sequence_number\":47}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"ScdZSRuNOSHQz\",\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"5\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"YebS5JUH5zZjhE3\",\"output_index\":0,\"sequence_number\":49}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"QFdxDaj6neUSV5a\",\"output_index\":0,\"sequence_number\":50}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Currency\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"QJAGSfs\",\"output_index\":0,\"sequence_number\":51}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"t26ZdgNECElY\",\"output_index\":0,\"sequence_number\":52}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"I\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"ibYCJV9wlAVW0h7\",\"output_index\":0,\"sequence_number\":53}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"’m\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"tMHm5qIJHY3EB5\",\"output_index\":0,\"sequence_number\":54}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" now\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"A2q2mZiMGDfn\",\"output_index\":0,\"sequence_number\":55}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" querying\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"5kBLHxv\",\"output_index\":0,\"sequence_number\":56}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" all\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"v5yMhCmV4pSe\",\"output_index\":0,\"sequence_number\":57}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" five\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"gOMvGroYp8z\",\"output_index\":0,\"sequence_number\":58}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" tools\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"HmkkanVeAC\",\"output_index\":0,\"sequence_number\":59}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"eHizCWWtfMrvj\",\"output_index\":0,\"sequence_number\":60}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"sim\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"UtrCx4kuEprkz\",\"output_index\":0,\"sequence_number\":61}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"ult\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"PTrPOivYpvJMg\",\"output_index\":0,\"sequence_number\":62}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"aneously\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"6yW2ROMs\",\"output_index\":0,\"sequence_number\":63}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"EEsXHdgIVYfr6E\",\"output_index\":0,\"sequence_number\":64}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" so\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"3KE696Ds1XsCy\",\"output_index\":0,\"sequence_number\":65}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" you\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"9uaS4rxaGFxr\",\"output_index\":0,\"sequence_number\":66}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" get\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"vHHUr4vplO48\",\"output_index\":0,\"sequence_number\":67}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"BMheklyiQGuJE9\",\"output_index\":0,\"sequence_number\":68}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" complete\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"Xzj8l0H\",\"output_index\":0,\"sequence_number\":69}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" report\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"rpTkUITR3\",\"output_index\":0,\"sequence_number\":70}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" as\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"RrWvpOXFcKFvf\",\"output_index\":0,\"sequence_number\":71}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" quickly\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"Tden4kyW\",\"output_index\":0,\"sequence_number\":72}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" as\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"qIipCGOqm2w1f\",\"output_index\":0,\"sequence_number\":73}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" possible\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"pjf83ck\",\"output_index\":0,\"sequence_number\":74}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"obfuscation\":\"x0UVy6CnPr7O4xl\",\"output_index\":0,\"sequence_number\":75}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":76,\"text\":\"Got it — I’ll compile a full city report for **Paris** by fetching exactly these five data points in one parallel step:\\n\\n1. Current weather  \\n2. Population  \\n3. Timezone  \\n4. Primary language  \\n5. Currency  \\n\\nI’m now querying all five tools **simultaneously** so you get a complete report as quickly as possible.\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Got it — I’ll compile a full city report for **Paris** by fetching exactly these five data points in one parallel step:\\n\\n1. Current weather  \\n2. Population  \\n3. Timezone  \\n4. Primary language  \\n5. Currency  \\n\\nI’m now querying all five tools **simultaneously** so you get a complete report as quickly as possible.\"},\"sequence_number\":77}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Got it — I’ll compile a full city report for **Paris** by fetching exactly these five data points in one parallel step:\\n\\n1. Current weather  \\n2. Population  \\n3. Timezone  \\n4. Primary language  \\n5. Currency  \\n\\nI’m now querying all five tools **simultaneously** so you get a complete report as quickly as possible.\"}],\"phase\":\"commentary\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":78}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b7108194b3332355cd8718cf\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_e5u7RgDfyTurSy0sE57lOS4W\",\"name\":\"getWeather\"},\"output_index\":1,\"sequence_number\":79}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_048dc3e63b812ef30069b3ecf9b7108194b3332355cd8718cf\",\"obfuscation\":\"\",\"output_index\":1,\"sequence_number\":80}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_048dc3e63b812ef30069b3ecf9b7108194b3332355cd8718cf\",\"output_index\":1,\"sequence_number\":81}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b7108194b3332355cd8718cf\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_e5u7RgDfyTurSy0sE57lOS4W\",\"name\":\"getWeather\"},\"output_index\":1,\"sequence_number\":82}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b71c8194853e38d4faa6fb1e\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_LRqlf7JJzh9ZPwDY2pZWKjhV\",\"name\":\"getPopulation\"},\"output_index\":2,\"sequence_number\":83}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_048dc3e63b812ef30069b3ecf9b71c8194853e38d4faa6fb1e\",\"obfuscation\":\"\",\"output_index\":2,\"sequence_number\":84}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_048dc3e63b812ef30069b3ecf9b71c8194853e38d4faa6fb1e\",\"output_index\":2,\"sequence_number\":85}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b71c8194853e38d4faa6fb1e\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_LRqlf7JJzh9ZPwDY2pZWKjhV\",\"name\":\"getPopulation\"},\"output_index\":2,\"sequence_number\":86}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b72881948da8a8a8ff1681f4\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_uEA6ISL8F6Ab52HYUqplRUWI\",\"name\":\"getTimezone\"},\"output_index\":3,\"sequence_number\":87}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_048dc3e63b812ef30069b3ecf9b72881948da8a8a8ff1681f4\",\"obfuscation\":\"\",\"output_index\":3,\"sequence_number\":88}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_048dc3e63b812ef30069b3ecf9b72881948da8a8a8ff1681f4\",\"output_index\":3,\"sequence_number\":89}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b72881948da8a8a8ff1681f4\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_uEA6ISL8F6Ab52HYUqplRUWI\",\"name\":\"getTimezone\"},\"output_index\":3,\"sequence_number\":90}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b72c81949f7318d929372dd8\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_H9VQsYYdt5phvRjWlzVxQvbc\",\"name\":\"getLanguage\"},\"output_index\":4,\"sequence_number\":91}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_048dc3e63b812ef30069b3ecf9b72c81949f7318d929372dd8\",\"obfuscation\":\"\",\"output_index\":4,\"sequence_number\":92}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_048dc3e63b812ef30069b3ecf9b72c81949f7318d929372dd8\",\"output_index\":4,\"sequence_number\":93}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b72c81949f7318d929372dd8\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_H9VQsYYdt5phvRjWlzVxQvbc\",\"name\":\"getLanguage\"},\"output_index\":4,\"sequence_number\":94}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b734819491632699c4b2c096\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_XfamsTY6yQYLcWemfLbDd8VB\",\"name\":\"getCurrency\"},\"output_index\":5,\"sequence_number\":95}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_048dc3e63b812ef30069b3ecf9b734819491632699c4b2c096\",\"obfuscation\":\"\",\"output_index\":5,\"sequence_number\":96}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_048dc3e63b812ef30069b3ecf9b734819491632699c4b2c096\",\"output_index\":5,\"sequence_number\":97}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b734819491632699c4b2c096\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_XfamsTY6yQYLcWemfLbDd8VB\",\"name\":\"getCurrency\"},\"output_index\":5,\"sequence_number\":98}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_048dc3e63b812ef30069b3ecf754a08194a746f8802bc0b949\",\"object\":\"response\",\"created_at\":1773399287,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399289,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[{\"id\":\"msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Got it — I’ll compile a full city report for **Paris** by fetching exactly these five data points in one parallel step:\\n\\n1. Current weather  \\n2. Population  \\n3. Timezone  \\n4. Primary language  \\n5. Currency  \\n\\nI’m now querying all five tools **simultaneously** so you get a complete report as quickly as possible.\"}],\"phase\":\"commentary\",\"role\":\"assistant\"},{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b7108194b3332355cd8718cf\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_e5u7RgDfyTurSy0sE57lOS4W\",\"name\":\"getWeather\"},{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b71c8194853e38d4faa6fb1e\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_LRqlf7JJzh9ZPwDY2pZWKjhV\",\"name\":\"getPopulation\"},{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b72881948da8a8a8ff1681f4\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_uEA6ISL8F6Ab52HYUqplRUWI\",\"name\":\"getTimezone\"},{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b72c81949f7318d929372dd8\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_H9VQsYYdt5phvRjWlzVxQvbc\",\"name\":\"getLanguage\"},{\"id\":\"fc_048dc3e63b812ef30069b3ecf9b734819491632699c4b2c096\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_XfamsTY6yQYLcWemfLbDd8VB\",\"name\":\"getCurrency\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":274,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":169,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":443},\"user\":null,\"metadata\":{}},\"sequence_number\":99}\n\n"
+        ],
+        "chunkTimings": [
+          5, 4, 251, 0, 26, 3, 3, 0, 3, 33, 3, 1, 1, 1, 39, 48, 0, 0, 42, 1, 4, 0, 0, 46, 0, 1, 2, 33, 51, 1, 2, 1, 40,
+          2, 3, 7, 1, 35, 1, 1, 1, 1, 38, 5, 2, 2, 1, 38, 4, 1, 2, 2, 32, 1, 2, 2, 41, 2, 2, 1, 40, 45, 1, 3, 0, 39, 48,
+          2, 1, 38, 47, 51, 2, 3, 1, 0, 1173, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 117
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "2b322fb794609565",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-5.3-codex",
+          "input": [
+            {
+              "role": "developer",
+              "content": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            },
+            {
+              "type": "item_reference",
+              "id": "msg_048dc3e63b812ef30069b3ecf7a50c819482d7645f11d20c42"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_048dc3e63b812ef30069b3ecf9b7108194b3332355cd8718cf"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_048dc3e63b812ef30069b3ecf9b71c8194853e38d4faa6fb1e"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_048dc3e63b812ef30069b3ecf9b72881948da8a8a8ff1681f4"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_048dc3e63b812ef30069b3ecf9b72c81949f7318d929372dd8"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_048dc3e63b812ef30069b3ecf9b734819491632699c4b2c096"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_e5u7RgDfyTurSy0sE57lOS4W",
+              "output": "{\"city\":\"Paris\",\"temperature\":22,\"condition\":\"sunny\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_LRqlf7JJzh9ZPwDY2pZWKjhV",
+              "output": "{\"city\":\"Paris\",\"population\":2161000}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_uEA6ISL8F6Ab52HYUqplRUWI",
+              "output": "{\"city\":\"Paris\",\"timezone\":\"CET\",\"utcOffset\":\"+01:00\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_H9VQsYYdt5phvRjWlzVxQvbc",
+              "output": "{\"city\":\"Paris\",\"language\":\"French\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_XfamsTY6yQYLcWemfLbDd8VB",
+              "output": "{\"city\":\"Paris\",\"currency\":\"EUR\",\"symbol\":\"€\"}"
+            }
+          ],
+          "tools": [
+            {
+              "type": "function",
+              "name": "getWeather",
+              "description": "Get the current weather for a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get weather for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getPopulation",
+              "description": "Get the population of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get population for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getTimezone",
+              "description": "Get the timezone of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get timezone for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getLanguage",
+              "description": "Get the primary language spoken in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the language for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            },
+            {
+              "type": "function",
+              "name": "getCurrency",
+              "description": "Get the currency used in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the currency for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              },
+              "strict": false
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399289942
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba80ba8cacfc93-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:54:50 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "129",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_c77549a3fd4e44da8346de7ea3ab634c"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_048dc3e63b812ef30069b3ecfa191081948701707295dee667\",\"object\":\"response\",\"created_at\":1773399290,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\nevent: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_048dc3e63b812ef30069b3ecfa191081948701707295dee667\",\"object\":\"response\",\"created_at\":1773399290,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Here\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"OWvsY8h9A5Og\",\"output_index\":0,\"sequence_number\":4}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"’s\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"eMjEOdQE9LTTKV\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" your\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"Y8ukH52QF20\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" comprehensive\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"ec\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" report\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"gI7L7k1Xk\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" for\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"25pXDQscox5Q\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"ICKo5NNZY8KoD\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Paris\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"p4CI5PQ2hpw\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"thbKJCfdJLiYGu\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\\n\\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"qOSzVqt9BwNti\",\"output_index\":0,\"sequence_number\":13}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"TRFOugN09VRoPmD\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"Wh3GSQlhlHxaO\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Weather\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"jwu7p8K7d\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"aSSlwY02Mjks5\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"tbqhV9VPH1E2uEr\",\"output_index\":0,\"sequence_number\":18}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"22\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"S5XCvTGtaIIUXz\",\"output_index\":0,\"sequence_number\":19}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"°C\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"LtYcQqPMz6hjUA\",\"output_index\":0,\"sequence_number\":20}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"FCrMxNt9KgQ290v\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" sunny\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"LQBlX2uk7U\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"5USMYIj83VrqZ\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"eh66OYk0ixBwnky\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"rKbx5MlwSvpNa\",\"output_index\":0,\"sequence_number\":25}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Population\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"1Y1J0U\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"9Us6VKexb2gd2\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"vxv97tVIiGXMcxK\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"UY0lD4rpOX90BKX\",\"output_index\":0,\"sequence_number\":29}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"5CSNDz4SWkrvjOP\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"161\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"H0vo3HNkHVGeF\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"efL8J85CHGuzyOk\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"000\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"dD5PrjFcgauzd\",\"output_index\":0,\"sequence_number\":33}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"Mbay9y2KwFnnm\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"YA8snix6cQ2BhmB\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"hKTRTWrqJCHuM\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Timezone\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"YrUfuipH\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"SJl3Dm4EbSubt\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" CET\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"OSX0qxd8VuW1\",\"output_index\":0,\"sequence_number\":39}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"HlUUGZnQuzgafR\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"UTC\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"DOsG57j4Vbwff\",\"output_index\":0,\"sequence_number\":41}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"+\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"0h09YDBkHXfpdts\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"01\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"hN3HmaS29UYL7J\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"W8VXyhlnIerPWnO\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"00\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"re6L97OhsonG3n\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\")\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"X63mHOcFeUb9Zp1\",\"output_index\":0,\"sequence_number\":46}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"vOiA6rQA4tKZe\",\"output_index\":0,\"sequence_number\":47}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"piXGwOLnN1NKsLA\",\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"Oh1SqtaR7pRzD\",\"output_index\":0,\"sequence_number\":49}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Primary\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"9u4WG9Toh\",\"output_index\":0,\"sequence_number\":50}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" language\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"fMtRVqQ\",\"output_index\":0,\"sequence_number\":51}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"d6goeJSnLa5yc\",\"output_index\":0,\"sequence_number\":52}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" French\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"uCee50kol\",\"output_index\":0,\"sequence_number\":53}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"a9wcyhtTHWDSz\",\"output_index\":0,\"sequence_number\":54}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"8YLGDovW0uReL4a\",\"output_index\":0,\"sequence_number\":55}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"SLPh8stMokbXD\",\"output_index\":0,\"sequence_number\":56}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Currency\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"qtlefM2i\",\"output_index\":0,\"sequence_number\":57}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"GoP7wlMphzOE7\",\"output_index\":0,\"sequence_number\":58}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Euro\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"HlWHlsyNAPK\",\"output_index\":0,\"sequence_number\":59}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"VanoueEks26sOz\",\"output_index\":0,\"sequence_number\":60}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"EUR\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"tKluFPDgu5ZYd\",\"output_index\":0,\"sequence_number\":61}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"YaF61HfcGdeBLzA\",\"output_index\":0,\"sequence_number\":62}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" €\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"7BaQjJSoC9GhVf\",\"output_index\":0,\"sequence_number\":63}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\")\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"n011QP9MeDwcMRH\",\"output_index\":0,\"sequence_number\":64}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\\n\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"AJttHZzdXmZb\",\"output_index\":0,\"sequence_number\":65}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"If\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"Rnern61fE0Q3vt\",\"output_index\":0,\"sequence_number\":66}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" you\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"XOOVLJbhUnrO\",\"output_index\":0,\"sequence_number\":67}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" want\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"CZxFN6CDXgP\",\"output_index\":0,\"sequence_number\":68}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"wlGI6bykWtDbInn\",\"output_index\":0,\"sequence_number\":69}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" I\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"XMAB5rEmnLAIbd\",\"output_index\":0,\"sequence_number\":70}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" can\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"PyDB0ZKACyed\",\"output_index\":0,\"sequence_number\":71}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" also\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"sblSOUBXg9B\",\"output_index\":0,\"sequence_number\":72}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" format\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"j2frgMs2h\",\"output_index\":0,\"sequence_number\":73}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" this\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"DhYTlCgVtuD\",\"output_index\":0,\"sequence_number\":74}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" as\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"4hj4AG5tpd2bg\",\"output_index\":0,\"sequence_number\":75}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"amcTfLox3g1tmn\",\"output_index\":0,\"sequence_number\":76}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" one\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"JOpVBN7E0sUH\",\"output_index\":0,\"sequence_number\":77}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-page\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"cCxS05pYE8E\",\"output_index\":0,\"sequence_number\":78}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" “\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"vMRW6FFpyZz2dV\",\"output_index\":0,\"sequence_number\":79}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"city\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"8RaWumfyMmoE\",\"output_index\":0,\"sequence_number\":80}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" brief\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"vlSR7LV54G\",\"output_index\":0,\"sequence_number\":81}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"”\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"9LfM0FoRFkgSdOK\",\"output_index\":0,\"sequence_number\":82}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"P1KRvuS4a2exTS\",\"output_index\":0,\"sequence_number\":83}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"with\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"812nF9dROjpQ\",\"output_index\":0,\"sequence_number\":84}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" quick\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"vmOOWVyovw\",\"output_index\":0,\"sequence_number\":85}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" travel\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"UoJTxjOpI\",\"output_index\":0,\"sequence_number\":86}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"/use\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"oPnx78BR32FX\",\"output_index\":0,\"sequence_number\":87}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"ful\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"DKeSlSuzbv5Ew\",\"output_index\":0,\"sequence_number\":88}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" context\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"88i8c22J\",\"output_index\":0,\"sequence_number\":89}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\").\",\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"obfuscation\":\"JhD3yrZx8YtTBG\",\"output_index\":0,\"sequence_number\":90}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":91,\"text\":\"Here’s your comprehensive report for **Paris**:\\n\\n- **Weather:** 22°C, sunny  \\n- **Population:** 2,161,000  \\n- **Timezone:** CET (UTC+01:00)  \\n- **Primary language:** French  \\n- **Currency:** Euro (EUR, €)  \\n\\nIf you want, I can also format this as a one-page “city brief” (with quick travel/useful context).\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here’s your comprehensive report for **Paris**:\\n\\n- **Weather:** 22°C, sunny  \\n- **Population:** 2,161,000  \\n- **Timezone:** CET (UTC+01:00)  \\n- **Primary language:** French  \\n- **Currency:** Euro (EUR, €)  \\n\\nIf you want, I can also format this as a one-page “city brief” (with quick travel/useful context).\"},\"sequence_number\":92}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here’s your comprehensive report for **Paris**:\\n\\n- **Weather:** 22°C, sunny  \\n- **Population:** 2,161,000  \\n- **Timezone:** CET (UTC+01:00)  \\n- **Primary language:** French  \\n- **Currency:** Euro (EUR, €)  \\n\\nIf you want, I can also format this as a one-page “city brief” (with quick travel/useful context).\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":93}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_048dc3e63b812ef30069b3ecfa191081948701707295dee667\",\"object\":\"response\",\"created_at\":1773399290,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399291,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[{\"id\":\"msg_048dc3e63b812ef30069b3ecfa8a3c819490c1f5b66b115926\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here’s your comprehensive report for **Paris**:\\n\\n- **Weather:** 22°C, sunny  \\n- **Population:** 2,161,000  \\n- **Timezone:** CET (UTC+01:00)  \\n- **Primary language:** French  \\n- **Currency:** Euro (EUR, €)  \\n\\nIf you want, I can also format this as a one-page “city brief” (with quick travel/useful context).\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":false}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":554,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":91,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":645},\"user\":null,\"metadata\":{}},\"sequence_number\":94}\n\n"
+        ],
+        "chunkTimings": [
+          0, 378, 1, 0, 0, 37, 46, 1, 2, 1, 2, 41, 2, 1, 3, 0, 41, 51, 3, 0, 1, 38, 1, 1, 2, 1, 44, 0, 2, 1, 0, 45, 0,
+          2, 1, 1, 39, 2, 1, 2, 1, 38, 1, 1, 1, 3, 65, 31, 2, 47, 2, 0, 44, 1, 50, 1, 2, 0, 0, 54, 29, 1, 1, 43, 2, 53,
+          50, 1, 3, 1, 0, 43, 40, 51, 6, 2, 13, 45, 2, 2, 114
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "923541941adf2406",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-5.3-codex",
+          "input": [
+            {
+              "role": "developer",
+              "content": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            }
+          ],
+          "tools": [
+            {
+              "type": "function",
+              "name": "getWeather",
+              "description": "Get the current weather for a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get weather for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getPopulation",
+              "description": "Get the population of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get population for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getTimezone",
+              "description": "Get the timezone of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get timezone for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getLanguage",
+              "description": "Get the primary language spoken in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the language for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getCurrency",
+              "description": "Get the currency used in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the currency for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399291902
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba80c6cf55ba5d-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:54:52 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "114",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_0cbcf12885564e088b640a1e34d0737a"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_09ebf0b1c87543630069b3ecfc0f8881938bb1275152d4d367\",\"object\":\"response\",\"created_at\":1773399292,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_09ebf0b1c87543630069b3ecfc0f8881938bb1275152d4d367\",\"object\":\"response\",\"created_at\":1773399292,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"commentary\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"I\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"hyC0Uf4aXeO5Tfb\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"’ll\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"PcvblRfpR4TS2\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" gather\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"m1xsKrxmD\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"OBixTm7LPGOkFj\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" full\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"Qly1GUA3KnE\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" city\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"82wdMP9SB3Q\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" snapshot\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"qedNE3E\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" for\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"esdvYNI5MHEU\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"DJdgfUX7kau0r\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Paris\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"P8X1an4WlXx\",\"output_index\":0,\"sequence_number\":13}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"38RDUJLDsdm4tx\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" by\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"UZJH9NvxuiAZz\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" looking\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"VbfRMnp0\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" up\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"Kby5j0d0sqO7o\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" exactly\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"l7H9C1UU\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" these\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"JHokG9HcMS\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" five\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"HZgDNoR8q1U\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" items\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"TLmE7zCMvR\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"xucZpdIa7ohqo\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" parallel\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"jEtJkYr\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"lWqT1VJ3PlpqMye\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"KTkmo56ukHAgb\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"current\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"ovmcrB9YV\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" weather\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"HnfvRYHA\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"GVuCKuWsWZN2nXN\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" population\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"PHlAm\",\"output_index\":0,\"sequence_number\":29}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"tKZJhKphaBr3YQj\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" timezone\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"4Qr8q5i\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"AKlu1k6iKYYVtrY\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" primary\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"HgCYhlnX\",\"output_index\":0,\"sequence_number\":33}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" language\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"qKiVEW9\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"QLyqahjGDgLXrp0\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" and\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"Lcmh1naKjKCh\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" currency\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"zP9y305\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"HP3aG06CRpCHDH\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"C25tzI2YgLgUgAR\",\"output_index\":0,\"sequence_number\":39}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"  \\n\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"BJ5ryE5VSWugZ\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"I\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"GoGAlKUitWp4UDj\",\"output_index\":0,\"sequence_number\":41}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"’m\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"W8Jd6OSSTs4ox6\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" now\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"hCSaAucwsEvR\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" running\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"xtLlbcuY\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" all\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"w8Zq2h8kRstp\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" five\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"AI7XvbMfPfB\",\"output_index\":0,\"sequence_number\":46}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" look\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"rJJYD6EIweX\",\"output_index\":0,\"sequence_number\":47}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"ups\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"04sjXVTZzrZ6i\",\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" at\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"HDZHfvfcxnbcg\",\"output_index\":0,\"sequence_number\":49}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"27aNoAUaaLYs\",\"output_index\":0,\"sequence_number\":50}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" same\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"RGzGq2659m7\",\"output_index\":0,\"sequence_number\":51}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" time\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"uQCbpKPHIxl\",\"output_index\":0,\"sequence_number\":52}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" so\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"Av06acdPdsz0U\",\"output_index\":0,\"sequence_number\":53}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" you\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"KZJ8CYmfO311\",\"output_index\":0,\"sequence_number\":54}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" get\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"kkUukaTICGdx\",\"output_index\":0,\"sequence_number\":55}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"IiD7uCgcPu1cOV\",\"output_index\":0,\"sequence_number\":56}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" complete\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"NLAcDTn\",\"output_index\":0,\"sequence_number\":57}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" report\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"qeLZCFTNP\",\"output_index\":0,\"sequence_number\":58}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" quickly\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"IsbYSHVJ\",\"output_index\":0,\"sequence_number\":59}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"obfuscation\":\"P2wxiwJwbdOB2Mp\",\"output_index\":0,\"sequence_number\":60}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":61,\"text\":\"I’ll gather a full city snapshot for **Paris** by looking up exactly these five items in parallel: **current weather, population, timezone, primary language, and currency**.  \\nI’m now running all five lookups at the same time so you get a complete report quickly.\"}\n\nevent: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I’ll gather a full city snapshot for **Paris** by looking up exactly these five items in parallel: **current weather, population, timezone, primary language, and currency**.  \\nI’m now running all five lookups at the same time so you get a complete report quickly.\"},\"sequence_number\":62}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I’ll gather a full city snapshot for **Paris** by looking up exactly these five items in parallel: **current weather, population, timezone, primary language, and currency**.  \\nI’m now running all five lookups at the same time so you get a complete report quickly.\"}],\"phase\":\"commentary\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":63}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_09ebf0b1c87543630069b3ecff20648193acb3c6634ed69823\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_icfos7UNd187DFjGnporXEOX\",\"name\":\"getWeather\"},\"output_index\":1,\"sequence_number\":64}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_09ebf0b1c87543630069b3ecff20648193acb3c6634ed69823\",\"obfuscation\":\"\",\"output_index\":1,\"sequence_number\":65}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_09ebf0b1c87543630069b3ecff20648193acb3c6634ed69823\",\"output_index\":1,\"sequence_number\":66}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_09ebf0b1c87543630069b3ecff20648193acb3c6634ed69823\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_icfos7UNd187DFjGnporXEOX\",\"name\":\"getWeather\"},\"output_index\":1,\"sequence_number\":67}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_09ebf0b1c87543630069b3ecff2074819380f56466b776656c\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_K2gNBLHMwYFST4nkYP6ObQkc\",\"name\":\"getPopulation\"},\"output_index\":2,\"sequence_number\":68}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_09ebf0b1c87543630069b3ecff2074819380f56466b776656c\",\"obfuscation\":\"\",\"output_index\":2,\"sequence_number\":69}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_09ebf0b1c87543630069b3ecff2074819380f56466b776656c\",\"output_index\":2,\"sequence_number\":70}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_09ebf0b1c87543630069b3ecff2074819380f56466b776656c\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_K2gNBLHMwYFST4nkYP6ObQkc\",\"name\":\"getPopulation\"},\"output_index\":2,\"sequence_number\":71}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_09ebf0b1c87543630069b3ecff20808193a7443c331601cd03\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_Mye1n9mkGnj7sX57RVwLo6dJ\",\"name\":\"getTimezone\"},\"output_index\":3,\"sequence_number\":72}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_09ebf0b1c87543630069b3ecff20808193a7443c331601cd03\",\"obfuscation\":\"\",\"output_index\":3,\"sequence_number\":73}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_09ebf0b1c87543630069b3ecff20808193a7443c331601cd03\",\"output_index\":3,\"sequence_number\":74}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_09ebf0b1c87543630069b3ecff20808193a7443c331601cd03\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_Mye1n9mkGnj7sX57RVwLo6dJ\",\"name\":\"getTimezone\"},\"output_index\":3,\"sequence_number\":75}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_09ebf0b1c87543630069b3ecff20888193a2eda2c09807ea58\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_nDAOCMyOAUbwEtWoUoJXcOlO\",\"name\":\"getLanguage\"},\"output_index\":4,\"sequence_number\":76}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_09ebf0b1c87543630069b3ecff20888193a2eda2c09807ea58\",\"obfuscation\":\"\",\"output_index\":4,\"sequence_number\":77}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_09ebf0b1c87543630069b3ecff20888193a2eda2c09807ea58\",\"output_index\":4,\"sequence_number\":78}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_09ebf0b1c87543630069b3ecff20888193a2eda2c09807ea58\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_nDAOCMyOAUbwEtWoUoJXcOlO\",\"name\":\"getLanguage\"},\"output_index\":4,\"sequence_number\":79}\n\nevent: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_09ebf0b1c87543630069b3ecff20908193b42f55de344c802a\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_VZ0ZjdiBycBEtLcEibPg1d5t\",\"name\":\"getCurrency\"},\"output_index\":5,\"sequence_number\":80}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_09ebf0b1c87543630069b3ecff20908193b42f55de344c802a\",\"obfuscation\":\"\",\"output_index\":5,\"sequence_number\":81}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"item_id\":\"fc_09ebf0b1c87543630069b3ecff20908193b42f55de344c802a\",\"output_index\":5,\"sequence_number\":82}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_09ebf0b1c87543630069b3ecff20908193b42f55de344c802a\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_VZ0ZjdiBycBEtLcEibPg1d5t\",\"name\":\"getCurrency\"},\"output_index\":5,\"sequence_number\":83}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_09ebf0b1c87543630069b3ecfc0f8881938bb1275152d4d367\",\"object\":\"response\",\"created_at\":1773399292,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399295,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[{\"id\":\"msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I’ll gather a full city snapshot for **Paris** by looking up exactly these five items in parallel: **current weather, population, timezone, primary language, and currency**.  \\nI’m now running all five lookups at the same time so you get a complete report quickly.\"}],\"phase\":\"commentary\",\"role\":\"assistant\"},{\"id\":\"fc_09ebf0b1c87543630069b3ecff20648193acb3c6634ed69823\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_icfos7UNd187DFjGnporXEOX\",\"name\":\"getWeather\"},{\"id\":\"fc_09ebf0b1c87543630069b3ecff2074819380f56466b776656c\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_K2gNBLHMwYFST4nkYP6ObQkc\",\"name\":\"getPopulation\"},{\"id\":\"fc_09ebf0b1c87543630069b3ecff20808193a7443c331601cd03\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_Mye1n9mkGnj7sX57RVwLo6dJ\",\"name\":\"getTimezone\"},{\"id\":\"fc_09ebf0b1c87543630069b3ecff20888193a2eda2c09807ea58\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_nDAOCMyOAUbwEtWoUoJXcOlO\",\"name\":\"getLanguage\"},{\"id\":\"fc_09ebf0b1c87543630069b3ecff20908193b42f55de344c802a\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\",\"call_id\":\"call_VZ0ZjdiBycBEtLcEibPg1d5t\",\"name\":\"getCurrency\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":274,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":154,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":428},\"user\":null,\"metadata\":{}},\"sequence_number\":84}\n\n"
+        ],
+        "chunkTimings": [
+          1, 0, 307, 2, 42, 3, 2, 53, 1, 64, 51, 3, 1, 3, 1, 57, 72, 3, 61, 73, 0, 69, 4, 0, 2, 5, 59, 2, 2, 1, 6, 56,
+          1, 4, 0, 6, 58, 3, 0, 1, 65, 1, 66, 2, 2, 2, 1, 68, 1, 0, 65, 3, 2, 66, 1, 0, 3, 64, 70, 73, 5, 1285, 142
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "6f74f08797863f94",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-5.3-codex",
+          "input": [
+            {
+              "role": "developer",
+              "content": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            },
+            {
+              "type": "item_reference",
+              "id": "msg_09ebf0b1c87543630069b3ecfc88f88193b7fcf421dc823d70"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_09ebf0b1c87543630069b3ecff20648193acb3c6634ed69823"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_09ebf0b1c87543630069b3ecff2074819380f56466b776656c"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_09ebf0b1c87543630069b3ecff20808193a7443c331601cd03"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_09ebf0b1c87543630069b3ecff20888193a2eda2c09807ea58"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_09ebf0b1c87543630069b3ecff20908193b42f55de344c802a"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_icfos7UNd187DFjGnporXEOX",
+              "output": "{\"city\":\"Paris\",\"temperature\":22,\"condition\":\"sunny\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_K2gNBLHMwYFST4nkYP6ObQkc",
+              "output": "{\"city\":\"Paris\",\"population\":2161000}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_Mye1n9mkGnj7sX57RVwLo6dJ",
+              "output": "{\"city\":\"Paris\",\"timezone\":\"CET\",\"utcOffset\":\"+01:00\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_nDAOCMyOAUbwEtWoUoJXcOlO",
+              "output": "{\"city\":\"Paris\",\"language\":\"French\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_VZ0ZjdiBycBEtLcEibPg1d5t",
+              "output": "{\"city\":\"Paris\",\"currency\":\"EUR\",\"symbol\":\"€\"}"
+            }
+          ],
+          "tools": [
+            {
+              "type": "function",
+              "name": "getWeather",
+              "description": "Get the current weather for a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get weather for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getPopulation",
+              "description": "Get the population of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get population for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getTimezone",
+              "description": "Get the timezone of a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get timezone for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getLanguage",
+              "description": "Get the primary language spoken in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the language for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "getCurrency",
+              "description": "Get the currency used in a city",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the currency for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399295331
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba80dc3fdefc93-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:54:55 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "150",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_c71551308a6247f79e54ee64f1e86fdb"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_09ebf0b1c87543630069b3ecff7f588193a907a7ef5a207744\",\"object\":\"response\",\"created_at\":1773399295,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_09ebf0b1c87543630069b3ecff7f588193a907a7ef5a207744\",\"object\":\"response\",\"created_at\":1773399295,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Here\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"BzroYiJLa3vr\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"’s\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"nbqWJbZvG7c9J0\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" your\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"Uavo6P32xzw\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"osE6BX046CarI\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"com\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"NIyIejTcXfktr\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"prehensive\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"cNtUMO\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" city\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"7AsXiR3RnfO\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" report\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"pmncY5wlV\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" for\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"qJAghngxnCY6\",\"output_index\":0,\"sequence_number\":12}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Paris\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"3YYnglZynq\",\"output_index\":0,\"sequence_number\":13}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"GDCwCTovK6MnYl\",\"output_index\":0,\"sequence_number\":14}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\\n\\n\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"YmECjwAYSnvoA\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"GW3IUFpjLh6bjAK\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"T6tD3Nl73FTKy\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Weather\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"6B4xQy2Sl\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"jvJHfNwsBDid0\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Sunny\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"hkdmfXrdgH\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"amVHCJ2FgggKQH8\",\"output_index\":0,\"sequence_number\":21}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"vxVSrsHzVWczM\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"22\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"4pJBFyXDw574US\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"°C\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"SD5sl0Yr98rOwX\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\\n\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"6RJ1RoQs48BL8\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"Hc7FgDyUVyNPXNs\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"QDiXuRX7HZWo7\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Population\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"52wtpY\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"HvlkTnsAPCbug\",\"output_index\":0,\"sequence_number\":29}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"wGGzBFSfMgdcR\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"KB8cgRHu0K0Hhrx\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"TqLPUocAGCdDZV9\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"161\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"We5OUH5GaUwGy\",\"output_index\":0,\"sequence_number\":33}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"HAd5x7F7Vw4jkZr\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"000\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"pDgGlIf5EmGRH\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\\n\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"3MCJgOOZ6ir7a\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"BgU2x2pvYizriOD\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"SuF1sYcYK7EbS\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Timezone\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"L6NMbriw\",\"output_index\":0,\"sequence_number\":39}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"CU860ErsaRbKY\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"yLCm1vUOKkZKA\",\"output_index\":0,\"sequence_number\":41}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"C\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"jnCP7TOMyLPD0yv\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"ET\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"eX990FsUr8DDmk\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"pMO8z0WzEo5Tjb\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"1RXsJE8VhDvM0X\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"UTC\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"F46lWX9R76YxZ\",\"output_index\":0,\"sequence_number\":46}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"UIGL4d3OEmRbt\",\"output_index\":0,\"sequence_number\":47}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"+\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"nPGJZVxT6l739P9\",\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"01\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"8QXPx9cQvfd1Y1\",\"output_index\":0,\"sequence_number\":49}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"e9LgnJBhTtg1JHJ\",\"output_index\":0,\"sequence_number\":50}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"00\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"UIGBmNaWMMGTyk\",\"output_index\":0,\"sequence_number\":51}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"DE6Kb9qTcKsRDr\",\"output_index\":0,\"sequence_number\":52}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\")\\n\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"qASGrdVea4FdAE\",\"output_index\":0,\"sequence_number\":53}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"bmndrl4UkqwZ45O\",\"output_index\":0,\"sequence_number\":54}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"vEWXJ5GhF3OEB\",\"output_index\":0,\"sequence_number\":55}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Primary\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"e4wCbpVF8\",\"output_index\":0,\"sequence_number\":56}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" language\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"emwweh0\",\"output_index\":0,\"sequence_number\":57}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"u7HZNH2tpY70v\",\"output_index\":0,\"sequence_number\":58}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"4MURyyYIROaT0\",\"output_index\":0,\"sequence_number\":59}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"French\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"mP2wuoj2kG\",\"output_index\":0,\"sequence_number\":60}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\\n\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"GAli1fAs1LWWP\",\"output_index\":0,\"sequence_number\":61}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"QcZBRDGkderMHtd\",\"output_index\":0,\"sequence_number\":62}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"eYIGTkyN9rF3K\",\"output_index\":0,\"sequence_number\":63}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Currency\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"aXBiSWKF\",\"output_index\":0,\"sequence_number\":64}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"EdNWRu18UVCDB\",\"output_index\":0,\"sequence_number\":65}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"E3hntdhr2Kimo\",\"output_index\":0,\"sequence_number\":66}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"EUR\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"ROGL6rSvgrdnR\",\"output_index\":0,\"sequence_number\":67}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"XkXE41ZS0SHoD4\",\"output_index\":0,\"sequence_number\":68}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"s2FHpafoO8nH\",\"output_index\":0,\"sequence_number\":69}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"€\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"5IFC3A2xvf4YNLx\",\"output_index\":0,\"sequence_number\":70}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"0YuvBZXQcR0Poe\",\"output_index\":0,\"sequence_number\":71}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\")\\n\\n\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"xCvQQd6edl5Uv\",\"output_index\":0,\"sequence_number\":72}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"If\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"vMndJkFrjAiKFR\",\"output_index\":0,\"sequence_number\":73}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" you\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"jSNSAGcf7q4A\",\"output_index\":0,\"sequence_number\":74}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" want\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"FlvWNDpU0AR\",\"output_index\":0,\"sequence_number\":75}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"gahqbzFoU6p3A2f\",\"output_index\":0,\"sequence_number\":76}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" I\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"FNo31nVMDWT0EM\",\"output_index\":0,\"sequence_number\":77}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" can\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"0FEm3qMntcbL\",\"output_index\":0,\"sequence_number\":78}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" also\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"uYrkZeni7qd\",\"output_index\":0,\"sequence_number\":79}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" format\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"ZKIXf0eAG\",\"output_index\":0,\"sequence_number\":80}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" this\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"ciqpAk0sWvA\",\"output_index\":0,\"sequence_number\":81}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" as\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"aBx78r6o4pYQz\",\"output_index\":0,\"sequence_number\":82}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"LG2jdDlefyPZ1v\",\"output_index\":0,\"sequence_number\":83}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" one\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"yGEMEXx8iinD\",\"output_index\":0,\"sequence_number\":84}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-page\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"IPBejjf5mUo\",\"output_index\":0,\"sequence_number\":85}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" “\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"ljNb1rAIBhHwmu\",\"output_index\":0,\"sequence_number\":86}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"city\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"13DisKTA4tNQ\",\"output_index\":0,\"sequence_number\":87}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" profile\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"6TU1PDKD\",\"output_index\":0,\"sequence_number\":88}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"”\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"n2H6IzLCdmTsBH3\",\"output_index\":0,\"sequence_number\":89}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" with\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"bwHHkzRL597\",\"output_index\":0,\"sequence_number\":90}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" quick\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"YhC2k9FyHj\",\"output_index\":0,\"sequence_number\":91}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" travel\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"H4NLSRaQ7\",\"output_index\":0,\"sequence_number\":92}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" tips\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"AxavCq8Wgdn\",\"output_index\":0,\"sequence_number\":93}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"1biA7Y4066IqKK\",\"output_index\":0,\"sequence_number\":94}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"best\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"WBA5XWhm1IUI\",\"output_index\":0,\"sequence_number\":95}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" season\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"EZt3gaKDs\",\"output_index\":0,\"sequence_number\":96}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"zaoAxncFsOG7jZR\",\"output_index\":0,\"sequence_number\":97}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" plug\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"NBoLag0G43i\",\"output_index\":0,\"sequence_number\":98}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" type\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"4t81eUQuyro\",\"output_index\":0,\"sequence_number\":99}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"itzGlnNM6gyko98\",\"output_index\":0,\"sequence_number\":100}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" transit\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"z5VzFMvT\",\"output_index\":0,\"sequence_number\":101}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" basics\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"Dl75myemo\",\"output_index\":0,\"sequence_number\":102}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"zmQWTNpq6M8VGrG\",\"output_index\":0,\"sequence_number\":103}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" etc\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"QOYxIEm8SvbC\",\"output_index\":0,\"sequence_number\":104}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".).\",\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"obfuscation\":\"b5raExrcflloD\",\"output_index\":0,\"sequence_number\":105}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":106,\"text\":\"Here’s your **comprehensive city report for Paris**:\\n\\n- **Weather:** Sunny, **22°C**\\n- **Population:** **2,161,000**\\n- **Timezone:** **CET** (UTC **+01:00**)\\n- **Primary language:** **French**\\n- **Currency:** **EUR** (**€**)\\n\\nIf you want, I can also format this as a one-page “city profile” with quick travel tips (best season, plug type, transit basics, etc.).\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here’s your **comprehensive city report for Paris**:\\n\\n- **Weather:** Sunny, **22°C**\\n- **Population:** **2,161,000**\\n- **Timezone:** **CET** (UTC **+01:00**)\\n- **Primary language:** **French**\\n- **Currency:** **EUR** (**€**)\\n\\nIf you want, I can also format this as a one-page “city profile” with quick travel tips (best season, plug type, transit basics, etc.).\"},\"sequence_number\":107}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here’s your **comprehensive city report for Paris**:\\n\\n- **Weather:** Sunny, **22°C**\\n- **Population:** **2,161,000**\\n- **Timezone:** **CET** (UTC **+01:00**)\\n- **Primary language:** **French**\\n- **Currency:** **EUR** (**€**)\\n\\nIf you want, I can also format this as a one-page “city profile” with quick travel tips (best season, plug type, transit basics, etc.).\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":108}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_09ebf0b1c87543630069b3ecff7f588193a907a7ef5a207744\",\"object\":\"response\",\"created_at\":1773399295,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399297,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.3-codex\",\"output\":[{\"id\":\"msg_09ebf0b1c87543630069b3ecffd60881938fe7f33be8445d31\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Here’s your **comprehensive city report for Paris**:\\n\\n- **Weather:** Sunny, **22°C**\\n- **Population:** **2,161,000**\\n- **Timezone:** **CET** (UTC **+01:00**)\\n- **Primary language:** **French**\\n- **Currency:** **EUR** (**€**)\\n\\nIf you want, I can also format this as a one-page “city profile” with quick travel tips (best season, plug type, transit basics, etc.).\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get the current weather for a city\",\"name\":\"getWeather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get weather for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the population of a city\",\"name\":\"getPopulation\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get population for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the timezone of a city\",\"name\":\"getTimezone\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get timezone for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the primary language spoken in a city\",\"name\":\"getLanguage\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the language for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Get the currency used in a city\",\"name\":\"getCurrency\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"The city to get the currency for\"}},\"required\":[\"city\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":539,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":106,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":645},\"user\":null,\"metadata\":{}},\"sequence_number\":109}\n\n"
+        ],
+        "chunkTimings": [
+          1, 3, 211, 3, 0, 1, 36, 6, 1, 0, 1, 42, 37, 3, 2, 43, 3, 1, 2, 40, 1, 2, 1, 3, 29, 4, 2, 1, 0, 40, 2, 3, 2, 2,
+          54, 3, 0, 3, 1, 32, 4, 42, 0, 50, 1, 1, 3, 2, 41, 0, 2, 1, 1, 46, 1, 5, 1, 0, 37, 2, 1, 2, 2, 37, 2, 7, 38, 2,
+          1, 1, 8, 67, 6, 1, 3, 3, 4, 32, 45, 50, 3, 2, 0, 36, 1, 1, 41, 48, 2, 1, 42, 5, 1, 44, 0, 40, 2, 7, 62, 4, 4,
+          118
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "f3aa27ba17e17d2b",
+      "request": {
+        "url": "https://api.anthropic.com/v1/messages",
+        "method": "POST",
+        "body": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 64000,
+          "temperature": 0,
+          "system": [
+            {
+              "type": "text",
+              "text": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+            }
+          ],
+          "messages": [
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            }
+          ],
+          "tools": [
+            {
+              "name": "getWeather",
+              "description": "Get the current weather for a city",
+              "input_schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get weather for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "name": "getPopulation",
+              "description": "Get the population of a city",
+              "input_schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get population for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "name": "getTimezone",
+              "description": "Get the timezone of a city",
+              "input_schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get timezone for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "name": "getLanguage",
+              "description": "Get the primary language spoken in a city",
+              "input_schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the language for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "name": "getCurrency",
+              "description": "Get the currency used in a city",
+              "input_schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the currency for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": {
+            "type": "auto"
+          },
+          "stream": true
+        },
+        "timestamp": 1773399297323
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "anthropic-organization-id": "a4b2106b-a1ab-4fd5-8d96-cdf4b3e9dc14",
+          "anthropic-ratelimit-input-tokens-limit": "4000000",
+          "anthropic-ratelimit-input-tokens-remaining": "3999000",
+          "anthropic-ratelimit-input-tokens-reset": "2026-03-13T10:54:57Z",
+          "anthropic-ratelimit-output-tokens-limit": "800000",
+          "anthropic-ratelimit-output-tokens-remaining": "800000",
+          "anthropic-ratelimit-output-tokens-reset": "2026-03-13T10:54:57Z",
+          "anthropic-ratelimit-requests-limit": "4000",
+          "anthropic-ratelimit-requests-remaining": "3999",
+          "anthropic-ratelimit-requests-reset": "2026-03-13T10:54:57Z",
+          "anthropic-ratelimit-tokens-limit": "4800000",
+          "anthropic-ratelimit-tokens-remaining": "4799000",
+          "anthropic-ratelimit-tokens-reset": "2026-03-13T10:54:57Z",
+          "cache-control": "no-cache",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba80e91a76aa57-BRU",
+          "connection": "keep-alive",
+          "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:54:58 GMT",
+          "request-id": "req_011CYzxRwzaFC6yqKwveRn8D",
+          "server": "cloudflare",
+          "server-timing": "proxy;dur=698",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "vary": "Accept-Encoding",
+          "x-envoy-upstream-service-time": "698",
+          "x-robots-tag": "none"
+        },
+        "chunks": [
+          "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-",
+          "4-5-20251001\",\"id\":\"msg_01VkpWKiA5WT38vDGth5zmP6\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":1070,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":3,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}           }\n\n",
+          "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"I'll create\"}}\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a comprehensive city report for Paris by\"}          }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" gathering all available\"}   }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" information. Here\"}  }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"'s my plan:\\n\\n**\"}             }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"What\"} }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" I'm about\"}               }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" to do:**\\n1. Get\"}          }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" the current weather in\"}     }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Paris\\n2. Get the population of\"}    }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Paris\\n3. Get the timezone for\"}        }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Paris\\n4. Get the primary language\"}      }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" spoken in Paris\\n5. Get the\"}           }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" currency used in Paris\\n\\nI\"}              }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"'ll call all 5 tools simultaneously\"}              }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" to\"}       }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" efficiently\"}}\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" gather this\"} }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" complete\"}        }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" information about\"}  }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Paris.\"}     }\n\n",
+          "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0   }\n\n",
+          "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_011hKxNSBEckTn7waqXaazS4\",\"name\":\"getWeather\",\"input\":{},\"caller\":{\"type\":\"direct\"}}               }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}            }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\": \\\"P\"}       }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"aris\"}             }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"}\"}             }\n\n",
+          "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+          "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01E9sS4sR2o9giQERfz7LpCg\",\"name\":\"getPopulation\",\"input\":{},\"caller\":{\"type\":\"direct\"}}              }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}          }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\":\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\" \\\"Paris\"}          }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"}\"}         }\n\n",
+          "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":2               }\n\n",
+          "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":3,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01VxCrnYLnHFvxKXxhiteqzx\",\"name\":\"getTimezone\",\"input\":{},\"caller\":{\"type\":\"direct\"}}       }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":3,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}        }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":3,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\": \\\"Pa\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":3,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"ris\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":3,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"}\"}      }\n\n",
+          "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":3        }\n\n",
+          "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":4,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01Yau6rwPjZ9mCaYWTKHzWiK\",\"name\":\"getLanguage\",\"input\":{},\"caller\":{\"type\":\"direct\"}} }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":4,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}               }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":4,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"\"}             }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":4,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"city\\\": \\\"\"}               }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":4,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"Paris\\\"}\"}}\n\n",
+          "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":4               }\n\n",
+          "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":5,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01LjnPsdHbhgqTH54rhSLX5e\",\"name\":\"getCurrency\",\"input\":{},\"caller\":{\"type\":\"direct\"}} }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":5,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}            }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":5,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"c\"}  }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":5,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"ity\\\":\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":5,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\" \\\"Paris\"}       }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":5,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"}\"}  }\n\n",
+          "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":5      }\n\n",
+          "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1070,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":289}               }\n\n",
+          "event: message_stop\ndata: {\"type\":\"message_stop\"      }\n\n"
+        ],
+        "chunkTimings": [
+          1, 0, 0, 283, 0, 0, 0, 1, 0, 0, 0, 203, 1, 0, 0, 0, 0, 0, 0, 147, 1, 0, 1, 2, 2, 1, 213, 0, 0, 1, 1, 0, 4, 0,
+          1, 0, 0, 200, 2, 1, 2, 117, 1, 1, 0, 1, 3, 1, 3, 1, 0, 11, 2
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "97392bc67c6ec6a7",
+      "request": {
+        "url": "https://api.anthropic.com/v1/messages",
+        "method": "POST",
+        "body": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 64000,
+          "temperature": 0,
+          "system": [
+            {
+              "type": "text",
+              "text": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+            }
+          ],
+          "messages": [
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            },
+            {
+              "role": "assistant",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "I'll create a comprehensive city report for Paris by gathering all available information. Here's my plan:\n\n**What I'm about to do:**\n1. Get the current weather in Paris\n2. Get the population of Paris\n3. Get the timezone for Paris\n4. Get the primary language spoken in Paris\n5. Get the currency used in Paris\n\nI'll call all 5 tools simultaneously to efficiently gather this complete information about Paris."
+                },
+                {
+                  "type": "tool_use",
+                  "id": "toolu_011hKxNSBEckTn7waqXaazS4",
+                  "name": "getWeather",
+                  "input": {
+                    "city": "Paris"
+                  }
+                },
+                {
+                  "type": "tool_use",
+                  "id": "toolu_01E9sS4sR2o9giQERfz7LpCg",
+                  "name": "getPopulation",
+                  "input": {
+                    "city": "Paris"
+                  }
+                },
+                {
+                  "type": "tool_use",
+                  "id": "toolu_01VxCrnYLnHFvxKXxhiteqzx",
+                  "name": "getTimezone",
+                  "input": {
+                    "city": "Paris"
+                  }
+                },
+                {
+                  "type": "tool_use",
+                  "id": "toolu_01Yau6rwPjZ9mCaYWTKHzWiK",
+                  "name": "getLanguage",
+                  "input": {
+                    "city": "Paris"
+                  }
+                },
+                {
+                  "type": "tool_use",
+                  "id": "toolu_01LjnPsdHbhgqTH54rhSLX5e",
+                  "name": "getCurrency",
+                  "input": {
+                    "city": "Paris"
+                  }
+                }
+              ]
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "tool_result",
+                  "tool_use_id": "toolu_011hKxNSBEckTn7waqXaazS4",
+                  "content": "{\"city\":\"Paris\",\"temperature\":22,\"condition\":\"sunny\"}"
+                },
+                {
+                  "type": "tool_result",
+                  "tool_use_id": "toolu_01E9sS4sR2o9giQERfz7LpCg",
+                  "content": "{\"city\":\"Paris\",\"population\":2161000}"
+                },
+                {
+                  "type": "tool_result",
+                  "tool_use_id": "toolu_01VxCrnYLnHFvxKXxhiteqzx",
+                  "content": "{\"city\":\"Paris\",\"timezone\":\"CET\",\"utcOffset\":\"+01:00\"}"
+                },
+                {
+                  "type": "tool_result",
+                  "tool_use_id": "toolu_01Yau6rwPjZ9mCaYWTKHzWiK",
+                  "content": "{\"city\":\"Paris\",\"language\":\"French\"}"
+                },
+                {
+                  "type": "tool_result",
+                  "tool_use_id": "toolu_01LjnPsdHbhgqTH54rhSLX5e",
+                  "content": "{\"city\":\"Paris\",\"currency\":\"EUR\",\"symbol\":\"€\"}"
+                }
+              ]
+            }
+          ],
+          "tools": [
+            {
+              "name": "getWeather",
+              "description": "Get the current weather for a city",
+              "input_schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get weather for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "name": "getPopulation",
+              "description": "Get the population of a city",
+              "input_schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get population for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "name": "getTimezone",
+              "description": "Get the timezone of a city",
+              "input_schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get timezone for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "name": "getLanguage",
+              "description": "Get the primary language spoken in a city",
+              "input_schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the language for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "name": "getCurrency",
+              "description": "Get the currency used in a city",
+              "input_schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "The city to get the currency for"
+                  }
+                },
+                "required": ["city"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": {
+            "type": "auto"
+          },
+          "stream": true
+        },
+        "timestamp": 1773399299459
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "anthropic-organization-id": "a4b2106b-a1ab-4fd5-8d96-cdf4b3e9dc14",
+          "anthropic-ratelimit-input-tokens-limit": "4000000",
+          "anthropic-ratelimit-input-tokens-remaining": "3999000",
+          "anthropic-ratelimit-input-tokens-reset": "2026-03-13T10:54:59Z",
+          "anthropic-ratelimit-output-tokens-limit": "800000",
+          "anthropic-ratelimit-output-tokens-remaining": "800000",
+          "anthropic-ratelimit-output-tokens-reset": "2026-03-13T10:54:59Z",
+          "anthropic-ratelimit-requests-limit": "4000",
+          "anthropic-ratelimit-requests-remaining": "3999",
+          "anthropic-ratelimit-requests-reset": "2026-03-13T10:54:59Z",
+          "anthropic-ratelimit-tokens-limit": "4800000",
+          "anthropic-ratelimit-tokens-remaining": "4799000",
+          "anthropic-ratelimit-tokens-reset": "2026-03-13T10:54:59Z",
+          "cache-control": "no-cache",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba80f60816aa57-BRU",
+          "connection": "keep-alive",
+          "content-security-policy": "default-src 'none'; frame-ancestors 'none'",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:54:59 GMT",
+          "request-id": "req_011CYzxS6kB9h1bBcJFMe1q7",
+          "server": "cloudflare",
+          "server-timing": "proxy;dur=268",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "vary": "Accept-Encoding",
+          "x-envoy-upstream-service-time": "268",
+          "x-robots-tag": "none"
+        },
+        "chunks": [
+          "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_01JGPCaoPHay7WbfAQ3xK1WQ\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":1560,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":1,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}              }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}      }\n\n",
+          "event: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"##\"}             }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Comprehensive City\"}  }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Report:\"}               }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Paris\\n\\nHere\"}         }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"'s your\"}         }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" complete\"}            }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Paris\"}            }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" city report:\\n\\n**\"}         }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Weather:**\\n- Temperature: 22\"}           }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"°C\"}          }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n- Condition: Sunny\"} }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n\\n**Population:**\\n- \"}         }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"2,161,000 residents\"}}\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n\\n**Timezone:**\\n- C\"}            }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ET (Central European Time)\"}              }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n- UTC\"}  }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Offset: +01:00\\n\\n**\"}         }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Language:**\\n- French\\n\\n**Currency\"}     }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\":**\\n- EUR\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" (Euro)\\n- Symbol: €\"} }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n\\nParis\"}             }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" is a vibrant city\"}    }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" with\"}             }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" over\"}       }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" 2 \"}    }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"million residents, currently\"}    }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" enjoying\"}             }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" sunny\"}              }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" weather at\"}            }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" a\"}   }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" pleasant\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" 22°C. As\"}     }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" the capital of France, it operates\"}   }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" on\"}             }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" Central European Time and\"}}\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" uses\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" the Euro as its currency,\"}      }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" with French\"}      }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" being\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" the primary language spoken\"}        }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" throughout\"}              }\n\n",
+          "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" the city.\"}        }\n\n",
+          "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0  }\n\n",
+          "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1560,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":156}       }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"            }\n\n"
+        ],
+        "chunkTimings": [
+          1, 0, 308, 35, 10, 5, 6, 2, 2, 1, 100, 2, 1, 10, 3, 2, 2, 1, 184, 0, 1, 0, 3, 0, 1, 204, 1, 1, 1, 1, 1, 1,
+          205, 1, 2, 4, 1, 1, 41, 1, 17
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "4a2d914ae13e3d06",
+      "request": {
+        "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+        "method": "POST",
+        "body": {
+          "generationConfig": {
+            "temperature": 0
+          },
+          "contents": [
+            {
+              "role": "user",
+              "parts": [
+                {
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            }
+          ],
+          "systemInstruction": {
+            "parts": [
+              {
+                "text": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+              }
+            ]
+          },
+          "tools": [
+            {
+              "functionDeclarations": [
+                {
+                  "name": "getWeather",
+                  "description": "Get the current weather for a city",
+                  "parameters": {
+                    "required": ["city"],
+                    "type": "object",
+                    "properties": {
+                      "city": {
+                        "description": "The city to get weather for",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "getPopulation",
+                  "description": "Get the population of a city",
+                  "parameters": {
+                    "required": ["city"],
+                    "type": "object",
+                    "properties": {
+                      "city": {
+                        "description": "The city to get population for",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "getTimezone",
+                  "description": "Get the timezone of a city",
+                  "parameters": {
+                    "required": ["city"],
+                    "type": "object",
+                    "properties": {
+                      "city": {
+                        "description": "The city to get timezone for",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "getLanguage",
+                  "description": "Get the primary language spoken in a city",
+                  "parameters": {
+                    "required": ["city"],
+                    "type": "object",
+                    "properties": {
+                      "city": {
+                        "description": "The city to get the language for",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "getCurrency",
+                  "description": "Get the currency used in a city",
+                  "parameters": {
+                    "required": ["city"],
+                    "type": "object",
+                    "properties": {
+                      "city": {
+                        "description": "The city to get the currency for",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "toolConfig": {
+            "functionCallingConfig": {
+              "mode": "AUTO"
+            }
+          }
+        },
+        "timestamp": 1773399301033
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+          "content-disposition": "attachment",
+          "content-type": "text/event-stream",
+          "date": "Fri, 13 Mar 2026 10:55:02 GMT",
+          "server": "scaffolding on HTTPServer2",
+          "server-timing": "gfet4t7; dur=1537",
+          "vary": "Origin, X-Origin, Referer",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "0"
+        },
+        "chunks": [
+          "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"I will now retrieve the weather, population, timezone, language, and currency for Paris.\\n\",\"thoughtSignature\": \"Cn0Bvj72++MFLMRWVK+PM7Ppac9hO+bKaEPnzJkNvyQiRRt3aDkH1Dk9ezecto2HFnRp/w1A7CeVYKHSpY13/JUu5K1xV+IZaLvKkcYM7RZZzAXlHIRh00HIdI5Xkf+WMQzBCycyGu5hke3Dcdb2GLpBTJ6Z0HCXFazwSpt7dwrlAQG+Pvb70twXI2eAXbyAfX7brj58rNX0aEjukoqT4Tzl/ZpZzGP0Gy1bjScJ0BzGCvNsuJvYBgnlQyQ5ozy78sxzE+yAJ8NALPsnmTcoNRMyShVzTUphdEVPTGipXGolXp3QzGiU1lNT97TlMu4qyJHGDwLUH/JdZoBf2mszkLV3dg7LS/eOx9eURpG8BTx7/QEU+gHxlzXpLfW5g9yOIreVUDtsdujyBNUbZY7pkdy1T+NWLhdY26/r+NYIBf4kfeiuwpyBqU14NAh+x+qaEPSluex/bo0Abok+7erBvlsTv8+dE14KkAEBvj72+86xt7JFlfkrWMvSOvSzbMXM6N0XAiWRcjkezLs2MO14hP7P25w/inG/lfa3I3OlrNbc8q3BFMWuwp8w3EidlRghx80GCJw5WnAanc0W0QNvt5B5++ZRZ7RsV7H2vXQ0a3mRJ60OI546otSOKpzs602gTqAqntVvqHRZiaWMIcCheu+uVH4NVTeXCgA=\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 313,\"candidatesTokenCount\": 18,\"totalTokenCount\": 42",
+          "4,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 313}],\"thoughtsTokenCount\": 93},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"Be2zafGfDZSjkdUP0_vJgQU\"}\r\n\r\n",
+          "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\": {\"name\": \"getWeather\",\"args\": {\"city\": \"Paris\"}}},{\"functionCall\": {\"name\": \"getPopulation\",\"args\": {\"city\": \"Paris\"}}},{\"functionCall\": {\"name\": \"getTimezone\",\"args\": {\"city\": \"Paris\"}}},{\"functionCall\": {\"name\": \"getLanguage\",\"args\": {\"city\": \"Paris\"}}},{\"functionCall\": {\"name\": \"getCurrency\",\"args\": {\"city\": \"Paris\"}}}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0,\"finishMessage\": \"Model generated function call(s).\"}],\"usageMetadata\": {\"promptTokenCount\": 313,\"candidatesTokenCount\": 87,\"totalTokenCount\": 493,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 313}],\"thoughtsTokenCount\": 93},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"Be2zafGfDZSjkdUP0_vJgQU\"}\r\n\r\n"
+        ],
+        "chunkTimings": [0, 0, 203],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "07f0741e9237c902",
+      "request": {
+        "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+        "method": "POST",
+        "body": {
+          "generationConfig": {
+            "temperature": 0
+          },
+          "contents": [
+            {
+              "role": "user",
+              "parts": [
+                {
+                  "text": "I need a comprehensive city report for Paris. Look up everything: weather, population, timezone, language, and currency. Explain what you are about to do first, then call all 5 tools simultaneously."
+                }
+              ]
+            },
+            {
+              "role": "model",
+              "parts": [
+                {
+                  "text": "I will now retrieve the weather, population, timezone, language, and currency for Paris.\n",
+                  "thoughtSignature": "Cn0Bvj72++MFLMRWVK+PM7Ppac9hO+bKaEPnzJkNvyQiRRt3aDkH1Dk9ezecto2HFnRp/w1A7CeVYKHSpY13/JUu5K1xV+IZaLvKkcYM7RZZzAXlHIRh00HIdI5Xkf+WMQzBCycyGu5hke3Dcdb2GLpBTJ6Z0HCXFazwSpt7dwrlAQG+Pvb70twXI2eAXbyAfX7brj58rNX0aEjukoqT4Tzl/ZpZzGP0Gy1bjScJ0BzGCvNsuJvYBgnlQyQ5ozy78sxzE+yAJ8NALPsnmTcoNRMyShVzTUphdEVPTGipXGolXp3QzGiU1lNT97TlMu4qyJHGDwLUH/JdZoBf2mszkLV3dg7LS/eOx9eURpG8BTx7/QEU+gHxlzXpLfW5g9yOIreVUDtsdujyBNUbZY7pkdy1T+NWLhdY26/r+NYIBf4kfeiuwpyBqU14NAh+x+qaEPSluex/bo0Abok+7erBvlsTv8+dE14KkAEBvj72+86xt7JFlfkrWMvSOvSzbMXM6N0XAiWRcjkezLs2MO14hP7P25w/inG/lfa3I3OlrNbc8q3BFMWuwp8w3EidlRghx80GCJw5WnAanc0W0QNvt5B5++ZRZ7RsV7H2vXQ0a3mRJ60OI546otSOKpzs602gTqAqntVvqHRZiaWMIcCheu+uVH4NVTeXCgA="
+                },
+                {
+                  "functionCall": {
+                    "name": "getWeather",
+                    "args": {
+                      "city": "Paris"
+                    }
+                  }
+                },
+                {
+                  "functionCall": {
+                    "name": "getPopulation",
+                    "args": {
+                      "city": "Paris"
+                    }
+                  }
+                },
+                {
+                  "functionCall": {
+                    "name": "getTimezone",
+                    "args": {
+                      "city": "Paris"
+                    }
+                  }
+                },
+                {
+                  "functionCall": {
+                    "name": "getLanguage",
+                    "args": {
+                      "city": "Paris"
+                    }
+                  }
+                },
+                {
+                  "functionCall": {
+                    "name": "getCurrency",
+                    "args": {
+                      "city": "Paris"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "role": "user",
+              "parts": [
+                {
+                  "functionResponse": {
+                    "name": "getWeather",
+                    "response": {
+                      "name": "getWeather",
+                      "content": {
+                        "city": "Paris",
+                        "temperature": 22,
+                        "condition": "sunny"
+                      }
+                    }
+                  }
+                },
+                {
+                  "functionResponse": {
+                    "name": "getPopulation",
+                    "response": {
+                      "name": "getPopulation",
+                      "content": {
+                        "city": "Paris",
+                        "population": 2161000
+                      }
+                    }
+                  }
+                },
+                {
+                  "functionResponse": {
+                    "name": "getTimezone",
+                    "response": {
+                      "name": "getTimezone",
+                      "content": {
+                        "city": "Paris",
+                        "timezone": "CET",
+                        "utcOffset": "+01:00"
+                      }
+                    }
+                  }
+                },
+                {
+                  "functionResponse": {
+                    "name": "getLanguage",
+                    "response": {
+                      "name": "getLanguage",
+                      "content": {
+                        "city": "Paris",
+                        "language": "French"
+                      }
+                    }
+                  }
+                },
+                {
+                  "functionResponse": {
+                    "name": "getCurrency",
+                    "response": {
+                      "name": "getCurrency",
+                      "content": {
+                        "city": "Paris",
+                        "currency": "EUR",
+                        "symbol": "€"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "systemInstruction": {
+            "parts": [
+              {
+                "text": "You are a helpful assistant with access to city information tools. When asked about a city, first explain your plan for what you will look up, then call ALL 5 tools in parallel. Always call all 5 tools at once while also providing text explaining what you are doing."
+              }
+            ]
+          },
+          "tools": [
+            {
+              "functionDeclarations": [
+                {
+                  "name": "getWeather",
+                  "description": "Get the current weather for a city",
+                  "parameters": {
+                    "required": ["city"],
+                    "type": "object",
+                    "properties": {
+                      "city": {
+                        "description": "The city to get weather for",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "getPopulation",
+                  "description": "Get the population of a city",
+                  "parameters": {
+                    "required": ["city"],
+                    "type": "object",
+                    "properties": {
+                      "city": {
+                        "description": "The city to get population for",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "getTimezone",
+                  "description": "Get the timezone of a city",
+                  "parameters": {
+                    "required": ["city"],
+                    "type": "object",
+                    "properties": {
+                      "city": {
+                        "description": "The city to get timezone for",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "getLanguage",
+                  "description": "Get the primary language spoken in a city",
+                  "parameters": {
+                    "required": ["city"],
+                    "type": "object",
+                    "properties": {
+                      "city": {
+                        "description": "The city to get the language for",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                {
+                  "name": "getCurrency",
+                  "description": "Get the currency used in a city",
+                  "parameters": {
+                    "required": ["city"],
+                    "type": "object",
+                    "properties": {
+                      "city": {
+                        "description": "The city to get the currency for",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "toolConfig": {
+            "functionCallingConfig": {
+              "mode": "AUTO"
+            }
+          }
+        },
+        "timestamp": 1773399302889
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+          "content-disposition": "attachment",
+          "content-type": "text/event-stream",
+          "date": "Fri, 13 Mar 2026 10:55:03 GMT",
+          "server": "scaffolding on HTTPServer2",
+          "server-timing": "gfet4t7; dur=869",
+          "vary": "Origin, X-Origin, Referer",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "0"
+        },
+        "chunks": [
+          "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Here is the comprehensive city report for Paris:\\n\\n**Weather:** The current weather in Paris is\",\"thoughtSignature\": \"Cm4Bvj72+9XFToc0bDK+Ny/hbcz6HFFl3UTpVT+Y4t5n/G69SZY5NuefC62MeIxBGQFJW4g9XmAFzqLBeLXhAU5JspOOWgHSl36R5PG1VhbTRasWGSelm8D2KqoBqxMmF4BpXQjehZxKnR68HX1W2gq0AQG+Pvb7fnkgMRm79JRnP9cDhTbK7dBNSXGc+yyodaFQpzxDtEd4Az0nFchcFwvd6+xUI5SBEwOAXz/BolZqVyuTqhMHPyhcxg24sj5cjaeFrljaei7uUl/jwR4yvNL72YwpUf3xE2wOpPFYdVk1Vc3f2tOw46y1Q4qrG/7bRMuOxZDrUk7EudmmDtChMNSx8S30AXeb5co68k2ZYQb79ehrZ1WOfE6nOZpaJB5XcSOeFdboMQqZAQG+Pvb7uYVmJY+VBtqfhkBapGg6yYiRcGi5TEPheVoRJeP0FielDRdcSo/njhCq6oEFOUKUKRfCp4MXLVdn8YwDFCwahNPLjM8pxocO2M4dFRaAkkWBcuwyyHCbCOsFVa6CnesvLgkIjUnCK7t5Wb/ssUNni77fEZW/qT3y3ef0e4p4/PWVKj6C86lWREaA1ep5lkq1ctchhg==\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 664,\"candidatesTokenCount\": 19,\"totalTokenCount\": 776,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 664}],\"",
+          "thoughtsTokenCount\": 93},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"Bu2zaaHCPO2YkdUPxZ37wAw\"}\r\n\r\n",
+          "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \" sunny with a temperature of 22 degrees Celsius.\\n**Population:** The population of Paris is 2,161,000.\\n**Timezone:** Paris is in the Central European Time (CET) zone, with a UTC\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 664,\"candidatesTokenCount\": 70,\"totalTokenCount\": 827,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 664}],\"thoughtsTokenCount\": 93},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"Bu2zaaHCPO2YkdUPxZ37wAw\"}\r\n\r\n",
+          "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \" offset of +01:00.\\n**Language:** The primary language spoken in Paris is French.\\n**Currency:** The currency used in Paris is the Euro (EUR), symbolized by €.\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 664,\"candidatesTokenCount\": 110,\"totalTokenCount\": 867,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 664}],\"thoughtsTokenCount\": 93},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"Bu2zaaHCPO2YkdUPxZ37wAw\"}\r\n\r\n"
+        ],
+        "chunkTimings": [0, 0, 115, 174],
+        "isStreaming": true
+      }
+    }
+  ]
+}

--- a/packages/core/__recordings__/core-src-processors-processors-structured-output.e2e.json
+++ b/packages/core/__recordings__/core-src-processors-processors-structured-output.e2e.json
@@ -1,0 +1,1152 @@
+{
+  "meta": {
+    "name": "core-src-processors-processors-structured-output.e2e",
+    "testFile": "src/processors/processors/structured-output.e2e.test.ts",
+    "model": "gpt-4o-mini",
+    "createdAt": "2026-03-13T10:50:42.518Z"
+  },
+  "recordings": [
+    {
+      "hash": "8292f6e5013156a8",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a data structuring specialist. Your job is to convert unstructured text into a specific JSON format.\n\nTASK: Convert the provided unstructured text into valid JSON that matches the following schema:\n\nREQUIREMENTS:\n- Return ONLY valid JSON, no additional text or explanation\n- Extract relevant information from the input text\n- If information is missing, use reasonable defaults or null values\n- Maintain data types as specified in the schema\n- Be consistent and accurate in your conversions\n\nThe input text may be in any format (sentences, bullet points, paragraphs, etc.). Extract the relevant data and structure it according to the schema."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "Extract and structure the key information from the following text according to the specified schema. Keep the original meaning and details:\n\n# Tool Calls\n## calculator\n### Input: {\"a\":5,\"b\":3}\n### Output: \n\n# Tool Results\ncalculator: {\n  \"sum\": 8\n}\n\n# Assistant Response\n{\"toolUsed\":\"calculator\",\"result\":\"8\",\"confidence\":0.95}"
+                }
+              ]
+            }
+          ],
+          "temperature": 0,
+          "text": {
+            "format": {
+              "type": "json_schema",
+              "strict": true,
+              "name": "response",
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "toolUsed": {
+                    "type": "string"
+                  },
+                  "result": {
+                    "type": "string"
+                  },
+                  "confidence": {
+                    "type": "number"
+                  }
+                },
+                "required": ["toolUsed", "result", "confidence"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "stream": true
+        },
+        "timestamp": 1773399026143
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba7a4a480cba5d-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:50:26 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "47",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_67c48247a74040faae5fcaa4e9960782"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0c481929d434a3f80069b3ebf2bc5c8195956fa5179b5fd969\",\"object\":\"response\",\"created_at\":1773399026,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"json_schema\",\"description\":null,\"name\":\"response\",\"schema\":{\"type\":\"object\",\"properties\":{\"toolUsed\":{\"type\":\"string\"},\"result\":{\"type\":\"string\"},\"confidence\":{\"type\":\"number\"}},\"required\":[\"toolUsed\",\"result\",\"confidence\"],\"additionalProperties\":false},\"strict\":true},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0c481929d434a3f80069b3ebf2bc5c8195956fa5179b5fd969\",\"object\":\"response\",\"created_at\":1773399026,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"json_schema\",\"description\":null,\"name\":\"response\",\"schema\":{\"type\":\"object\",\"properties\":{\"toolUsed\":{\"type\":\"string\"},\"result\":{\"type\":\"string\"},\"confidence\":{\"type\":\"number\"}},\"required\":[\"toolUsed\",\"result\",\"confidence\"],\"additionalProperties\":false},\"strict\":true},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\nevent: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"{\\\"\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"PDXzN3RxscLAkM\",\"output_index\":0,\"sequence_number\":4}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"tool\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"VMrlvZ1krleY\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Used\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"pzGv8yTSPG0s\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\":\\\"\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"50vQXUUFpNElG\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"calculator\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"cAl9lh\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\",\\\"\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"RPNZYzPLZ4u7H\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"result\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"AfnGHxbNCv\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\":\\\"\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"9zhuH7ZSmyfyn\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"8\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"CV55Im7VDIUclhl\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\",\\\"\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"gHCicN7MS5RWY\",\"output_index\":0,\"sequence_number\":13}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"confidence\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"P13oFN\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\":\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"ASVcJRbYOfKRua\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"0\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"NMpytTm5whCQA3m\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"3Gn9WInLESNQDed\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"95\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"VY3zK32Vqzaz8P\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"}\",\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"obfuscation\":\"5udwda8wpPZ4vzO\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":20,\"text\":\"{\\\"toolUsed\\\":\\\"calculator\\\",\\\"result\\\":\\\"8\\\",\\\"confidence\\\":0.95}\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"{\\\"toolUsed\\\":\\\"calculator\\\",\\\"result\\\":\\\"8\\\",\\\"confidence\\\":0.95}\"},\"sequence_number\":21}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"{\\\"toolUsed\\\":\\\"calculator\\\",\\\"result\\\":\\\"8\\\",\\\"confidence\\\":0.95}\"}],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0c481929d434a3f80069b3ebf2bc5c8195956fa5179b5fd969\",\"object\":\"response\",\"created_at\":1773399026,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399027,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_0c481929d434a3f80069b3ebf37d388195a57dfb9124e78334\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"{\\\"toolUsed\\\":\\\"calculator\\\",\\\"result\\\":\\\"8\\\",\\\"confidence\\\":0.95}\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"json_schema\",\"description\":null,\"name\":\"response\",\"schema\":{\"type\":\"object\",\"properties\":{\"toolUsed\":{\"type\":\"string\"},\"result\":{\"type\":\"string\"},\"confidence\":{\"type\":\"number\"}},\"required\":[\"toolUsed\",\"result\",\"confidence\"],\"additionalProperties\":false},\"strict\":true},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\"",
+          ":256,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":17,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":273},\"user\":null,\"metadata\":{}},\"sequence_number\":23}\n\n"
+        ],
+        "chunkTimings": [2, 0, 708, 44, 40, 0, 42, 3, 24, 0, 29, 1, 26, 1, 39, 2, 8, 0, 26, 2, 1, 107, 1],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "614cd25456f612f7",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a helpful assistant. Figure out the weather and then using that weather plan some activities. Always use the weather tool first, and then the plan activities tool with the result of the weather tool. Every tool call you make IMMEDIATELY explain the tool results after executing the tool, before moving on to other steps or tool calls\n\nYour response will be processed by another agent to extract structured data. Please ensure your response contains comprehensive information for all the following fields that will be extracted:\n\n{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"activities\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"toolsCalled\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"location\":{\"type\":\"string\"}},\"required\":[\"activities\",\"toolsCalled\",\"location\"],\"additionalProperties\":false}\n\n\nYou don't need to format your response as JSON unless the user asks you to. Just ensure your natural language response includes relevant information for each field in the schema above."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "What is the weather in Toronto?"
+                }
+              ]
+            }
+          ],
+          "temperature": 0,
+          "tools": [
+            {
+              "type": "function",
+              "name": "weatherTool",
+              "description": "Get weather for a location",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string"
+                  }
+                },
+                "required": ["location"],
+                "additionalProperties": false
+              },
+              "strict": true
+            },
+            {
+              "type": "function",
+              "name": "planActivities",
+              "description": "Plan activities based on the weather",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "temperature": {
+                    "type": "string"
+                  }
+                },
+                "required": ["temperature"],
+                "additionalProperties": false
+              },
+              "strict": true
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399027956
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba7a554f28867c-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:50:28 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "58",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_5f89f6cf7a2a4b169d4acf319de70199"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0ae8fd830b7035e90069b3ebf47f3881908cb03dd5c519ede2\",\"object\":\"response\",\"created_at\":1773399028,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get weather for a location\",\"name\":\"weatherTool\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Plan activities based on the weather\",\"name\":\"planActivities\",\"parameters\":{\"type\":\"object\",\"properties\":{\"temperature\":{\"type\":\"string\"}},\"required\":[\"temperature\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0ae8fd830b7035e90069b3ebf47f3881908cb03dd5c519ede2\",\"object\":\"response\",\"created_at\":1773399028,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get weather for a location\",\"name\":\"weatherTool\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Plan activities based on the weather\",\"name\":\"planActivities\",\"parameters\":{\"type\":\"object\",\"properties\":{\"temperature\":{\"type\":\"string\"}},\"required\":[\"temperature\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_mPzw2pri84Z1o0VUbM8KE7T4\",\"name\":\"weatherTool\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651\",\"obfuscation\":\"b4DxrKUGTAx9bt\",\"output_index\":0,\"sequence_number\":3}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"location\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651\",\"obfuscation\":\"WgxPCMfP\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\":\\\"\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651\",\"obfuscation\":\"JtssWx3HvkwQe\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"Toronto\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651\",\"obfuscation\":\"N0vfL3NZp\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\"}\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651\",\"obfuscation\":\"GtwmVe6JDed50o\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"location\\\":\\\"Toronto\\\"}\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"location\\\":\\\"Toronto\\\"}\",\"call_id\":\"call_mPzw2pri84Z1o0VUbM8KE7T4\",\"name\":\"weatherTool\"},\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0ae8fd830b7035e90069b3ebf47f3881908cb03dd5c519ede2\",\"object\":\"response\",\"created_at\":1773399028,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399029,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"location\\\":\\\"Toronto\\\"}\",\"call_id\":\"call_mPzw2pri84Z1o0VUbM8KE7T4\",\"name\":\"weatherTool\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get weather for a location\",\"name\":\"weatherTool\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Plan activities based on the weather\",\"name\":\"planActivities\",\"parameters\":{\"type\":\"object\",\"properties\":{\"temperature\":{\"type\":\"str",
+          "ing\"}},\"required\":[\"temperature\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":272,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":15,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":287},\"user\":null,\"metadata\":{}},\"sequence_number\":10}\n\n"
+        ],
+        "chunkTimings": [3, 5, 958, 3, 56, 0, 15, 7, 21, 3, 61, 1],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "a32b460204664ddb",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a helpful assistant. Figure out the weather and then using that weather plan some activities. Always use the weather tool first, and then the plan activities tool with the result of the weather tool. Every tool call you make IMMEDIATELY explain the tool results after executing the tool, before moving on to other steps or tool calls\n\nYour response will be processed by another agent to extract structured data. Please ensure your response contains comprehensive information for all the following fields that will be extracted:\n\n{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"activities\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"toolsCalled\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"location\":{\"type\":\"string\"}},\"required\":[\"activities\",\"toolsCalled\",\"location\"],\"additionalProperties\":false}\n\n\nYou don't need to format your response as JSON unless the user asks you to. Just ensure your natural language response includes relevant information for each field in the schema above."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "What is the weather in Toronto?"
+                }
+              ]
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_mPzw2pri84Z1o0VUbM8KE7T4",
+              "output": "{\"temperature\":70,\"feelsLike\":65,\"humidity\":50,\"windSpeed\":10,\"windGust\":15,\"conditions\":\"sunny\",\"location\":\"Toronto\"}"
+            }
+          ],
+          "temperature": 0,
+          "tools": [
+            {
+              "type": "function",
+              "name": "weatherTool",
+              "description": "Get weather for a location",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string"
+                  }
+                },
+                "required": ["location"],
+                "additionalProperties": false
+              },
+              "strict": true
+            },
+            {
+              "type": "function",
+              "name": "planActivities",
+              "description": "Plan activities based on the weather",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "temperature": {
+                    "type": "string"
+                  }
+                },
+                "required": ["temperature"],
+                "additionalProperties": false
+              },
+              "strict": true
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399029716
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba7a602842ba5d-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:50:30 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "115",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_94327372ae4d492ca731da57b63bd369"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0ae8fd830b7035e90069b3ebf663808190ae975f693edf37f6\",\"object\":\"response\",\"created_at\":1773399030,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get weather for a location\",\"name\":\"weatherTool\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Plan activities based on the weather\",\"name\":\"planActivities\",\"parameters\":{\"type\":\"object\",\"properties\":{\"temperature\":{\"type\":\"string\"}},\"required\":[\"temperature\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0ae8fd830b7035e90069b3ebf663808190ae975f693edf37f6\",\"object\":\"response\",\"created_at\":1773399030,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get weather for a location\",\"name\":\"weatherTool\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Plan activities based on the weather\",\"name\":\"planActivities\",\"parameters\":{\"type\":\"object\",\"properties\":{\"temperature\":{\"type\":\"string\"}},\"required\":[\"temperature\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0ae8fd830b7035e90069b3ebf7982481908fdd5950642f0984\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_eUYpeEsqJI4qLozo19VRlrg3\",\"name\":\"planActivities\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf7982481908fdd5950642f0984\",\"obfuscation\":\"fVy6YmBdTqEDMu\",\"output_index\":0,\"sequence_number\":3}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"temperature\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf7982481908fdd5950642f0984\",\"obfuscation\":\"V6AO6\",\"output_index\":0,\"sequence_number\":4}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\":\\\"\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf7982481908fdd5950642f0984\",\"obfuscation\":\"j6bdcdniOXslm\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"70\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf7982481908fdd5950642f0984\",\"obfuscation\":\"M7TXlCE5JTCxi0\",\"output_index\":0,\"sequence_number\":6}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\"}\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf7982481908fdd5950642f0984\",\"obfuscation\":\"Tftr7Q2RDqngVX\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"temperature\\\":\\\"70\\\"}\",\"item_id\":\"fc_0ae8fd830b7035e90069b3ebf7982481908fdd5950642f0984\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0ae8fd830b7035e90069b3ebf7982481908fdd5950642f0984\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"temperature\\\":\\\"70\\\"}\",\"call_id\":\"call_eUYpeEsqJI4qLozo19VRlrg3\",\"name\":\"planActivities\"},\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0ae8fd830b7035e90069b3ebf663808190ae975f693edf37f6\",\"object\":\"response\",\"created_at\":1773399030,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399031,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"fc_0ae8fd830b7035e90069b3ebf7982481908fdd5950642f0984\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"temperature\\\":\\\"70\\\"}\",\"call_id\":\"call_eUYpeEsqJI4qLozo19VRlrg3\",\"name\":\"planActivities\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get weather for a location\",\"name\":\"weatherTool\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Plan activities based on the weather\",\"name\":\"planActivities\",\"parameters\":{\"type\":\"object\",\"properties\":{\"temperature\":{\"type\":\"st",
+          "ring\"}},\"required\":[\"temperature\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":330,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":15,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":345},\"user\":null,\"metadata\":{}},\"sequence_number\":10}\n\n"
+        ],
+        "chunkTimings": [1, 1, 1100, 0, 65, 10, 22, 2, 116, 0],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "84eea1349cee3eb4",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a helpful assistant. Figure out the weather and then using that weather plan some activities. Always use the weather tool first, and then the plan activities tool with the result of the weather tool. Every tool call you make IMMEDIATELY explain the tool results after executing the tool, before moving on to other steps or tool calls\n\nYour response will be processed by another agent to extract structured data. Please ensure your response contains comprehensive information for all the following fields that will be extracted:\n\n{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"activities\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"toolsCalled\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"location\":{\"type\":\"string\"}},\"required\":[\"activities\",\"toolsCalled\",\"location\"],\"additionalProperties\":false}\n\n\nYou don't need to format your response as JSON unless the user asks you to. Just ensure your natural language response includes relevant information for each field in the schema above."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "What is the weather in Toronto?"
+                }
+              ]
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_0ae8fd830b7035e90069b3ebf58348819084926f6df7cae651"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_0ae8fd830b7035e90069b3ebf7982481908fdd5950642f0984"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_mPzw2pri84Z1o0VUbM8KE7T4",
+              "output": "{\"temperature\":70,\"feelsLike\":65,\"humidity\":50,\"windSpeed\":10,\"windGust\":15,\"conditions\":\"sunny\",\"location\":\"Toronto\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_eUYpeEsqJI4qLozo19VRlrg3",
+              "output": "{\"activities\":\"Plan activities based on the weather\"}"
+            }
+          ],
+          "temperature": 0,
+          "tools": [
+            {
+              "type": "function",
+              "name": "weatherTool",
+              "description": "Get weather for a location",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string"
+                  }
+                },
+                "required": ["location"],
+                "additionalProperties": false
+              },
+              "strict": true
+            },
+            {
+              "type": "function",
+              "name": "planActivities",
+              "description": "Plan activities based on the weather",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "temperature": {
+                    "type": "string"
+                  }
+                },
+                "required": ["temperature"],
+                "additionalProperties": false
+              },
+              "strict": true
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1773399031843
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba7a6d6fc1ba5d-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:50:32 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "91",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_7be4923ee94d443ea584c5f8fc7a4669"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0ae8fd830b7035e90069b3ebf84f3081908e1f1e7c2240b280\",\"object\":\"response\",\"created_at\":1773399032,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get weather for a location\",\"name\":\"weatherTool\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Plan activities based on the weather\",\"name\":\"planActivities\",\"parameters\":{\"type\":\"object\",\"properties\":{\"temperature\":{\"type\":\"string\"}},\"required\":[\"temperature\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0ae8fd830b7035e90069b3ebf84f3081908e1f1e7c2240b280\",\"object\":\"response\",\"created_at\":1773399032,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get weather for a location\",\"name\":\"weatherTool\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Plan activities based on the weather\",\"name\":\"planActivities\",\"parameters\":{\"type\":\"object\",\"properties\":{\"temperature\":{\"type\":\"string\"}},\"required\":[\"temperature\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"The\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Qu1lEGi15lrjM\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" current\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"RE1CIPED\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" weather\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"CcVyRzuC\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"90juJ5Ce0CDzd\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Toronto\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"qGj3B3Pe\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"FYk4lbL2QqRfP\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" sunny\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"UznHxHJSAs\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" with\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"R4qYc4c7Ru8\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"z5cTk7t4aIrYAh\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" temperature\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"bp7l\",\"output_index\":0,\"sequence_number\":13}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"xZ0uHzP1SYvI6\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"6ONBkV407q45JZr\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"70\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"ggCltPu6ePCJxc\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"°F\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"KDmadggvwGRGwT\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"C3q9InJ2sMcDpPL\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" It\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"mvLIgcPkhC97J\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" feels\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"7MPqixrbPy\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" like\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"7AU8kCWRTHU\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"zYwc2DRaen8oimh\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"65\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"5c2DYvFPjrZvmi\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"°F\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"j7A5k2kANAiO89\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"JSW8deufLgXTyw8\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" with\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"GemYb6TLXjk\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"PAUqZ3rhJWLq0N\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" humidity\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"mXZjJrX\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" level\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"V0xTsURub3\",\"output_index\":0,\"sequence_number\":29}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"f5k15iz6gt6K6\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"h37ypjxGZcC9Sp6\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"50\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"5w7h9R22xgTpfG\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"%.\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"AyeUTe9t5UEChq\",\"output_index\":0,\"sequence_number\":33}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" The\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"3iUgLoKyidxR\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" wind\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"4n2YEmBQwja\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"XtDvx9jwzeEmW\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" blowing\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"MMPvy5fN\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" at\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"TVSWY8GqanDpz\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Q02GPHZaUqEw6F\",\"output_index\":0,\"sequence_number\":39}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" speed\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"bqQ6Q0Qor5\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"6yox6yJZvysSt\",\"output_index\":0,\"sequence_number\":41}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"CEWXEHU6To5VogT\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"10\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"aTMDTVlFbp50cp\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" mph\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"mhEijzXocRvo\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"NhmIBMw48YnA09v\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" with\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"SJ5M0IipXgb\",\"output_index\":0,\"sequence_number\":46}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" gust\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"e41yqJn0qcw\",\"output_index\":0,\"sequence_number\":47}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"s\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Rg8EPg0gROzAu0z\",\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" up\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"L9kaVWQYjSTGi\",\"output_index\":0,\"sequence_number\":49}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" to\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"uxT3bU4EiXWg1\",\"output_index\":0,\"sequence_number\":50}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Ewrwky3kgi7asiB\",\"output_index\":0,\"sequence_number\":51}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"15\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"IQjdVqIpLxkaRx\",\"output_index\":0,\"sequence_number\":52}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" mph\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"bBWvDcoyBxKG\",\"output_index\":0,\"sequence_number\":53}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"PLS6oHkAEnXXy\",\"output_index\":0,\"sequence_number\":54}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Based\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"zinnIuvIBoJ\",\"output_index\":0,\"sequence_number\":55}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" on\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"58TyFPahX9CPf\",\"output_index\":0,\"sequence_number\":56}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" this\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"8qC10gXWGQg\",\"output_index\":0,\"sequence_number\":57}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" pleasant\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Rk4OEsd\",\"output_index\":0,\"sequence_number\":58}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" weather\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"AgMfTQ06\",\"output_index\":0,\"sequence_number\":59}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"TItQfS8mHBjUtXQ\",\"output_index\":0,\"sequence_number\":60}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" here\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"VWiArdhzhxR\",\"output_index\":0,\"sequence_number\":61}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" are\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"PFEp5sPBu8B7\",\"output_index\":0,\"sequence_number\":62}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" some\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"35FbLiTDr34\",\"output_index\":0,\"sequence_number\":63}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" suggested\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"rY7cpk\",\"output_index\":0,\"sequence_number\":64}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" activities\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"beOxx\",\"output_index\":0,\"sequence_number\":65}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"1DXLljd4TqxIJv\",\"output_index\":0,\"sequence_number\":66}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"1\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"K9pe5H3lbbzKnqL\",\"output_index\":0,\"sequence_number\":67}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"5pzGsF1MsZJ8pWE\",\"output_index\":0,\"sequence_number\":68}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Go\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"UJxz38Rn3ScPN\",\"output_index\":0,\"sequence_number\":69}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" for\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"auzaJ6I8wWJx\",\"output_index\":0,\"sequence_number\":70}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"ShCFFvVA0VaBhJ\",\"output_index\":0,\"sequence_number\":71}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" walk\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"fu3WePsBkep\",\"output_index\":0,\"sequence_number\":72}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" or\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"qWlsPAZkim3Ec\",\"output_index\":0,\"sequence_number\":73}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" bike\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"XKCaTqr9Jth\",\"output_index\":0,\"sequence_number\":74}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" ride\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"CAYHOUuL2rH\",\"output_index\":0,\"sequence_number\":75}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"QkK9dS5lL5J2f\",\"output_index\":0,\"sequence_number\":76}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" one\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"nt2Paw4f7rPP\",\"output_index\":0,\"sequence_number\":77}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"14ywU6nOlwPgU\",\"output_index\":0,\"sequence_number\":78}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Toronto\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"6ZwJPEAn\",\"output_index\":0,\"sequence_number\":79}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"'s\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"hPcduLxm2f7UYS\",\"output_index\":0,\"sequence_number\":80}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" parks\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"uajwPhqOEO\",\"output_index\":0,\"sequence_number\":81}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"oI1KeN0Ju8AdEr\",\"output_index\":0,\"sequence_number\":82}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"wvU5K40LLIN9Hxq\",\"output_index\":0,\"sequence_number\":83}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"qicJ4lVd3OGgne9\",\"output_index\":0,\"sequence_number\":84}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Have\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"9s2JPaW4wNb\",\"output_index\":0,\"sequence_number\":85}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"4BgRSfWGBo3Zqh\",\"output_index\":0,\"sequence_number\":86}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" picnic\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"oM2b5DxYK\",\"output_index\":0,\"sequence_number\":87}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" at\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"pPOro34VN7vHp\",\"output_index\":0,\"sequence_number\":88}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"brHdH3WFQuqvFS\",\"output_index\":0,\"sequence_number\":89}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" local\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Kvbj6OytnK\",\"output_index\":0,\"sequence_number\":90}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" outdoor\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"d2huCrTb\",\"output_index\":0,\"sequence_number\":91}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" space\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"BTV5VS4c7S\",\"output_index\":0,\"sequence_number\":92}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"O7TsalMcZ3vmSZ\",\"output_index\":0,\"sequence_number\":93}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"3\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"IGqfP7IEkofe9nj\",\"output_index\":0,\"sequence_number\":94}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"9kP7x7WGxb8lJiY\",\"output_index\":0,\"sequence_number\":95}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Visit\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"FDqSXufRNg\",\"output_index\":0,\"sequence_number\":96}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" an\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"IeS67d2QSF2tx\",\"output_index\":0,\"sequence_number\":97}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" outdoor\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"XLTiu3yw\",\"output_index\":0,\"sequence_number\":98}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" market\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"yAgA4o1uh\",\"output_index\":0,\"sequence_number\":99}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" or\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"cjBkXQiO4Zgrk\",\"output_index\":0,\"sequence_number\":100}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" festival\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"DjWC479\",\"output_index\":0,\"sequence_number\":101}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"dSQWnFjw8JIZxE\",\"output_index\":0,\"sequence_number\":102}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"4\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"PIBokgb9NyQzmp1\",\"output_index\":0,\"sequence_number\":103}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"z8YliRThV2ZsjeW\",\"output_index\":0,\"sequence_number\":104}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Enjoy\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"KgVjo740rl\",\"output_index\":0,\"sequence_number\":105}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"gquzkIYBYKjchH\",\"output_index\":0,\"sequence_number\":106}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" meal\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Y0kYY0Vm43r\",\"output_index\":0,\"sequence_number\":107}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" at\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"IQQ3LTaXRg07v\",\"output_index\":0,\"sequence_number\":108}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"H0X8qq4kgwjIJ9\",\"output_index\":0,\"sequence_number\":109}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" patio\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"NU8zaYnYif\",\"output_index\":0,\"sequence_number\":110}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" restaurant\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"C1r2u\",\"output_index\":0,\"sequence_number\":111}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"U5AA2SIoKyDIER\",\"output_index\":0,\"sequence_number\":112}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"5\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"VrvzJIXeN3R9CCo\",\"output_index\":0,\"sequence_number\":113}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"c5UNkDYphXbg1aM\",\"output_index\":0,\"sequence_number\":114}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Explore\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"gJfEsBiu\",\"output_index\":0,\"sequence_number\":115}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"y5FbJR0kd49V\",\"output_index\":0,\"sequence_number\":116}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" waterfront\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"pwWYl\",\"output_index\":0,\"sequence_number\":117}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" area\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"E9gPVDgcsc1\",\"output_index\":0,\"sequence_number\":118}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"ttKvkWjVBMvJ7\",\"output_index\":0,\"sequence_number\":119}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"###\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"yjO4Gmh9392nJ\",\"output_index\":0,\"sequence_number\":120}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Summary\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"x9OgyBOQ\",\"output_index\":0,\"sequence_number\":121}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"qrmpgY4JBfvLmA\",\"output_index\":0,\"sequence_number\":122}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"AbyutBPw34eC0Y3\",\"output_index\":0,\"sequence_number\":123}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"xUI5IKlGSsqXP\",\"output_index\":0,\"sequence_number\":124}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Location\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Iqrlpk8K\",\"output_index\":0,\"sequence_number\":125}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"ojkq1FQcJI9ql\",\"output_index\":0,\"sequence_number\":126}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Toronto\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"BiQ1wlsI\",\"output_index\":0,\"sequence_number\":127}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"SjQmjsnIJdtCDwc\",\"output_index\":0,\"sequence_number\":128}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"JOvQwa3gMW2cOs7\",\"output_index\":0,\"sequence_number\":129}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"RXQom5B45Kle0\",\"output_index\":0,\"sequence_number\":130}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Weather\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Z18gv8beB\",\"output_index\":0,\"sequence_number\":131}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"r7o5PKfbNV6KR\",\"output_index\":0,\"sequence_number\":132}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Sunny\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"seVyHLDdZ5\",\"output_index\":0,\"sequence_number\":133}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"b6UfHPGuiFeGUM2\",\"output_index\":0,\"sequence_number\":134}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"YkUjkrujE1gLM3x\",\"output_index\":0,\"sequence_number\":135}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"70\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"IzN70S4RRh7hZB\",\"output_index\":0,\"sequence_number\":136}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"°F\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"OjHZkhxHQkxkjo\",\"output_index\":0,\"sequence_number\":137}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" (\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"1esJN2a2PLDvd6\",\"output_index\":0,\"sequence_number\":138}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"fe\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"R4ucXL4taxaJ64\",\"output_index\":0,\"sequence_number\":139}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"els\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"x2UlUlToEGYHY\",\"output_index\":0,\"sequence_number\":140}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" like\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"lQxDgBms5XF\",\"output_index\":0,\"sequence_number\":141}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"GJ2ZdVLRCRDKDVp\",\"output_index\":0,\"sequence_number\":142}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"65\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"hmoFGKF3mvNdMq\",\"output_index\":0,\"sequence_number\":143}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"°F\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"mkRVAe9FGWyH0A\",\"output_index\":0,\"sequence_number\":144}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"),\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"gjkZUaf8c3okjb\",\"output_index\":0,\"sequence_number\":145}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Y16LcOkcDSwZ857\",\"output_index\":0,\"sequence_number\":146}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"50\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"MFKHNBZz3clgt6\",\"output_index\":0,\"sequence_number\":147}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"%\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"cEnIWHTxuF9z809\",\"output_index\":0,\"sequence_number\":148}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" humidity\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"58NXhP8\",\"output_index\":0,\"sequence_number\":149}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"UDbG7HZXt5CJmSi\",\"output_index\":0,\"sequence_number\":150}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"-\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"4NZhC0jY466Gave\",\"output_index\":0,\"sequence_number\":151}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" **\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"9DpR2GtzXpxc2\",\"output_index\":0,\"sequence_number\":152}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Activities\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"2nb7t5\",\"output_index\":0,\"sequence_number\":153}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":**\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"gAzuMxlDoMr5M\",\"output_index\":0,\"sequence_number\":154}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"R91dQVzPgAw1lF\",\"output_index\":0,\"sequence_number\":155}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"dn9uXqFeb4xqYs4\",\"output_index\":0,\"sequence_number\":156}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" -\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"VBlA7djkFYjvPP\",\"output_index\":0,\"sequence_number\":157}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Go\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"RALoeNDkPoZaO\",\"output_index\":0,\"sequence_number\":158}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" for\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Uo6x4xkoeVB2\",\"output_index\":0,\"sequence_number\":159}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"UOjOcpCqxRxCGK\",\"output_index\":0,\"sequence_number\":160}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" walk\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"XiBteO9r2Ry\",\"output_index\":0,\"sequence_number\":161}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" or\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"O84Ij5dSB3PkC\",\"output_index\":0,\"sequence_number\":162}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" bike\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Qqy5NRJx1L9\",\"output_index\":0,\"sequence_number\":163}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" ride\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"GWnSSkSyoAD\",\"output_index\":0,\"sequence_number\":164}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"NKSQbUgLGObiike\",\"output_index\":0,\"sequence_number\":165}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"72GG8rdnvTgUVhb\",\"output_index\":0,\"sequence_number\":166}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" -\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"H8dXWUr50o5GX5\",\"output_index\":0,\"sequence_number\":167}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Have\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"hZwaVuswXUy\",\"output_index\":0,\"sequence_number\":168}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"HSCqQ737Zh0YGU\",\"output_index\":0,\"sequence_number\":169}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" picnic\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"nlmlxVBGT\",\"output_index\":0,\"sequence_number\":170}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"RAnWDbhCvrhHOuh\",\"output_index\":0,\"sequence_number\":171}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"bykML86UAYiMqvR\",\"output_index\":0,\"sequence_number\":172}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" -\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"K8gV4q487m8w3N\",\"output_index\":0,\"sequence_number\":173}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Visit\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"TPaA3mXuSh\",\"output_index\":0,\"sequence_number\":174}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" an\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"SGtDhGvirXfUM\",\"output_index\":0,\"sequence_number\":175}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" outdoor\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"OQSoNXV2\",\"output_index\":0,\"sequence_number\":176}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" market\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"6yJrErfdX\",\"output_index\":0,\"sequence_number\":177}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"fZ03kz1busUD2qK\",\"output_index\":0,\"sequence_number\":178}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"fjQ5sAIJ4XBndsY\",\"output_index\":0,\"sequence_number\":179}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" -\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"8wSSZdodZ2RQLK\",\"output_index\":0,\"sequence_number\":180}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Enjoy\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"ikn6V6xZzr\",\"output_index\":0,\"sequence_number\":181}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"iPEyMM2nGntlui\",\"output_index\":0,\"sequence_number\":182}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" meal\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"BdBdObkAVww\",\"output_index\":0,\"sequence_number\":183}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" on\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"LsZO59XESINa8\",\"output_index\":0,\"sequence_number\":184}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"UfhqmbT4a6Ft3H\",\"output_index\":0,\"sequence_number\":185}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" patio\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"x25qRR4s20\",\"output_index\":0,\"sequence_number\":186}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"Hc8zT8sTlQMImro\",\"output_index\":0,\"sequence_number\":187}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"k5yiJleSRgiRHJN\",\"output_index\":0,\"sequence_number\":188}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" -\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"FBsaiyblFu0ZnS\",\"output_index\":0,\"sequence_number\":189}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Explore\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"3FNuoljt\",\"output_index\":0,\"sequence_number\":190}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"geHonBRW3Nln\",\"output_index\":0,\"sequence_number\":191}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" waterfront\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"GZ1w7\",\"output_index\":0,\"sequence_number\":192}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\n\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"4TvtJzSPJJgTbh\",\"output_index\":0,\"sequence_number\":193}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"###\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"I8Gdwh9p39eSg\",\"output_index\":0,\"sequence_number\":194}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Tools\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"4ds4BG7zWu\",\"output_index\":0,\"sequence_number\":195}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Called\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"HQLWf4bDw\",\"output_index\":0,\"sequence_number\":196}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"oIyyAV0Z8uJ48u\",\"output_index\":0,\"sequence_number\":197}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"1\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"vo30qIJg0C9Czwg\",\"output_index\":0,\"sequence_number\":198}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"r9pdMBAHBy2EYCN\",\"output_index\":0,\"sequence_number\":199}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Weather\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"2CNMX4SL\",\"output_index\":0,\"sequence_number\":200}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Tool\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"7M2sCpRgVZi\",\"output_index\":0,\"sequence_number\":201}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\n\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"V34KVer2sqsw5f5\",\"output_index\":0,\"sequence_number\":202}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"1Tq0Siaq3L68hAK\",\"output_index\":0,\"sequence_number\":203}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"JvZQvwuB69s6flv\",\"output_index\":0,\"sequence_number\":204}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Plan\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"TJdc7mpEdyz\",\"output_index\":0,\"sequence_number\":205}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Activities\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"d5Bh5\",\"output_index\":0,\"sequence_number\":206}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Tool\",\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"obfuscation\":\"NRMcx9Zmfvn\",\"output_index\":0,\"sequence_number\":207}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":208,\"text\":\"The current weather in Toronto is sunny with a temperature of 70°F. It feels like 65°F, with a humidity level of 50%. The wind is blowing at a speed of 10 mph, with gusts up to 15 mph.\\n\\nBased on this pleasant weather, here are some suggested activities:\\n1. Go for a walk or bike ride in one of Toronto's parks.\\n2. Have a picnic at a local outdoor space.\\n3. Visit an outdoor market or festival.\\n4. Enjoy a meal at a patio restaurant.\\n5. Explore the waterfront area.\\n\\n### Summary:\\n- **Location:** Toronto\\n- **Weather:** Sunny, 70°F (feels like 65°F), 50% humidity\\n- **Activities:** \\n  - Go for a walk or bike ride\\n  - Have a picnic\\n  - Visit an outdoor market\\n  - Enjoy a meal on a patio\\n  - Explore the waterfront\\n\\n### Tools Called:\\n1. Weather Tool\\n2. Plan Activities Tool\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"The current weather in Toronto is sunny with a temperature of 70°F. It feels like 65°F, with a humidity level of 50%. The wind is blowing at a speed of 10 mph, with gusts up to 15 mph.\\n\\nBased on this pleasant weather, here are some suggested activities:\\n1. Go for a walk or bike ride in one of Toronto's parks.\\n2. Have a picnic at a local outdoor space.\\n3. Visit an outdoor market or festival.\\n4. Enjoy a meal at a patio restaurant.\\n5. Explore the waterfront area.\\n\\n### Summary:\\n- **Location:** Toronto\\n- **Weather:** Sunny, 70°F (feels like 65°F), 50% humidity\\n- **Activities:** \\n  - Go for a walk or bike ride\\n  - Have a picnic\\n  - Visit an outdoor market\\n  - Enjoy a meal on a patio\\n  - Explore the waterfront\\n\\n### Tools Called:\\n1. Weather Tool\\n2. Plan Activities Tool\"},\"sequence_number\":209}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"The current weather in Toronto is sunny with a temperature of 70°F. It feels like 65°F, with a humidity level of 50%. The wind is blowing at a speed of 10 mph, with gusts up to 15 mph.\\n\\nBased on this pleasant weather, here are some suggested activities:\\n1. Go for a walk or bike ride in one of Toronto's parks.\\n2. Have a picnic at a local outdoor space.\\n3. Visit an outdoor market or festival.\\n4. Enjoy a meal at a patio restaurant.\\n5. Explore the waterfront area.\\n\\n### Summary:\\n- **Location:** Toronto\\n- **Weather:** Sunny, 70°F (feels like 65°F), 50% humidity\\n- **Activities:** \\n  - Go for a walk or bike ride\\n  - Have a picnic\\n  - Visit an outdoor market\\n  - Enjoy a meal on a patio\\n  - Explore the waterfront\\n\\n### Tools Called:\\n1. Weather Tool\\n2. Plan Activities Tool\"}],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":210}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0ae8fd830b7035e90069b3ebf84f3081908e1f1e7c2240b280\",\"object\":\"response\",\"created_at\":1773399032,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399036,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_0ae8fd830b7035e90069b3ebf8f7648190b8e91e636c88a0a3\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"The current weather in Toronto is sunny with a temperature of 70°F. It feels like 65°F, with a humidity level of 50%. The wind is blowing at a speed of 10 mph, with gusts up to 15 mph.\\n\\nBased on this pleasant weather, here are some suggested activities:\\n1. Go for a walk or bike ride in one of Toronto's parks.\\n2. Have a picnic at a local outdoor space.\\n3. Visit an outdoor market or festival.\\n4. Enjoy a meal at a patio restaurant.\\n5. Explore the waterfront area.\\n\\n### Summary:\\n- **Location:** Toronto\\n- **Weather:** Sunny, 70°F (feels like 65°F), 50% humidity\\n- **Activities:** \\n  - Go for a walk or bike ride\\n  - Have a picnic\\n  - Visit an outdoor market\\n  - Enjoy a meal on a patio\\n  - Explore the waterfront\\n\\n### Tools Called:\\n1. Weather Tool\\n2. Plan Activities Tool\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Get weather for a location\",\"name\":\"weatherTool\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Plan activities based on the weather\",\"name\":\"planActivities\",\"parameters\":{\"type\":\"object\",\"properties\":{\"temperature\":{\"type\":\"string\"}},\"required\":[\"temperature\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":363,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":206,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":569},\"user\":null,\"metadata\":{}},\"sequence_number\":211}\n\n"
+        ],
+        "chunkTimings": [
+          3, 3, 567, 0, 1, 32, 0, 26, 0, 48, 1, 69, 1, 47, 0, 56, 0, 58, 1, 58, 2, 60, 2, 51, 0, 27, 0, 40, 0, 39, 1,
+          23, 1, 24, 0, 44, 1, 33, 1, 34, 0, 26, 21, 0, 40, 1, 52, 38, 0, 24, 32, 1, 41, 0, 29, 0, 21, 0, 21, 1, 23, 0,
+          24, 0, 27, 0, 70, 2, 24, 1, 31, 0, 44, 1, 24, 1, 34, 26, 40, 1, 28, 0, 25, 1, 25, 1, 32, 1, 35, 0, 30, 1, 25,
+          0, 24, 1, 33, 1, 28, 1, 42, 0, 30, 1, 22, 1, 41, 1, 66, 1, 22, 2, 35, 1, 33, 1, 42, 0, 37, 1, 34, 50, 1, 6, 2,
+          1, 1, 27, 2, 54, 1, 1, 1, 66, 1, 2, 1, 15, 0, 26, 1, 31, 1, 30, 1, 28, 1, 22, 1, 31, 1, 10, 1, 51, 0, 24, 2,
+          23, 1, 19, 2, 23, 0, 32, 0, 22, 1, 28, 1, 22, 2, 23, 1, 58, 0, 65, 1, 53, 57, 0, 26, 1, 25, 1, 40, 1, 48, 0,
+          30, 1, 27, 3, 29, 22, 1, 31, 1, 18, 1, 1, 33, 2, 2, 69
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "a8bf83ad93561666",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a data structuring specialist. Your job is to convert unstructured text into a specific JSON format.\n\nTASK: Convert the provided unstructured text into valid JSON that matches the following schema:\n\nREQUIREMENTS:\n- Return ONLY valid JSON, no additional text or explanation\n- Extract relevant information from the input text\n- If information is missing, use reasonable defaults or null values\n- Maintain data types as specified in the schema\n- Be consistent and accurate in your conversions\n\nThe input text may be in any format (sentences, bullet points, paragraphs, etc.). Extract the relevant data and structure it according to the schema."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "Extract and structure the key information from the following text according to the specified schema. Keep the original meaning and details:\n\n# Tool Calls\n## weatherTool\n### Input: {\"location\":\"Toronto\"}\n### Output: \n## planActivities\n### Input: {\"temperature\":\"70\"}\n### Output: \n\n# Tool Results\nweatherTool: {\n  \"temperature\": 70,\n  \"feelsLike\": 65,\n  \"humidity\": 50,\n  \"windSpeed\": 10,\n  \"windGust\": 15,\n  \"conditions\": \"sunny\",\n  \"location\": \"Toronto\"\n}\nplanActivities: {\n  \"activities\": \"Plan activities based on the weather\"\n}\n\n# Assistant Response\nThe current weather in Toronto is sunny with a temperature of 70°F. It feels like 65°F, with a humidity level of 50%. The wind is blowing at a speed of 10 mph, with gusts up to 15 mph.\n\nBased on this pleasant weather, here are some suggested activities:\n1. Go for a walk or bike ride in one of Toronto's parks.\n2. Have a picnic at a local outdoor space.\n3. Visit an outdoor market or festival.\n4. Enjoy a meal at a patio restaurant.\n5. Explore the waterfront area.\n\n### Summary:\n- **Location:** Toronto\n- **Weather:** Sunny, 70°F (feels like 65°F), 50% humidity\n- **Activities:** \n  - Go for a walk or bike ride\n  - Have a picnic\n  - Visit an outdoor market\n  - Enjoy a meal on a patio\n  - Explore the waterfront\n\n### Tools Called:\n1. Weather Tool\n2. Plan Activities Tool"
+                }
+              ]
+            }
+          ],
+          "temperature": 0,
+          "text": {
+            "format": {
+              "type": "json_schema",
+              "strict": true,
+              "name": "response",
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "activities": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "toolsCalled": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "location": {
+                    "type": "string"
+                  }
+                },
+                "required": ["activities", "toolsCalled", "location"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "stream": true
+        },
+        "timestamp": 1773399036574
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba7a8b3e17b5e9-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:50:36 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "93",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_9de5d19a8fa041b5b682570a513d536f"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0e7e59bf98125d7f0069b3ebfcc25881949996e00cbebf55fc\",\"object\":\"response\",\"created_at\":1773399036,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"json_schema\",\"description\":null,\"name\":\"response\",\"schema\":{\"type\":\"object\",\"properties\":{\"activities\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"toolsCalled\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"location\":{\"type\":\"string\"}},\"required\":[\"activities\",\"toolsCalled\",\"location\"],\"additionalProperties\":false},\"strict\":true},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0e7e59bf98125d7f0069b3ebfcc25881949996e00cbebf55fc\",\"object\":\"response\",\"created_at\":1773399036,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"json_schema\",\"description\":null,\"name\":\"response\",\"schema\":{\"type\":\"object\",\"properties\":{\"activities\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"toolsCalled\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"location\":{\"type\":\"string\"}},\"required\":[\"activities\",\"toolsCalled\",\"location\"],\"additionalProperties\":false},\"strict\":true},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"{\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"yfkMlOtRO66reR\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"activities\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"1BjaVH\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\":[\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"QPooL6V4jtZ5\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Go\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"JeUwlqRSGbAxQa\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" for\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"xYKpd7HWBPAR\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"KAzQq5U6aWHXWR\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" walk\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"MqnoPqLM5O7\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" or\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"uKvrhHB0fk7Fo\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" bike\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"ICzYsGNzXWA\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" ride\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"Gm9qZHVyRnE\",\"output_index\":0,\"sequence_number\":13}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"hF9hiMMLo2QcG\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" one\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"nCyHPAcQNyDP\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" of\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"SVyRPxzOtvxZu\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" Toronto\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"yDB6uAOr\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"'s\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"Oa362e6HHjdB9W\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" parks\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"ncpJPJGgyG\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\\",\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"mKQEHA3gQUfY\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Have\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"fRavXlCm2w6v\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"rZiWqgazOE0lNC\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" picnic\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"qxwQ5asm0\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" at\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"MjtjdHzo4oeVi\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"uX46DhBC5e8wI3\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" local\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"Tujh2K4TY0\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" outdoor\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"MXbUCDBB\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" space\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"EmXbLgsnYA\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\\",\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"LWa9upuce1wg\",\"output_index\":0,\"sequence_number\":29}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Visit\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"d3z93Y4PQXb\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" an\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"IG4LZUqh43H0e\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" outdoor\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"L4zYyAFw\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" market\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"DgRKHXFeL\",\"output_index\":0,\"sequence_number\":33}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" or\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"ZyAO9XWmH1Zl8\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" festival\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"W6kXsUh\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\\",\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"IligqxjbID8U\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Enjoy\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"4z1OkzM56eu\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"r0Nk4gi2Ao6TFH\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" meal\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"9rLElaznJyQ\",\"output_index\":0,\"sequence_number\":39}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" at\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"BqXWSyDD5oqfk\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" a\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"sJc16awNQQv9Cv\",\"output_index\":0,\"sequence_number\":41}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" patio\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"GZxbOzR7ax\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" restaurant\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"i3n1g\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\\",\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"XHlK0k853nbc\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Explore\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"JTTrWgGGU\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" the\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"rZNdC1lmusO8\",\"output_index\":0,\"sequence_number\":46}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" waterfront\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"30HuN\",\"output_index\":0,\"sequence_number\":47}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" area\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"ooWzpvVvRMn\",\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"JeEpf259yN7upZ\",\"output_index\":0,\"sequence_number\":49}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"],\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"9Xqxs7ne9QIXw\",\"output_index\":0,\"sequence_number\":50}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"tools\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"gGulIR60hhK\",\"output_index\":0,\"sequence_number\":51}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Called\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"aosFxXqIf1\",\"output_index\":0,\"sequence_number\":52}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\":[\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"LpHqSmDZPWOu\",\"output_index\":0,\"sequence_number\":53}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"weather\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"jDeOwfgpt\",\"output_index\":0,\"sequence_number\":54}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Tool\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"jJvPHxPYb007\",\"output_index\":0,\"sequence_number\":55}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\",\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"OF2XvpXvj9RlB\",\"output_index\":0,\"sequence_number\":56}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"plan\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"dEcqaq09SHz3\",\"output_index\":0,\"sequence_number\":57}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Activities\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"4CmQTv\",\"output_index\":0,\"sequence_number\":58}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\"],\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"apjWiJzhpM3lr\",\"output_index\":0,\"sequence_number\":59}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"EMCBJQ8Py2j7z3T\",\"output_index\":0,\"sequence_number\":60}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"location\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"lbKDgUsV\",\"output_index\":0,\"sequence_number\":61}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\":\\\"\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"OeROFSTKMrJYI\",\"output_index\":0,\"sequence_number\":62}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Toronto\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"7JRVyHAgs\",\"output_index\":0,\"sequence_number\":63}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\"}\",\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"obfuscation\":\"xYCK98ww7IS1mt\",\"output_index\":0,\"sequence_number\":64}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":65,\"text\":\"{\\\"activities\\\":[\\\"Go for a walk or bike ride in one of Toronto's parks.\\\",\\\"Have a picnic at a local outdoor space.\\\",\\\"Visit an outdoor market or festival.\\\",\\\"Enjoy a meal at a patio restaurant.\\\",\\\"Explore the waterfront area.\\\"],\\\"toolsCalled\\\":[\\\"weatherTool\\\",\\\"planActivities\\\"],\\\"location\\\":\\\"Toronto\\\"}\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"{\\\"activities\\\":[\\\"Go for a walk or bike ride in one of Toronto's parks.\\\",\\\"Have a picnic at a local outdoor space.\\\",\\\"Visit an outdoor market or festival.\\\",\\\"Enjoy a meal at a patio restaurant.\\\",\\\"Explore the waterfront area.\\\"],\\\"toolsCalled\\\":[\\\"weatherTool\\\",\\\"planActivities\\\"],\\\"location\\\":\\\"Toronto\\\"}\"},\"sequence_number\":66}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"{\\\"activities\\\":[\\\"Go for a walk or bike ride in one of Toronto's parks.\\\",\\\"Have a picnic at a local outdoor space.\\\",\\\"Visit an outdoor market or festival.\\\",\\\"Enjoy a meal at a patio restaurant.\\\",\\\"Explore the waterfront area.\\\"],\\\"toolsCalled\\\":[\\\"weatherTool\\\",\\\"planActivities\\\"],\\\"location\\\":\\\"Toronto\\\"}\"}],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":67}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0e7e59bf98125d7f0069b3ebfcc25881949996e00cbebf55fc\",\"object\":\"response\",\"created_at\":1773399036,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399038,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_0e7e59bf98125d7f0069b3ebfd1e548194b4e5ecffa52026b0\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"{\\\"activities\\\":[\\\"Go for a walk or bike ride in one of Toronto's parks.\\\",\\\"Have a picnic at a local outdoor space.\\\",\\\"Visit an outdoor market or festival.\\\",\\\"Enjoy a meal at a patio restaurant.\\\",\\\"Explore the waterfront area.\\\"],\\\"toolsCalled\\\":[\\\"weatherTool\\\",\\\"planActivities\\\"],\\\"location\\\":\\\"Toronto\\\"}\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"json_schema\",\"description\":null,\"name\":\"response\",\"schema\":{\"type\":\"object\",\"properties\":{\"activities\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"toolsCalled\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"location\":{\"type\":\"string\"}},\"required\":[\"activities\",\"toolsCalled\",\"location\"],\"additionalProperties\":false},\"strict\":true},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":535,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":62,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":597},\"user\":null,\"metadata\":{}},\"sequence_number\":68}\n\n"
+        ],
+        "chunkTimings": [
+          1, 0, 178, 1, 7, 1, 32, 1, 19, 1, 26, 3, 27, 1, 33, 1, 34, 1, 18, 1, 41, 1, 50, 1, 31, 1, 64, 0, 3, 3, 0, 24,
+          0, 22, 1, 61, 3, 41, 1, 17, 1, 18, 1, 35, 7, 49, 0, 10, 2, 39, 0, 18, 1, 50, 2, 32, 4, 149, 62, 22, 25, 10, 6,
+          4, 11, 38, 2, 4, 82
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "41d43dc2c4395fdd",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a helpful assistant. Respond with JSON matching the required schema."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "What is 2+2?"
+                }
+              ]
+            }
+          ],
+          "temperature": 0,
+          "text": {
+            "format": {
+              "type": "json_schema",
+              "strict": true,
+              "name": "response",
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "answer": {
+                    "type": "string"
+                  },
+                  "confidence": {
+                    "type": "number"
+                  }
+                },
+                "required": ["answer", "confidence"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "timestamp": 1773399038432
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba7a969d91ba5d-BRU",
+          "connection": "keep-alive",
+          "content-type": "application/json",
+          "date": "Fri, 13 Mar 2026 10:50:39 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "843",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "30000",
+          "x-ratelimit-limit-tokens": "150000000",
+          "x-ratelimit-remaining-requests": "29999",
+          "x-ratelimit-remaining-tokens": "149999920",
+          "x-ratelimit-reset-requests": "2ms",
+          "x-ratelimit-reset-tokens": "0s",
+          "x-request-id": "req_64d1def50ebd4f32a1179ba3126b1022"
+        },
+        "body": {
+          "id": "resp_0f9d4f3946c459e10069b3ebfeebc08195a86c64b2972a2e79",
+          "object": "response",
+          "created_at": 1773399038,
+          "status": "completed",
+          "background": false,
+          "billing": {
+            "payer": "developer"
+          },
+          "completed_at": 1773399039,
+          "error": null,
+          "frequency_penalty": 0,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "max_tool_calls": null,
+          "model": "gpt-4o-mini-2024-07-18",
+          "output": [
+            {
+              "id": "msg_0f9d4f3946c459e10069b3ebff780c81959862a8a2ccd3d160",
+              "type": "message",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "annotations": [],
+                  "logprobs": [],
+                  "text": "{\"answer\":\"4\",\"confidence\":1.0}"
+                }
+              ],
+              "role": "assistant"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "presence_penalty": 0,
+          "previous_response_id": null,
+          "prompt_cache_key": null,
+          "prompt_cache_retention": null,
+          "reasoning": {
+            "effort": null,
+            "summary": null
+          },
+          "safety_identifier": null,
+          "service_tier": "default",
+          "store": true,
+          "temperature": 0,
+          "text": {
+            "format": {
+              "type": "json_schema",
+              "description": null,
+              "name": "response",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "answer": {
+                    "type": "string"
+                  },
+                  "confidence": {
+                    "type": "number"
+                  }
+                },
+                "required": ["answer", "confidence"],
+                "additionalProperties": false
+              },
+              "strict": true
+            },
+            "verbosity": "medium"
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_logprobs": 0,
+          "top_p": 1,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 61,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 12,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 73
+          },
+          "user": null,
+          "metadata": {}
+        },
+        "isStreaming": false
+      }
+    },
+    {
+      "hash": "20510000d5c426c9",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a helpful assistant. Answer the question.\n\nYour response will be processed by another agent to extract structured data. Please ensure your response contains comprehensive information for all the following fields that will be extracted:\n\n{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"},\"confidence\":{\"type\":\"number\"}},\"required\":[\"answer\",\"confidence\"],\"additionalProperties\":false}\n\n\nYou don't need to format your response as JSON unless the user asks you to. Just ensure your natural language response includes relevant information for each field in the schema above."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "What is 2+2?"
+                }
+              ]
+            }
+          ],
+          "temperature": 0,
+          "stream": true
+        },
+        "timestamp": 1773399039848
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba7a9f7fc7ba5d-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:50:40 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "53",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_0a5790736ed6428f9859a9bc727b6dd9"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_00db6fa814abfaf90069b3ebfffee0819696a40ba2a7ed7a06\",\"object\":\"response\",\"created_at\":1773399040,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_00db6fa814abfaf90069b3ebfffee0819696a40ba2a7ed7a06\",\"object\":\"response\",\"created_at\":1773399040,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"The\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"h2zeCqmw0BJMK\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" answer\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"VOoU8sVSz\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" to\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"llsRmQQ8AJ915\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"OHGVzpPg3Cs1lHU\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"U7EBCnrYUozZAEY\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" +\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"rcexscXkvg2MSH\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"wlTWx53m3NTjVmG\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"Rm1srjLTcwvf4IB\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"WBxRpLY9aHyDA\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"jeBtAKtcmeyEzig\",\"output_index\":0,\"sequence_number\":13}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"4\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"TzCti1c6tgHr6Vz\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"MWejLOFIN9ZsMa3\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" I\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"yJg9pSDNScMV2g\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" am\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"kpzsgjwKQaKoR\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" very\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"tftHER9CPZj\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" confident\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"G1WnSj\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"xmMhMsmbgBiY2\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" this\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"k2fbl6hhEfv\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" answer\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"mtN4Ls4Ns\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\",\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"3x8yApYg8YDn6rv\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" so\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"lkgYAFvv8fF2a\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" I\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"NqKutBeDJJOSDO\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" would\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"OmU21fpFNo\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" rate\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"oUTFQ54nQCo\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" my\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"gN88UMf8KVKKX\",\"output_index\":0,\"sequence_number\":28}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" confidence\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"epLgi\",\"output_index\":0,\"sequence_number\":29}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" at\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"zrYXdKZbKHxXn\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"xvgzY2J1b0CmGzI\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"1\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"5Jx7yANf9pwxANG\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"inOcj5594Lm8Ovp\",\"output_index\":0,\"sequence_number\":33}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"0\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"8xLryF5hoVemKyA\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"obfuscation\":\"SM7A5ytWVghgUIE\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":36,\"text\":\"The answer to 2 + 2 is 4. I am very confident in this answer, so I would rate my confidence at 1.0.\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"The answer to 2 + 2 is 4. I am very confident in this answer, so I would rate my confidence at 1.0.\"},\"sequence_number\":37}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"The answer to 2 + 2 is 4. I am very confident in this answer, so I would rate my confidence at 1.0.\"}],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_00db6fa814abfaf90069b3ebfffee0819696a40ba2a7ed7a06\",\"object\":\"response\",\"created_at\":1773399040,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399040,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_00db6fa814abfaf90069b3ec0055508196bc3463c29534a538\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"The answer to 2 + 2 is 4. I am very confident in this answer, so I would rate my confidence at 1.0.\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":139,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":33,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":172},\"user\":null,\"metadata\":{}},\"sequence_number\":39}\n\n"
+        ],
+        "chunkTimings": [
+          2, 8, 301, 0, 9, 1, 27, 2, 29, 1, 30, 0, 29, 1, 46, 1, 37, 1, 26, 1, 25, 1, 28, 1, 28, 1, 24, 1, 29, 0, 29, 0,
+          25, 3, 13, 4, 29, 1, 0, 107
+        ],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "cffbffd725f32a10",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-4o-mini",
+          "input": [
+            {
+              "role": "system",
+              "content": "You are a data structuring specialist. Your job is to convert unstructured text into a specific JSON format.\n\nTASK: Convert the provided unstructured text into valid JSON that matches the following schema:\n\nREQUIREMENTS:\n- Return ONLY valid JSON, no additional text or explanation\n- Extract relevant information from the input text\n- If information is missing, use reasonable defaults or null values\n- Maintain data types as specified in the schema\n- Be consistent and accurate in your conversions\n\nThe input text may be in any format (sentences, bullet points, paragraphs, etc.). Extract the relevant data and structure it according to the schema."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "Extract and structure the key information from the following text according to the specified schema. Keep the original meaning and details:\n\n# Assistant Response\nThe answer to 2 + 2 is 4. I am very confident in this answer, so I would rate my confidence at 1.0."
+                }
+              ]
+            }
+          ],
+          "temperature": 0,
+          "text": {
+            "format": {
+              "type": "json_schema",
+              "strict": true,
+              "name": "response",
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "answer": {
+                    "type": "string"
+                  },
+                  "confidence": {
+                    "type": "number"
+                  }
+                },
+                "required": ["answer", "confidence"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "stream": true
+        },
+        "timestamp": 1773399040985
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9dba7aa68f5bb5e9-BRU",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Fri, 13 Mar 2026 10:50:41 GMT",
+          "openai-organization": "mastra-qb2kpb",
+          "openai-processing-ms": "54",
+          "openai-project": "proj_Cvw1JiXoxHTeEWgnnK3t9AYG",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-request-id": "req_93390080253549a1a84b5980e3919776"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0f6bae0221eb990d0069b3ec0174ec81949ba60542c4c0cd45\",\"object\":\"response\",\"created_at\":1773399041,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"json_schema\",\"description\":null,\"name\":\"response\",\"schema\":{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"},\"confidence\":{\"type\":\"number\"}},\"required\":[\"answer\",\"confidence\"],\"additionalProperties\":false},\"strict\":true},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0f6bae0221eb990d0069b3ec0174ec81949ba60542c4c0cd45\",\"object\":\"response\",\"created_at\":1773399041,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"json_schema\",\"description\":null,\"name\":\"response\",\"schema\":{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"},\"confidence\":{\"type\":\"number\"}},\"required\":[\"answer\",\"confidence\"],\"additionalProperties\":false},\"strict\":true},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\nevent: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"{\\\"\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"mSmevs9iCw6wJB\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"answer\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"MRq7f3KpGb\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\":\\\"\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"g6ZUxhj4tiDiM\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"The\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"AtGsoGy472emJ\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" answer\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"XPiRapZFY\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" to\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"lBVb8JUdjWZdL\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"mLvDM9r6UsCSC7M\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"MRRC9TXJ161LrgS\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" +\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"V5NhzyGcBXt6R9\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"dLn1qLQYyqoodlM\",\"output_index\":0,\"sequence_number\":13}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"Ist7TXGD0tJCLc3\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" is\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"URbgyHjw56QDM\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"EnVB0qfVPleWX18\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"4\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"710257G14T68r9e\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\\",\\\"\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"axtWf1NC6dp6\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"confidence\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"aB0kYg\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"\\\":\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"kMrJnzSUlCWTKw\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"1\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"bW9l5cZrljvlOSm\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"tpP5o8vXZyyrziE\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"0\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"LClZinGXAV80KD2\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"}\",\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"obfuscation\":\"2SaCQvggocCkdHI\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":25,\"text\":\"{\\\"answer\\\":\\\"The answer to 2 + 2 is 4.\\\",\\\"confidence\\\":1.0}\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"{\\\"answer\\\":\\\"The answer to 2 + 2 is 4.\\\",\\\"confidence\\\":1.0}\"},\"sequence_number\":26}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"{\\\"answer\\\":\\\"The answer to 2 + 2 is 4.\\\",\\\"confidence\\\":1.0}\"}],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0f6bae0221eb990d0069b3ec0174ec81949ba60542c4c0cd45\",\"object\":\"response\",\"created_at\":1773399041,\"status\":\"completed\",\"background\":false,\"completed_at\":1773399042,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_0f6bae0221eb990d0069b3ec0206e08194956930d276151e43\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"{\\\"answer\\\":\\\"The answer to 2 + 2 is 4.\\\",\\\"confidence\\\":1.0}\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":0.0,\"text\":{\"format\":{\"type\":\"json_schema\",\"description\":null,\"name\":\"response\",\"schema\":{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"},\"confidence\":{\"type\":\"number\"}},\"required\":[\"answer\",\"confidence\"],\"additionalProperties\":false},\"strict\":true},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":226,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":22,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":248},\"user\":null,\"metadata\":{}},\"sequence_number\":28}\n\n"
+        ],
+        "chunkTimings": [
+          1, 0, 511, 0, 0, 39, 3, 36, 3, 7, 1, 31, 1, 15, 0, 37, 1, 33, 3, 29, 1, 22, 1, 0, 30, 2, 2, 107
+        ],
+        "isStreaming": true
+      }
+    }
+  ]
+}

--- a/packages/core/src/agent/__tests__/tool-calls-finish-reason.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/tool-calls-finish-reason.e2e.test.ts
@@ -9,13 +9,18 @@ import { anthropic } from '@ai-sdk/anthropic-v5';
 import { google } from '@ai-sdk/google-v5';
 import { openai as openai_v5 } from '@ai-sdk/openai-v5';
 import { openai as openai_v6 } from '@ai-sdk/openai-v6';
+import { createGatewayMock } from '@internal/test-utils';
 import { config } from 'dotenv';
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { createTool } from '../../tools';
 import { Agent } from '../agent';
 
 config();
+
+const mock = createGatewayMock();
+beforeAll(() => mock.start());
+afterAll(() => mock.saveAndStop());
 
 const getWeather = createTool({
   id: 'getWeather',

--- a/packages/core/src/processors/processors/structured-output.e2e.test.ts
+++ b/packages/core/src/processors/processors/structured-output.e2e.test.ts
@@ -1,11 +1,16 @@
 import { openai } from '@ai-sdk/openai-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
-import { describe, it, expect, vi } from 'vitest';
+import { createGatewayMock } from '@internal/test-utils';
+import { afterAll, beforeAll, describe, it, expect, vi } from 'vitest';
 import z from 'zod';
 import { Agent } from '../../agent';
 
 import { createTool } from '../../tools';
 import type { Processor } from '../index';
+
+const mock = createGatewayMock();
+beforeAll(() => mock.start());
+afterAll(() => mock.saveAndStop());
 
 describe('Structured Output with Tool Execution', () => {
   it('should generate structured output when tools are involved', async () => {


### PR DESCRIPTION
## Summary

Two e2e test files were making live API calls on every run with no recording/replay infrastructure, causing slow tests and flaky failures from transient API issues.

### Changes

Added `createGatewayMock()` to:
- **`structured-output.e2e.test.ts`** — 4 tests, 8 recordings (OpenAI)
- **`tool-calls-finish-reason.e2e.test.ts`** — 6 tests, 12 recordings (OpenAI, Anthropic, Google)

### Impact

- Tests replay from recordings (~100ms) instead of hitting live APIs (~40s)
- Eliminates flaky failures like the `gpt-5.3-codex (v6)` tool-call count assertion that was intermittently returning 0
- Follows the same pattern used by other e2e tests (e.g. `token-accuracy.e2e.test.ts`)

### Test plan

Both test files verified passing in record mode (live API) and replay mode (from recordings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with gateway mock setup for improved integration testing across multiple test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->