### PR TITLE
fix(mastracode): don't pass custom headers to anthropic/codex providers

### DIFF
--- a/mastracode/src/providers/claude-max.ts
+++ b/mastracode/src/providers/claude-max.ts
@@ -134,15 +134,11 @@ export const promptCacheMiddleware: LanguageModelMiddleware = {
  * Creates an Anthropic model using Claude Max OAuth authentication
  * Uses OAuth tokens from AuthStorage (auto-refreshes when needed)
  */
-export function opencodeClaudeMaxProvider(
-  modelId: string = 'claude-sonnet-4-20250514',
-  options?: { headers?: Record<string, string> },
-): MastraModelConfig {
+export function opencodeClaudeMaxProvider(modelId: string = 'claude-sonnet-4-20250514'): MastraModelConfig {
   // Test environment: use API key
   if (process.env.NODE_ENV === 'test' || process.env.VITEST) {
     const anthropic = createAnthropic({
       apiKey: 'test-api-key',
-      headers: options?.headers,
     });
     return wrapLanguageModel({
       model: anthropic(modelId),
@@ -175,7 +171,6 @@ export function opencodeClaudeMaxProvider(
     return fetch(url, {
       ...init,
       headers: {
-        ...(init?.headers instanceof Headers ? Object.fromEntries(init.headers.entries()) : (init?.headers ?? {})),
         Authorization: `Bearer ${accessToken}`,
         'anthropic-beta':
           'oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14',
@@ -188,7 +183,6 @@ export function opencodeClaudeMaxProvider(
     // Provide a dummy API key - the actual auth is handled via OAuth in oauthFetch
     // This prevents the SDK from throwing "API key is missing" at model creation time
     apiKey: 'oauth-placeholder',
-    headers: options?.headers,
     fetch: oauthFetch as any,
   });
 

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -108,7 +108,7 @@ function createCodexMiddleware(reasoningEffort?: string): LanguageModelMiddlewar
  */
 export function openaiCodexProvider(
   modelId: string = 'codex-mini-latest',
-  options?: { thinkingLevel?: ThinkingLevel; headers?: Record<string, string> },
+  options?: { thinkingLevel?: ThinkingLevel },
 ): MastraModelConfig {
   // Map thinkingLevel to OpenAI reasoningEffort, defaulting to 'medium'.
   // When level is 'off', reasoningEffort is undefined and the parameter is omitted.
@@ -122,7 +122,6 @@ export function openaiCodexProvider(
   if (process.env.NODE_ENV === 'test' || process.env.VITEST) {
     const openai = createOpenAI({
       apiKey: 'test-api-key',
-      headers: options?.headers,
     });
     return wrapLanguageModel({
       model: openai.responses(modelId),
@@ -207,7 +206,6 @@ export function openaiCodexProvider(
   const openai = createOpenAI({
     // Use a dummy API key since we're using OAuth
     apiKey: 'oauth-dummy-key',
-    headers: options?.headers,
     fetch: oauthFetch as any,
   });
 


### PR DESCRIPTION
This can cause the api to reject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed custom headers configuration option from Claude Max provider
  * Removed custom headers configuration option from OpenAI Codex provider
  * Authentication now exclusively relies on OAuth tokens for both providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->