### PR TITLE
fix(server): fix zod v3/v4 cross-instance crash in observability query params

### DIFF
--- a/packages/server/src/server/handlers/observability-new-endpoints.ts
+++ b/packages/server/src/server/handlers/observability-new-endpoints.ts
@@ -44,7 +44,7 @@ import { coreFeatures } from '@mastra/core/features';
 import type { z } from 'zod';
 import { HTTPException } from '../http-exception';
 import type { InferParams, ServerContext, ServerRouteHandler } from '../server-adapter/routes';
-import { createRoute, pickParams, wrapSchemaForQueryParams } from '../server-adapter/routes/route-builder';
+import { createRoute, pickParams } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
 import { getObservabilityStore, NEW_ROUTE_DEFS } from './observability-shared';
 import type { RouteDetails } from './observability-shared';
@@ -96,9 +96,7 @@ function createNewRoute<
 // ============================================================================
 
 export const LIST_LOGS = createNewRoute(NEW_ROUTE_DEFS.LIST_LOGS, {
-  queryParamSchema: wrapSchemaForQueryParams(
-    logsFilterSchema.extend(paginationArgsSchema.shape).extend(logsOrderBySchema.shape).partial(),
-  ),
+  queryParamSchema: logsFilterSchema.extend(paginationArgsSchema.shape).extend(logsOrderBySchema.shape).partial(),
   responseSchema: listLogsResponseSchema,
   handler: async ({ mastra, ...params }) => {
     const filters = pickParams(logsFilterSchema, params);
@@ -115,9 +113,7 @@ export const LIST_LOGS = createNewRoute(NEW_ROUTE_DEFS.LIST_LOGS, {
 // ============================================================================
 
 export const LIST_SCORES = createNewRoute(NEW_ROUTE_DEFS.LIST_SCORES, {
-  queryParamSchema: wrapSchemaForQueryParams(
-    scoresFilterSchema.extend(paginationArgsSchema.shape).extend(scoresOrderBySchema.shape).partial(),
-  ),
+  queryParamSchema: scoresFilterSchema.extend(paginationArgsSchema.shape).extend(scoresOrderBySchema.shape).partial(),
   responseSchema: obsListScoresResponseSchema,
   handler: async ({ mastra, ...params }) => {
     const filters = pickParams(scoresFilterSchema, params);
@@ -144,9 +140,10 @@ export const CREATE_SCORE = createNewRoute(NEW_ROUTE_DEFS.CREATE_SCORE, {
 // ============================================================================
 
 export const LIST_FEEDBACK = createNewRoute(NEW_ROUTE_DEFS.LIST_FEEDBACK, {
-  queryParamSchema: wrapSchemaForQueryParams(
-    feedbackFilterSchema.extend(paginationArgsSchema.shape).extend(feedbackOrderBySchema.shape).partial(),
-  ),
+  queryParamSchema: feedbackFilterSchema
+    .extend(paginationArgsSchema.shape)
+    .extend(feedbackOrderBySchema.shape)
+    .partial(),
   responseSchema: listFeedbackResponseSchema,
   handler: async ({ mastra, ...params }) => {
     const filters = pickParams(feedbackFilterSchema, params);
@@ -217,7 +214,7 @@ export const GET_METRIC_PERCENTILES = createNewRoute(NEW_ROUTE_DEFS.GET_METRIC_P
 // ============================================================================
 
 export const GET_METRIC_NAMES = createNewRoute(NEW_ROUTE_DEFS.GET_METRIC_NAMES, {
-  queryParamSchema: wrapSchemaForQueryParams(getMetricNamesArgsSchema.partial()),
+  queryParamSchema: getMetricNamesArgsSchema.partial(),
   responseSchema: getMetricNamesResponseSchema,
   handler: async ({ mastra, ...params }) => {
     const args = getMetricNamesArgsSchema.parse(pickParams(getMetricNamesArgsSchema, params));
@@ -227,7 +224,7 @@ export const GET_METRIC_NAMES = createNewRoute(NEW_ROUTE_DEFS.GET_METRIC_NAMES, 
 });
 
 export const GET_METRIC_LABEL_KEYS = createNewRoute(NEW_ROUTE_DEFS.GET_METRIC_LABEL_KEYS, {
-  queryParamSchema: wrapSchemaForQueryParams(getMetricLabelKeysArgsSchema),
+  queryParamSchema: getMetricLabelKeysArgsSchema,
   responseSchema: getMetricLabelKeysResponseSchema,
   handler: async ({ mastra, ...params }) => {
     const args = getMetricLabelKeysArgsSchema.parse(pickParams(getMetricLabelKeysArgsSchema, params));
@@ -237,7 +234,7 @@ export const GET_METRIC_LABEL_KEYS = createNewRoute(NEW_ROUTE_DEFS.GET_METRIC_LA
 });
 
 export const GET_METRIC_LABEL_VALUES = createNewRoute(NEW_ROUTE_DEFS.GET_METRIC_LABEL_VALUES, {
-  queryParamSchema: wrapSchemaForQueryParams(getMetricLabelValuesArgsSchema),
+  queryParamSchema: getMetricLabelValuesArgsSchema,
   responseSchema: getMetricLabelValuesResponseSchema,
   handler: async ({ mastra, ...params }) => {
     const args = getMetricLabelValuesArgsSchema.parse(pickParams(getMetricLabelValuesArgsSchema, params));
@@ -255,7 +252,7 @@ export const GET_ENTITY_TYPES = createNewRoute(NEW_ROUTE_DEFS.GET_ENTITY_TYPES, 
 });
 
 export const GET_ENTITY_NAMES = createNewRoute(NEW_ROUTE_DEFS.GET_ENTITY_NAMES, {
-  queryParamSchema: wrapSchemaForQueryParams(getEntityNamesArgsSchema.partial()),
+  queryParamSchema: getEntityNamesArgsSchema.partial(),
   responseSchema: getEntityNamesResponseSchema,
   handler: async ({ mastra, ...params }) => {
     const args = getEntityNamesArgsSchema.parse(pickParams(getEntityNamesArgsSchema, params));
@@ -281,7 +278,7 @@ export const GET_ENVIRONMENTS = createNewRoute(NEW_ROUTE_DEFS.GET_ENVIRONMENTS, 
 });
 
 export const GET_TAGS = createNewRoute(NEW_ROUTE_DEFS.GET_TAGS, {
-  queryParamSchema: wrapSchemaForQueryParams(getTagsArgsSchema.partial()),
+  queryParamSchema: getTagsArgsSchema.partial(),
   responseSchema: getTagsResponseSchema,
   handler: async ({ mastra, ...params }) => {
     const args = getTagsArgsSchema.parse(pickParams(getTagsArgsSchema, params));

--- a/packages/server/src/server/handlers/observability.ts
+++ b/packages/server/src/server/handlers/observability.ts
@@ -14,9 +14,9 @@ import {
   getTraceResponseSchema,
   dateRangeSchema,
 } from '@mastra/core/storage';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { HTTPException } from '../http-exception';
-import { createRoute, pickParams, wrapSchemaForQueryParams } from '../server-adapter/routes/route-builder';
+import { createRoute, pickParams } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
 import { getObservabilityStore, getStorage } from './observability-shared';
 
@@ -97,13 +97,11 @@ export const LIST_TRACES_ROUTE = createRoute({
   method: 'GET',
   path: '/observability/traces',
   responseType: 'json',
-  queryParamSchema: wrapSchemaForQueryParams(
-    tracesFilterSchema
-      .extend(paginationArgsSchema.shape)
-      .extend(tracesOrderBySchema.shape)
-      .extend(legacyQueryParamsSchema.shape) // Accept legacy params for backward compatibility
-      .partial(),
-  ),
+  queryParamSchema: tracesFilterSchema
+    .extend(paginationArgsSchema.shape)
+    .extend(tracesOrderBySchema.shape)
+    .extend(legacyQueryParamsSchema.shape) // Accept legacy params for backward compatibility
+    .partial(),
   responseSchema: listTracesResponseSchema,
   summary: 'List traces',
   description: 'Returns a paginated list of traces with optional filtering and sorting',
@@ -202,7 +200,7 @@ export const LIST_SCORES_BY_SPAN_ROUTE = createRoute({
   responseType: 'json',
   pathParamSchema: spanIdsSchema,
   // List endpoints accept optional query params; use partial() to allow empty queries.
-  queryParamSchema: wrapSchemaForQueryParams(paginationArgsSchema.partial()),
+  queryParamSchema: paginationArgsSchema.partial(),
   responseSchema: listScoresResponseSchema,
   summary: 'List scores by span',
   description: 'Returns all scores for a specific span within a trace',

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -5,7 +5,7 @@ import { MastraServerBase } from '@mastra/core/server';
 import type { ApiRoute, HttpLoggingConfig, ValidationErrorContext, ValidationErrorResponse } from '@mastra/core/server';
 import { Hono } from 'hono';
 import type { ZodError } from 'zod';
-import { z } from 'zod/v4';
+import type { z } from 'zod/v4';
 
 import type { InMemoryTaskStore } from '../a2a/store';
 import { coreAuthMiddleware } from '../auth/helpers';
@@ -115,12 +115,15 @@ function parseComplexQueryParams(
   queryParamSchema: z.ZodTypeAny,
   params: Record<string, QueryParamValue>,
 ): Record<string, QueryParamValue | unknown> {
-  if (!(queryParamSchema instanceof z.ZodObject)) {
+  // Use type name check instead of instanceof to work across zod instances (v3/v4, file: overrides)
+  const typeName = getSchemaTypeName(queryParamSchema);
+  const schemaShape = (queryParamSchema as any).shape;
+  if ((typeName !== 'ZodObject' && typeName !== 'object') || !schemaShape) {
     return params;
   }
 
   const parsedParams: Record<string, QueryParamValue | unknown> = { ...params };
-  const shape = queryParamSchema.shape as Record<string, z.ZodTypeAny>;
+  const shape = schemaShape as Record<string, z.ZodTypeAny>;
 
   for (const [key, fieldSchema] of Object.entries(shape)) {
     const rawValue = parsedParams[key];


### PR DESCRIPTION
## Summary
- Remove redundant `wrapSchemaForQueryParams()` from observability handlers — the server adapter's `parseComplexQueryParams` already handles JSON string preprocessing for complex query params
- Fix `observability.ts` to import `z` from `zod/v4` so `legacyQueryParamsSchema` fields are compatible with the v4 storage domain schemas they get `.extend()`ed into
- Make `parseComplexQueryParams` use type name checking instead of `instanceof z.ZodObject` to work across zod instances

## Test plan
- [ ] Verify Studio observability tab loads traces without errors
- [ ] Verify trace filtering (by date, tags, status) works
- [ ] Verify `pnpm test:core` and server tests pass