### PR TITLE
fix(client-js): ensure ZodObject schemas have type: 'object' for AWS Bedrock compatibility

### DIFF
--- a/client-sdks/client-js/src/utils/zod-to-json-schema.test.ts
+++ b/client-sdks/client-js/src/utils/zod-to-json-schema.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { zodToJsonSchema } from './zod-to-json-schema';
+
+describe('zodToJsonSchema', () => {
+  it('should convert z.object({}) to have type: object', () => {
+    const emptySchema = z.object({});
+    const result = zodToJsonSchema(emptySchema);
+
+    expect(result.type).toBe('object');
+    expect(result.properties).toEqual({});
+  });
+
+  it('should handle nested empty object schemas', () => {
+    const schema = z.object({
+      data: z.object({}),
+    });
+    const result = zodToJsonSchema(schema);
+
+    expect(result.type).toBe('object');
+    expect(result.properties?.data).toBeDefined();
+    expect((result.properties?.data as any).type).toBe('object');
+  });
+
+  it('should pass through non-Zod values unchanged', () => {
+    const plainObject = { type: 'object', properties: {} };
+    const result = zodToJsonSchema(plainObject);
+
+    expect(result).toEqual(plainObject);
+  });
+
+  it('should handle object with properties', () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+    const result = zodToJsonSchema(schema);
+
+    expect(result.type).toBe('object');
+    expect(result.properties?.name).toBeDefined();
+    expect(result.properties?.age).toBeDefined();
+  });
+
+  it('should handle arrays with object items', () => {
+    const schema = z.array(z.object({}));
+    const result = zodToJsonSchema(schema);
+
+    expect(result.type).toBe('array');
+    expect((result.items as any)?.type).toBe('object');
+  });
+
+  it('should handle optional object schemas', () => {
+    const schema = z.object({
+      data: z.object({}).optional(),
+    });
+    const result = zodToJsonSchema(schema);
+
+    expect(result.type).toBe('object');
+    expect(result.properties?.data).toBeDefined();
+  });
+});

--- a/client-sdks/client-js/src/utils/zod-to-json-schema.ts
+++ b/client-sdks/client-js/src/utils/zod-to-json-schema.ts
@@ -1,4 +1,5 @@
 import { zodToJsonSchema as schemaCompatZodToJsonSchema } from '@mastra/schema-compat/zod-to-json';
+import type { JSONSchema7 } from 'json-schema';
 import type { ZodType } from 'zod';
 
 /**
@@ -18,17 +19,98 @@ function isZodType(value: unknown): value is ZodType {
 }
 
 /**
+ * Check if a value is a ZodObject type (compatible with both Zod v3 and v4).
+ */
+function isZodObject(value: unknown): boolean {
+  if (!isZodType(value)) return false;
+
+  const valueAny = value as any;
+
+  // Zod v3: _def.typeName === 'ZodObject'
+  if (valueAny._def?.typeName === 'ZodObject') return true;
+
+  // Zod v4: _def.type === 'object' or _zod.def.type === 'object'
+  if (valueAny._def?.type === 'object') return true;
+  if (valueAny._zod?.def?.type === 'object') return true;
+
+  return false;
+}
+
+/**
+ * Ensures that object schemas have type: 'object' at the root level.
+ * This is required for AWS Bedrock compatibility.
+ */
+function ensureObjectType(schema: JSONSchema7): JSONSchema7 {
+  if (typeof schema !== 'object' || schema === null) {
+    return schema;
+  }
+
+  const result = { ...schema };
+
+  // If the schema has properties but no type, add type: 'object'
+  if (result.properties !== undefined && result.type === undefined) {
+    result.type = 'object';
+  }
+
+  // If the schema has additionalProperties but no type, add type: 'object'
+  if (result.additionalProperties !== undefined && result.type === undefined) {
+    result.type = 'object';
+  }
+
+  // Recursively fix nested schemas in properties
+  if (result.properties) {
+    result.properties = Object.fromEntries(
+      Object.entries(result.properties).map(([key, value]) => [key, ensureObjectType(value as JSONSchema7)]),
+    );
+  }
+
+  // Recursively fix items in arrays
+  if (result.items) {
+    if (Array.isArray(result.items)) {
+      result.items = result.items.map(item => ensureObjectType(item as JSONSchema7));
+    } else {
+      result.items = ensureObjectType(result.items as JSONSchema7);
+    }
+  }
+
+  // Recursively fix anyOf/oneOf/allOf schemas
+  if (result.anyOf && Array.isArray(result.anyOf)) {
+    result.anyOf = result.anyOf.map(s => ensureObjectType(s as JSONSchema7));
+  }
+  if (result.oneOf && Array.isArray(result.oneOf)) {
+    result.oneOf = result.oneOf.map(s => ensureObjectType(s as JSONSchema7));
+  }
+  if (result.allOf && Array.isArray(result.allOf)) {
+    result.allOf = result.allOf.map(s => ensureObjectType(s as JSONSchema7));
+  }
+
+  return result;
+}
+
+/**
  * Converts a Zod schema to JSON Schema, or passes through non-Zod values unchanged.
  *
  * Uses the schema-compat implementation which includes:
  * - Zod v4 z.record() bug fix
  * - Date to date-time format conversion
  * - Handling of unrepresentable types
+ *
+ * Additionally ensures that object schemas have type: 'object' for AWS Bedrock compatibility.
  */
 export function zodToJsonSchema<T extends ZodType | any>(zodSchema: T) {
   if (!isZodType(zodSchema)) {
     return zodSchema;
   }
 
-  return schemaCompatZodToJsonSchema(zodSchema);
+  const jsonSchema = schemaCompatZodToJsonSchema(zodSchema);
+
+  // For ZodObject schemas, ensure the root type is 'object'
+  // This is required for AWS Bedrock which expects type: 'object' at the root
+  if (isZodObject(zodSchema)) {
+    if (typeof jsonSchema === 'object' && jsonSchema !== null && jsonSchema.type !== 'object') {
+      return ensureObjectType({ ...jsonSchema, type: 'object' });
+    }
+  }
+
+  return ensureObjectType(jsonSchema);
 }


### PR DESCRIPTION
## Description

Fixes #14338

When using client tools with `z.object({})` schemas, AWS Bedrock expects `type: 'object'` at the root level of the JSON schema. Previously, some schemas were being converted without the required type field, causing validation errors like:

> The value at toolConfig.tools.X.toolSpec.inputSchema.json.type must be one of the following: object.

## Changes

- Modified `zodToJsonSchema` in `client-sdks/client-js/src/utils/zod-to-json-schema.ts` to:
  - Detect ZodObject schemas (compatible with both Zod v3 and v4)
  - Ensure the resulting JSON schema always has `type: 'object'` at the root for object schemas
  - Recursively fix nested object schemas

- Added comprehensive tests in `client-sdks/client-js/src/utils/zod-to-json-schema.test.ts`

## Testing

- All new tests pass
- Existing tests in `schema-compat` pass (870 tests)
- Existing tests in `process-client-tools` pass (5 tests)

## Checklist

- [x] Code compiles correctly
- [x] Tests pass
- [x] Follows the existing code style
- [x] Fixes the reported issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Zod-to-JSON-Schema conversion, validating empty objects, nested structures, arrays, and optional schemas.

* **Bug Fixes**
  * Enhanced JSON Schema generation to ensure proper object type handling across nested and composite schemas for improved schema consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->