### PR TITLE
feat(memory): add configurable toolInstruction to WorkingMemoryConfig

### DIFF
--- a/.changeset/working-memory-configurable-tool-instruction.md
+++ b/.changeset/working-memory-configurable-tool-instruction.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": patch
+"@mastra/memory": patch
+---
+
+Added optional `toolInstruction` field to `WorkingMemoryConfig` to allow customizing the system prompt used by the `updateWorkingMemory` tool. When provided, replaces the default hardcoded instruction — giving developers control over when and how working memory updates occur without breaking existing behavior.

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -653,6 +653,10 @@ https://mastra.ai/en/docs/memory/overview`,
               'version' in effectiveConfig.workingMemory &&
               effectiveConfig.workingMemory.version === 'vnext',
             templateProvider: this,
+            toolInstruction:
+              typeof effectiveConfig.workingMemory === 'object'
+                ? effectiveConfig.workingMemory.toolInstruction
+                : undefined,
           }),
         );
       }

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -179,6 +179,19 @@ type BaseWorkingMemory = {
    * @default 'resource'
    */
   scope?: 'thread' | 'resource';
+  /**
+   * Custom instruction given to the LLM about when and how to use the
+   * updateWorkingMemory tool. When provided, completely replaces the
+   * default instruction. Use this to enforce constraints such as limiting
+   * what gets saved or how frequently memory updates occur.
+   *
+   * @example
+   * ```typescript
+   * toolInstruction: `Only call updateWorkingMemory for preferences
+   * the user has explicitly stated. Maximum 3 items total.`
+   * ```
+   */
+  toolInstruction?: string;
   /** @deprecated The `use` option has been removed. Working memory always uses tool-call mode. */
   use?: never;
 };

--- a/packages/core/src/processors/memory/working-memory.test.ts
+++ b/packages/core/src/processors/memory/working-memory.test.ts
@@ -789,4 +789,60 @@ describe('WorkingMemory', () => {
       expect(mockStorage.getThreadById).not.toHaveBeenCalled();
     });
   });
+
+  describe('Custom toolInstruction', () => {
+    it('should use custom toolInstruction instead of default when provided', async () => {
+      const customInstruction = 'Only save explicit user preferences. Maximum 3 items.';
+      const processor = new WorkingMemory({
+        storage: mockStorage,
+        scope: 'thread',
+        toolInstruction: customInstruction,
+      });
+
+      const threadId = 'thread-123';
+      const workingMemoryData = '# User Info\n- Name: John';
+
+      requestContext.set('MastraMemory', {
+        thread: { id: threadId, resourceId: 'resource-1', title: 'Test', createdAt: new Date(), updatedAt: new Date() },
+        resourceId: 'resource-1',
+      });
+
+      vi.mocked(mockStorage.getThreadById).mockResolvedValue({
+        id: threadId,
+        resourceId: 'resource-1',
+        title: 'Test Thread',
+        metadata: { workingMemory: workingMemoryData },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const messages = [
+        {
+          id: 'msg-1',
+          role: 'user' as const,
+          content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+          createdAt: new Date(),
+        },
+      ];
+
+      const { MessageList } = await import('../../agent');
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await processor.processInput({
+        messages,
+        messageList,
+        abort: () => {
+          throw new Error('Aborted');
+        },
+        requestContext,
+      });
+
+      const resultMessages = result instanceof MessageList ? result.get.all.aiV5.prompt() : result;
+      expect(resultMessages[0].role).toBe('system');
+      expect(resultMessages[0].content).toContain(customInstruction);
+      expect(resultMessages[0].content).toContain(workingMemoryData);
+      expect(resultMessages[0].content).not.toContain('WORKING_MEMORY_SYSTEM_INSTRUCTION');
+    });
+  });
 });

