### PR TITLE
fix(observability): update snapshot for fixed serialization

### DIFF
--- a/observability/mastra/src/__snapshots__/agent-processors-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace.json
@@ -473,7 +473,14 @@
                   "role": "assistant",
                   "content": {
                     "format": 2,
-                    "parts": ["[Circular]"],
+                    "parts": [
+                      {
+                        "type": "text",
+                        "text": {
+                          "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                        }
+                      }
+                    ],
                     "metadata": {
                       "modelId": "mock-model-id"
                     },


### PR DESCRIPTION
PR #14263 fixed false `[Circular]` markers in span serialization. The `agent-processors-trace.json` snapshot still had the old incorrect marker for `content.parts`. Updated it to expect the actual text part objects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated observability trace snapshots to reflect improved internal data formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->