### PR TITLE
fix(ci): check e2e-test result in PR status and update workflow deps

### DIFF
--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm test:navigation
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-docs

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -104,7 +104,7 @@ jobs:
           # To solve *that*, we'd have to extract to root (/), which isn't safe.
           tar -czvf $cache_archive -C $cache_dir .
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         if: github.event.inputs.repoCache != 'disabled'
         with:
           name: ${{ env.cache_key }}

--- a/.github/workflows/vitest-all.yml
+++ b/.github/workflows/vitest-all.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vitest-blob-${{ matrix.shard }}
           path: .vitest-reports/
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vitest-blob-${{ steps.normalize.outputs.project_id }}
           path: .vitest-reports/
@@ -162,7 +162,7 @@ jobs:
         uses: ./.github/actions/setup-pnpm-node
 
       - name: Download all test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: vitest-blob-*
           path: .vitest-reports

--- a/.github/workflows/vitest-changed.yml
+++ b/.github/workflows/vitest-changed.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vitest-blob-${{ matrix.shard }}
           path: .vitest-reports/
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vitest-blob-${{ steps.normalize.outputs.project_id }}
           path: .vitest-reports/
@@ -610,7 +610,7 @@ jobs:
         uses: ./.github/actions/setup-pnpm-node
 
       - name: Download all test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: vitest-blob-*
           path: .vitest-reports
@@ -639,7 +639,7 @@ jobs:
         id: status
         run: |
           # Check if any of the test jobs failed or were cancelled
-          if [[ "${{ needs.test.result }}" =~ ^(failure|cancelled)$ ]] then
+          if [[ "${{ needs.test.result }}" =~ ^(failure|cancelled)$ ]] || [[ "${{ needs.e2e-test.result }}" =~ ^(failure|cancelled)$ ]]; then
             echo "status=failure" >> $GITHUB_OUTPUT
             echo "description=Some tests failed or were cancelled" >> $GITHUB_OUTPUT
           else

--- a/packages/core/src/agent/agent.e2e.test.ts
+++ b/packages/core/src/agent/agent.e2e.test.ts
@@ -4,7 +4,8 @@ import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import type { ToolInvocationUIPart } from '@ai-sdk/ui-utils-v5';
 import type { LanguageModelV1 } from '@internal/ai-sdk-v4';
 import { stepCountIs, tool } from '@internal/ai-sdk-v5';
-import { createGatewayMock } from '@internal/test-utils';
+import { getLLMTestMode } from '@internal/llm-recorder';
+import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
 import { config } from 'dotenv';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -19,6 +20,9 @@ import { assertNoDuplicateParts } from './test-utils';
 import { Agent } from './index';
 
 config();
