### PR TITLE
fix: include tool calls in generation span output for PostHog tools tab

### DIFF
--- a/.changeset/rich-chairs-attack.md
+++ b/.changeset/rich-chairs-attack.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/posthog': patch
+---
+
+Fixed generation span output to include tool call data, enabling PostHog's LLM Analytics Tools tab to extract and display tool usage

--- a/observability/posthog/src/tracing.test.ts
+++ b/observability/posthog/src/tracing.test.ts
@@ -352,6 +352,64 @@ describe('PosthogExporter', () => {
       );
     });
 
+    it('should format tool calls in output as PostHog-compatible content blocks', async () => {
+      const generation = createSpan({
+        type: SpanType.MODEL_GENERATION,
+        parentSpanId: 'parent-1',
+        attributes: {
+          model: 'gpt-4o',
+          provider: 'openai',
+          usage: { inputTokens: 50, outputTokens: 80 },
+        },
+        input: [{ role: 'user', content: 'What is the weather in Paris?' }],
+        output: {
+          text: '',
+          toolCalls: [
+            { type: 'tool-call', toolCallId: 'call_abc', toolName: 'get_weather', args: { city: 'Paris' } },
+            { type: 'tool-call', toolCallId: 'call_def', toolName: 'get_time', args: { timezone: 'CET' } },
+          ],
+        },
+      });
+
+      await exportSpanLifecycle(exporter, generation);
+
+      const props = mockCapture.mock.calls[0][0].properties;
+      expect(props.$ai_output_choices).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'tool-call', id: 'call_abc', function: { name: 'get_weather', arguments: { city: 'Paris' } } },
+            { type: 'tool-call', id: 'call_def', function: { name: 'get_time', arguments: { timezone: 'CET' } } },
+          ],
+        },
+      ]);
+    });
+
+    it('should include both text and tool calls in output when present', async () => {
+      const generation = createSpan({
+        type: SpanType.MODEL_GENERATION,
+        parentSpanId: 'parent-1',
+        attributes: { model: 'gpt-4o', provider: 'openai' },
+        output: {
+          text: 'Let me check the weather for you.',
+          toolCalls: [{ type: 'tool-call', toolCallId: 'call_123', toolName: 'get_weather', args: { city: 'Paris' } }],
+        },
+      });
+
+      await exportSpanLifecycle(exporter, generation);
+
+      const props = mockCapture.mock.calls[0][0].properties;
+      expect(props.$ai_output_choices).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me check the weather for you.' },
+            { type: 'tool-call', id: 'call_123', function: { name: 'get_weather', arguments: { city: 'Paris' } } },
+          ],
+        },
+      ]);
+    });
+
     it('should handle minimal LLM attributes gracefully with defaults', async () => {
       // Use non-root span since root spans only send $ai_trace
       const generation = createSpan({

--- a/observability/posthog/src/tracing.ts
+++ b/observability/posthog/src/tracing.ts
@@ -491,7 +491,30 @@ export class PosthogExporter extends TrackingExporter<
       return [{ role: defaultRole, content: [{ type: 'text', text: data }] }];
     }
 
+    if (this.isSpanOutputWithToolCalls(data)) {
+      const content: PostHogContent[] = [];
+      if (data.text) {
+        content.push({ type: 'text', text: data.text });
+      }
+      for (const tc of data.toolCalls) {
+        content.push({
+          type: 'tool-call',
+          id: tc.toolCallId,
+          function: { name: tc.toolName, arguments: tc.args },
+        });
+      }
+      return [{ role: 'assistant', content }];
+    }
+
     return [{ role: defaultRole, content: [{ type: 'text', text: this.safeStringify(data) }] }];
+  }
+
+  private isSpanOutputWithToolCalls(
+    data: unknown,
+  ): data is { text?: string; toolCalls: Array<{ toolCallId: string; toolName: string; args: unknown }> } {
+    if (typeof data !== 'object' || data === null || !('toolCalls' in data)) return false;
+    const { toolCalls } = data as Record<string, unknown>;
+    return Array.isArray(toolCalls) && toolCalls.length > 0;
   }
 
   private isMessageArray(data: unknown): data is MastraMessage[] {

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -284,6 +284,7 @@ export class MastraLLMV1 extends MastraBase {
           reasoningText: result.reasoning,
           files: result.files,
           sources: result.sources,
+          toolCalls: result.toolCalls,
           warnings: result.warnings,
         },
         attributes: {
@@ -618,6 +619,7 @@ export class MastraLLMV1 extends MastraBase {
             reasoningText: props?.reasoning,
             files: props?.files,
             sources: props?.sources,
+            toolCalls: props?.toolCalls,
             warnings: props?.warnings,
           },
           attributes: {


### PR DESCRIPTION
## Description
  <!-- Provide a brief description of the changes in this PR -->
Generation span output was missing `toolCalls` data from the AI SDK result, causing PostHog's LLM Analytics Tools tab to remain empty. The PostHog exporter's `formatMessages()` also lacked handling for tool call objects, falling through to a generic JSON stringify path that PostHog's ingestion couldn't parse.

  This PR:
  - Adds `toolCalls` to the span output in both `__text()` and `__stream()` paths in `MastraLLMV1`
  - Adds tool call detection and formatting in `PosthogExporter.formatMessages()` to convert AI SDK tool calls (`toolName`/`toolCallId`/`args`) into
  PostHog's expected content block format (`type: "tool-call"` with `function.name`/`function.arguments`/`id`)

## Before
<img width="1631" height="541" alt="Screenshot 2026-03-17 120409" src="https://github.com/user-attachments/assets/dc1b103b-df86-4a33-84d7-08726c2c774f" />

## After
<img width="1622" height="788" alt="image" src="https://github.com/user-attachments/assets/61614b14-fcd1-4eb8-a3c9-b9ad06039066" />

  ## Related Issue(s)
  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
  Fixes #14135

  ## Type of Change
  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist
  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generation span output to include tool call data, enabling PostHog's LLM Analytics Tools tab to properly extract and display tool usage information.

* **Tests**
  * Added tests verifying correct formatting of tool call data in generation output for observability tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->