### PR TITLE
perf(memory): skip index validation on semantic recall read path

### DIFF
--- a/.changeset/thirty-camels-fetch.md
+++ b/.changeset/thirty-camels-fetch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved semantic recall performance by skipping redundant index validation on the read path

--- a/packages/core/src/processors/memory/semantic-recall.ts
+++ b/packages/core/src/processors/memory/semantic-recall.ts
@@ -347,9 +347,7 @@ export class SemanticRecall implements Processor {
     // Ensure vector index exists
     const indexName = this.indexName || this.getDefaultIndexName();
 
-    // Generate embeddings for the query
-    const { embeddings, dimension } = await this.embedMessageContent(query, indexName);
-    await this.ensureVectorIndex(indexName, dimension);
+    const { embeddings } = await this.embedMessageContent(query, indexName);
 
     // Perform vector search for each embedding
     const vectorResults: Array<{


### PR DESCRIPTION
## Description
Small optimization: `ensureVectorIndex` (which calls `createIndex`) was being called on the read path on every recall query. The index is guaranteed to exist if there are messages to recall, so this call is unnecessary there.

## Related Issue(s)
No linked issue — standalone minor improvement.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized semantic search performance by streamlining validation checks during query execution. This enhancement removes redundant verification steps on the read path, delivering faster search results and improving overall system efficiency while maintaining all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->