### PR TITLE
fix(core): preserve usage/finishReason in ModelRouter doGenerate

### DIFF
--- a/packages/core/src/llm/model/aisdk/v5/model.ts
+++ b/packages/core/src/llm/model/aisdk/v5/model.ts
@@ -45,6 +45,7 @@ export class AISDKV5LanguageModel implements MastraLanguageModelV2 {
     const result = await this.#model.doGenerate(options);
 
     return {
+      ...result,
       request: result.request!,
       response: result.response as unknown as StreamResult['response'],
       stream: createStreamFromGenerateResult(result),

--- a/packages/core/src/llm/model/aisdk/v6/model.ts
+++ b/packages/core/src/llm/model/aisdk/v6/model.ts
@@ -69,6 +69,7 @@ export class AISDKV6LanguageModel implements MastraLanguageModelV3 {
     const result = await this.#model.doGenerate(remapToolsToV3(options));
 
     return {
+      ...result,
       request: result.request!,
       response: result.response as unknown as StreamResult['response'],
       stream: createStreamFromGenerateResult(result),


### PR DESCRIPTION
## Related Issue
Fixes #14281

## Description
`AISDKV5LanguageModel.doGenerate()` and `AISDKV6LanguageModel.doGenerate()` were only returning `{ request, response, stream }`, stripping `usage`, `finishReason`, `text`, `content`, and `warnings` from the underlying model's result.

When `ModelRouterLanguageModel` (`specificationVersion: 'v2'`) is used with AI SDK v6's `generateObject()`/`generateText()`, the SDK wraps it via `asLanguageModelV3()` which calls `convertV2UsageToV3(result.usage)`. Since `usage` was `undefined`, it crashed:

```
TypeError: Cannot read properties of undefined (reading 'inputTokens')
    at convertV2UsageToV3
```

## Changes
In both `packages/core/src/llm/model/aisdk/v5/model.ts` and `v6/model.ts`:
- Spread the full `result` before overriding `request`/`response`/`stream`
- This preserves `usage`, `finishReason`, `text`, `content`, `warnings`, and any other properties from the underlying model

```diff
return {
+     ...result,
      request: result.request!,
      response: result.response as unknown as StreamResult['response'],
      stream: createStreamFromGenerateResult(result),
};
```

## How did you test it?
- Verified the fix matches the approach suggested and verified by the issue reporter
- The change is minimal (adding `...result` spread) and preserves existing behavior while adding the missing properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal handling of LLM model responses to better preserve all data fields provided by underlying model implementations across SDK versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->