### PR TITLE
fix: wrap long inline question answers

### DIFF
--- a/.changeset/curvy-brooms-take.md
+++ b/.changeset/curvy-brooms-take.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed inline text questions so long answers wrap inside the question box instead of crashing the terminal render.

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -179,9 +179,15 @@ class AskQuestionBorderedBox {
     } else if (this.answered && this.selectedValue != null) {
       // Free-text input answered
       const icon = this.answerIsNegative ? theme.fg('error', '✗') : theme.fg('success', '✓');
-      const label = theme.fg('text', this.selectedValue!);
-      const line = `${icon}  ${label}`;
-      addLine(line, visibleWidth(line));
+      const iconPrefix = `${icon}  `;
+      const continuationPrefix = '   ';
+      const wrappedAnswer = wrapTextWithAnsi(this.selectedValue!, Math.max(1, innerWidth - visibleWidth(iconPrefix)));
+
+      wrappedAnswer.forEach((line, index) => {
+        const prefix = index === 0 ? iconPrefix : continuationPrefix;
+        const content = `${prefix}${theme.fg('text', line)}`;
+        addLine(content, visibleWidth(prefix) + visibleWidth(line));
+      });
     } else if (this.answered && this.cancelled) {
       // Free-text cancelled
       const cancelLine = `${theme.fg('error', '✗')}  ${theme.fg('dim', '(cancelled)')}`;


### PR DESCRIPTION
This fixes inline text questions when a submitted answer is longer than the available width. Before this, pi-tui would error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long answers in inline text questions now properly wrap within the question box, preventing terminal rendering crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->