--- a/packages/core/src/processors/memory/working-memory.ts
+++ b/packages/core/src/processors/memory/working-memory.ts
@@ -173,12 +173,9 @@ export class WorkingMemory implements Processor {
   }): string {
     if (toolInstruction) {
       return `${toolInstruction}
-
 <working_memory_data>
 ${data}
 </working_memory_data>`;
-
-      return `${toolInstruction}\n<working_memory_data>\n${data}\n</working_memory_data>`;
     }
     const emptyWorkingMemoryTemplateObject =
       template.format === 'json' ? this.generateEmptyFromSchemaInternal(template.content) : null;

--- a/packages/core/src/processors/memory/working-memory.ts
+++ b/packages/core/src/processors/memory/working-memory.ts
@@ -74,6 +74,7 @@ export class WorkingMemory implements Processor {
       templateProvider?: {
         getWorkingMemoryTemplate(args: { memoryConfig?: MemoryConfigInternal }): Promise<WorkingMemoryTemplate | null>;
       };
+      toolInstruction?: string;
       logger?: IMastraLogger;
     },
   ) {
@@ -176,6 +177,8 @@ export class WorkingMemory implements Processor {
 <working_memory_data>
 ${data}
 </working_memory_data>`;
+
+      return `${toolInstruction}\n<working_memory_data>\n${data}\n</working_memory_data>`;
     }
     const emptyWorkingMemoryTemplateObject =
       template.format === 'json' ? this.generateEmptyFromSchemaInternal(template.content) : null;

--- a/packages/core/src/processors/memory/working-memory.ts
+++ b/packages/core/src/processors/memory/working-memory.ts
@@ -74,7 +74,6 @@ export class WorkingMemory implements Processor {
       templateProvider?: {
         getWorkingMemoryTemplate(args: { memoryConfig?: MemoryConfigInternal }): Promise<WorkingMemoryTemplate | null>;
       };
-      toolInstruction?: string;
       logger?: IMastraLogger;
     },
   ) {

--- a/packages/core/src/processors/memory/working-memory.ts
+++ b/packages/core/src/processors/memory/working-memory.ts
@@ -70,6 +70,7 @@ export class WorkingMemory implements Processor {
       scope?: 'thread' | 'resource';
       useVNext?: boolean;
       readOnly?: boolean;
+      toolInstruction?: string;
       templateProvider?: {
         getWorkingMemoryTemplate(args: { memoryConfig?: MemoryConfigInternal }): Promise<WorkingMemoryTemplate | null>;
       };
@@ -141,7 +142,11 @@ export class WorkingMemory implements Processor {
     } else if (this.options.useVNext) {
       instruction = this.getWorkingMemoryToolInstructionVNext({ template, data: workingMemoryData });
     } else {
-      instruction = this.getWorkingMemoryToolInstruction({ template, data: workingMemoryData });
+      instruction = this.getWorkingMemoryToolInstruction({
+        template,
+        data: workingMemoryData,
+        toolInstruction: this.options.toolInstruction,
+      });
     }
 
     // If we have a MessageList, add working memory to it with source: 'memory'
@@ -159,10 +164,19 @@ export class WorkingMemory implements Processor {
   private getWorkingMemoryToolInstruction({
     template,
     data,
+    toolInstruction,
   }: {
     template: WorkingMemoryTemplate;
     data: string | null;
+    toolInstruction?: string;
   }): string {
+    if (toolInstruction) {
+      return `${toolInstruction}
+
+<working_memory_data>
+${data}
+</working_memory_data>`;
+    }
     const emptyWorkingMemoryTemplateObject =
       template.format === 'json' ? this.generateEmptyFromSchemaInternal(template.content) : null;
     const hasEmptyWorkingMemoryTemplateObject =

--- a/packages/core/src/processors/memory/working-memory.ts
+++ b/packages/core/src/processors/memory/working-memory.ts
@@ -139,14 +139,16 @@ export class WorkingMemory implements Processor {
     let instruction: string;
     if (isReadOnly) {
       instruction = this.getReadOnlyWorkingMemoryInstruction({ template, data: workingMemoryData });
-    } else if (this.options.useVNext) {
-      instruction = this.getWorkingMemoryToolInstructionVNext({ template, data: workingMemoryData });
-    } else {
+    } else if (this.options.toolInstruction) {
       instruction = this.getWorkingMemoryToolInstruction({
         template,
         data: workingMemoryData,
         toolInstruction: this.options.toolInstruction,
       });
+    } else if (this.options.useVNext) {
+      instruction = this.getWorkingMemoryToolInstructionVNext({ template, data: workingMemoryData });
+    } else {
+      instruction = this.getWorkingMemoryToolInstruction({ template, data: workingMemoryData });
     }
 
     // If we have a MessageList, add working memory to it with source: 'memory'

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1043,6 +1043,7 @@ ${workingMemory}`;
       : this.getWorkingMemoryToolInstruction({
           template: workingMemoryTemplate,
           data: workingMemoryData,
+          toolInstruction: memoryConfig?.workingMemory?.toolInstruction,
         });
   }
 
@@ -1062,10 +1063,19 @@ ${workingMemory}`;
   protected getWorkingMemoryToolInstruction({
     template,
     data,
+    toolInstruction,
   }: {
     template: WorkingMemoryTemplate;
     data: string | null;
+    toolInstruction?: string;
   }) {
+    if (toolInstruction) {
+      return `${toolInstruction}
+
+<working_memory_data>
+${data}
+</working_memory_data>`;
+    }
     const emptyWorkingMemoryTemplateObject =
       template.format === 'json' ? generateEmptyFromSchema(template.content) : null;
     const hasEmptyWorkingMemoryTemplateObject =

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1043,7 +1043,7 @@ ${workingMemory}`;
       : this.getWorkingMemoryToolInstruction({
           template: workingMemoryTemplate,
           data: workingMemoryData,
-          toolInstruction: memoryConfig?.workingMemory?.toolInstruction,
+          toolInstruction: config.workingMemory?.toolInstruction,
         });
   }
 


### PR DESCRIPTION
Closes #14345

## What does this PR do?

Adds an optional `toolInstruction` field to `WorkingMemoryConfig` that lets 
developers replace the default hardcoded working memory system prompt with 
their own instruction.

## Problem

`getWorkingMemoryToolInstruction()` had a hardcoded instruction telling the 
LLM to save information aggressively. This overrode constraints set in custom 
templates, causing the memory to update too frequently and ignore template rules.

## Solution
```typescript
new Memory({
  workingMemory: {
    enabled: true,
    toolInstruction: `Only call updateWorkingMemory for preferences 
    the user has explicitly stated. Maximum 3 items total.`,
  },
})
```

When `toolInstruction` is provided, it replaces the default instruction 
entirely. When not provided, existing behavior is unchanged — zero breaking 
changes.

## Changes

- Added `toolInstruction?: string` to `BaseWorkingMemory` type in `packages/core/src/memory/types.ts`
- Updated `getWorkingMemoryToolInstruction()` in both `packages/core/src/processors/memory/working-memory.ts` and `packages/memory/src/index.ts`
- Added test verifying custom instruction replaces default
- Added changeset for `@mastra/core` and `@mastra/memory`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional configuration to customize the working-memory tool instruction. When set, the custom instruction is prepended to working-memory data used during updates; leaving it unset preserves prior behavior and causes no breaking changes.

* **Tests**
  * Added tests verifying custom tool instructions appear in generated system messages, include existing working memory data, and replace the default instruction when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->