### PR TITLE
fix(test): set dummy keys in router e2e replay mode

### DIFF
--- a/.changeset/chatty-falcons-punch.md
+++ b/.changeset/chatty-falcons-punch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed replay-mode router integration tests by setting dummy API keys before model validation.

--- a/.changeset/chatty-falcons-punch.md
+++ b/.changeset/chatty-falcons-punch.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': patch
----
-
-Fixed replay-mode router integration tests by setting dummy API keys before model validation.

--- a/packages/core/src/agent/__tests__/stream.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/stream.e2e.test.ts
@@ -6,7 +6,8 @@ import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import type { LanguageModelV3 } from '@ai-sdk/provider-v6';
 import type { ToolInvocationUIPart } from '@ai-sdk/ui-utils-v5';
 import type { LanguageModelV1 } from '@internal/ai-sdk-v4';
-import { createGatewayMock } from '@internal/test-utils';
+import { getLLMTestMode } from '@internal/llm-recorder';
+import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
 import { config } from 'dotenv';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import z from 'zod';
@@ -21,6 +22,9 @@ import { MessageList } from '../message-list/index';
 import { assertNoDuplicateParts } from '../test-utils';
 
 config();
+
+const MODE = getLLMTestMode();
+setupDummyApiKeys(MODE, ['openai']);
 
 const mock = createGatewayMock();
 beforeAll(() => mock.start());

--- a/packages/core/src/agent/__tests__/tool-suspension.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/tool-suspension.e2e.test.ts
@@ -1,10 +1,14 @@
-import { createGatewayMock } from '@internal/test-utils';
+import { getLLMTestMode } from '@internal/llm-recorder';
+import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { MockMemory } from '../../memory/mock';
 import { createTool } from '../../tools';
 import { delay } from '../../utils';
 import { Agent } from '../agent';
+
+const MODE = getLLMTestMode();
+setupDummyApiKeys(MODE, ['openai']);
 
 const mock = createGatewayMock();
 beforeAll(() => mock.start());

--- a/packages/core/src/llm/model/router.e2e.test.ts
+++ b/packages/core/src/llm/model/router.e2e.test.ts
@@ -1,7 +1,11 @@
-import { createGatewayMock } from '@internal/test-utils';
+import { getLLMTestMode } from '@internal/llm-recorder';
+import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
 import { afterAll, beforeAll, describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import { Agent } from '../../agent/index.js';
+
+const MODE = getLLMTestMode();
+setupDummyApiKeys(MODE, ['openai', 'anthropic', 'google', 'openrouter']);
 
 const mock = createGatewayMock();
 beforeAll(() => mock.start());


### PR DESCRIPTION
## Summary
- update the router model e2e test to initialize replay-mode dummy API keys
- keep the existing gateway mock flow so recorded/replayed provider requests still work
- add a patch changeset for @mastra/core

## Test Plan
- pnpm vitest run packages/core/src/llm/model/router.e2e.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test setup across agent streaming, tool suspension, and model routing test modules with enhanced LLM test mode initialization and automatic dummy API key configuration. Strengthens test environment consistency and simplifies test infrastructure management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->