### PR TITLE
fix(tui): remove italic styling from tool arguments

### DIFF
--- a/.changeset/calm-tips-poke.md
+++ b/.changeset/calm-tips-poke.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Removed italic styling from tool arguments (shell commands, web search queries, and generic tool args) for improved readability in the terminal.

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -341,7 +341,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     // Helper to render shell command with bordered box
     const renderBorderedShell = (status: string, outputLines: string[]) => {
       const border = (char: string) => theme.bold(theme.fg('toolBorderSuccess', char));
-      const footerText = `${theme.bold(theme.fg('toolTitle', '$'))} ${theme.italic(theme.fg('toolArgs', command))}${cwdSuffix}${timeSuffix}${status}`;
+      const footerText = `${theme.bold(theme.fg('toolTitle', '$'))} ${theme.fg('toolArgs', command)}${cwdSuffix}${timeSuffix}${status}`;
 
       // Top border
       this.contentBox.addChild(new Text(border('╭──'), 0, 0));
@@ -955,7 +955,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     }
     const status = this.getStatusIndicator();
 
-    const queryDisplay = query ? ` ${theme.italic(theme.fg('toolArgs', `"${query}"`))}` : '';
+    const queryDisplay = query ? ` ${theme.fg('toolArgs', `"${query}"`)}` : '';
     const footerText = `${theme.bold(theme.fg('toolTitle', 'web_search'))}${queryDisplay}${status}`;
     const border = (char: string) => theme.bold(theme.fg('toolBorderSuccess', char));
 
@@ -1233,7 +1233,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       currentLen += part.length + 2;
     }
 
-    return ' ' + theme.italic(theme.fg('toolArgs', parts.join(', ')));
+    return ' ' + theme.fg('toolArgs', parts.join(', '));
   }
 
   private getStatusIndicator(): string {


### PR DESCRIPTION
Removes italic styling from tool arguments in the TUI. Italic monospace doesn't render well in many terminal fonts and the `toolArgs` color already provides enough visual distinction.
Applies to shell command args, web search queries, and generic tool arg summaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Improved terminal readability by removing italic formatting from shell commands, web search queries, and tool arguments in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->