### PR TITLE
fix(core): deduplicate messages by ID before LLM conversion

### DIFF
--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -10,6 +10,31 @@ import type { AIV5Type } from '../types';
 import { ensureAnthropicCompatibleMessages } from '../utils/provider-compat';
 
 /**
+ * Deduplicates UI messages by ID, keeping the first occurrence of each message.
+ * This prevents "Duplicate item found" errors from LLM providers (e.g., OpenAI Responses API)
+ * when multiple processors add the same messages to the message list.
+ *
+ * @param messages - Array of UI messages that may contain duplicates
+ * @returns Array of UI messages with duplicates removed (first occurrence kept)
+ */
+function deduplicateMessagesById<T extends { id?: string }>(messages: T[]): T[] {
+  const seenIds = new Set<string>();
+  return messages.filter(message => {
+    if (!message.id) {
+      // Messages without IDs are always kept
+      return true;
+    }
+    if (seenIds.has(message.id)) {
+      // Duplicate found, filter it out
+      return false;
+    }
+    // First occurrence, track it and keep it
+    seenIds.add(message.id);
+    return true;
+  });
+}
+
+/**
  * Sanitizes AIV4 UI messages by filtering out incomplete tool calls.
  * Removes messages with empty parts arrays after sanitization.
  */
@@ -207,7 +232,9 @@ export function addStartStepPartsForAIV5(messages: AIV5Type.UIMessage[]): AIV5Ty
  * Converts AIV4 UI messages to AIV4 Core messages.
  */
 export function aiV4UIMessagesToAIV4CoreMessages(messages: UIMessageV4[]): CoreMessageV4[] {
-  return convertToCoreMessagesV4(sanitizeAIV4UIMessages(messages));
+  // Deduplicate messages by ID to prevent "Duplicate item found" errors
+  const deduplicated = deduplicateMessagesById(messages);
+  return convertToCoreMessagesV4(sanitizeAIV4UIMessages(deduplicated));
 }
 
 /**
@@ -223,7 +250,10 @@ export function aiV5UIMessagesToAIV5ModelMessages(
   dbMessages: MastraDBMessage[],
   filterIncompleteToolCalls = false,
 ): AIV5Type.ModelMessage[] {
-  const sanitized = sanitizeV5UIMessages(messages, filterIncompleteToolCalls);
+  // Deduplicate messages by ID before processing to prevent "Duplicate item found" errors
+  // from LLM providers (e.g., OpenAI Responses API) when multiple processors add the same messages
+  const deduplicated = deduplicateMessagesById(messages);
+  const sanitized = sanitizeV5UIMessages(deduplicated, filterIncompleteToolCalls);
   const preprocessed = addStartStepPartsForAIV5(sanitized);
   const result = AIV5.convertToModelMessages(preprocessed);
 


### PR DESCRIPTION
## Description

Fixes #14319 - AI_APICallError: Duplicate item found

When multiple processors (e.g., `SemanticRecall` and `MessageHistory`) add messages to the message list, duplicate messages with the same ID can end up in the final prompt sent to the LLM. This causes "Duplicate item found" errors from providers like OpenAI's Responses API.

## Root Cause

The `MessageHistory` processor fetches historical messages from storage and adds them to the message list. However, if `SemanticRecall` (or other processors) have already added some of those same messages, duplicates can occur in the final message list. When these messages are converted to AI SDK format and sent to the LLM, providers that enforce unique message IDs reject the request.

## Solution

Add a deduplication step in `aiV5UIMessagesToAIV5ModelMessages` and `aiV4UIMessagesToAIV4CoreMessages` that filters out duplicate messages by ID before converting to the format sent to LLMs. The deduplication keeps the first occurrence of each message ID and removes subsequent duplicates.

## Changes

- Added `deduplicateMessagesById` helper function in `output-converter.ts`
- Applied deduplication in `aiV5UIMessagesToAIV5ModelMessages` for AI SDK V5 messages
- Applied deduplication in `aiV4UIMessagesToAIV4CoreMessages` for AI SDK V4 messages

## Testing

The fix handles the following scenarios:
- Duplicate messages with the same ID are deduplicated (first occurrence kept)
- Messages without IDs are preserved (some messages may not have IDs)
- Empty message arrays are handled correctly
- All unique messages pass through unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed duplicate message handling in AI message processing pipelines to ensure consistent and reliable message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->