### PR TITLE
fix(playground): prevent thundering herd on SSE reconnection

### DIFF
--- a/.changeset/fix-sse-thundering-herd.md
+++ b/.changeset/fix-sse-thundering-herd.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed SSE reconnection to use exponential backoff with jitter, preventing thundering herd when the dev server restarts. Also fixed a memory leak where beforeunload listeners accumulated on each reconnection.

--- a/.changeset/fix-sse-thundering-herd.md
+++ b/.changeset/fix-sse-thundering-herd.md
@@ -2,4 +2,4 @@
 '@internal/playground': patch
 ---
 
-Fixed SSE reconnection to use exponential backoff with jitter, preventing thundering herd when the dev server restarts. Also fixed a memory leak where beforeunload listeners accumulated on each reconnection.
+Improved Studio reconnect behavior after dev server restarts by spreading retry attempts over time to prevent many clients reconnecting at once. Also fixed a memory leak from repeated event handler registration during reconnects.

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -19,27 +19,51 @@
       window.MASTRA_AUTO_DETECT_URL = '%%MASTRA_AUTO_DETECT_URL%%';
       window.MASTRA_REQUEST_CONTEXT_PRESETS = '%%MASTRA_REQUEST_CONTEXT_PRESETS%%';
 
-      function connectSSE() {
-        const basePath = window.MASTRA_STUDIO_BASE_PATH || '';
-        const events = new EventSource(`${basePath}/refresh-events`);
+      (function() {
+        let retryCount = 0;
+        let currentEvents = null;
+        const baseDelay = 1000;
+        const maxDelay = 30000;
 
-        events.onmessage = event => {
-          if (event.data === 'refresh') {
-            window.location.reload();
-          }
-        };
+        function getRetryDelay() {
+          // Exponential backoff: 1s, 2s, 4s, 8s... capped at 30s
+          const exponentialDelay = Math.min(baseDelay * Math.pow(2, retryCount), maxDelay);
+          // Add jitter: random value between 0 and 50% of the delay
+          const jitter = Math.random() * exponentialDelay * 0.5;
+          return exponentialDelay + jitter;
+        }
 
-        events.onerror = () => {
-          events.close();
-          setTimeout(connectSSE, 1000);
-        };
+        function connectSSE() {
+          const basePath = window.MASTRA_STUDIO_BASE_PATH || '';
+          currentEvents = new EventSource(`${basePath}/refresh-events`);
+
+          currentEvents.onopen = () => {
+            // Reset retry count on successful connection
+            retryCount = 0;
+          };
+
+          currentEvents.onmessage = event => {
+            if (event.data === 'refresh') {
+              window.location.reload();
+            }
+          };
+
+          currentEvents.onerror = () => {
+            currentEvents.close();
+            const delay = getRetryDelay();
+            retryCount++;
+            setTimeout(connectSSE, delay);
+          };
+        }
 
         window.addEventListener('beforeunload', () => {
-          events.close();
+          if (currentEvents) {
+            currentEvents.close();
+          }
         });
-      }
 
-      connectSSE();
+        connectSSE();
+      })();
     </script>
   </head>
 

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -19,7 +19,7 @@
       window.MASTRA_AUTO_DETECT_URL = '%%MASTRA_AUTO_DETECT_URL%%';
       window.MASTRA_REQUEST_CONTEXT_PRESETS = '%%MASTRA_REQUEST_CONTEXT_PRESETS%%';
 
-      (function() {
+      (function () {
         let retryCount = 0;
         let currentEvents = null;
         const baseDelay = 1000;


### PR DESCRIPTION
## Summary
- Replace fixed 1000ms SSE retry delay with exponential backoff (1s → 2s → 4s → ... capped at 30s)
- Add jitter (0-50% random delay) to spread reconnection attempts across clients
- Fix memory leak: move `beforeunload` listener outside `connectSSE()` to prevent accumulation

## Test plan
- [ ] Stop and restart the dev server while Studio is open
- [ ] Verify reconnection happens with increasing delays (check Network tab)
- [ ] Confirm no duplicate `beforeunload` listeners after multiple reconnections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Server-Sent Events (SSE) reconnection reliability using progressive retries with jitter to prevent connection storms during dev server restarts.
  * Fixed a memory leak by ensuring event handlers and previous connections are properly cleaned up during reconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->