### PR TITLE
fix(core): persist workflow snapshot on success for resumeStream visibility

### DIFF
--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -89,7 +89,7 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
         // VNext execution as internal
         internal: InternalSpans.WORKFLOW,
       },
-      shouldPersistSnapshot: ({ workflowStatus }) => workflowStatus === 'suspended',
+      shouldPersistSnapshot: ({ workflowStatus }) => workflowStatus === 'suspended' || workflowStatus === 'success',
       validateInputs: false,
     },
   })

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -64,7 +64,9 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
         internal: InternalSpans.WORKFLOW,
       },
       shouldPersistSnapshot: params => {
-        return params.workflowStatus === 'suspended';
+        // Persist snapshot on suspend to enable resume, and on success to ensure
+        // completed runs are visible after page refresh (issue #14320)
+        return params.workflowStatus === 'suspended' || params.workflowStatus === 'success';
       },
       validateInputs: false,
     },


### PR DESCRIPTION
## Issue

Closes #14320

## Problem

When calling `resumeStream()` for a suspended tool, the stream is visible correctly. But once the page is refreshed, the resumed stream is not visible (not persisted in the database).

## Root Cause

The `agentic-loop` and `agentic-execution` workflows had `shouldPersistSnapshot` options that only returned `true` when the workflow status was `'suspended'`. This meant that when a workflow was resumed and completed successfully, the final state was never persisted to the database.

## Fix

Updated the `shouldPersistSnapshot` function in both workflows to also return `true` when the workflow status is `'success'`, ensuring that completed runs are properly persisted and visible after page refresh.

### Files Changed

- `packages/core/src/loop/workflows/agentic-loop/index.ts`
- `packages/core/src/loop/workflows/agentic-execution/index.ts`

### Change Summary

```diff
- shouldPersistSnapshot: ({ workflowStatus }) => workflowStatus === 'suspended',
+ shouldPersistSnapshot: ({ workflowStatus }) => workflowStatus === 'suspended' || workflowStatus === 'success',
```

This minimal change ensures that:
1. Snapshots are still persisted on suspend (to enable resume functionality)
2. Snapshots are now also persisted on success (to ensure completed runs are visible after page refresh)

## Testing

This fix addresses the persistence gap described in #14320. The resumed stream data will now be available in the database after successful completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved snapshot persistence to save workflow states upon successful completion, in addition to when suspended. This ensures completed workflow runs remain visible after page refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->