### PR TITLE
fix(core): escape dollar signs in replaceString to prevent regex backreference interpretation

### DIFF
--- a/.changeset/fix-string-replace-dollar-sign.md
+++ b/.changeset/fix-string-replace-dollar-sign.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `replaceString` utility to properly escape `$` characters in replacement strings. Previously, patterns like `$&` in the replacement text would be interpreted as regex backreferences instead of literal text.

--- a/packages/core/src/workspace/line-utils.ts
+++ b/packages/core/src/workspace/line-utils.ts
@@ -189,13 +189,17 @@ export function replaceString(
     throw new StringNotUniqueError(oldString, count);
   }
 
+  // Escape $ in newString to prevent replacement pattern interpretation.
+  // In String.prototype.replace(), $& means "matched substring", $$ means literal $, etc.
+  // We want literal replacement, so escape all $ as $$.
+  const escapedNewString = newString.replace(/\$/g, '$$$$');
   if (replaceAll) {
-    // Replace all occurrences
+    // Replace all occurrences - split/join doesn't interpret $ patterns
     const result = content.split(oldString).join(newString);
     return { content: result, replacements: count };
   } else {
-    // Replace first (and only) occurrence
-    const result = content.replace(oldString, newString);
+    // Replace first (and only) occurrence - use escaped string
+    const result = content.replace(oldString, escapedNewString);
     return { content: result, replacements: 1 };
   }
 }


### PR DESCRIPTION
## Summary

Fixes a bug in the `replaceString` utility where `$` characters in replacement strings were interpreted as regex backreferences instead of literal text.

## Problem

In JavaScript's `String.prototype.replace()`, special patterns in the replacement string are interpreted:
- `$&` → inserts the matched substring
- `$$` → inserts a literal `$`
- `$'` → inserts the portion of the string after the match
- etc.

This caused issues when replacement text contained literal `$` characters (e.g., `'\\$&'` in regex patterns).

## Solution

Escape all `$` characters as `$$` before passing to `replace()`, ensuring the replacement is literal.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added a changeset for this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed string replacement functionality to correctly handle dollar signs in replacement text. Dollar signs are now treated as literal characters instead of being interpreted as regex backreferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->