### PR TITLE
fix(core): merge multiple system messages into one

### DIFF
--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -42,6 +42,7 @@ export {
   hasOpenAIReasoningItemId,
   getOpenAIReasoningItemId,
   findToolCallArgs,
+  mergeSystemMessages,
 } from './utils/provider-compat';
 export type { ToolResultWithInput } from './utils/provider-compat';
 

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -35,7 +35,7 @@ import type {
   SerializedMessageListState,
 } from './state';
 import type { AIV5Type, AIV5ResponseMessage, MessageInput, MessageListInput } from './types';
-import { ensureGeminiCompatibleMessages } from './utils/provider-compat';
+import { ensureGeminiCompatibleMessages, mergeSystemMessages } from './utils/provider-compat';
 
 export class MessageList {
   private messages: MastraDBMessage[] = [];
@@ -363,7 +363,7 @@ export class MessageList {
         // Filter incomplete tool calls when sending messages TO the LLM
         const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true);
 
-        const messages = [...systemMessages, ...modelMessages];
+        const messages = mergeSystemMessages([...systemMessages, ...modelMessages]);
 
         return ensureGeminiCompatibleMessages(messages, this.logger);
       },
@@ -437,6 +437,7 @@ export class MessageList {
           });
         }
 
+        messages = mergeSystemMessages(messages);
         messages = ensureGeminiCompatibleMessages(messages, this.logger);
 
         return messages
@@ -460,7 +461,11 @@ export class MessageList {
       // Used when calling AI SDK streamText/generateText
       prompt: () => {
         const coreMessages = this.all.aiV4.core();
-        const messages = [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat(), ...coreMessages];
+        const messages = mergeSystemMessages([
+          ...this.systemMessages,
+          ...Object.values(this.taggedSystemMessages).flat(),
+          ...coreMessages,
+        ]);
 
         return ensureGeminiCompatibleMessages(messages, this.logger);
       },
@@ -470,7 +475,7 @@ export class MessageList {
         const coreMessages = this.all.aiV4.core();
 
         const systemMessages = [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat()];
-        let messages = [...systemMessages, ...coreMessages];
+        let messages = mergeSystemMessages([...systemMessages, ...coreMessages]);
 
         messages = ensureGeminiCompatibleMessages(messages, this.logger);
 

--- a/packages/core/src/agent/message-list/utils/provider-compat.ts
+++ b/packages/core/src/agent/message-list/utils/provider-compat.ts
@@ -12,6 +12,73 @@ export type ToolResultWithInput = ToolResultPart & {
 };
 
 // ============================================================================
+// Single System Message Compatibility
+// ============================================================================
+
+/**
+ * Merges multiple consecutive system messages at the start of the array into a single system message.
+ *
+ * Some models (e.g., Qwen 3.5-27b and other local models) only support a single system message
+ * and will error if multiple system messages are provided. This function consolidates all
+ * system messages at the beginning of the message array into one.
+ *
+ * The merged content preserves the order of original messages, separated by double newlines
+ * to maintain clear boundaries between different instruction sets.
+ *
+ * @param messages - Array of model messages to process
+ * @returns Modified messages array with merged system message
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/14384 - Multiple system messages issue
+ */
+export function mergeSystemMessages<T extends ModelMessage | CoreMessageV4>(messages: T[]): T[] {
+  if (messages.length === 0) return messages;
+
+  // Find the last consecutive system message at the start
+  let lastSystemIndex = -1;
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i]?.role === 'system') {
+      lastSystemIndex = i;
+    } else {
+      break;
+    }
+  }
+
+  // If 0 or 1 system messages, no merging needed
+  if (lastSystemIndex <= 0) return messages;
+
+  // Extract all system messages at the start
+  const systemMessages = messages.slice(0, lastSystemIndex + 1);
+  const remainingMessages = messages.slice(lastSystemIndex + 1);
+
+  // Merge content from all system messages
+  const mergedContent = systemMessages
+    .map(m => {
+      if (typeof m.content === 'string') {
+        return m.content;
+      }
+      // For array content, extract text parts and join
+      if (Array.isArray(m.content)) {
+        return m.content
+          .filter((part: any) => part.type === 'text')
+          .map((part: any) => part.text)
+          .join('');
+      }
+      return '';
+    })
+    .filter(content => content.length > 0)
+    .join('\n\n');
+
+  // Create merged system message preserving the first message's structure
+  const firstSystem = systemMessages[0];
+  const mergedSystemMessage = {
+    ...firstSystem,
+    content: mergedContent,
+  } as T;
+
+  return [mergedSystemMessage, ...remainingMessages];
+}
+
+// ============================================================================
 // Gemini Compatibility
 // ============================================================================
 


### PR DESCRIPTION
Some models (e.g., Qwen 3.5-27b and other local models) only support a single system message at the beginning. When using workspaces/skills, Mastra generates multiple system messages which causes these models to error with 'System message must be at the beginning.'

This fix adds a \`mergeSystemMessages\` function that consolidates all consecutive system messages at the start of the message array into a single message, with content separated by double newlines to preserve boundaries between different instruction sets.

Fixes #14384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exposed `mergeSystemMessages` utility in the public API for advanced message handling scenarios.

* **Refactor**
  * Improved system message consolidation logic in message list construction for more consistent handling across different prompt paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->