### PR TITLE
fix(mcp): populate requestContext from mcp.extra for regular tools

### DIFF
--- a/.changeset/rich-adults-switch.md
+++ b/.changeset/rich-adults-switch.md
@@ -2,4 +2,4 @@
 '@mastra/mcp': patch
 ---
 
-Fixed regular tools executed via MCPServer missing requestContext populated from mcp.extra. Agent tools and workflow tools already proxied auth info into requestContext, but regular tools in the CallToolRequestSchema handler did not. Now all tool types consistently populate requestContext from mcp.extra.
+Fixed regular tools executed via MCPServer now receive `requestContext` populated from `mcp.extra`, matching the behavior of agent and workflow tools. All tool types now consistently propagate authentication and request context.

--- a/.changeset/rich-adults-switch.md
+++ b/.changeset/rich-adults-switch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed regular tools executed via MCPServer missing requestContext populated from mcp.extra. Agent tools and workflow tools already proxied auth info into requestContext, but regular tools in the CallToolRequestSchema handler did not. Now all tool types consistently populate requestContext from mcp.extra.

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -196,14 +196,21 @@ This allows you to quickly expose the generative capabilities of your agents thr
 
 ### Accessing MCP Context in Tools
 
-Tools exposed through `MCPServer` can access MCP request context (authentication, session IDs, etc.) via `context.requestContext` or `context.mcp.extra`. Both are populated for all tool types — direct tool calls, agent tool calls, and workflow tool calls.
+Tools exposed through `MCPServer` can access MCP request context (authentication, session IDs, etc.) via two different properties depending on how the tool is invoked:
 
-| Access Method | Description |
+| Call Pattern | Access Method |
 | - | - |
-| `context?.mcp?.extra` | Raw MCP extra data (auth info, session ID, etc.) |
-| `context?.requestContext` | `RequestContext` instance populated from `mcp.extra` |
+| Direct tool call | `context?.mcp?.extra` |
+| Agent tool call | `context?.requestContext?.get("mcp.extra")` |
 
-#### Example
+**Universal pattern** (works in both contexts):
+
+```typescript
+const mcpExtra = context?.mcp?.extra ?? context?.requestContext?.get('mcp.extra')
+const authInfo = mcpExtra?.authInfo
+```
+
+#### Example: Tool that works in both contexts
 
 ```typescript
 import { createTool } from '@mastra/core/tools'
@@ -216,11 +223,11 @@ const fetchUserData = createTool({
     userId: z.string().describe('The ID of the user to fetch'),
   }),
   execute: async (inputData, context) => {
-    // Access auth info via mcp.extra
-    const authInfo = context?.mcp?.extra?.authInfo
-
-    // Or via requestContext
-    // const authInfo = context?.requestContext?.get('authInfo')
+    // Access MCP authentication context
+    // When called directly via MCP: context.mcp.extra
+    // When called via agent: context.requestContext.get('mcp.extra')
+    const mcpExtra = context?.mcp?.extra || context?.requestContext?.get('mcp.extra')
+    const authInfo = mcpExtra?.authInfo
 
     if (!authInfo?.token) {
       throw new Error('Authentication required')
@@ -1371,15 +1378,20 @@ execute: async (inputData, context) => {
 
 ### Passing `RequestContext` through to agent
 
-`requestContext` is automatically populated from `mcp.extra` for all tool types, so you can pass it directly to agents:
-
 ```typescript
 execute: async (inputData, context) => {
+  // Access the auth data you set in middleware
   const authInfo = context?.mcp?.extra?.authInfo
+
+  const requestContext = context.requestContext || new RequestContext().set('someKey', authInfo)
 
   if (!authInfo?.extra?.userId) {
     return { error: 'Authentication required' }
   }
+
+  // Use the auth data
+  console.log('User ID:', authInfo.extra.userId)
+  console.log('Email:', authInfo.extra.email)
 
   const agent = context?.mastra?.getAgentById('some-agent-id')
 
@@ -1387,8 +1399,7 @@ execute: async (inputData, context) => {
     return { error: "Agent 'some-agent-id' not found" }
   }
 
-  // requestContext is already populated from mcp.extra
-  const response = await agent.generate(prompt, { requestContext: context.requestContext })
+  const response = await agent.generate(prompt, { requestContext })
 
   return response.text
 }

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -196,21 +196,14 @@ This allows you to quickly expose the generative capabilities of your agents thr
 
 ### Accessing MCP Context in Tools
 
-Tools exposed through `MCPServer` can access MCP request context (authentication, session IDs, etc.) via two different properties depending on how the tool is invoked:
+Tools exposed through `MCPServer` can access MCP request context (authentication, session IDs, etc.) via `context.requestContext` or `context.mcp.extra`. Both are populated for all tool types — direct tool calls, agent tool calls, and workflow tool calls.
 
