### PR TITLE
fix(mastracode): remove border string render caching in editor

### DIFF
--- a/.changeset/fix-render-cache.md
+++ b/.changeset/fix-render-cache.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed potential rendering artifacts by removing border string caching in the editor input box. Borders are now recomputed each frame to ensure they stay in sync with terminal dimensions.

--- a/mastracode/src/tui/components/custom-editor.ts
+++ b/mastracode/src/tui/components/custom-editor.ts
@@ -65,16 +65,9 @@ export class CustomEditor extends Editor {
 
   private pendingBracketedPaste: string | null = null;
 
-  // Render caches
-  private _cachedModeColorHex?: string;
-  private _cachedModeColorRgb?: [number, number, number];
-  // Border cache — keyed on (offset, fade, width, contentLineCount, color)
-  private _borderCacheKey = '';
-  private _cachedTopBorder = '';
-  private _cachedBottomBorder = '';
-  private _cachedLeftBorders: string[] = [];
-  private _cachedRightBorders: string[] = [];
-  private _cachedColorFn?: (s: string) => string;
+  private _lastModeColorHex?: string;
+  private _lastModeColorRgb?: [number, number, number];
+  private _colorFn?: (s: string) => string;
 
   constructor(tui: TUI, theme: EditorTheme) {
     super(tui, theme);
@@ -116,14 +109,12 @@ export class CustomEditor extends Editor {
     const color = this.getModeColor?.() || mastra.green;
     const promptChar = isSlash ? '/' : isAt ? '@' : '›';
 
-    // Cache colorFn and prompt — only recreate when color changes
-    if (this._cachedModeColorHex !== color) {
-      this._cachedModeColorHex = color;
-      this._cachedModeColorRgb = parseHex(color);
-      this._cachedColorFn = chalk.hex(color);
-      this._borderCacheKey = ''; // invalidate border cache on color change
+    if (this._lastModeColorHex !== color) {
+      this._lastModeColorHex = color;
+      this._lastModeColorRgb = parseHex(color);
+      this._colorFn = chalk.hex(color);
     }
-    const colorFn = this._cachedColorFn!;
+    const colorFn = this._colorFn!;
     const b = colorFn;
     // Prompt changes with slash/at mode, so rebuild each time (cheap)
     const prompt = chalk.bold.hex(color)(promptChar);
@@ -176,107 +167,93 @@ export class CustomEditor extends Editor {
     // Gradient animation for border
     const gradInfo = this.getGradientInfo?.();
     const animating = gradInfo?.running;
-    const modeColorRgb = this._cachedModeColorRgb!;
+    const modeColorRgb = this._lastModeColorRgb!;
+    const perimeterLen = width * 2 + contentLines.length * 2;
 
-    // Build a cache key from animation state + dimensions
-    // Borders only change when animation params or box dimensions change
-    const cacheKey = animating
-      ? `${gradInfo!.offset.toFixed(4)}:${gradInfo!.fade.toFixed(3)}:${width}:${contentLines.length}:${color}`
-      : `static:${width}:${contentLines.length}:${color}`;
+    // Pre-compute shared animation values (constant for all chars in this frame)
+    let breath = 0;
+    let inhaleBright = 0;
+    let inhaleR = 0,
+      inhaleG = 0,
+      inhaleB = 0;
+    let exhaleBright = 0;
+    let easedFade = 0;
+    let offsetVal = 0;
 
-    if (cacheKey !== this._borderCacheKey) {
-      // Recompute all border strings
-      this._borderCacheKey = cacheKey;
-      const perimeterLen = width * 2 + contentLines.length * 2;
-
-      // Pre-compute shared animation values (constant for all chars in this frame)
-      let breath = 0;
-      let inhaleBright = 0;
-      let inhaleR = 0,
-        inhaleG = 0,
-        inhaleB = 0;
-      let exhaleBright = 0;
-      let easedFade = 0;
-      let offsetVal = 0;
-
-      if (animating) {
-        const { offset, fade } = gradInfo!;
-        offsetVal = offset;
-        const breathPhase = offset * 0.6 * Math.PI * 2;
-        const breathRaw = (Math.sin(breathPhase - Math.PI / 2) + 1) / 2;
-        breath = breathRaw * breathRaw * (3 - 2 * breathRaw); // smoothstep
-        inhaleBright = 0.4 + 0.5 * breath;
-        inhaleR = modeColorRgb[0] * inhaleBright;
-        inhaleG = modeColorRgb[1] * inhaleBright;
-        inhaleB = modeColorRgb[2] * inhaleBright;
-        exhaleBright = 0.55 + 0.25 * (1 - breath);
-        easedFade = fade * fade * (3 - 2 * fade);
-      }
-
-      const borderChar = (ch: string, perimPos: number): string => {
-        if (!animating) return b(ch);
-
-        // Exhale: gradient colors spinning radially (per-char computation)
-        const norm = perimPos / perimeterLen;
-        const radialPos = (norm + offsetVal * 0.15) % 1;
-        const stopCount = GRADIENT_COLORS.length;
-        const scaledPos = radialPos * stopCount;
-        const si = Math.floor(scaledPos) % stopCount;
-        const frac = scaledPos - Math.floor(scaledPos);
-        const ni = (si + 1) % stopCount;
-        const eA = GRADIENT_COLORS[si]!,
-          eB = GRADIENT_COLORS[ni]!;
-        const exR = (eA[0] + (eB[0] - eA[0]) * frac) * exhaleBright;
-        const exG = (eA[1] + (eB[1] - eA[1]) * frac) * exhaleBright;
-        const exB = (eA[2] + (eB[2] - eA[2]) * frac) * exhaleBright;
-
-        // Crossfade exhale → inhale based on breath
-        const bR = exR + (inhaleR - exR) * breath;
-        const bG = exG + (inhaleG - exG) * breath;
-        const bB = exB + (inhaleB - exB) * breath;
-
-        // Fade toward static mode color
-        const fR = bR + (modeColorRgb[0] - bR) * easedFade;
-        const fG = bG + (modeColorRgb[1] - bG) * easedFade;
-        const fB = bB + (modeColorRgb[2] - bB) * easedFade;
-
-        return chalk.rgb(Math.round(fR), Math.round(fG), Math.round(fB))(ch);
-      };
-
-      // Top border
-      let top = borderChar('╭', 0);
-      for (let i = 0; i < hBarLen; i++) top += borderChar('─', i + 1);
-      top += borderChar('╮', width - 1);
-      this._cachedTopBorder = top;
-
-      // Side borders
-      this._cachedLeftBorders = [];
-      this._cachedRightBorders = [];
-      for (let i = 0; i < contentLines.length; i++) {
-        const leftPerim = perimeterLen - 1 - i;
-        const rightPerim = width + i;
-        this._cachedLeftBorders.push(borderChar('│', leftPerim));
-        this._cachedRightBorders.push(borderChar('│', rightPerim));
-      }
-
-      // Bottom border
-      const bottomStart = width + contentLines.length;
-      let bottom = borderChar('╰', bottomStart + width - 1);
-      for (let i = 0; i < hBarLen; i++) bottom += borderChar('─', bottomStart + width - 2 - i);
-      bottom += borderChar('╯', bottomStart);
-      this._cachedBottomBorder = bottom;
+    if (animating) {
+      const { offset, fade } = gradInfo!;
+      offsetVal = offset;
+      const breathPhase = offset * 0.6 * Math.PI * 2;
+      const breathRaw = (Math.sin(breathPhase - Math.PI / 2) + 1) / 2;
+      breath = breathRaw * breathRaw * (3 - 2 * breathRaw); // smoothstep
+      inhaleBright = 0.4 + 0.5 * breath;
+      inhaleR = modeColorRgb[0] * inhaleBright;
+      inhaleG = modeColorRgb[1] * inhaleBright;
+      inhaleB = modeColorRgb[2] * inhaleBright;
+      exhaleBright = 0.55 + 0.25 * (1 - breath);
+      easedFade = fade * fade * (3 - 2 * fade);
     }
 
-    // Assemble box from cached borders + fresh content
-    // Wrap editor content with explicit text color so it adapts to light/dark mode
+    const borderChar = (ch: string, perimPos: number): string => {
+      if (!animating) return b(ch);
+
+      // Exhale: gradient colors spinning radially (per-char computation)
+      const norm = perimPos / perimeterLen;
+      const radialPos = (norm + offsetVal * 0.15) % 1;
+      const stopCount = GRADIENT_COLORS.length;
+      const scaledPos = radialPos * stopCount;
+      const si = Math.floor(scaledPos) % stopCount;
+      const frac = scaledPos - Math.floor(scaledPos);
+      const ni = (si + 1) % stopCount;
+      const eA = GRADIENT_COLORS[si]!,
+        eB = GRADIENT_COLORS[ni]!;
+      const exR = (eA[0] + (eB[0] - eA[0]) * frac) * exhaleBright;
+      const exG = (eA[1] + (eB[1] - eA[1]) * frac) * exhaleBright;
+      const exB = (eA[2] + (eB[2] - eA[2]) * frac) * exhaleBright;
+
+      // Crossfade exhale → inhale based on breath
+      const bR = exR + (inhaleR - exR) * breath;
+      const bG = exG + (inhaleG - exG) * breath;
+      const bB = exB + (inhaleB - exB) * breath;
+
+      // Fade toward static mode color
+      const fR = bR + (modeColorRgb[0] - bR) * easedFade;
+      const fG = bG + (modeColorRgb[1] - bG) * easedFade;
+      const fB = bB + (modeColorRgb[2] - bB) * easedFade;
+
+      return chalk.rgb(Math.round(fR), Math.round(fG), Math.round(fB))(ch);
+    };
+
+    // Top border
+    let top = borderChar('╭', 0);
+    for (let i = 0; i < hBarLen; i++) top += borderChar('─', i + 1);
+    top += borderChar('╮', width - 1);
+
+    // Side borders
+    const leftBorders: string[] = [];
+    const rightBorders: string[] = [];
+    for (let i = 0; i < contentLines.length; i++) {
+      const leftPerim = perimeterLen - 1 - i;
+      const rightPerim = width + i;
+      leftBorders.push(borderChar('│', leftPerim));
+      rightBorders.push(borderChar('│', rightPerim));
+    }
+
+    // Bottom border
+    const bottomStart = width + contentLines.length;
+    let bottom = borderChar('╰', bottomStart + width - 1);
+    for (let i = 0; i < hBarLen; i++) bottom += borderChar('─', bottomStart + width - 2 - i);
+    bottom += borderChar('╯', bottomStart);
+
+    // Assemble box
     const textColorOpen = `\x1b[38;2;${parseHex(theme.getTheme().text).join(';')}m`;
     const textColorClose = '\x1b[39m';
-    result.push(this._cachedTopBorder);
+    result.push(top);
 
     for (let i = 0; i < contentLines.length; i++) {
       const line = `${textColorOpen}${contentLines[i]!}${textColorClose}`;
-      const leftBorder = this._cachedLeftBorders[i] ?? b('│');
-      const rightBorder = this._cachedRightBorders[i] ?? b('│');
+      const leftBorder = leftBorders[i] ?? b('│');
+      const rightBorder = rightBorders[i] ?? b('│');
       if (i === 0) {
         result.push(`${leftBorder} ${prompt} ${line} ${rightBorder}`);
       } else {
@@ -284,7 +261,7 @@ export class CustomEditor extends Editor {
       }
     }
 
-    result.push(this._cachedBottomBorder);
+    result.push(bottom);
 
     // Scroll indicators below the box
     for (const ind of scrollIndicators) {


### PR DESCRIPTION
## Summary

Removes the border string render cache from the `CustomEditor` component to fix potential TUI rendering artifacts (corruption/garbled text) reported in certain terminal emulators.

## What changed

The editor's `render()` method previously cached pre-computed border strings (top, bottom, left, right) keyed on animation state, dimensions, and color. When the cache key matched, it reused stored strings instead of recomputing.

This cache could produce stale output when terminal dimensions change mid-frame or when the framework's differential rendering expects fresh strings, leading to visual corruption.

**Before:** Border strings cached and reused across renders via a cache key.
**After:** Border strings computed inline each render cycle. The per-character gradient math and chalk calls remain identical.

## Test plan

- `tsc --noEmit` passes with no new errors
- `vitest` TUI test suite passes (no new failures)
- Manual verification: editor borders render correctly without artifacts during animation, resize, and typing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed editor borders to properly synchronize with terminal dimensions by recomputing them dynamically each frame.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->