### PR TITLE
fix(core): skip processOutputStream when part is null in workflow processor path

### DIFF
--- a/.changeset/yellow-drinks-shave.md
+++ b/.changeset/yellow-drinks-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a bug where workflow-based processor execution would pass null stream parts to subsequent processors. When a processor's processOutputStream returns null (e.g., a guardrail filtering a part), the next processor in the chain would receive null as the part, causing potential errors. The null guard now matches the inline processor path behavior, skipping processors when the part is null.

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1033,7 +1033,7 @@ function createStepFromProcessor<TProcessorId extends string>(
           }
 
           case 'outputStream': {
-            if (processor.processOutputStream) {
+            if (processor.processOutputStream && part) {
               // Manage per-processor span lifecycle across stream chunks
               // Use unique key to store span on shared state object
               const spanKey = `__outputStreamSpan_${processor.id}`;

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1005,7 +1005,7 @@ function createStepFromProcessor<TProcessorId extends string>(
             if (part && (part as ChunkType).type.startsWith('data-') && !processor.processDataParts) {
               return { ...passThrough, part };
             }
-            if (processor.processOutputStream) {
+            if (processor.processOutputStream && part) {
               // Manage per-processor span lifecycle across stream chunks
               // Use unique key to store span on shared state object
               const spanKey = `__outputStreamSpan_${processor.id}`;


### PR DESCRIPTION
The workflow-based processor execution path was calling `processOutputStream` even when `part` is `null`. This happens when an earlier processor filters out a stream part by returning `null`.

The inline runner path at `runner.ts:481` already guards against this:
```ts
if (processor.processOutputStream && processedPart) {
```

But the workflow path only checked for the method, not the part:
```ts
// before
if (processor.processOutputStream) {

// after
if (processor.processOutputStream && part) {
```

Applied to both `workflow.ts` and `evented/workflow.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed processor chain handling to skip subsequent processors when an output part is filtered out, preventing downstream processors from receiving invalid parts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->