### PR TITLE
fix(agent): skip input processors during resumeStream

### DIFF
--- a/packages/core/src/agent/workflows/prepare-stream/index.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/index.ts
@@ -88,6 +88,7 @@ export function createPrepareStreamWorkflow<OUTPUT = undefined>({
     instructions,
     memoryConfig,
     memory,
+    resumeContext,
   });
 
   const streamStep = createStreamStep({

--- a/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
@@ -44,6 +44,10 @@ interface PrepareMemoryStepOptions<OUTPUT = undefined> {
   instructions: SystemMessage;
   memoryConfig?: MemoryConfigInternal;
   memory?: MastraMemory;
+  resumeContext?: {
+    resumeData: any;
+    snapshot: any;
+  };
 }
 
 export function createPrepareMemoryStep<OUTPUT = undefined>({
@@ -56,6 +60,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
   instructions,
   memoryConfig,
   memory,
+  resumeContext,
 }: PrepareMemoryStepOptions<OUTPUT>) {
   return createStep({
     id: 'prepare-memory-step',
@@ -87,19 +92,29 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
 
       if (!memory || (!thread?.id && !resourceId)) {
         messageList.add(options.messages, 'input');
-        const { tripwire } = await capabilities.runInputProcessors({
-          requestContext,
-          ...observabilityContext,
-          messageList,
-          inputProcessorOverrides: options.inputProcessors,
-          processorStates,
-        });
+        // Skip input processors during resume - messages come from snapshot, not new input
+        if (!resumeContext) {
+          const { tripwire } = await capabilities.runInputProcessors({
+            requestContext,
+            ...observabilityContext,
+            messageList,
+            inputProcessorOverrides: options.inputProcessors,
+            processorStates,
+          });
+          return {
+            threadExists: false,
+            thread: undefined,
+            messageList,
+            processorStates,
+            tripwire,
+          };
+        }
         return {
           threadExists: false,
           thread: undefined,
           messageList,
           processorStates,
-          tripwire,
+          tripwire: undefined,
         };
       }
 
@@ -171,19 +186,29 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
       // Add user messages - memory processors will handle history/semantic recall/working memory
       messageList.add(options.messages, 'input');
 
-      const { tripwire } = await capabilities.runInputProcessors({
-        requestContext,
-        ...observabilityContext,
-        messageList,
-        inputProcessorOverrides: options.inputProcessors,
-        processorStates,
-      });
+      // Skip input processors during resume - messages come from snapshot, not new input
+      if (!resumeContext) {
+        const { tripwire } = await capabilities.runInputProcessors({
+          requestContext,
+          ...observabilityContext,
+          messageList,
+          inputProcessorOverrides: options.inputProcessors,
+          processorStates,
+        });
+        return {
+          thread: threadObject,
+          messageList: messageList,
+          processorStates,
+          tripwire,
+          threadExists: !!existingThread,
+        };
+      }
 
       return {
         thread: threadObject,
         messageList: messageList,
         processorStates,
-        tripwire,
+        tripwire: undefined,
         threadExists: !!existingThread,
       };
     },


### PR DESCRIPTION
Fixes #14379

When resuming a suspended tool call with an InputProcessor applied to the Agent, the TokenLimiterProcessor would fail with:

```
TokenLimiterProcessor: No messages to process. Cannot send LLM a request with no messages.
```

This happened because `resumeStream` passes an empty messages array (`messages: []`) to the execution workflow, and the TokenLimiterProcessor throws a TripWire error when there are no messages.

**Changes:**
- Modified `prepare-memory-step.ts` to skip running input processors during resume operations
- Added `resumeContext` parameter to `createPrepareMemoryStep` to detect resume operations

**Why this fix is correct:**
1. Input processors are meant to process *new* user input messages
2. During resume, messages come from the snapshot, not from the input
3. The empty messages array is expected during resume and shouldn't trigger validation errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent workflows now support resuming from saved snapshots, allowing interrupted workflows to seamlessly continue without reprocessing input data.
  * Enhanced memory preparation to intelligently detect resume scenarios and preserve existing memory state and context.

* **Improvements**
  * Optimized state propagation throughout the streaming workflow to ensure consistency during resume operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->