### PR TITLE
feat(workspace): pass images to model in read_file tool

### DIFF
--- a/.changeset/workspace-read-file-images.md
+++ b/.changeset/workspace-read-file-images.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Workspace `read_file` tool now shows images to the LLM using native image input. When reading image files (png, jpg, gif, webp, bmp, avif, ico), the tool returns the image in a format the model can see, enabling screenshot-based iteration and visual analysis tasks.

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -420,7 +420,7 @@ Added when a filesystem is configured:
 
 | Tool | Description |
 | - | - |
-| `mastra_workspace_read_file` | Read file contents. Supports optional line range for reading specific portions of large files. |
+| `mastra_workspace_read_file` | Read file contents. Supports optional line range for large files. For image files (png, jpg, gif, webp, etc.), the image is shown to the model so it can see the content. |
 | `mastra_workspace_write_file` | Create or overwrite a file with new content. Creates parent directories automatically. |
 | `mastra_workspace_edit_file` | Edit an existing file by finding and replacing text. Useful for targeted changes without rewriting the entire file. |
 | `mastra_workspace_list_files` | List directory contents as a tree structure. Supports recursive listing with depth limits, glob patterns, and `.gitignore` filtering (enabled by default). |

--- a/packages/core/src/workspace/tools/__tests__/read-file.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/read-file.test.ts
@@ -99,4 +99,55 @@ describe('workspace_read_file', () => {
 
     expect(result).toContain('[output truncated');
   });
+
+  it('should return image object for image files so model can see the image', async () => {
+    const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await fs.writeFile(path.join(tempDir, 'screenshot.png'), pngHeader);
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'screenshot.png' },
+      { workspace },
+    )) as { type: string; path: string; size: number; data: string; mediaType: string };
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        type: 'image',
+        path: expect.stringContaining('screenshot.png'),
+        size: 8,
+        mediaType: 'image/png',
+      }),
+    );
+    expect(typeof result.data).toBe('string');
+    expect(Buffer.from(result.data, 'base64').length).toBe(8);
+
+    const toModelOutput = (tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE] as { toModelOutput?: (o: unknown) => unknown })
+      .toModelOutput;
+    expect(toModelOutput).toBeDefined();
+    const modelOutput = toModelOutput!(result);
+    expect(modelOutput).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: expect.stringContaining('screenshot.png') },
+        { type: 'image-data', data: result.data, mediaType: 'image/png' },
+      ],
+    });
+  });
+
+  it('should read image as text when encoding is explicitly set', async () => {
+    const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    await fs.writeFile(path.join(tempDir, 'img.png'), pngHeader);
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'img.png', encoding: 'base64' },
+      { workspace },
+    )) as string;
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('img.png');
+    expect(result).toContain('base64');
+  });
 });

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -5,10 +5,49 @@ import { extractLinesWithLimit, formatWithLineNumbers } from '../line-utils';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
 import { applyTokenLimit } from './output-helpers';
 
+const IMAGE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.avif',
+  '.ico',
+]);
+
+const EXTENSION_TO_MIME: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.avif': 'image/avif',
+  '.ico': 'image/x-icon',
+};
+
+function getExtension(path: string): string {
+  const lastDot = path.lastIndexOf('.');
+  if (lastDot === -1) return '';
+  return path.slice(lastDot).toLowerCase();
+}
+
+function isImagePath(path: string, mimeType?: string): boolean {
+  if (mimeType?.toLowerCase().startsWith('image/')) return true;
+  return IMAGE_EXTENSIONS.has(getExtension(path));
+}
+
+function getImageMimeType(path: string, statMimeType?: string): string {
+  if (statMimeType?.toLowerCase().startsWith('image/')) return statMimeType;
+  const ext = getExtension(path);
+  return EXTENSION_TO_MIME[ext] ?? 'image/png';
+}
+
 export const readFileTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.READ_FILE,
   description:
-    'Read the contents of a file from the workspace filesystem. Use offset/limit parameters to read specific line ranges for large files.',
+    'Read the contents of a file from the workspace filesystem. Use offset/limit parameters to read specific line ranges for large files. For image files (png, jpg, gif, webp, etc.), the image is shown to the model so it can see the content.',
   inputSchema: z.object({
     path: z.string().describe('The path to the file to read (e.g., "/data/config.json")'),
     encoding: z
@@ -30,12 +69,19 @@ export const readFileTool = createTool({
     const { workspace, filesystem } = requireFilesystem(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.READ_FILE);
 
-    const effectiveEncoding = (encoding as BufferEncoding) ?? 'utf-8';
-    const fullContent = await filesystem.readFile(path, { encoding: effectiveEncoding });
     const stat = await filesystem.stat(path);
-
+    const effectiveEncoding = (encoding as BufferEncoding) ?? 'utf-8';
     const isTextEncoding = !encoding || encoding === 'utf-8' || encoding === 'utf8';
 
+    if (isTextEncoding && isImagePath(path, stat.mimeType)) {
+      const raw = await filesystem.readFile(path);
+      const data =
+        typeof raw === 'string' ? Buffer.from(raw, 'binary').toString('base64') : (raw as Buffer).toString('base64');
+      const mediaType = getImageMimeType(path, stat.mimeType);
+      return { type: 'image' as const, path: stat.path, size: stat.size, data, mediaType };
+    }
+
+    const fullContent = await filesystem.readFile(path, { encoding: effectiveEncoding });
     const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]?.maxOutputTokens;
 
     if (!isTextEncoding) {
@@ -70,5 +116,21 @@ export const readFileTool = createTool({
     }
 
     return await applyTokenLimit(`${header}\n${formattedContent}`, tokenLimit, 'end');
+  },
+  toModelOutput: (output: unknown) => {
+    if (typeof output === 'object' && output !== null && 'type' in output && (output as { type: string }).type === 'image') {
+      const img = output as unknown as { path: string; size: number; data: string; mediaType: string };
+      return {
+        type: 'content',
+        value: [
+          { type: 'text', text: `${img.path} (${img.size} bytes)` },
+          { type: 'image-data', data: img.data, mediaType: img.mediaType },
+        ],
+      };
+    }
+    if (typeof output === 'string') {
+      return { type: 'text', value: output };
+    }
+    return output;
   },
 });


### PR DESCRIPTION
### Related Issue(s)

Fixes #14199

### Type of Change
[x] New feature (non-breaking change that adds functionality)

### Checklist

[x] I have made corresponding changes to the documentation (if applicable)
[x] I have added tests that prove my fix is effective or that my feature works
[ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `read_file` workspace function now supports image files (PNG, JPG, GIF, WebP, BMP, AVIF, ICO) in native format, enabling screenshot-based iteration and visual analysis for LLMs.

* **Documentation**
  * Updated workspace `read_file` documentation to reflect new image file support and clarified line-range functionality for large files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->