### PR TITLE
fix(agent): preserve workflow run after resumeStream() completion

### DIFF
--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -232,7 +232,12 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
         return;
       }
 
-      await agenticLoopWorkflow.deleteWorkflowRunById(runId);
+      // Only delete the workflow run if we're not resuming.
+      // When resuming, we need to preserve the workflow run so that
+      // the resumed stream is persisted and can be retrieved after page refresh.
+      if (!resumeContext) {
+        await agenticLoopWorkflow.deleteWorkflowRunById(runId);
+      }
 
       // Always emit finish chunk, even for abort (tripwire) cases
       // This ensures the stream properly completes and all promises are resolved


### PR DESCRIPTION
**Problem:**
When `resumeStream()` was called for a suspended tool and the workflow completed successfully, the resumed stream was not persisted to the database. After refreshing the page, the resumed stream was not visible.

**Root Cause:**
After successful workflow execution in `workflowLoopStream`, the workflow run was unconditionally deleted from storage via `agenticLoopWorkflow.deleteWorkflowRunById(runId)`. This removed the snapshot from the database, making it unavailable after page refresh.

**Fix:**
Only delete the workflow run after successful execution when NOT in a resumed context. When resuming (`resumeContext` is present), preserve the workflow run so that the resumed stream remains persisted.

**Changes:**
- Modified `packages/core/src/loop/workflows/stream.ts` to conditionally delete workflow runs based on `resumeContext`

**Testing:**
- Existing tests pass (`tool-suspension.test.ts`, `tool-approval.test.ts`, `stream.test.ts`)

Fixes #14320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow resume functionality: workflow run data is now preserved when resuming after a page refresh, allowing users to continue from where they left off rather than losing progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->