### PR TITLE
feat(core): add agent-level heartbeat — context-aware periodic agent turns

### DIFF
--- a/packages/core/src/agent/__tests__/heartbeat.test.ts
+++ b/packages/core/src/agent/__tests__/heartbeat.test.ts
@@ -1,0 +1,322 @@
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Agent } from '../agent';
+
+function createMockModel(responseText: string) {
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      content: [{ type: 'text' as const, text: responseText }],
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      warnings: [],
+    }),
+  });
+}
+
+function createAgent(overrides: Record<string, any> = {}) {
+  return new Agent({
+    id: 'heartbeat-test-agent',
+    name: 'Heartbeat Test Agent',
+    model: createMockModel(overrides.responseText ?? 'HEARTBEAT_OK Everything is fine.'),
+    instructions: 'You are a monitoring agent.',
+    heartbeat: {
+      intervalMs: 1000,
+      prompt: 'Check if all services are running.',
+      ...overrides.heartbeat,
+    },
+    ...overrides.agentOverrides,
+  });
+}
+
+describe('Agent Heartbeat', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('runHeartbeatTick()', () => {
+    it('should run an agent turn and return a result with status ok', async () => {
+      const agent = createAgent();
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe('ok');
+      expect(result!.text).toContain('HEARTBEAT_OK');
+      expect(result!.timestamp).toBeInstanceOf(Date);
+    });
+
+    it('should return status alert when response does not start with HEARTBEAT_OK', async () => {
+      const agent = createAgent({ responseText: 'WARNING: Service X is down!' });
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe('alert');
+      expect(result!.text).toContain('WARNING');
+    });
+
+    it('should capture token usage from the model response', async () => {
+      const agent = createAgent();
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).not.toBeNull();
+      expect(result!.usage).toBeDefined();
+      expect(result!.usage!.inputTokens).toBe(10);
+      expect(result!.usage!.outputTokens).toBe(20);
+      expect(result!.usage!.totalTokens).toBe(30);
+    });
+
+    it('should call onHeartbeat callback with the result', async () => {
+      const onHeartbeat = vi.fn();
+      const agent = createAgent({ heartbeat: { onHeartbeat } });
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(onHeartbeat).toHaveBeenCalledOnce();
+      expect(onHeartbeat).toHaveBeenCalledWith(result);
+    });
+
+    it('should not crash if onHeartbeat callback throws', async () => {
+      const onHeartbeat = vi.fn().mockRejectedValue(new Error('callback error'));
+      const agent = createAgent({ heartbeat: { onHeartbeat } });
+
+      const result = await agent.runHeartbeatTick();
+
+      // Should still return the result despite callback failure
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe('ok');
+    });
+
+    it('should return null when agent has no heartbeat config', async () => {
+      const agent = new Agent({
+        id: 'no-heartbeat',
+        name: 'No Heartbeat Agent',
+        model: createMockModel('Hello'),
+        instructions: 'You are helpful.',
+      });
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('preCheck gate', () => {
+    it('should skip agent turn when preCheck returns false', async () => {
+      const onHeartbeat = vi.fn();
+      const agent = createAgent({
+        heartbeat: {
+          preCheck: () => false,
+          onHeartbeat,
+        },
+      });
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).toBeNull();
+      expect(onHeartbeat).not.toHaveBeenCalled();
+    });
+
+    it('should run agent turn when preCheck returns true', async () => {
+      const onHeartbeat = vi.fn();
+      const agent = createAgent({
+        heartbeat: {
+          preCheck: () => true,
+          onHeartbeat,
+        },
+      });
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe('ok');
+      expect(onHeartbeat).toHaveBeenCalledOnce();
+    });
+
+    it('should support async preCheck', async () => {
+      const agent = createAgent({
+        heartbeat: {
+          preCheck: async () => false,
+        },
+      });
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('dynamic prompt', () => {
+    it('should support a function that returns a prompt string', async () => {
+      const promptFn = vi.fn().mockReturnValue('Check database connections.');
+      const agent = createAgent({
+        heartbeat: {
+          prompt: promptFn,
+        },
+      });
+
+      await agent.runHeartbeatTick();
+
+      expect(promptFn).toHaveBeenCalledOnce();
+    });
+
+    it('should support an async function prompt', async () => {
+      const promptFn = vi.fn().mockResolvedValue('Check API endpoints.');
+      const agent = createAgent({
+        heartbeat: {
+          prompt: promptFn,
+        },
+      });
+
+      await agent.runHeartbeatTick();
+
+      expect(promptFn).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('startHeartbeat() / stopHeartbeat()', () => {
+    it('should schedule periodic ticks', async () => {
+      const onHeartbeat = vi.fn();
+      const agent = createAgent({
+        heartbeat: {
+          intervalMs: 5000,
+          onHeartbeat,
+        },
+      });
+
+      agent.startHeartbeat();
+
+      // No immediate run (default)
+      expect(onHeartbeat).not.toHaveBeenCalled();
+
+      // Advance past one interval
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(onHeartbeat).toHaveBeenCalledTimes(1);
+
+      // Advance past another interval
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(onHeartbeat).toHaveBeenCalledTimes(2);
+
+      agent.stopHeartbeat();
+    });
+
+    it('should run immediately when immediate is true', async () => {
+      const onHeartbeat = vi.fn();
+      const agent = createAgent({
+        heartbeat: {
+          intervalMs: 60000,
+          immediate: true,
+          onHeartbeat,
+        },
+      });
+
+      agent.startHeartbeat();
+
+      // Flush the microtask queue for the immediate tick
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(onHeartbeat).toHaveBeenCalledTimes(1);
+
+      agent.stopHeartbeat();
+    });
+
+    it('should stop ticks after stopHeartbeat()', async () => {
+      const onHeartbeat = vi.fn();
+      const agent = createAgent({
+        heartbeat: {
+          intervalMs: 5000,
+          onHeartbeat,
+        },
+      });
+
+      agent.startHeartbeat();
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(onHeartbeat).toHaveBeenCalledTimes(1);
+
+      agent.stopHeartbeat();
+
+      await vi.advanceTimersByTimeAsync(5000);
+      // Should not have been called again
+      expect(onHeartbeat).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw when stopping without starting', () => {
+      const agent = createAgent();
+      expect(() => agent.stopHeartbeat()).not.toThrow();
+    });
+
+    it('should not throw when starting without heartbeat config', () => {
+      const agent = new Agent({
+        id: 'no-config',
+        name: 'No Config Agent',
+        model: createMockModel('Hello'),
+        instructions: 'You are helpful.',
+      });
+      expect(() => agent.startHeartbeat()).not.toThrow();
+    });
+  });
+
+  describe('overlap prevention', () => {
+    it('should skip a tick if the previous one is still running', async () => {
+      vi.useRealTimers(); // Need real timers for this test
+
+      let resolveGenerate: (() => void) | undefined;
+      let onGenerateEntered: (() => void) | undefined;
+      const generateEntered = new Promise<void>(resolve => {
+        onGenerateEntered = resolve;
+      });
+
+      const slowModel = new MockLanguageModelV2({
+        doGenerate: async () => {
+          onGenerateEntered!();
+          await new Promise<void>(resolve => {
+            resolveGenerate = resolve;
+          });
+          return {
+            content: [{ type: 'text' as const, text: 'HEARTBEAT_OK' }],
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+            warnings: [],
+          };
+        },
+      });
+
+      const onHeartbeat = vi.fn();
+      const agent = new Agent({
+        id: 'overlap-test',
+        name: 'Overlap Agent',
+        model: slowModel,
+        instructions: 'Monitor things.',
+        heartbeat: {
+          intervalMs: 1000,
+          prompt: 'Check services.',
+          onHeartbeat,
+        },
+      });
+
+      // Start a tick (will be blocked by slow model)
+      const tick1 = agent.runHeartbeatTick();
+
+      // Wait until the model's doGenerate is actually entered
+      await generateEntered;
+
+      // Try a second tick — should be skipped because tick1 is still running
+      const tick2 = await agent.runHeartbeatTick();
+      expect(tick2).toBeNull();
+
+      // Now unblock the first tick
+      resolveGenerate!();
+      const result1 = await tick1;
+
+      expect(result1).not.toBeNull();
+      expect(result1!.status).toBe('ok');
+      expect(onHeartbeat).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/core/src/agent/__tests__/heartbeat.test.ts
+++ b/packages/core/src/agent/__tests__/heartbeat.test.ts
@@ -1,5 +1,8 @@
 import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+import { MockMemory } from '../../memory/mock';
+import { createTool } from '../../tools';
 import { Agent } from '../agent';
 
 function createMockModel(responseText: string) {
@@ -317,6 +320,307 @@ describe('Agent Heartbeat', () => {
       expect(result1).not.toBeNull();
       expect(result1!.status).toBe('ok');
       expect(onHeartbeat).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should return null and not throw when generate() fails', async () => {
+      vi.useRealTimers();
+
+      const failingModel = new MockLanguageModelV2({
+        doGenerate: async () => {
+          throw new Error('Model API is down');
+        },
+      });
+
+      const onHeartbeat = vi.fn();
+      const agent = new Agent({
+        id: 'error-test',
+        name: 'Error Test Agent',
+        model: failingModel,
+        instructions: 'Monitor things.',
+        heartbeat: {
+          intervalMs: 1000,
+          prompt: 'Check services.',
+          onHeartbeat,
+        },
+      });
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).toBeNull();
+      expect(onHeartbeat).not.toHaveBeenCalled();
+    });
+
+    it('should still return result when onHeartbeat callback throws', async () => {
+      const onHeartbeat = vi.fn().mockImplementation(() => {
+        throw new Error('Callback blew up!');
+      });
+      const agent = createAgent({ heartbeat: { onHeartbeat } });
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe('ok');
+      expect(onHeartbeat).toHaveBeenCalled();
+    });
+
+    it('should return null when preCheck throws', async () => {
+      vi.useRealTimers();
+
+      const agent = createAgent({
+        heartbeat: {
+          preCheck: async () => {
+            throw new Error('preCheck exploded');
+          },
+          onHeartbeat: vi.fn(),
+        },
+      });
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('heartbeatActive getter', () => {
+    it('should return true when heartbeat is running', async () => {
+      const onHeartbeat = vi.fn();
+      const agent = createAgent({ heartbeat: { onHeartbeat } });
+
+      expect(agent.heartbeatActive).toBe(false);
+
+      agent.startHeartbeat();
+      expect(agent.heartbeatActive).toBe(true);
+
+      agent.stopHeartbeat();
+      expect(agent.heartbeatActive).toBe(false);
+    });
+  });
+
+  describe('integration: heartbeat with tools', () => {
+    it('should allow agent to use tools during heartbeat tick', async () => {
+      vi.useRealTimers();
+
+      const checkServiceStatus = vi.fn().mockResolvedValue({ status: 'healthy' });
+
+      const serviceTool = createTool({
+        id: 'check-service',
+        description: 'Check a service status',
+        inputSchema: z.object({ service: z.string() }),
+        execute: checkServiceStatus,
+      });
+
+      // Model that calls the tool, then responds
+      let callCount = 0;
+      const toolCallingModel = new MockLanguageModelV2({
+        doGenerate: async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              content: [
+                {
+                  type: 'tool-call' as const,
+                  toolCallId: 'tc-1',
+                  toolName: 'check-service',
+                  input: JSON.stringify({ service: 'database' }),
+                },
+              ],
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              warnings: [],
+            };
+          }
+          return {
+            content: [{ type: 'text' as const, text: 'HEARTBEAT_OK All services healthy.' }],
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+            warnings: [],
+          };
+        },
+      });
+
+      const onHeartbeat = vi.fn();
+      const agent = new Agent({
+        id: 'tool-heartbeat',
+        name: 'Tool Heartbeat Agent',
+        model: toolCallingModel,
+        instructions: 'Monitor services.',
+        tools: { checkService: serviceTool },
+        heartbeat: {
+          intervalMs: 30000,
+          prompt: 'Check database service status.',
+          onHeartbeat,
+        },
+      });
+
+      const result = await agent.runHeartbeatTick();
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe('ok');
+      expect(checkServiceStatus).toHaveBeenCalledWith({ service: 'database' }, expect.anything());
+    });
+  });
+
+  describe('integration: heartbeat with memory (contextMode: full)', () => {
+    it('should pass memory options to generate when contextMode is full', async () => {
+      vi.useRealTimers();
+
+      const memory = new MockMemory();
+
+      const agent = new Agent({
+        id: 'memory-heartbeat-full',
+        name: 'Memory Heartbeat Agent',
+        model: createMockModel('HEARTBEAT_OK'),
+        instructions: 'Monitor with memory.',
+        memory,
+        heartbeat: {
+          intervalMs: 30000,
+          prompt: 'Check everything.',
+          contextMode: 'full',
+          onHeartbeat: vi.fn(),
+        },
+      });
+
+      // Spy on the agent's generate method
+      const generateSpy = vi.spyOn(agent, 'generate');
+
+      await agent.runHeartbeatTick();
+
+      expect(generateSpy).toHaveBeenCalled();
+
+      // Cast to any to access the second argument (options) since TS doesn't know about overloads
+      const args = generateSpy.mock.calls[0] as unknown as [unknown, Record<string, unknown> | undefined];
+      const options = args[1];
+
+      // In full mode, memory option should be passed with heartbeat thread
+      expect(options).toBeDefined();
+      expect(options?.memory).toMatchObject({
+        thread: expect.stringContaining('heartbeat-'),
+        resource: 'heartbeat',
+      });
+    });
+
+    it('should NOT pass memory options to generate when contextMode is light (default)', async () => {
+      vi.useRealTimers();
+
+      const memory = new MockMemory();
+
+      const agent = new Agent({
+        id: 'light-heartbeat',
+        name: 'Light Heartbeat Agent',
+        model: createMockModel('HEARTBEAT_OK All good.'),
+        instructions: 'Monitor without memory.',
+        memory,
+        heartbeat: {
+          intervalMs: 30000,
+          prompt: 'Quick check.',
+          // contextMode defaults to 'light'
+          onHeartbeat: vi.fn(),
+        },
+      });
+
+      // Spy on the agent's generate method
+      const generateSpy = vi.spyOn(agent, 'generate');
+
+      await agent.runHeartbeatTick();
+
+      expect(generateSpy).toHaveBeenCalled();
+
+      // Cast to any to access the second argument (options)
+      const args = generateSpy.mock.calls[0] as unknown as [unknown, Record<string, unknown> | undefined];
+      const options = args[1];
+
+      // In light mode, memory option should NOT be passed (empty object)
+      expect(options?.memory).toBeUndefined();
+    });
+  });
+
+  describe('prompt content verification', () => {
+    it('should include the checklist prompt in the message sent to the model', async () => {
+      vi.useRealTimers();
+
+      let capturedPrompt: unknown;
+      const capturingModel = new MockLanguageModelV2({
+        doGenerate: async ({ prompt }) => {
+          capturedPrompt = prompt;
+          return {
+            content: [{ type: 'text' as const, text: 'HEARTBEAT_OK' }],
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+            warnings: [],
+          };
+        },
+      });
+
+      const agent = new Agent({
+        id: 'prompt-verify',
+        name: 'Prompt Verify Agent',
+        model: capturingModel,
+        instructions: 'You are helpful.',
+        heartbeat: {
+          intervalMs: 30000,
+          prompt: '1. Check API health\n2. Check database connection',
+          onHeartbeat: vi.fn(),
+        },
+      });
+
+      await agent.runHeartbeatTick();
+
+      expect(capturedPrompt).toBeDefined();
+      // The prompt should contain our checklist items
+      const promptStr = JSON.stringify(capturedPrompt);
+      expect(promptStr).toContain('Check API health');
+      expect(promptStr).toContain('Check database connection');
+      expect(promptStr).toContain('HEARTBEAT_OK');
+    });
+  });
+
+  describe('restart scenarios', () => {
+    it('should allow restarting heartbeat after stopping', async () => {
+      const onHeartbeat = vi.fn();
+      const agent = createAgent({ heartbeat: { intervalMs: 5000, onHeartbeat } });
+
+      // First cycle
+      agent.startHeartbeat();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(onHeartbeat).toHaveBeenCalledTimes(1);
+
+      agent.stopHeartbeat();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(onHeartbeat).toHaveBeenCalledTimes(1); // No new calls
+
+      // Restart
+      agent.startHeartbeat();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(onHeartbeat).toHaveBeenCalledTimes(2);
+
+      agent.stopHeartbeat();
+    });
+
+    it('should handle multiple sequential ticks correctly', async () => {
+      const onHeartbeat = vi.fn();
+      const agent = createAgent({ heartbeat: { intervalMs: 1000, onHeartbeat } });
+
+      agent.startHeartbeat();
+
+      // Run 5 ticks
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(1000);
+      }
+
+      expect(onHeartbeat).toHaveBeenCalledTimes(5);
+
+      // Each call should have a valid result
+      for (const call of onHeartbeat.mock.calls) {
+        expect(call[0]).toMatchObject({
+          status: 'ok',
+          text: expect.stringContaining('HEARTBEAT_OK'),
+          timestamp: expect.any(Date),
+        });
+      }
+
+      agent.stopHeartbeat();
     });
   });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -100,6 +100,8 @@ import type {
   StructuredOutputOptions,
   PublicStructuredOutputOptions,
   ModelWithRetries,
+  HeartbeatConfig,
+  HeartbeatResult,
 } from './types';
 import { isSupportedLanguageModel, resolveThreadIdFromArgs, supportedLanguageModelSpecifications } from './utils';
 import { createPrepareStreamWorkflow } from './workflows/prepare-stream';
@@ -177,6 +179,9 @@ export class Agent<
   #requestContextSchema?: StandardSchemaWithJSON<TRequestContext>;
   readonly #options?: AgentCreateOptions;
   #legacyHandler?: AgentLegacyHandler;
+  #heartbeatConfig?: HeartbeatConfig;
+  #heartbeatTimer?: ReturnType<typeof setInterval>;
+  #heartbeatRunning = false;
 
   // This flag is for agent network messages. We should change the agent network formatting and remove this flag after.
   private _agentNetworkAppend = false;
@@ -315,6 +320,10 @@ export class Agent<
 
     if (config.requestContextSchema) {
       this.#requestContextSchema = toStandardSchema(config.requestContextSchema);
+    }
+
+    if (config.heartbeat) {
+      this.#heartbeatConfig = config.heartbeat;
     }
 
     // @ts-expect-error Flag for agent network messages
@@ -5374,6 +5383,146 @@ export class Agent<
       return resolveMaybePromise(result, resolvedInstructions => {
         return resolvedInstructions || DEFAULT_TITLE_INSTRUCTIONS;
       });
+    }
+  }
+
+  // ===========================================================================
+  // Heartbeat
+  // ===========================================================================
+
+  /**
+   * Starts the periodic heartbeat. On each tick the agent runs an agent turn
+   * with the configured prompt and surfaces the result via the `onHeartbeat`
+   * callback.
+   *
+   * Does nothing if no `heartbeat` config was provided or if a heartbeat
+   * is already running.
+   */
+  startHeartbeat(): void {
+    if (!this.#heartbeatConfig) {
+      this.logger.warn(`[Heartbeat:${this.name}] No heartbeat config — skipping start`);
+      return;
+    }
+
+    if (this.#heartbeatTimer) {
+      return; // already running
+    }
+
+    const intervalMs = this.#heartbeatConfig.intervalMs ?? 30 * 60 * 1000;
+
+    if (this.#heartbeatConfig.immediate) {
+      void this.#runHeartbeatTick();
+    }
+
+    this.#heartbeatTimer = setInterval(() => {
+      void this.#runHeartbeatTick();
+    }, intervalMs);
+
+    // Don't block the process from exiting
+    if (typeof this.#heartbeatTimer === 'object' && 'unref' in this.#heartbeatTimer) {
+      this.#heartbeatTimer.unref();
+    }
+
+    this.logger.debug(`[Heartbeat:${this.name}] Started (interval=${intervalMs}ms)`);
+  }
+
+  /**
+   * Stops the periodic heartbeat and waits for any in-flight tick to settle.
+   */
+  stopHeartbeat(): void {
+    if (this.#heartbeatTimer) {
+      clearInterval(this.#heartbeatTimer);
+      this.#heartbeatTimer = undefined;
+      this.logger.debug(`[Heartbeat:${this.name}] Stopped`);
+    }
+  }
+
+  /**
+   * Returns `true` if the heartbeat timer is currently active.
+   */
+  get heartbeatActive(): boolean {
+    return this.#heartbeatTimer !== undefined;
+  }
+
+  /**
+   * Runs a single heartbeat tick. Can be called manually outside the timer
+   * for testing or on-demand checks.
+   */
+  async runHeartbeatTick(): Promise<HeartbeatResult | null> {
+    return this.#runHeartbeatTick();
+  }
+
+  async #runHeartbeatTick(): Promise<HeartbeatResult | null> {
+    const config = this.#heartbeatConfig;
+    if (!config) return null;
+
+    // Prevent overlapping ticks
+    if (this.#heartbeatRunning) {
+      this.logger.debug(`[Heartbeat:${this.name}] Skipping tick — previous still running`);
+      return null;
+    }
+
+    this.#heartbeatRunning = true;
+
+    try {
+      // Pre-check gate
+      if (config.preCheck) {
+        const shouldRun = await config.preCheck();
+        if (!shouldRun) {
+          this.logger.debug(`[Heartbeat:${this.name}] preCheck returned false — skipping agent turn`);
+          return null;
+        }
+      }
+
+      // Resolve the prompt
+      const prompt = typeof config.prompt === 'function' ? await config.prompt() : config.prompt;
+
+      const heartbeatUserMessage =
+        `You are running a periodic heartbeat check. Review the following checklist and determine if anything needs attention.\n` +
+        `If everything is fine, respond with HEARTBEAT_OK at the start of your message.\n` +
+        `If something needs attention, describe what needs action.\n\n` +
+        `Checklist:\n${prompt}`;
+
+      // Build generate options based on context mode.
+      // 'light' (default) — no thread history, just the heartbeat prompt.
+      // 'full' — uses a dedicated heartbeat thread so the agent has memory across ticks.
+      const contextMode = config.contextMode ?? 'light';
+      const generateOptions: Record<string, unknown> =
+        contextMode === 'full' ? { memory: { thread: `heartbeat-${this.id}`, resource: 'heartbeat' } } : {};
+
+      // Run the agent turn
+      const result = await this.generate([{ role: 'user', content: heartbeatUserMessage }], generateOptions as any);
+
+      const text = typeof result.text === 'string' ? result.text : '';
+      const isOk = text.trim().startsWith('HEARTBEAT_OK');
+
+      const heartbeatResult: HeartbeatResult = {
+        text,
+        status: isOk ? 'ok' : 'alert',
+        timestamp: new Date(),
+        usage: result.usage ? { ...result.usage } : undefined,
+      };
+
+      this.logger.debug(
+        `[Heartbeat:${this.name}] Tick complete — status=${heartbeatResult.status}` +
+          (heartbeatResult.usage ? ` tokens=${heartbeatResult.usage.totalTokens}` : ''),
+      );
+
+      // Deliver result via callback
+      if (config.onHeartbeat) {
+        try {
+          await config.onHeartbeat(heartbeatResult);
+        } catch (callbackError) {
+          this.logger.error(`[Heartbeat:${this.name}] onHeartbeat callback failed:`, callbackError);
+        }
+      }
+
+      return heartbeatResult;
+    } catch (error) {
+      this.logger.error(`[Heartbeat:${this.name}] Tick failed:`, error);
+      return null;
+    } finally {
+      this.#heartbeatRunning = false;
     }
   }
 }

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -29,7 +29,7 @@ import type { Span, SpanType, TracingOptions, TracingPolicy, ObservabilityContex
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors/index';
 import type { RequestContext } from '../request-context';
 import type { PublicSchema, StandardSchemaWithJSON } from '../schema';
-import type { MastraOnFinishCallbackArgs, ModelManagerModelConfig } from '../stream/types';
+import type { LanguageModelUsage, MastraOnFinishCallbackArgs, ModelManagerModelConfig } from '../stream/types';
 import type { ToolAction, VercelTool, VercelToolV5 } from '../tools';
 import type { DynamicArgument } from '../types';
 import type { MastraVoice } from '../voice';
@@ -332,6 +332,15 @@ export interface AgentConfig<
    * If validation fails, an error is thrown.
    */
   requestContextSchema?: PublicSchema<TRequestContext>;
+  /**
+   * Periodic heartbeat configuration.
+   * When set, the agent can be started on a timer that periodically runs
+   * an agent turn with the given prompt, applies judgment, and surfaces
+   * alerts or stays quiet.
+   *
+   * Call `agent.startHeartbeat()` to begin and `agent.stopHeartbeat()` to stop.
+   */
+  heartbeat?: HeartbeatConfig;
 }
 
 export type AgentMemoryOption = {
@@ -518,3 +527,55 @@ export type AgentExecuteOnFinishOptions = {
 };
 
 export type AgentMethodType = 'generate' | 'stream' | 'generateLegacy' | 'streamLegacy';
+
+// =============================================================================
+// Heartbeat
+// =============================================================================
+
+/**
+ * Result of a single heartbeat agent turn.
+ */
+export interface HeartbeatResult {
+  /** The agent's text response */
+  text: string;
+  /** Whether the agent flagged something needing attention (`alert`) or everything is fine (`ok`) */
+  status: 'ok' | 'alert';
+  /** Timestamp of the run */
+  timestamp: Date;
+  /** Token usage for this run (shape matches LanguageModelUsage from the model) */
+  usage?: LanguageModelUsage;
+}
+
+/**
+ * Configuration for an agent-level heartbeat — a context-aware periodic agent turn
+ * where the agent wakes up, evaluates a prompt/checklist, and decides whether
+ * anything needs attention.
+ *
+ * When configured, call `agent.startHeartbeat()` to begin and `agent.stopHeartbeat()` to stop.
+ */
+export interface HeartbeatConfig {
+  /** Interval between heartbeat runs in milliseconds. @default 1_800_000 (30 minutes) */
+  intervalMs?: number;
+  /**
+   * The prompt/checklist the agent evaluates on each tick.
+   * Can be a static string or a function that returns one dynamically.
+   */
+  prompt: string | (() => string | Promise<string>);
+  /**
+   * Context mode for heartbeat runs.
+   * - `'light'` — uses only the heartbeat prompt (no thread history). Cheaper.
+   * - `'full'` — loads a dedicated heartbeat thread with memory. Richer context.
+   * @default 'light'
+   */
+  contextMode?: 'full' | 'light';
+  /** Whether to run the first heartbeat immediately on start. @default false */
+  immediate?: boolean;
+  /**
+   * Optional cheap pre-check that runs before the agent turn.
+   * Return `false` to skip the LLM call entirely (saves tokens).
+   * Useful for quick checks like "is the service even reachable?"
+   */
+  preCheck?: () => boolean | Promise<boolean>;
+  /** Called after each heartbeat run with the agent's response. */
+  onHeartbeat?: (result: HeartbeatResult) => void | Promise<void>;
+}


### PR DESCRIPTION
## Description

Upgrades heartbeat from a dumb `setInterval` wrapper to a **context-aware periodic agent turn** where an agent wakes up on a schedule, runs through a prompt/checklist, uses its tools, and returns a result with judgment (`ok` or `alert`).

This is an **agent-level** feature — each agent can have its own heartbeat config (like voice, memory, tools). Results are delivered via `onHeartbeat` callback + logging. No channel dependency; channels can be wired in later.

### Key features
- **`HeartbeatConfig`** on `AgentConfig` — `prompt`, `intervalMs`, `contextMode`, `immediate`, `preCheck`, `onHeartbeat`
- **`preCheck` gate** — optional cheap function that runs before the LLM call; return `false` to skip (saves tokens)
- **`contextMode`** — `light` (just the heartbeat prompt, no memory) vs `full` (dedicated heartbeat thread with memory across ticks)
- **Overlap prevention** — if a tick is still running when the next fires, it's skipped
- **`unref()` on timers** — heartbeat doesn't prevent process exit
- **Public `runHeartbeatTick()`** — for manual/test invocation outside the interval

### Example usage
```typescript
const agent = new Agent({
  id: "monitor",
  name: "Monitor Agent",
  model: openai("gpt-4o-mini"),
  instructions: "You monitor system health.",
  heartbeat: {
    intervalMs: 5 * 60 * 1000, // every 5 minutes
    prompt: "- Check if API response times are under 200ms\n- Check if error rate is below 1%",
    preCheck: async () => await isServiceReachable(),
    onHeartbeat: (result) => {
      if (result.status === "alert") {
        notifyOpsTeam(result.text);
      }
    },
  },
});

agent.startHeartbeat();
// later...
agent.stopHeartbeat();
```

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR