### PR TITLE
fix(deployer): resolve extensionless relative imports in workspace packages during dev mode

### DIFF
--- a/.changeset/lemon-corners-teach.md
+++ b/.changeset/lemon-corners-teach.md
@@ -2,4 +2,4 @@
 '@mastra/deployer': patch
 ---
 
-Fixed workspace packages with extensionless relative imports (e.g. `import { x } from './common'`) failing during `mastra dev`. Pre-compiled workspace packages (built with `tsc` or similar tools) that don't include `.js` extensions in their import paths now work correctly in dev mode.
+Fixed `mastra dev` failing with `ERR_MODULE_NOT_FOUND` when workspace packages use extensionless relative imports (e.g. `import { x } from './common'` instead of `'./common.js'`).

--- a/.changeset/lemon-corners-teach.md
+++ b/.changeset/lemon-corners-teach.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed workspace packages with extensionless relative imports (e.g. `import { x } from './common'`) failing during `mastra dev`. Pre-compiled workspace packages (built with `tsc` or similar tools) that don't include `.js` extensions in their import paths now work correctly in dev mode.

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -20,6 +20,7 @@ import { aliasHono } from '../plugins/hono-alias';
 import { moduleResolveMap } from '../plugins/module-resolve-map';
 import { nodeGypDetector } from '../plugins/node-gyp-detector';
 import { protocolExternalResolver } from '../plugins/protocol-external-resolver';
+import { relativeExtensionResolver } from '../plugins/relative-extension-resolver';
 import { subpathExternalsResolver } from '../plugins/subpath-externals-resolver';
 import { tsConfigPaths } from '../plugins/tsconfig-paths';
 import type { DependencyMetadata } from '../types';
@@ -240,6 +241,7 @@ async function getInputPlugins(
       ignoreTryCatch: false,
     }),
     bundlerOptions.noBundling ? null : nodeResolve(getNodeResolveOptions(platform)),
+    bundlerOptions.noBundling ? relativeExtensionResolver() : null,
     bundlerOptions.noBundling ? esmShim() : null,
     // hono is imported from deployer, so we need to resolve from here instead of the project root
     aliasHono(),

