### PR TITLE
fix(hono): populate requestContext with user before server.middleware executes

### DIFF
--- a/.changeset/fix-hono-auth-middleware-execution-order.md
+++ b/.changeset/fix-hono-auth-middleware-execution-order.md
@@ -1,0 +1,5 @@
+---
+"@mastra/hono": patch
+---
+
+Fixed auth middleware execution order in the Hono adapter. Previously, `requestContext.get('user')` always returned null inside `server.middleware` because authentication ran per-route after custom middleware. Now `authenticateToken` runs eagerly as a global middleware, populating `requestContext` with the user before `server.middleware` executes. Per-route auth enforcement is unchanged.

--- a/server-adapters/hono/src/__tests__/auth-middleware-order.test.ts
+++ b/server-adapters/hono/src/__tests__/auth-middleware-order.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Auth Middleware Execution Order Tests
+ *
+ * Verifies that requestContext.get('user') is populated before
+ * server.middleware executes, so custom middleware can access the
+ * authenticated user without decoding the token a second time.
+ */
+import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
+import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
+import { Hono } from 'hono';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MastraServer } from '../index';
+
+function createMockAuthConfig() {
+  return {
+    authenticateToken: async (token: string) => {
+      if (token === 'valid-token') {
+        return { id: 'user-123', email: 'test@example.com' };
+      }
+      return null;
+    },
+    authorizeUser: async () => true,
+  };
+}
+
+describe('Auth middleware execution order', () => {
+  let context: AdapterTestContext;
+
+  beforeEach(async () => {
+    context = await createDefaultTestContext();
+  });
+
+  it('should populate requestContext with user before server.middleware executes', async () => {
+    const app = new Hono();
+    let userInMiddleware: unknown = undefined;
+
+    const originalGetServer = context.mastra.getServer.bind(context.mastra);
+    context.mastra.getServer = () => ({
+      ...originalGetServer(),
+      auth: createMockAuthConfig(),
+    });
+
+    const adapter = new MastraServer({ app, mastra: context.mastra });
+
+    adapter.registerContextMiddleware();
+    adapter.registerAuthMiddleware();
+
+    // Simulate server.middleware registered after registerAuthMiddleware
+    app.use('*', async (c, next) => {
+      const requestContext = c.get('requestContext');
+      userInMiddleware = requestContext?.get('user');
+      return next();
+    });
+
+    const testRoute = {
+      method: 'GET' as const,
+      path: '/api/test',
+      responseType: 'json' as const,
+      handler: async () => ({ success: true }),
+    };
+    await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+    await app.request(
+      new Request('http://localhost/api/test', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' },
+      }),
+    );
+
+    expect(userInMiddleware).toBeDefined();
+    expect((userInMiddleware as any).id).toBe('user-123');
+  });
+
+  it('should not block request when token is missing', async () => {
+    const app = new Hono();
+
+    const originalGetServer = context.mastra.getServer.bind(context.mastra);
+    context.mastra.getServer = () => ({
+      ...originalGetServer(),
+      auth: createMockAuthConfig(),
+    });
+
+    const adapter = new MastraServer({ app, mastra: context.mastra });
+    adapter.registerContextMiddleware();
+    adapter.registerAuthMiddleware();
+
+    const testRoute = {
+      method: 'GET' as const,
+      path: '/api/public',
+      responseType: 'json' as const,
+      requiresAuth: false,
+      handler: async () => ({ success: true }),
+    };
+    await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+    const response = await app.request(new Request('http://localhost/api/public', { method: 'GET' }));
+
+    expect(response.status).toBe(200);
+  });
+
+  it('should not populate user when token is invalid', async () => {
+    const app = new Hono();
+    let userInMiddleware: unknown = 'not-set';
+
+    const originalGetServer = context.mastra.getServer.bind(context.mastra);
+    context.mastra.getServer = () => ({
+      ...originalGetServer(),
+      auth: createMockAuthConfig(),
+    });
+
+    const adapter = new MastraServer({ app, mastra: context.mastra });
+    adapter.registerContextMiddleware();
+    adapter.registerAuthMiddleware();
+
+    app.use('*', async (c, next) => {
+      const requestContext = c.get('requestContext');
+      userInMiddleware = requestContext?.get('user');
+      return next();
+    });
+
+    const testRoute = {
+      method: 'GET' as const,
+      path: '/api/test',
+      responseType: 'json' as const,
+      requiresAuth: false,
+      handler: async () => ({ success: true }),
+    };
+    await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+    await app.request(
+      new Request('http://localhost/api/test', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer invalid-token' },
+      }),
+    );
+
+    expect(userInMiddleware).toBeUndefined();
+  });
+});

