### PR TITLE
fix(memory): update working memory tool description to match actual behavior

### DIFF
--- a/.changeset/fix-working-memory-tool-description.md
+++ b/.changeset/fix-working-memory-tool-description.md
@@ -1,0 +1,5 @@
+---
+"@mastra/memory": patch
+---
+
+Fixed working memory tool description to accurately reflect merge behavior. The previous description incorrectly stated "Set a field to null to remove it" but null values are stripped by validation before reaching the merge logic. The updated description clarifies: omit fields to preserve existing data, and pass complete arrays or omit them since arrays are replaced entirely.

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -96,7 +96,7 @@ export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfigInternal) => 
   const usesMergeSemantics = Boolean(schema);
 
   const description = schema
-    ? `Update the working memory with new information. Data is merged with existing memory - you only need to include fields you want to add or update. Set a field to null to remove it. Arrays are replaced entirely when provided. NEVER pass empty arrays or objects unless you want to delete the existing value, instead use null to keep existing value.`
+    ? `Update the working memory with new information. Data is merged with existing memory - only include fields you want to add or update. To preserve existing data, omit the field entirely. Arrays are replaced entirely when provided, so pass the complete array or omit it to keep the existing values.`
     : `Update the working memory with new information. Any data not included will be overwritten. Always pass data as string to the memory field. Never pass an object.`;
 
   return createTool({

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -96,7 +96,7 @@ export const updateWorkingMemoryTool = (memoryConfig?: MemoryConfigInternal) => 
   const usesMergeSemantics = Boolean(schema);
 
   const description = schema
-    ? `Update the working memory with new information. Data is merged with existing memory - you only need to include fields you want to add or update. Set a field to null to remove it. Arrays are replaced entirely when provided.`
+    ? `Update the working memory with new information. Data is merged with existing memory - you only need to include fields you want to add or update. Set a field to null to remove it. Arrays are replaced entirely when provided. NEVER pass empty arrays or objects unless you want to delete the existing value, instead use null to keep existing value.`
     : `Update the working memory with new information. Any data not included will be overwritten. Always pass data as string to the memory field. Never pass an object.`;
 
   return createTool({


### PR DESCRIPTION
## Problem

The working memory tool description told LLMs to "Set a field to null to remove it", but this doesn't actually work because the validation layer strips `null` values before they reach `deepMergeWorkingMemory`.

This caused LLMs to send `null` for fields they didn't want to update (especially with OpenAI's reasoning models that convert `.optional()` to `.nullable()`), and also send empty arrays `[]` thinking it was equivalent to omitting the field — but empty arrays actually **replace** existing arrays, causing data loss.

## Solution

Updated the tool description to accurately reflect the actual behavior:
- **To preserve existing data**: omit the field entirely
- **Arrays are replaced entirely**: pass the complete array or omit it to keep existing values

Removed the misleading "Set a field to null to remove it" instruction.

## Testing

Verified with the `working-memory-additive.ts` integration tests that were previously failing due to LLMs sending `"people": []` and wiping out existing data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified memory update behavior: only specified fields are modified; omitted fields preserve existing values.
  * Noted that null values are removed during validation (so omit a field to keep it).
  * Clarified array handling: arrays are replaced entirely when provided—supply the complete array to change it, or omit the array to retain existing items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->