+
+const MODE = getLLMTestMode();
+setupDummyApiKeys(MODE, ['openai']);
 
 const mockFindUser = vi.fn().mockImplementation(async data => {
   const list = [

--- a/packages/core/src/tools/provider-tools.e2e.test.ts
+++ b/packages/core/src/tools/provider-tools.e2e.test.ts
@@ -3,9 +3,13 @@ import type { AnthropicProviderOptions } from '@ai-sdk/anthropic-v5';
 import { google } from '@ai-sdk/google-v5';
 import { openai } from '@ai-sdk/openai-v5';
 import { openai as openaiV6 } from '@ai-sdk/openai-v6';
-import { createGatewayMock } from '@internal/test-utils';
+import { getLLMTestMode } from '@internal/llm-recorder';
+import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { Agent } from '../agent';
+
+const MODE = getLLMTestMode();
+setupDummyApiKeys(MODE, ['openai']);
 
 const mock = createGatewayMock();
 beforeAll(() => mock.start());

--- a/server-adapters/_test-utils/src/mcp-transport-test-suite.ts
+++ b/server-adapters/_test-utils/src/mcp-transport-test-suite.ts
@@ -209,13 +209,7 @@ export function createMCPTransportTestSuite(config: MCPTransportTestConfig) {
           const result = await calculateTool.execute!({ operation: 'multiply', a: 6, b: 7 });
 
           expect(result).toBeDefined();
-          expect(result.content).toBeInstanceOf(Array);
-          expect(result.content.length).toBeGreaterThan(0);
-
-          const toolOutput = result.content[0];
-          expect(toolOutput.type).toBe('text');
-          const toolResult = JSON.parse(toolOutput.text);
-          expect(toolResult.result).toBe(42);
+          expect(result).toMatchObject({ result: 42 });
         });
 
         it('should execute weather tool via MCPClient', async () => {
@@ -228,13 +222,10 @@ export function createMCPTransportTestSuite(config: MCPTransportTestConfig) {
           const result = await weatherToolInstance.execute!({ location: 'Austin' });
 
           expect(result).toBeDefined();
-          expect(result.content).toBeInstanceOf(Array);
-
-          const toolOutput = result.content[0];
-          expect(toolOutput.type).toBe('text');
-          const toolResult = JSON.parse(toolOutput.text);
-          expect(toolResult.temperature).toBe(72);
-          expect(toolResult.condition).toBe('Sunny in Austin');
+          expect(result).toMatchObject({
+            temperature: 72,
+            condition: 'Sunny in Austin',
+          });
         });
 
         it('should handle multiple MCP servers', async () => {
@@ -373,13 +364,7 @@ export function createMCPTransportTestSuite(config: MCPTransportTestConfig) {
           const result = await calculateTool.execute!({ operation: 'add', a: 10, b: 5 });
 
           expect(result).toBeDefined();
-          expect(result.content).toBeInstanceOf(Array);
-          expect(result.content.length).toBeGreaterThan(0);
-
-          const toolOutput = result.content[0];
-          expect(toolOutput.type).toBe('text');
-          const toolResult = JSON.parse(toolOutput.text);
-          expect(toolResult.result).toBe(15);
+          expect(result).toMatchObject({ result: 15 });
         });
 
         it('should execute weather tool via MCPClient over SSE', async () => {
@@ -392,13 +377,10 @@ export function createMCPTransportTestSuite(config: MCPTransportTestConfig) {
           const result = await weatherToolInstance.execute!({ location: 'New York' });
 
           expect(result).toBeDefined();
-          expect(result.content).toBeInstanceOf(Array);
-
-          const toolOutput = result.content[0];
-          expect(toolOutput.type).toBe('text');
-          const toolResult = JSON.parse(toolOutput.text);
-          expect(toolResult.temperature).toBe(72);
-          expect(toolResult.condition).toBe('Sunny in New York');
+          expect(result).toMatchObject({
+            temperature: 72,
+            condition: 'Sunny in New York',
+          });
         });
       });
 


### PR DESCRIPTION
## Summary

The `pr-status` job in `vitest-changed.yml` only checked `needs.test.result` but ignored `needs.e2e-test.result`, causing the PR status check to report **success even when e2e tests failed**.

## Changes

### Bug fix
- **`vitest-changed.yml`**: Added `needs.e2e-test.result` check to the PR status determination logic
- Fixed bash syntax: missing semicolon before `then` in the conditional

### Dependency updates
- Bumped `actions/upload-artifact` from v4/v5 to v6 across workflows (`vitest-changed.yml`, `vitest-all.yml`, `e2e-docs.yml`, `renovate.yml`)
- Bumped `actions/download-artifact` from v4 to v6

### Test improvements
- Updated `agent.e2e.test.ts` and `provider-tools.e2e.test.ts` to use `llm-recorder` and `setupDummyApiKeys`
- Simplified MCP transport test assertions to match updated tool result format

## Test plan
- CI should now correctly report failure when e2e tests fail
- Existing tests should continue to pass with the updated assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Tests**
  * Updated end-to-end test environment initialization.
  * Simplified test assertions for improved maintainability.

* **Chores**
  * Updated GitHub Actions workflows to use latest artifact handling versions across multiple CI/CD pipelines.
  * Enhanced PR status determination logic in test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->