### PR TITLE
fix: pre-authenticate requests before user middleware runs

### DIFF
--- a/.changeset/warm-dogs-march.md
+++ b/.changeset/warm-dogs-march.md
@@ -1,0 +1,6 @@
+---
+'@mastra/server': patch
+'@mastra/deployer': patch
+---
+
+Fixed `requestContext.get('user')` returning `undefined` in `server.middleware` handlers before `next()`. The authenticated user is now available in middleware for both built-in and custom routes, enabling patterns like user isolation and per-user resource scoping as documented.

--- a/packages/deployer/src/server/__tests__/auth-integration.test.ts
+++ b/packages/deployer/src/server/__tests__/auth-integration.test.ts
@@ -420,4 +420,131 @@ describe('auth middleware integration tests', () => {
       expect(data.ok).toBe(true);
     });
   });
+
+  describe('Pre-authentication in server.middleware', () => {
+    it('should make user available in server.middleware before next() on built-in routes', async () => {
+      let userBeforeNext: any;
+      let userAfterNext: any;
+
+      const mastra = new Mastra({
+        server: {
+          auth: authConfig,
+          middleware: [
+            {
+              path: '/api/*',
+              handler: async (c: any, next: any) => {
+                const requestContext = c.get('requestContext');
+                userBeforeNext = requestContext.get('user');
+                await next();
+                userAfterNext = requestContext.get('user');
+              },
+            },
+          ],
+        },
+      });
+
+      const app = await createHonoServer(mastra, { tools: {} });
+
+      const req = new Request('http://localhost/api/agents', {
+        headers: { Authorization: 'Bearer valid-token' },
+      });
+      await app.request(req);
+
+      expect(userBeforeNext).toEqual({ id: '123', name: 'Test User', role: 'user' });
+      expect(userAfterNext).toEqual({ id: '123', name: 'Test User', role: 'user' });
+    });
+
+    it('should make user available in server.middleware before next() on custom routes', async () => {
+      let userBeforeNext: any;
+
+      const routes = [
+        registerApiRoute('/custom/test', {
+          method: 'GET',
+          handler: (c: any) => c.json({ ok: true }),
+        }),
+      ];
+
+      const mastra = new Mastra({
+        server: {
+          auth: authConfig,
+          apiRoutes: routes,
+          middleware: [
+            {
+              path: '/custom/*',
+              handler: async (c: any, next: any) => {
+                const requestContext = c.get('requestContext');
+                userBeforeNext = requestContext.get('user');
+                await next();
+              },
+            },
+          ],
+        },
+      });
+
+      const app = await createHonoServer(mastra, { tools: {} });
+
+      const req = new Request('http://localhost/custom/test', {
+        headers: { Authorization: 'Bearer valid-token' },
+      });
+      await app.request(req);
+
+      expect(userBeforeNext).toEqual({ id: '123', name: 'Test User', role: 'user' });
+    });
+
+    it('should leave user undefined in middleware when no token is provided', async () => {
+      let userBeforeNext: any = 'NOT_SET';
+
+      const mastra = new Mastra({
+        server: {
+          auth: authConfig,
+          middleware: [
+            {
+              path: '/api/*',
+              handler: async (c: any, next: any) => {
+                const requestContext = c.get('requestContext');
+                userBeforeNext = requestContext.get('user');
+                await next();
+              },
+            },
+          ],
+        },
+      });
+
+      const app = await createHonoServer(mastra, { tools: {} });
+
+      const req = new Request('http://localhost/api/agents');
+      await app.request(req);
+
+      expect(userBeforeNext).toBeUndefined();
+    });
+
+    it('should leave user undefined in middleware when token is invalid', async () => {
+      let userBeforeNext: any = 'NOT_SET';
+
+      const mastra = new Mastra({
+        server: {
+          auth: authConfig,
+          middleware: [
+            {
+              path: '/api/*',
+              handler: async (c: any, next: any) => {
+                const requestContext = c.get('requestContext');
+                userBeforeNext = requestContext.get('user');
+                await next();
+              },
+            },
+          ],
+        },
+      });
+
+      const app = await createHonoServer(mastra, { tools: {} });
+
+      const req = new Request('http://localhost/api/agents', {
+        headers: { Authorization: 'Bearer invalid-token' },
+      });
+      await app.request(req);
+
+      expect(userBeforeNext).toBeUndefined();
+    });
+  });
 });

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -10,6 +10,7 @@ import { Tool } from '@mastra/core/tools';
 import { MastraServer } from '@mastra/hono';
 import type { HonoBindings, HonoVariables } from '@mastra/hono';
 import { InMemoryTaskStore } from '@mastra/server/a2a/store';
