### PR TITLE
fix(core): createRequire call

### DIFF
--- a/.changeset/six-waves-admire.md
+++ b/.changeset/six-waves-admire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Lazily load createRequire to fix 'Uncaught (in promise) TypeError: lzt.createRequire is not a function' error

--- a/packages/schema-compat/src/standard-schema/adapters/zod-v4.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/zod-v4.ts
@@ -56,8 +56,15 @@ function convertToJsonSchema(
  */
 let _toJSONSchema: ((schema: unknown, options?: unknown) => unknown) | null = null;
 let _toJSONSchemaResolved = false;
-const __require = createRequire(import.meta.url);
 
+let __require: ReturnType<typeof createRequire>;
+
+function getRequire(): ReturnType<typeof createRequire> {
+  if (!__require) {
+    __require = createRequire(import.meta.url);
+  }
+  return __require;
+}
 function pickToJSONSchema(mod: unknown): ((schema: unknown, options?: unknown) => unknown) | null {
   const candidate = mod as {
     toJSONSchema?: unknown;
@@ -99,7 +106,7 @@ function getToJSONSchema(): ((schema: unknown, options?: unknown) => unknown) | 
     return _toJSONSchema;
   }
 
-  _toJSONSchema = resolveToJSONSchema(moduleName => __require(moduleName));
+  _toJSONSchema = resolveToJSONSchema(moduleName => getRequire()(moduleName));
   _toJSONSchemaResolved = true;
   return _toJSONSchema;
 }


### PR DESCRIPTION
Lazily load createRequire to fix 'Uncaught (in promise) TypeError: lzt.createRequire is not a function' error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical runtime error in schema compatibility that was triggering "createRequire is not a function" exceptions and causing application failures. This improves system stability and ensures schema validation and compatibility operations work consistently across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->