### PR TITLE
fix(playground): prevent crash when template error is non-string

### DIFF
--- a/.changeset/easy-clubs-leave.md
+++ b/.changeset/easy-clubs-leave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed crash during template installation by ensuring error values from stream events are converted to strings before being passed to the UI. This prevents the 'e?.includes is not a function' TypeError when the server returns non-string error payloads.

--- a/.changeset/eighty-jobs-invite.md
+++ b/.changeset/eighty-jobs-invite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed crash when template installation errors are non-string values (e.g. objects). The error is now safely converted to a string before calling .includes(), preventing the 'e?.includes is not a function' TypeError in the studio.

--- a/packages/playground-ui/src/domains/templates/template-failure.tsx
+++ b/packages/playground-ui/src/domains/templates/template-failure.tsx
@@ -8,8 +8,10 @@ type TemplateFailureProps = {
 };
 
 export function TemplateFailure({ errorMsg, validationErrors }: TemplateFailureProps) {
-  const isSchemaError = errorMsg?.includes('Invalid schema for function');
-  const isValidationError = errorMsg?.includes('validation issue') || (validationErrors && validationErrors.length > 0);
+  const errorString = typeof errorMsg === 'string' ? errorMsg : errorMsg != null ? String(errorMsg) : undefined;
+  const isSchemaError = errorString?.includes('Invalid schema for function');
+  const isValidationError =
+    errorString?.includes('validation issue') || (validationErrors && validationErrors.length > 0);
 
   const getUserFriendlyMessage = () => {
     if (isValidationError) {
@@ -69,13 +71,13 @@ export function TemplateFailure({ errorMsg, validationErrors }: TemplateFailureP
       )}
 
       {/* General Error Details */}
-      {errorMsg && !isValidationError && (
+      {errorString && !isValidationError && (
         <details className="text-xs">
           <summary className="cursor-pointer text-neutral3 hover:text-neutral4 select-none text-center">
             Show Details
           </summary>
           <div className="mt-4 p-3 bg-gray-100 dark:bg-gray-800 rounded text-xs font-mono overflow-auto max-h-60 text-left">
-            <div className="whitespace-pre-wrap break-words">{errorMsg}</div>
+            <div className="whitespace-pre-wrap break-words">{errorString}</div>
           </div>
         </details>
       )}

--- a/packages/playground/src/hooks/use-templates.ts
+++ b/packages/playground/src/hooks/use-templates.ts
@@ -187,6 +187,20 @@ export const useGetTemplateInstallRun = () => {
   });
 };
 
+const normalizeError = (error: unknown): string => {
+  if (typeof error === 'string') return error;
+  if (error == null) return 'Unknown error';
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object') {
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error);
+};
+
 // Helper function to process template installation records (like workflows' sanitizeWorkflowWatchResult)
 const processTemplateInstallRecord = (
   record: { type: string; payload: any; runId?: string; eventTimestamp?: string },
@@ -312,14 +326,15 @@ const processTemplateInstallRecord = (
 
     // If this step failed, also set workflow-level error state
     if (status === 'failed' && hasError) {
+      const errorString = normalizeError(hasError);
       newState = {
         ...newState,
         status: 'failed',
-        error: hasError,
+        error: errorString,
         phase: 'error',
         failedStep: {
           id: stepId,
-          error: hasError,
+          error: errorString,
           description: record.payload.description || stepId,
         },
         payload: {
@@ -374,10 +389,11 @@ const processTemplateInstallRecord = (
   }
 
   if (record.type === 'error') {
+    const errorStr = normalizeError(record.payload.error);
     newState = {
       ...newState,
       status: 'failed',
-      error: record.payload.error,
+      error: errorStr,
       phase: 'error',
       payload: {
         ...newState.payload,

--- a/packages/playground/src/hooks/use-templates.ts
+++ b/packages/playground/src/hooks/use-templates.ts
@@ -190,7 +190,8 @@ export const useGetTemplateInstallRun = () => {
 const normalizeError = (error: unknown): string => {
   if (typeof error === 'string') return error;
   if (error == null) return 'Unknown error';
-  if (error instanceof Error) return error.message;
+  if (error instanceof Error)
+    return typeof error.message === 'string' && error.message.length > 0 ? error.message : 'Unknown error';
   if (typeof error === 'object') {
     try {
       return JSON.stringify(error);

--- a/packages/playground/src/pages/templates/template/index.tsx
+++ b/packages/playground/src/pages/templates/template/index.tsx
@@ -95,7 +95,8 @@ export default function Template() {
               setFailure(errorMessage);
               setCompletedRunValidationErrors(errors || []);
             } else {
-              setFailure(snapshot?.result?.message || snapshot?.result?.error || 'Template installation failed');
+              const errorValue = snapshot?.result?.message || snapshot?.result?.error || 'Template installation failed';
+              setFailure(typeof errorValue === 'string' ? errorValue : String(errorValue));
             }
           }
         })
@@ -239,7 +240,7 @@ export default function Template() {
     const result = streamResult || observeStreamResult;
 
     if (result?.phase === 'error' && result?.error) {
-      setFailure(result.error);
+      setFailure(typeof result.error === 'string' ? result.error : String(result.error));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [streamResult?.phase, streamResult?.error, observeStreamResult?.phase, observeStreamResult?.error]);


### PR DESCRIPTION
## Summary
- Fixed `e?.includes is not a function` TypeError that crashes the studio when installing templates (e.g. Browser Agent)
- Error payloads from the server/stream can be objects rather than strings — calling `.includes()` on them crashes React with no recovery
- All error values are now safely converted to strings before `.includes()` checks and before being set into React state

Fixes #14251

## Changes
- `packages/playground-ui/src/domains/templates/template-failure.tsx` — safely coerce `errorMsg` to string before calling `.includes()`
- `packages/playground/src/hooks/use-templates.ts` — stringify error values from stream events before propagating to state
- `packages/playground/src/pages/templates/template/index.tsx` — ensure `setFailure()` always receives a string

## Test plan
- [ ] Install a template (e.g. Browser Agent) that triggers a server-side error — verify the error is displayed gracefully instead of crashing
- [ ] Install a template successfully — verify no regressions in the success flow
- [ ] Trigger a network error during installation — verify error message displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when template installation or stream-event errors are non-string values by coercing error payloads to readable strings before processing or display.
  * Improved stability of template install flows and error viewers by normalizing diverse error payload shapes into consistent messages.

* **Chores**
  * Added a patch release changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->