### PR TITLE
docs(auth): link JWT auth page to authorization middleware pattern

### DIFF
--- a/docs/src/content/en/docs/server/auth/jwt.mdx
+++ b/docs/src/content/en/docs/server/auth/jwt.mdx
@@ -114,3 +114,14 @@ Once `MastraClient` is configured, you can send authenticated requests from your
     ```
   </TabItem>
 </Tabs>
+## Creating a JWT
+To authenticate requests to your Mastra server, you'll need a valid JSON Web Token (JWT) signed with your `MASTRA_JWT_SECRET`.
+The easiest way to generate one is using [jwt.io](https://www.jwt.io/):
+1. Select **JWT Encoder**.
+1. Scroll down to the **Sign JWT: Secret** section.
+1. Enter your secret (for example: `supersecretdevkeythatishs256safe!`).
+1. Click **Generate example** to create a valid JWT.
+1. Copy the generated token and set it as `MASTRA_JWT_TOKEN` in your `.env` file.
+
+## Related
+- [Authorization middleware](/docs/server/middleware#authorization-user-isolation) — how to access the decoded user in middleware to set `resource_id`


### PR DESCRIPTION
Fixes #14293
Users setting up JWT auth have no way to discover the existing [Authorization (User Isolation)](https://mastra.ai/docs/server/middleware#authorization-user-isolation) middleware pattern that shows how to access the decoded user via requestContext.get('user') to set resource_id.
This adds a Related link at the bottom of jwt.mdx pointing directly to that section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a repeated "Creating a JWT" guidance block after the "Making authenticated requests" section to clarify JWT generation and usage.
  * Added a "Related" subsection linking to the Authorization middleware to improve navigation between authentication topics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->