### PR TITLE
fix: resolve type mismatch between handleChatStream() and createUIMessageStreamResponse()

### DIFF
--- a/.changeset/fix-ai-sdk-type-mismatch.md
+++ b/.changeset/fix-ai-sdk-type-mismatch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed type mismatch between `handleChatStream()` and `createUIMessageStreamResponse()` when using `ai@6`. The published `.d.ts` files now import types from the user's installed `ai` package instead of embedding vendored types from `ai@5`, which had an incompatible `FinishReason` definition.

--- a/.changeset/fix-ai-sdk-type-mismatch.md
+++ b/.changeset/fix-ai-sdk-type-mismatch.md
@@ -2,4 +2,4 @@
 '@mastra/ai-sdk': patch
 ---
 
-Fixed type mismatch between `handleChatStream()` and `createUIMessageStreamResponse()` when using `ai@6`. The published `.d.ts` files now import types from the user's installed `ai` package instead of embedding vendored types from `ai@5`, which had an incompatible `FinishReason` definition.
+Fixed type compatibility issue between `handleChatStream()` and `createUIMessageStreamResponse()` when using `ai@6`. The `FinishReason` type mismatch error no longer occurs when passing the stream from `handleChatStream()` to `createUIMessageStreamResponse()`.

--- a/client-sdks/ai-sdk/package.json
+++ b/client-sdks/ai-sdk/package.json
@@ -34,6 +34,7 @@
   ],
   "peerDependencies": {
     "@mastra/core": ">=1.5.0-0 <2.0.0-0",
+    "ai": "^5.0.0 || ^6.0.0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/client-sdks/ai-sdk/tsup.config.ts
+++ b/client-sdks/ai-sdk/tsup.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
   },
   sourcemap: true,
   onSuccess: async () => {
-    await generateTypes(process.cwd(), new Set(['@ai-sdk/*', '@internal/ai-sdk-v4', '@internal/ai-sdk-v5']));
+    await generateTypes(process.cwd(), new Set(['@ai-sdk/*', '@internal/ai-sdk-v4', '@internal/ai-sdk-v5']), {
+      '@internal/ai-sdk-v5': 'ai',
+    });
   },
 });

--- a/packages/_types-builder/src/index.js
+++ b/packages/_types-builder/src/index.js
@@ -31,9 +31,10 @@ function getFilteredEnv() {
  *
  * @param {string} rootDir
  * @param {Set<string>} bundledPackages
+ * @param {Record<string, string>} [typeAliases] - Map of bundled package names to their public module names.
  * @returns {Promise<void>}
  */
-export async function generateTypes(rootDir, bundledPackages = new Set()) {
+export async function generateTypes(rootDir, bundledPackages = new Set(), typeAliases = {}) {
   try {
     // Use spawn instead of exec to properly inherit stdio
     // Use shell: true for cross-platform compatibility
@@ -65,7 +66,7 @@ export async function generateTypes(rootDir, bundledPackages = new Set()) {
       const fullPath = path.join(rootDir, dtsFile);
       if (bundledPackages.size) {
         try {
-          await replaceTypes(fullPath, rootDir, bundledPackages);
+          await replaceTypes(fullPath, rootDir, bundledPackages, typeAliases);
         } catch (err) {
           // eslint-disable-next-line no-console
           console.log(`failed to embed types: ${fullPath}`, err);

--- a/packages/_types-builder/src/replace-types.js
+++ b/packages/_types-builder/src/replace-types.js
@@ -40,7 +40,14 @@ async function getPackageRootPath(packageName, parentPath) {
   return rootPath;
 }
 
-export async function replaceTypes(file, rootDir, bundledPackages) {
+/**
+ * @param {string} file
+ * @param {string} rootDir
+ * @param {Set<string>} bundledPackages
+ * @param {Record<string, string>} [typeAliases] - Map of bundled package names to their public module names.
+ *   When set, the import is rewritten to the alias instead of copying vendored types.
+ */
+export async function replaceTypes(file, rootDir, bundledPackages, typeAliases = {}) {
   const normalizedBundledPackages = Array.from(bundledPackages).map(pkg => pkg.replace('*', ''));
   const shouldRunEmbed = await new Promise((resolve, reject) => {
     let found = false;
@@ -105,7 +112,16 @@ export async function replaceTypes(file, rootDir, bundledPackages) {
     const typesDestDir = join(rootDir, 'dist', '_types');
 
     for (const moduleSpecifier of importsToReplace) {
-      const pkgName = await getPackageName(moduleSpecifier.getLiteralValue());
+      const specifierValue = moduleSpecifier.getLiteralValue();
+      const pkgName = await getPackageName(specifierValue);
+
+      if (typeAliases[pkgName]) {
+        const aliasTarget = typeAliases[pkgName];
+        const subpath = specifierValue.slice(pkgName.length);
+        moduleSpecifier.setLiteralValue(aliasTarget + subpath);
+        continue;
+      }
+
       const pkgRootPath = await getPackageRootPath(pkgName, file);
       if (pkgRootPath) {
         const pkgJson = JSON.parse(await readFile(join(pkgRootPath, 'package.json'), 'utf8'));


### PR DESCRIPTION
## Description
  <!-- Provide a brief description of the changes in this PR -->
The published `@mastra/ai-sdk` `.d.ts` files embedded vendored types from `@internal/ai-sdk-v5` (which pins `ai@5.0.101`) into `dist/_types/`. When users install `ai@6.x`, TypeScript sees two incompatible `FinishReason` definitions — the vendored one (includes `'unknown'`) and the user's (does not), causing a type error when passing `handleChatStream()` output to
`createUIMessageStreamResponse()`.

The fix adds a `typeAliases` option to the `replaceTypes` build pipeline. When a bundled package has an alias (e.g., `@internal/ai-sdk-v5` → `ai`), the generated `.d.ts` imports are rewritten to the alias directly instead of copying vendored types. This ensures consumers use their own installed `ai` package types, eliminating the version mismatch. Also adds `ai` as
  a peer dependency of `@mastra/ai-sdk`.

  ## Related Issue(s)
  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
  Fixes #14292

  ## Type of Change
  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist
  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [ ] I have added tests that prove my fix is effective or that my feature work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved type compatibility issues so the AI SDK works correctly with both ai v5 and v6, preventing type mismatch errors when streaming responses.

* **Chores**
  * Updated packaging/type generation to ensure types and peer dependency resolution align across supported ai versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->