### PR TITLE
fix(e2e): skip changeset pre exit when repo is not in pre mode

### DIFF
--- a/e2e-tests/_local-registry-setup/prepare.js
+++ b/e2e-tests/_local-registry-setup/prepare.js
@@ -1,5 +1,5 @@
 import { exec, execSync, spawn } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
@@ -196,15 +196,21 @@ export async function prepareMonorepo(monorepoDir, glob, tag) {
     }
     changeset += `---`;
     writeFileSync(join(monorepoDir, `.changeset/test-${new Date().toISOString()}.md`), changeset);
-    // process.exit(0); // Remove this - it prevents changeset commands from running
-    console.log('Running pnpm changeset-cli pre exit');
-    await retryWithTimeout(
-      async () => {
-        await execWithTimeout('pnpm changeset-cli pre exit', { cwd: monorepoDir }, defaultTimeout);
-      },
-      defaultTimeout,
-      'pnpm changeset-cli pre exit',
-    );
+
+    // Only run `pre exit` if the repo is in pre mode (pre.json exists)
+    const preJsonPath = join(monorepoDir, '.changeset/pre.json');
+    if (existsSync(preJsonPath)) {
+      console.log('Running pnpm changeset-cli pre exit');
+      await retryWithTimeout(
+        async () => {
+          await execWithTimeout('pnpm changeset-cli pre exit', { cwd: monorepoDir }, defaultTimeout);
+        },
+        defaultTimeout,
+        'pnpm changeset-cli pre exit',
+      );
+    } else {
+      console.log('Skipping pre exit - repo is not in pre mode');
+    }
 
     console.log(`Running pnpm changeset-cli version --snapshot ${tag}`);
     await retryWithTimeout(


### PR DESCRIPTION
## Summary
- Fix E2E test setup that was unconditionally running `changeset pre exit`
- This command fails when the repo is not in prerelease mode (no `.changeset/pre.json`)
- Started failing after commit e535208c8e exited prerelease mode

## Changes
- Check if `.changeset/pre.json` exists before running `pre exit`
- Skip the command with a log message if not in pre mode

## Test plan
- [ ] E2E tests should pass now that `pre exit` is skipped when not in pre mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made the pre-release exit step conditional based on configuration file presence, with appropriate logging when skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->