### PR TITLE
fix: update pi-tui keybindings API for v0.61.0

### DIFF
--- a/mastracode/src/tui/components/__tests__/api-key-dialog.test.ts
+++ b/mastracode/src/tui/components/__tests__/api-key-dialog.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@mariozechner/pi-tui', () => {
+  class MockNode {
+    children: any[] = [];
+    addChild(child: any) {
+      this.children.push(child);
+      return child;
+    }
+    clear() {
+      this.children = [];
+    }
+  }
+
+  class Box extends MockNode {
+    constructor(..._args: any[]) {
+      super();
+    }
+  }
+
+  class Input extends MockNode {
+    value = '';
+    focused = false;
+    onSubmit?: (value: string) => void;
+    getValue() {
+      return this.value;
+    }
+    handleInput(keyData: string) {
+      if (keyData === '\r') {
+        this.onSubmit?.(this.value);
+        return;
+      }
+      if (keyData === '\u007f') {
+        this.value = this.value.slice(0, -1);
+        return;
+      }
+      if (keyData.length === 1) {
+        this.value += keyData;
+      }
+    }
+  }
+
+  class Text {
+    constructor(
+      public text: string,
+      public x = 0,
+      public y = 0,
+    ) {}
+  }
+
+  class Spacer {
+    constructor(public size: number) {}
+  }
+
+  return {
+    Box,
+    Input,
+    Text,
+    Spacer,
+    getKeybindings: () => ({
+      matches: (keyData: string, action: string) => {
+        if (action === 'tui.select.cancel') return keyData === 'ESC';
+        return false;
+      },
+    }),
+  };
+});
+
+vi.mock('../../theme.js', () => ({
+  theme: {
+    bg: (_token: string, text: string) => text,
+    bold: (text: string) => text,
+    fg: (_token: string, text: string) => text,
+  },
+}));
+
+import { ApiKeyDialogComponent } from '../api-key-dialog.js';
+
+describe('ApiKeyDialogComponent keybindings', () => {
+  it('calls onCancel on escape via tui.select.cancel', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const dialog = new ApiKeyDialogComponent({
+      providerName: 'OpenAI',
+      onSubmit,
+      onCancel,
+    });
+
+    dialog.handleInput('ESC');
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('passes non-escape input to the inner Input for typing', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const dialog = new ApiKeyDialogComponent({
+      providerName: 'OpenAI',
+      onSubmit,
+      onCancel,
+    });
+
+    // Type a key
+    dialog.handleInput('s');
+    dialog.handleInput('k');
+    dialog.handleInput('-');
+
+    // Neither callback should fire from typing
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('calls onSubmit with trimmed value when Enter is pressed via Input', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const dialog = new ApiKeyDialogComponent({
+      providerName: 'OpenAI',
+      onSubmit,
+      onCancel,
+    });
+
+    // Type an API key and submit
+    for (const ch of 'sk-test-key') {
+      dialog.handleInput(ch);
+    }
+    dialog.handleInput('\r');
+
+    expect(onSubmit).toHaveBeenCalledWith('sk-test-key');
+  });
+
+  it('calls onCancel when Enter is pressed with empty input', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const dialog = new ApiKeyDialogComponent({
+      providerName: 'OpenAI',
+      onSubmit,
+      onCancel,
+    });
+
+    // Submit with empty input
+    dialog.handleInput('\r');
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/src/tui/components/__tests__/login-selector.test.ts
+++ b/mastracode/src/tui/components/__tests__/login-selector.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@mariozechner/pi-tui', () => {
+  class MockNode {
+    children: any[] = [];
+    addChild(child: any) {
+      this.children.push(child);
+      return child;
+    }
+    clear() {
+      this.children = [];
+    }
+  }
+
+  class Box extends MockNode {
+    constructor(..._args: any[]) {
+      super();
+    }
+  }
+
+  class Container extends MockNode {}
+
+  class Text {
+    constructor(
+      public text: string,
+      public x = 0,
+      public y = 0,
+    ) {}
+  }
+
+  class Spacer {
+    constructor(public size: number) {}
+  }
+
+  return {
+    Box,
+    Container,
+    Text,
+    Spacer,
+    getKeybindings: () => ({
+      matches: (keyData: string, action: string) => {
+        if (action === 'tui.select.up') return keyData === 'UP';
+        if (action === 'tui.select.down') return keyData === 'DOWN';
+        if (action === 'tui.select.confirm') return keyData === '\r';
+        if (action === 'tui.select.cancel') return keyData === 'ESC';
+        return false;
+      },
+    }),
+  };
+});
+
+vi.mock('../../theme.js', () => ({
+  theme: {
+    bg: (_token: string, text: string) => text,
+    bold: (text: string) => text,
+    fg: (_token: string, text: string) => text,
+  },
+}));
+
+import type { AuthProviderSource } from '../login-selector.js';
+import { LoginSelectorComponent } from '../login-selector.js';
+
+function createAuthSource(
+  providers: { id: string; name: string }[],
+  loggedIn: Set<string> = new Set(),
+): AuthProviderSource {
+  return {
+    getOAuthProviders: () => providers.map(p => ({ id: p.id, name: p.name }) as any),
+    isLoggedIn: (id: string) => loggedIn.has(id),
+  };
+}
+
+describe('LoginSelectorComponent keybindings', () => {
+  const providers = [
+    { id: 'github', name: 'GitHub' },
+    { id: 'google', name: 'Google' },
+    { id: 'gitlab', name: 'GitLab' },
+  ];
+
+  it('navigates down through providers', () => {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    const selector = new LoginSelectorComponent('login', createAuthSource(providers), onSelect, onCancel);
+
+    // Navigate down twice, then confirm — should select 'google' (index 2)
+    selector.handleInput('DOWN');
+    selector.handleInput('DOWN');
+    selector.handleInput('\r');
+
+    expect(onSelect).toHaveBeenCalledWith('gitlab');
+  });
+
+  it('navigates up through providers', () => {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    const selector = new LoginSelectorComponent('login', createAuthSource(providers), onSelect, onCancel);
+
+    // Navigate down then back up, confirm — should select first provider
+    selector.handleInput('DOWN');
+    selector.handleInput('UP');
+    selector.handleInput('\r');
+
+    expect(onSelect).toHaveBeenCalledWith('github');
+  });
+
+  it('clamps at top when pressing up at start', () => {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    const selector = new LoginSelectorComponent('login', createAuthSource(providers), onSelect, onCancel);
+
+    // Press up at start, should stay at index 0
+    selector.handleInput('UP');
+    selector.handleInput('\r');
+
+    expect(onSelect).toHaveBeenCalledWith('github');
+  });
+
+  it('clamps at bottom when pressing down past last', () => {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    const selector = new LoginSelectorComponent('login', createAuthSource(providers), onSelect, onCancel);
+
+    // Press down 10 times, should clamp at last provider
+    for (let i = 0; i < 10; i++) selector.handleInput('DOWN');
+    selector.handleInput('\r');
+
+    expect(onSelect).toHaveBeenCalledWith('gitlab');
+  });
+
+  it('calls onCancel on escape', () => {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    const selector = new LoginSelectorComponent('login', createAuthSource(providers), onSelect, onCancel);
+
+    selector.handleInput('ESC');
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('selects correct provider after navigating', () => {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    const selector = new LoginSelectorComponent('login', createAuthSource(providers), onSelect, onCancel);
+
+    selector.handleInput('DOWN');
+    selector.handleInput('\r');
+
+    expect(onSelect).toHaveBeenCalledWith('google');
+  });
+});

--- a/mastracode/src/tui/components/__tests__/model-selector.test.ts
+++ b/mastracode/src/tui/components/__tests__/model-selector.test.ts
@@ -1,0 +1,189 @@
+import type { TUI } from '@mariozechner/pi-tui';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@mariozechner/pi-tui', () => {
+  class MockNode {
+    children: any[] = [];
+    addChild(child: any) {
+      this.children.push(child);
+      return child;
+    }
+    clear() {
+      this.children = [];
+    }
+  }
+
+  class Box extends MockNode {
+    constructor(..._args: any[]) {
+      super();
+    }
+  }
+
+  class Container extends MockNode {}
+
+  class Input extends MockNode {
+    value = '';
+    focused = false;
+    onSubmit?: (value: string) => void;
+    getValue() {
+      return this.value;
+    }
+    handleInput(keyData: string) {
+      if (keyData === '\r') {
+        this.onSubmit?.(this.value);
+        return;
+      }
+      if (keyData === '\u007f') {
+        this.value = this.value.slice(0, -1);
+        return;
+      }
+      if (keyData.length === 1) {
+        this.value += keyData;
+      }
+    }
+  }
+
+  class Text {
+    constructor(
+      public text: string,
+      public x = 0,
+      public y = 0,
+    ) {}
+  }
+
+  class Spacer {
+    constructor(public size: number) {}
+  }
+
+  return {
+    Box,
+    Container,
+    Input,
+    Text,
+    Spacer,
+    fuzzyFilter: (items: any[], query: string, getText: (item: any) => string) =>
+      items.filter(item => getText(item).toLowerCase().includes(query.toLowerCase())),
+    getKeybindings: () => ({
+      matches: (keyData: string, action: string) => {
+        if (action === 'tui.select.up') return keyData === 'UP';
+        if (action === 'tui.select.down') return keyData === 'DOWN';
+        if (action === 'tui.select.confirm') return keyData === '\r';
+        if (action === 'tui.select.cancel') return keyData === 'ESC';
+        return false;
+      },
+    }),
+  };
+});
+
+vi.mock('../../theme.js', () => ({
+  theme: {
+    bg: (_token: string, text: string) => text,
+    bold: (text: string) => text,
+    fg: (_token: string, text: string) => text,
+    getTheme: () => ({ dim: '#888888', text: '#ffffff' }),
+  },
+}));
+
+vi.mock('chalk', () => ({
+  default: {
+    hex: () => (text: string) => text,
+    bgHex: () => ({
+      white: { bold: (text: string) => text },
+    }),
+  },
+}));
+
+import type { ModelItem } from '../model-selector.js';
+import { ModelSelectorComponent } from '../model-selector.js';
+
+function makeModel(id: string, hasApiKey = true): ModelItem {
+  const [provider = '', modelName = ''] = id.split('/');
+  return { id, provider, modelName, hasApiKey };
+}
+
+function createSelector(models: ModelItem[], currentModelId?: string) {
+  const onSelect = vi.fn<(model: ModelItem) => void>();
+  const onCancel = vi.fn<() => void>();
+  const requestRender = vi.fn();
+  const tui = { requestRender } as unknown as TUI;
+
+  const selector = new ModelSelectorComponent({
+    tui,
+    models,
+    currentModelId,
+    onSelect,
+    onCancel,
+  });
+
+  return { selector, onSelect, onCancel, requestRender };
+}
+
+describe('ModelSelectorComponent keybindings', () => {
+  const models = [makeModel('anthropic/claude-sonnet-4'), makeModel('openai/gpt-5'), makeModel('google/gemini-3')];
+
+  it('selects first model on immediate confirm', () => {
+    const { selector, onSelect } = createSelector(models);
+
+    selector.handleInput('\r');
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]![0].id).toBe('anthropic/claude-sonnet-4');
+  });
+
+  it('navigates down and selects second model', () => {
+    const { selector, onSelect } = createSelector(models);
+
+    selector.handleInput('DOWN');
+    selector.handleInput('\r');
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]![0].id).toBe('google/gemini-3');
+  });
+
+  it('wraps around when navigating down past last item', () => {
+    const { selector, onSelect } = createSelector(models);
+
+    // Navigate past all 3 items — should wrap to first
+    selector.handleInput('DOWN');
+    selector.handleInput('DOWN');
+    selector.handleInput('DOWN');
+    selector.handleInput('\r');
+
+    expect(onSelect.mock.calls[0]![0].id).toBe('anthropic/claude-sonnet-4');
+  });
+
+  it('wraps around when navigating up from first item', () => {
+    const { selector, onSelect } = createSelector(models);
+
+    // Navigate up from first — should wrap to last
+    selector.handleInput('UP');
+    selector.handleInput('\r');
+
+    expect(onSelect.mock.calls[0]![0].id).toBe('openai/gpt-5');
+  });
+
+  it('calls onCancel on escape', () => {
+    const { selector, onCancel, onSelect } = createSelector(models);
+
+    selector.handleInput('ESC');
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('calls requestRender on navigation', () => {
+    const { selector, requestRender } = createSelector(models);
+
+    selector.handleInput('DOWN');
+
+    expect(requestRender).toHaveBeenCalled();
+  });
+
+  it('calls requestRender on search input', () => {
+    const { selector, requestRender } = createSelector(models);
+
+    selector.handleInput('g');
+
+    expect(requestRender).toHaveBeenCalled();
+  });
+});

