### PR TITLE
fix(observability): read cache token fallback from inputTokenDetails

### DIFF
--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -1272,6 +1272,34 @@ describe('DatadogExporter', () => {
       expect(annotateCall.metadata).not.toHaveProperty('parameters');
     });
 
+    it('includes cachedInputTokens in metrics when usage has inputDetails.cacheRead', async () => {
+      const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+      const span = createMockSpan({
+        type: SpanType.MODEL_GENERATION,
+        attributes: {
+          usage: {
+            inputTokens: 1000,
+            outputTokens: 200,
+            inputDetails: { cacheRead: 400 },
+          },
+        },
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          metrics: expect.objectContaining({
+            inputTokens: 1000,
+            outputTokens: 200,
+            totalTokens: 1200,
+            cachedInputTokens: 400,
+          }),
+        }),
+      );
+    });
+
     it('handles spans without attributes gracefully', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({

--- a/observability/mastra/src/usage.test.ts
+++ b/observability/mastra/src/usage.test.ts
@@ -229,5 +229,36 @@ describe('extractUsageMetrics', () => {
       expect(result.inputTokens).toBe(100);
       expect(result.inputDetails).toBeUndefined();
     });
+
+    it('should use inputTokenDetails.cacheReadTokens as fallback when providerMetadata has no cache data', () => {
+      const usage = {
+        inputTokens: 500,
+        outputTokens: 100,
+        inputTokenDetails: {
+          cacheReadTokens: 300,
+          cacheWriteTokens: 50,
+        },
+      } as LanguageModelUsage;
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.inputDetails?.cacheRead).toBe(300);
+      expect(result.inputDetails?.cacheWrite).toBe(50);
+    });
+
+    it('should prefer usage.cachedInputTokens over inputTokenDetails when both present', () => {
+      const usage = {
+        inputTokens: 500,
+        outputTokens: 100,
+        cachedInputTokens: 200,
+        inputTokenDetails: {
+          cacheReadTokens: 300,
+        },
+      } as LanguageModelUsage;
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.inputDetails?.cacheRead).toBe(200);
+    });
   });
 });

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -51,7 +51,7 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
   // ===== OpenAI / OpenRouter =====
   // cachedInputTokens is already in the usage object
   // inputTokens INCLUDES cached tokens (no adjustment needed)
-  if (usage.cachedInputTokens) {
+  if (usage.cachedInputTokens !== undefined) {
     inputDetails.cacheRead = usage.cachedInputTokens;
   }
 
@@ -96,6 +96,19 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
     if (google.usageMetadata.thoughtsTokenCount) {
       outputDetails.reasoning = google.usageMetadata.thoughtsTokenCount;
     }
+  }
+
+  // ===== AI SDK aggregated format (inputTokenDetails) =====
+  // AI SDK v5/v6 may provide aggregated cache tokens in inputTokenDetails.
+  // Use as fallback when provider-specific extraction did not yield cache data
+  // (e.g. multi-step runs where providerMetadata reflects only the last step).
+  const inputTokenDetails = (usage as { inputTokenDetails?: { cacheReadTokens?: number; cacheWriteTokens?: number } })
+    .inputTokenDetails;
+  if (inputDetails.cacheRead === undefined && inputTokenDetails?.cacheReadTokens !== undefined) {
+    inputDetails.cacheRead = inputTokenDetails.cacheReadTokens;
+  }
+  if (inputDetails.cacheWrite === undefined && inputTokenDetails?.cacheWriteTokens !== undefined) {
+    inputDetails.cacheWrite = inputTokenDetails.cacheWriteTokens;
   }
 
   // Build the final UsageStats object

--- a/packages/core/src/stream/aisdk/v5/transform.test.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.test.ts
@@ -564,5 +564,30 @@ describe('convertFullStreamChunkToMastra', () => {
         expect(result.payload.stepResult.reason).toBe('stop');
       }
     });
+
+    it('should extract cachedInputTokens from inputTokenDetails in finish usage', () => {
+      const chunk = {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          inputTokenDetails: { cacheReadTokens: 80 },
+        },
+        providerMetadata: {},
+        messages: { all: [], user: [], nonUser: [] },
+      } as StreamPart;
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('finish');
+      if (result?.type === 'finish') {
+        expect(result.payload.output.usage).toMatchObject({
+          inputTokens: 100,
+          outputTokens: 50,
+          cachedInputTokens: 80,
+        });
+      }
+    });
   });
 });

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -610,14 +610,19 @@ function normalizeUsage(usage: LanguageModelV2Usage | LanguageModelV3Usage | und
     };
   }
 
-  // V2 format - already flat
-  const v2Usage = usage as LanguageModelV2Usage;
+  // V2 format - already flat, or AI SDK format with inputTokenDetails
+  const v2Usage = usage as LanguageModelV2Usage & {
+    cachedInputTokens?: number;
+    inputTokenDetails?: { cacheReadTokens?: number; cacheWriteTokens?: number };
+  };
+  const cachedInputTokens =
+    v2Usage.cachedInputTokens ?? v2Usage.inputTokenDetails?.cacheReadTokens;
   return {
     inputTokens: v2Usage.inputTokens,
     outputTokens: v2Usage.outputTokens,
     totalTokens: v2Usage.totalTokens ?? (v2Usage.inputTokens ?? 0) + (v2Usage.outputTokens ?? 0),
     reasoningTokens: (v2Usage as { reasoningTokens?: number }).reasoningTokens,
-    cachedInputTokens: (v2Usage as { cachedInputTokens?: number }).cachedInputTokens,
+    cachedInputTokens,
     raw: usage,
   };
 }


### PR DESCRIPTION
### description

- Fixes cache token propagation so Datadog LLM spans can include cached input tokens in usage metrics, especially in multi-step/aggregated usage paths.

### Related Issue(s)

Fixes #14475

### Type of Change
[x] Bug fix (non-breaking change that fixes an issue)
[x] Test update

### Checklist

[x] I have added tests that prove my fix is effective or that my feature works





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extended test coverage for cache token metrics handling in usage reporting across observability and stream transformations

* **Bug Fixes**
  * Fixed cache token detection to properly preserve zero values
  * Added fallback extraction logic for cache tokens when provider-specific data is unavailable
  * Improved cache token metric derivation in stream transformations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->