### PR TITLE
fix: handle multiple system messages correctly

### DIFF
--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -42,6 +42,7 @@ export {
   hasOpenAIReasoningItemId,
   getOpenAIReasoningItemId,
   findToolCallArgs,
+  mergeSystemMessages,
 } from './utils/provider-compat';
 export type { ToolResultWithInput } from './utils/provider-compat';
 

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -35,7 +35,7 @@ import type {
   SerializedMessageListState,
 } from './state';
 import type { AIV5Type, AIV5ResponseMessage, MessageInput, MessageListInput } from './types';
-import { ensureGeminiCompatibleMessages } from './utils/provider-compat';
+import { ensureGeminiCompatibleMessages, mergeSystemMessages } from './utils/provider-compat';
 
 export class MessageList {
   private messages: MastraDBMessage[] = [];
@@ -363,7 +363,9 @@ export class MessageList {
         // Filter incomplete tool calls when sending messages TO the LLM
         const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true);
 
-        const messages = [...systemMessages, ...modelMessages];
+        // Merge all system messages into one to support models that only accept single system message
+        // See: https://github.com/mastra-ai/mastra/issues/14384
+        const messages = mergeSystemMessages([...systemMessages, ...modelMessages]);
 
         return ensureGeminiCompatibleMessages(messages, this.logger);
       },
@@ -396,7 +398,9 @@ export class MessageList {
           supportedUrls: options?.supportedUrls,
         });
 
-        let messages = [...systemMessages, ...modelMessages];
+        // Merge all system messages into one to support models that only accept single system message
+        // See: https://github.com/mastra-ai/mastra/issues/14384
+        let messages = mergeSystemMessages([...systemMessages, ...modelMessages]);
 
         // Check if any messages have image/file content that needs processing
         const hasImageOrFileContent = modelMessages.some(
@@ -460,7 +464,11 @@ export class MessageList {
       // Used when calling AI SDK streamText/generateText
       prompt: () => {
         const coreMessages = this.all.aiV4.core();
-        const messages = [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat(), ...coreMessages];
+        // Merge all system messages into one to support models that only accept single system message
+        // See: https://github.com/mastra-ai/mastra/issues/14384
+        const systemMessages = [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat()];
+        const allMessages = [...systemMessages, ...coreMessages];
+        const messages = mergeSystemMessages(allMessages);
 
         return ensureGeminiCompatibleMessages(messages, this.logger);
       },
@@ -470,7 +478,8 @@ export class MessageList {
         const coreMessages = this.all.aiV4.core();
 
         const systemMessages = [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat()];
-        let messages = [...systemMessages, ...coreMessages];
+        const allMessages = [...systemMessages, ...coreMessages];
+        let messages = mergeSystemMessages(allMessages);
 
         messages = ensureGeminiCompatibleMessages(messages, this.logger);
 

--- a/packages/core/src/agent/message-list/utils/provider-compat.ts
+++ b/packages/core/src/agent/message-list/utils/provider-compat.ts
@@ -12,6 +12,78 @@ export type ToolResultWithInput = ToolResultPart & {
 };
 
 // ============================================================================
+// System Message Merging
+// ============================================================================
+
+/**
+ * Merges multiple system messages into a single system message.
+ *
+ * Some LLM providers (e.g., Qwen, some OpenAI-compatible local models) only support
+ * a single system message at the beginning of the conversation. This function
+ * consolidates multiple system messages into one by concatenating their content
+ * with double newlines.
+ *
+ * @param messages - Array of messages that may contain multiple system messages
+ * @returns Messages array with all consecutive system messages merged into one
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/14384 - Multiple system messages issue
+ */
+export function mergeSystemMessages<T extends { role: string; content: unknown }>(messages: T[]): T[] {
+  if (messages.length === 0) return messages;
+
+  const result: T[] = [];
+  let currentSystemContent: string[] = [];
+
+  for (const message of messages) {
+    if (message.role === 'system') {
+      // Collect system message content
+      const content = typeof message.content === 'string' ? message.content : JSON.stringify(message.content);
+      if (content.trim()) {
+        currentSystemContent.push(content);
+      }
+    } else {
+      // Non-system message: flush any accumulated system content first
+      if (currentSystemContent.length > 0) {
+        result.push({
+          ...message,
+          role: 'system',
+          content: currentSystemContent.join('\n\n'),
+        } as T);
+        currentSystemContent = [];
+      }
+      result.push(message);
+    }
+  }
+
+  // Handle trailing system messages
+  if (currentSystemContent.length > 0) {
+    // Find the last system message to use as template, or create a new one
+    let lastSystem: T | undefined;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]!.role === 'system') {
+        lastSystem = messages[i]!;
+        break;
+      }
+    }
+    if (lastSystem) {
+      result.push({
+        ...lastSystem,
+        role: 'system',
+        content: currentSystemContent.join('\n\n'),
+      } as T);
+    } else {
+      // Should not happen, but handle gracefully
+      result.push({
+        role: 'system',
+        content: currentSystemContent.join('\n\n'),
+      } as T);
+    }
+  }
+
+  return result;
+}
+
+// ============================================================================
 // Gemini Compatibility
 // ============================================================================
 


### PR DESCRIPTION
## Problem

Some LLM providers (e.g., Qwen3.5-27b and other local models) only support a single system message at the beginning of the conversation. When using Mastra with workspace or skill features, multiple system messages were being generated (agent instructions + workspace instructions + skills metadata), causing errors like:

```
System message must be at the beginning.
```

## Solution

This PR adds a `mergeSystemMessages()` function that consolidates multiple system messages into a single system message by concatenating their content with double newlines. This is applied to all message prompt generation paths:

- `aiV5.prompt()` - AI SDK v5 streamText/generateText
- `aiV5.llmPrompt()` - Direct LLM prompts
- `aiV4.prompt()` - Legacy AI SDK v4 (deprecated but still used)
- `aiV4.llmPrompt()` - Legacy direct LLM prompts

## Changes

- Added `mergeSystemMessages()` in `provider-compat.ts`
- Updated all prompt generation methods in `MessageList` to use the merge function
- Exports the new function from the index for potential external use

## Testing

The fix ensures that when multiple processors add system messages (agent instructions, workspace instructions, skills metadata), they are merged into one before being sent to the LLM.

Fixes #14384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * System messages are now consolidated into a single unified message to improve compatibility with AI models expecting unified system messages, ensuring more reliable prompt processing across supported model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->