### PR TITLE
fix(mcp): populate requestContext from mcp.extra for regular tools in MCPServer

### DIFF
--- a/.changeset/fix-mcp-server-requestcontext-regular-tools.md
+++ b/.changeset/fix-mcp-server-requestcontext-regular-tools.md
@@ -1,0 +1,8 @@
+---
+"@mastra/mcp": patch
+---
+
+Fix MCPServer regular tools missing requestContext populated from mcp.extra
+
+Regular tools executed via CallToolRequestSchema now receive requestContext
+populated from mcp.extra, consistent with agent tools and workflow tools.

--- a/.changeset/fix-mcp-server-requestcontext-regular-tools.md
+++ b/.changeset/fix-mcp-server-requestcontext-regular-tools.md
@@ -2,7 +2,8 @@
 "@mastra/mcp": patch
 ---
 
-Fix MCPServer regular tools missing requestContext populated from mcp.extra
+Fixed: MCPServer regular tools now receive requestContext consistently
 
-Regular tools executed via CallToolRequestSchema now receive requestContext
-populated from mcp.extra, consistent with agent tools and workflow tools.
+Previously, regular tools in MCPServer did not receive requestContext from
+mcp.extra, causing inconsistent auth context access compared to agent and
+workflow tools. This is now unified across all tool types.

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -490,9 +490,17 @@ export class MCPServer extends MCPServerBase {
           },
         };
 
+        const proxiedContext = new RequestContext();
+        if (extra) {
+          Object.entries(extra).forEach(([key, value]) => {
+            proxiedContext.set(key, value);
+          });
+        }
+
         const mcpOptions: MastraToolInvocationOptions = {
           messages: [],
           toolCallId: '',
+          requestContext: proxiedContext,
           // Pass MCP-specific context through the mcp property
           mcp: {
             elicitation: sessionElicitation,


### PR DESCRIPTION
## What does this PR do?

Closes #14323

## Problem

When MCPServer executes regular tools via `CallToolRequestSchema`, it passes 
`mcp.extra` (containing auth info from `req.auth`) but does NOT populate 
`requestContext`. This means tools can't access user/auth data through the 
standard `context.requestContext` path.

Agent tools (line 854-860) and workflow tools (line 939-945) already proxy 
`mcp.extra` into `requestContext` correctly — regular tools were inconsistent.

## Fix

Added the same `proxiedContext` pattern to the `CallToolRequestSchema` handler 
(~line 493) in `packages/mcp/src/server/server.ts`:
```typescript
const proxiedContext = new RequestContext();
if (extra) {
  Object.entries(extra).forEach(([key, value]) => {
    proxiedContext.set(key, value);
  });
}
```

`requestContext: proxiedContext` is now passed into `mcpOptions`, matching the 
existing pattern for agent and workflow tools.

## Testing

The fix follows the identical pattern already used and tested for agent tools 
and workflow tools in the same file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Regular tools now receive context data consistently with agent and workflow tools, ensuring unified behavior across tool types and reliable per-call context propagation during tool invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->