### PR TITLE
fix(llm-recorder): enable LLM recording for memory integration tests

### DIFF
--- a/packages/_llm-recorder/src/vite-plugin.ts
+++ b/packages/_llm-recorder/src/vite-plugin.ts
@@ -121,7 +121,12 @@ function matchesPattern(filepath: string, patterns: string[]): boolean {
         .replace(/\*\*/g, '.*')
         // Replace single * with segment matcher (no path separators)
         .replace(/\*/g, '[^/]*');
-      return new RegExp(`^${regex}$`).test(normalized);
+      // If pattern starts with **, allow matching anywhere in path (after / or at start)
+      // This lets **/*.test.ts match absolute paths like /Users/.../foo.test.ts
+      const startsWithGlobstar = pattern.startsWith('**/');
+      const endAnchor = '\x24'; // $ character
+      const startPrefix = startsWithGlobstar ? '(?:^|/)' : '^';
+      return new RegExp(startPrefix + regex + endAnchor).test(normalized);
     } catch {
       // Invalid pattern — skip it
       return false;

--- a/packages/memory/integration-tests/vitest.config.ts
+++ b/packages/memory/integration-tests/vitest.config.ts
@@ -1,15 +1,15 @@
-// import { llmRecorderPlugin } from '@internal/llm-recorder/vite-plugin';
+import { llmRecorderPlugin } from '@internal/llm-recorder/vite-plugin';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   // Cast to any to avoid vite version mismatch type errors between workspace packages
   plugins: [
-    // llmRecorderPlugin({
-    //   transformRequest: {
-    //     importPath: './src/transform-request',
-    //     exportName: 'transformRequest',
-    //   },
-    // }) as any,
+    llmRecorderPlugin({
+      transformRequest: {
+        importPath: './src/transform-request',
+        exportName: 'transformRequest',
+      },
+    }) as any,
   ],
   test: {
     //pool: 'forks',


### PR DESCRIPTION
## Summary
Fixes LLM recording for memory integration tests by:
1. Uncommenting the `llmRecorderPlugin` in vitest.config.ts
2. Fixing the plugin's pattern matching to handle absolute paths (Vite passes absolute paths to the transform hook)

## Problem
The `**/*.test.ts` pattern wasn't matching because the regex was anchored to the start of the string, but Vite passes absolute paths like `/Users/.../foo.test.ts`.

## Solution
Changed the regex anchor from `^` to `(?:^|/)` so patterns starting with `**/` can match anywhere in the path.

## Test Plan
To re-record all tests:
```bash
cd packages/memory/integration-tests
OPENAI_API_KEY=<key> UPDATE_RECORDINGS=true pnpm test
```

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-5) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pattern matching for paths starting with `**/` to correctly identify both absolute and nested paths.

* **Chores**
  * Enabled LLM recorder plugin in integration test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->