### PR TITLE
fix(agent): skip input processors during resumeStream

### DIFF
--- a/packages/core/src/agent/workflows/prepare-stream/index.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/index.ts
@@ -88,6 +88,7 @@ export function createPrepareStreamWorkflow<OUTPUT = undefined>({
     instructions,
     memoryConfig,
     memory,
+    resumeContext,
   });
 
   const streamStep = createStreamStep({

--- a/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
@@ -44,6 +44,10 @@ interface PrepareMemoryStepOptions<OUTPUT = undefined> {
   instructions: SystemMessage;
   memoryConfig?: MemoryConfigInternal;
   memory?: MastraMemory;
+  resumeContext?: {
+    resumeData: any;
+    snapshot: any;
+  };
 }
 
 export function createPrepareMemoryStep<OUTPUT = undefined>({
@@ -56,6 +60,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
   instructions,
   memoryConfig,
   memory,
+  resumeContext,
 }: PrepareMemoryStepOptions<OUTPUT>) {
   return createStep({
     id: 'prepare-memory-step',
@@ -87,6 +92,18 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
 
       if (!memory || (!thread?.id && !resourceId)) {
         messageList.add(options.messages, 'input');
+
+        // Skip input processors during resume - messages are loaded from snapshot and processors have already run
+        if (resumeContext) {
+          return {
+            threadExists: false,
+            thread: undefined,
+            messageList,
+            processorStates,
+            tripwire: undefined,
+          };
+        }
+
         const { tripwire } = await capabilities.runInputProcessors({
           requestContext,
           ...observabilityContext,
@@ -170,6 +187,17 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
 
       // Add user messages - memory processors will handle history/semantic recall/working memory
       messageList.add(options.messages, 'input');
+
+      // Skip input processors during resume - messages are loaded from snapshot and processors have already run
+      if (resumeContext) {
+        return {
+          thread: threadObject,
+          messageList: messageList,
+          processorStates,
+          tripwire: undefined,
+          threadExists: !!existingThread,
+        };
+      }
 
       const { tripwire } = await capabilities.runInputProcessors({
         requestContext,


### PR DESCRIPTION
## Issue
When resuming a suspended tool call with `resumeStream` and an input processor (like `TokenLimiterProcessor`) applied to the Agent, the following error occurs:

> TokenLimiterProcessor: No messages to process. Cannot send LLM a request with no messages.

## Root Cause
When `resumeStream` is called, it passes `messages: []` to the execution because messages are loaded from the snapshot. However, the input processor was still being run on this empty message list, causing the TokenLimiterProcessor to fail.

## Fix
Skip running input processors during resume since:
1. Messages are loaded from the snapshot, not from `options.messages`
2. Input processors have already run before the suspension
3. Running them on an empty message list causes the TokenLimiterProcessor to fail

## Changes
- `prepare-memory-step.ts`: Accept `resumeContext` parameter and skip input processors when resuming
- `index.ts`: Pass `resumeContext` to `createPrepareMemoryStep`

Fixes #14379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflows can now resume from saved states, preserving agent memory and context. Resume flows bypass reprocessing of existing inputs, maintaining state integrity during continuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->