+import { preAuthenticateUser } from '@mastra/server/auth';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { compress } from 'hono/compress';
@@ -234,8 +235,34 @@ export async function createHonoServer(
   await honoServerAdapter.validateEELicense();
 
   // Register auth middleware (authentication and authorization)
-  // This is handled by the server adapter now
   honoServerAdapter.registerAuthMiddleware();
+
+  // Pre-authenticate requests so user-defined middleware can access requestContext.get('user')
+  const authConfig = server?.auth;
+  if (authConfig && typeof authConfig === 'object') {
+    const authenticateToken = 'authenticateToken' in authConfig ? authConfig.authenticateToken : undefined;
+    if (typeof authenticateToken === 'function') {
+      app.use('*', async (c, next) => {
+        const requestContext = c.get('requestContext');
+        if (requestContext) {
+          const authHeader = c.req.header('authorization');
+          let token: string | null = authHeader ? authHeader.replace('Bearer ', '') : null;
+          if (!token) {
+            token = c.req.query('apiKey') || null;
+          }
+
+          await preAuthenticateUser({
+            mastra,
+            authConfig: authConfig as any,
+            requestContext,
+            rawRequest: c.req.raw,
+            token,
+          });
+        }
+        await next();
+      });
+    }
+  }
 
   if (server?.middleware) {
     const normalizedMiddlewares = Array.isArray(server.middleware) ? server.middleware : [server.middleware];

--- a/packages/server/src/server/auth/helpers.ts
+++ b/packages/server/src/server/auth/helpers.ts
@@ -285,7 +285,7 @@ export const preAuthenticateUser = async (ctx: {
         }
       }
     } catch {
-      // Non-fatal; per-route auth will retry
+      // Non-fatal; coreAuthMiddleware will retry RBAC loading
     }
   } catch {
     // Non-fatal; per-route auth will reject later
@@ -334,35 +334,35 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
       }
 
       requestContext.set('user', user);
-
-      try {
-        const serverConfig = mastra.getServer();
-        const rbacProvider = serverConfig?.rbac as IRBACProvider<EEUser> | undefined;
-
-        if (rbacProvider) {
-          if (!user || typeof user !== 'object' || !('id' in user)) {
-            mastra
-              .getLogger()
-              ?.warn('RBAC: authenticated user missing required "id" field, skipping permission loading');
-          } else {
-            const permissions = await rbacProvider.getPermissions(user as EEUser);
-            requestContext.set('userPermissions', permissions);
-
-            const roles = await rbacProvider.getRoles(user as EEUser);
-            requestContext.set('userRoles', roles);
-          }
-        }
-      } catch (rbacError) {
-        mastra.getLogger()?.error('RBAC: failed to load user permissions/roles', {
-          error: rbacError instanceof Error ? { message: rbacError.message, stack: rbacError.stack } : rbacError,
-        });
-      }
     } catch (err) {
       mastra.getLogger()?.error('Authentication error', {
         error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
       });
       return { action: 'error', status: 401, body: { error: 'Invalid or expired token' } };
     }
+  }
+
+  // Load RBAC permissions/roles if configured and not already loaded
+  // (handles both fresh auth and pre-authenticated requests where RBAC may have failed)
+  try {
+    const serverConfig = mastra.getServer();
+    const rbacProvider = serverConfig?.rbac as IRBACProvider<EEUser> | undefined;
+
+    if (rbacProvider && !requestContext.get('userPermissions')) {
+      if (!user || typeof user !== 'object' || !('id' in user)) {
+        mastra.getLogger()?.warn('RBAC: authenticated user missing required "id" field, skipping permission loading');
+      } else {
+        const permissions = await rbacProvider.getPermissions(user as EEUser);
+        requestContext.set('userPermissions', permissions);
+
+        const roles = await rbacProvider.getRoles(user as EEUser);
+        requestContext.set('userRoles', roles);
+      }
+    }
+  } catch (rbacError) {
+    mastra.getLogger()?.error('RBAC: failed to load user permissions/roles', {
+      error: rbacError instanceof Error ? { message: rbacError.message, stack: rbacError.stack } : rbacError,
+    });
   }
 
   // ── Authorization ──

