### PR TITLE
fix(ci): avoid npm publish race conditions when main advances

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -182,8 +182,8 @@ jobs:
 
       - name: Add tags
         run: |
-          pnpm changeset-cli tag;
-          git push --follow-tags
+          pnpm changeset-cli tag
+          git push origin --tags
 
   enter_prerelease:
     needs: stable
@@ -237,7 +237,9 @@ jobs:
       - name: Push prerelease changes
         if: ${{ !inputs.dry_run }}
         run: |
-          git push --follow-tags
+          git fetch origin main
+          git rebase origin/main
+          git push origin HEAD:main
         env:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
 


### PR DESCRIPTION
## Summary
- update stable publish tag step to push tags only () instead of 
- harden  push by rebasing on latest  immediately before push
- prevents non-fast-forward failures when new commits land on  during workflow execution

## Test plan
- [x] Review workflow diff in 
- [x] Validate  now pushes tags independently
- [x] Validate  now fetches/rebases before pushing to main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release publishing workflow to improve deployment process consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->