### PR TITLE
fix(server): remove broken zod mocks from agent-builder and workflows tests

### DIFF
--- a/packages/server/src/server/handlers/agent-builder.test.ts
+++ b/packages/server/src/server/handlers/agent-builder.test.ts
@@ -32,28 +32,6 @@ vi.mock('@mastra/agent-builder', () => ({
   },
 }));
 
-vi.mock('zod', async importOriginal => {
-  const actual = (await importOriginal()) as { z?: Record<string, unknown> };
-
-  const object = vi.fn(() => ({
-    parse: vi.fn(input => input),
-    safeParse: vi.fn(input => ({ success: true, data: input })),
-  }));
-
-  const string = vi.fn(() => ({
-    parse: vi.fn(input => input),
-  }));
-
-  return {
-    ...actual,
-    z: {
-      ...(actual.z ?? {}),
-      object,
-      string,
-    },
-  };
-});
-
 function createMockWorkflow(name: string) {
   const execute = vi.fn<any>().mockResolvedValue({ result: 'success' });
   const stepA = createStep({

--- a/packages/server/src/server/handlers/workflows.test.ts
+++ b/packages/server/src/server/handlers/workflows.test.ts
@@ -24,28 +24,6 @@ import {
   STREAM_WORKFLOW_ROUTE,
 } from './workflows';
 
-vi.mock('zod', async importOriginal => {
-  const actual = (await importOriginal()) as { z?: Record<string, unknown> };
-
-  const object = vi.fn(() => ({
-    parse: vi.fn(input => input),
-    safeParse: vi.fn(input => ({ success: true, data: input })),
-  }));
-
-  const string = vi.fn(() => ({
-    parse: vi.fn(input => input),
-  }));
-
-  return {
-    ...actual,
-    z: {
-      ...(actual.z ?? {}),
-      object,
-      string,
-    },
-  };
-});
-
 function createMockWorkflow(name: string) {
   const execute = vi.fn<any>().mockResolvedValue({ result: 'success' });
   const stepA = createStep({


### PR DESCRIPTION
## Problem

`agent-builder.test.ts` and `workflows.test.ts` both had a `vi.mock("zod")` that replaced `z.string()` and `z.object()` with partial mocks (only `.parse()` / `.safeParse()`). When `@mastra/core` added workspace tools that call `z.string().describe(...)`, these tests started failing with:

```
TypeError: __vite_ssr_import_18__.z.string(...).describe is not a function
```

## Fix

Removed the `vi.mock("zod", ...)` blocks entirely. The mocks were unnecessary — real zod works fine for creating workflow test fixtures.

## Verification

- `agent-builder.test.ts`: 41/41 tests pass
- `workflows.test.ts`: 47/47 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed custom zod mock implementations from test files, allowing tests to validate against actual library behavior instead of stubbed implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->