### PR TITLE
fix(schema-compat): add draft-2020-12 fallback to Zod v3 adapter TARGET_MAP

### DIFF
--- a/.changeset/fix-schema-compat-zod-v3-draft-2020-12.md
+++ b/.changeset/fix-schema-compat-zod-v3-draft-2020-12.md
@@ -1,0 +1,5 @@
+---
+"@mastra/schema-compat": patch
+---
+
+Fixed crash when serializing tools with Zod v3 schemas using the draft-2020-12 JSON Schema target. Previously threw "Unsupported JSON Schema target: draft-2020-12" — now falls back to draft-07 output, matching the behavior of the Zod v4 adapter.

--- a/packages/schema-compat/src/standard-schema/adapters/zod-v3.test.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/zod-v3.test.ts
@@ -88,6 +88,17 @@ describe('zod-v3 standard-schema adapter', () => {
       // For Zod schemas, input and output JSON schemas are typically the same
       expect(inputJsonSchema).toEqual(outputJsonSchema);
     });
+    it('should fall back to draft-07 for draft-2020-12 target', () => {
+      const zodSchema = z.object({
+        name: z.string(),
+      });
+      const standardSchema = toStandardSchema(zodSchema);
+      const outputSchema = standardSchema['~standard'].jsonSchema.output({ target: 'draft-2020-12' });
+      // Zod v3 does not support draft-2020-12 natively — falls back to jsonSchema7 (draft-07)
+      expect(outputSchema).toBeDefined();
+      expect(outputSchema.type).toBe('object');
+      expect(outputSchema.properties).toHaveProperty('name');
+    });
 
     it('should throw for unsupported targets', () => {
       const zodSchema = z.object({

--- a/packages/schema-compat/src/standard-schema/adapters/zod-v3.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/zod-v3.ts
@@ -14,6 +14,8 @@ import type {
 const TARGET_MAP: Record<string, ZodToJsonSchemaTarget> = {
   'draft-07': 'jsonSchema7',
   'openapi-3.0': 'openApi3',
+  // draft-2020-12 is not supported by zod-to-json-schema, fall back to jsonSchema7
+  'draft-2020-12': 'jsonSchema7',
 };
 
 /**


### PR DESCRIPTION
Closes #14446

## Root cause

`packages/schema-compat/src/standard-schema/adapters/zod-v3.ts` only had
`draft-07` and `openapi-3.0` in its `TARGET_MAP`. When
`schemaToJsonSchema()` in `agents.ts` calls
`standardSchemaToJSONSchema(toStandardSchema(schema), { target: 'draft-2020-12' })`
and the schema is a Zod v3 schema, the v3 adapter throws:
```
Unsupported JSON Schema target: "draft-2020-12". Supported targets are: draft-07, openapi-3.0
```
## Fix

Added `draft-2020-12` to the `TARGET_MAP` mapping to `jsonSchema7` as a
fallback — identical to how the Zod v4 adapter handles unsupported targets.
Zod v3's `zod-to-json-schema` library does not natively support
`draft-2020-12`, so `jsonSchema7` (draft-07) is the closest valid output.

## Changes

- Added `'draft-2020-12': 'jsonSchema7'` to `TARGET_MAP` in `zod-v3.ts`
- Added test verifying `draft-2020-12` no longer throws and produces valid output
- Added changeset for `@mastra/schema-compat`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when serializing tools with Zod v3 schemas when targeting draft-2020-12 JSON Schema format. The adapter now automatically falls back to draft-07 output for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->