### PR TITLE
fix(pg): schema-qualify operator classes for custom schema

### DIFF
--- a/stores/pg/src/vector/index.schema-name.test.ts
+++ b/stores/pg/src/vector/index.schema-name.test.ts
@@ -118,7 +118,6 @@ describe('PgVector halfvec version detection after custom schema install', () =>
 
   let vectorStore: PgVector;
   let listIndexesSpy: ReturnType<typeof vi.spyOn>;
-  const queryHistory: QueryCall[] = [];
 
   beforeEach(async () => {
     queryHistory.length = 0;
@@ -187,6 +186,90 @@ describe('PgVector halfvec version detection after custom schema install', () =>
   });
 });
 
+describe('PgVector schema-aware operator class handling for custom schema', () => {
+  const config: PgVectorConfig & { id: string } = {
+    connectionString: 'postgresql://postgres:postgres@localhost:5432/mastra',
+    schemaName: 'custom_schema',
+    id: 'pg-vector-operator-class-test',
+  };
+
+  let vectorStore: PgVector;
+  let listIndexesSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    queryHistory.length = 0;
+
+    mockClient.query.mockImplementation(async (text: any, values?: any[]) => {
+      const sql = typeof text === 'string' ? text : text?.text || '';
+      queryHistory.push({ text: sql, values });
+
+      // Schema check
+      if (sql.includes('information_schema.schemata')) {
+        return { rows: [{ exists: true }] };
+      }
+
+      // Extension detection - extension installed in custom schema
+      if (sql.includes('FROM pg_extension e')) {
+        return { rows: [{ schema_name: 'custom_schema', version: '0.8.0' }] };
+      }
+
+      // For describeIndex - simulate table exists, return type based on dimension
+      if (sql.includes('information_schema.columns') && sql.includes('udt_name')) {
+        // Check if this is for halfvecTestIndex
+        return { rows: [{ udt_name: 'vector' }] };
+      }
+
+      // For dimension query - return dimension based on index
+      if (sql.includes('pg_attribute') && sql.includes('atttypmod')) {
+        return { rows: [{ dimension: 1536 }] };
+      }
+
+      // For count query
+      if (sql.includes('COUNT(*)')) {
+        return { rows: [{ count: '100' }] };
+      }
+
+      // For index info query - no index exists yet (flat)
+      if (sql.includes('pg_index') && sql.includes('pg_am')) {
+        return { rows: [] };
+      }
+
+      return { rows: [] };
+    });
+    mockClient.release.mockReset();
+
+    listIndexesSpy = vi.spyOn(PgVector.prototype, 'listIndexes').mockResolvedValue([]);
+
+    vectorStore = new PgVector(config);
+    await (vectorStore as any).cacheWarmupPromise;
+  });
+
+  afterEach(async () => {
+    await vectorStore.disconnect();
+    listIndexesSpy.mockRestore();
+    mockClient.query.mockReset();
+  });
+
+  it('should schema-qualify operator class when extension is in custom schema', async () => {
+    // Issue #14357: When PgVector is configured with a custom schemaName and the vector
+    // extension is installed in that custom schema, operator classes like vector_cosine_ops
+    // must be schema-qualified (e.g., custom_schema.vector_cosine_ops) for index creation
+    // to work, because the custom schema is not on the default search_path.
+
+    await vectorStore.createIndex({
+      indexName: 'testIndex',
+      dimension: 1536,
+      metric: 'cosine',
+      indexConfig: { type: 'hnsw' },
+    });
+
+    const createIndexCall = queryHistory.find(call => call.text.includes('CREATE INDEX'));
+    expect(createIndexCall).toBeDefined();
+    // Should use schema-qualified operator class
+    expect(createIndexCall?.text ?? '').toContain('custom_schema.vector_cosine_ops');
+  });
+});
+
 describe('PgVector buildIndex uses correct operator class for halfvec', () => {
   const config: PgVectorConfig & { id: string } = {
     connectionString: 'postgresql://postgres:postgres@localhost:5432/mastra',
@@ -195,7 +278,6 @@ describe('PgVector buildIndex uses correct operator class for halfvec', () => {
 
   let vectorStore: PgVector;
   let listIndexesSpy: ReturnType<typeof vi.spyOn>;
-  const queryHistory: QueryCall[] = [];
 
   beforeEach(async () => {
     queryHistory.length = 0;

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -295,6 +295,27 @@ export class PgVector extends MastraVector<PGVectorFilter> {
   }
 
   /**
+   * Gets the properly qualified operator class name for index creation
+   * @param operatorClass - The operator class name (e.g., 'vector_cosine_ops')
+   */
+  private getOperatorClassName(operatorClass: string): string {
+    // If we know where the extension is, qualify the operator class
+    if (this.vectorExtensionSchema) {
+      // If it's in pg_catalog, return the operator class directly
+      if (this.vectorExtensionSchema === 'pg_catalog') {
+        return operatorClass;
+      }
+      // Issue #14357: Qualify operator class with schema where vector extension is installed
+      // This ensures the operator class is found during index creation regardless of search_path
+      const validatedSchema = parseSqlIdentifier(this.vectorExtensionSchema, 'vector extension schema');
+      return `${validatedSchema}.${operatorClass}`;
+    }
+
+    // Fallback to unqualified (will use search_path)
+    return operatorClass;
+  }
+
+  /**
    * Returns the operator class, distance operator, and score expression for a
    * standard (non-bit) vector type prefix and metric.
    */
@@ -1091,6 +1112,19 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       // Use the detected vectorType from existing table if available, otherwise use the parameter
       const effectiveVectorType = existingIndexInfo?.vectorType ?? vectorType;
       const metricOp = this.getVectorOps(effectiveVectorType, metric).operatorClass;
+      // Issue #14357: Schema-qualify the operator class when extension is in custom schema
+      const qualifiedMetricOp = this.getOperatorClassName(metricOp);
+
+      // Set search path to include both schemas if needed before creating index
+      // This ensures operators and functions are resolvable during index creation
+      if (
+        this.schema &&
+        this.vectorExtensionSchema &&
+        this.schema !== this.vectorExtensionSchema &&
+        this.vectorExtensionSchema !== 'pg_catalog'
+      ) {
+        await client.query(`SET search_path TO ${this.getSchemaName()}, "${this.vectorExtensionSchema}"`);
+      }
 
       let indexSQL: string;
       if (indexType === 'hnsw') {
@@ -1100,7 +1134,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
         indexSQL = `
           CREATE INDEX IF NOT EXISTS ${vectorIndexName}
           ON ${tableName}
-          USING hnsw (embedding ${metricOp})
+          USING hnsw (embedding ${qualifiedMetricOp})
           WITH (
             m = ${m},
             ef_construction = ${efConstruction}
@@ -1117,7 +1151,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
         indexSQL = `
           CREATE INDEX IF NOT EXISTS ${vectorIndexName}
           ON ${tableName}
-          USING ivfflat (embedding ${metricOp})
+          USING ivfflat (embedding ${qualifiedMetricOp})
           WITH (lists = ${lists});
         `;
       }


### PR DESCRIPTION

## Description

When PgVector is configured with a custom schemaName and the vector extension is installed in that custom schema (instead of public), index creation fails because operator classes like "vector_cosine_ops" cannot be resolved.

This fix schema-qualifies operator classes (e.g., "custom_schema.vector_cosine_ops") and sets search_path before index creation when the extension is in a custom schema.

## Related Issue(s)

Fixes #14357

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes

- Add getOperatorClassName() method to schema-qualify operator classes when needed
- Set search_path before index creation when extension is in custom schema
- Use qualified operator class in HNSW and IVFFlat index creation SQL
- Add test verifying operator classes are schema-qualified

## Checklist

- [x] I have added tests that prove my fix is effective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of vector indexes when database extensions are installed in custom schemas, ensuring proper operator class resolution during index creation.
  
* **Tests**
  * Added test coverage for schema-aware operator class handling in custom schema configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->