### PR TITLE
fix(schema-compat): ensure all anyOf branches have a type key for OpenAI strict mode

### DIFF
--- a/.changeset/fix-typeless-anyof-branches.md
+++ b/.changeset/fix-typeless-anyof-branches.md
@@ -9,6 +9,7 @@ fix: ensure all anyOf branches have a type key for OpenAI strict mode
 producing `anyOf: [{ description: "..." }, { type: "null" }]` where the first
 branch had no `type` key. OpenAI rejects this when using structuredOutput.
 
-The OpenAI compat layer now assigns `type: "object"` to typeless anyOf branches,
-and `fixTypelessProperties` now recurses into anyOf/oneOf/allOf branches as a
-safety net.
+The OpenAI compat layer now expands typeless branches into concrete typed
+branches, and `fixTypelessProperties` now recurses into anyOf/oneOf/allOf
+branches while preserving a strict object variant with
+`additionalProperties: false`.

--- a/.changeset/fix-typeless-anyof-branches.md
+++ b/.changeset/fix-typeless-anyof-branches.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': patch
+'@mastra/schema-compat': patch
+---
+
+fix: ensure all anyOf branches have a type key for OpenAI strict mode
+
+`z.any().optional()` in agent delegation tool schemas (e.g. `resumeData`) was
+producing `anyOf: [{ description: "..." }, { type: "null" }]` where the first
+branch had no `type` key. OpenAI rejects this when using structuredOutput.
+
+The OpenAI compat layer now assigns `type: "object"` to typeless anyOf branches,
+and `fixTypelessProperties` now recurses into anyOf/oneOf/allOf branches as a
+safety net.

--- a/packages/core/src/agent/__tests__/structured-output-delegation-openai.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output-delegation-openai.e2e.test.ts
@@ -1,6 +1,6 @@
 import { openai as openai_v5 } from '@ai-sdk/openai-v5';
 import { getLLMTestMode } from '@internal/llm-recorder';
-import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
+import { createGatewayMock, hasRealApiKey, setupDummyApiKeys } from '@internal/test-utils';
 import { config } from 'dotenv';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
