### PR TITLE
fix(core): support https:// JSON schema URLs in client tool processing

### DIFF
--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -145,7 +145,8 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
                 if (
                   '$schema' in sdkTool.inputSchema &&
                   typeof sdkTool.inputSchema.$schema === 'string' &&
-                  sdkTool.inputSchema.$schema.startsWith('http://json-schema.org/')
+                  (sdkTool.inputSchema.$schema.startsWith('http://json-schema.org/') ||
+                    sdkTool.inputSchema.$schema.startsWith('https://json-schema.org/'))
                 ) {
                   parameters = sdkTool.inputSchema;
                 } else if (isStandardSchemaWithJSON(sdkTool.inputSchema)) {


### PR DESCRIPTION
## Summary

Fix issue #14338 where client tools created with `@mastra/client-js` were failing validation on the backend when using Zod v4 schemas.

## Root Cause

The `prepare-tools.ts` file only recognized JSON schema `$schema` URLs starting with `http://json-schema.org/`, but Zod v4 produces schemas with `https://json-schema.org/draft/2020-12/schema` URLs.

When a schema with an `https://` URL was passed, the code failed to recognize it as a valid JSON schema and incorrectly re-converted it using `asSchema().jsonSchema`, producing an `anyOf` pattern instead of preserving the `type: "object"` that providers like AWS Bedrock require.

## Fix

Updated the condition in `prepare-tools.ts` to also accept `https://json-schema.org/` URLs.

## Changes

- `packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts`: Added support for `https://` JSON schema URLs

Fixes #14338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input schema validation to properly support both HTTP and HTTPS protocol variants for better compatibility. This improvement ensures more consistent and reliable schema processing across different deployment environments and configurations, supporting schemas hosted over either standard or secure connections while maintaining complete backward compatibility with existing setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->