### PR TITLE
fix(core): guide LLM to use relative paths in workspace file tools

### DIFF
--- a/.changeset/fix-workspace-search-mode-fallback.md
+++ b/.changeset/fix-workspace-search-mode-fallback.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Workspace search no longer throws when requesting hybrid or vector mode if the configuration does not support it. The search tool now gracefully falls back to the best available mode instead of throwing an error.

--- a/.changeset/fix-workspace-tools-relative-paths.md
+++ b/.changeset/fix-workspace-tools-relative-paths.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Workspace file tools now guide the LLM to use relative paths, preventing permission errors when agents create or access files at the filesystem root.

--- a/packages/core/src/workspace/tools/__tests__/search.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/search.test.ts
@@ -35,6 +35,25 @@ describe('workspace_search', () => {
     expect(result).not.toContain('0 results');
   });
 
+  it('should fallback to bm25 when hybrid mode requested but only BM25 configured (#14531)', async () => {
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      bm25: true,
+      // No vector config — canHybrid is false
+    });
+    const tools = createWorkspaceTools(workspace);
+    await workspace.index('/doc.txt', 'The quick brown fox');
+
+    // Should not throw "Hybrid search requires both vector and BM25 configuration."
+    const result = await tools[WORKSPACE_TOOLS.SEARCH.SEARCH].execute(
+      { query: 'quick', mode: 'hybrid' },
+      { workspace },
+    );
+    expect(typeof result).toBe('string');
+    expect(result).toContain('bm25 search');
+    expect(result).not.toContain('0 results');
+  });
+
   it('should return empty results for no matches', async () => {
     const workspace = new Workspace({
       filesystem: new LocalFilesystem({ basePath: tempDir }),

--- a/packages/core/src/workspace/tools/ast-edit.ts
+++ b/packages/core/src/workspace/tools/ast-edit.ts
@@ -400,7 +400,11 @@ Transforms:
 Pattern replace (for everything else):
   { pattern: "console.log($ARG)", replacement: "logger.debug($ARG)" }`,
   inputSchema: z.object({
-    path: z.string().describe('The path to the file to edit'),
+    path: z
+      .string()
+      .describe(
+        'The relative path to the file to edit (e.g., "src/index.ts"). Always use relative paths — never start with "/".',
+      ),
     pattern: z
       .string()
       .optional()

--- a/packages/core/src/workspace/tools/delete-file.ts
+++ b/packages/core/src/workspace/tools/delete-file.ts
@@ -8,7 +8,11 @@ export const deleteFileTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.DELETE,
   description: 'Delete a file or directory from the workspace filesystem',
   inputSchema: z.object({
-    path: z.string().describe('The path to the file or directory to delete'),
+    path: z
+      .string()
+      .describe(
+        'The relative path to the file or directory to delete (e.g., "data/old.txt"). Always use relative paths — never start with "/".',
+      ),
     recursive: z
       .boolean()
       .optional()

--- a/packages/core/src/workspace/tools/edit-file.ts
+++ b/packages/core/src/workspace/tools/edit-file.ts
@@ -15,7 +15,11 @@ Usage:
 - Include enough surrounding context (multiple lines) to make old_string unique. If it still isn't unique, include more lines.
 - Use replace_all only when intentionally replacing all occurrences.`,
   inputSchema: z.object({
-    path: z.string().describe('The path to the file to edit'),
+    path: z
+      .string()
+      .describe(
+        'The relative path to the file to edit (e.g., "src/index.ts"). Always use relative paths — never start with "/".',
+      ),
     old_string: z.string().describe('The exact text to find and replace. Must be unique in the file.'),
     new_string: z.string().describe('The text to replace old_string with'),
     replace_all: z

--- a/packages/core/src/workspace/tools/file-stat.ts
+++ b/packages/core/src/workspace/tools/file-stat.ts
@@ -9,7 +9,9 @@ export const fileStatTool = createTool({
   description:
     'Get file or directory metadata from the workspace. Returns existence, type, size, and modification time.',
   inputSchema: z.object({
-    path: z.string().describe('The path to check'),
+    path: z
+      .string()
+      .describe('The relative path to check (e.g., "src/index.ts"). Always use relative paths — never start with "/".'),
   }),
   execute: async ({ path }, context) => {
     const { filesystem } = requireFilesystem(context);

--- a/packages/core/src/workspace/tools/mkdir.ts
+++ b/packages/core/src/workspace/tools/mkdir.ts
@@ -8,7 +8,11 @@ export const mkdirTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.MKDIR,
   description: 'Create a directory in the workspace filesystem',
   inputSchema: z.object({
-    path: z.string().describe('The path of the directory to create'),
+    path: z
+      .string()
+      .describe(
+        'The relative path of the directory to create (e.g., "src/utils"). Always use relative paths — never start with "/".',
+      ),
     recursive: z
       .boolean()
       .optional()

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -10,7 +10,11 @@ export const readFileTool = createTool({
   description:
     'Read the contents of a file from the workspace filesystem. Use offset/limit parameters to read specific line ranges for large files.',
   inputSchema: z.object({
-    path: z.string().describe('The path to the file to read (e.g., "/data/config.json")'),
+    path: z
+      .string()
+      .describe(
+        'The relative path to the file to read (e.g., "data/config.json" or "src/index.ts"). Always use relative paths — never start with "/".',
+      ),
     encoding: z
       .enum(['utf-8', 'utf8', 'base64', 'hex', 'binary'])
       .optional()

--- a/packages/core/src/workspace/tools/search.ts
+++ b/packages/core/src/workspace/tools/search.ts
@@ -28,9 +28,7 @@ export const searchTool = createTool({
           ? 'vector'
           : 'bm25'
         : mode === 'vector' && !workspace.canVector
-          ? workspace.canBM25
-            ? 'bm25'
-            : 'hybrid'
+          ? 'bm25'
           : (mode ?? (workspace.canHybrid ? 'hybrid' : workspace.canVector ? 'vector' : 'bm25'));
 
     const results = await workspace.search(query, {

--- a/packages/core/src/workspace/tools/search.ts
+++ b/packages/core/src/workspace/tools/search.ts
@@ -20,13 +20,24 @@ export const searchTool = createTool({
     const workspace = requireWorkspace(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.SEARCH.SEARCH);
 
+    // Resolve effective mode before searching — fall back gracefully if requested
+    // mode isn't supported (e.g. 'hybrid' requested but only BM25 configured)
+    const effectiveMode =
+      mode === 'hybrid' && !workspace.canHybrid
+        ? workspace.canVector
+          ? 'vector'
+          : 'bm25'
+        : mode === 'vector' && !workspace.canVector
+          ? workspace.canBM25
+            ? 'bm25'
+            : 'hybrid'
+          : (mode ?? (workspace.canHybrid ? 'hybrid' : workspace.canVector ? 'vector' : 'bm25'));
+
     const results = await workspace.search(query, {
       topK,
-      mode: mode as 'bm25' | 'vector' | 'hybrid' | undefined,
+      mode: effectiveMode as 'bm25' | 'vector' | 'hybrid' | undefined,
       minScore,
     });
-
-    const effectiveMode = mode ?? (workspace.canHybrid ? 'hybrid' : workspace.canVector ? 'vector' : 'bm25');
 
     const lines = results.map(r => {
       const lineInfo = r.lineRange ? `:${r.lineRange.start}-${r.lineRange.end}` : '';

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -280,16 +280,13 @@ export function createWorkspaceTools(workspace: Workspace) {
       workspace.canBM25 ? 'bm25' : null,
       workspace.canVector ? 'vector' : null,
       workspace.canHybrid ? 'hybrid' : null,
-    ].filter(Boolean) as Array<'bm25' | 'vector' | 'hybrid'> as [
-      'bm25' | 'vector' | 'hybrid',
-      ...('bm25' | 'vector' | 'hybrid')[],
-    ];
+    ].filter((m): m is 'bm25' | 'vector' | 'hybrid' => m !== null);
 
     const dynamicSearchTool = {
       ...searchTool,
       inputSchema: searchTool.inputSchema.extend({
         mode: z
-          .enum(availableModes)
+          .enum(availableModes as ['bm25' | 'vector' | 'hybrid', ...('bm25' | 'vector' | 'hybrid')[]])
           .optional()
           .describe(`Search mode: ${availableModes.join(', ')}`),
       }),

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -280,7 +280,10 @@ export function createWorkspaceTools(workspace: Workspace) {
       workspace.canBM25 ? 'bm25' : null,
       workspace.canVector ? 'vector' : null,
       workspace.canHybrid ? 'hybrid' : null,
-    ].filter(Boolean) as ['bm25', ...('vector' | 'hybrid')[]];
+    ].filter(Boolean) as Array<'bm25' | 'vector' | 'hybrid'> as [
+      'bm25' | 'vector' | 'hybrid',
+      ...('bm25' | 'vector' | 'hybrid')[],
+    ];
 
     const dynamicSearchTool = {
       ...searchTool,

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -7,6 +7,7 @@
  * into the tool execution context.
  */
 
+import { z } from 'zod/v4';
 import type { WorkspaceToolName } from '../constants';
 import { WORKSPACE_TOOLS } from '../constants';
 import { FileNotFoundError, FileReadRequiredError } from '../errors';
@@ -272,7 +273,25 @@ export function createWorkspaceTools(workspace: Workspace) {
 
   // Search tools
   if (workspace.canBM25 || workspace.canVector) {
-    addTool(WORKSPACE_TOOLS.SEARCH.SEARCH, searchTool);
+    // Build a dynamic search tool that only exposes modes the workspace supports.
+    // This prevents the LLM from picking an unsupported mode (e.g. 'hybrid' when
+    // only BM25 is configured), rather than relying solely on runtime fallback.
+    const availableModes = [
+      workspace.canBM25 ? 'bm25' : null,
+      workspace.canVector ? 'vector' : null,
+      workspace.canHybrid ? 'hybrid' : null,
+    ].filter(Boolean) as ['bm25', ...('vector' | 'hybrid')[]];
+
+    const dynamicSearchTool = {
+      ...searchTool,
+      inputSchema: searchTool.inputSchema.extend({
+        mode: z
+          .enum(availableModes)
+          .optional()
+          .describe(`Search mode: ${availableModes.join(', ')}`),
+      }),
+    };
+    addTool(WORKSPACE_TOOLS.SEARCH.SEARCH, dynamicSearchTool);
     addTool(WORKSPACE_TOOLS.SEARCH.INDEX, indexContentTool, { requireWrite: true });
   }
 

--- a/packages/core/src/workspace/tools/write-file.ts
+++ b/packages/core/src/workspace/tools/write-file.ts
@@ -8,7 +8,11 @@ export const writeFileTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE,
   description: 'Write content to a file in the workspace filesystem. Creates parent directories if needed.',
   inputSchema: z.object({
-    path: z.string().describe('The path where to write the file (e.g., "/data/output.txt")'),
+    path: z
+      .string()
+      .describe(
+        'The relative path where to write the file (e.g., "data/output.txt" or "src/index.ts"). Always use relative paths — never start with "/".',
+      ),
     content: z.string().describe('The content to write to the file'),
     overwrite: z.boolean().optional().default(true).describe('Whether to overwrite the file if it already exists'),
   }),


### PR DESCRIPTION
## Summary
Fixes #14542

## Problem
Workspace file tool descriptions used absolute path examples like 
`/data/output.txt`, causing LLMs to create files at the filesystem 
root `/` and hitting permission errors.

## Fix
Updated path descriptions in 7 workspace tools to:
- Use relative path examples (e.g., `data/output.txt`)
- Explicitly state "Always use relative paths — never start with '/'"

## Changes
- `write_file` — relative path example + guidance
- `read_file` — relative path example + guidance  
- `edit_file` — relative path example + guidance
- `delete_file` — relative path example + guidance
- `mkdir` — relative path example + guidance
- `file_stat` — relative path example + guidance
- `ast_edit` — relative path example + guidance

## Tests
- 295/295 tests passing ✅
- 0 type errors ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace search now gracefully falls back to the best available search mode when hybrid or vector search is requested but not supported, instead of throwing an error.
  * Workspace file tools now enforce relative paths to prevent permission errors when accessing files.

* **Documentation**
  * Updated tool documentation to clarify that file paths must be relative and never start with "/".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->