### PR TITLE
test(core): add LLM recording mock to composite-voice e2e test

### DIFF
--- a/packages/core/src/voice/aisdk/__tests__/composite-voice.e2e.test.ts
+++ b/packages/core/src/voice/aisdk/__tests__/composite-voice.e2e.test.ts
@@ -1,11 +1,14 @@
 import { writeFileSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { openai } from '@ai-sdk/openai-v5';
+import { useLLMRecording } from '@internal/llm-recorder';
 import { describe, expect, it, beforeAll } from 'vitest';
 
 import { CompositeVoice } from '../../composite-voice';
 
 describe('CompositeVoice with AI SDK Models', () => {
+  useLLMRecording('core-src-voice-aisdk-__tests__-composite-voice.e2e');
+
   const outputDir = path.join(process.cwd(), 'test-outputs');
 
   beforeAll(() => {


### PR DESCRIPTION
Adds `useLLMRecording` to `composite-voice.e2e.test.ts` so it records/replays OpenAI API calls instead of hitting the live API on every run.

Matches the pattern already used by the sibling `aisdk-voice.e2e.test.ts`.

**Changes:**
- Import `useLLMRecording` from `@internal/llm-recorder`
- Call `useLLMRecording('core-src-voice-aisdk-__tests__-composite-voice.e2e')` at the top of the describe block

**Test plan:**
- First run records against real OpenAI, subsequent runs replay from `__recordings__/`
- TypeScript compiles cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added LLM recording integration to test infrastructure for improved test monitoring and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->