### PR TITLE
fix(server): use same Zod version as input in wrapSchemaForQueryParams to fix Observability crash

### DIFF
--- a/packages/server/src/server/handlers/observability.ts
+++ b/packages/server/src/server/handlers/observability.ts
@@ -14,7 +14,7 @@ import {
   getTraceResponseSchema,
   dateRangeSchema,
 } from '@mastra/core/storage';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { HTTPException } from '../http-exception';
 import { createRoute, pickParams, wrapSchemaForQueryParams } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';

--- a/packages/server/src/server/server-adapter/routes/route-builder.ts
+++ b/packages/server/src/server/server-adapter/routes/route-builder.ts
@@ -1,6 +1,7 @@
 import type { ValidationErrorHook } from '@mastra/core/server';
 import { z } from 'zod';
 import type { ZodObject, ZodRawShape, ZodTypeAny } from 'zod';
+import { z as zV4 } from 'zod/v4';
 import { generateRouteOpenAPI } from '../openapi-utils';
 import type { InferParams, ResponseType, RouteSchemas, ServerRoute, ServerRouteHandler } from './index';
 
@@ -49,6 +50,16 @@ export function pickParams<T extends z.ZodRawShape, P extends Record<string, unk
  * // Accepts: { gte: "2024-01-01" } OR '{"gte": "2024-01-01"}'
  * ```
  */
+
+/**
+ * Detects if a schema is from Zod v4 (uses _zod) vs v3 (uses _def).
+ * Used to pick the correct zod version when wrapping schemas from @mastra/core/storage
+ * (which uses zod/v4) to avoid "keyValidator._parse is not a function" when mixing versions.
+ */
+function isZodV4Schema(schema: unknown): boolean {
+  return typeof schema === 'object' && schema !== null && '_zod' in schema;
+}
+
 export function jsonQueryParam<T extends ZodTypeAny>(schema: T): z.ZodType<z.infer<T>> {
   return z.union([
     schema, // Already the expected type (non-string input)
@@ -149,22 +160,54 @@ function isComplexType(schema: ZodTypeAny): boolean {
  * // ?tags=["tag1","tag2"]&startedAt={"gte":"2024-01-01"}&perPage=10
  * ```
  */
+
+/**
+ * Internal: jsonQueryParam using a specific zod instance (v3 or v4).
+ * Used by wrapSchemaForQueryParams to avoid mixing zod versions.
+ */
+function jsonQueryParamWithZ<T extends ZodTypeAny>(zLib: typeof z, schema: T): ZodTypeAny {
+  const zAny = zLib as any;
+  return zLib.union([
+    schema,
+    zLib.string().transform((val: string, ctx: any) => {
+      try {
+        const parsed = JSON.parse(val);
+        const result = schema.safeParse(parsed);
+        if (!result.success) {
+          for (const issue of (result.error as { issues: Array<{ message: string; path: unknown[] }> }).issues) {
+            ctx.addIssue({ code: zAny.ZodIssueCode?.custom ?? 'custom', message: issue.message, path: issue.path });
+          }
+          return zAny.NEVER ?? z.NEVER;
+        }
+        return result.data;
+      } catch (e) {
+        ctx.addIssue({
+          code: zAny.ZodIssueCode?.custom ?? 'custom',
+          message: `Invalid JSON: ${e instanceof Error ? e.message : 'parse error'}`,
+        });
+        return zAny.NEVER ?? z.NEVER;
+      }
+    }),
+  ]) as ZodTypeAny;
+}
+
 export function wrapSchemaForQueryParams<T extends ZodRawShape>(schema: ZodObject<T>): ZodObject<ZodRawShape> {
   const newShape: Record<string, ZodTypeAny> = {};
+  const zLib = isZodV4Schema(schema) ? zV4 : z;
 
   // schema.shape is Readonly in Zod v4, so we need to create a mutable copy
   const shape = schema.shape as unknown as Record<string, ZodTypeAny>;
   for (const [key, fieldSchema] of Object.entries(shape)) {
     if (isComplexType(fieldSchema)) {
-      // Wrap complex types to accept JSON strings
-      newShape[key] = jsonQueryParam(fieldSchema);
+      // Wrap complex types to accept JSON strings (use same zod version as schema)
+      newShape[key] = jsonQueryParamWithZ(zLib, fieldSchema);
     } else {
       // Keep simple types as-is
       newShape[key] = fieldSchema;
     }
   }
 
-  return z.object(newShape);
+  return zLib.object(newShape) as ZodObject<ZodRawShape>;
 }
 
 interface RouteConfig<


### PR DESCRIPTION
## Summary

Fixes #14347

When `@mastra/core/storage` schemas (Zod v4) were wrapped with `wrapSchemaForQueryParams` using Zod v3, the resulting mixed schema caused `keyValidator._parse is not a function` when parsing query params for `/observability/traces`. This crashed the Studio Observability/Traces tab.

## Root cause

- `@mastra/core/storage` uses `zod/v4` for its schemas (`tracesFilterSchema`, `paginationArgsSchema`, etc.)
- The server's `wrapSchemaForQueryParams` used `zod` (v3 when user has zod v3) to create `z.object(newShape)`
- Mixing v4 shape values with v3's `ZodObject` caused parse failures: v3's `ZodObject._parse` calls `keyValidator._parse()` on v4 schemas which use a different internal API

## Changes

- Detect Zod v4 schemas via `_zod` property
- Use `zod/v4` for `wrapSchemaForQueryParams` output when input schema is v4
- Use `zod/v4` in observability handler for `legacyQueryParamsSchema` (storage schemas are v4)

## Testing

- `pnpm run build --filter=@mastra/server` passes
- All 820 server package tests pass

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced schema handling infrastructure to support Zod v4 alongside existing Zod v3 support.
  * Improved server route builder to automatically detect and handle different Zod versions for query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->