-| Call Pattern | Access Method |
+| Access Method | Description |
 | - | - |
-| Direct tool call | `context?.mcp?.extra` |
-| Agent tool call | `context?.requestContext?.get("mcp.extra")` |
+| `context?.mcp?.extra` | Raw MCP extra data (auth info, session ID, etc.) |
+| `context?.requestContext` | `RequestContext` instance populated from `mcp.extra` |
 
-**Universal pattern** (works in both contexts):
-
-```typescript
-const mcpExtra = context?.mcp?.extra ?? context?.requestContext?.get('mcp.extra')
-const authInfo = mcpExtra?.authInfo
-```
-
-#### Example: Tool that works in both contexts
+#### Example
 
 ```typescript
 import { createTool } from '@mastra/core/tools'
@@ -223,11 +216,11 @@ const fetchUserData = createTool({
     userId: z.string().describe('The ID of the user to fetch'),
   }),
   execute: async (inputData, context) => {
-    // Access MCP authentication context
-    // When called directly via MCP: context.mcp.extra
-    // When called via agent: context.requestContext.get('mcp.extra')
-    const mcpExtra = context?.mcp?.extra || context?.requestContext?.get('mcp.extra')
-    const authInfo = mcpExtra?.authInfo
+    // Access auth info via mcp.extra
+    const authInfo = context?.mcp?.extra?.authInfo
+
+    // Or via requestContext
+    // const authInfo = context?.requestContext?.get('authInfo')
 
     if (!authInfo?.token) {
       throw new Error('Authentication required')
@@ -1378,20 +1371,15 @@ execute: async (inputData, context) => {
 
 ### Passing `RequestContext` through to agent
 
+`requestContext` is automatically populated from `mcp.extra` for all tool types, so you can pass it directly to agents:
+
 ```typescript
 execute: async (inputData, context) => {
-  // Access the auth data you set in middleware
   const authInfo = context?.mcp?.extra?.authInfo
-
-  const requestContext = context.requestContext || new RequestContext().set('someKey', authInfo)
 
   if (!authInfo?.extra?.userId) {
     return { error: 'Authentication required' }
   }
-
-  // Use the auth data
-  console.log('User ID:', authInfo.extra.userId)
-  console.log('Email:', authInfo.extra.email)
 
   const agent = context?.mastra?.getAgentById('some-agent-id')
 
@@ -1399,7 +1387,8 @@ execute: async (inputData, context) => {
     return { error: "Agent 'some-agent-id' not found" }
   }
 
-  const response = await agent.generate(prompt, { requestContext })
+  // requestContext is already populated from mcp.extra
+  const response = await agent.generate(prompt, { requestContext: context.requestContext })
 
   return response.text
 }

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -1645,6 +1645,15 @@ describe('MCPServer - Agent to Tool Conversion', () => {
     expect(directToolOptions.mcp.extra.authInfo.clientId).toBe('test-client-456');
     expect(directToolOptions.mcp.extra.sessionId).toBe('auth-test-session');
 
+    // Verify requestContext is populated from mcp.extra for regular tools
+    expect(directToolOptions.requestContext).toBeDefined();
+    expect(directToolOptions.requestContext.get('authInfo')).toEqual({
+      token: 'test-auth-token-123',
+      clientId: 'test-client-456',
+      scopes: ['read', 'write'],
+    });
+    expect(directToolOptions.requestContext.get('sessionId')).toBe('auth-test-session');
+
     let agentContextObj: any = null;
     let agentExecOptions: any = null;
 

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -488,9 +488,17 @@ export class MCPServer extends MCPServerBase {
           },
         };
 
+        const proxiedContext = new RequestContext();
+        if (extra) {
+          Object.entries(extra).forEach(([key, value]) => {
+            proxiedContext.set(key, value);
+          });
+        }
+
         const mcpOptions: MastraToolInvocationOptions = {
           messages: [],
           toolCallId: '',
+          requestContext: proxiedContext,
           // Pass MCP-specific context through the mcp property
           mcp: {
             elicitation: sessionElicitation,


### PR DESCRIPTION
## Description

Regular tools executed via MCPServer's CallToolRequestSchema handler were missing requestContext populated from mcp.extra, while agent tools and workflow tools already had this. Now all tool types consistently populate requestContext from auth info passed through the MCP protocol.

## Related Issue(s)

Fixes #14323

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified context handling so all tool types consistently receive authentication and session information during execution.

* **Tests**
  * Added tests to verify request context and auth/session propagation for both agent-to-tool and direct tool invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->