### PR TITLE
fix(agent): skip input processors during resumeStream

### DIFF
--- a/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
@@ -87,13 +87,21 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
 
       if (!memory || (!thread?.id && !resourceId)) {
         messageList.add(options.messages, 'input');
-        const { tripwire } = await capabilities.runInputProcessors({
-          requestContext,
-          ...observabilityContext,
-          messageList,
-          inputProcessorOverrides: options.inputProcessors,
-          processorStates,
-        });
+
+        // Skip input processors during resumeStream - messages will be loaded from snapshot
+        // and input processors will run later in the loop with the full message context
+        const isResume = options.resumeContext?.snapshot !== undefined;
+
+        const { tripwire } = isResume
+          ? { tripwire: undefined }
+          : await capabilities.runInputProcessors({
+              requestContext,
+              ...observabilityContext,
+              messageList,
+              inputProcessorOverrides: options.inputProcessors,
+              processorStates,
+            });
+
         return {
           threadExists: false,
           thread: undefined,
@@ -171,13 +179,19 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
       // Add user messages - memory processors will handle history/semantic recall/working memory
       messageList.add(options.messages, 'input');
 
-      const { tripwire } = await capabilities.runInputProcessors({
-        requestContext,
-        ...observabilityContext,
-        messageList,
-        inputProcessorOverrides: options.inputProcessors,
-        processorStates,
-      });
+      // Skip input processors during resumeStream - messages will be loaded from snapshot
+      // and input processors will run later in the loop with the full message context
+      const isResume = options.resumeContext?.snapshot !== undefined;
+
+      const { tripwire } = isResume
+        ? { tripwire: undefined }
+        : await capabilities.runInputProcessors({
+            requestContext,
+            ...observabilityContext,
+            messageList,
+            inputProcessorOverrides: options.inputProcessors,
+            processorStates,
+          });
 
       return {
         thread: threadObject,


### PR DESCRIPTION
When using `resumeStream` with an Agent that has an input processor (like `TokenLimiterProcessor`), the system threw an error because the message list appeared empty during the prepare-memory-step.

**Root cause:** `resumeStream` passes `messages: []` since messages are loaded from the snapshot later in the loop. Input processors like `TokenLimiterProcessor` would throw `"No messages to process"` because they ran before the snapshot was loaded.

**Fix:** Skip input processors in `prepare-memory-step` when `resumeContext.snapshot` is present. The processors will run later in the agent loop when the full message context is available from the snapshot.

Fixes #14379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input processor execution timing when resuming from a saved snapshot, ensuring processors run with full message context for improved reliability during restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->