### PR TITLE
test(server): add regression tests for observability date filter parsing

### DIFF
--- a/.changeset/empty-pots-cover.md
+++ b/.changeset/empty-pots-cover.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Added regression tests for Studio Observability date filter parsing to prevent query parameter validation errors when filtering traces by date range (issue #13962)

--- a/packages/server/src/server/server-adapter/routes/route-builder.test.ts
+++ b/packages/server/src/server/server-adapter/routes/route-builder.test.ts
@@ -515,4 +515,93 @@ describe('wrapSchemaForQueryParams', () => {
       }
     });
   });
+
+  describe('observability date filter regression (issue #13962)', () => {
+    // Replicate the exact schema assembly from the observability handler
+    const dateRangeSchema = z.object({
+      start: z.coerce.date().optional(),
+      end: z.coerce.date().optional(),
+      startExclusive: z.boolean().optional(),
+      endExclusive: z.boolean().optional(),
+    });
+
+    const tracesFilterSchema = z.object({
+      startedAt: dateRangeSchema.optional(),
+      endedAt: dateRangeSchema.optional(),
+      entityId: z.string().optional(),
+      entityType: z.string().optional(),
+    });
+
+    const paginationArgsSchema = z.object({
+      page: z.coerce.number().default(0),
+      perPage: z.coerce.number().default(100),
+    });
+
+    const tracesOrderBySchema = z.object({
+      field: z.enum(['startedAt', 'endedAt']).default('startedAt'),
+      direction: z.enum(['ASC', 'DESC']).default('DESC'),
+    });
+
+    const combinedSchema = tracesFilterSchema
+      .extend(paginationArgsSchema.shape)
+      .extend(tracesOrderBySchema.shape)
+      .partial();
+
+    const querySchema = wrapSchemaForQueryParams(combinedSchema);
+
+    it('should parse JSON-stringified startedAt date range from query params', () => {
+      const result = querySchema.safeParse({
+        startedAt: '{"start":"2024-06-15T00:00:00.000Z"}',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.startedAt?.start).toBeInstanceOf(Date);
+        expect(result.data.startedAt?.start?.toISOString()).toBe('2024-06-15T00:00:00.000Z');
+      }
+    });
+
+    it('should parse JSON-stringified endedAt date range from query params', () => {
+      const result = querySchema.safeParse({
+        endedAt: '{"end":"2024-06-20T23:59:59.999Z"}',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.endedAt?.end).toBeInstanceOf(Date);
+        expect(result.data.endedAt?.end?.toISOString()).toBe('2024-06-20T23:59:59.999Z');
+      }
+    });
+
+    it('should parse combined date filters with pagination as query strings', () => {
+      // Simulates the exact query params sent by the playground client
+      const result = querySchema.safeParse({
+        page: '0',
+        perPage: '25',
+        startedAt: '{"start":"2024-06-15T00:00:00.000Z"}',
+        endedAt: '{"end":"2024-06-20T23:59:59.999Z"}',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.startedAt?.start).toBeInstanceOf(Date);
+        expect(result.data.endedAt?.end).toBeInstanceOf(Date);
+        expect(result.data.page).toBe(0);
+        expect(result.data.perPage).toBe(25);
+      }
+    });
+
+    it('should work without any date filters', () => {
+      const result = querySchema.safeParse({
+        page: '0',
+        perPage: '25',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.startedAt).toBeUndefined();
+        expect(result.data.endedAt).toBeUndefined();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds regression tests for the Studio Observability date filter issue where using date range filters produced "Invalid query parameters" errors.

## Root Cause

The bug was already fixed in `mastra@1.3.8` via Zod v4 compatibility (#12238, commit `17c4145`). The `getZodTypeName()` function in `route-builder.ts` only checked `schema._def?.typeName` (Zod v3), but Zod v4 uses `schema._def.type`. This caused `isComplexType()` to return `false` for date range objects, so `wrapSchemaForQueryParams()` never wrapped them with `jsonQueryParam()`, leading to validation failures.

## Changes

Added 4 regression tests in `packages/server/src/server/server-adapter/routes/route-builder.test.ts` that replicate the exact schema assembly from the observability handler:

- `startedAt` JSON string parsing
- `endedAt` JSON string parsing  
- Combined date filters + pagination as query strings
- No date filters (empty case)

All 37 tests pass (33 existing + 4 new).

## Test Plan

- `pnpm test -- --run src/server/server-adapter/routes/route-builder.test.ts` in `packages/server`: 37/37 pass

Closes #13962


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed query parameter validation errors when filtering Studio Observability traces by date range, ensuring date filters and pagination parse correctly together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->