--- a/packages/server/src/server/auth/helpers.ts
+++ b/packages/server/src/server/auth/helpers.ts
@@ -240,6 +240,59 @@ export type AuthResult = { action: 'next' } | { action: 'error'; status: number;
 const pass: AuthResult = { action: 'next' };
 
 /**
+ * Pre-authenticate a request by validating the token and setting the user
+ * on requestContext. Runs before user-defined middleware so that
+ * `requestContext.get('user')` is available in `server.middleware` handlers.
+ *
+ * Never blocks — if authentication fails, per-route auth will reject later.
+ */
+export const preAuthenticateUser = async (ctx: {
+  mastra: Mastra;
+  authConfig: MastraAuthConfig;
+  requestContext: { get: (key: string) => unknown; set: (key: string, value: unknown) => void };
+  rawRequest: unknown;
+  token: string | null;
+}): Promise<void> => {
+  const { mastra, authConfig, requestContext, rawRequest, token } = ctx;
+
+  if (requestContext.get('user')) {
+    return;
+  }
+
+  if (!token || typeof authConfig.authenticateToken !== 'function') {
+    return;
+  }
+
+  try {
+    const user = await authConfig.authenticateToken(token, rawRequest as any);
+    if (!user) {
+      return;
+    }
+
+    requestContext.set('user', user);
+
+    try {
+      const serverConfig = mastra.getServer();
+      const rbacProvider = serverConfig?.rbac as IRBACProvider<EEUser> | undefined;
+
+      if (rbacProvider) {
+        if (user && typeof user === 'object' && 'id' in user) {
+          const permissions = await rbacProvider.getPermissions(user as EEUser);
+          requestContext.set('userPermissions', permissions);
+
+          const roles = await rbacProvider.getRoles(user as EEUser);
+          requestContext.set('userRoles', roles);
+        }
+      }
+    } catch {
+      // Non-fatal; per-route auth will retry
+    }
+  } catch {
+    // Non-fatal; per-route auth will reject later
+  }
+};
+
+/**
  * Single auth middleware: authenticate → authorize.
  * Skip checks (dev playground, unprotected path, public path) are evaluated once.
  */
@@ -266,46 +319,50 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
 
   // ── Authentication ──
 
-  let user: unknown;
+  let user: unknown = requestContext.get('user');
 
-  try {
-    if (typeof authConfig.authenticateToken === 'function') {
-      user = await authConfig.authenticateToken(token ?? '', rawRequest as any);
-    } else {
-      throw new Error('No token verification method configured');
-    }
+  if (!user) {
+    try {
+      if (typeof authConfig.authenticateToken === 'function') {
+        user = await authConfig.authenticateToken(token ?? '', rawRequest as any);
+      } else {
+        throw new Error('No token verification method configured');
+      }
 
-    if (!user) {
+      if (!user) {
+        return { action: 'error', status: 401, body: { error: 'Invalid or expired token' } };
+      }
+
+      requestContext.set('user', user);
+
+      try {
+        const serverConfig = mastra.getServer();
+        const rbacProvider = serverConfig?.rbac as IRBACProvider<EEUser> | undefined;
+
+        if (rbacProvider) {
+          if (!user || typeof user !== 'object' || !('id' in user)) {
+            mastra
+              .getLogger()
+              ?.warn('RBAC: authenticated user missing required "id" field, skipping permission loading');
+          } else {
+            const permissions = await rbacProvider.getPermissions(user as EEUser);
+            requestContext.set('userPermissions', permissions);
+
+            const roles = await rbacProvider.getRoles(user as EEUser);
+            requestContext.set('userRoles', roles);
+          }
+        }
+      } catch (rbacError) {
+        mastra.getLogger()?.error('RBAC: failed to load user permissions/roles', {
+          error: rbacError instanceof Error ? { message: rbacError.message, stack: rbacError.stack } : rbacError,
+        });
+      }
+    } catch (err) {
+      mastra.getLogger()?.error('Authentication error', {
+        error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+      });
       return { action: 'error', status: 401, body: { error: 'Invalid or expired token' } };
     }
-
-    requestContext.set('user', user);
-
-    try {
-      const serverConfig = mastra.getServer();
-      const rbacProvider = serverConfig?.rbac as IRBACProvider<EEUser> | undefined;
-
-      if (rbacProvider) {
-        if (!user || typeof user !== 'object' || !('id' in user)) {
-          mastra.getLogger()?.warn('RBAC: authenticated user missing required "id" field, skipping permission loading');
-        } else {
-          const permissions = await rbacProvider.getPermissions(user as EEUser);
-          requestContext.set('userPermissions', permissions);
-
-          const roles = await rbacProvider.getRoles(user as EEUser);
-          requestContext.set('userRoles', roles);
-        }
-      }
-    } catch (rbacError) {
-      mastra.getLogger()?.error('RBAC: failed to load user permissions/roles', {
-        error: rbacError instanceof Error ? { message: rbacError.message, stack: rbacError.stack } : rbacError,
-      });
-    }
-  } catch (err) {
-    mastra.getLogger()?.error('Authentication error', {
-      error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
-    });
-    return { action: 'error', status: 401, body: { error: 'Invalid or expired token' } };
   }
 
   // ── Authorization ──


### PR DESCRIPTION
## Description
  <!-- Provide a brief description of the changes in this PR -->
`requestContext.get('user')` was `undefined` in `server.middleware` handlers before `next()` because authentication ran inline inside route handlers (after middleware). Added a global pre-authentication middleware that validates the token and sets the user on `requestContext` before user-defined middleware executes. Per-route authorization still runs in `checkRouteAuth`,  the pre-auth step only authenticates without blocking.

  ## Related Issue(s)
  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
  Fixes #14288

  ## Type of Change
  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist
  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-authentication now runs before other middleware so authenticated user info is available earlier.

* **Bug Fixes**
  * Authenticated user is reliably available in middleware for built-in and custom routes.
  * RBAC (permissions/roles) loading is more robust and non-fatal on errors.

* **Tests**
  * Added integration tests covering pre-auth visibility and token presence/validity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->