### PR TITLE
fix(schema-compat): support draft-2020-12 and fix target name mapping in zod-v3 adapter

### DIFF
--- a/.changeset/fix-zod-v3-json-schema-target.md
+++ b/.changeset/fix-zod-v3-json-schema-target.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Add support for `draft-2020-12` and `draft-04` JSON Schema targets in the Zod v3 adapter, and fix the `toJSONSchema` target mapping to properly translate all `zod-to-json-schema` target names (like `openApi3`) to standard-schema target names. Fixes "Unsupported JSON Schema target" errors when serializing tool schemas.

--- a/packages/schema-compat/src/schema-compatibility.ts
+++ b/packages/schema-compat/src/schema-compatibility.ts
@@ -658,8 +658,13 @@ export abstract class SchemaCompatLayer {
    * Uses 'input' io mode so that fields with defaults are optional (appropriate for tool parameters).
    */
   public toJSONSchema(zodSchema: ZodType): JSONSchema7 {
-    const target =
-      this.getSchemaTarget() === 'jsonSchema7' ? ('draft-07' as StandardJSONSchemaV1.Target) : this.getSchemaTarget();
+    const SCHEMA_TARGET_TO_STANDARD: Record<string, StandardJSONSchemaV1.Target> = {
+      jsonSchema7: 'draft-07',
+      'jsonSchema2019-09': 'draft-2020-12',
+      openApi3: 'openapi-3.0',
+    };
+    const schemaTarget = this.getSchemaTarget();
+    const target = (schemaTarget && SCHEMA_TARGET_TO_STANDARD[schemaTarget]) ?? schemaTarget;
     const standardSchema = toStandardSchema(zodSchema);
     const jsonSchema = standardSchemaToJSONSchema(standardSchema, {
       target,

--- a/packages/schema-compat/src/standard-schema/adapters/__snapshots__/zod-v3.test.ts.snap
+++ b/packages/schema-compat/src/standard-schema/adapters/__snapshots__/zod-v3.test.ts.snap
@@ -1,5 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`zod-v3 standard-schema adapter > toStandardSchema > should convert to JSON Schema with draft-04 target 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "age": {
+      "type": "number",
+    },
+    "name": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+    "age",
+  ],
+  "type": "object",
+}
+`;
+
 exports[`zod-v3 standard-schema adapter > toStandardSchema > should convert to JSON Schema with draft-07 target 1`] = `
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -19,6 +39,26 @@ exports[`zod-v3 standard-schema adapter > toStandardSchema > should convert to J
     "name",
     "age",
     "isActive",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`zod-v3 standard-schema adapter > toStandardSchema > should convert to JSON Schema with draft-2020-12 target 1`] = `
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "age": {
+      "type": "number",
+    },
+    "name": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+    "age",
   ],
   "type": "object",
 }

--- a/packages/schema-compat/src/standard-schema/adapters/zod-v3.test.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/zod-v3.test.ts
@@ -89,6 +89,30 @@ describe('zod-v3 standard-schema adapter', () => {
       expect(inputJsonSchema).toEqual(outputJsonSchema);
     });
 
+    it('should convert to JSON Schema with draft-2020-12 target', () => {
+      const zodSchema = z.object({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const standardSchema = toStandardSchema(zodSchema);
+      const jsonSchema = standardSchema['~standard'].jsonSchema.output({ target: 'draft-2020-12' });
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should convert to JSON Schema with draft-04 target', () => {
+      const zodSchema = z.object({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const standardSchema = toStandardSchema(zodSchema);
+      const jsonSchema = standardSchema['~standard'].jsonSchema.output({ target: 'draft-04' });
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
     it('should throw for unsupported targets', () => {
       const zodSchema = z.object({
         name: z.string(),

--- a/packages/schema-compat/src/standard-schema/adapters/zod-v3.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/zod-v3.ts
@@ -12,7 +12,9 @@ import type {
  * Target mapping from Standard Schema targets to zod-to-json-schema targets.
  */
 const TARGET_MAP: Record<string, ZodToJsonSchemaTarget> = {
+  'draft-04': 'jsonSchema7',
   'draft-07': 'jsonSchema7',
+  'draft-2020-12': 'jsonSchema2019-09',
   'openapi-3.0': 'openApi3',
 };
 


### PR DESCRIPTION
The zod-v3 adapter's `TARGET_MAP` was missing `draft-2020-12` and `draft-04`, so requesting those targets would throw `Unsupported JSON Schema target`. This broke tool serialization in the playground since `agents.ts` passes `draft-2020-12`.

Also, `toJSONSchema()` in `schema-compatibility.ts` only mapped `jsonSchema7` → `draft-07`, but passed other `zod-to-json-schema` internal names (like `openApi3` from the openai-reasoning compat) through raw — which the adapter didn't recognize as `openapi-3.0`.

Fixed by adding the missing targets to the zod-v3 `TARGET_MAP` and properly translating all internal target names to standard-schema names.

Fixes #14467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved "Unsupported JSON Schema target" errors when serializing tool schemas
  * Fixed JSON Schema target mapping for improved compatibility

* **New Features**
  * Added support for draft-2020-12 and draft-04 JSON Schema targets in the Zod v3 adapter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->