### PR TITLE
fix(observability): prefer aggregated inputTokenDetails for cache tokens and fix Datadog metric keys

### DIFF
--- a/.changeset/fix-cache-token-aggregation.md
+++ b/.changeset/fix-cache-token-aggregation.md
@@ -1,5 +1,8 @@
 ---
 '@mastra/observability': patch
+'@mastra/datadog': patch
 ---
 
 Fix cache token extraction in multi-step agent runs. Prefer AI SDK aggregated `inputTokenDetails` over `providerMetadata` (which only reflects the last step). Also fix truthiness checks to correctly handle zero values for cache and reasoning tokens.
+
+Fix Datadog metric keys to match dd-trace expected format: `cacheReadTokens`, `cacheWriteTokens`, `reasoningOutputTokens`.

--- a/.changeset/fix-cache-token-aggregation.md
+++ b/.changeset/fix-cache-token-aggregation.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fix cache token extraction in multi-step agent runs. Prefer AI SDK aggregated `inputTokenDetails` over `providerMetadata` (which only reflects the last step). Also fix truthiness checks to correctly handle zero values for cache and reasoning tokens.

--- a/observability/datadog/src/metrics.test.ts
+++ b/observability/datadog/src/metrics.test.ts
@@ -23,9 +23,9 @@ describe('formatUsageMetrics', () => {
       inputTokens: 200,
       outputTokens: 100,
       totalTokens: 300,
-      cachedInputTokens: 100,
-      cachedOutputTokens: 50,
-      reasoningTokens: 20,
+      cacheReadTokens: 100,
+      cacheWriteTokens: 50,
+      reasoningOutputTokens: 20,
     });
   });
 
@@ -75,7 +75,7 @@ describe('formatUsageMetrics', () => {
       inputTokens: 100,
       outputTokens: 50,
       totalTokens: 150,
-      reasoningTokens: 20,
+      reasoningOutputTokens: 20,
     });
   });
 
@@ -92,7 +92,7 @@ describe('formatUsageMetrics', () => {
       inputTokens: 100,
       outputTokens: 50,
       totalTokens: 150,
-      cachedInputTokens: 30,
+      cacheReadTokens: 30,
     });
   });
 });

--- a/observability/datadog/src/metrics.ts
+++ b/observability/datadog/src/metrics.ts
@@ -19,17 +19,17 @@ export function formatUsageMetrics(usage?: UsageStats): DatadogAnnotationMetrics
   }
 
   if (usage?.outputDetails?.reasoning !== undefined) {
-    result.reasoningTokens = usage.outputDetails.reasoning;
+    result.reasoningOutputTokens = usage.outputDetails.reasoning;
   }
 
