### PR TITLE
fix(datadog): use ddSpan.finish() to set correct span end times

### DIFF
--- a/.changeset/fix-datadog-span-end-time.md
+++ b/.changeset/fix-datadog-span-end-time.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': patch
+---
+
+Fixed span duration accuracy in Datadog LLM Observability traces. Previously, all spans in a trace appeared to have the same end time because dd-trace's `llmobs.trace()` does not honor `endTime` in span options. Now uses `ddSpan.finish()` to explicitly set each span's correct end time, so tools, LLM calls, and agent runs show their actual durations in Datadog.

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -51,6 +51,7 @@ const {
         id: `mock-dd-span-${parents.length}`,
         options,
         setTag: vi.fn(),
+        finish: vi.fn(),
       };
       spans.push(ddSpan);
       // Activate this span in scope for the duration of the callback
@@ -494,10 +495,13 @@ describe('DatadogExporter', () => {
       expect(mockTrace).toHaveBeenCalledWith(
         expect.objectContaining({
           startTime,
-          endTime: startTime,
         }),
         expect.any(Function),
       );
+
+      // endTime is set via ddSpan.finish() instead of trace options
+      const ddSpan = capturedSpans[0];
+      expect(ddSpan.finish).toHaveBeenCalledWith(startTime.getTime());
     });
 
     it('buffers event spans until parent exists and emits with parent context', async () => {

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -28,7 +28,9 @@ import { ensureTracer, kindFor, toDate, formatInput, formatOutput } from './util
 import type { DatadogSpanKind } from './utils';
 
 /**
- * LLMObs span options with required name and kind properties.
+ * LLMObs span options passed to dd-trace's llmobs.trace().
+ * Note: endTime is not included because dd-trace does not honor it in trace options.
+ * Instead, we call ddSpan.finish(endTimeMs) explicitly inside the trace callback.
  */
 interface LLMObsSpanOptions {
   kind: DatadogSpanKind;
@@ -39,7 +41,6 @@ interface LLMObsSpanOptions {
   modelName?: string;
   modelProvider?: string;
   startTime?: Date;
-  endTime?: Date;
 }
 
 /**
@@ -572,7 +573,7 @@ export class DatadogExporter extends BaseExporter {
    * Builds LLMObs span options from a Mastra span.
    * Handles trace context, timestamps, and conditional model information for LLM spans.
    */
-  private buildSpanOptions(span: AnyExportedSpan): LLMObsSpanOptions {
+  private buildSpanOptions(span: AnyExportedSpan): { traceOptions: LLMObsSpanOptions; endTimeMs: number } {
     const traceCtx = this.traceContext.get(span.traceId) || {
       userId: span.metadata?.userId,
       sessionId: span.metadata?.sessionId,
@@ -587,14 +588,18 @@ export class DatadogExporter extends BaseExporter {
     const endTime = span.endTime ? toDate(span.endTime) : span.isEvent ? startTime : new Date();
 
     return {
-      kind,
-      name: span.name,
-      sessionId: traceCtx.sessionId,
-      userId: traceCtx.userId,
-      startTime,
-      endTime,
-      ...(kind === 'llm' && attrs?.model ? { modelName: attrs.model } : {}),
-      ...(kind === 'llm' && attrs?.provider ? { modelProvider: attrs.provider } : {}),
+      traceOptions: {
+        kind,
+        name: span.name,
+        sessionId: traceCtx.sessionId,
+        userId: traceCtx.userId,
+        startTime,
+        ...(kind === 'llm' && attrs?.model ? { modelName: attrs.model } : {}),
+        ...(kind === 'llm' && attrs?.provider ? { modelProvider: attrs.provider } : {}),
+      },
+      // endTime as milliseconds for ddSpan.finish() — dd-trace's llmobs.trace() does not
+      // honor endTime in options, so we must call finish(ms) explicitly on the span.
+      endTimeMs: endTime.getTime(),
     };
   }
 
@@ -605,12 +610,12 @@ export class DatadogExporter extends BaseExporter {
    */
   private emitSpanTree(node: SpanNode, state: TraceState): void {
     const span = node.span;
-    const options = this.buildSpanOptions(span);
+    const { traceOptions, endTimeMs } = this.buildSpanOptions(span);
 
     // Use nested llmobs.trace() calls - children are emitted INSIDE the parent's callback
     // This ensures the Datadog SDK automatically establishes parent-child relationships
-    tracer.llmobs.trace(options as any, (ddSpan: any) => {
-      // Annotate this span
+    tracer.llmobs.trace(traceOptions as any, (ddSpan: any) => {
+      // Annotate this span (must happen before finish — annotate throws on finished spans)
       const annotations = this.buildAnnotations(span);
       if (Object.keys(annotations).length > 0) {
         tracer.llmobs.annotate(ddSpan, annotations);
@@ -630,6 +635,14 @@ export class DatadogExporter extends BaseExporter {
       for (const child of node.children) {
         this.emitSpanTree(child, state);
       }
+
+      // Explicitly finish with the correct end time. dd-trace's llmobs.trace() does not
+      // honor endTime in span options — it auto-finishes with Date.now() when the callback
+      // returns. By calling finish() here first, the auto-finish becomes a no-op (dd-trace
+      // skips finish if _duration is already set).
+      if (typeof ddSpan.finish === 'function') {
+        ddSpan.finish(endTimeMs);
+      }
     });
   }
 
@@ -638,10 +651,10 @@ export class DatadogExporter extends BaseExporter {
    * Used for late-arriving spans after the main tree has been emitted.
    */
   private emitSingleSpan(span: AnyExportedSpan, state: TraceState, parent?: any) {
-    const options = this.buildSpanOptions(span);
+    const { traceOptions, endTimeMs } = this.buildSpanOptions(span);
 
     const runTrace = () =>
-      tracer.llmobs.trace(options as any, (ddSpan: any) => {
+      tracer.llmobs.trace(traceOptions as any, (ddSpan: any) => {
         const annotations = this.buildAnnotations(span);
         if (Object.keys(annotations).length > 0) {
           tracer.llmobs.annotate(ddSpan, annotations);
@@ -654,6 +667,11 @@ export class DatadogExporter extends BaseExporter {
 
         const exported = tracer.llmobs.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
         state.contexts.set(span.id, { ddSpan, exported });
+
+        // Explicitly finish with the correct end time (see emitSpanTree for details)
+        if (typeof ddSpan.finish === 'function') {
+          ddSpan.finish(endTimeMs);
+        }
       });
 
     if (parent) {


### PR DESCRIPTION
## Description
  <!-- Provide a brief description of the changes in this PR -->
dd-trace's `llmobs.trace()` does not honor `endTime` in span options — it auto-finishes spans with the current wall-clock time when the synchronous callback returns. Since all spans in a trace tree are emitted in a single synchronous loop, they all receive the same end time, making duration metrics in Datadog LLM Observability inaccurate.
This fix calls `ddSpan.finish(endTimeMs)` explicitly inside the `llmobs.trace()` callback, using dd-trace's own API to set the correct end time before auto-finish kicks in. Once `finish()` is called, dd-trace's subsequent auto-finish is a no-op since `_duration` is already set.

Changes:
  - `buildSpanOptions()` now returns `endTimeMs` separately (not in trace options, since dd-trace ignores it)
  - `emitSpanTree()` and `emitSingleSpan()` call `ddSpan.finish(endTimeMs)` after annotations
  - Removed `endTime` from `LLMObsSpanOptions` interface (not part of dd-trace's API)
  - Updated mock and test to verify `finish()` is called with correct timestamp

## Before 
<img width="1335" height="179" alt="image" src="https://github.com/user-attachments/assets/e11c0f81-48b0-4209-834d-b5591f4aeb3a" />

## After
<img width="1360" height="296" alt="Screenshot 2026-03-19 150228" src="https://github.com/user-attachments/assets/3f6a269e-92c1-46af-939c-71eb7f4bafa1" />

  ## Related Issue(s)
  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
  Fixes #14474

  ## Type of Change
  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist
  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Datadog LLM Observability trace span duration accuracy. Spans now correctly report their individual end times, improving visibility into LLM calls and agent run timing in Datadog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->