### PR TITLE
fix: stop writing .env secrets to wrangler.jsonc in CloudflareDeployer

### DIFF
--- a/.changeset/fix-cloudflare-env-secrets.md
+++ b/.changeset/fix-cloudflare-env-secrets.md
@@ -1,0 +1,9 @@
+---
+'@mastra/deployer-cloudflare': patch
+---
+
+Stop writing `.env` variables to `wrangler.jsonc` to prevent secrets from leaking into source control.
+
+- Environment variables from `.env` are no longer merged into the `vars` field of the generated wrangler config.
+- User-provided `vars` from the `CloudflareDeployer` constructor are still written as before.
+- A warning is logged during build with instructions to upload secrets via `npx wrangler secret bulk .env`.

--- a/deployers/cloudflare/src/index.test.ts
+++ b/deployers/cloudflare/src/index.test.ts
@@ -44,6 +44,46 @@ describe('CloudflareDeployer', () => {
   });
 
   describe('writeFiles', () => {
+    describe('environment variable handling', () => {
+      it('should exclude .env variables from wrangler config vars', async () => {
+        deployer = new CloudflareDeployer({
+          name: 'test-worker',
+          vars: { NODE_ENV: 'production' },
+        });
+
+        vi.spyOn(deployer, 'loadEnvVars').mockResolvedValue(
+          new Map([
+            ['OPENAI_API_KEY', 'sk-secret-key'],
+            ['DATABASE_URL', 'postgres://user:pass@host/db'],
+          ]),
+        );
+
+        await deployer.writeFiles(tempDir);
+
+        const wranglerConfigPath = join(tempDir, 'output', 'wrangler.json');
+        const wranglerConfig = JSON.parse(await readFile(wranglerConfigPath, 'utf-8'));
+
+        expect(wranglerConfig.vars).not.toHaveProperty('OPENAI_API_KEY');
+        expect(wranglerConfig.vars).not.toHaveProperty('DATABASE_URL');
+        expect(wranglerConfig.vars).toHaveProperty('NODE_ENV', 'production');
+      });
+
+      it('should include only user-provided vars when no .env file exists', async () => {
+        deployer = new CloudflareDeployer({
+          name: 'test-worker',
+          vars: { APP_MODE: 'live' },
+        });
+        vi.spyOn(deployer, 'loadEnvVars').mockResolvedValue(new Map());
+
+        await deployer.writeFiles(tempDir);
+
+        const wranglerConfigPath = join(tempDir, 'output', 'wrangler.json');
+        const wranglerConfig = JSON.parse(await readFile(wranglerConfigPath, 'utf-8'));
+
+        expect(wranglerConfig.vars).toEqual({ APP_MODE: 'live' });
+      });
+    });
+
     describe('TypeScript stub for bundle size optimization', () => {
       it('should create typescript-stub.mjs and configure wrangler alias', async () => {
         deployer = new CloudflareDeployer({ name: 'test-worker' });

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -88,9 +88,9 @@ export class CloudflareDeployer extends Deployer {
     if (loadedEnvVars.size > 0) {
       const envKeys = [...loadedEnvVars.keys()].join(', ');
       this.logger.warn(
-        `Environment variables from .env (${envKeys}) were not written to wrangler.jsonc.\n` +
-          `  Upload them as Cloudflare Secrets instead:\n` +
-          `    npx wrangler secret bulk .env`,
+        `Environment variables from .env (${envKeys}) were not written to wrangler.jsonc.
+Upload them as Cloudflare Secrets instead:
+npx wrangler secret bulk .env`,
       );
     }
 

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -83,9 +83,16 @@ export class CloudflareDeployer extends Deployer {
       kvNamespaces?: unknown;
     };
     const loadedEnvVars = await this.loadEnvVars();
+    const envsAsObject = Object.assign({}, userVars);
 
-    // Merge env vars from .env files with user-provided vars
-    const envsAsObject = Object.assign({}, Object.fromEntries(loadedEnvVars.entries()), userVars);
+    if (loadedEnvVars.size > 0) {
+      const envKeys = [...loadedEnvVars.keys()].join(', ');
+      this.logger.warn(
+        `Environment variables from .env (${envKeys}) were not written to wrangler.jsonc.\n` +
+          `  Upload them as Cloudflare Secrets instead:\n` +
+          `    npx wrangler secret bulk .env`,
+      );
+    }
 
     // Write TypeScript stub to prevent bundling the full TypeScript library (~10MB)
     // The agent-builder package dynamically imports TypeScript for code validation,

--- a/docs/src/content/en/guides/deployment/cloudflare.mdx
+++ b/docs/src/content/en/guides/deployment/cloudflare.mdx
@@ -67,7 +67,7 @@ After setting up your project, push it to your remote Git provider of choice (e.
 
     :::note
 
-    Remember to set your environment variables needed to run your application (e.g. your [model provider](/models/providers) API key).
+    Remember to set your environment variables needed to run your application (e.g. your [model provider](/models/providers) API key). You can upload secrets from your `.env` file using `npx wrangler secret bulk .env`. See [Secrets](/reference/deployer/cloudflare#secrets) for details.
 
     :::
   </StepItem>

--- a/docs/src/content/en/reference/deployer/cloudflare.mdx
+++ b/docs/src/content/en/reference/deployer/cloudflare.mdx
@@ -37,7 +37,6 @@ export const mastra = new Mastra({
     ],
     vars: {
       NODE_ENV: 'production',
-      API_KEY: '<api-key>',
     },
     d1_databases: [
       {
@@ -60,6 +59,18 @@ export const mastra = new Mastra({
 ## Constructor options
 
 The `CloudflareDeployer` constructor accepts the same configuration options as `wrangler.jsonc`. See the [Wrangler configuration documentation](https://developers.cloudflare.com/workers/wrangler/configuration/) for all available options.
+
+## Secrets
+
+Environment variables from your `.env` file are **not** written to `wrangler.jsonc`. This prevents secrets from being committed to source control.
+
+To make your `.env` secrets available to your Cloudflare Worker, upload them as [Cloudflare Secrets](https://developers.cloudflare.com/workers/configuration/secrets/):
+
+```bash
+npx wrangler secret bulk .env
+```
+
+Use `vars` in the `CloudflareDeployer` constructor only for non-sensitive configuration values like `NODE_ENV`.
 
 ## Build output
 


### PR DESCRIPTION
## Description
  <!-- Provide a brief description of the changes in this PR -->
The CloudflareDeployer was writing all `.env` variables into `wrangler.jsonc` under `vars`, causing secrets like API keys and database credentials to be committed to source control. This change stops merging `.env` values into the wrangler config and instead warns users to upload them as Cloudflare Secrets via `npx wrangler secret bulk .env`. User-provided `vars` from the `CloudflareDeployer` constructor are still written as before.

  ## Related Issue(s)
  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
  Fixes #14300

  ## Type of Change
  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist
  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * .env variables are no longer merged into wrangler.jsonc vars; users should upload secrets via `npx wrangler secret bulk .env`. A runtime warning now advises this.

* **Documentation**
  * Cloudflare deployment docs updated to explain using Cloudflare Secrets for sensitive values and reserving vars for non-sensitive config.

* **Tests**
  * Added tests validating the new environment-variable handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->