### PR TITLE
fix(core): preserve providerExecuted and providerMetadata when updating tool invocations

### DIFF
--- a/.changeset/fix-tool-invocation-metadata-preservation.md
+++ b/.changeset/fix-tool-invocation-metadata-preservation.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed tool invocation updates to preserve `providerExecuted` and `providerMetadata` from the original tool call when updating to result state.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -648,12 +648,27 @@ export class MessageList {
       for (let i = 0; i < msg.content.parts.length; i++) {
         const part = msg.content.parts[i];
         if (part?.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCallId) {
+          // Cast to access providerExecuted/providerMetadata which exist at runtime but aren't in the base type
+          const originalPart = part as typeof part & { providerExecuted?: boolean; providerMetadata?: unknown };
+          const inputPartWithMeta = inputPart as typeof inputPart & {
+            providerExecuted?: boolean;
+            providerMetadata?: unknown;
+          };
+
           msg.content.parts[i] = {
             ...inputPart,
             toolInvocation: {
               ...inputPart.toolInvocation,
               args: part.toolInvocation.args,
             },
+            // Preserve providerExecuted from original call if not in result
+            ...(originalPart.providerExecuted !== undefined && inputPartWithMeta.providerExecuted === undefined
+              ? { providerExecuted: originalPart.providerExecuted }
+              : {}),
+            // Preserve providerMetadata from original call if not in result
+            ...(originalPart.providerMetadata !== undefined && inputPartWithMeta.providerMetadata === undefined
+              ? { providerMetadata: originalPart.providerMetadata }
+              : {}),
           };
 
           // Move the message to the response source so it gets

--- a/packages/core/src/agent/message-list/tests/update-tool-invocation.test.ts
+++ b/packages/core/src/agent/message-list/tests/update-tool-invocation.test.ts
@@ -375,4 +375,140 @@ describe('MessageList.updateToolInvocation', () => {
     const part = msg.content.parts[0] as any;
     expect(part.providerMetadata).toEqual({ mastra: { modelOutput: true } });
   });
+
+  it('should preserve providerExecuted from original call when result does not include it', () => {
+    const messageList = new MessageList();
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-1',
+          toolName: 'web_search',
+          args: { query: 'test' },
+        },
+        providerExecuted: true,
+      } as any,
+    ]);
+    messageList.add(msg, 'response');
+
+    // Result does NOT include providerExecuted
+    messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'result',
+        toolCallId: 'tc-1',
+        toolName: 'web_search',
+        args: {},
+        result: { data: 'search' },
+      },
+    });
+
+    const part = msg.content.parts[0] as any;
+    expect(part.toolInvocation.state).toBe('result');
+    expect(part.providerExecuted).toBe(true);
+  });
+
+  it('should preserve providerMetadata from original call when result does not include it', () => {
+    const messageList = new MessageList();
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-1',
+          toolName: 'web_search',
+          args: { query: 'test' },
+        },
+        providerMetadata: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+      } as any,
+    ]);
+    messageList.add(msg, 'response');
+
+    // Result does NOT include providerMetadata
+    messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'result',
+        toolCallId: 'tc-1',
+        toolName: 'web_search',
+        args: {},
+        result: { data: 'search' },
+      },
+    });
+
+    const part = msg.content.parts[0] as any;
+    expect(part.toolInvocation.state).toBe('result');
+    expect(part.providerMetadata).toEqual({ anthropic: { cacheControl: { type: 'ephemeral' } } });
+  });
+
+  it('should allow result to override providerExecuted from original call', () => {
+    const messageList = new MessageList();
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-1',
+          toolName: 'web_search',
+          args: { query: 'test' },
+        },
+        providerExecuted: true,
+      } as any,
+    ]);
+    messageList.add(msg, 'response');
+
+    // Result explicitly sets providerExecuted to false
+    messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'result',
+        toolCallId: 'tc-1',
+        toolName: 'web_search',
+        args: {},
+        result: { data: 'search' },
+      },
+      providerExecuted: false,
+    } as any);
+
+    const part = msg.content.parts[0] as any;
+    expect(part.providerExecuted).toBe(false);
+  });
+
+  it('should allow result to override providerMetadata from original call', () => {
+    const messageList = new MessageList();
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-1',
+          toolName: 'web_search',
+          args: { query: 'test' },
+        },
+        providerMetadata: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+      } as any,
+    ]);
+    messageList.add(msg, 'response');
+
+    // Result provides different providerMetadata
+    messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'result',
+        toolCallId: 'tc-1',
+        toolName: 'web_search',
+        args: {},
+        result: { data: 'search' },
+      },
+      providerMetadata: { mastra: { modelOutput: true } },
+    } as any);
+
+    const part = msg.content.parts[0] as any;
+    expect(part.providerMetadata).toEqual({ mastra: { modelOutput: true } });
+  });
 });


### PR DESCRIPTION
## Summary

When `updateToolInvocation` is called to update a tool-call with its result, the code was spreading the input part over the original, which caused `providerExecuted` and `providerMetadata` to be lost if they weren't present in the update.

## Problem

When a tool-result comes through (e.g., from a provider-executed tool like Anthropic's `web_search`), the result chunk typically doesn't include `providerExecuted` or `providerMetadata` - those are set on the original `tool-call`. The old code would overwrite the original part and lose these properties.

## Solution

This fix preserves `providerExecuted` and `providerMetadata` from the original call part when they are not provided in the update.

## Why This Matters

This is a prerequisite for cross-provider history patching. When switching between providers (e.g., Anthropic to OpenAI), we need to know which tool calls were provider-executed so we can handle provider-specific tool call IDs appropriately:
- Anthropic uses `srvtoolu_...` prefixes for provider tools
- OpenAI uses `call_...` prefixes
- OpenAI rejects conversation history with Anthropic-specific tool call IDs

## Test Plan

- Added 4 new tests covering preservation and override behavior for both properties
- All 13 tests in `update-tool-invocation.test.ts` pass
- All 307 tests in `message-list/` pass
- TypeScript compiles without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool invocation metadata and execution status from the original call are now preserved when updating results, unless explicitly overridden by the new result.

* **Tests**
  * Added tests covering preservation and overriding of invocation execution status and metadata across multiple scenarios.

* **Chores**
  * Added a release changeset documenting the metadata preservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->