### PR TITLE
fix(core): strip OpenAI provider metadata to prevent duplicate item errors

### DIFF
--- a/packages/core/src/agent/message-list/conversion/output-converter-openai-fix.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-openai-fix.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import type { AIV5Type } from '../types';
+import { sanitizeV5UIMessages } from './output-converter';
+
+describe('sanitizeV5UIMessages - OpenAI duplicate item fix', () => {
+  it('should strip OpenAI provider metadata with item IDs when filterIncompleteToolCalls is true', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      {
+        id: 'msg-test-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'Hello, how can I help you?',
+            providerMetadata: {
+              openai: {
+                id: 'msg_0a9f55fbab18fe4e0069b78644c718819c8dea51fff043aaaa',
+              },
+            },
+          },
+        ],
+        metadata: {},
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages, true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.parts[0]?.type).toBe('text');
+    expect((result[0]?.parts[0] as any).providerMetadata?.openai).toBeUndefined();
+  });
+
+  it('should strip OpenAI provider metadata from tool parts with call IDs', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      {
+        id: 'msg-test-2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-toolName',
+            toolCallId: 'call_123',
+            toolName: 'toolName',
+            state: 'output-available',
+            input: { query: 'test' },
+            output: { result: 'success' },
+            callProviderMetadata: {
+              openai: {
+                callId: 'fc_1234567890',
+              },
+            },
+          },
+        ],
+        metadata: {},
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages, true);
+
+    expect(result).toHaveLength(1);
+    expect((result[0]?.parts[0] as any).callProviderMetadata?.openai).toBeUndefined();
+  });
+
+  it('should NOT strip OpenAI provider metadata when filterIncompleteToolCalls is false', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      {
+        id: 'msg-test-3',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'Hello',
+            providerMetadata: {
+              openai: {
+                id: 'msg_123',
+              },
+            },
+          },
+        ],
+        metadata: {},
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages, false);
+
+    expect(result).toHaveLength(1);
+    expect((result[0]?.parts[0] as any).providerMetadata?.openai).toBeDefined();
+  });
+
+  it('should preserve non-OpenAI provider metadata', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      {
+        id: 'msg-test-4',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'Hello',
+            providerMetadata: {
+              anthropic: {
+                cacheControl: 'ephemeral',
+              },
+            },
+          },
+        ],
+        metadata: {},
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages, true);
+
+    expect(result).toHaveLength(1);
+    expect((result[0]?.parts[0] as any).providerMetadata?.anthropic).toBeDefined();
+    expect((result[0]?.parts[0] as any).providerMetadata?.openai).toBeUndefined();
+  });
+
+  it('should strip OpenAI provider metadata from message-level metadata', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      {
+        id: 'msg-test-5',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'Hello',
+          },
+        ],
+        metadata: {
+          providerMetadata: {
+            openai: {
+              id: 'msg_1234567890',
+              previousResponseId: 'resp_123',
+            },
+          },
+        },
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages, true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.metadata?.providerMetadata).toBeUndefined();
+  });
+
+  it('should preserve non-OpenAI provider metadata in message-level metadata', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      {
+        id: 'msg-test-6',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'Hello',
+          },
+        ],
+        metadata: {
+          providerMetadata: {
+            anthropic: {
+              cacheControl: 'ephemeral',
+            },
+          },
+        },
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages, true);
+
+    expect(result).toHaveLength(1);
+    expect((result[0]?.metadata?.providerMetadata as any)?.anthropic).toBeDefined();
+  });
+
+  it('should strip OpenAI metadata from both parts and message metadata', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      {
+        id: 'msg-test-7',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'Hello',
+            providerMetadata: {
+              openai: {
+                id: 'msg_123',
+              },
+            },
+          },
+        ],
+        metadata: {
+          providerMetadata: {
+            openai: {
+              id: 'msg_456',
+            },
+          },
+        },
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages, true);
+
+    expect(result).toHaveLength(1);
+    expect((result[0]?.parts[0] as any).providerMetadata?.openai).toBeUndefined();
+    expect(result[0]?.metadata?.providerMetadata).toBeUndefined();
+  });
+});

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -45,6 +45,87 @@ export function sanitizeAIV4UIMessages(messages: UIMessageV4[]): UIMessageV4[] {
 }
 
 /**
+ * Checks if a message part has OpenAI provider metadata with item IDs.
+ * OpenAI's Responses API uses item IDs (msg_*, rs_*, fc_*) that can cause
+ * "Duplicate item found" errors when replayed to the API.
+ */
+function hasOpenAIProviderMetadata(part: AIV5Type.UIMessage['parts'][number]): boolean {
+  if ('providerMetadata' in part && part.providerMetadata) {
+    const meta = part.providerMetadata as Record<string, unknown>;
+    if ('openai' in meta && meta.openai && typeof meta.openai === 'object') {
+      const openaiMeta = meta.openai as Record<string, unknown>;
+      // Check for item IDs that would cause duplicate errors
+      if (openaiMeta.id || openaiMeta.itemId) {
+        return true;
+      }
+    }
+  }
+  if ('callProviderMetadata' in part && part.callProviderMetadata) {
+    const callMeta = part.callProviderMetadata as Record<string, unknown>;
+    if ('openai' in callMeta && callMeta.openai && typeof callMeta.openai === 'object') {
+      const openaiMeta = callMeta.openai as Record<string, unknown>;
+      if (openaiMeta.id || openaiMeta.callId) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Strips OpenAI provider metadata from a message part to prevent duplicate item errors.
+ */
+function stripOpenAIProviderMetadata<T extends AIV5Type.UIMessage['parts'][number]>(part: T): T {
+  let result = { ...part };
+
+  if ('providerMetadata' in result && result.providerMetadata) {
+    const meta = result.providerMetadata as Record<string, unknown>;
+    if ('openai' in meta) {
+      const { openai: _, ...restMeta } = meta;
+      result.providerMetadata = Object.keys(restMeta).length > 0 ? restMeta : undefined;
+    }
+  }
+
+  if ('callProviderMetadata' in result && result.callProviderMetadata) {
+    const callMeta = result.callProviderMetadata as Record<string, unknown>;
+    if ('openai' in callMeta) {
+      const { openai: _, ...restCallMeta } = callMeta;
+      result.callProviderMetadata =
+        Object.keys(restCallMeta).length > 0 ? (restCallMeta as typeof result.callProviderMetadata) : undefined;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Checks if message metadata has OpenAI provider metadata with item IDs.
+ */
+function hasOpenAIMessageMetadata(metadata: Record<string, unknown> | undefined): boolean {
+  if (!metadata?.providerMetadata) return false;
+  const providerMetadata = metadata.providerMetadata as Record<string, unknown>;
+  if (!providerMetadata.openai || typeof providerMetadata.openai !== 'object') return false;
+  const openaiMeta = providerMetadata.openai as Record<string, unknown>;
+  // Check for item IDs that would cause duplicate errors
+  return !!(openaiMeta.id || openaiMeta.itemId || openaiMeta.previousResponseId);
+}
+
+/**
+ * Strips OpenAI provider metadata from message metadata.
+ */
+function stripOpenAIMessageMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  if (!metadata.providerMetadata) return metadata;
+  const providerMetadata = metadata.providerMetadata as Record<string, unknown>;
+  if (!providerMetadata.openai) return metadata;
+
+  const { openai: _, ...restProviderMetadata } = providerMetadata;
+  return {
+    ...metadata,
+    providerMetadata: Object.keys(restProviderMetadata).length > 0 ? restProviderMetadata : undefined,
+  };
+}
+
+/**
  * Sanitizes AIV5 UI messages by filtering out streaming states, data-* parts, empty text parts, and optionally incomplete tool calls.
  * Handles legacy data by filtering empty text parts that may exist in pre-existing DB records.
  */
@@ -70,6 +151,10 @@ export function sanitizeV5UIMessages(
             typeof p.providerMetadata === 'object' &&
             'openai' in (p.providerMetadata as Record<string, unknown>),
         );
+
+      // Check if any part has OpenAI provider metadata with item IDs
+      // This can cause "Duplicate item found" errors when messages are replayed to the API
+      const hasOpenAIItemIds = filterIncompleteToolCalls && m.parts.some(hasOpenAIProviderMetadata);
 
       // Filter out streaming states and optionally input-available (which aren't supported by convertToModelMessages)
       const safeParts = m.parts.filter(p => {
@@ -125,42 +210,25 @@ export function sanitizeV5UIMessages(
         return p.state !== 'input-streaming';
       });
 
+      // Check if message-level metadata has OpenAI item IDs
+      const hasOpenAIMeta = filterIncompleteToolCalls && hasOpenAIMessageMetadata(m.metadata);
+
       if (!safeParts.length) return false;
 
-      const sanitized = {
+      let sanitized = {
         ...m,
         parts: safeParts.map(part => {
-          // When OpenAI reasoning was stripped, clear openai metadata from ALL remaining
-          // parts so the SDK sends inline content instead of item_reference. This covers:
+          // When OpenAI reasoning was stripped OR when message has OpenAI item IDs,
+          // clear openai metadata from ALL remaining parts so the SDK sends inline
+          // content instead of item_reference. This covers:
           //   - providerMetadata.openai on text/reasoning parts (msg_*/rs_* itemIds)
           //   - callProviderMetadata.openai on tool parts (fc_* itemIds used by convertToModelMessages)
-          // Without paired reasoning items, OpenAI rejects orphaned item_references with:
+          // Without paired reasoning items or when replaying messages with item IDs,
+          // OpenAI rejects orphaned item_references with:
           //   "function_call was provided without its required reasoning item"
-          if (hasOpenAIReasoning) {
-            if ('providerMetadata' in part && part.providerMetadata) {
-              const meta = part.providerMetadata as Record<string, unknown>;
-              if ('openai' in meta) {
-                const { openai: _, ...restMeta } = meta;
-                part = {
-                  ...part,
-                  providerMetadata:
-                    Object.keys(restMeta).length > 0 ? (restMeta as typeof part.providerMetadata) : undefined,
-                };
-              }
-            }
-            if ('callProviderMetadata' in part && part.callProviderMetadata) {
-              const callMeta = part.callProviderMetadata as Record<string, unknown>;
-              if ('openai' in callMeta) {
-                const { openai: _, ...restCallMeta } = callMeta;
-                part = {
-                  ...part,
-                  callProviderMetadata:
-                    Object.keys(restCallMeta).length > 0
-                      ? (restCallMeta as typeof part.callProviderMetadata)
-                      : undefined,
-                } as typeof part;
-              }
-            }
+          //   "Duplicate item found with id msg_*"
+          if (hasOpenAIReasoning || hasOpenAIItemIds) {
+            return stripOpenAIProviderMetadata(part);
           }
 
           if (AIV5.isToolUIPart(part) && part.state === 'output-available') {
@@ -175,6 +243,11 @@ export function sanitizeV5UIMessages(
           return part;
         }),
       };
+
+      // Strip OpenAI metadata from message-level metadata if present
+      if (hasOpenAIMeta) {
+        sanitized.metadata = stripOpenAIMessageMetadata(sanitized.metadata);
+      }
 
       return sanitized;
     })


### PR DESCRIPTION
## Description

When messages are recalled from memory and sent back to OpenAI's API, provider metadata containing item IDs (msg_*, rs_*, fc_*) can cause "Duplicate item found" errors.

This fix strips OpenAI provider metadata from both message parts and message-level metadata when sending messages to the LLM (when `filterIncompleteToolCalls=true`).

## Changes

- Added `hasOpenAIProviderMetadata()` function to detect OpenAI provider metadata with item IDs in message parts
- Added `stripOpenAIProviderMetadata()` function to strip OpenAI metadata from message parts
- Added `hasOpenAIMessageMetadata()` function to detect OpenAI provider metadata in message-level metadata
- Added `stripOpenAIMessageMetadata()` function to strip OpenAI metadata from message-level metadata
- Updated `sanitizeV5UIMessages()` to strip OpenAI metadata when sending messages to the LLM

## Related Issue

Fixes #14319

## Testing

Added comprehensive test cases in `output-converter-openai-fix.test.ts` covering:
- Stripping OpenAI metadata from text parts with item IDs
- Stripping OpenAI metadata from tool parts with call IDs
- Preserving OpenAI metadata when filterIncompleteToolCalls=false
- Preserving non-OpenAI provider metadata (e.g., Anthropic)
- Stripping OpenAI metadata from message-level metadata
- Combined stripping from both parts and message metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate item errors when processing OpenAI messages with incomplete tool calls by removing conflicting metadata.

* **Tests**
  * Added comprehensive test suite validating proper handling of OpenAI message metadata, including sanitization across text and tool components while preserving non-OpenAI provider data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->