-  const cachedTokens = usage?.inputDetails?.cacheRead;
-  if (cachedTokens !== undefined) {
-    result.cachedInputTokens = cachedTokens;
+  const cacheReadTokens = usage?.inputDetails?.cacheRead;
+  if (cacheReadTokens !== undefined) {
+    result.cacheReadTokens = cacheReadTokens;
   }
 
-  const cachedOutputTokens = usage?.inputDetails?.cacheWrite;
-  if (cachedOutputTokens !== undefined) {
-    result.cachedOutputTokens = cachedOutputTokens;
+  const cacheWriteTokens = usage?.inputDetails?.cacheWrite;
+  if (cacheWriteTokens !== undefined) {
+    result.cacheWriteTokens = cacheWriteTokens;
   }
 
   return Object.keys(result).length > 0 ? result : undefined;

--- a/observability/mastra/src/usage.test.ts
+++ b/observability/mastra/src/usage.test.ts
@@ -48,6 +48,30 @@ describe('extractUsageMetrics', () => {
 
       expect(result.outputDetails?.reasoning).toBe(400);
     });
+
+    it('should handle cachedInputTokens with value 0', () => {
+      const usage = {
+        inputTokens: 500,
+        outputTokens: 100,
+        cachedInputTokens: 0,
+      } as LanguageModelUsage;
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.inputDetails?.cacheRead).toBe(0);
+    });
+
+    it('should handle reasoningTokens with value 0', () => {
+      const usage = {
+        inputTokens: 100,
+        outputTokens: 50,
+        reasoningTokens: 0,
+      } as LanguageModelUsage;
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.outputDetails?.reasoning).toBe(0);
+    });
   });
 
   describe('Anthropic cache tokens', () => {
@@ -174,6 +198,153 @@ describe('extractUsageMetrics', () => {
 
       expect(result.inputDetails?.cacheRead).toBe(150);
       expect(result.outputDetails?.reasoning).toBe(250);
+    });
+  });
+
+  describe('AI SDK inputTokenDetails (multi-step aggregation)', () => {
+    it('should prefer inputTokenDetails.cacheReadTokens over providerMetadata', () => {
+      // Simulates multi-step: inputTokenDetails is aggregated, providerMetadata is last step only
+      const usage = {
+        inputTokens: 500,
+        outputTokens: 100,
+        inputTokenDetails: {
+          cacheReadTokens: 10000, // aggregated across all steps
+          cacheWriteTokens: 5000,
+        },
+      } as LanguageModelUsage;
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          cacheReadInputTokens: 3000, // last step only (wrong for aggregation)
+          cacheCreationInputTokens: 0, // last step only
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      // Should use inputTokenDetails values (aggregated), not providerMetadata (last step)
+      expect(result.inputDetails?.cacheRead).toBe(10000);
+      expect(result.inputDetails?.cacheWrite).toBe(5000);
+    });
+
+    it('should use inputTokenDetails as fallback when providerMetadata has no cache data', () => {
+      const usage = {
+        inputTokens: 500,
+        outputTokens: 100,
+        inputTokenDetails: {
+          cacheReadTokens: 300,
+          cacheWriteTokens: 50,
+        },
+      } as LanguageModelUsage;
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.inputDetails?.cacheRead).toBe(300);
+      expect(result.inputDetails?.cacheWrite).toBe(50);
+    });
+
+    it('should handle inputTokenDetails with zero values', () => {
+      const usage = {
+        inputTokens: 500,
+        outputTokens: 100,
+        inputTokenDetails: {
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      } as LanguageModelUsage;
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.inputDetails?.cacheRead).toBe(0);
+      expect(result.inputDetails?.cacheWrite).toBe(0);
+    });
+
+    it('should fall back to providerMetadata when inputTokenDetails is absent', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 100,
+        outputTokens: 50,
+      };
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          cacheReadInputTokens: 800,
+          cacheCreationInputTokens: 200,
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputDetails?.cacheRead).toBe(800);
+      expect(result.inputDetails?.cacheWrite).toBe(200);
+      expect(result.inputTokens).toBe(1100); // Anthropic adjustment: 100 + 800 + 200
+    });
+
+    it('should prefer inputTokenDetails over usage.cachedInputTokens', () => {
+      const usage = {
+        inputTokens: 1000,
+        outputTokens: 200,
+        cachedInputTokens: 400, // stale or partial value
+        inputTokenDetails: {
+          cacheReadTokens: 800, // aggregated value
+        },
+      } as LanguageModelUsage;
+
+      const result = extractUsageMetrics(usage);
+
+      expect(result.inputDetails?.cacheRead).toBe(800);
+    });
+
+    it('should use Anthropic inputTokens adjustment with inputTokenDetails values', () => {
+      // Multi-step Anthropic run: inputTokenDetails has aggregated cache,
+      // providerMetadata has last step only
+      const usage = {
+        inputTokens: 100, // Anthropic base (does NOT include cache)
+        outputTokens: 50,
+        inputTokenDetails: {
+          cacheReadTokens: 8000,
+          cacheWriteTokens: 2000,
+        },
+      } as LanguageModelUsage;
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          cacheReadInputTokens: 3000, // last step only — should be ignored
+          cacheCreationInputTokens: 0,
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      // inputTokenDetails values should be used (aggregated)
+      expect(result.inputDetails?.cacheRead).toBe(8000);
+      expect(result.inputDetails?.cacheWrite).toBe(2000);
+      // Anthropic adjustment uses the correct aggregated values
+      expect(result.inputTokens).toBe(10100); // 100 + 8000 + 2000
+      expect(result.inputDetails?.text).toBe(100);
+    });
+
+    it('should prefer inputTokenDetails over Google providerMetadata for cacheRead', () => {
+      const usage = {
+        inputTokens: 500,
+        outputTokens: 100,
+        inputTokenDetails: {
+          cacheReadTokens: 7000, // aggregated
+        },
+      } as LanguageModelUsage;
+
+      const providerMetadata: ProviderMetadata = {
+        google: {
+          usageMetadata: {
+            cachedContentTokenCount: 3000, // last step only
+            thoughtsTokenCount: 49,
+          },
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputDetails?.cacheRead).toBe(7000); // inputTokenDetails wins
+      expect(result.outputDetails?.reasoning).toBe(49); // thoughts still extracted from Google
     });
   });
 

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -47,6 +47,16 @@ function isDefined(value: unknown): value is number {
  * 1. AI SDK aggregated inputTokenDetails (properly summed across all steps in multi-step runs)
  * 2. Provider-specific providerMetadata (accurate for single-step, last step only in multi-step)
  * 3. usage.cachedInputTokens (OpenAI/OpenRouter direct field)
+ *
+ * Handles:
+ * - OpenAI: cachedInputTokens in usage object
+ * - Anthropic: cacheCreationInputTokens, cacheReadInputTokens in providerMetadata.anthropic
+ * - Google/Gemini: cachedContentTokenCount, thoughtsTokenCount in providerMetadata.google.usageMetadata
+ * - OpenRouter: Uses OpenAI-compatible structure (cache tokens in usage)
+ *
+ * @param usage - The LanguageModelV2Usage from AI SDK response
+ * @param providerMetadata - Optional provider-specific metadata
+ * @returns UsageStats with inputDetails and outputDetails
  */
 export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata?: ProviderMetadata): UsageStats {
   if (!usage) {

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -24,18 +24,29 @@ interface GoogleMetadata {
 }
 
 /**
+ * AI SDK aggregated input token details.
+ * Available on totalUsage in multi-step runs — properly summed across all steps.
+ */
+interface AISdkInputTokenDetails {
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+/**
+ * Null-safe check: returns true if value is a number (including 0).
+ */
+function isDefined(value: unknown): value is number {
+  return value != null;
+}
+
+/**
  * Extracts and normalizes token usage from AI SDK response, including
  * provider-specific cache tokens from providerMetadata.
  *
- * Handles:
- * - OpenAI: cachedInputTokens in usage object
- * - Anthropic: cacheCreationInputTokens, cacheReadInputTokens in providerMetadata.anthropic
- * - Google/Gemini: cachedContentTokenCount, thoughtsTokenCount in providerMetadata.google.usageMetadata
- * - OpenRouter: Uses OpenAI-compatible structure (cache tokens in usage)
- *
- * @param usage - The LanguageModelV2Usage from AI SDK response
- * @param providerMetadata - Optional provider-specific metadata
- * @returns UsageStats with inputDetails and outputDetails
+ * Cache token extraction priority (highest to lowest):
+ * 1. AI SDK aggregated inputTokenDetails (properly summed across all steps in multi-step runs)
+ * 2. Provider-specific providerMetadata (accurate for single-step, last step only in multi-step)
+ * 3. usage.cachedInputTokens (OpenAI/OpenRouter direct field)
  */
 export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata?: ProviderMetadata): UsageStats {
   if (!usage) {
@@ -48,15 +59,28 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
   let inputTokens = usage.inputTokens;
   const outputTokens = usage.outputTokens;
 
+  // ===== AI SDK aggregated format (inputTokenDetails) =====
+  // In multi-step runs, providerMetadata only reflects the LAST step.
+  // AI SDK's inputTokenDetails is properly aggregated across all steps,
+  // so we prefer it as the primary source for cache tokens.
+  const aiSdkDetails = (usage as { inputTokenDetails?: AISdkInputTokenDetails }).inputTokenDetails;
+
+  if (isDefined(aiSdkDetails?.cacheReadTokens)) {
+    inputDetails.cacheRead = aiSdkDetails.cacheReadTokens;
+  }
+  if (isDefined(aiSdkDetails?.cacheWriteTokens)) {
+    inputDetails.cacheWrite = aiSdkDetails.cacheWriteTokens;
+  }
+
   // ===== OpenAI / OpenRouter =====
   // cachedInputTokens is already in the usage object
   // inputTokens INCLUDES cached tokens (no adjustment needed)
-  if (usage.cachedInputTokens) {
+  if (!isDefined(inputDetails.cacheRead) && isDefined(usage.cachedInputTokens)) {
     inputDetails.cacheRead = usage.cachedInputTokens;
   }
 
   // reasoningTokens from usage (OpenAI o1 models)
-  if (usage.reasoningTokens) {
+  if (isDefined(usage.reasoningTokens)) {
     outputDetails.reasoning = usage.reasoningTokens;
   }
 
@@ -66,34 +90,32 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
   const anthropic = providerMetadata?.anthropic as AnthropicMetadata | undefined;
 
   if (anthropic) {
-    if (anthropic.cacheReadInputTokens) {
+    if (!isDefined(inputDetails.cacheRead) && isDefined(anthropic.cacheReadInputTokens)) {
       inputDetails.cacheRead = anthropic.cacheReadInputTokens;
     }
-    if (anthropic.cacheCreationInputTokens) {
+    if (!isDefined(inputDetails.cacheWrite) && isDefined(anthropic.cacheCreationInputTokens)) {
       inputDetails.cacheWrite = anthropic.cacheCreationInputTokens;
     }
 
     // For Anthropic, adjust inputTokens to include cache tokens
     // Per Anthropic docs: "Total input tokens is the summation of input_tokens,
     // cache_creation_input_tokens, and cache_read_input_tokens"
-    if (anthropic.cacheReadInputTokens || anthropic.cacheCreationInputTokens) {
+    if (isDefined(inputDetails.cacheRead) || isDefined(inputDetails.cacheWrite)) {
       inputDetails.text = usage.inputTokens;
-      inputTokens =
-        (usage.inputTokens ?? 0) + (anthropic.cacheReadInputTokens ?? 0) + (anthropic.cacheCreationInputTokens ?? 0);
+      inputTokens = (usage.inputTokens ?? 0) + (inputDetails.cacheRead ?? 0) + (inputDetails.cacheWrite ?? 0);
     }
   }
 
   // ===== Google/Gemini =====
   // Cache tokens and thoughts are in providerMetadata.google.usageMetadata
-  // Available in @ai-sdk/google@1.2.23+
   const google = providerMetadata?.google as GoogleMetadata | undefined;
 
   if (google?.usageMetadata) {
-    if (google.usageMetadata.cachedContentTokenCount) {
+    if (!isDefined(inputDetails.cacheRead) && isDefined(google.usageMetadata.cachedContentTokenCount)) {
       inputDetails.cacheRead = google.usageMetadata.cachedContentTokenCount;
     }
     // Gemini "thoughts" are similar to reasoning tokens
-    if (google.usageMetadata.thoughtsTokenCount) {
+    if (isDefined(google.usageMetadata.thoughtsTokenCount)) {
       outputDetails.reasoning = google.usageMetadata.thoughtsTokenCount;
     }
   }


### PR DESCRIPTION
## Description
  <!-- Provide a brief description of the changes in this PR -->
In multi-step agent runs, `extractUsageMetrics()` read cache tokens (cacheRead/cacheWrite) from `providerMetadata`, which only reflects the **last step** - not the aggregated total across all steps. This caused MODEL_GENERATION spans to report incorrect or missing cache token counts in Datadog (and all other observability exporters).

**Changes:**
  - Prefer AI SDK's `inputTokenDetails.cacheReadTokens` / `cacheWriteTokens` as the primary source for cache tokens (properly aggregated across all steps by
   the AI SDK)
  - Fall back to provider-specific `providerMetadata` (Anthropic, Google) and `usage.cachedInputTokens` (OpenAI) when `inputTokenDetails` is absent
  (single-step runs, older SDK versions)
  - Fix all truthiness checks (`if (x)` → `isDefined(x)`) to correctly handle zero values instead of silently dropping them

  ## Related Issue(s)
  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
  Fixes #14475

  ## Type of Change
  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist
  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cache token extraction during multi-step agent runs by prioritizing aggregated token data over provider metadata
  * Fixed token handling to correctly process zero-value tokens instead of misinterpreting them as absent
  * Updated Datadog metric key names to align with expected format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->