### PR TITLE
fix(tools): detect null-related validation failures by checking actual values instead of error messages

### DIFF
--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -468,9 +468,24 @@ export function validateToolInput<T = unknown>(
   // LLMs like Gemini send null for optional fields, but Zod's .optional() only
   // accepts undefined, not null. We only strip nulls for fields that caused
   // validation errors, preserving null for .nullable() schemas that need it.
+  // Check actual values at failing paths instead of relying on error message text.
+  // Error messages vary across schema validators — "null" may not appear even when
+  // the issue is caused by a null value (e.g., "must be string" from JSON Schema).
   const failingNullPaths = new Set(
     validation.issues
-      .filter(issue => issue.message?.includes('null'))
+      .filter(issue => {
+        // Resolve the value at the failing path in the original input
+        const path = issue.path;
+        if (!path || path.length === 0) return false;
+        let value: unknown = input;
+        for (const segment of path) {
+          const key = typeof segment === 'object' && 'key' in segment ? segment.key : segment;
+          if (value === null || value === undefined || typeof value !== 'object') return false;
+          value = (value as Record<string, unknown>)[String(key)];
+        }
+        // The issue is null-related if the actual value is null or undefined
+        return value === null || value === undefined;
+      })
       .map(issue => issue.path?.map(p => (typeof p === 'object' && 'key' in p ? String(p.key) : String(p))).join('.'))
       .filter((p): p is string => !!p),
   );


### PR DESCRIPTION
## Summary

Fixes #14476

`validateToolInput` previously detected null-related validation failures by checking if `issue.message?.includes('null')`. This misses cases where validators return messages like `"must be string"` or `"must be object"` for null values — common with Standard JSON Schema / JSON Schema-based validators.

## Change

Instead of string-matching error messages, the fix resolves the **actual value** at each failing path in the input and checks whether it is `null` or `undefined`.

**Before:**
```ts
.filter(issue => issue.message?.includes('null'))
```

**After:**
```ts
.filter(issue => {
  // Resolve the value at the failing path in the original input
  const path = issue.path;
  if (!path || path.length === 0) return false;
  let value: unknown = input;
  for (const segment of path) {
    const key = typeof segment === 'object' && 'key' in segment ? segment.key : segment;
    if (value === null || value === undefined || typeof value !== 'object') return false;
    value = (value as Record<string, unknown>)[String(key)];
  }
  return value === null || value === undefined;
})
```

## Why This Matters

As reported in #14476, ~7% of tool calls in production fail because:
1. LLM sends `null` for optional fields
2. Validator returns `"must be string"` (not mentioning `"null"`)
3. `failingNullPaths` is empty → falls back to `stripNullishValues(input)`
4. Fallback still fails for nested structures

With this fix, the null-related paths are correctly detected regardless of error message format, so the targeted `stripNullishValuesAtPaths` runs on the right fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation accuracy by detecting null and undefined values through direct inspection rather than error message pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->