--- a/server-adapters/hono/src/__tests__/auth-middleware-order.test.ts
+++ b/server-adapters/hono/src/__tests__/auth-middleware-order.test.ts
@@ -60,7 +60,7 @@ describe('Auth middleware execution order', () => {
     };
     await adapter.registerRoute(app, testRoute, { prefix: '' });
 
-    await app.request(
+    const response = await app.request(
       new Request('http://localhost/api/test', {
         method: 'GET',
         headers: { Authorization: 'Bearer valid-token' },
@@ -69,6 +69,7 @@ describe('Auth middleware execution order', () => {
 
     expect(userInMiddleware).toBeDefined();
     expect((userInMiddleware as any).id).toBe('user-123');
+    expect(response.status).toBe(200);
   });
 
   it('should not block request when token is missing', async () => {

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -617,8 +617,33 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
   }
 
   registerAuthMiddleware(): void {
-    // Auth is handled per-route in registerRoute() and registerCustomApiRoutes()
-    // No global middleware needed
+    const authConfig = this.mastra.getServer()?.auth;
+    if (!authConfig) return;
+
+    // Eagerly populate requestContext with the authenticated user so that
+    // server.middleware handlers can access requestContext.get('user').
+    // This does NOT enforce auth — protected/public path logic still runs
+    // per-route in checkRouteAuth(). A missing or invalid token is silently
+    // ignored here; the per-route check will return 401 when required.
+    this.app.use('*', async (c, next) => {
+      const requestContext = c.get('requestContext') as RequestContext;
+      if (!requestContext) return next();
+
+      const authHeader = c.req.header('authorization');
+      const token = authHeader ? authHeader.replace('Bearer ', '') : c.req.query('apiKey');
+      if (!token) return next();
+
+      try {
+        const user = await authConfig.authenticateToken(token, c.req.raw as any);
+        if (user) {
+          requestContext.set('user', user);
+        }
+      } catch {
+        // Ignore auth errors here — per-route auth will handle them
+      }
+
+      return next();
+    });
   }
 
   registerHttpLoggingMiddleware(): void {

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -634,7 +634,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
       if (!token) return next();
 
       try {
-        const user = await authConfig.authenticateToken(token, c.req.raw as any);
+        const user = await authConfig.authenticateToken(token, c.req);
         if (user) {
           requestContext.set('user', user);
         }


### PR DESCRIPTION
Closes #14293
Related to #14303

## What does this PR do?

Fixes the auth middleware execution order in the Hono adapter so that
`requestContext.get('user')` is populated before `server.middleware` executes.

## Root cause

`registerAuthMiddleware()` was empty — auth only ran per-route inside
`checkRouteAuth()`, which is called after custom middleware. This meant
`requestContext.get('user')` was always `null` or `undefined` inside
`server.middleware`.

## Fix

`registerAuthMiddleware()` now adds a global middleware that eagerly calls
`authenticateToken` and populates `requestContext` with the user when a valid
token is present. This runs before `server.middleware`, so the user is
available downstream.

Per-route auth enforcement (401 on protected routes) is completely unchanged.
Missing or invalid tokens are silently ignored in this global middleware — the
per-route check handles rejection.

## Changes

- Updated `registerAuthMiddleware()` in `server-adapters/hono/src/index.ts`
- Added 3 tests in `auth-middleware-order.test.ts`
- Added changeset for `@mastra/hono`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication middleware execution order in the Hono adapter so the authenticated user is populated in request context before general server middleware runs; per-route auth enforcement and access checks remain unchanged. Token parsing errors are now ignored here so routes handle failures as configured.

* **Tests**
  * Added tests verifying middleware execution order: user context is set for valid tokens, remains absent for missing/invalid tokens, and public routes stay accessible without a token.

* **Documentation**
  * Added a changelog entry describing the patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->