### PR TITLE
fix(mastracode): remove hardcoded terminal width buffer causing rendering corruption

### DIFF
--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -28,7 +28,7 @@ import type { SubagentExecutionComponent } from './components/subagent-execution
 import type { TaskProgressComponent } from './components/task-progress.js';
 import type { IToolExecutionComponent } from './components/tool-execution-interface.js';
 import type { UserMessageComponent } from './components/user-message.js';
-import { getEditorTheme, TERM_WIDTH_BUFFER } from './theme.js';
+import { getEditorTheme } from './theme.js';
 // =============================================================================
 // MastraTUIOptions
 // =============================================================================
@@ -181,10 +181,6 @@ export interface TUIState {
  */
 export function createTUIState(options: MastraTUIOptions): TUIState {
   const terminal = new ProcessTerminal();
-  // Override columns getter to prevent line wrapping in nested terminal emulators
-  Object.defineProperty(terminal, 'columns', {
-    get: () => (process.stdout.columns || 80) - TERM_WIDTH_BUFFER,
-  });
   const ui = new TUI(terminal);
 
   // Perf profiling removed

--- a/mastracode/src/tui/theme.ts
+++ b/mastracode/src/tui/theme.ts
@@ -181,10 +181,8 @@ const textThemeKeys: (keyof ThemeColors)[] = [
 // Comfortable minimum contrast for TUI body text — above WCAG AA (4.5:1) for better readability
 export const TUI_MIN_CONTRAST = 5.5;
 
-/** Terminal width buffer applied at the framework level to prevent wrapping in nested terminals */
-export const TERM_WIDTH_BUFFER = 3;
-/** Get the effective terminal width (matching the framework's reduced width) */
-export const getTermWidth = () => (process.stdout.columns || 80) - TERM_WIDTH_BUFFER;
+/** Get the current terminal width */
+export const getTermWidth = () => process.stdout.columns || 80;
 
 /** Left indent (in spaces) applied to assistant text (Markdown body) */
 export const CHAT_INDENT = 2;


### PR DESCRIPTION
## Problem

The `-3` terminal width buffer introduced in #14337 to prevent line wrapping in embedded terminals causes ANSI escape sequence corruption in other terminal emulators (e.g. Supersets). Characters get eaten by the width mismatch, resulting in garbled text and visible escape codes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal width calculation to utilize the full available terminal width without unnecessary constraints. This results in better text wrapping and more efficient line display in the terminal interface, providing optimal use of your screen space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->