@@ -17,7 +17,7 @@ beforeAll(() => mock.start());
 afterAll(() => mock.saveAndStop());
 
 describe('OpenAI structured output delegation', () => {
-  it.skipIf(!process.env.OPENAI_API_KEY)(
+  it.skipIf(!hasRealApiKey('openai'))(
     'should allow structured output when a parent agent exposes a sub-agent as a tool',
     async () => {
       const subAgent = new Agent({

--- a/packages/core/src/agent/__tests__/structured-output-delegation-openai.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output-delegation-openai.e2e.test.ts
@@ -1,0 +1,54 @@
+import { openai as openai_v5 } from '@ai-sdk/openai-v5';
+import { getLLMTestMode } from '@internal/llm-recorder';
+import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
+import { config } from 'dotenv';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { Agent } from '../agent';
+import { getSingleDummyResponseModel } from './mock-model';
+
+config();
+
+const MODE = getLLMTestMode();
+setupDummyApiKeys(MODE, ['openai']);
+
+const mock = createGatewayMock();
+beforeAll(() => mock.start());
+afterAll(() => mock.saveAndStop());
+
+describe('OpenAI structured output delegation', () => {
+  it.skipIf(!process.env.OPENAI_API_KEY)(
+    'should allow structured output when a parent agent exposes a sub-agent as a tool',
+    async () => {
+      const subAgent = new Agent({
+        id: 'research-agent',
+        name: 'Research Agent',
+        instructions: 'You are a concise research agent.',
+        model: getSingleDummyResponseModel('v2'),
+      });
+
+      const orchestrator = new Agent({
+        id: 'orchestrator-agent',
+        name: 'Orchestrator Agent',
+        instructions:
+          'You can delegate to the research agent when useful. Always return a concise answer that matches the schema.',
+        model: openai_v5('gpt-4o-mini'),
+        agents: { researchAgent: subAgent },
+      });
+
+      const result = await orchestrator.generate('Return a short structured summary about TypeScript.', {
+        structuredOutput: {
+          schema: z.object({
+            summary: z.string(),
+            delegated: z.boolean().optional(),
+          }),
+        },
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.object).toBeDefined();
+      expect(result.object.summary).toEqual(expect.any(String));
+    },
+    120_000,
+  );
+});

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -455,6 +455,38 @@ describe('prepareToolsAndToolChoice', () => {
     });
   });
 
+  describe('fixTypelessProperties anyOf branch recursion', () => {
+    it('should fix typeless branches inside anyOf', () => {
+      const toolWithAnyOf = {
+        description: 'A tool with anyOf containing a typeless branch',
+        parameters: jsonSchema({
+          type: 'object',
+          properties: {
+            data: {
+              anyOf: [{ description: 'typeless branch' }, { type: 'null' }],
+            },
+          },
+        }),
+        execute: async () => 'ok',
+      };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { testTool: toolWithAnyOf as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v2',
+      });
+
+      const toolDef = result.tools![0] as { type: string; inputSchema: Record<string, any> };
+      const dataProp = toolDef.inputSchema.properties.data as Record<string, any>;
+
+      expect(dataProp.anyOf).toBeDefined();
+      for (const branch of dataProp.anyOf) {
+        expect(branch.type).toBeDefined();
+      }
+    });
+  });
+
   describe('default targetVersion', () => {
     it('should default to v2 when targetVersion is not specified', () => {
       const providerTool = {

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -416,9 +416,14 @@ describe('prepareToolsAndToolChoice', () => {
       }
 
       const resumeDataSchema = properties.resumeData as Record<string, any>;
-      expect(Array.isArray(resumeDataSchema.type)).toBe(true);
-      expect(resumeDataSchema.type).not.toContain('array');
+      expect(resumeDataSchema.anyOf).toBeDefined();
       expect(resumeDataSchema.items).toBeUndefined();
+      for (const branch of resumeDataSchema.anyOf) {
+        expect(branch.type).toBeDefined();
+      }
+      expect(
+        resumeDataSchema.anyOf.find((branch: Record<string, any>) => branch.type === 'object')?.additionalProperties,
+      ).toBe(false);
     });
 
     it('should drop items for typeless properties when applying non-array fallback type', () => {
@@ -449,9 +454,12 @@ describe('prepareToolsAndToolChoice', () => {
       expect(toolDef.type).toBe('function');
 
       const resumeDataSchema = toolDef.inputSchema.properties.resumeData as Record<string, any>;
-      expect(Array.isArray(resumeDataSchema.type)).toBe(true);
-      expect(resumeDataSchema.type).not.toContain('array');
+      expect(resumeDataSchema.anyOf).toBeDefined();
       expect(resumeDataSchema.items).toBeUndefined();
+      expect(resumeDataSchema.anyOf.some((branch: Record<string, any>) => branch.type === 'object')).toBe(true);
+      expect(
+        resumeDataSchema.anyOf.find((branch: Record<string, any>) => branch.type === 'object')?.additionalProperties,
+      ).toBe(false);
     });
   });
 

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -493,6 +493,66 @@ describe('prepareToolsAndToolChoice', () => {
         expect(branch.type).toBeDefined();
       }
     });
+
+    it('should fix typeless branches inside oneOf', () => {
+      const toolWithOneOf = {
+        description: 'A tool with oneOf containing a typeless branch',
+        parameters: jsonSchema({
+          type: 'object',
+          properties: {
+            data: {
+              oneOf: [{ description: 'typeless branch' }, { type: 'null' }],
+            },
+          },
+        }),
+        execute: async () => 'ok',
+      };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { testTool: toolWithOneOf as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v2',
+      });
+
+      const toolDef = result.tools![0] as { type: string; inputSchema: Record<string, any> };
+      const dataProp = toolDef.inputSchema.properties.data as Record<string, any>;
+
+      expect(dataProp.oneOf).toBeDefined();
+      for (const branch of dataProp.oneOf) {
+        expect(branch.type).toBeDefined();
+      }
+    });
+
+    it('should fix typeless branches inside allOf', () => {
+      const toolWithAllOf = {
+        description: 'A tool with allOf containing a typeless branch',
+        parameters: jsonSchema({
+          type: 'object',
+          properties: {
+            data: {
+              allOf: [{ description: 'typeless branch' }, { type: 'null' }],
+            },
+          },
+        }),
+        execute: async () => 'ok',
+      };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { testTool: toolWithAllOf as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v2',
+      });
+
+      const toolDef = result.tools![0] as { type: string; inputSchema: Record<string, any> };
+      const dataProp = toolDef.inputSchema.properties.data as Record<string, any>;
+
+      expect(dataProp.allOf).toBeDefined();
+      for (const branch of dataProp.allOf) {
+        expect(branch.type).toBeDefined();
+      }
+    });
   });
 
   describe('default targetVersion', () => {

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -46,11 +46,14 @@ function fixTypelessProperties(schema: Record<string, unknown>): Record<string, 
         if (typeof value !== 'object' || value === null || Array.isArray(value)) {
           return [key, value];
         }
+
         const propSchema = value as Record<string, unknown>;
+
         if (isTypelessSchema(propSchema)) {
           const { items: _items, ...rest } = propSchema;
           return [key, { ...rest, type: PERMISSIVE_TYPE }];
         }
+
         return [key, fixTypelessProperties(propSchema)];
       }),
     );

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -25,10 +25,15 @@ type PreparedTool =
 
 type PreparedToolChoice = LanguageModelV2ToolChoice | LanguageModelV3ToolChoice;
 
+const PERMISSIVE_TYPE = ['string', 'number', 'integer', 'boolean', 'object', 'null'];
+
+function isTypelessSchema(s: Record<string, unknown>): boolean {
+  return !('type' in s) && !('$ref' in s) && !('anyOf' in s) && !('oneOf' in s) && !('allOf' in s);
+}
+
 /**
- * Recursively fixes JSON Schema properties that lack a 'type' key.
- * Zod v4's toJSONSchema serializes z.any() to just { description: "..." } with no 'type',
- * which providers like OpenAI reject. This converts such schemas to a permissive type union.
+ * Recursively fixes JSON Schema nodes that lack a 'type' key.
+ * z.any() serializes to { description: "..." } with no 'type', which providers like OpenAI reject.
  */
 function fixTypelessProperties(schema: Record<string, unknown>): Record<string, unknown> {
   if (typeof schema !== 'object' || schema === null) return schema;
@@ -41,19 +46,11 @@ function fixTypelessProperties(schema: Record<string, unknown>): Record<string, 
         if (typeof value !== 'object' || value === null || Array.isArray(value)) {
           return [key, value];
         }
-
         const propSchema = value as Record<string, unknown>;
-        const hasType = 'type' in propSchema;
-        const hasRef = '$ref' in propSchema;
-        const hasAnyOf = 'anyOf' in propSchema;
-        const hasOneOf = 'oneOf' in propSchema;
-        const hasAllOf = 'allOf' in propSchema;
-
-        if (!hasType && !hasRef && !hasAnyOf && !hasOneOf && !hasAllOf) {
+        if (isTypelessSchema(propSchema)) {
           const { items: _items, ...rest } = propSchema;
-          return [key, { ...rest, type: ['string', 'number', 'integer', 'boolean', 'object', 'null'] }];
+          return [key, { ...rest, type: PERMISSIVE_TYPE }];
         }
-
         return [key, fixTypelessProperties(propSchema)];
       }),
     );
@@ -64,6 +61,20 @@ function fixTypelessProperties(schema: Record<string, unknown>): Record<string, 
       result.items = (result.items as Record<string, unknown>[]).map(item => fixTypelessProperties(item));
     } else if (typeof result.items === 'object') {
       result.items = fixTypelessProperties(result.items as Record<string, unknown>);
+    }
+  }
+
+  for (const keyword of ['anyOf', 'oneOf', 'allOf'] as const) {
+    if (Array.isArray(result[keyword])) {
+      result[keyword] = (result[keyword] as Record<string, unknown>[]).map(branch => {
+        if (typeof branch !== 'object' || branch === null || Array.isArray(branch)) return branch;
+        const b = branch as Record<string, unknown>;
+        if (isTypelessSchema(b)) {
+          const { items: _items, ...rest } = b;
+          return { ...rest, type: PERMISSIVE_TYPE };
+        }
+        return fixTypelessProperties(b);
+      });
     }
   }
 

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -25,10 +25,20 @@ type PreparedTool =
 
 type PreparedToolChoice = LanguageModelV2ToolChoice | LanguageModelV3ToolChoice;
 
