### PR TITLE
fix(cli): validate org membership before using project.json org

### DIFF
--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -128,14 +128,13 @@ async function resolveOrg(
     return { orgId: flagOrg, orgName: match?.name ?? flagOrg };
   }
 
-  // 2. project.json
+  // 2. project.json (only if user is a member of that org)
   if (projectConfig?.organizationId) {
     const orgs = await fetchOrgs(token);
     const match = orgs.find(o => o.id === projectConfig.organizationId);
-    return {
-      orgId: projectConfig.organizationId,
-      orgName: match?.name ?? projectConfig.organizationId,
-    };
+    if (match) {
+      return { orgId: match.id, orgName: match.name };
+    }
   }
 
   // 3. credentials currentOrgId


### PR DESCRIPTION
## Problem

`resolveOrg` in the deploy command blindly used the `organizationId` from `.mastra/project.json` without checking if the current user is a member of that org. This caused 403/401 errors when a user deployed a folder that was previously linked to a different org they don't belong to.

## Fix

If the user isn't a member of the org stored in `project.json`, fall through to the next resolution strategy (credentials `currentOrgId`, auto-select if 1 org, or interactive picker) instead of sending a request with an org the user can't access.

## Test Plan

1. Deploy a project with Org A → `.mastra/project.json` stores Org A's ID
2. Log in as a user who is NOT a member of Org A
3. Run `mastra deploy` in the same directory
4. **Before**: 401/403 error on the deploy call
5. **After**: Falls through to org picker, user selects their own org, deploy succeeds