### PR TITLE
fix(core): TokenLimiterProcessor incompatible with resumeStream

### DIFF
--- a/packages/core/src/processors/processors/token-accuracy.e2e.test.ts
+++ b/packages/core/src/processors/processors/token-accuracy.e2e.test.ts
@@ -55,11 +55,12 @@ describe('TokenLimiterProcessor', () => {
     expect(result[1].id).toBe('message-9');
   });
 
-  it('should throw TripWire for empty messages array', async () => {
+  it('should return early for empty messages array without throwing', async () => {
     const limiter = new TokenLimiterProcessor(1000);
     const mockAbort = vi.fn() as any;
     const emptyMessageList = new MessageList({ threadId: 'test-empty', resourceId: 'test' });
 
+    // Should not throw when there are no messages (e.g., during resumeStream)
     await expect(
       limiter.processInputStep({
         messageList: emptyMessageList,
@@ -72,7 +73,10 @@ describe('TokenLimiterProcessor', () => {
         model: { modelId: 'test-model' } as any,
         retryCount: 0,
       }),
-    ).rejects.toThrow('TokenLimiterProcessor: No messages to process');
+    ).resolves.not.toThrow();
+
+    // Message list should remain empty
+    expect(emptyMessageList.get.all.db().length).toBe(0);
   });
 
   it('should use different encodings based on configuration', async () => {

--- a/packages/core/src/processors/processors/token-limiter.test.ts
+++ b/packages/core/src/processors/processors/token-limiter.test.ts
@@ -811,7 +811,7 @@ describe('TokenLimiterProcessor', () => {
       expect(messagesAfter.length).toBeLessThan(beforeCount);
     });
 
-    it('should throw TripWire for empty messages', async () => {
+    it('should return early for empty messages without throwing', async () => {
       const processor = new TokenLimiterProcessor({ limit: 1000 });
 
       const runner = new ProcessorRunner({
@@ -822,6 +822,7 @@ describe('TokenLimiterProcessor', () => {
 
       const messageList = new MessageList();
 
+      // Should not throw when there are no messages (e.g., during resumeStream)
       await expect(
         runner.runProcessInputStep({
           messageList,
@@ -829,7 +830,10 @@ describe('TokenLimiterProcessor', () => {
           model: createMockModel(),
           steps: [],
         }),
-      ).rejects.toThrow('TokenLimiterProcessor: No messages to process');
+      ).resolves.not.toThrow();
+
+      // Message list should remain empty
+      expect(messageList.get.all.db().length).toBe(0);
     });
 
     it('should throw TripWire when system messages exceed limit', async () => {

--- a/packages/core/src/processors/processors/token-limiter.ts
+++ b/packages/core/src/processors/processors/token-limiter.ts
@@ -97,11 +97,10 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', { syste
 
     const messages = messageList.get.all.db();
 
-    // If no messages or empty array, throw TripWire - can't send LLM a request with no messages
+    // If no messages or empty array, return early - nothing to limit
+    // This can happen during resumeStream where messages are loaded from memory asynchronously
     if (!messages || messages.length === 0) {
-      throw new TripWire('TokenLimiterProcessor: No messages to process. Cannot send LLM a request with no messages.', {
-        retry: false,
-      });
+      return;
     }
 
     // Calculate token count for system messages (always included, never filtered)


### PR DESCRIPTION
## Problem

When using `resumeStream` to resume a suspended tool call with an `InputProcessor` (specifically `TokenLimiterProcessor`) applied to the Agent, the following error was thrown:

```
TokenLimiterProcessor: No messages to process. Cannot send LLM a request with no messages.
```

This happened because:
1. `resumeStream` passes an empty `messages: []` array to the execution workflow
2. The `TokenLimiterProcessor.processInputStep` method checked for empty messages and threw a `TripWire` error
3. However, during resume, messages are loaded asynchronously from memory by memory processors that run after the check

## Solution

Modified `TokenLimiterProcessor.processInputStep` to return early instead of throwing an error when there are no messages. This is safe because:

1. If there are no messages, there'\''s nothing to limit/filter
2. Memory processors will load conversation history after this check
3. On subsequent steps, messages will be present and the limiter will work normally

## Changes

- Changed empty message check from throwing `TripWire` to returning early
- Updated tests to reflect the new behavior

Fixes #14379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token limiter now gracefully handles empty message lists by returning early instead of throwing errors, improving stability during stream processing operations. Token accuracy processor updated with the same behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->