### PR TITLE
fix(core): add scanMode option to PromptInjectionDetector for better performance

### DIFF
--- a/packages/core/src/processors/processors/prompt-injection-detector.test.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.test.ts
@@ -705,4 +705,191 @@ describe('PromptInjectionDetector', () => {
       });
     });
   });
+
+  describe('scanMode: latest', () => {
+    it('should only scan the latest message when scanMode is latest', async () => {
+      // Only the last message should be checked
+      const model = setupMockModel(createMockDetectionResult(false));
+      const detector = new PromptInjectionDetector({
+        model,
+        scanMode: 'latest',
+      });
+
+      const mockAbort = vi.fn();
+
+      const messages = [
+        createTestMessage('First message', 'user', 'msg1'),
+        createTestMessage('Second message', 'user', 'msg2'),
+        createTestMessage('Third message', 'user', 'msg3'),
+      ];
+
+      const result = await detector.processInput({ messages, abort: mockAbort as any });
+
+      // All messages should pass through since only the last one was checked
+      expect(result).toEqual(messages);
+      // Model should only be called once (for the last message)
+      expect(mockAbort).not.toHaveBeenCalled();
+    });
+
+    it('should block only when latest message has injection with scanMode latest', async () => {
+      const model = setupMockModel(createMockDetectionResult(true, ['injection']));
+      const detector = new PromptInjectionDetector({
+        model,
+        scanMode: 'latest',
+        strategy: 'block',
+      });
+
+      const mockAbort = vi.fn().mockImplementation(() => {
+        throw new TripWire('Injection blocked');
+      });
+
+      const messages = [
+        createTestMessage('Safe first message', 'user', 'msg1'),
+        createTestMessage('Safe second message', 'user', 'msg2'),
+        createTestMessage('Malicious content', 'user', 'msg3'),
+      ];
+
+      await expect(async () => {
+        await detector.processInput({ messages, abort: mockAbort as any });
+      }).rejects.toThrow('Injection blocked');
+
+      expect(mockAbort).toHaveBeenCalledWith(expect.stringContaining('Prompt injection detected'));
+    });
+
+    it('should filter only the latest message when scanMode is latest', async () => {
+      const model = setupMockModel(createMockDetectionResult(true, ['injection']));
+      const detector = new PromptInjectionDetector({
+        model,
+        scanMode: 'latest',
+        strategy: 'filter',
+      });
+
+      const mockAbort = vi.fn();
+      const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      const messages = [
+        createTestMessage('Safe first message', 'user', 'msg1'),
+        createTestMessage('Safe second message', 'user', 'msg2'),
+        createTestMessage('Malicious content', 'user', 'msg3'),
+      ];
+
+      const result = await detector.processInput({ messages, abort: mockAbort as any });
+
+      // Only the last message should be filtered, first two should remain
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('msg1');
+      expect(result[1].id).toBe('msg2');
+
+      consoleInfoSpy.mockRestore();
+    });
+
+    it('should rewrite only the latest message when scanMode is latest', async () => {
+      const rewrittenContent = 'Safe rewritten content';
+      const model = setupMockModel(createMockDetectionResult(true, ['injection'], rewrittenContent));
+      const detector = new PromptInjectionDetector({
+        model,
+        scanMode: 'latest',
+        strategy: 'rewrite',
+      });
+
+      const mockAbort = vi.fn();
+
+      const messages = [
+        createTestMessage('Safe first message', 'user', 'msg1'),
+        createTestMessage('Safe second message', 'user', 'msg2'),
+        createTestMessage('Malicious content', 'user', 'msg3'),
+      ];
+
+      const result = await detector.processInput({ messages, abort: mockAbort as any });
+
+      // All three messages should be returned, with the last one rewritten
+      expect(result).toHaveLength(3);
+      expect(result[0].id).toBe('msg1');
+      expect(result[1].id).toBe('msg2');
+      expect(result[2].content.parts?.[0]).toEqual({
+        type: 'text',
+        text: rewrittenContent,
+      });
+    });
+
+    it('should allow all messages when latest is safe with scanMode latest', async () => {
+      const model = setupMockModel(createMockDetectionResult(false));
+      const detector = new PromptInjectionDetector({
+        model,
+        scanMode: 'latest',
+        strategy: 'block',
+      });
+
+      const mockAbort = vi.fn();
+
+      const messages = [
+        createTestMessage('First message', 'user', 'msg1'),
+        createTestMessage('Second message', 'user', 'msg2'),
+        createTestMessage('Third message', 'user', 'msg3'),
+      ];
+
+      const result = await detector.processInput({ messages, abort: mockAbort as any });
+
+      // All messages should pass through since the latest was safe
+      expect(result).toEqual(messages);
+      expect(mockAbort).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scanMode: all (default)', () => {
+    it('should scan all messages by default', async () => {
+      // Multiple results - all messages will be checked
+      const model = setupMockModel([
+        createMockDetectionResult(false),
+        createMockDetectionResult(false),
+        createMockDetectionResult(false),
+      ]);
+      const detector = new PromptInjectionDetector({
+        model,
+        // scanMode defaults to 'all'
+      });
+
+      const mockAbort = vi.fn();
+
+      const messages = [
+        createTestMessage('First message', 'user', 'msg1'),
+        createTestMessage('Second message', 'user', 'msg2'),
+        createTestMessage('Third message', 'user', 'msg3'),
+      ];
+
+      const result = await detector.processInput({ messages, abort: mockAbort as any });
+
+      expect(result).toEqual(messages);
+      expect(mockAbort).not.toHaveBeenCalled();
+    });
+
+    it('should block when any message has injection with scanMode all', async () => {
+      const model = setupMockModel([
+        createMockDetectionResult(false),
+        createMockDetectionResult(true, ['injection']),
+        createMockDetectionResult(false),
+      ]);
+      const detector = new PromptInjectionDetector({
+        model,
+        scanMode: 'all',
+        strategy: 'block',
+      });
+
+      const mockAbort = vi.fn().mockImplementation(() => {
+        throw new TripWire('Injection blocked');
+      });
+
+      const messages = [
+        createTestMessage('Safe first message', 'user', 'msg1'),
+        createTestMessage('Malicious content', 'user', 'msg2'),
+        createTestMessage('Safe third message', 'user', 'msg3'),
+      ];
+
+      await expect(async () => {
+        await detector.processInput({ messages, abort: mockAbort as any });
+      }).rejects.toThrow('Injection blocked');
+
+      expect(mockAbort).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -58,6 +58,13 @@ export interface PromptInjectionOptions {
   strategy?: 'block' | 'warn' | 'filter' | 'rewrite';
 
   /**
+   * Which messages to scan for prompt injection:
+   * - 'all': Scan all messages (default, more secure but slower)
+   * - 'latest': Scan only the latest user message (faster, suitable for most use cases)
+   */
+  scanMode?: 'all' | 'latest';
+
+  /**
    * Custom detection instructions for the agent
    * If not provided, uses default instructions based on detection types
    */
@@ -108,6 +115,7 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
   private detectionTypes: string[];
   private threshold: number;
   private strategy: 'block' | 'warn' | 'filter' | 'rewrite';
+  private scanMode: 'all' | 'latest';
   private includeScores: boolean;
   private structuredOutputOptions?: PromptInjectionOptions['structuredOutputOptions'];
   private providerOptions?: ProviderOptions;
@@ -126,6 +134,7 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
     this.detectionTypes = options.detectionTypes ?? PromptInjectionDetector.DEFAULT_DETECTION_TYPES;
     this.threshold = options.threshold ?? 0.7; // Higher default threshold for security
     this.strategy = options.strategy || 'block';
+    this.scanMode = options.scanMode || 'all';
     this.includeScores = options.includeScores ?? false;
     this.structuredOutputOptions = options.structuredOutputOptions;
     this.providerOptions = options.providerOptions;
@@ -152,37 +161,91 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
         return messages;
       }
 
-      const results: PromptInjectionResult[] = [];
+      // Determine which messages to scan based on scanMode
+      // 'latest' scans only the last message (much faster for most use cases)
+      // 'all' scans every message (more thorough but slower)
+      const messagesToScan = this.scanMode === 'latest' ? [messages[messages.length - 1]] : messages;
+
+      // For 'block' strategy, we need to check sequentially to abort on first detection
+      // For other strategies, we can process concurrently for better performance
+      if (this.strategy === 'block') {
+        for (const message of messagesToScan) {
+          const textContent = this.extractTextContent(message);
+          if (!textContent.trim()) {
+            continue;
+          }
+
+          const detectionResult = await this.detectPromptInjection(textContent, observabilityContext);
+
+          if (this.isInjectionFlagged(detectionResult)) {
+            // This will throw TripWire and abort
+            this.handleDetectedInjection(message, detectionResult, this.strategy, abort);
+          }
+        }
+
+        // For 'latest' mode with 'block' strategy, we need to return all messages
+        // since we only checked the last one and it was clean
+        return this.scanMode === 'latest' ? messages : messages;
+      }
+
+      // For non-block strategies, process concurrently for better performance
+      const detectionResults = await Promise.all(
+        messagesToScan.map(async message => {
+          const textContent = this.extractTextContent(message);
+          if (!textContent.trim()) {
+            return { message, result: null, hasInjection: false };
+          }
+
+          const result = await this.detectPromptInjection(textContent, observabilityContext);
+          const hasInjection = this.isInjectionFlagged(result);
+          return { message, result, hasInjection };
+        }),
+      );
+
+      // Handle results based on strategy
       const processedMessages: MastraDBMessage[] = [];
 
-      // Evaluate each message
-      for (const message of messages) {
-        const textContent = this.extractTextContent(message);
-        if (!textContent.trim()) {
-          // No text content to analyze
+      for (const { message, result, hasInjection } of detectionResults) {
+        if (result === null) {
+          // No text content to analyze - pass through unchanged
           processedMessages.push(message);
           continue;
         }
 
-        const detectionResult = await this.detectPromptInjection(textContent, observabilityContext);
-        results.push(detectionResult);
+        if (hasInjection) {
+          const processedMessage = this.handleDetectedInjection(message, result, this.strategy, abort);
 
-        if (this.isInjectionFlagged(detectionResult)) {
-          const processedMessage = this.handleDetectedInjection(message, detectionResult, this.strategy, abort);
-
-          // If we reach here, strategy is 'warn', 'filter', or 'rewrite'
           if (this.strategy === 'filter') {
             continue;
           } else if (this.strategy === 'rewrite') {
             if (processedMessage) {
               processedMessages.push(processedMessage);
             }
-            // If processedMessage is null (no rewrite available), skip the message
             continue;
           }
         }
 
         processedMessages.push(message);
+      }
+
+      // For 'latest' scanMode, we need to include all unscanned messages
+      if (this.scanMode === 'latest') {
+        const lastMessage = messages[messages.length - 1];
+        const lastResult = detectionResults[0];
+        const otherMessages = messages.slice(0, -1);
+
+        if (lastResult?.hasInjection) {
+          if (this.strategy === 'filter') {
+            return otherMessages;
+          } else if (this.strategy === 'rewrite' && lastResult.result) {
+            const rewrittenMessage = this.createRewrittenMessage(
+              lastMessage,
+              lastResult.result.rewritten_content || '',
+            );
+            return [...otherMessages, rewrittenMessage];
+          }
+        }
+        return messages;
       }
 
       return processedMessages;


### PR DESCRIPTION
## Description

The built-in PromptInjectionDetector was iterating over all messages and making sequential LLM calls for each, causing significant slowdowns (5x response time increase as reported in #14341).

This fix adds a new `scanMode` option to control which messages get scanned:
- `'all'` (default): Scan all messages for maximum security
- `'latest'`: Scan only the latest user message for better performance

Additionally, non-blocking strategies (warn, filter, rewrite) now process messages concurrently using Promise.all for improved throughput.

## Related Issue(s)

Fixes #14341

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `scanMode` option to the prompt injection detector, allowing users to choose between scanning all messages (default) or only the latest message for improved performance.

* **Tests**
  * Expanded test coverage for the new scan mode functionality across multiple strategies and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->