### PR TITLE
chore(docs): Update Auth docs

### DIFF
--- a/docs/src/content/en/docs/deployment/studio.mdx
+++ b/docs/src/content/en/docs/deployment/studio.mdx
@@ -57,6 +57,8 @@ Running `mastra studio` as a long-running process is no different from running a
 
 Once Studio is connected to your Mastra server, it has full access to your agents, workflows, and tools. Be sure to secure it properly in production (e.g. behind authentication, VPN, etc.) to prevent unauthorized access.
 
+Visit the [Authentication](/docs/server/auth/) docs to learn more.
+
 :::
 
 ### Alongside your API

--- a/docs/src/content/en/docs/server/auth/auth0.mdx
+++ b/docs/src/content/en/docs/server/auth/auth0.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MastraAuthAuth0 class | Auth"
-description: "Documentation for the MastraAuthAuth0 class, which authenticates Mastra applications using Auth0 authentication."
+title: "Auth0 | Auth"
+description: "Documentation for the @mastra/auth-auth0 package, which authenticates Mastra applications using Auth0 authentication."
 packages:
   - "@mastra/auth-auth0"
   - "@mastra/client-js"
@@ -10,9 +10,9 @@ packages:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# MastraAuthAuth0 class
+# Auth0
 
-The `MastraAuthAuth0` class provides authentication for Mastra using Auth0. It verifies incoming requests using Auth0-issued JWT tokens and integrates with the Mastra server using the `auth` option.
+The `@mastra/auth-auth0` package provides authentication for Mastra using Auth0. It verifies incoming requests using Auth0-issued JWT tokens and integrates with the Mastra server using the `auth` option.
 
 ## Prerequisites
 
