### PR TITLE
fix(schema-compat): fix "Dynamic require of zod/v4 is not supported" in ESM bundles

### DIFF
--- a/.changeset/afraid-papayas-appear.md
+++ b/.changeset/afraid-papayas-appear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed "Dynamic require of zod/v4 is not supported" error when schema-compat is consumed by ESM bundles (e.g. via npx mastracode). The dynamic require fallback was incorrectly selecting esbuild's require shim instead of Node.js createRequire.

--- a/packages/schema-compat/src/standard-schema/adapters/zod-v4.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/zod-v4.ts
@@ -56,7 +56,7 @@ function convertToJsonSchema(
  */
 let _toJSONSchema: ((schema: unknown, options?: unknown) => unknown) | null = null;
 let _toJSONSchemaResolved = false;
-const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
+const __require = createRequire(import.meta.url);
 
 function pickToJSONSchema(mod: unknown): ((schema: unknown, options?: unknown) => unknown) | null {
   const candidate = mod as {


### PR DESCRIPTION
## Problem

When `@mastra/schema-compat` is consumed by an ESM bundle (e.g. via `npx mastracode`), the dynamic require fallback in `zod-v4.ts` fails with:

```
Error: Dynamic require of "zod/v4" is not supported
```

This happens because tsup/esbuild replaces `require` with a shim function in ESM output. The shim IS a function (so `typeof require === "function"` is true), but it always throws when called. This meant the code never reached `createRequire(import.meta.url)`, which would actually work.

## Fix

Use `createRequire(import.meta.url)` unconditionally instead of checking for `require` first. The CJS build is unaffected — tsup handles the `import.meta.url` → `__filename` conversion automatically.

## Testing

- All 840 tests in `@mastra/schema-compat` pass
- Manually verified the fix resolves the `npx mastracode` error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved "Dynamic require of zod/v4 is not supported" error when using @mastra/schema-compat with ESM bundles and tools like npx mastracode. Module dependencies now resolve correctly in ESM environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->