--- a/packages/deployer/src/build/plugins/relative-extension-resolver.test.ts
+++ b/packages/deployer/src/build/plugins/relative-extension-resolver.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import type { Plugin, PluginContext } from 'rollup';
+import type { Plugin } from 'rollup';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('node:fs', () => ({
@@ -8,7 +8,6 @@ vi.mock('node:fs', () => ({
 
 describe('relativeExtensionResolver', () => {
   let plugin: Plugin;
-  let mockContext: PluginContext;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -16,12 +15,11 @@ describe('relativeExtensionResolver', () => {
 
     const mod = await import('./relative-extension-resolver');
     plugin = mod.relativeExtensionResolver();
-    mockContext = {} as PluginContext;
   });
 
   const resolveId = (id: string, importer?: string) => {
     const fn = plugin.resolveId as Function;
-    return fn.call(mockContext, id, importer, {});
+    return fn.call({}, id, importer, {});
   };
 
   describe('skips resolution for', () => {

--- a/packages/deployer/src/build/plugins/relative-extension-resolver.test.ts
+++ b/packages/deployer/src/build/plugins/relative-extension-resolver.test.ts
@@ -1,0 +1,122 @@
+import { existsSync } from 'node:fs';
+import type { Plugin, PluginContext } from 'rollup';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+describe('relativeExtensionResolver', () => {
+  let plugin: Plugin;
+  let mockContext: PluginContext;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    const mod = await import('./relative-extension-resolver');
+    plugin = mod.relativeExtensionResolver();
+    mockContext = {} as PluginContext;
+  });
+
+  const resolveId = (id: string, importer?: string) => {
+    const fn = plugin.resolveId as Function;
+    return fn.call(mockContext, id, importer, {});
+  };
+
+  describe('skips resolution for', () => {
+    it('bare module imports', () => {
+      const result = resolveId('lodash', '/project/src/index.ts');
+      expect(result).toBeNull();
+    });
+
+    it('scoped package imports', () => {
+      const result = resolveId('@acme/constants', '/project/src/index.ts');
+      expect(result).toBeNull();
+    });
+
+    it('imports without an importer', () => {
+      const result = resolveId('./utils');
+      expect(result).toBeNull();
+    });
+
+    it('absolute path imports', () => {
+      const result = resolveId('/absolute/path', '/project/src/index.ts');
+      expect(result).toBeNull();
+    });
+
+    it('imports that already have an extension', () => {
+      const result = resolveId('./common.js', '/project/dist/index.js');
+      expect(result).toBeNull();
+      expect(existsSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolves extensionless relative imports', () => {
+    it('resolves ./common to ./common.js', () => {
+      vi.mocked(existsSync).mockImplementation((p: any) => {
+        return String(p).endsWith('/project/dist/common.js');
+      });
+
+      const result = resolveId('./common', '/project/dist/index.js');
+      expect(result).toBe('/project/dist/common.js');
+    });
+
+    it('resolves ./common to ./common.ts', () => {
+      vi.mocked(existsSync).mockImplementation((p: any) => {
+        return String(p).endsWith('/project/src/common.ts');
+      });
+
+      const result = resolveId('./common', '/project/src/index.ts');
+      expect(result).toBe('/project/src/common.ts');
+    });
+
+    it('resolves ../shared/utils to ../shared/utils.mjs', () => {
+      vi.mocked(existsSync).mockImplementation((p: any) => {
+        return String(p).endsWith('/project/shared/utils.mjs');
+      });
+
+      const result = resolveId('../shared/utils', '/project/src/index.ts');
+      expect(result).toBe('/project/shared/utils.mjs');
+    });
+
+    it('prefers .ts over .js when both exist', () => {
+      vi.mocked(existsSync).mockImplementation((p: any) => {
+        const s = String(p);
+        return s.endsWith('/project/src/tool.ts') || s.endsWith('/project/src/tool.js');
+      });
+
+      const result = resolveId('./tool', '/project/src/index.ts');
+      expect(result).toBe('/project/src/tool.ts');
+    });
+  });
+
+  describe('resolves directory imports via index files', () => {
+    it('resolves ./utils to ./utils/index.ts', () => {
+      vi.mocked(existsSync).mockImplementation((p: any) => {
+        return String(p).endsWith('/project/src/utils/index.ts');
+      });
+
+      const result = resolveId('./utils', '/project/src/index.ts');
+      expect(result).toBe('/project/src/utils/index.ts');
+    });
+
+    it('resolves ./utils to ./utils/index.js', () => {
+      vi.mocked(existsSync).mockImplementation((p: any) => {
+        return String(p).endsWith('/project/dist/utils/index.js');
+      });
+
+      const result = resolveId('./utils', '/project/dist/index.js');
+      expect(result).toBe('/project/dist/utils/index.js');
+    });
+  });
+
+  describe('returns null for unresolvable imports', () => {
+    it('returns null when no matching file exists', () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = resolveId('./nonexistent', '/project/src/index.ts');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/deployer/src/build/plugins/relative-extension-resolver.ts
+++ b/packages/deployer/src/build/plugins/relative-extension-resolver.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { dirname, extname, join, resolve } from 'node:path';
 import type { Plugin } from 'rollup';
+import { slash } from '../utils';
 
 const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
 
@@ -28,14 +29,14 @@ export function relativeExtensionResolver(): Plugin {
       for (const ext of EXTENSIONS) {
         const candidate = resolved + ext;
         if (existsSync(candidate)) {
-          return candidate;
+          return slash(candidate);
         }
       }
 
       for (const ext of EXTENSIONS) {
         const candidate = join(resolved, `index${ext}`);
         if (existsSync(candidate)) {
-          return candidate;
+          return slash(candidate);
         }
       }
 

--- a/packages/deployer/src/build/plugins/relative-extension-resolver.ts
+++ b/packages/deployer/src/build/plugins/relative-extension-resolver.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'node:fs';
+import { dirname, extname, join, resolve } from 'node:path';
+import type { Plugin } from 'rollup';
+
+const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+/**
+ * Rollup plugin that resolves file extensions for relative imports.
+ *
+ * When nodeResolve is not used (e.g. during noBundling/dev mode), relative
+ * imports like `./common` won't resolve to `./common.js` or `./common.ts`.
+ * This plugin fills that gap by trying common extensions and index files.
+ */
+export function relativeExtensionResolver(): Plugin {
+  return {
+    name: 'relative-extension-resolver',
+    resolveId(id, importer) {
+      if (!importer || !(id.startsWith('./') || id.startsWith('../'))) {
+        return null;
+      }
+
+      if (extname(id)) {
+        return null;
+      }
+
+      const resolved = resolve(dirname(importer), id);
+
+      for (const ext of EXTENSIONS) {
+        const candidate = resolved + ext;
+        if (existsSync(candidate)) {
+          return candidate;
+        }
+      }
+
+      for (const ext of EXTENSIONS) {
+        const candidate = join(resolved, `index${ext}`);
+        if (existsSync(candidate)) {
+          return candidate;
+        }
+      }
+
+      return null;
+    },
+  };
+}


### PR DESCRIPTION
## Description
  <!-- Provide a brief description of the changes in this PR -->
When `mastra dev` pre-bundles workspace packages, it uses Rollup with `noBundling: true` which deliberately excludes `@rollup/plugin-node-resolve` to prevent npm dependencies from being bundled. However, this also removes extension resolution for relative imports within workspace packages. Pre-compiled packages (built with `tsc`) that use extensionless imports like `import { x } from './common'` fail at runtime with `ERR_MODULE_NOT_FOUND` because Node ESM requires explicit file extensions.
This PR adds a lightweight `relativeExtensionResolver` Rollup plugin that handles only relative imports (`./` and `../`) by trying common extensions (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`) and index files. It activates only in `noBundling` mode (dev / `externals: true`), filling the gap left by the removed `nodeResolve` without re-introducing npm dependency bundling. This follows the same standard pattern used by Vite, Webpack, and esbuild for extension resolution.

  ## Related Issue(s)
  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
  Fixes #14536

  ## Type of Change
  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist
  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Development now handles extensionless relative imports (e.g., `./common`) in workspace and pre-compiled packages, preventing ERR_MODULE_NOT_FOUND.
  * Resolution now detects common file extensions and index entry files automatically.

* **Tests**
  * Added tests covering resolution behavior for extensionless imports and directory/index resolution.

* **Chores**
  * Added changelog entry and patch version bump for the deployer package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->