### PR TITLE
Fix #13280: Error: Vercel Gateway fails on mastra 1.3.2 / @mastra-core 1

### DIFF
--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -43,6 +43,9 @@ const PROVIDER_OVERRIDES: Record<string, Partial<ProviderConfig>> = {
   groq: {
     url: 'https://api.groq.com/openai/v1',
   },
+  // vercel uses @internal/ai-v6 createGateway which manages its own endpoints
+  // Do not set a URL override so createGateway can use its default base URL
+  vercel: {},
   // moonshotai uses Anthropic-compatible API, not OpenAI-compatible
   moonshotai: {
     url: 'https://api.moonshot.ai/anthropic/v1',
@@ -106,7 +109,9 @@ export class ModelsDevGateway extends MastraModelGateway {
           .sort();
 
         // Get the API URL - overrides take priority over models.dev data
-        const url = PROVIDER_OVERRIDES[normalizedId]?.url || providerInfo.api;
+        // For vercel, don't use providerInfo.api even if it's available, because createGateway
+        // manages its own endpoint. For other providers, use providerInfo.api as fallback.
+        const url = PROVIDER_OVERRIDES[normalizedId]?.url || (normalizedId === 'vercel' ? undefined : providerInfo.api);
 
         // Skip if we don't have a URL
         if (!hasInstalledPackage && !url) {


### PR DESCRIPTION
Fixes #13280

## Summary
This PR fixes: Error: Vercel Gateway fails on mastra 1.3.2 / @mastra-core 1.5.0

## Changes
```
packages/core/src/llm/model/gateways/models-dev.ts | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: high (extended thinking). Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified provider endpoint configuration and selection logic to handle Vercel provider integration with updated fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->