### PR TITLE
fix(mcp): populate requestContext from extra for regular tools

### DIFF
--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -488,9 +488,18 @@ export class MCPServer extends MCPServerBase {
           },
         };
 
+        // Populate requestContext from mcp.extra (matching agent tools & workflow tools behavior)
+        const proxiedContext = new RequestContext();
+        if (extra) {
+          Object.entries(extra).forEach(([key, value]) => {
+            proxiedContext.set(key, value);
+          });
+        }
+
         const mcpOptions: MastraToolInvocationOptions = {
           messages: [],
           toolCallId: '',
+          requestContext: proxiedContext,
           // Pass MCP-specific context through the mcp property
           mcp: {
             elicitation: sessionElicitation,


### PR DESCRIPTION
## Related Issue
Fixes #14323

## Description
Regular tools executed via MCPServer's `CallToolRequestSchema` handler were missing `requestContext` populated from `mcp.extra`. This meant tools couldn't access auth/user data through the standard `context.requestContext` path — they had to dig into `context.mcp.extra` instead.

Agent tools (lines ~849-860) and workflow tools (lines ~934-945) already proxy `mcp.extra` into a `RequestContext`, but regular tools in the `CallToolRequestSchema` handler (~line 493) were missing this.

## Changes
Added the same `RequestContext` proxy pattern used by agent and workflow tools to the regular tool execution path in `CallToolRequestSchema`:

```typescript
const proxiedContext = new RequestContext();
if (extra) {
  Object.entries(extra).forEach(([key, value]) => {
    proxiedContext.set(key, value);
  });
}
```

Then passes `requestContext: proxiedContext` in `mcpOptions`.

## How did you test it?
- Verified the pattern matches the existing agent tools (line ~849) and workflow tools (line ~934) implementations
- The `RequestContext` import was already present at line 13

## Notes
This is a one-line-pattern fix for consistency. The same proxy logic is already battle-tested in agent and workflow tool paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal context propagation mechanisms in tool invocation workflows to ensure consistent context handling and data flow across system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->