### PR TITLE
feat: forward harness headers to mastracode model providers

### DIFF
--- a/.changeset/all-meals-sing.md
+++ b/.changeset/all-meals-sing.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed mastracode to forward harness thread and resource headers to model providers.

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -1,3 +1,4 @@
+import { RequestContext } from '@mastra/core/request-context';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Clear the module registry so vi.mock factories take effect even when
@@ -60,21 +61,46 @@ vi.mock('ai', () => ({
 
 // Mock ModelRouterLanguageModel
 vi.mock('@mastra/core/llm', () => ({
-  ModelRouterLanguageModel: vi.fn(function (this: Record<string, unknown>, modelId: string) {
+  ModelRouterLanguageModel: vi.fn(function (
+    this: Record<string, unknown>,
+    config: string | { id: string; url?: string; apiKey?: string; headers?: Record<string, string> },
+  ) {
     this.__provider = 'model-router';
-    this.modelId = modelId;
+    this.modelId = typeof config === 'string' ? config : config.id;
+    this.url = typeof config === 'string' ? undefined : config.url;
+    this.apiKey = typeof config === 'string' ? undefined : config.apiKey;
+    this.headers = typeof config === 'string' ? undefined : config.headers;
   }),
+}));
+
+const mockLoadSettings = vi.hoisted(() =>
+  vi.fn<() => { customProviders: Array<{ name: string; url: string; apiKey?: string }> }>(() => ({ customProviders: [] })),
+);
+
+vi.mock('../../onboarding/settings.js', () => ({
+  loadSettings: mockLoadSettings,
+  getCustomProviderId: (name: string) => name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''),
 }));
 
 import { opencodeClaudeMaxProvider } from '../../providers/claude-max.js';
 import { openaiCodexProvider } from '../../providers/openai-codex.js';
 import { resolveModel, getAnthropicApiKey, getOpenAIApiKey } from '../model.js';
 
+function makeRequestContext({ threadId, resourceId }: { threadId?: string; resourceId?: string } = {}) {
+  const requestContext = new RequestContext();
+  requestContext.set('harness', {
+    threadId,
+    resourceId,
+  });
+  return requestContext;
+}
+
 describe('resolveModel', () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLoadSettings.mockReturnValue({ customProviders: [] });
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.MOONSHOT_AI_API_KEY;
   });
@@ -94,7 +120,7 @@ describe('resolveModel', () => {
 
       resolveModel('anthropic/claude-sonnet-4-20250514');
 
-      expect(opencodeClaudeMaxProvider).toHaveBeenCalledWith('claude-sonnet-4-20250514');
+      expect(opencodeClaudeMaxProvider).toHaveBeenCalledWith('claude-sonnet-4-20250514', { headers: undefined });
     });
 
     it('uses API key when stored credential is api_key, even if isLoggedIn reports true', () => {
@@ -116,7 +142,7 @@ describe('resolveModel', () => {
       const result = resolveModel('anthropic/claude-sonnet-4-20250514') as Record<string, unknown>;
 
       expect(result.__provider).toBe('claude-max-oauth');
-      expect(opencodeClaudeMaxProvider).toHaveBeenCalledWith('claude-sonnet-4-20250514');
+      expect(opencodeClaudeMaxProvider).toHaveBeenCalledWith('claude-sonnet-4-20250514', { headers: undefined });
     });
 
     it('uses stored API key credential when not logged in via OAuth', () => {
@@ -136,7 +162,27 @@ describe('resolveModel', () => {
 
       resolveModel('anthropic/claude-sonnet-4-20250514');
 
-      expect(opencodeClaudeMaxProvider).toHaveBeenCalledWith('claude-sonnet-4-20250514');
+      expect(opencodeClaudeMaxProvider).toHaveBeenCalledWith('claude-sonnet-4-20250514', { headers: undefined });
+    });
+
+    it('passes harness headers to the Anthropic OAuth provider', () => {
+      mockAuthStorageInstance.get.mockReturnValue({
+        type: 'oauth',
+        access: 'oauth-access-token',
+        refresh: 'oauth-refresh-token',
+        expires: Date.now() + 60_000,
+      });
+
+      resolveModel('anthropic/claude-sonnet-4-20250514', {
+        requestContext: makeRequestContext({ threadId: 'thread-123', resourceId: 'resource-456' }),
+      });
+
+      expect(opencodeClaudeMaxProvider).toHaveBeenCalledWith('claude-sonnet-4-20250514', {
+        headers: {
+          'x-thread-id': 'thread-123',
+          'x-resource-id': 'resource-456',
+        },
+      });
     });
 
     it('reloads auth storage before resolving', () => {
@@ -172,12 +218,70 @@ describe('resolveModel', () => {
       const result = resolveModel('openai/gpt-4o') as Record<string, unknown>;
       expect(result.__provider).toBe('model-router');
     });
+
+    it('passes harness headers to the OpenAI OAuth provider', () => {
+      mockAuthStorageInstance.get.mockReturnValue({
+        type: 'oauth',
+        access: 'openai-oauth-access-token',
+        refresh: 'openai-oauth-refresh-token',
+        expires: Date.now() + 60_000,
+      });
+
+      resolveModel('openai/gpt-4o', {
+        requestContext: makeRequestContext({ threadId: 'thread-123', resourceId: 'resource-456' }),
+      });
+
+      expect(openaiCodexProvider).toHaveBeenCalledWith('gpt-4o', {
+        thinkingLevel: undefined,
+        headers: {
+          'x-thread-id': 'thread-123',
+          'x-resource-id': 'resource-456',
+        },
+      });
+    });
   });
 
   describe('other providers', () => {
     it('uses model router for unknown providers', () => {
       const result = resolveModel('google/gemini-2.0-flash') as Record<string, unknown>;
       expect(result.__provider).toBe('model-router');
+    });
+
+    it('passes harness headers to model router providers', () => {
+      const result = resolveModel('google/gemini-2.0-flash', {
+        requestContext: makeRequestContext({ threadId: 'thread-123', resourceId: 'resource-456' }),
+      }) as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.headers).toEqual({
+        'x-thread-id': 'thread-123',
+        'x-resource-id': 'resource-456',
+      });
+    });
+
+    it('passes harness headers to custom providers', () => {
+      mockLoadSettings.mockReturnValue({
+        customProviders: [
+          {
+            name: 'Acme',
+            url: 'https://llm.acme.dev/v1',
+            apiKey: 'acme-secret',
+          },
+        ],
+      });
+
+      const result = resolveModel('acme/reasoner-v1', {
+        requestContext: makeRequestContext({ threadId: 'thread-123', resourceId: 'resource-456' }),
+      }) as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.modelId).toBe('acme/reasoner-v1');
+      expect(result.url).toBe('https://llm.acme.dev/v1');
+      expect(result.apiKey).toBe('acme-secret');
+      expect(result.headers).toEqual({
+        'x-thread-id': 'thread-123',
+        'x-resource-id': 'resource-456',
+      });
     });
   });
 });

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -74,12 +74,18 @@ vi.mock('@mastra/core/llm', () => ({
 }));
 
 const mockLoadSettings = vi.hoisted(() =>
-  vi.fn<() => { customProviders: Array<{ name: string; url: string; apiKey?: string }> }>(() => ({ customProviders: [] })),
+  vi.fn<() => { customProviders: Array<{ name: string; url: string; apiKey?: string }> }>(() => ({
+    customProviders: [],
+  })),
 );
 
 vi.mock('../../onboarding/settings.js', () => ({
   loadSettings: mockLoadSettings,
-  getCustomProviderId: (name: string) => name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''),
+  getCustomProviderId: (name: string) =>
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, ''),
 }));
 
 import { opencodeClaudeMaxProvider } from '../../providers/claude-max.js';

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -24,7 +24,10 @@ function getHarnessState(requestContext: RequestContext) {
  */
 function getObserverModel({ requestContext }: { requestContext: RequestContext }) {
   const state = getHarnessState(requestContext);
-  return resolveModel(state?.observerModelId ?? DEFAULT_OM_MODEL_ID, { remapForCodexOAuth: true });
+  return resolveModel(state?.observerModelId ?? DEFAULT_OM_MODEL_ID, {
+    remapForCodexOAuth: true,
+    requestContext,
+  });
 }
 
 /**
@@ -33,7 +36,10 @@ function getObserverModel({ requestContext }: { requestContext: RequestContext }
  */
 function getReflectorModel({ requestContext }: { requestContext: RequestContext }) {
   const state = getHarnessState(requestContext);
-  return resolveModel(state?.reflectorModelId ?? DEFAULT_OM_MODEL_ID, { remapForCodexOAuth: true });
+  return resolveModel(state?.reflectorModelId ?? DEFAULT_OM_MODEL_ID, {
+    remapForCodexOAuth: true,
+    requestContext,
+  });
 }
 
 /**

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -10,7 +10,6 @@ import { getCustomProviderId, loadSettings } from '../onboarding/settings.js';
 import { opencodeClaudeMaxProvider, promptCacheMiddleware } from '../providers/claude-max.js';
 import { openaiCodexProvider } from '../providers/openai-codex.js';
 import type { ThinkingLevel } from '../providers/openai-codex.js';
-import type { stateSchema } from '../schema.js';
 
 const authStorage = new AuthStorage();
 
@@ -30,6 +29,18 @@ type ResolvedModel =
   | ModelRouterLanguageModel
   | ReturnType<ReturnType<typeof createAnthropic>>
   | ReturnType<ReturnType<typeof createOpenAI>>;
+
+type ModelRequestHeaders = Record<string, string>;
+
+function getHarnessHeaders(requestContext?: RequestContext): ModelRequestHeaders | undefined {
+  const harnessContext = requestContext?.get('harness') as HarnessRequestContext<any> | undefined;
+  const headers = {
+    ...(harnessContext?.threadId ? { 'x-thread-id': harnessContext.threadId } : {}),
+    ...(harnessContext?.resourceId ? { 'x-resource-id': harnessContext.resourceId } : {}),
+  };
+
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
 
 export function remapOpenAIModelForCodexOAuth(modelId: string): string {
   if (!modelId.startsWith(OPENAI_PREFIX)) {
@@ -80,8 +91,8 @@ export function getOpenAIApiKey(): string | undefined {
  * Applies prompt caching but NOT the Claude Code identity middleware
  * (which is only required for Claude Max OAuth).
  */
-function anthropicApiKeyProvider(modelId: string, apiKey: string): LanguageModelV1 {
-  const anthropic = createAnthropic({ apiKey });
+function anthropicApiKeyProvider(modelId: string, apiKey: string, headers?: ModelRequestHeaders): LanguageModelV1 {
+  const anthropic = createAnthropic({ apiKey, headers });
   return wrapLanguageModel({
     model: anthropic(modelId),
     middleware: [promptCacheMiddleware],
@@ -91,10 +102,11 @@ function anthropicApiKeyProvider(modelId: string, apiKey: string): LanguageModel
 /**
  * Create an OpenAI model using a direct API key from AuthStorage.
  */
-function openaiApiKeyProvider(modelId: string, apiKey: string): LanguageModelV1 {
-  const openai = createOpenAI({ apiKey });
+function openaiApiKeyProvider(modelId: string, apiKey: string, headers?: ModelRequestHeaders): LanguageModelV1 {
+  const openai = createOpenAI({ apiKey, headers });
   return wrapLanguageModel({
     model: openai.responses(modelId),
+    middleware: [],
   });
 }
 
@@ -109,9 +121,10 @@ function openaiApiKeyProvider(modelId: string, apiKey: string): LanguageModelV1 
  */
 export function resolveModel(
   modelId: string,
-  options?: { thinkingLevel?: ThinkingLevel; remapForCodexOAuth?: boolean },
+  options?: { thinkingLevel?: ThinkingLevel; remapForCodexOAuth?: boolean; requestContext?: RequestContext },
 ): ResolvedModel {
   authStorage.reload();
+  const headers = getHarnessHeaders(options?.requestContext);
   const [providerId, modelName] = modelId.split('/', 2);
   const settings = loadSettings();
   const customProvider =
@@ -123,9 +136,10 @@ export function resolveModel(
 
   if (customProvider) {
     return new ModelRouterLanguageModel({
-      id: modelId,
+      id: modelId as `${string}/${string}`,
       url: customProvider.url,
       apiKey: customProvider.apiKey,
+      headers,
     });
   }
 
@@ -141,6 +155,7 @@ export function resolveModel(
       apiKey: process.env.MOONSHOT_AI_API_KEY!,
       baseURL: 'https://api.moonshot.ai/anthropic/v1',
       name: 'moonshotai.anthropicv1',
+      headers,
     })(modelId.substring('moonshotai/'.length));
   } else if (isAnthropicModel) {
     const bareModelId = modelId.substring('anthropic/'.length);
@@ -148,21 +163,21 @@ export function resolveModel(
 
     // Primary path: explicit OAuth credential
     if (storedCred?.type === 'oauth') {
-      return opencodeClaudeMaxProvider(bareModelId);
+      return opencodeClaudeMaxProvider(bareModelId, { headers });
     }
 
     // Secondary path: explicit stored API key credential
     if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
-      return anthropicApiKeyProvider(bareModelId, storedCred.key.trim());
+      return anthropicApiKeyProvider(bareModelId, storedCred.key.trim(), headers);
     }
 
     // Fallback: direct API key from AuthStorage
     const apiKey = getAnthropicApiKey();
     if (apiKey) {
-      return anthropicApiKeyProvider(bareModelId, apiKey);
+      return anthropicApiKeyProvider(bareModelId, apiKey, headers);
     }
     // No auth configured — attempt OAuth provider which will prompt login
-    return opencodeClaudeMaxProvider(bareModelId);
+    return opencodeClaudeMaxProvider(bareModelId, { headers });
   } else if (isOpenAIModel) {
     const bareModelId = modelId.substring(OPENAI_PREFIX.length);
     const storedCred = authStorage.get('openai-codex');
@@ -171,17 +186,18 @@ export function resolveModel(
       const resolvedModelId = options?.remapForCodexOAuth ? remapOpenAIModelForCodexOAuth(modelId) : modelId;
       return openaiCodexProvider(resolvedModelId.substring(OPENAI_PREFIX.length), {
         thinkingLevel: options?.thinkingLevel,
+        headers,
       });
     }
 
     const apiKey = getOpenAIApiKey();
     if (apiKey) {
-      return openaiApiKeyProvider(bareModelId, apiKey);
+      return openaiApiKeyProvider(bareModelId, apiKey, headers);
     }
 
-    return new ModelRouterLanguageModel(modelId);
+    return new ModelRouterLanguageModel({ id: modelId as `${string}/${string}`, headers });
   } else {
-    return new ModelRouterLanguageModel(modelId);
+    return new ModelRouterLanguageModel({ id: modelId as `${string}/${string}`, headers });
   }
 }
 
@@ -190,7 +206,7 @@ export function resolveModel(
  * This allows runtime model switching via the /models picker.
  */
 export function getDynamicModel({ requestContext }: { requestContext: RequestContext }): ResolvedModel {
-  const harnessContext = requestContext.get('harness') as HarnessRequestContext<typeof stateSchema> | undefined;
+  const harnessContext = requestContext.get('harness') as HarnessRequestContext<any> | undefined;
 
   const modelId = harnessContext?.state?.currentModelId;
   if (!modelId) {
@@ -199,5 +215,5 @@ export function getDynamicModel({ requestContext }: { requestContext: RequestCon
 
   const thinkingLevel = harnessContext?.state?.thinkingLevel as ThinkingLevel | undefined;
 
-  return resolveModel(modelId, { thinkingLevel });
+  return resolveModel(modelId, { thinkingLevel, requestContext });
 }

--- a/mastracode/src/providers/claude-max.ts
+++ b/mastracode/src/providers/claude-max.ts
@@ -134,11 +134,15 @@ export const promptCacheMiddleware: LanguageModelMiddleware = {
  * Creates an Anthropic model using Claude Max OAuth authentication
  * Uses OAuth tokens from AuthStorage (auto-refreshes when needed)
  */
-export function opencodeClaudeMaxProvider(modelId: string = 'claude-sonnet-4-20250514'): MastraModelConfig {
+export function opencodeClaudeMaxProvider(
+  modelId: string = 'claude-sonnet-4-20250514',
+  options?: { headers?: Record<string, string> },
+): MastraModelConfig {
   // Test environment: use API key
   if (process.env.NODE_ENV === 'test' || process.env.VITEST) {
     const anthropic = createAnthropic({
       apiKey: 'test-api-key',
+      headers: options?.headers,
     });
     return wrapLanguageModel({
       model: anthropic(modelId),
@@ -171,6 +175,7 @@ export function opencodeClaudeMaxProvider(modelId: string = 'claude-sonnet-4-202
     return fetch(url, {
       ...init,
       headers: {
+        ...(init?.headers instanceof Headers ? Object.fromEntries(init.headers.entries()) : (init?.headers ?? {})),
         Authorization: `Bearer ${accessToken}`,
         'anthropic-beta':
           'oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14',
@@ -183,6 +188,7 @@ export function opencodeClaudeMaxProvider(modelId: string = 'claude-sonnet-4-202
     // Provide a dummy API key - the actual auth is handled via OAuth in oauthFetch
     // This prevents the SDK from throwing "API key is missing" at model creation time
     apiKey: 'oauth-placeholder',
+    headers: options?.headers,
     fetch: oauthFetch as any,
   });
 

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -108,7 +108,7 @@ function createCodexMiddleware(reasoningEffort?: string): LanguageModelMiddlewar
  */
 export function openaiCodexProvider(
   modelId: string = 'codex-mini-latest',
-  options?: { thinkingLevel?: ThinkingLevel },
+  options?: { thinkingLevel?: ThinkingLevel; headers?: Record<string, string> },
 ): MastraModelConfig {
   // Map thinkingLevel to OpenAI reasoningEffort, defaulting to 'medium'.
   // When level is 'off', reasoningEffort is undefined and the parameter is omitted.
@@ -122,6 +122,7 @@ export function openaiCodexProvider(
   if (process.env.NODE_ENV === 'test' || process.env.VITEST) {
     const openai = createOpenAI({
       apiKey: 'test-api-key',
+      headers: options?.headers,
     });
     return wrapLanguageModel({
       model: openai.responses(modelId),
@@ -206,6 +207,7 @@ export function openaiCodexProvider(
   const openai = createOpenAI({
     // Use a dummy API key since we're using OAuth
     apiKey: 'oauth-dummy-key',
+    headers: options?.headers,
     fetch: oauthFetch as any,
   });
 

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -242,4 +242,244 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     );
     expect(executeSpy).not.toHaveBeenCalled();
   });
+
+  it('merges model config headers with explicit modelSettings headers and lets modelSettings override duplicates', async () => {
+    const doStream = vi.fn(async () => ({
+      stream: convertArrayToReadableStream([
+        {
+          type: 'response-metadata',
+          id: 'resp-1',
+          modelId: 'mock-model-id',
+          timestamp: new Date(0),
+        },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: testUsage,
+        },
+      ]),
+      request: {},
+      response: {
+        headers: undefined,
+      },
+      warnings: [],
+    }));
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      modelSettings: {
+        headers: {
+          authorization: 'Bearer settings-token',
+          'x-thread-id': 'thread-from-settings',
+          'x-resource-id': 'resource-from-settings',
+          'x-custom-header': 'settings-value',
+        },
+      },
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          headers: {
+            authorization: 'Bearer model-token',
+            'x-model-header': 'model-value',
+          },
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream,
+          } as any,
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+        threadId: 'thread-123',
+        resourceId: 'resource-456',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<{}>);
+
+    const input = createIterationInput();
+    input.stepResult.isContinued = false;
+
+    await llmExecutionStep.execute(createExecuteParams(input));
+
+    expect(doStream).toHaveBeenCalledOnce();
+    expect(doStream.mock.calls[0]?.[0]?.headers).toEqual({
+      authorization: 'Bearer settings-token',
+      'x-model-header': 'model-value',
+      'x-thread-id': 'thread-from-settings',
+      'x-resource-id': 'resource-from-settings',
+      'x-custom-header': 'settings-value',
+    });
+  });
+
+  it('preserves model config headers when modelSettings adds non-conflicting headers', async () => {
+    const doStream = vi.fn(async () => ({
+      stream: convertArrayToReadableStream([
+        {
+          type: 'response-metadata',
+          id: 'resp-1',
+          modelId: 'mock-model-id',
+          timestamp: new Date(0),
+        },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: testUsage,
+        },
+      ]),
+      request: {},
+      response: {
+        headers: undefined,
+      },
+      warnings: [],
+    }));
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      modelSettings: {
+        headers: {
+          'x-custom-header': 'settings-value',
+        },
+      },
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          headers: {
+            authorization: 'Bearer model-token',
+          },
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream,
+          } as any,
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+        threadId: 'thread-123',
+        resourceId: 'resource-456',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<{}>);
+
+    const input = createIterationInput();
+    input.stepResult.isContinued = false;
+
+    await llmExecutionStep.execute(createExecuteParams(input));
+
+    expect(doStream).toHaveBeenCalledOnce();
+    expect(doStream.mock.calls[0]?.[0]?.headers).toEqual({
+      authorization: 'Bearer model-token',
+      'x-custom-header': 'settings-value',
+    });
+  });
+
+  it('should not create headers when neither model nor modelSettings provide them', async () => {
+    const doStream = vi.fn(async () => ({
+      stream: convertArrayToReadableStream([
+        {
+          type: 'response-metadata',
+          id: 'resp-1',
+          modelId: 'mock-model-id',
+          timestamp: new Date(0),
+        },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: testUsage,
+        },
+      ]),
+      request: {},
+      response: {
+        headers: undefined,
+      },
+      warnings: [],
+    }));
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream,
+          } as any,
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<{}>);
+
+    const input = createIterationInput();
+    input.stepResult.isContinued = false;
+
+    await llmExecutionStep.execute(createExecuteParams(input));
+
+    expect(doStream).toHaveBeenCalledOnce();
+    expect(doStream.mock.calls[0]?.[0]?.headers).toBeUndefined();
+  });
 });


### PR DESCRIPTION
This forwards harness thread/resource headers through mastracode model resolution so OAuth, API key, and custom provider paths all receive them.

Before:
```ts
resolveModel(modelId)
```

After:
```ts
resolveModel(modelId, { requestContext })
// sends x-thread-id / x-resource-id when available
```

I also added coverage for the custom provider path in mastracode and kept the core header-merge tests focused on generic model header behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed thread and resource context identifiers not being properly forwarded to model providers, improving request traceability throughout agent operations.

* **New Features**
  * Model providers now receive and process context headers for enhanced request tracking and context preservation across agent executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->