@@ -40,7 +40,7 @@ For detailed setup instructions, refer to the [Auth0 quickstarts](https://auth0.
 
 Before you can use the `MastraAuthAuth0` class you have to install the `@mastra/auth-auth0` package.
 
-```bash
+```bash npm2yarn
 npm install @mastra/auth-auth0@latest
 ```
 
@@ -113,7 +113,7 @@ When using Auth0 auth, you'll need to set up the Auth0 React SDK, authenticate u
 
 First, install and configure the Auth0 React SDK in your application:
 
-```bash
+```bash npm2yarn
 npm install @auth0/auth0-react
 ```
 

--- a/docs/src/content/en/docs/server/auth/better-auth.mdx
+++ b/docs/src/content/en/docs/server/auth/better-auth.mdx
@@ -1,5 +1,5 @@
 ---
-title: MastraAuthBetterAuth Class
+title: "Better Auth | Auth"
 description: Authenticate your Mastra server using Better Auth (self-hosted, open-source auth).
 packages:
   - "@mastra/auth-better-auth"
@@ -8,7 +8,9 @@ packages:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-The `MastraAuthBetterAuth` class provides authentication for Mastra using Better Auth. It verifies incoming requests using your Better Auth instance and integrates with the Mastra server via the `server.auth` option.
+# Better Auth
+
+The `@mastra/auth-better-auth` package provides authentication for Mastra using Better Auth. It verifies incoming requests using your Better Auth instance and integrates with the Mastra server via the `server.auth` option.
 
 ## Prerequisites
 

--- a/docs/src/content/en/docs/server/auth/clerk.mdx
+++ b/docs/src/content/en/docs/server/auth/clerk.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MastraAuthClerk class | Auth"
-description: "Documentation for the MastraAuthClerk class, which authenticates Mastra applications using Clerk authentication."
+title: "Clerk | Auth"
+description: "Documentation for the `@mastra/auth-clerk` package, which authenticates Mastra applications using Clerk authentication."
 packages:
   - "@mastra/auth-clerk"
   - "@mastra/client-js"
@@ -10,9 +10,9 @@ packages:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# MastraAuthClerk class
+# Clerk
 
-The `MastraAuthClerk` class provides authentication for Mastra using Clerk. It verifies incoming requests using Clerk's authentication system and integrates with the Mastra server using the `auth` option.
+The `@mastra/auth-clerk` package provides authentication for Mastra using Clerk. It verifies incoming requests using Clerk's authentication system and integrates with the Mastra server using the `auth` option.
 
 ## Prerequisites
 
@@ -34,7 +34,7 @@ You can find these keys in your Clerk Dashboard under "API Keys".
 
 Before you can use the `MastraAuthClerk` class you have to install the `@mastra/auth-clerk` package.
 
-```bash
+```bash npm2yarn
 npm install @mastra/auth-clerk@latest
 ```
 

--- a/docs/src/content/en/docs/server/auth/composite-auth.mdx
+++ b/docs/src/content/en/docs/server/auth/composite-auth.mdx
@@ -1,11 +1,11 @@
 ---
-title: "CompositeAuth class | Auth"
+title: "Composite Auth | Auth"
 description: "Documentation for the CompositeAuth class, which combines multiple authentication providers into a single auth handler."
 packages:
   - "@mastra/core"
 ---
 
-# CompositeAuth class
+# Composite Auth
 
 The `CompositeAuth` class allows you to combine multiple authentication providers into a single auth handler. It tries each provider in order until one succeeds.
 

--- a/docs/src/content/en/docs/server/auth/custom-auth-provider.mdx
+++ b/docs/src/content/en/docs/server/auth/custom-auth-provider.mdx
@@ -6,7 +6,7 @@ packages:
   - "@mastra/auth"
 ---
 
-# Custom auth providers
+# Custom auth provider
 
 Custom auth providers allow you to implement authentication for identity systems that aren't covered by the built-in providers. Extend the `MastraAuthProvider` base class to integrate with any authentication system.
 

--- a/docs/src/content/en/docs/server/auth/firebase.mdx
+++ b/docs/src/content/en/docs/server/auth/firebase.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MastraAuthFirebase class | Auth"
-description: "Documentation for the MastraAuthFirebase class, which authenticates Mastra applications using Firebase Authentication."
+title: "Firebase | Auth"
+description: "Documentation for the `@mastra/auth-firebase` package, which authenticates Mastra applications using Firebase Authentication."
 packages:
   - "@mastra/auth-firebase"
   - "@mastra/client-js"
@@ -10,9 +10,9 @@ packages:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# MastraAuthFirebase class
+# Firebase
 
-The `MastraAuthFirebase` class provides authentication for Mastra using Firebase Authentication. It verifies incoming requests using Firebase ID tokens and integrates with the Mastra server using the `auth` option.
+The `@mastra/auth-firebase` package provides authentication for Mastra using Firebase Authentication. It verifies incoming requests using Firebase ID tokens and integrates with the Mastra server using the `auth` option.
 
 ## Prerequisites
 
@@ -40,7 +40,7 @@ Store your service account JSON file securely and never commit it to version con
 
 Before you can use the `MastraAuthFirebase` class you have to install the `@mastra/auth-firebase` package.
 
-```bash
+```bash npm2yarn
 npm install @mastra/auth-firebase@latest
 ```
 

--- a/docs/src/content/en/docs/server/auth/index.mdx
+++ b/docs/src/content/en/docs/server/auth/index.mdx
@@ -26,8 +26,8 @@ See [Custom API Routes](/docs/server/custom-api-routes#authentication) for contr
 
 ### Built-in
 
-- [Simple Auth](/docs/server/auth/simple-auth) - Token-to-user mapping for development and API keys
-- [JSON Web Token (JWT)](/docs/server/auth/jwt) - HMAC-signed JWT verification
+- [Simple Auth](/docs/server/auth/simple-auth): Token-to-user mapping for development and API keys
+- [JSON Web Token (JWT)](/docs/server/auth/jwt): HMAC-signed JWT verification
 
 ### Third-party integrations
 
@@ -40,5 +40,5 @@ See [Custom API Routes](/docs/server/custom-api-routes#authentication) for contr
 
 ### Advanced
 
-- [Composite Auth](/docs/server/auth/composite-auth) - Combine multiple auth providers
-- [Custom Auth Provider](/docs/server/auth/custom-auth-provider) - Build your own provider
+- [Composite Auth](/docs/server/auth/composite-auth): Combine multiple auth providers
+- [Custom Auth Provider](/docs/server/auth/custom-auth-provider): Build your own provider

--- a/docs/src/content/en/docs/server/auth/index.mdx
+++ b/docs/src/content/en/docs/server/auth/index.mdx
@@ -22,6 +22,12 @@ Authentication is optional. If no auth is configured, all routes and Studio are 
 
 See [Custom API Routes](/docs/server/custom-api-routes#authentication) for controlling authentication on custom endpoints.
 
+:::note
+
+Authentication for Studio is currently supported by the following providers: Simple Auth, JWT, WorkOS, and Better Auth.
+
+:::
+
 ## Available providers
 
 ### Built-in

--- a/docs/src/content/en/docs/server/auth/jwt.mdx
+++ b/docs/src/content/en/docs/server/auth/jwt.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MastraJwtAuth class | Auth"
-description: "Documentation for the MastraJwtAuth class, which authenticates Mastra applications using JSON Web Tokens."
+title: "JSON Web Token | Auth"
+description: "Documentation for JSON Web Token usage inside Mastra."
 packages:
   - "@mastra/auth"
   - "@mastra/client-js"
@@ -10,7 +10,7 @@ packages:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# MastraJwtAuth class
+# JSON Web Token
 
 The `MastraJwtAuth` class provides a lightweight authentication mechanism for Mastra using JSON Web Tokens (JWTs). It verifies incoming requests based on a shared secret and integrates with the Mastra server using the `auth` option.
 
@@ -22,7 +22,21 @@ Before you can use the `MastraJwtAuth` class you have to install the `@mastra/au
 npm install @mastra/auth@latest
 ```
 
+## Creating a JWT
+
+To authenticate requests to your Mastra server, you'll need a valid JSON Web Token (JWT) signed with your `MASTRA_JWT_SECRET`.
+
+The easiest way to generate one is using [jwt.io](https://www.jwt.io/):
+
+1. Select **JWT Encoder**.
+1. Scroll down to the **Sign JWT: Secret** section.
+1. Enter your secret (for example: `supersecretdevkeythatishs256safe!`).
+1. Click **Generate example** to create a valid JWT.
+1. Copy the generated token and set it as `MASTRA_JWT_TOKEN` in your `.env` file.
+
 ## Usage example
+
+Take your generated JWT and use it to configure `MastraJwtAuth` in your Mastra server:
 
 ```typescript {2,6-8} title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -42,6 +56,8 @@ export const mastra = new Mastra({
 Visit [MastraJwtAuth](/reference/auth/jwt) for all available configuration options.
 
 :::
+
+Inside [Studio](/docs/getting-started/studio), go to **Settings** and under **Headers** select the **"Add Header"** button. Enter `Authorization` as the header name and `Bearer <your-jwt>` as the value.
 
 ## Configuring `MastraClient`
 
@@ -98,15 +114,3 @@ Once `MastraClient` is configured, you can send authenticated requests from your
     ```
   </TabItem>
 </Tabs>
-
-## Creating a JWT
-
-To authenticate requests to your Mastra server, you'll need a valid JSON Web Token (JWT) signed with your `MASTRA_JWT_SECRET`.
-
-The easiest way to generate one is using [jwt.io](https://www.jwt.io/):
-
-1. Select **JWT Encoder**.
-1. Scroll down to the **Sign JWT: Secret** section.
-1. Enter your secret (for example: `supersecretdevkeythatishs256safe!`).
-1. Click **Generate example** to create a valid JWT.
-1. Copy the generated token and set it as `MASTRA_JWT_TOKEN` in your `.env` file.

--- a/docs/src/content/en/docs/server/auth/simple-auth.mdx
+++ b/docs/src/content/en/docs/server/auth/simple-auth.mdx
@@ -1,11 +1,11 @@
 ---
-title: "SimpleAuth class | Auth"
+title: "Simple Auth | Auth"
 description: "Documentation for the SimpleAuth class, which provides token-to-user mapping authentication for development and basic API key scenarios."
 packages:
   - "@mastra/core"
 ---
 
-# SimpleAuth class
+# Simple Auth
 
 The `SimpleAuth` class provides token-based authentication using a basic token-to-user mapping. It's included in `@mastra/core/server` and is useful for development, testing, and basic API key authentication scenarios.
 
@@ -18,7 +18,7 @@ The `SimpleAuth` class provides token-based authentication using a basic token-t
 
 ## Installation
 
-SimpleAuth is included in `@mastra/core`, no additional packages required.
+`SimpleAuth` is included in `@mastra/core`, no additional packages required.
 
 ```typescript
 import { SimpleAuth } from '@mastra/core/server'

--- a/docs/src/content/en/docs/server/auth/supabase.mdx
+++ b/docs/src/content/en/docs/server/auth/supabase.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MastraAuthSupabase class | Auth"
-description: "Documentation for the MastraAuthSupabase class, which authenticates Mastra applications using Supabase Auth."
+title: "Supabase | Auth"
+description: "Documentation for the `@mastra/auth-supabase` package, which authenticates Mastra applications using Supabase Auth."
 packages:
   - "@mastra/auth-supabase"
   - "@mastra/client-js"
@@ -10,9 +10,9 @@ packages:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# MastraAuthSupabase class
+# Supabase
 
-The `MastraAuthSupabase` class provides authentication for Mastra using Supabase Auth. It verifies incoming requests using Supabase's authentication system and integrates with the Mastra server using the `auth` option.
+The `@mastra/auth-supabase` package provides authentication for Mastra using Supabase Auth. It verifies incoming requests using Supabase's authentication system and integrates with the Mastra server using the `auth` option.
 
 ## Prerequisites
 
@@ -33,7 +33,7 @@ Review your Supabase Row Level Security (RLS) settings to ensure proper data acc
 
 Before you can use the `MastraAuthSupabase` class you have to install the `@mastra/auth-supabase` package.
 
-```bash
+```bash npm2yarn
 npm install @mastra/auth-supabase@latest
 ```
 

--- a/docs/src/content/en/docs/server/auth/workos.mdx
+++ b/docs/src/content/en/docs/server/auth/workos.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MastraAuthWorkos class | Auth"
-description: "Documentation for the MastraAuthWorkos class, which authenticates Mastra applications using WorkOS authentication."
+title: "WorkOS | Auth"
+description: "Documentation for the `@mastra/auth-workos` package, which authenticates Mastra applications using WorkOS authentication."
 packages:
   - "@mastra/auth-workos"
   - "@mastra/client-js"
@@ -10,9 +10,9 @@ packages:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# MastraAuthWorkos class
+# WorkOS
 
-The `MastraAuthWorkos` class provides authentication for Mastra using WorkOS. It verifies incoming requests using WorkOS access tokens and integrates with the Mastra server using the `auth` option.
+The `@mastra/auth-workos` package provides authentication for Mastra using WorkOS. It verifies incoming requests using WorkOS access tokens and integrates with the Mastra server using the `auth` option.
 
 ## Prerequisites
 
@@ -40,7 +40,7 @@ For detailed setup instructions, refer to the [WorkOS documentation](https://wor
 
 Before you can use the `MastraAuthWorkos` class you have to install the `@mastra/auth-workos` package.
 
-```bash
+```bash npm2yarn
 npm install @mastra/auth-workos@latest
 ```
 
@@ -114,7 +114,7 @@ When using WorkOS auth, you'll need to implement the WorkOS authentication flow 
 
 First, install the WorkOS SDK in your application:
 
-```bash
+```bash npm2yarn
 npm install @workos-inc/node
 ```
 

--- a/docs/src/content/en/guides/guide/docs-manager.mdx
+++ b/docs/src/content/en/guides/guide/docs-manager.mdx
@@ -74,7 +74,7 @@ Quick start guide for the project.
 
 ## Installation
 
-```bash
+```bash npm2yarn
 npm install example-package
 ```
 
@@ -171,7 +171,7 @@ Learn how to add authentication to your application.
 
 Install the auth package:
 
-```bash
+```bash npm2yarn
 npm install @example/auth
 ```
 

--- a/docs/src/content/en/reference/auth/jwt.mdx
+++ b/docs/src/content/en/reference/auth/jwt.mdx
@@ -40,4 +40,4 @@ export const mastra = new Mastra({
 
 ## Related
 
-[MastraJwtAuth](/docs/server/auth/jwt)
+- [JSON Web Token](/docs/server/auth/jwt)


### PR DESCRIPTION
## Description

I started with this PR to fix https://github.com/mastra-ai/mastra/issues/14350 but I noticed that the titles for all the auth provider docs were incorrect (they all said "MastraAuthX class" instead of the correct title for the package). So I updated the titles for all the auth provider docs to be consistent and descriptive. Also added missing `npm2yarn` tags to some installation instructions.

And added to the JWT auth docs instructions on how to configure Studio.

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/14350

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated auth provider docs to use package-focused titles and descriptions (Auth0, Clerk, Firebase, Supabase, WorkOS, Better Auth, Composite Auth, Simple Auth) and added @mastra/core to package lists.
  * Enhanced JWT guide with creation/configuration steps, Studio setup instructions, and streamlined examples.
  * Added "Use cases" for Simple Auth and a note listing supported providers.
  * Standardized installation code blocks to include npm2yarn and made minor heading/formatting refinements.
  * Added link to Authentication docs in deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->