### PR TITLE
chore: add missing changeset for revert of #14173

### DIFF
--- a/.changeset/revert-new-list-pages.md
+++ b/.changeset/revert-new-list-pages.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Revert "New style for list-type pages (#14173)" - restores Table components that were replaced with List components


### PR DESCRIPTION
## Description

Adds a patch changeset for `@mastra/playground-ui` that was missing from the revert PR #14277.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-6) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Reverted recent list-type pages styling, restoring original Table components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->