### PR TITLE
feat(deployer): add MASTRA_HOST env var for server bind address

### DIFF
--- a/.changeset/cece-ktmbl-wwuwv.md
+++ b/.changeset/cece-ktmbl-wwuwv.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Added `MASTRA_HOST` environment variable support for configuring the server bind address. Previously, the host could only be set via `server.host` in the Mastra config. Now it follows the same pattern as `PORT`: config value takes precedence, then env var, then defaults to `localhost`.

--- a/docs/src/content/en/docs/server/mastra-server.mdx
+++ b/docs/src/content/en/docs/server/mastra-server.mdx
@@ -36,8 +36,8 @@ import { Mastra } from '@mastra/core'
 
 export const mastra = new Mastra({
   server: {
-    port: 3000, // Defaults to 4111
-    host: '0.0.0.0', // Defaults to 'localhost'
+    port: 3000, // Defaults to PORT env var or 4111
+    host: '0.0.0.0', // Defaults to MASTRA_HOST env var or 'localhost'
   },
 })
 ```

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -654,9 +654,9 @@ export const mastra = new Mastra({
 ### server.host
 
 **Type:** `string`\
-**Default:** `localhost`
+**Default:** `localhost` (or `MASTRA_HOST` environment variable if set)
 
-Host address the Mastra development server binds to.
+Host address the Mastra development server binds to. If the `MASTRA_HOST` environment variable is set, it takes precedence over the default.
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -392,7 +392,7 @@ export async function createHonoServer(
       // Inject the server configuration into index.html placeholders
       const port = serverOptions?.port ?? (Number(process.env.PORT) || 4111);
       const hideCloudCta = process.env.MASTRA_HIDE_CLOUD_CTA === 'true';
-      const host = serverOptions?.host ?? 'localhost';
+      const host = serverOptions?.host ?? process.env.MASTRA_HOST ?? 'localhost';
       const key =
         serverOptions?.https?.key ??
         (process.env.MASTRA_HTTPS_KEY ? Buffer.from(process.env.MASTRA_HTTPS_KEY, 'base64') : undefined);
@@ -474,7 +474,7 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
     (process.env.MASTRA_HTTPS_CERT ? Buffer.from(process.env.MASTRA_HTTPS_CERT, 'base64') : undefined);
   const isHttpsEnabled = Boolean(key && cert);
 
-  const host = serverOptions?.host ?? 'localhost';
+  const host = serverOptions?.host ?? process.env.MASTRA_HOST ?? 'localhost';
   const port = serverOptions?.port ?? (Number(process.env.PORT) || 4111);
   const protocol = isHttpsEnabled ? 'https' : 'http';
 
@@ -482,7 +482,7 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
     {
       fetch: app.fetch,
       port,
-      hostname: serverOptions?.host,
+      hostname: host,
       ...(isHttpsEnabled
         ? {
             createServer: https.createServer,


### PR DESCRIPTION
## Summary

Adds `MASTRA_HOST` environment variable support for configuring the server bind address, matching the existing `PORT` env var pattern.

### Changes

- **`packages/deployer/src/server/index.ts`**: Added `process.env.MASTRA_HOST` fallback in both `createHonoServer` and `createNodeServer`. Also fixed `hostname` passed to `serve()` to use the resolved `host` value instead of only `serverOptions?.host`.
- **`docs/src/content/en/reference/configuration.mdx`**: Updated `server.host` reference to document the `MASTRA_HOST` env var.
- **`docs/src/content/en/docs/server/mastra-server.mdx`**: Updated inline comments in the config example.

### Priority

`server.host` config > `MASTRA_HOST` env var > `'localhost'` default

### Usage

```bash
MASTRA_HOST=0.0.0.0 mastra dev
```

### Test plan

- Verified `pnpm build --filter @mastra/deployer` passes cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `MASTRA_HOST` environment variable to configure the server bind address. When set, this variable takes precedence over the default `localhost` setting.

* **Documentation**
  * Updated configuration and server documentation to reflect the new environment variable support and clarified default behavior for host and port settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->