### PR TITLE
fix(core): return top-level agent run span ID instead of nested model spans

### DIFF
--- a/.changeset/fair-garlics-relax.md
+++ b/.changeset/fair-garlics-relax.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent.stream() so the returned spanId matches the top-level agent run span instead of the nested model span.

--- a/observability/mastra/src/integration-tests.test.ts
+++ b/observability/mastra/src/integration-tests.test.ts
@@ -923,6 +923,7 @@ describe('Tracing Integration Tests', () => {
 
     expect(fullText).toBe('Mock V2 stream response');
     expect(result.traceId).toBeDefined();
+    expect(result.spanId).toBeDefined();
 
     const [agentRunSpan] = testExporter.getSpansByType(SpanType.AGENT_RUN);
     const [modelGenerationSpan] = testExporter.getSpansByType(SpanType.MODEL_GENERATION);
@@ -935,6 +936,7 @@ describe('Tracing Integration Tests', () => {
     expect(rootSpans).toHaveLength(1);
     expect(rootSpans[0]?.id).toBe(agentRunSpan?.id);
     expect(agentRunSpan?.traceId).toBe(result.traceId);
+    expect(result.spanId).toBe(agentRunSpan?.id);
     expect(modelGenerationSpan?.parentSpanId).toBe(agentRunSpan?.id);
     expect(modelStepSpan?.parentSpanId).toBe(modelGenerationSpan?.id);
 

--- a/observability/mastra/src/integration-tests.test.ts
+++ b/observability/mastra/src/integration-tests.test.ts
@@ -900,6 +900,47 @@ describe('Tracing Integration Tests', () => {
     },
   );
 
+  it('should export agent stream spans with AGENT_RUN as the root span', async () => {
+    const testAgent = new Agent({
+      id: 'test-agent-stream-root',
+      name: 'Test Agent Stream Root',
+      instructions: 'You are a test agent',
+      model: mockModelV2,
+    });
+
+    const mastra = new Mastra({
+      ...getBaseMastraConfig(testExporter),
+      agents: { testAgent },
+    });
+
+    const agent = mastra.getAgent('testAgent');
+    const result = await agent.stream('Hello');
+
+    let fullText = '';
+    for await (const chunk of result.textStream) {
+      fullText += chunk;
+    }
+
+    expect(fullText).toBe('Mock V2 stream response');
+    expect(result.traceId).toBeDefined();
+
+    const [agentRunSpan] = testExporter.getSpansByType(SpanType.AGENT_RUN);
+    const [modelGenerationSpan] = testExporter.getSpansByType(SpanType.MODEL_GENERATION);
+    const [modelStepSpan] = testExporter.getSpansByType(SpanType.MODEL_STEP);
+    const rootSpans = testExporter.getRootSpans();
+
+    expect(agentRunSpan).toBeDefined();
+    expect(modelGenerationSpan).toBeDefined();
+    expect(modelStepSpan).toBeDefined();
+    expect(rootSpans).toHaveLength(1);
+    expect(rootSpans[0]?.id).toBe(agentRunSpan?.id);
+    expect(agentRunSpan?.traceId).toBe(result.traceId);
+    expect(modelGenerationSpan?.parentSpanId).toBe(agentRunSpan?.id);
+    expect(modelStepSpan?.parentSpanId).toBe(modelGenerationSpan?.id);
+
+    finalExpectations(testExporter);
+  });
+
   describe.each(agentMethods)('should trace agent using structuredOutput format using $name', ({ method, model }) => {
     it(`should trace spans correctly`, async () => {
       const testAgent = new Agent({

--- a/packages/core/src/agent/__tests__/stream-id.test.ts
+++ b/packages/core/src/agent/__tests__/stream-id.test.ts
@@ -4,8 +4,10 @@ import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { Observability, TestExporter } from '../../../../../observability/mastra/src';
 import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
+import { SpanType } from '../../observability';
 import type { Processor } from '../../processors';
 import { createTool } from '../../tools';
 import { Agent } from '../agent';
@@ -278,6 +280,69 @@ describe('Stream ID Consistency', () => {
     expect(savedMessages).toHaveLength(1);
     expect(savedMessages[0].id).toBe(messageId!);
     expect(customIdGenerator).toHaveBeenCalled();
+  });
+
+  it('should expose the root agent span ID on traced stream results', async () => {
+    const testExporter = new TestExporter({ logMetricsOnFlush: false, storeLogs: false });
+    const tracedMastra = new Mastra({
+      logger: false,
+      observability: new Observability({
+        configs: {
+          default: {
+            serviceName: 'stream-span-id-test',
+            exporters: [testExporter],
+          },
+        },
+      }),
+      agents: {
+        assistant: new Agent({
+          id: 'assistant',
+          name: 'Assistant',
+          instructions: 'You are a concise assistant.',
+          model: new MockLanguageModelV2({
+            doStream: async () => ({
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              warnings: [],
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'response-metadata',
+                  id: 'v2-msg-span-test',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: 'text-1' },
+                { type: 'text-delta', id: 'text-1', delta: 'Hello from Mastra.' },
+                { type: 'text-end', id: 'text-1' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                },
+              ]),
+            }),
+          }),
+        }),
+      },
+    });
+
+    try {
+      const streamResult = await tracedMastra.getAgent('assistant').stream('Say hello from Mastra in one sentence.');
+
+      await streamResult.consumeStream();
+      await tracedMastra.observability.getDefaultInstance()?.flush();
+
+      const [agentRunSpan] = testExporter.getSpansByType(SpanType.AGENT_RUN);
+      const [modelGenerationSpan] = testExporter.getSpansByType(SpanType.MODEL_GENERATION);
+
+      expect(agentRunSpan).toBeDefined();
+      expect(modelGenerationSpan).toBeDefined();
+      expect(streamResult.traceId).toBe(agentRunSpan?.traceId);
+      expect(streamResult.spanId).not.toBe(modelGenerationSpan?.id);
+      expect(streamResult.spanId).toBe(agentRunSpan?.id);
+    } finally {
+      await tracedMastra.observability.shutdown();
+    }
   });
 
   it('should let processInputStep rotate the active response message ID for stream output and persistence', async () => {

--- a/packages/core/src/agent/__tests__/stream-id.test.ts
+++ b/packages/core/src/agent/__tests__/stream-id.test.ts
@@ -4,10 +4,8 @@ import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { Observability, TestExporter } from '../../../../../observability/mastra/src';
 import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
-import { SpanType } from '../../observability';
 import type { Processor } from '../../processors';
 import { createTool } from '../../tools';
 import { Agent } from '../agent';
@@ -280,69 +278,6 @@ describe('Stream ID Consistency', () => {
     expect(savedMessages).toHaveLength(1);
     expect(savedMessages[0].id).toBe(messageId!);
     expect(customIdGenerator).toHaveBeenCalled();
-  });
-
-  it('should expose the root agent span ID on traced stream results', async () => {
-    const testExporter = new TestExporter({ logMetricsOnFlush: false, storeLogs: false });
-    const tracedMastra = new Mastra({
-      logger: false,
-      observability: new Observability({
-        configs: {
-          default: {
-            serviceName: 'stream-span-id-test',
-            exporters: [testExporter],
-          },
-        },
-      }),
-      agents: {
-        assistant: new Agent({
-          id: 'assistant',
-          name: 'Assistant',
-          instructions: 'You are a concise assistant.',
-          model: new MockLanguageModelV2({
-            doStream: async () => ({
-              rawCall: { rawPrompt: null, rawSettings: {} },
-              warnings: [],
-              stream: convertArrayToReadableStream([
-                { type: 'stream-start', warnings: [] },
-                {
-                  type: 'response-metadata',
-                  id: 'v2-msg-span-test',
-                  modelId: 'mock-model-id',
-                  timestamp: new Date(0),
-                },
-                { type: 'text-start', id: 'text-1' },
-                { type: 'text-delta', id: 'text-1', delta: 'Hello from Mastra.' },
-                { type: 'text-end', id: 'text-1' },
-                {
-                  type: 'finish',
-                  finishReason: 'stop',
-                  usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-                },
-              ]),
-            }),
-          }),
-        }),
-      },
-    });
-
-    try {
-      const streamResult = await tracedMastra.getAgent('assistant').stream('Say hello from Mastra in one sentence.');
-
-      await streamResult.consumeStream();
-      await tracedMastra.observability.getDefaultInstance()?.flush();
-
-      const [agentRunSpan] = testExporter.getSpansByType(SpanType.AGENT_RUN);
-      const [modelGenerationSpan] = testExporter.getSpansByType(SpanType.MODEL_GENERATION);
-
-      expect(agentRunSpan).toBeDefined();
-      expect(modelGenerationSpan).toBeDefined();
-      expect(streamResult.traceId).toBe(agentRunSpan?.traceId);
-      expect(streamResult.spanId).not.toBe(modelGenerationSpan?.id);
-      expect(streamResult.spanId).toBe(agentRunSpan?.id);
-    } finally {
-      await tracedMastra.observability.shutdown();
-    }
   });
 
   it('should let processInputStep rotate the active response message ID for stream output and persistence', async () => {

--- a/packages/core/src/observability/utils.ts
+++ b/packages/core/src/observability/utils.ts
@@ -104,3 +104,28 @@ export function executeWithContextSync<T>(params: { span?: AnySpan; fn: () => T 
 
   return fn();
 }
+
+/**
+ * Returns the top-most non-internal span that would appear in exported tracing output.
+ *
+ * Public API results should use this span for trace/span correlation because internal Mastra
+ * workflow spans are omitted from external exporters.
+ */
+export function getRootExportSpan(span?: AnySpan): AnySpan | undefined {
+  if (!span?.isValid) {
+    return undefined;
+  }
+
+  let current: AnySpan | undefined = span;
+  let rootExportSpan: AnySpan | undefined = span.isInternal ? undefined : span;
+
+  while (current?.parent) {
+    current = current.parent;
+
+    if (!current.isInternal) {
+      rootExportSpan = current;
+    }
+  }
+
+  return rootExportSpan;
+}

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -175,6 +175,33 @@ describe('MastraModelOutput', () => {
       const messageList = new MessageList({ threadId: 'test-thread' });
 
       const stream = createChunkStream([createStepFinishChunk(runId), createFinishChunk(runId)]);
+      const agentRunSpan = {
+        id: 'mastra-agent-span-id',
+        externalTraceId: 'mastra-trace-id',
+        isInternal: false,
+        isValid: true,
+      };
+      const workflowStepSpan = {
+        id: 'mastra-workflow-step-span-id',
+        externalTraceId: 'mastra-trace-id',
+        isInternal: true,
+        isValid: true,
+        parent: agentRunSpan,
+      };
+      const modelGenerationSpan = {
+        id: 'mastra-model-span-id',
+        externalTraceId: 'mastra-trace-id',
+        isInternal: false,
+        isValid: true,
+        parent: workflowStepSpan,
+      };
+      const modelStepSpan = {
+        id: 'mastra-model-step-span-id',
+        externalTraceId: 'mastra-trace-id',
+        isInternal: false,
+        isValid: true,
+        parent: modelGenerationSpan,
+      };
 
       const output = new MastraModelOutput({
         model: { modelId: 'test-model', provider: 'test', version: 'v3' },
@@ -184,10 +211,7 @@ describe('MastraModelOutput', () => {
         options: {
           runId,
           tracingContext: {
-            currentSpan: {
-              id: 'mastra-root-span-id',
-              externalTraceId: 'mastra-trace-id',
-            },
+            currentSpan: modelStepSpan,
           } as any,
         },
       });
@@ -196,7 +220,7 @@ describe('MastraModelOutput', () => {
       const result = await output.getFullOutput();
 
       expect(result.traceId).toBe('mastra-trace-id');
-      expect(result.spanId).toBe('mastra-root-span-id');
+      expect(result.spanId).toBe('mastra-agent-span-id');
     });
   });
 });

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -7,7 +7,7 @@ import { MastraBase } from '../../base';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import { getErrorFromUnknown } from '../../error/utils.js';
 import type { ScorerRunInputForAgent, ScorerRunOutputForAgent } from '../../evals';
-import { resolveObservabilityContext } from '../../observability';
+import { getRootExportSpan, resolveObservabilityContext } from '../../observability';
 import type { OutputResult } from '../../processors';
 import { STRUCTURED_OUTPUT_PROCESSOR_NAME } from '../../processors/processors/structured-output';
 import { ProcessorState, ProcessorRunner } from '../../processors/runner';
@@ -281,8 +281,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     this.#transportRef = options.transportRef;
     this.#returnScorerData = !!options.returnScorerData;
     this.runId = options.runId;
-    this.traceId = options.tracingContext?.currentSpan?.externalTraceId;
-    this.spanId = options.tracingContext?.currentSpan?.id;
+    const resultSpan = getRootExportSpan(options.tracingContext?.currentSpan);
+    this.traceId = resultSpan?.externalTraceId;
+    this.spanId = resultSpan?.id;
 
     this.#model = _model;
 

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -125,9 +125,9 @@ export type FullOutput<OUTPUT = undefined> = {
     input: Omit<ScorerRunInputForAgent, 'runId'>;
     output: ScorerRunOutputForAgent;
   };
-  /** Trace ID for observability */
+  /** Trace ID for this execution. */
   traceId: string | undefined;
-  /** Span ID for observability (root span ID for a top-level agent execution) */
+  /** Root span ID for this execution, identifying the top-level span in the trace. */
   spanId: string | undefined;
   /** Run ID for this execution */
   runId: string | undefined;
@@ -248,11 +248,11 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
    */
   public messageList: MessageList;
   /**
-   * Trace ID used on the execution (if the execution was traced).
+   * Trace ID for this execution.
    */
   public traceId?: string;
   /**
-   * Span ID used on the execution (if the execution was traced).
+   * Root span ID for this execution, identifying the top-level span in the trace.
    */
   public spanId?: string;
   public messageId: string;


### PR DESCRIPTION
### Summary

Fix `stream.spanId` / `stream.traceId` so public stream results point to the root exported span, not whichever nested span happens to be active during execution.

### Problem

MastraModelOutput was deriving traceId and spanId from tracingContext.currentSpan. In real agent.stream() execution, that span can be a workflow step, model generation, or model step span, so the returned spanId could point to an internal or nested child instead of the root span users see in e.g. Braintrust.

### Reasoning

`currentSpan` is an execution-local cursor, not a stable public API identifier. For public-facing APIs, the returned spanId should match the root span of the trace tree that is actually exported. That keeps lookup and correlation consistent even when internal workflow/model spans are active.

### What changed

- Added a helper to resolve the top-most non-internal exported span from the current tracing context.
- Updated `MastraModelOutput` to use that exported root span for `traceId` / `spanId`.
- Kept the behavior generic so it applies to public APIs beyond just `agent.stream()`.

### Tests

- Added a regression test covering the real traced `agent.stream()` path.
- Added a unit test proving nested/internal current spans still resolve to the exported root span.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent.stream() to correctly return the root agent run span ID instead of nested model span ID for improved trace correlation in observability integrations.
  * Results now properly expose rootSpanId for clearer span context across traced operations.

* **Tests**
  * Added integration tests validating proper span hierarchy, parent-child span relationships, and root span exposure in agent stream operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->