### PR TITLE
fix(client-js): add missing break in tool-call switch case causing recursive stream failure

### DIFF
--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -999,6 +999,7 @@ export class Agent extends BaseResource {
                 execUpdate();
               }
             }
+            break;
           }
 
           case 'tool-call-input-streaming-start': {

--- a/client-sdks/client-js/src/resources/agent.vnext.test.ts
+++ b/client-sdks/client-js/src/resources/agent.vnext.test.ts
@@ -1123,6 +1123,74 @@ describe('Agent vNext', () => {
     expect(hasToolResult).toBe(true);
   });
 
+  it('stream: tool-call event should not create duplicate toolInvocations from switch fallthrough (issue #14364)', async () => {
+    // Regression test: a missing `break` after `case 'tool-call'` caused fallthrough
+    // into `case 'tool-call-input-streaming-start'`, creating a duplicate partial-call
+    // entry in toolInvocations. The corrupted message then caused the recursive stream
+    // request to fail with HTTP 400.
+    const toolCallId = 'call_1';
+
+    const firstCycle = [
+      { type: 'step-start', payload: { messageId: 'm1' } },
+      {
+        type: 'tool-call',
+        payload: { toolCallId, toolName: 'weatherTool', args: { location: 'NYC' } },
+      },
+      { type: 'step-finish', payload: { stepResult: { isContinued: false } } },
+      { type: 'finish', payload: { stepResult: { reason: 'tool-calls' }, usage: { totalTokens: 2 } } },
+    ];
+
+    const secondCycle = [
+      { type: 'step-start', payload: { messageId: 'm2' } },
+      { type: 'text-delta', payload: { text: 'Weather is sunny.' } },
+      { type: 'step-finish', payload: { stepResult: { isContinued: false } } },
+      { type: 'finish', payload: { stepResult: { reason: 'stop' }, usage: { totalTokens: 3 } } },
+    ];
+
+    (global.fetch as any)
+      .mockResolvedValueOnce(sseResponse(firstCycle))
+      .mockResolvedValueOnce(sseResponse(secondCycle));
+
+    const executeSpy = vi.fn(async () => ({ temperature: 72 }));
+    const weatherTool = createTool({
+      id: 'weatherTool',
+      description: 'Weather',
+      inputSchema: z.object({ location: z.string() }),
+      outputSchema: z.object({ temperature: z.number() }),
+      execute: executeSpy,
+    });
+
+    const resp = await agent.stream('weather?', { clientTools: { weatherTool } });
+
+    await resp.processDataStream({
+      onChunk: async () => {},
+    });
+
+    // Verify two requests were made (initial + recursive)
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    // Parse the recursive call's body to inspect the messages sent to the server
+    const secondCallBody = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+
+    // Find the assistant message that contains toolInvocations
+    const assistantMsg = secondCallBody.messages.find(
+      (msg: any) => msg.role === 'assistant' && Array.isArray(msg.toolInvocations) && msg.toolInvocations.length > 0,
+    );
+
+    expect(assistantMsg).toBeDefined();
+
+    // The bug: without the break, toolInvocations would have 2 entries for the same
+    // toolCallId — one with state 'result' (or 'call') and one with state 'partial-call'.
+    // After the fix, there should be exactly 1 entry per toolCallId.
+    const invocationsForCall = assistantMsg.toolInvocations.filter((inv: any) => inv.toolCallId === toolCallId);
+    expect(invocationsForCall).toHaveLength(1);
+    expect(invocationsForCall[0].state).toBe('result');
+
+    // Verify no partial-call entries exist (these come from the fallthrough bug)
+    const partialCalls = assistantMsg.toolInvocations.filter((inv: any) => inv.state === 'partial-call');
+    expect(partialCalls).toHaveLength(0);
+  });
+
   it('stream: should receive error chunks with serialized error properties', async () => {
     const testAPICallError = new APICallError({
       message: 'API Error',


### PR DESCRIPTION
## Description

Fix a missing `break` statement in `processChatResponse_vNext()` that caused the `case 'tool-call'` block to fall through into `case 'tool-call-input-streaming-start'`. This created duplicate `toolInvocations` entries — one with state `'call'`/`'result'` and a spurious one with state `'partial-call'` — for the same `toolCallId`. When the corrupted message was sent in the recursive stream request after client tool execution, the server rejected it with HTTP 400.

The fix is a single `break;` statement at the end of the `case 'tool-call'` block (line 1002 in `agent.ts`).

**Root cause trace:**
1. `case 'tool-call'` processes the tool call and pushes a `'call'` state invocation
2. Missing `break` causes fallthrough into `case 'tool-call-input-streaming-start'`
3. Fallthrough pushes a second `'partial-call'` invocation for the same `toolCallId`
4. The `parts` array's tool-invocation part gets overwritten from `'call'` to `'partial-call'`
5. `onFinish` fires with the corrupted message (duplicate/inconsistent toolInvocations)
6. The recursive stream sends this corrupted message to the server → HTTP 400

## Related Issue(s)

Fixes #14364

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where streaming tool invocations could produce duplicates in agent interactions.

* **Tests**
  * Added regression tests to ensure tool invocation behavior remains consistent during streaming operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->