--- a/mastracode/src/tui/components/__tests__/thread-selector.test.ts
+++ b/mastracode/src/tui/components/__tests__/thread-selector.test.ts
@@ -66,12 +66,12 @@ vi.mock('@mariozechner/pi-tui', () => {
     Text,
     fuzzyFilter: (threads: HarnessThread[], query: string, getText: (thread: HarnessThread) => string) =>
       threads.filter(thread => getText(thread).toLowerCase().includes(query.toLowerCase())),
-    getEditorKeybindings: () => ({
+    getKeybindings: () => ({
       matches: (keyData: string, action: string) => {
-        if (action === 'selectUp') return keyData === 'UP';
-        if (action === 'selectDown') return keyData === 'DOWN';
-        if (action === 'selectConfirm') return keyData === '\r';
-        if (action === 'selectCancel') return keyData === 'ESC';
+        if (action === 'tui.select.up') return keyData === 'UP';
+        if (action === 'tui.select.down') return keyData === 'DOWN';
+        if (action === 'tui.select.confirm') return keyData === '\r';
+        if (action === 'tui.select.cancel') return keyData === 'ESC';
         return false;
       },
     }),

--- a/mastracode/src/tui/components/__tests__/tool-approval-dialog.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-approval-dialog.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@mariozechner/pi-tui', () => {
+  class MockNode {
+    children: any[] = [];
+    addChild(child: any) {
+      this.children.push(child);
+      return child;
+    }
+    clear() {
+      this.children = [];
+    }
+  }
+
+  class Box extends MockNode {
+    constructor(..._args: any[]) {
+      super();
+    }
+  }
+
+  class Text {
+    constructor(
+      public text: string,
+      public x = 0,
+      public y = 0,
+    ) {}
+  }
+
+  class Spacer {
+    constructor(public size: number) {}
+  }
+
+  return {
+    Box,
+    Text,
+    Spacer,
+    getKeybindings: () => ({
+      matches: (keyData: string, action: string) => {
+        if (action === 'tui.select.cancel') return keyData === 'ESC';
+        return false;
+      },
+    }),
+  };
+});
+
+vi.mock('../../theme.js', () => ({
+  theme: {
+    bg: (_token: string, text: string) => text,
+    bold: (text: string) => text,
+    fg: (_token: string, text: string) => text,
+    getTheme: () => ({ dim: '#888888', text: '#ffffff' }),
+  },
+}));
+
+vi.mock('chalk', () => {
+  const passthrough = (text: string) => text;
+  const chainable = new Proxy(passthrough, {
+    get: () => chainable,
+    apply: (_target, _thisArg, args) => args[0],
+  });
+  return {
+    default: new Proxy({} as any, {
+      get:
+        () =>
+        (..._args: any[]) =>
+          chainable,
+    }),
+  };
+});
+
+import { ToolApprovalDialogComponent } from '../tool-approval-dialog.js';
+
+describe('ToolApprovalDialogComponent keybindings', () => {
+  function createDialog(onAction = vi.fn()) {
+    return {
+      dialog: new ToolApprovalDialogComponent({
+        toolCallId: 'call-1',
+        toolName: 'write_file',
+        args: { path: '/tmp/test.txt', content: 'hello' },
+        onAction,
+      }),
+      onAction,
+    };
+  }
+
+  it('approves on "y"', () => {
+    const { dialog, onAction } = createDialog();
+    dialog.handleInput('y');
+    expect(onAction).toHaveBeenCalledWith({ type: 'approve' });
+  });
+
+  it('declines on "n"', () => {
+    const { dialog, onAction } = createDialog();
+    dialog.handleInput('n');
+    expect(onAction).toHaveBeenCalledWith({ type: 'decline' });
+  });
+
+  it('declines on escape via tui.select.cancel', () => {
+    const { dialog, onAction } = createDialog();
+    dialog.handleInput('ESC');
+    expect(onAction).toHaveBeenCalledWith({ type: 'decline' });
+  });
+
+  it('always allows category on "a"', () => {
+    const { dialog, onAction } = createDialog();
+    dialog.handleInput('a');
+    expect(onAction).toHaveBeenCalledWith({ type: 'always_allow_category' });
+  });
+
+  it('enters yolo mode on "Y"', () => {
+    const { dialog, onAction } = createDialog();
+    dialog.handleInput('Y');
+    expect(onAction).toHaveBeenCalledWith({ type: 'yolo' });
+  });
+
+  it('ignores unrecognized keys', () => {
+    const { dialog, onAction } = createDialog();
+    dialog.handleInput('z');
+    dialog.handleInput('1');
+    dialog.handleInput(' ');
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/src/tui/components/api-key-dialog.ts
+++ b/mastracode/src/tui/components/api-key-dialog.ts
@@ -4,7 +4,7 @@
  * Allows entering a key or cancelling to proceed without one.
  */
 
-import { Box, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, getKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable } from '@mariozechner/pi-tui';
 import { theme } from '../theme.js';
 
@@ -68,8 +68,8 @@ export class ApiKeyDialogComponent extends Box implements Focusable {
   }
 
   handleInput(data: string): void {
-    const kb = getEditorKeybindings();
-    if (kb.matches(data, 'selectCancel')) {
+    const kb = getKeybindings();
+    if (kb.matches(data, 'tui.select.cancel')) {
       this.onCancel();
       return;
     }

--- a/mastracode/src/tui/components/ask-question-dialog.ts
+++ b/mastracode/src/tui/components/ask-question-dialog.ts
@@ -4,7 +4,7 @@
  * Used by the ask_user tool to collect structured answers from the user.
  */
 
-import { Box, getEditorKeybindings, Input, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, getKeybindings, Input, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem } from '@mariozechner/pi-tui';
 import { theme, getSelectListTheme } from '../theme.js';
 
@@ -89,8 +89,8 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
     if (this.selectList) {
       this.selectList.handleInput(data);
     } else if (this.input) {
-      const kb = getEditorKeybindings();
-      if (kb.matches(data, 'selectCancel')) {
+      const kb = getKeybindings();
+      if (kb.matches(data, 'tui.select.cancel')) {
         this.onCancel();
         return;
       }

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -14,7 +14,7 @@
 
 import {
   Container,
-  getEditorKeybindings,
+  getKeybindings,
   Input,
   SelectList,
   Spacer,
@@ -402,7 +402,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
         this.handleAnswer(trimmed);
       }
     };
-    (this.input as any).keybindings = getEditorKeybindings();
+    (this.input as any).keybindings = getKeybindings();
   }
 
   private handleAnswer(answer: string): void {
@@ -431,8 +431,8 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     if (this.selectList) {
       this.selectList.handleInput(data);
     } else if (this.input) {
-      const kb = getEditorKeybindings();
-      if (kb.matches(data, 'selectCancel')) {
+      const kb = getKeybindings();
+      if (kb.matches(data, 'tui.select.cancel')) {
         this.handleCancel();
         return;
       }

--- a/mastracode/src/tui/components/login-dialog.ts
+++ b/mastracode/src/tui/components/login-dialog.ts
@@ -3,7 +3,7 @@
  */
 
 import { exec } from 'node:child_process';
-import { Box, Container, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, getKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import { getOAuthProviders } from '../../auth/index.js';
 import { theme } from '../theme.js';
@@ -130,9 +130,9 @@ export class LoginDialogComponent extends Box implements Focusable {
   }
 
   handleInput(data: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
-    if (kb.matches(data, 'selectCancel')) {
+    if (kb.matches(data, 'tui.select.cancel')) {
       this.cancel();
       return;
     }

--- a/mastracode/src/tui/components/login-selector.ts
+++ b/mastracode/src/tui/components/login-selector.ts
@@ -2,7 +2,7 @@
  * OAuth provider selector component for /login and /logout commands
  */
 
-import { Box, Container, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, getKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { OAuthProviderInterface } from '../../auth/types.js';
 import { theme } from '../theme.js';
 
@@ -93,27 +93,27 @@ export class LoginSelectorComponent extends Box {
   }
 
   handleInput(keyData: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
     // Up arrow
-    if (kb.matches(keyData, 'selectUp')) {
+    if (kb.matches(keyData, 'tui.select.up')) {
       this.selectedIndex = Math.max(0, this.selectedIndex - 1);
       this.updateList();
     }
     // Down arrow
-    else if (kb.matches(keyData, 'selectDown')) {
+    else if (kb.matches(keyData, 'tui.select.down')) {
       this.selectedIndex = Math.min(this.allProviders.length - 1, this.selectedIndex + 1);
       this.updateList();
     }
     // Enter
-    else if (kb.matches(keyData, 'selectConfirm')) {
+    else if (kb.matches(keyData, 'tui.select.confirm')) {
       const selectedProvider = this.allProviders[this.selectedIndex];
       if (selectedProvider) {
         this.onSelectCallback(selectedProvider.id);
       }
     }
     // Escape or Ctrl+C
-    else if (kb.matches(keyData, 'selectCancel')) {
+    else if (kb.matches(keyData, 'tui.select.cancel')) {
       this.onCancelCallback();
     }
   }

--- a/mastracode/src/tui/components/mcp-selector.ts
+++ b/mastracode/src/tui/components/mcp-selector.ts
@@ -3,7 +3,7 @@
  * Uses pi-tui overlay pattern with navigation.
  */
 
-import { Box, Container, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, getKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import type { McpServerStatus, McpSkippedServer } from '../../mcp/types.js';
@@ -256,11 +256,11 @@ export class McpSelectorComponent extends Box implements Focusable {
   }
 
   handleInput(data: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
     // During reload, only allow closing the selector
     if (this._reloading) {
-      if (kb.matches(data, 'selectCancel')) {
+      if (kb.matches(data, 'tui.select.cancel')) {
         this.onCloseCallback();
       }
       return;
@@ -269,7 +269,7 @@ export class McpSelectorComponent extends Box implements Focusable {
 
     // Detail view (tool list or error) — Esc goes back to server list
     if (this._detailView) {
-      if (kb.matches(data, 'selectCancel')) {
+      if (kb.matches(data, 'tui.select.cancel')) {
         this._detailView = false;
         this.updateList();
       }
@@ -282,19 +282,19 @@ export class McpSelectorComponent extends Box implements Focusable {
     }
 
     // Up arrow
-    if (kb.matches(data, 'selectUp')) {
+    if (kb.matches(data, 'tui.select.up')) {
       if (totalItems === 0) return;
       this.selectedIndex = this.selectedIndex === 0 ? totalItems - 1 : this.selectedIndex - 1;
       this.updateList();
     }
     // Down arrow
-    else if (kb.matches(data, 'selectDown')) {
+    else if (kb.matches(data, 'tui.select.down')) {
       if (totalItems === 0) return;
       this.selectedIndex = this.selectedIndex === totalItems - 1 ? 0 : this.selectedIndex + 1;
       this.updateList();
     }
     // Enter — open sub-menu for the selected server
-    else if (kb.matches(data, 'selectConfirm')) {
+    else if (kb.matches(data, 'tui.select.confirm')) {
       if (this.selectedIndex < this.statuses.length) {
         this.openSubMenu();
       }
@@ -305,7 +305,7 @@ export class McpSelectorComponent extends Box implements Focusable {
       this.doReloadAll();
     }
     // Escape or Ctrl+C
-    else if (kb.matches(data, 'selectCancel')) {
+    else if (kb.matches(data, 'tui.select.cancel')) {
       this.stopPolling();
       this.onCloseCallback();
     }
@@ -328,25 +328,25 @@ export class McpSelectorComponent extends Box implements Focusable {
     this.updateList();
   }
 
-  private handleSubMenuInput(data: string, kb: ReturnType<typeof getEditorKeybindings>): void {
+  private handleSubMenuInput(data: string, kb: ReturnType<typeof getKeybindings>): void {
     // Up arrow
-    if (kb.matches(data, 'selectUp')) {
+    if (kb.matches(data, 'tui.select.up')) {
       this.subMenuIndex = this.subMenuIndex === 0 ? this.subMenuActions.length - 1 : this.subMenuIndex - 1;
       this.updateList();
     }
     // Down arrow
-    else if (kb.matches(data, 'selectDown')) {
+    else if (kb.matches(data, 'tui.select.down')) {
       this.subMenuIndex = this.subMenuIndex === this.subMenuActions.length - 1 ? 0 : this.subMenuIndex + 1;
       this.updateList();
     }
     // Enter — execute action
-    else if (kb.matches(data, 'selectConfirm')) {
+    else if (kb.matches(data, 'tui.select.confirm')) {
       const action = this.subMenuActions[this.subMenuIndex];
       if (!action || action.key === 'none') return;
       this.executeAction(action.key);
     }
     // Escape — close sub-menu
-    else if (kb.matches(data, 'selectCancel')) {
+    else if (kb.matches(data, 'tui.select.cancel')) {
       this.subMenuOpen = false;
       this.updateList();
     }

--- a/mastracode/src/tui/components/model-selector.ts
+++ b/mastracode/src/tui/components/model-selector.ts
@@ -3,7 +3,7 @@
  * Uses pi-tui overlay pattern with search and fuzzy filtering.
  */
 
-import { Box, Container, fuzzyFilter, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, fuzzyFilter, getKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import { theme } from '../theme.js';
@@ -237,26 +237,26 @@ export class ModelSelectorComponent extends Box implements Focusable {
   }
 
   handleInput(keyData: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
     const totalItems = this.filteredModels.length + (this.hasCustomItem ? 1 : 0);
 
     // Up arrow
-    if (kb.matches(keyData, 'selectUp')) {
+    if (kb.matches(keyData, 'tui.select.up')) {
       if (totalItems === 0) return;
       this.selectedIndex = this.selectedIndex === 0 ? totalItems - 1 : this.selectedIndex - 1;
       this.updateList();
       this.tui.requestRender();
     }
     // Down arrow
-    else if (kb.matches(keyData, 'selectDown')) {
+    else if (kb.matches(keyData, 'tui.select.down')) {
       if (totalItems === 0) return;
       this.selectedIndex = this.selectedIndex === totalItems - 1 ? 0 : this.selectedIndex + 1;
       this.updateList();
       this.tui.requestRender();
     }
     // Enter
-    else if (kb.matches(keyData, 'selectConfirm')) {
+    else if (kb.matches(keyData, 'tui.select.confirm')) {
       if (this.hasCustomItem && this.selectedIndex === 0) {
         const query = this.searchInput.getValue().trim();
         if (query) this.handleSelect(this.makeCustomModelItem(query));
@@ -267,7 +267,7 @@ export class ModelSelectorComponent extends Box implements Focusable {
       }
     }
     // Escape or Ctrl+C
-    else if (kb.matches(keyData, 'selectCancel')) {
+    else if (kb.matches(keyData, 'tui.select.cancel')) {
       this.onCancelCallback();
     }
     // Pass everything else to search input

--- a/mastracode/src/tui/components/om-settings.ts
+++ b/mastracode/src/tui/components/om-settings.ts
@@ -10,7 +10,7 @@ import {
   Box,
   Container,
   fuzzyFilter,
-  getEditorKeybindings,
+  getKeybindings,
   Input,
   SelectList,
   SettingsList,
@@ -298,23 +298,23 @@ export class ModelSelectSubmenu extends Container {
   }
 
   handleInput(data: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
     const total = this.filteredModels.length;
 
-    if (kb.matches(data, 'selectUp')) {
+    if (kb.matches(data, 'tui.select.up')) {
       if (total === 0) return;
       this.selectedIndex = this.selectedIndex === 0 ? total - 1 : this.selectedIndex - 1;
       this.updateList();
       this.tui.requestRender();
-    } else if (kb.matches(data, 'selectDown')) {
+    } else if (kb.matches(data, 'tui.select.down')) {
       if (total === 0) return;
       this.selectedIndex = this.selectedIndex === total - 1 ? 0 : this.selectedIndex + 1;
       this.updateList();
       this.tui.requestRender();
-    } else if (kb.matches(data, 'selectConfirm')) {
+    } else if (kb.matches(data, 'tui.select.confirm')) {
       const selected = this.filteredModels[this.selectedIndex];
       if (selected) void this.onSelect(selected.id);
-    } else if (kb.matches(data, 'selectCancel')) {
+    } else if (kb.matches(data, 'tui.select.cancel')) {
       this.onCancel();
     } else {
       const normalized = normalizeSearchInput(data);

--- a/mastracode/src/tui/components/plan-approval-inline.ts
+++ b/mastracode/src/tui/components/plan-approval-inline.ts
@@ -4,7 +4,7 @@
  * directly in the conversation flow.
  */
 
-import { Box, Container, getEditorKeybindings, Input, Markdown, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, getKeybindings, Input, Markdown, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, TUI } from '@mariozechner/pi-tui';
 import { BOX_INDENT, theme, getSelectListTheme, getMarkdownTheme } from '../theme.js';
 
@@ -181,8 +181,8 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     if (this.resolved) return;
 
     if (this.mode === 'feedback' && this.feedbackInput) {
-      const kb = getEditorKeybindings();
-      if (kb.matches(data, 'selectCancel')) {
+      const kb = getKeybindings();
+      if (kb.matches(data, 'tui.select.cancel')) {
         this.handleReject();
         return;
       }

--- a/mastracode/src/tui/components/thread-selector.ts
+++ b/mastracode/src/tui/components/thread-selector.ts
@@ -3,7 +3,7 @@
  * Uses pi-tui overlay pattern with search and navigation.
  */
 
-import { Box, Container, fuzzyFilter, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, fuzzyFilter, getKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import type { HarnessThread } from '@mastra/core/harness';
 import { theme } from '../theme.js';
@@ -329,26 +329,26 @@ export class ThreadSelectorComponent extends Box implements Focusable {
   }
 
   handleInput(keyData: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
-    if (kb.matches(keyData, 'selectUp')) {
+    if (kb.matches(keyData, 'tui.select.up')) {
       if (this.filteredThreads.length === 0) return;
       this.selectedIndex = this.selectedIndex === 0 ? this.filteredThreads.length - 1 : this.selectedIndex - 1;
       this.updateList();
       this.tui.requestRender();
       this.scheduleMessagePreviewLoad({ delayMs: INTERACTION_PREVIEW_LOAD_DELAY_MS });
-    } else if (kb.matches(keyData, 'selectDown')) {
+    } else if (kb.matches(keyData, 'tui.select.down')) {
       if (this.filteredThreads.length === 0) return;
       this.selectedIndex = this.selectedIndex === this.filteredThreads.length - 1 ? 0 : this.selectedIndex + 1;
       this.updateList();
       this.tui.requestRender();
       this.scheduleMessagePreviewLoad({ delayMs: INTERACTION_PREVIEW_LOAD_DELAY_MS });
-    } else if (kb.matches(keyData, 'selectConfirm')) {
+    } else if (kb.matches(keyData, 'tui.select.confirm')) {
       const selected = this.filteredThreads[this.selectedIndex];
       if (selected) {
         this.onSelectCallback(selected);
       }
-    } else if (kb.matches(keyData, 'selectCancel')) {
+    } else if (kb.matches(keyData, 'tui.select.cancel')) {
       this.onCancelCallback();
     } else if (keyData === 'c' && this.onCloneCallback && !this.searchInput.getValue()) {
       const selected = this.filteredThreads[this.selectedIndex];

--- a/mastracode/src/tui/components/tool-approval-dialog.ts
+++ b/mastracode/src/tui/components/tool-approval-dialog.ts
@@ -8,7 +8,7 @@
  *   a       — always allow this category for the session
  *   Y       — switch to YOLO mode (approve all)
  */
-import { Box, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, getKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import { theme } from '../theme.js';
@@ -126,10 +126,10 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
   }
 
   handleInput(data: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
     // Escape to decline
-    if (kb.matches(data, 'selectCancel')) {
+    if (kb.matches(data, 'tui.select.cancel')) {
       this.onAction({ type: 'decline' });
       return;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1308,7 +1308,7 @@ importers:
         version: 0.41.1
       '@mariozechner/pi-tui':
         specifier: latest
-        version: 0.58.4
+        version: 0.61.0
       '@mastra/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -3725,16 +3725,16 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.2.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.8)
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
-        version: 7.0.1(eslint@9.39.4(jiti@1.21.7))
+        version: 7.0.1(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
-        version: 0.5.2(eslint@9.39.4(jiti@1.21.7))
+        version: 0.5.2(eslint@9.39.4(jiti@2.6.1))
       nanoid:
         specifier: ^5.1.7
         version: 5.1.7
@@ -3749,7 +3749,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/playground-ui:
     dependencies:
@@ -3875,7 +3875,7 @@ importers:
         version: 4.25.8(@codemirror/language@6.11.3)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)
       '@uiw/react-codemirror':
         specifier: ^4.25.8
-        version: 4.25.8(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.0)(@codemirror/search@6.5.11)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.40.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.25.8(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.0)(@codemirror/search@6.5.11)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.40.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3963,10 +3963,10 @@ importers:
         version: link:../schema-compat
       '@storybook/addon-docs':
         specifier: ^9.1.20
-        version: 9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/react-vite':
         specifier: ^9.1.20
-        version: 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tailwindcss/container-queries':
         specifier: ^0.1.1
         version: 0.1.1(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -3996,7 +3996,7 @@ importers:
         version: 7.7.1
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.2.0(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/ui':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18)
@@ -4017,7 +4017,7 @@ importers:
         version: 8.1.2(rollup@4.59.0)
       storybook:
         specifier: ^9.1.20
-        version: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -4029,16 +4029,16 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@22.19.15)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.5.4(@types/node@22.19.15)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-lib-inject-css:
         specifier: ^2.2.2
-        version: 2.2.2(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.2.2(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -8251,6 +8251,10 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -8461,6 +8465,9 @@ packages:
 
   '@codemirror/commands@6.10.1':
     resolution: {integrity: sha512-uWDWFypNdQmz2y1LaNJzK7fL7TYKLeUAU0npEC685OKTF3KcQ2Vu3klIM78D7I6wGhktme0lh3CuQLv0ZCrD9Q==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
 
   '@codemirror/lang-angular@0.1.4':
     resolution: {integrity: sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==}
@@ -11092,8 +11099,8 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@mariozechner/pi-tui@0.58.4':
-    resolution: {integrity: sha512-EVju7Baj8H7F8dOx3pTKHvQ7i1FW2cR8v9DhSfOdELrdDepkl7v20ufO5lBkuJm+nkRJHbplN861lAI7cwM7gw==}
+  '@mariozechner/pi-tui@0.61.0':
+    resolution: {integrity: sha512-gll0kAcBgSK7RFgsS1GrdlNglE2msh+fJS+1OXYUi3CVrWRUVGyCqEhbY9ogQ0qdrEkYT3o/6X1cnTj3yV6MuA==}
     engines: {node: '>=20.0.0'}
 
   '@mastra/schema-compat@1.1.0':
@@ -17569,6 +17576,9 @@ packages:
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
 
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
@@ -19989,6 +19999,10 @@ packages:
 
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+    engines: {node: '>=16'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
   is-yarn-global@0.4.1:
@@ -28175,6 +28189,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -28490,6 +28506,13 @@ snapshots:
       '@lezer/common': 1.5.1
 
   '@codemirror/commands@6.10.1':
+    dependencies:
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+
+  '@codemirror/commands@6.10.3':
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.6.0
@@ -29347,7 +29370,7 @@ snapshots:
       '@babel/preset-env': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@babel/runtime-corejs3': 7.29.0
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.9.2
@@ -30623,11 +30646,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
-    dependencies:
-      eslint: 9.39.4(jiti@1.21.7)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
@@ -31011,7 +31029,7 @@ snapshots:
 
   '@hcaptcha/react-hcaptcha@1.17.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@hcaptcha/loader': 2.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -31354,6 +31372,15 @@ snapshots:
       '@types/node': 22.19.15
       '@types/yargs': 17.0.35
       chalk: 4.1.2
+
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      glob: 10.5.0
+      magic-string: 0.30.21
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -31794,7 +31821,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mariozechner/pi-tui@0.58.4':
+  '@mariozechner/pi-tui@0.61.0':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2
@@ -36151,7 +36178,7 @@ snapshots:
 
   '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.3.1
@@ -36804,18 +36831,25 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-docs@9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-docs@9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/icons': 1.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
+
+  '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      ts-dedent: 2.2.0
+      vite: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -36823,6 +36857,11 @@ snapshots:
       storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))':
+    dependencies:
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      unplugin: 1.16.1
 
   '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
@@ -36836,11 +36875,37 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))':
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+
   '@storybook/react-dom-shim@9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+
+  '@storybook/react-vite@9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
+      '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/react': 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      find-up: 7.0.0
+      magic-string: 0.30.21
+      react: 19.2.4
+      react-docgen: 8.0.2
+      react-dom: 19.2.4(react@19.2.4)
+      resolve: 1.22.11
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      tsconfig-paths: 4.2.0
+      vite: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
 
   '@storybook/react-vite@9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -36861,6 +36926,16 @@ snapshots:
       - rollup
       - supports-color
       - typescript
+
+  '@storybook/react@9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@storybook/react@9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
@@ -37250,7 +37325,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -38019,9 +38094,9 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.40.0
 
-  '@uiw/react-codemirror@4.25.8(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.0)(@codemirror/search@6.5.11)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.40.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@uiw/react-codemirror@4.25.8(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.0)(@codemirror/search@6.5.11)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.40.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@codemirror/commands': 6.10.1
       '@codemirror/state': 6.6.0
       '@codemirror/theme-one-dark': 6.1.3
@@ -38368,6 +38443,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/mocker@3.2.4(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.13(@types/node@22.19.15)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/mocker@3.2.4(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -38376,6 +38460,15 @@ snapshots:
     optionalDependencies:
       msw: 2.12.13(@types/node@22.19.15)(typescript@5.9.3)
       vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/mocker@4.0.18(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.13(@types/node@22.19.15)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.0.18(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -39426,7 +39519,7 @@ snapshots:
   c12@3.3.3(magicast@0.5.1):
     dependencies:
       chokidar: 5.0.0
-      confbox: 0.2.2
+      confbox: 0.2.4
       defu: 6.1.4
       dotenv: 17.3.1
       exsolve: 1.0.8
@@ -39801,7 +39894,7 @@ snapshots:
   codemirror@6.0.2:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
-      '@codemirror/commands': 6.10.1
+      '@codemirror/commands': 6.10.3
       '@codemirror/language': 6.11.3
       '@codemirror/lint': 6.9.0
       '@codemirror/search': 6.5.11
@@ -39938,6 +40031,8 @@ snapshots:
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
+
+  confbox@0.2.4: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -40984,17 +41079,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@1.21.7)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
-      eslint: 9.39.4(jiti@1.21.7)
-      hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
@@ -41006,9 +41090,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.5.2(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-react-refresh@0.5.2(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@2.6.1)
 
   eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
@@ -41087,47 +41171,6 @@ snapshots:
   eslint-visitor-keys@4.2.1: {}
 
   eslint-visitor-keys@5.0.1: {}
-
-  eslint@9.39.4(jiti@1.21.7):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
-      '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.21.2
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
-      '@eslint/js': 9.39.4
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.14.0
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.5
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 1.21.7
-    transitivePeerDependencies:
-      - supports-color
 
   eslint@9.39.4(jiti@2.6.1):
     dependencies:
@@ -42390,7 +42433,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -43055,6 +43098,10 @@ snapshots:
       is-docker: 2.2.1
 
   is-wsl@3.1.0:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
@@ -44967,7 +45014,7 @@ snapshots:
     dependencies:
       citty: 0.2.1
       pathe: 2.0.3
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
 
   object-assign@4.1.1: {}
 
@@ -46457,7 +46504,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.104.1(@swc/core@1.15.7(@swc/helpers@0.5.17))):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
       webpack: 5.104.1(@swc/core@1.15.7(@swc/helpers@0.5.17))
 
@@ -46575,13 +46622,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 18.3.1
       react-router: 5.3.4(react@18.3.1)
 
   react-router-dom@5.3.4(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -46592,7 +46639,7 @@ snapshots:
 
   react-router@5.3.4(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -46649,7 +46696,7 @@ snapshots:
 
   react-textarea-autosize@8.5.9(@types/react@19.2.14)(react@19.2.4):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 19.2.4
       use-composed-ref: 1.4.0(@types/react@19.2.14)(react@19.2.4)
       use-latest: 1.3.0(@types/react@19.2.14)(react@19.2.4)
@@ -48055,6 +48102,30 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/spy': 3.2.4
+      better-opn: 3.0.2
+      esbuild: 0.25.11
+      esbuild-register: 3.6.0(esbuild@0.25.11)
+      recast: 0.23.11
+      semver: 7.7.4
+      ws: 8.19.0
+    optionalDependencies:
+      prettier: 3.8.1
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - msw
+      - supports-color
+      - utf-8-validate
+      - vite
+
   storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.1)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@storybook/global': 5.0.0
@@ -49396,7 +49467,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-dts@4.5.4(@types/node@22.19.15)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-dts@4.5.4(@types/node@22.19.15)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@microsoft/api-extractor': 7.57.7(@types/node@22.19.15)
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
@@ -49409,18 +49480,18 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-lib-inject-css@2.2.2(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-lib-inject-css@2.2.2(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@ast-grep/napi': 0.36.3
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -49455,6 +49526,46 @@ snapshots:
       terser: 5.44.1
       tsx: 4.21.0
       yaml: 2.8.2
+
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.15
+      '@vitest/ui': 4.0.18(vitest@4.0.18)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -49978,7 +50089,7 @@ snapshots:
 
   wsl-utils@0.3.1:
     dependencies:
-      is-wsl: 3.1.0
+      is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
   xdg-basedir@5.1.0: {}


### PR DESCRIPTION
## Summary

Updates mastracode to use the renamed keybindings API from `@mariozechner/pi-tui` v0.61.0.

### Changes

- `getEditorKeybindings()` → `getKeybindings()` (imports, call sites, type annotations)
- Keybinding action names updated to new `tui.select.*` namespace:
  - `selectUp` → `tui.select.up`
  - `selectDown` → `tui.select.down`
  - `selectConfirm` → `tui.select.confirm`
  - `selectCancel` → `tui.select.cancel`
- Test mock in `thread-selector.test.ts` updated to match
- `pnpm-lock.yaml` updated for pi-tui 0.58.4 → 0.61.0

### Files modified (12 source + lockfile)

All under `mastracode/src/tui/components/`:
`api-key-dialog.ts`, `ask-question-dialog.ts`, `ask-question-inline.ts`, `login-dialog.ts`, `login-selector.ts`, `mcp-selector.ts`, `model-selector.ts`, `om-settings.ts`, `plan-approval-inline.ts`, `thread-selector.ts`, `tool-approval-dialog.ts`, `__tests__/thread-selector.test.ts`

### Test plan

- `npx tsc --noEmit` — no pi-tui related type errors
- `npx vitest run src/tui/components/__tests__/thread-selector.test.ts` — 2/2 tests pass
- Searched for all old API names — zero remaining references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/expanded keyboard-interaction tests for API key, login selector, model selector, thread selector, and tool approval dialogs to validate navigation, input, confirm, and cancel behaviors.

* **Chores**
  * Standardized TUI keybinding handling across multiple components to use the unified keybinding API and namespaced action identifiers for consistent cancel/confirm/navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->