-const PERMISSIVE_TYPE = ['string', 'number', 'integer', 'boolean', 'object', 'null'];
-
 function isTypelessSchema(s: Record<string, unknown>): boolean {
   return !('type' in s) && !('$ref' in s) && !('anyOf' in s) && !('oneOf' in s) && !('allOf' in s);
+}
+
+function expandTypelessSchema(schema: Record<string, unknown>) {
+  const { items: _items, ...rest } = schema;
+  return [
+    { ...rest, type: 'string' },
+    { ...rest, type: 'number' },
+    { ...rest, type: 'integer' },
+    { ...rest, type: 'boolean' },
+    { ...rest, type: 'object', properties: {}, additionalProperties: false },
+    { ...rest, type: 'null' },
+  ];
 }
 
 /**
@@ -50,8 +60,7 @@ function fixTypelessProperties(schema: Record<string, unknown>): Record<string, 
         const propSchema = value as Record<string, unknown>;
 
         if (isTypelessSchema(propSchema)) {
-          const { items: _items, ...rest } = propSchema;
-          return [key, { ...rest, type: PERMISSIVE_TYPE }];
+          return [key, { anyOf: expandTypelessSchema(propSchema) }];
         }
 
         return [key, fixTypelessProperties(propSchema)];
@@ -69,12 +78,11 @@ function fixTypelessProperties(schema: Record<string, unknown>): Record<string, 
 
   for (const keyword of ['anyOf', 'oneOf', 'allOf'] as const) {
     if (Array.isArray(result[keyword])) {
-      result[keyword] = (result[keyword] as Record<string, unknown>[]).map(branch => {
+      result[keyword] = (result[keyword] as Record<string, unknown>[]).flatMap(branch => {
         if (typeof branch !== 'object' || branch === null || Array.isArray(branch)) return branch;
         const b = branch as Record<string, unknown>;
         if (isTypelessSchema(b)) {
-          const { items: _items, ...rest } = b;
-          return { ...rest, type: PERMISSIVE_TYPE };
+          return expandTypelessSchema(b);
         }
         return fixTypelessProperties(b);
       });

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod/v4';
 import { SpanType } from '../../observability';
 import type { AnySpan } from '../../observability';
 import { RequestContext } from '../../request-context';
+import { toStandardSchema } from '../../schema';
 import { createTool } from '../../tools';
 import { isProviderDefinedTool, isVercelTool } from '../toolchecks';
 import { CoreToolBuilder } from './builder';
@@ -245,5 +246,69 @@ describe('Provider-defined Tool Handling', () => {
         autoResumeSuspendedTools: true,
       });
     }).not.toThrow();
+  });
+});
+
+describe('Workflow-style schema handling', () => {
+  it('should produce OpenAI-safe resumeData branches for non-Zod workflow-style schemas', () => {
+    const workflowTool = createTool({
+      id: 'workflow-subWorkflow',
+      description: 'A workflow tool',
+      inputSchema: toStandardSchema({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          inputData: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+            required: ['name'],
+            additionalProperties: false,
+          },
+        },
+        required: ['inputData'],
+        additionalProperties: true,
+      }),
+      execute: async () => 'result',
+    });
+
+    const mockModel = {
+      modelId: 'openai/gpt-4.1-mini',
+      provider: 'openrouter',
+      specificationVersion: 'v2',
+      supportsStructuredOutputs: false,
+    } as any;
+
+    const toolDef = new CoreToolBuilder({
+      originalTool: workflowTool,
+      options: {
+        name: 'workflow-tool',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        description: 'Run workflow',
+        requestContext: new RequestContext(),
+        tracingContext: {},
+        model: mockModel,
+      },
+      autoResumeSuspendedTools: true,
+    }).buildV5();
+
+    const properties = (toolDef.inputSchema as any).jsonSchema.properties;
+    const resumeDataSchema = properties.resumeData as Record<string, any>;
+    const suspendedToolRunIdSchema = properties.suspendedToolRunId as Record<string, any>;
+
+    expect(suspendedToolRunIdSchema.anyOf).toBeDefined();
+    expect(resumeDataSchema.anyOf).toBeDefined();
+    expect(
+      resumeDataSchema.anyOf.find((branch: Record<string, any>) => branch.type === 'object')?.additionalProperties,
+    ).toBe(false);
+    for (const branch of resumeDataSchema.anyOf) {
+      expect(branch.type).toBeDefined();
+    }
   });
 });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -43,6 +43,22 @@ import { validateToolInput, validateToolOutput, validateToolSuspendData } from '
 export type ToolToConvert = VercelTool | ToolAction<any, any, any> | VercelToolV5 | ProviderDefinedTool;
 export type LogType = 'tool' | 'toolset' | 'client-tool';
 
+function createPermissiveResumeDataBranches(description: string) {
+  return [
+    { type: 'string' },
+    { type: 'number' },
+    { type: 'integer' },
+    { type: 'boolean' },
+    {
+      type: 'object',
+      description,
+      properties: {},
+      additionalProperties: false,
+    },
+    { type: 'null' },
+  ];
+}
+
 interface LogOptions {
   agentName?: string;
   toolName: string;
@@ -102,14 +118,14 @@ export class CoreToolBuilder extends MastraBase {
           jsonSchema.properties = {
             ...jsonSchema.properties,
             suspendedToolRunId: {
-              type: ['string', 'null'],
+              anyOf: [{ type: 'string', description: 'The runId of the suspended tool' }, { type: 'null' }],
               description: 'The runId of the suspended tool',
             },
             resumeData: {
-              type: 'object',
               description: 'The resumeData object created from the resumeSchema of suspended tool',
-              properties: {},
-              additionalProperties: true,
+              anyOf: createPermissiveResumeDataBranches(
+                'The resumeData object created from the resumeSchema of suspended tool',
+              ),
             },
           };
           this.originalTool.inputSchema = toStandardSchema(jsonSchema) as any;

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -106,7 +106,10 @@ export class CoreToolBuilder extends MastraBase {
               description: 'The runId of the suspended tool',
             },
             resumeData: {
+              type: 'object',
               description: 'The resumeData object created from the resumeSchema of suspended tool',
+              properties: {},
+              additionalProperties: true,
             },
           };
           this.originalTool.inputSchema = toStandardSchema(jsonSchema) as any;

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -10,6 +10,7 @@ import {
   convertZodSchemaToAISDKSchema,
   jsonSchema,
 } from '@mastra/schema-compat';
+import type { JSONSchema7Definition } from 'json-schema';
 import { z } from 'zod/v4';
 import { MastraBase } from '../../base';
 import { ErrorCategory, MastraError, ErrorDomain } from '../../error';
@@ -43,19 +44,19 @@ import { validateToolInput, validateToolOutput, validateToolSuspendData } from '
 export type ToolToConvert = VercelTool | ToolAction<any, any, any> | VercelToolV5 | ProviderDefinedTool;
 export type LogType = 'tool' | 'toolset' | 'client-tool';
 
-function createPermissiveResumeDataBranches(description: string) {
+function createPermissiveResumeDataBranches(description: string): JSONSchema7Definition[] {
   return [
-    { type: 'string' },
-    { type: 'number' },
-    { type: 'integer' },
-    { type: 'boolean' },
+    { type: 'string' as const },
+    { type: 'number' as const },
+    { type: 'integer' as const },
+    { type: 'boolean' as const },
     {
-      type: 'object',
+      type: 'object' as const,
       description,
       properties: {},
       additionalProperties: false,
     },
-    { type: 'null' },
+    { type: 'null' as const },
   ];
 }
 

--- a/packages/schema-compat/src/provider-compats/openai.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai.test.ts
@@ -1629,15 +1629,20 @@ describe('OpenAISchemaCompatLayer - typeless anyOf branches from z.any()', () =>
     const resumeData = result.properties?.resumeData as Record<string, any>;
 
     expect(resumeData).toBeDefined();
+    expect(resumeData.description).toBe('Resume data from suspended tool');
     expect(resumeData.anyOf).toBeDefined();
-    expect(resumeData.anyOf).toHaveLength(2);
 
-    // First branch must have a concrete type (was missing before the fix)
-    expect(resumeData.anyOf[0].type).toBe('object');
-    expect(resumeData.anyOf[0].description).toBe('Resume data from suspended tool');
-    expect(resumeData.anyOf[0].additionalProperties).toBe(false);
+    // Every branch must have a concrete type
+    for (const branch of resumeData.anyOf) {
+      expect(branch.type).toBeDefined();
+    }
 
-    // Second branch is the null option
-    expect(resumeData.anyOf[1].type).toBe('null');
+    // Should cover common JSON types including null
+    const types = resumeData.anyOf.map((b: any) => b.type);
+    expect(types).toContain('string');
+    expect(types).toContain('number');
+    expect(types).toContain('boolean');
+    expect(types).toContain('object');
+    expect(types).toContain('null');
   });
 });

--- a/packages/schema-compat/src/provider-compats/openai.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai.test.ts
@@ -1641,6 +1641,7 @@ describe('OpenAISchemaCompatLayer - typeless anyOf branches from z.any()', () =>
     const types = resumeData.anyOf.map((b: any) => b.type);
     expect(types).toContain('string');
     expect(types).toContain('number');
+    expect(types).toContain('integer');
     expect(types).toContain('boolean');
     expect(types).toContain('object');
     expect(types).toContain('null');

--- a/packages/schema-compat/src/provider-compats/openai.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai.test.ts
@@ -1611,3 +1611,33 @@ describe('OpenAISchemaCompatLayer - ZodIntersection', () => {
     `);
   });
 });
+
+describe('OpenAISchemaCompatLayer - typeless anyOf branches from z.any()', () => {
+  const layer = new OpenAISchemaCompatLayer({
+    provider: 'openai.responses',
+    modelId: 'gpt-4.1',
+    supportsStructuredOutputs: true,
+  });
+
+  it('should give every anyOf branch a type key for z.any().optional()', () => {
+    const schema = z.object({
+      prompt: z.string(),
+      resumeData: z.any().describe('Resume data from suspended tool').optional(),
+    });
+
+    const result = layer.toJSONSchema(schema);
+    const resumeData = result.properties?.resumeData as Record<string, any>;
+
+    expect(resumeData).toBeDefined();
+    expect(resumeData.anyOf).toBeDefined();
+    expect(resumeData.anyOf).toHaveLength(2);
+
+    // First branch must have a concrete type (was missing before the fix)
+    expect(resumeData.anyOf[0].type).toBe('object');
+    expect(resumeData.anyOf[0].description).toBe('Resume data from suspended tool');
+    expect(resumeData.anyOf[0].additionalProperties).toBe(false);
+
+    // Second branch is the null option
+    expect(resumeData.anyOf[1].type).toBe('null');
+  });
+});

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -234,6 +234,7 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
         schema.anyOf = [
           { type: 'string' },
           { type: 'number' },
+          { type: 'integer' },
           { type: 'boolean' },
           { type: 'object', properties: {}, additionalProperties: false },
           { type: 'null' },

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -226,19 +226,26 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
         delete schema[key];
       }
 
-      // Typeless schemas (e.g. z.any()) need a concrete type for OpenAI strict mode
       if (!subSchema.type && !subSchema.$ref && !subSchema.anyOf && !subSchema.oneOf && !subSchema.allOf) {
-        subSchema.type = 'object';
-        subSchema.properties = subSchema.properties || {};
-        subSchema.additionalProperties = false;
+        // Typeless schemas (e.g. z.any()) — expand into concrete typed branches
+        if (subSchema.description) {
+          schema.description = subSchema.description;
+        }
+        schema.anyOf = [
+          { type: 'string' },
+          { type: 'number' },
+          { type: 'boolean' },
+          { type: 'object', properties: {}, additionalProperties: false },
+          { type: 'null' },
+        ];
+      } else {
+        schema.anyOf = [
+          subSchema,
+          {
+            type: 'null',
+          },
+        ];
       }
-
-      schema.anyOf = [
-        subSchema,
-        {
-          type: 'null',
-        },
-      ];
     }
 
     // Ensure bare {"type":"object"} nodes (e.g., inside anyOf) have additionalProperties: false.

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -226,6 +226,13 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
         delete schema[key];
       }
 
+      // Typeless schemas (e.g. z.any()) need a concrete type for OpenAI strict mode
+      if (!subSchema.type && !subSchema.$ref && !subSchema.anyOf && !subSchema.oneOf && !subSchema.allOf) {
+        subSchema.type = 'object';
+        subSchema.properties = subSchema.properties || {};
+        subSchema.additionalProperties = false;
+      }
+
       schema.anyOf = [
         subSchema,
         {


### PR DESCRIPTION
## Description

This fixes OpenAI invalid_function_parameters errors when a parent agent uses structuredOutput and delegates to sub-agents exposed as tools. 

The real user issue was that delegated tool schemas could generate resumeData branches without a valid OpenAI-strict type/object shape, so OpenAI rejected the request before execution.

This update fixes that by expanding typeless schemas into concrete OpenAI-safe branches, recursively handling anyOf/oneOf/allOf, and ensuring the object variant is strict (additionalProperties: false). Verified with a real OpenAI API repro and added regression coverage.

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #14403

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works