### PR TITLE
 feat(core): add WORKSPACE_ACTION span type for workspace tracing

### DIFF
--- a/.changeset/workspace-action-tracing.md
+++ b/.changeset/workspace-action-tracing.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added `WORKSPACE_ACTION` span type for workspace tracing. All workspace tools (filesystem, sandbox, search) now create child spans with metadata including category, operation, file paths, commands, exit codes, bytes transferred, and duration. Added `startWorkspaceSpan()` utility for span creation with graceful no-op when tracing is inactive.

--- a/.changeset/workspace-action-tracing.md
+++ b/.changeset/workspace-action-tracing.md
@@ -2,4 +2,4 @@
 '@mastra/core': minor
 ---
 
-Added `WORKSPACE_ACTION` span type for workspace tracing. All workspace tools (filesystem, sandbox, search) now create child spans with metadata including category, operation, file paths, commands, exit codes, bytes transferred, and duration. Added `startWorkspaceSpan()` utility for span creation with graceful no-op when tracing is inactive.
+Added `WORKSPACE_ACTION` span type for workspace tracing. All workspace tools (filesystem, sandbox, search, skill, LSP) now create child spans with metadata including category, operation, file paths, commands, exit codes, bytes transferred, and duration. Added `startWorkspaceSpan()` utility for span creation with graceful no-op when tracing is inactive.

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -70,6 +70,8 @@ export enum SpanType {
   WORKFLOW_WAIT_EVENT = 'workflow_wait_event',
   /** Memory operation (recall, save, delete, update working memory) */
   MEMORY_OPERATION = 'memory_operation',
+  /** Workspace action (filesystem, sandbox, search, skill, mount operations) */
+  WORKSPACE_ACTION = 'workspace_action',
 }
 
 export { EntityType };
@@ -404,6 +406,26 @@ export interface MemoryOperationAttributes extends AIBaseAttributes {
 }
 
 /**
+ * Workspace Action attributes — metadata about the span context.
+ * Operation-specific inputs/outputs are recorded via span input/output,
+ * not as attributes.
+ */
+export interface WorkspaceActionAttributes extends AIBaseAttributes {
+  /** Workspace identifier */
+  workspaceId?: string;
+  /** Human-readable workspace name */
+  workspaceName?: string;
+  /** Action category */
+  category: 'filesystem' | 'sandbox' | 'search' | 'skill' | 'mount';
+  /** Sandbox provider name (e.g. 'e2b', 'docker', 'local') */
+  sandboxProvider?: string;
+  /** Filesystem provider name (e.g. 'local', 'agentfs', 's3') */
+  filesystemProvider?: string;
+  /** Whether the operation succeeded */
+  success?: boolean;
+}
+
+/**
  * AI-specific span types mapped to their attributes
  */
 export interface SpanTypeMap {
@@ -424,6 +446,7 @@ export interface SpanTypeMap {
   [SpanType.WORKFLOW_LOOP]: WorkflowLoopAttributes;
   [SpanType.WORKFLOW_SLEEP]: WorkflowSleepAttributes;
   [SpanType.WORKFLOW_WAIT_EVENT]: WorkflowWaitEventAttributes;
+  [SpanType.WORKSPACE_ACTION]: WorkspaceActionAttributes;
   [SpanType.GENERIC]: AIBaseAttributes;
   [SpanType.MEMORY_OPERATION]: MemoryOperationAttributes;
 }

--- a/packages/core/src/workspace/skills/tools.ts
+++ b/packages/core/src/workspace/skills/tools.ts
@@ -14,6 +14,7 @@ import { z } from 'zod/v4';
 
 import { createTool } from '../../tools';
 import { extractLines } from '../line-utils';
+import { startWorkspaceSpan } from '../tools/tracing';
 import type { Skill, WorkspaceSkills } from './types';
 
 // =============================================================================
@@ -66,10 +67,19 @@ function createSkillTool(skills: WorkspaceSkills) {
         .string()
         .describe('The name or path of the skill to activate. Use the path when multiple skills share the same name.'),
     }),
-    execute: async ({ name }) => {
+    execute: async ({ name }, context) => {
+      const span = startWorkspaceSpan(context, context?.workspace, {
+        category: 'skill',
+        operation: 'activate',
+        input: { name },
+      });
+
       const result = await resolveSkill(skills, name);
 
-      if ('notFound' in result) return result.notFound;
+      if ('notFound' in result) {
+        span.end({ success: false });
+        return result.notFound;
+      }
 
       const { skill } = result;
       const parts = [skill.instructions];
@@ -84,6 +94,7 @@ function createSkillTool(skills: WorkspaceSkills) {
         parts.push(`\n\n## Assets\n${skill.assets.map(a => `- assets/${a}`).join('\n')}`);
       }
 
+      span.end({ success: true });
       return parts.join('');
     },
   });
@@ -101,20 +112,34 @@ function createSkillSearchTool(skills: WorkspaceSkills) {
       skillNames: z.array(z.string()).optional().describe('Optional list of skill names to search within'),
       topK: z.number().optional().describe('Maximum number of results to return (default: 5)'),
     }),
-    execute: async ({ query, skillNames, topK }) => {
-      const results = await skills.search(query, { topK, skillNames });
+    execute: async ({ query, skillNames, topK }, context) => {
+      const span = startWorkspaceSpan(context, context?.workspace, {
+        category: 'skill',
+        operation: 'search',
+        input: { query, skillNames, topK },
+        attributes: { query },
+      });
 
-      if (results.length === 0) {
-        return 'No results found.';
+      try {
+        const results = await skills.search(query, { topK, skillNames });
+
+        if (results.length === 0) {
+          span.end({ success: true, resultCount: 0 });
+          return 'No results found.';
+        }
+
+        span.end({ success: true, resultCount: results.length });
+        return results
+          .map(r => {
+            const preview = r.content.substring(0, 200) + (r.content.length > 200 ? '...' : '');
+            const location = r.lineRange ? ` (lines ${r.lineRange.start}-${r.lineRange.end})` : '';
+            return `[${r.skillName}]${location} (score: ${r.score.toFixed(2)})\n${preview}`;
+          })
+          .join('\n\n');
+      } catch (err) {
+        span.error(err, { query });
+        throw err;
       }
-
-      return results
-        .map(r => {
-          const preview = r.content.substring(0, 200) + (r.content.length > 200 ? '...' : '');
-          const location = r.lineRange ? ` (lines ${r.lineRange.start}-${r.lineRange.end})` : '';
-          return `[${r.skillName}]${location} (score: ${r.score.toFixed(2)})\n${preview}`;
-        })
-        .join('\n\n');
     },
   });
 
@@ -142,39 +167,57 @@ function createSkillReadTool(skills: WorkspaceSkills) {
         .optional()
         .describe('Ending line number (1-indexed, inclusive). If omitted, reads to the end.'),
     }),
-    execute: async ({ skillName, path, startLine, endLine }) => {
+    execute: async ({ skillName, path, startLine, endLine }, context) => {
+      const span = startWorkspaceSpan(context, context?.workspace, {
+        category: 'skill',
+        operation: 'read',
+        input: { skillName, path, startLine, endLine },
+        attributes: { filePath: path },
+      });
+
       // Resolve skill by name or path (get() handles both with tie-breaking)
       const resolved = await resolveSkill(skills, skillName);
-      if ('notFound' in resolved) return resolved.notFound;
-
-      const resolvedPath = resolved.skill.path;
-
-      // Try each reader using the resolved path to target the exact skill candidate
-      let content: string | Buffer | null = null;
-      content = await skills.getReference(resolvedPath, path);
-      if (content === null) content = await skills.getScript(resolvedPath, path);
-      if (content === null) content = await skills.getAsset(resolvedPath, path);
-
-      if (content === null) {
-        const refs = (await skills.listReferences(resolvedPath)).map(f => `references/${f}`);
-        const scriptsList = (await skills.listScripts(resolvedPath)).map(f => `scripts/${f}`);
-        const assets = (await skills.listAssets(resolvedPath)).map(f => `assets/${f}`);
-        const allFiles = [...refs, ...scriptsList, ...assets];
-        const fileList = allFiles.length > 0 ? `\nAvailable files: ${allFiles.join(', ')}` : '';
-        return `File "${path}" not found in skill "${skillName}".${fileList}`;
+      if ('notFound' in resolved) {
+        span.end({ success: false });
+        return resolved.notFound;
       }
 
-      // Detect binary content — getReference/getScript may return binary as garbled utf-8 strings
-      const textContent = typeof content === 'string' ? content : content.toString('utf-8');
-      if (textContent.slice(0, 1000).includes('\0')) {
-        const fullPath = `${resolved.skill.path}/${path}`;
-        const size = typeof content === 'string' ? Buffer.byteLength(content) : content.length;
-        return `Binary file: ${fullPath} (${size} bytes)`;
-      }
-      content = textContent;
+      try {
+        const resolvedPath = resolved.skill.path;
 
-      const result = extractLines(content, startLine, endLine);
-      return result.content;
+        // Try each reader using the resolved path to target the exact skill candidate
+        let content: string | Buffer | null = null;
+        content = await skills.getReference(resolvedPath, path);
+        if (content === null) content = await skills.getScript(resolvedPath, path);
+        if (content === null) content = await skills.getAsset(resolvedPath, path);
+
+        if (content === null) {
+          const refs = (await skills.listReferences(resolvedPath)).map(f => `references/${f}`);
+          const scriptsList = (await skills.listScripts(resolvedPath)).map(f => `scripts/${f}`);
+          const assets = (await skills.listAssets(resolvedPath)).map(f => `assets/${f}`);
+          const allFiles = [...refs, ...scriptsList, ...assets];
+          const fileList = allFiles.length > 0 ? `\nAvailable files: ${allFiles.join(', ')}` : '';
+          span.end({ success: false });
+          return `File "${path}" not found in skill "${skillName}".${fileList}`;
+        }
+
+        // Detect binary content — getReference/getScript may return binary as garbled utf-8 strings
+        const textContent = typeof content === 'string' ? content : content.toString('utf-8');
+        if (textContent.slice(0, 1000).includes('\0')) {
+          const fullPath = `${resolved.skill.path}/${path}`;
+          const size = typeof content === 'string' ? Buffer.byteLength(content) : content.length;
+          span.end({ success: true, bytesTransferred: size });
+          return `Binary file: ${fullPath} (${size} bytes)`;
+        }
+        content = textContent;
+
+        const result = extractLines(content, startLine, endLine);
+        span.end({ success: true, bytesTransferred: Buffer.byteLength(result.content, 'utf-8') });
+        return result.content;
+      } catch (err) {
+        span.error(err, { filePath: path });
+        throw err;
+      }
     },
   });
 

--- a/packages/core/src/workspace/skills/tools.ts
+++ b/packages/core/src/workspace/skills/tools.ts
@@ -122,18 +122,18 @@ function createSkillSearchTool(skills: WorkspaceSkills) {
         category: 'skill',
         operation: 'search',
         input: { query, skillNames, topK },
-        attributes: { query },
+        attributes: {},
       });
 
       try {
         const results = await skills.search(query, { topK, skillNames });
 
         if (results.length === 0) {
-          span.end({ success: true, resultCount: 0 });
+          span.end({ success: true }, { resultCount: 0 });
           return 'No results found.';
         }
 
-        span.end({ success: true, resultCount: results.length });
+        span.end({ success: true }, { resultCount: results.length });
         return results
           .map(r => {
             const preview = r.content.substring(0, 200) + (r.content.length > 200 ? '...' : '');
@@ -142,7 +142,7 @@ function createSkillSearchTool(skills: WorkspaceSkills) {
           })
           .join('\n\n');
       } catch (err) {
-        span.error(err, { query });
+        span.error(err);
         throw err;
       }
     },
@@ -177,7 +177,7 @@ function createSkillReadTool(skills: WorkspaceSkills) {
         category: 'skill',
         operation: 'read',
         input: { skillName, path, startLine, endLine },
-        attributes: { filePath: path },
+        attributes: {},
       });
 
       try {
@@ -210,16 +210,16 @@ function createSkillReadTool(skills: WorkspaceSkills) {
         if (textContent.slice(0, 1000).includes('\0')) {
           const fullPath = `${resolved.skill.path}/${path}`;
           const size = typeof content === 'string' ? Buffer.byteLength(content) : content.length;
-          span.end({ success: true, bytesTransferred: size });
+          span.end({ success: true }, { bytesTransferred: size });
           return `Binary file: ${fullPath} (${size} bytes)`;
         }
         content = textContent;
 
         const result = extractLines(content, startLine, endLine);
-        span.end({ success: true, bytesTransferred: Buffer.byteLength(result.content, 'utf-8') });
+        span.end({ success: true }, { bytesTransferred: Buffer.byteLength(result.content, 'utf-8') });
         return result.content;
       } catch (err) {
-        span.error(err, { filePath: path });
+        span.error(err);
         throw err;
       }
     },

--- a/packages/core/src/workspace/skills/tools.ts
+++ b/packages/core/src/workspace/skills/tools.ts
@@ -180,14 +180,13 @@ function createSkillReadTool(skills: WorkspaceSkills) {
         attributes: { filePath: path },
       });
 
-      // Resolve skill by name or path (get() handles both with tie-breaking)
-      const resolved = await resolveSkill(skills, skillName);
-      if ('notFound' in resolved) {
-        span.end({ success: false });
-        return resolved.notFound;
-      }
-
       try {
+        // Resolve skill by name or path (get() handles both with tie-breaking)
+        const resolved = await resolveSkill(skills, skillName);
+        if ('notFound' in resolved) {
+          span.end({ success: false });
+          return resolved.notFound;
+        }
         const resolvedPath = resolved.skill.path;
 
         // Try each reader using the resolved path to target the exact skill candidate

--- a/packages/core/src/workspace/skills/tools.ts
+++ b/packages/core/src/workspace/skills/tools.ts
@@ -74,28 +74,33 @@ function createSkillTool(skills: WorkspaceSkills) {
         input: { name },
       });
 
-      const result = await resolveSkill(skills, name);
+      try {
+        const result = await resolveSkill(skills, name);
 
-      if ('notFound' in result) {
-        span.end({ success: false });
-        return result.notFound;
-      }
+        if ('notFound' in result) {
+          span.end({ success: false });
+          return result.notFound;
+        }
 
-      const { skill } = result;
-      const parts = [skill.instructions];
+        const { skill } = result;
+        const parts = [skill.instructions];
 
-      if (skill.references?.length) {
-        parts.push(`\n\n## References\n${skill.references.map(r => `- references/${r}`).join('\n')}`);
-      }
-      if (skill.scripts?.length) {
-        parts.push(`\n\n## Scripts\n${skill.scripts.map(s => `- scripts/${s}`).join('\n')}`);
-      }
-      if (skill.assets?.length) {
-        parts.push(`\n\n## Assets\n${skill.assets.map(a => `- assets/${a}`).join('\n')}`);
-      }
+        if (skill.references?.length) {
+          parts.push(`\n\n## References\n${skill.references.map(r => `- references/${r}`).join('\n')}`);
+        }
+        if (skill.scripts?.length) {
+          parts.push(`\n\n## Scripts\n${skill.scripts.map(s => `- scripts/${s}`).join('\n')}`);
+        }
+        if (skill.assets?.length) {
+          parts.push(`\n\n## Assets\n${skill.assets.map(a => `- assets/${a}`).join('\n')}`);
+        }
 
-      span.end({ success: true });
-      return parts.join('');
+        span.end({ success: true });
+        return parts.join('');
+      } catch (err) {
+        span.error(err);
+        throw err;
+      }
     },
   });
 

--- a/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
@@ -1,0 +1,431 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { SpanType } from '../../../observability/types/tracing';
+import type { AnySpan, WorkspaceActionAttributes } from '../../../observability/types/tracing';
+import { WORKSPACE_TOOLS } from '../../constants';
+import { LocalFilesystem } from '../../filesystem';
+import { Workspace } from '../../workspace';
+import { indexContentTool } from '../index-content';
+import { searchTool } from '../search';
+import { createWorkspaceTools } from '../tools';
+import { startWorkspaceSpan } from '../tracing';
+import { writeFileTool } from '../write-file';
+
+/**
+ * Creates a mock span that records createChildSpan calls.
+ * Returns both the mock span and a list of captured child span calls.
+ */
+function createMockSpan() {
+  const childSpans: Array<{
+    type: SpanType;
+    name: string;
+    input?: unknown;
+    attributes?: Record<string, unknown>;
+    ended: boolean;
+    errored: boolean;
+    endAttributes?: Partial<WorkspaceActionAttributes>;
+    endOutput?: unknown;
+    errorObj?: unknown;
+    errorAttributes?: Partial<WorkspaceActionAttributes>;
+  }> = [];
+
+  const mockParentSpan = {
+    createChildSpan: vi.fn((options: any) => {
+      const childRecord = {
+        type: options.type,
+        name: options.name,
+        input: options.input,
+        attributes: options.attributes,
+        ended: false,
+        errored: false,
+        endAttributes: undefined as Partial<WorkspaceActionAttributes> | undefined,
+        endOutput: undefined as unknown,
+        errorObj: undefined as unknown,
+        errorAttributes: undefined as Partial<WorkspaceActionAttributes> | undefined,
+      };
+      childSpans.push(childRecord);
+
+      return {
+        end: vi.fn((options?: any) => {
+          childRecord.ended = true;
+          childRecord.endAttributes = options?.attributes;
+          childRecord.endOutput = options?.output;
+        }),
+        error: vi.fn((options?: any) => {
+          childRecord.errored = true;
+          childRecord.errorObj = options?.error;
+          childRecord.errorAttributes = options?.attributes;
+        }),
+        update: vi.fn(),
+        createChildSpan: vi.fn(),
+      };
+    }),
+  } as unknown as AnySpan;
+
+  return { mockParentSpan, childSpans };
+}
+
+describe('startWorkspaceSpan', () => {
+  it('creates a WORKSPACE_ACTION child span with correct attributes', () => {
+    const { mockParentSpan, childSpans } = createMockSpan();
+    const workspace = new Workspace({ id: 'ws-1', name: 'test-workspace', skills: ['./skills'] });
+
+    const handle = startWorkspaceSpan({ tracing: { currentSpan: mockParentSpan } } as any, workspace, {
+      category: 'filesystem',
+      operation: 'readFile',
+      input: { path: '/data/file.txt' },
+      attributes: { filePath: '/data/file.txt' },
+    });
+
+    expect(handle.span).toBeDefined();
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.type).toBe(SpanType.WORKSPACE_ACTION);
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:readFile');
+    expect(childSpans[0]!.attributes).toMatchObject({
+      category: 'filesystem',
+      operation: 'readFile',
+      workspaceId: 'ws-1',
+      workspaceName: 'test-workspace',
+      filePath: '/data/file.txt',
+    });
+  });
+
+  it('returns no-op handle when no tracing context is available', () => {
+    const handle = startWorkspaceSpan(undefined, undefined, {
+      category: 'sandbox',
+      operation: 'executeCommand',
+    });
+
+    expect(handle.span).toBeUndefined();
+    // Should not throw
+    handle.end();
+    handle.error(new Error('test'));
+  });
+
+  it('returns no-op handle when context has no currentSpan', () => {
+    const handle = startWorkspaceSpan({ tracing: { currentSpan: undefined } } as any, undefined, {
+      category: 'filesystem',
+      operation: 'readFile',
+    });
+
+    expect(handle.span).toBeUndefined();
+    handle.end();
+    handle.error(new Error('test'));
+  });
+
+  it('end() sets success=true and records durationMs', async () => {
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    const handle = startWorkspaceSpan({ tracing: { currentSpan: mockParentSpan } } as any, undefined, {
+      category: 'search',
+      operation: 'search',
+    });
+
+    // Small delay to ensure durationMs > 0
+    await new Promise(r => setTimeout(r, 5));
+    handle.end({ resultCount: 3 });
+
+    expect(childSpans[0]!.ended).toBe(true);
+    expect(childSpans[0]!.endAttributes?.success).toBe(true);
+    expect(childSpans[0]!.endAttributes?.durationMs).toBeGreaterThanOrEqual(0);
+    expect(childSpans[0]!.endAttributes?.resultCount).toBe(3);
+  });
+
+  it('error() sets success=false and records the error', () => {
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    const handle = startWorkspaceSpan({ tracing: { currentSpan: mockParentSpan } } as any, undefined, {
+      category: 'filesystem',
+      operation: 'writeFile',
+    });
+
+    const testError = new Error('disk full');
+    handle.error(testError, { filePath: '/data/out.txt' });
+
+    expect(childSpans[0]!.errored).toBe(true);
+    expect(childSpans[0]!.errorObj).toBe(testError);
+    expect(childSpans[0]!.errorAttributes?.success).toBe(false);
+    expect(childSpans[0]!.errorAttributes?.filePath).toBe('/data/out.txt');
+  });
+
+  it('error() wraps non-Error values in an Error', () => {
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    const handle = startWorkspaceSpan({ tracing: { currentSpan: mockParentSpan } } as any, undefined, {
+      category: 'sandbox',
+      operation: 'executeCommand',
+    });
+
+    handle.error('string error');
+
+    expect(childSpans[0]!.errored).toBe(true);
+    expect(childSpans[0]!.errorObj).toBeInstanceOf(Error);
+    expect((childSpans[0]!.errorObj as Error).message).toBe('string error');
+  });
+
+  it('falls back to tracingContext when tracing is not set', () => {
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    const handle = startWorkspaceSpan({ tracingContext: { currentSpan: mockParentSpan } } as any, undefined, {
+      category: 'filesystem',
+      operation: 'delete',
+    });
+
+    expect(handle.span).toBeDefined();
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:delete');
+  });
+});
+
+describe('workspace tool tracing integration', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workspace-tracing-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('readFile tool creates a WORKSPACE_ACTION span on success', async () => {
+    await fs.writeFile(path.join(tempDir, 'hello.txt'), 'Hello World');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'hello.txt' },
+      { workspace, tracing: { currentSpan: mockParentSpan } },
+    );
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.type).toBe(SpanType.WORKSPACE_ACTION);
+    expect(childSpans[0]!.attributes?.category).toBe('filesystem');
+    expect(childSpans[0]!.attributes?.operation).toBe('readFile');
+    expect(childSpans[0]!.attributes?.filePath).toBe('hello.txt');
+    expect(childSpans[0]!.ended).toBe(true);
+    expect(childSpans[0]!.endAttributes?.success).toBe(true);
+    expect(childSpans[0]!.endAttributes?.bytesTransferred).toBe(11);
+  });
+
+  it('writeFile tool creates a WORKSPACE_ACTION span on success', async () => {
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].execute(
+      { path: 'out.txt', content: 'test content' },
+      { workspace, tracing: { currentSpan: mockParentSpan } },
+    );
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.attributes?.category).toBe('filesystem');
+    expect(childSpans[0]!.attributes?.operation).toBe('writeFile');
+    expect(childSpans[0]!.ended).toBe(true);
+    expect(childSpans[0]!.endAttributes?.bytesTransferred).toBe(12);
+  });
+
+  it('editFile tool creates a WORKSPACE_ACTION span on success', async () => {
+    await fs.writeFile(path.join(tempDir, 'edit.txt'), 'foo bar baz');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE].execute(
+      { path: 'edit.txt', old_string: 'bar', new_string: 'qux' },
+      { workspace, tracing: { currentSpan: mockParentSpan } },
+    );
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.attributes?.category).toBe('filesystem');
+    expect(childSpans[0]!.attributes?.operation).toBe('editFile');
+    expect(childSpans[0]!.ended).toBe(true);
+  });
+
+  it('deleteFile tool creates a WORKSPACE_ACTION span on success', async () => {
+    await fs.writeFile(path.join(tempDir, 'del.txt'), 'delete me');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.DELETE].execute(
+      { path: 'del.txt' },
+      { workspace, tracing: { currentSpan: mockParentSpan } },
+    );
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.attributes?.category).toBe('filesystem');
+    expect(childSpans[0]!.attributes?.operation).toBe('delete');
+    expect(childSpans[0]!.ended).toBe(true);
+    expect(childSpans[0]!.endAttributes?.success).toBe(true);
+  });
+
+  it('listFiles tool creates a WORKSPACE_ACTION span', async () => {
+    await fs.writeFile(path.join(tempDir, 'a.txt'), 'a');
+    await fs.writeFile(path.join(tempDir, 'b.txt'), 'b');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES].execute(
+      { path: '.' },
+      { workspace, tracing: { currentSpan: mockParentSpan } },
+    );
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.attributes?.category).toBe('filesystem');
+    expect(childSpans[0]!.attributes?.operation).toBe('listFiles');
+    expect(childSpans[0]!.ended).toBe(true);
+  });
+
+  it('fileStat tool creates a WORKSPACE_ACTION span', async () => {
+    await fs.writeFile(path.join(tempDir, 'stat.txt'), 'hello');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT].execute(
+      { path: 'stat.txt' },
+      { workspace, tracing: { currentSpan: mockParentSpan } },
+    );
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.attributes?.category).toBe('filesystem');
+    expect(childSpans[0]!.attributes?.operation).toBe('stat');
+    expect(childSpans[0]!.ended).toBe(true);
+    expect(childSpans[0]!.endAttributes?.bytesTransferred).toBe(5);
+  });
+
+  it('fileStat tool ends span with success=false for missing file', async () => {
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT].execute(
+      { path: 'nonexistent.txt' },
+      { workspace, tracing: { currentSpan: mockParentSpan } },
+    );
+
+    expect(result).toContain('not found');
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.ended).toBe(true);
+    expect(childSpans[0]!.endAttributes?.success).toBe(false);
+  });
+
+  it('mkdir tool creates a WORKSPACE_ACTION span', async () => {
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.MKDIR].execute(
+      { path: 'subdir' },
+      { workspace, tracing: { currentSpan: mockParentSpan } },
+    );
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.attributes?.category).toBe('filesystem');
+    expect(childSpans[0]!.attributes?.operation).toBe('mkdir');
+    expect(childSpans[0]!.ended).toBe(true);
+  });
+
+  it('grep tool creates a WORKSPACE_ACTION span with resultCount', async () => {
+    await fs.writeFile(path.join(tempDir, 'code.ts'), 'function hello() {}\nfunction world() {}');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.GREP].execute(
+      { pattern: 'function' },
+      { workspace, tracing: { currentSpan: mockParentSpan } },
+    );
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.attributes?.category).toBe('filesystem');
+    expect(childSpans[0]!.attributes?.operation).toBe('grep');
+    expect(childSpans[0]!.attributes?.query).toBe('function');
+    expect(childSpans[0]!.ended).toBe(true);
+    expect(childSpans[0]!.endAttributes?.resultCount).toBe(2);
+  });
+
+  it('search tool creates a WORKSPACE_ACTION span with error when search not configured', async () => {
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await expect(
+      searchTool.execute({ query: 'test query', topK: 5 }, {
+        workspace,
+        tracing: { currentSpan: mockParentSpan },
+      } as any),
+    ).rejects.toThrow();
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.attributes?.category).toBe('search');
+    expect(childSpans[0]!.attributes?.operation).toBe('search');
+    expect(childSpans[0]!.attributes?.query).toBe('test query');
+    expect(childSpans[0]!.errored).toBe(true);
+    expect(childSpans[0]!.errorAttributes?.success).toBe(false);
+  });
+
+  it('index tool creates a WORKSPACE_ACTION span with error when search not configured', async () => {
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await expect(
+      indexContentTool.execute({ path: 'doc.txt', content: 'indexed content' }, {
+        workspace,
+        tracing: { currentSpan: mockParentSpan },
+      } as any),
+    ).rejects.toThrow();
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.attributes?.category).toBe('search');
+    expect(childSpans[0]!.attributes?.operation).toBe('index');
+    expect(childSpans[0]!.errored).toBe(true);
+    expect(childSpans[0]!.errorAttributes?.success).toBe(false);
+  });
+
+  it('tools work correctly without tracing context (no span created)', async () => {
+    await fs.writeFile(path.join(tempDir, 'no-trace.txt'), 'content');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = createWorkspaceTools(workspace);
+
+    // No tracing context — should not throw
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'no-trace.txt' }, { workspace });
+
+    expect(result).toContain('content');
+  });
+
+  it('writeFile tool records error span on failure', async () => {
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir, readOnly: true }),
+    });
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await expect(
+      writeFileTool.execute({ path: 'fail.txt', content: 'data', overwrite: true }, {
+        workspace,
+        tracing: { currentSpan: mockParentSpan },
+      } as any),
+    ).rejects.toThrow();
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.errored).toBe(true);
+    expect(childSpans[0]!.errorAttributes?.success).toBe(false);
+  });
+});

--- a/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
@@ -116,7 +116,7 @@ describe('startWorkspaceSpan', () => {
     handle.error(new Error('test'));
   });
 
-  it('end() sets success=true and records durationMs', async () => {
+  it('end() records durationMs and passes through attributes without implicit success', async () => {
     const { mockParentSpan, childSpans } = createMockSpan();
 
     const handle = startWorkspaceSpan({ tracing: { currentSpan: mockParentSpan } } as any, undefined, {
@@ -126,12 +126,27 @@ describe('startWorkspaceSpan', () => {
 
     // Small delay to ensure durationMs > 0
     await new Promise(r => setTimeout(r, 5));
-    handle.end({ resultCount: 3 });
+    handle.end({ success: true, resultCount: 3 });
 
     expect(childSpans[0]!.ended).toBe(true);
     expect(childSpans[0]!.endAttributes?.success).toBe(true);
     expect(childSpans[0]!.endAttributes?.durationMs).toBeGreaterThanOrEqual(0);
     expect(childSpans[0]!.endAttributes?.resultCount).toBe(3);
+  });
+
+  it('end() does not set success when caller omits it', () => {
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    const handle = startWorkspaceSpan({ tracing: { currentSpan: mockParentSpan } } as any, undefined, {
+      category: 'filesystem',
+      operation: 'readFile',
+    });
+
+    handle.end({ bytesTransferred: 100 });
+
+    expect(childSpans[0]!.ended).toBe(true);
+    expect(childSpans[0]!.endAttributes?.success).toBeUndefined();
+    expect(childSpans[0]!.endAttributes?.bytesTransferred).toBe(100);
   });
 
   it('error() sets success=false and records the error', () => {

--- a/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
@@ -209,7 +209,7 @@ describe('workspace tool tracing integration', () => {
   it('readFile tool creates a WORKSPACE_ACTION span on success', async () => {
     await fs.writeFile(path.join(tempDir, 'hello.txt'), 'Hello World');
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const { mockParentSpan, childSpans } = createMockSpan();
 
@@ -230,7 +230,7 @@ describe('workspace tool tracing integration', () => {
 
   it('writeFile tool creates a WORKSPACE_ACTION span on success', async () => {
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const { mockParentSpan, childSpans } = createMockSpan();
 
@@ -249,7 +249,7 @@ describe('workspace tool tracing integration', () => {
   it('editFile tool creates a WORKSPACE_ACTION span on success', async () => {
     await fs.writeFile(path.join(tempDir, 'edit.txt'), 'foo bar baz');
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const { mockParentSpan, childSpans } = createMockSpan();
 
@@ -267,7 +267,7 @@ describe('workspace tool tracing integration', () => {
   it('deleteFile tool creates a WORKSPACE_ACTION span on success', async () => {
     await fs.writeFile(path.join(tempDir, 'del.txt'), 'delete me');
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const { mockParentSpan, childSpans } = createMockSpan();
 
@@ -287,7 +287,7 @@ describe('workspace tool tracing integration', () => {
     await fs.writeFile(path.join(tempDir, 'a.txt'), 'a');
     await fs.writeFile(path.join(tempDir, 'b.txt'), 'b');
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const { mockParentSpan, childSpans } = createMockSpan();
 
@@ -305,7 +305,7 @@ describe('workspace tool tracing integration', () => {
   it('fileStat tool creates a WORKSPACE_ACTION span', async () => {
     await fs.writeFile(path.join(tempDir, 'stat.txt'), 'hello');
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const { mockParentSpan, childSpans } = createMockSpan();
 
@@ -323,7 +323,7 @@ describe('workspace tool tracing integration', () => {
 
   it('fileStat tool ends span with success=false for missing file', async () => {
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const { mockParentSpan, childSpans } = createMockSpan();
 
@@ -340,7 +340,7 @@ describe('workspace tool tracing integration', () => {
 
   it('mkdir tool creates a WORKSPACE_ACTION span', async () => {
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const { mockParentSpan, childSpans } = createMockSpan();
 
@@ -358,7 +358,7 @@ describe('workspace tool tracing integration', () => {
   it('grep tool creates a WORKSPACE_ACTION span with resultCount', async () => {
     await fs.writeFile(path.join(tempDir, 'code.ts'), 'function hello() {}\nfunction world() {}');
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const { mockParentSpan, childSpans } = createMockSpan();
 
@@ -417,7 +417,7 @@ describe('workspace tool tracing integration', () => {
   it('tools work correctly without tracing context (no span created)', async () => {
     await fs.writeFile(path.join(tempDir, 'no-trace.txt'), 'content');
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     // No tracing context — should not throw
     const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'no-trace.txt' }, { workspace });

--- a/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
@@ -86,10 +86,8 @@ describe('startWorkspaceSpan', () => {
     expect(childSpans[0]!.name).toBe('workspace:filesystem:readFile');
     expect(childSpans[0]!.attributes).toMatchObject({
       category: 'filesystem',
-      operation: 'readFile',
       workspaceId: 'ws-1',
       workspaceName: 'test-workspace',
-      filePath: '/data/file.txt',
     });
   });
 
@@ -116,7 +114,7 @@ describe('startWorkspaceSpan', () => {
     handle.error(new Error('test'));
   });
 
-  it('end() records durationMs and passes through attributes without implicit success', async () => {
+  it('end() passes through attributes and output separately', async () => {
     const { mockParentSpan, childSpans } = createMockSpan();
 
     const handle = startWorkspaceSpan({ tracing: { currentSpan: mockParentSpan } } as any, undefined, {
@@ -124,14 +122,11 @@ describe('startWorkspaceSpan', () => {
       operation: 'search',
     });
 
-    // Small delay to ensure durationMs > 0
-    await new Promise(r => setTimeout(r, 5));
-    handle.end({ success: true, resultCount: 3 });
+    handle.end({ success: true }, { resultCount: 3 });
 
     expect(childSpans[0]!.ended).toBe(true);
     expect(childSpans[0]!.endAttributes?.success).toBe(true);
-    expect(childSpans[0]!.endAttributes?.durationMs).toBeGreaterThanOrEqual(0);
-    expect(childSpans[0]!.endAttributes?.resultCount).toBe(3);
+    expect(childSpans[0]!.endOutput).toEqual({ resultCount: 3 });
   });
 
   it('end() does not set success when caller omits it', () => {
@@ -142,11 +137,11 @@ describe('startWorkspaceSpan', () => {
       operation: 'readFile',
     });
 
-    handle.end({ bytesTransferred: 100 });
+    handle.end(undefined, { bytesTransferred: 100 });
 
     expect(childSpans[0]!.ended).toBe(true);
     expect(childSpans[0]!.endAttributes?.success).toBeUndefined();
-    expect(childSpans[0]!.endAttributes?.bytesTransferred).toBe(100);
+    expect(childSpans[0]!.endOutput).toEqual({ bytesTransferred: 100 });
   });
 
   it('error() sets success=false and records the error', () => {
@@ -158,12 +153,11 @@ describe('startWorkspaceSpan', () => {
     });
 
     const testError = new Error('disk full');
-    handle.error(testError, { filePath: '/data/out.txt' });
+    handle.error(testError);
 
     expect(childSpans[0]!.errored).toBe(true);
     expect(childSpans[0]!.errorObj).toBe(testError);
     expect(childSpans[0]!.errorAttributes?.success).toBe(false);
-    expect(childSpans[0]!.errorAttributes?.filePath).toBe('/data/out.txt');
   });
 
   it('error() wraps non-Error values in an Error', () => {
@@ -221,11 +215,10 @@ describe('workspace tool tracing integration', () => {
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.type).toBe(SpanType.WORKSPACE_ACTION);
     expect(childSpans[0]!.attributes?.category).toBe('filesystem');
-    expect(childSpans[0]!.attributes?.operation).toBe('readFile');
-    expect(childSpans[0]!.attributes?.filePath).toBe('hello.txt');
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:readFile');
     expect(childSpans[0]!.ended).toBe(true);
     expect(childSpans[0]!.endAttributes?.success).toBe(true);
-    expect(childSpans[0]!.endAttributes?.bytesTransferred).toBe(11);
+    expect(childSpans[0]!.endOutput).toEqual({ bytesTransferred: 11 });
   });
 
   it('writeFile tool creates a WORKSPACE_ACTION span on success', async () => {
@@ -241,9 +234,9 @@ describe('workspace tool tracing integration', () => {
 
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.attributes?.category).toBe('filesystem');
-    expect(childSpans[0]!.attributes?.operation).toBe('writeFile');
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:writeFile');
     expect(childSpans[0]!.ended).toBe(true);
-    expect(childSpans[0]!.endAttributes?.bytesTransferred).toBe(12);
+    expect(childSpans[0]!.endOutput).toEqual({ bytesTransferred: 12 });
   });
 
   it('editFile tool creates a WORKSPACE_ACTION span on success', async () => {
@@ -260,7 +253,7 @@ describe('workspace tool tracing integration', () => {
 
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.attributes?.category).toBe('filesystem');
-    expect(childSpans[0]!.attributes?.operation).toBe('editFile');
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:editFile');
     expect(childSpans[0]!.ended).toBe(true);
   });
 
@@ -278,7 +271,7 @@ describe('workspace tool tracing integration', () => {
 
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.attributes?.category).toBe('filesystem');
-    expect(childSpans[0]!.attributes?.operation).toBe('delete');
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:delete');
     expect(childSpans[0]!.ended).toBe(true);
     expect(childSpans[0]!.endAttributes?.success).toBe(true);
   });
@@ -298,7 +291,7 @@ describe('workspace tool tracing integration', () => {
 
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.attributes?.category).toBe('filesystem');
-    expect(childSpans[0]!.attributes?.operation).toBe('listFiles');
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:listFiles');
     expect(childSpans[0]!.ended).toBe(true);
   });
 
@@ -316,9 +309,9 @@ describe('workspace tool tracing integration', () => {
 
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.attributes?.category).toBe('filesystem');
-    expect(childSpans[0]!.attributes?.operation).toBe('stat');
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:stat');
     expect(childSpans[0]!.ended).toBe(true);
-    expect(childSpans[0]!.endAttributes?.bytesTransferred).toBe(5);
+    expect(childSpans[0]!.endOutput).toEqual({ bytesTransferred: 5 });
   });
 
   it('fileStat tool ends span with success=false for missing file', async () => {
@@ -351,7 +344,7 @@ describe('workspace tool tracing integration', () => {
 
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.attributes?.category).toBe('filesystem');
-    expect(childSpans[0]!.attributes?.operation).toBe('mkdir');
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:mkdir');
     expect(childSpans[0]!.ended).toBe(true);
   });
 
@@ -369,10 +362,9 @@ describe('workspace tool tracing integration', () => {
 
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.attributes?.category).toBe('filesystem');
-    expect(childSpans[0]!.attributes?.operation).toBe('grep');
-    expect(childSpans[0]!.attributes?.query).toBe('function');
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:grep');
     expect(childSpans[0]!.ended).toBe(true);
-    expect(childSpans[0]!.endAttributes?.resultCount).toBe(2);
+    expect(childSpans[0]!.endOutput).toEqual({ resultCount: 2 });
   });
 
   it('search tool creates a WORKSPACE_ACTION span with error when search not configured', async () => {
@@ -389,8 +381,7 @@ describe('workspace tool tracing integration', () => {
 
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.attributes?.category).toBe('search');
-    expect(childSpans[0]!.attributes?.operation).toBe('search');
-    expect(childSpans[0]!.attributes?.query).toBe('test query');
+    expect(childSpans[0]!.name).toBe('workspace:search:search');
     expect(childSpans[0]!.errored).toBe(true);
     expect(childSpans[0]!.errorAttributes?.success).toBe(false);
   });
@@ -409,7 +400,7 @@ describe('workspace tool tracing integration', () => {
 
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.attributes?.category).toBe('search');
-    expect(childSpans[0]!.attributes?.operation).toBe('index');
+    expect(childSpans[0]!.name).toBe('workspace:search:index');
     expect(childSpans[0]!.errored).toBe(true);
     expect(childSpans[0]!.errorAttributes?.success).toBe(false);
   });

--- a/packages/core/src/workspace/tools/ast-edit.ts
+++ b/packages/core/src/workspace/tools/ast-edit.ts
@@ -439,7 +439,7 @@ Pattern replace (for everything else):
       category: 'filesystem',
       operation: 'astEdit',
       input: { path, transform, pattern },
-      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+      attributes: { filesystemProvider: filesystem.provider },
     });
 
     try {
@@ -552,10 +552,10 @@ Pattern replace (for everything else):
 
       let output = `${path}: ${changes.join('; ')}`;
       output += await getEditDiagnosticsText(workspace, path, modifiedContent);
-      span.end({ success: true, bytesTransferred: Buffer.byteLength(modifiedContent, 'utf-8') });
+      span.end({ success: true }, { bytesTransferred: Buffer.byteLength(modifiedContent, 'utf-8') });
       return output;
     } catch (err) {
-      span.error(err, { filePath: path });
+      span.error(err);
       throw err;
     }
   },

--- a/packages/core/src/workspace/tools/ast-edit.ts
+++ b/packages/core/src/workspace/tools/ast-edit.ts
@@ -15,6 +15,7 @@ import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { FileNotFoundError, WorkspaceReadOnlyError } from '../errors';
 import { emitWorkspaceMetadata, getEditDiagnosticsText, requireFilesystem } from './helpers';
+import { startWorkspaceSpan } from './tracing';
 
 // =============================================================================
 // Types
@@ -434,103 +435,128 @@ Pattern replace (for everything else):
     const { workspace, filesystem } = requireFilesystem(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.AST_EDIT);
 
-    if (filesystem.readOnly) {
-      throw new WorkspaceReadOnlyError('ast_edit');
-    }
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'astEdit',
+      input: { path, transform, pattern },
+      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+    });
 
-    // Load ast-grep (cached after first call)
-    const astGrep = await loadAstGrep();
-    if (!astGrep) {
-      return '@ast-grep/napi is not available. Install it to use AST editing.';
-    }
-    const { parse, Lang } = astGrep;
-
-    // Read current content
-    let content: string | Buffer;
     try {
-      content = await filesystem.readFile(path, { encoding: 'utf-8' });
-    } catch (error) {
-      if (error instanceof FileNotFoundError) {
-        return `File not found: ${path}. Use the write file tool to create it first.`;
+      if (filesystem.readOnly) {
+        throw new WorkspaceReadOnlyError('ast_edit');
       }
-      throw error;
-    }
 
-    if (typeof content !== 'string') {
-      return `Cannot perform AST edits on binary files. Use the write file tool instead.`;
-    }
-
-    // Parse AST
-    const lang = getLanguageFromPath(path, Lang);
-    if (!lang) {
-      return `Unsupported file type for AST editing: ${path}`;
-    }
-    const ast = parse(lang, content);
-    const root = ast.root();
-
-    let modifiedContent = content;
-    const changes: string[] = [];
-
-    if (transform) {
-      switch (transform) {
-        case 'add-import': {
-          if (!importSpec) {
-            return 'Error: importSpec is required for add-import transform';
-          }
-          modifiedContent = addImport(content, root, importSpec);
-          changes.push(`Added import from '${importSpec.module}'`);
-          break;
-        }
-
-        case 'remove-import': {
-          if (!targetName) {
-            return 'Error: targetName is required for remove-import transform';
-          }
-          modifiedContent = removeImport(content, root, targetName);
-          changes.push(`Removed import '${targetName}'`);
-          break;
-        }
-
-        case 'rename': {
-          if (!targetName || !newName) {
-            return 'Error: targetName and newName are required for rename transform';
-          }
-          const renameResult = renameIdentifiers(content, root, targetName, newName);
-          modifiedContent = renameResult.content;
-          changes.push(`Renamed '${targetName}' to '${newName}' (${renameResult.count} occurrences)`);
-          break;
-        }
+      // Load ast-grep (cached after first call)
+      const astGrep = await loadAstGrep();
+      if (!astGrep) {
+        span.end({ success: false });
+        return '@ast-grep/napi is not available. Install it to use AST editing.';
       }
-    } else if (pattern && replacement !== undefined) {
-      const result = patternReplace(content, root, pattern, replacement);
-      if (result.error) {
-        return `Error: AST pattern matching failed: ${result.error}`;
+      const { parse, Lang } = astGrep;
+
+      // Read current content
+      let content: string | Buffer;
+      try {
+        content = await filesystem.readFile(path, { encoding: 'utf-8' });
+      } catch (error) {
+        if (error instanceof FileNotFoundError) {
+          span.end({ success: false });
+          return `File not found: ${path}. Use the write file tool to create it first.`;
+        }
+        throw error;
       }
-      modifiedContent = result.content;
-      changes.push(`Replaced ${result.count} occurrences of pattern`);
-    } else if (pattern && replacement === undefined) {
-      return 'Error: replacement is required when pattern is provided';
-    } else if (!pattern && replacement !== undefined) {
-      return 'Error: pattern is required when replacement is provided';
-    } else {
-      return 'Error: Must provide either transform or pattern/replacement';
-    }
 
-    // Write back if modified
-    const wasModified = modifiedContent !== content;
-    if (wasModified) {
-      await filesystem.writeFile(path, modifiedContent, {
-        overwrite: true,
-        expectedMtime: (context as any)?.__expectedMtime,
-      });
-    }
+      if (typeof content !== 'string') {
+        span.end({ success: false });
+        return `Cannot perform AST edits on binary files. Use the write file tool instead.`;
+      }
 
-    if (!wasModified) {
-      return `No changes made to ${path} (${changes.join('; ')})`;
-    }
+      // Parse AST
+      const lang = getLanguageFromPath(path, Lang);
+      if (!lang) {
+        span.end({ success: false });
+        return `Unsupported file type for AST editing: ${path}`;
+      }
+      const ast = parse(lang, content);
+      const root = ast.root();
 
-    let output = `${path}: ${changes.join('; ')}`;
-    output += await getEditDiagnosticsText(workspace, path, modifiedContent);
-    return output;
+      let modifiedContent = content;
+      const changes: string[] = [];
+
+      if (transform) {
+        switch (transform) {
+          case 'add-import': {
+            if (!importSpec) {
+              span.end({ success: false });
+              return 'Error: importSpec is required for add-import transform';
+            }
+            modifiedContent = addImport(content, root, importSpec);
+            changes.push(`Added import from '${importSpec.module}'`);
+            break;
+          }
+
+          case 'remove-import': {
+            if (!targetName) {
+              span.end({ success: false });
+              return 'Error: targetName is required for remove-import transform';
+            }
+            modifiedContent = removeImport(content, root, targetName);
+            changes.push(`Removed import '${targetName}'`);
+            break;
+          }
+
+          case 'rename': {
+            if (!targetName || !newName) {
+              span.end({ success: false });
+              return 'Error: targetName and newName are required for rename transform';
+            }
+            const renameResult = renameIdentifiers(content, root, targetName, newName);
+            modifiedContent = renameResult.content;
+            changes.push(`Renamed '${targetName}' to '${newName}' (${renameResult.count} occurrences)`);
+            break;
+          }
+        }
+      } else if (pattern && replacement !== undefined) {
+        const result = patternReplace(content, root, pattern, replacement);
+        if (result.error) {
+          span.end({ success: false });
+          return `Error: AST pattern matching failed: ${result.error}`;
+        }
+        modifiedContent = result.content;
+        changes.push(`Replaced ${result.count} occurrences of pattern`);
+      } else if (pattern && replacement === undefined) {
+        span.end({ success: false });
+        return 'Error: replacement is required when pattern is provided';
+      } else if (!pattern && replacement !== undefined) {
+        span.end({ success: false });
+        return 'Error: pattern is required when replacement is provided';
+      } else {
+        span.end({ success: false });
+        return 'Error: Must provide either transform or pattern/replacement';
+      }
+
+      // Write back if modified
+      const wasModified = modifiedContent !== content;
+      if (wasModified) {
+        await filesystem.writeFile(path, modifiedContent, {
+          overwrite: true,
+          expectedMtime: (context as any)?.__expectedMtime,
+        });
+      }
+
+      if (!wasModified) {
+        span.end({ success: true });
+        return `No changes made to ${path} (${changes.join('; ')})`;
+      }
+
+      let output = `${path}: ${changes.join('; ')}`;
+      output += await getEditDiagnosticsText(workspace, path, modifiedContent);
+      span.end({ success: true, bytesTransferred: Buffer.byteLength(modifiedContent, 'utf-8') });
+      return output;
+    } catch (err) {
+      span.error(err, { filePath: path });
+      throw err;
+    }
   },
 });

--- a/packages/core/src/workspace/tools/delete-file.ts
+++ b/packages/core/src/workspace/tools/delete-file.ts
@@ -3,6 +3,7 @@ import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { WorkspaceReadOnlyError } from '../errors';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
+import { startWorkspaceSpan } from './tracing';
 
 export const deleteFileTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.DELETE,
@@ -16,20 +17,33 @@ export const deleteFileTool = createTool({
       .describe('If true, delete directories and their contents recursively. Required for non-empty directories.'),
   }),
   execute: async ({ path, recursive }, context) => {
-    const { filesystem } = requireFilesystem(context);
+    const { workspace, filesystem } = requireFilesystem(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.DELETE);
 
-    if (filesystem.readOnly) {
-      throw new WorkspaceReadOnlyError('delete');
-    }
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'delete',
+      input: { path, recursive },
+      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+    });
 
-    const stat = await filesystem.stat(path);
-    if (stat.type === 'directory') {
-      await filesystem.rmdir(path, { recursive, force: recursive });
-    } else {
-      await filesystem.deleteFile(path);
-    }
+    try {
+      if (filesystem.readOnly) {
+        throw new WorkspaceReadOnlyError('delete');
+      }
 
-    return `Deleted ${path}`;
+      const stat = await filesystem.stat(path);
+      if (stat.type === 'directory') {
+        await filesystem.rmdir(path, { recursive, force: recursive });
+      } else {
+        await filesystem.deleteFile(path);
+      }
+
+      span.end();
+      return `Deleted ${path}`;
+    } catch (err) {
+      span.error(err, { filePath: path });
+      throw err;
+    }
   },
 });

--- a/packages/core/src/workspace/tools/delete-file.ts
+++ b/packages/core/src/workspace/tools/delete-file.ts
@@ -39,7 +39,7 @@ export const deleteFileTool = createTool({
         await filesystem.deleteFile(path);
       }
 
-      span.end();
+      span.end({ success: true });
       return `Deleted ${path}`;
     } catch (err) {
       span.error(err, { filePath: path });

--- a/packages/core/src/workspace/tools/delete-file.ts
+++ b/packages/core/src/workspace/tools/delete-file.ts
@@ -24,7 +24,7 @@ export const deleteFileTool = createTool({
       category: 'filesystem',
       operation: 'delete',
       input: { path, recursive },
-      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+      attributes: { filesystemProvider: filesystem.provider },
     });
 
     try {
@@ -42,7 +42,7 @@ export const deleteFileTool = createTool({
       span.end({ success: true });
       return `Deleted ${path}`;
     } catch (err) {
-      span.error(err, { filePath: path });
+      span.error(err);
       throw err;
     }
   },

--- a/packages/core/src/workspace/tools/edit-file.ts
+++ b/packages/core/src/workspace/tools/edit-file.ts
@@ -44,7 +44,7 @@ Usage:
       const content = await filesystem.readFile(path, { encoding: 'utf-8' });
 
       if (typeof content !== 'string') {
-        span.end();
+        span.end({ success: false });
         return `Cannot edit binary files. Use the write file tool instead.`;
       }
 

--- a/packages/core/src/workspace/tools/edit-file.ts
+++ b/packages/core/src/workspace/tools/edit-file.ts
@@ -33,7 +33,7 @@ Usage:
       category: 'filesystem',
       operation: 'editFile',
       input: { path, replace_all },
-      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+      attributes: { filesystemProvider: filesystem.provider },
     });
 
     try {
@@ -56,7 +56,7 @@ Usage:
 
       let output = `Replaced ${result.replacements} occurrence${result.replacements !== 1 ? 's' : ''} in ${path}`;
       output += await getEditDiagnosticsText(workspace, path, result.content);
-      span.end({ success: true, bytesTransferred: Buffer.byteLength(result.content, 'utf-8') });
+      span.end({ success: true }, { bytesTransferred: Buffer.byteLength(result.content, 'utf-8') });
       return output;
     } catch (error) {
       if (error instanceof StringNotFoundError) {
@@ -67,7 +67,7 @@ Usage:
         span.end({ success: false });
         return error.message;
       }
-      span.error(error, { filePath: path });
+      span.error(error);
       throw error;
     }
   },

--- a/packages/core/src/workspace/tools/edit-file.ts
+++ b/packages/core/src/workspace/tools/edit-file.ts
@@ -4,6 +4,7 @@ import { WORKSPACE_TOOLS } from '../constants';
 import { WorkspaceReadOnlyError } from '../errors';
 import { replaceString, StringNotFoundError, StringNotUniqueError } from '../line-utils';
 import { emitWorkspaceMetadata, getEditDiagnosticsText, requireFilesystem } from './helpers';
+import { startWorkspaceSpan } from './tracing';
 
 export const editFileTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE,
@@ -28,14 +29,22 @@ Usage:
     const { workspace, filesystem } = requireFilesystem(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE);
 
-    if (filesystem.readOnly) {
-      throw new WorkspaceReadOnlyError('edit_file');
-    }
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'editFile',
+      input: { path, replace_all },
+      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+    });
 
     try {
+      if (filesystem.readOnly) {
+        throw new WorkspaceReadOnlyError('edit_file');
+      }
+
       const content = await filesystem.readFile(path, { encoding: 'utf-8' });
 
       if (typeof content !== 'string') {
+        span.end();
         return `Cannot edit binary files. Use the write file tool instead.`;
       }
 
@@ -47,14 +56,18 @@ Usage:
 
       let output = `Replaced ${result.replacements} occurrence${result.replacements !== 1 ? 's' : ''} in ${path}`;
       output += await getEditDiagnosticsText(workspace, path, result.content);
+      span.end({ bytesTransferred: Buffer.byteLength(result.content, 'utf-8') });
       return output;
     } catch (error) {
       if (error instanceof StringNotFoundError) {
+        span.end({ success: false });
         return error.message;
       }
       if (error instanceof StringNotUniqueError) {
+        span.end({ success: false });
         return error.message;
       }
+      span.error(error, { filePath: path });
       throw error;
     }
   },

--- a/packages/core/src/workspace/tools/edit-file.ts
+++ b/packages/core/src/workspace/tools/edit-file.ts
@@ -56,7 +56,7 @@ Usage:
 
       let output = `Replaced ${result.replacements} occurrence${result.replacements !== 1 ? 's' : ''} in ${path}`;
       output += await getEditDiagnosticsText(workspace, path, result.content);
-      span.end({ bytesTransferred: Buffer.byteLength(result.content, 'utf-8') });
+      span.end({ success: true, bytesTransferred: Buffer.byteLength(result.content, 'utf-8') });
       return output;
     } catch (error) {
       if (error instanceof StringNotFoundError) {

--- a/packages/core/src/workspace/tools/execute-command.ts
+++ b/packages/core/src/workspace/tools/execute-command.ts
@@ -84,7 +84,7 @@ async function executeCommand(input: Record<string, any>, context: any) {
     category: 'sandbox',
     operation: background ? 'spawnProcess' : 'executeCommand',
     input: { command, cwd, timeout: input.timeout, background },
-    attributes: { command, sandboxProvider: sandbox.provider },
+    attributes: { sandboxProvider: sandbox.provider },
   });
 
   // Background mode: spawn via process manager and return immediately
@@ -129,7 +129,7 @@ async function executeCommand(input: Record<string, any>, context: any) {
       });
     }
 
-    span.end({ success: true, pid: Number(handle.pid) || undefined });
+    span.end({ success: true }, { pid: Number(handle.pid) || undefined });
     return `Started background process (PID: ${handle.pid})`;
   }
 
@@ -176,11 +176,7 @@ async function executeCommand(input: Record<string, any>, context: any) {
       },
     });
 
-    span.end({
-      exitCode: result.exitCode,
-      success: result.success,
-      durationMs: result.executionTimeMs,
-    });
+    span.end({ success: result.success }, { exitCode: result.exitCode });
 
     if (!result.success) {
       const parts = [
@@ -202,7 +198,7 @@ async function executeCommand(input: Record<string, any>, context: any) {
         toolCallId,
       },
     });
-    span.end({ success: false, command, exitCode: -1, durationMs: Date.now() - startedAt });
+    span.end({ success: false }, { exitCode: -1 });
     const parts = [
       await truncateOutput(stdout, tail, tokenLimit, tokenFrom),
       await truncateOutput(stderr, tail, tokenLimit, tokenFrom),

--- a/packages/core/src/workspace/tools/execute-command.ts
+++ b/packages/core/src/workspace/tools/execute-command.ts
@@ -4,6 +4,7 @@ import { WORKSPACE_TOOLS } from '../constants';
 import { SandboxFeatureNotSupportedError } from '../errors';
 import { emitWorkspaceMetadata, requireSandbox } from './helpers';
 import { DEFAULT_TAIL_LINES, truncateOutput, sandboxToModelOutput } from './output-helpers';
+import { startWorkspaceSpan } from './tracing';
 
 /**
  * Base input schema for execute_command (no background param).
@@ -79,10 +80,19 @@ async function executeCommand(input: Record<string, any>, context: any) {
   const tokenLimit = toolConfig?.maxOutputTokens;
   const tokenFrom = 'sandwich' as const;
 
+  const span = startWorkspaceSpan(context, workspace, {
+    category: 'sandbox',
+    operation: background ? 'spawnProcess' : 'executeCommand',
+    input: { command, cwd, timeout: input.timeout, background },
+    attributes: { command, sandboxProvider: sandbox.provider },
+  });
+
   // Background mode: spawn via process manager and return immediately
   if (background) {
     if (!sandbox.processes) {
-      throw new SandboxFeatureNotSupportedError('processes');
+      const err = new SandboxFeatureNotSupportedError('processes');
+      span.error(err);
+      throw err;
     }
 
     const bgConfig = toolConfig?.backgroundProcesses;
@@ -119,12 +129,15 @@ async function executeCommand(input: Record<string, any>, context: any) {
       });
     }
 
+    span.end({ pid: Number(handle.pid) || undefined });
     return `Started background process (PID: ${handle.pid})`;
   }
 
   // Foreground mode: execute and wait for completion
   if (!sandbox.executeCommand) {
-    throw new SandboxFeatureNotSupportedError('executeCommand');
+    const err = new SandboxFeatureNotSupportedError('executeCommand');
+    span.error(err);
+    throw err;
   }
 
   const startedAt = Date.now();
@@ -163,6 +176,12 @@ async function executeCommand(input: Record<string, any>, context: any) {
       },
     });
 
+    span.end({
+      exitCode: result.exitCode,
+      success: result.success,
+      durationMs: result.executionTimeMs,
+    });
+
     if (!result.success) {
       const parts = [
         await truncateOutput(result.stdout, tail, tokenLimit, tokenFrom),
@@ -183,6 +202,7 @@ async function executeCommand(input: Record<string, any>, context: any) {
         toolCallId,
       },
     });
+    span.error(error, { command, exitCode: -1, durationMs: Date.now() - startedAt });
     const parts = [
       await truncateOutput(stdout, tail, tokenLimit, tokenFrom),
       await truncateOutput(stderr, tail, tokenLimit, tokenFrom),

--- a/packages/core/src/workspace/tools/execute-command.ts
+++ b/packages/core/src/workspace/tools/execute-command.ts
@@ -129,7 +129,7 @@ async function executeCommand(input: Record<string, any>, context: any) {
       });
     }
 
-    span.end({ pid: Number(handle.pid) || undefined });
+    span.end({ success: true, pid: Number(handle.pid) || undefined });
     return `Started background process (PID: ${handle.pid})`;
   }
 
@@ -202,7 +202,7 @@ async function executeCommand(input: Record<string, any>, context: any) {
         toolCallId,
       },
     });
-    span.error(error, { command, exitCode: -1, durationMs: Date.now() - startedAt });
+    span.end({ success: false, command, exitCode: -1, durationMs: Date.now() - startedAt });
     const parts = [
       await truncateOutput(stdout, tail, tokenLimit, tokenFrom),
       await truncateOutput(stderr, tail, tokenLimit, tokenFrom),

--- a/packages/core/src/workspace/tools/file-stat.ts
+++ b/packages/core/src/workspace/tools/file-stat.ts
@@ -30,7 +30,7 @@ export const fileStatTool = createTool({
       const parts = [`${path}`, `Type: ${stat.type}`];
       if (stat.size !== undefined) parts.push(`Size: ${stat.size} bytes`);
       parts.push(`Modified: ${modifiedAt}`);
-      span.end({ bytesTransferred: stat.size });
+      span.end({ success: true, bytesTransferred: stat.size });
       return parts.join(' ');
     } catch (error) {
       if (error instanceof FileNotFoundError) {

--- a/packages/core/src/workspace/tools/file-stat.ts
+++ b/packages/core/src/workspace/tools/file-stat.ts
@@ -3,6 +3,7 @@ import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { FileNotFoundError } from '../errors';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
+import { startWorkspaceSpan } from './tracing';
 
 export const fileStatTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT,
@@ -12,8 +13,15 @@ export const fileStatTool = createTool({
     path: z.string().describe('The path to check'),
   }),
   execute: async ({ path }, context) => {
-    const { filesystem } = requireFilesystem(context);
+    const { workspace, filesystem } = requireFilesystem(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'stat',
+      input: { path },
+      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+    });
 
     try {
       const stat = await filesystem.stat(path);
@@ -22,11 +30,14 @@ export const fileStatTool = createTool({
       const parts = [`${path}`, `Type: ${stat.type}`];
       if (stat.size !== undefined) parts.push(`Size: ${stat.size} bytes`);
       parts.push(`Modified: ${modifiedAt}`);
+      span.end({ bytesTransferred: stat.size });
       return parts.join(' ');
     } catch (error) {
       if (error instanceof FileNotFoundError) {
+        span.end({ success: false });
         return `${path}: not found`;
       }
+      span.error(error, { filePath: path });
       throw error;
     }
   },

--- a/packages/core/src/workspace/tools/file-stat.ts
+++ b/packages/core/src/workspace/tools/file-stat.ts
@@ -20,7 +20,7 @@ export const fileStatTool = createTool({
       category: 'filesystem',
       operation: 'stat',
       input: { path },
-      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+      attributes: { filesystemProvider: filesystem.provider },
     });
 
     try {
@@ -30,14 +30,14 @@ export const fileStatTool = createTool({
       const parts = [`${path}`, `Type: ${stat.type}`];
       if (stat.size !== undefined) parts.push(`Size: ${stat.size} bytes`);
       parts.push(`Modified: ${modifiedAt}`);
-      span.end({ success: true, bytesTransferred: stat.size });
+      span.end({ success: true }, { bytesTransferred: stat.size });
       return parts.join(' ');
     } catch (error) {
       if (error instanceof FileNotFoundError) {
         span.end({ success: false });
         return `${path}: not found`;
       }
-      span.error(error, { filePath: path });
+      span.error(error);
       throw error;
     }
   },

--- a/packages/core/src/workspace/tools/get-process-output.ts
+++ b/packages/core/src/workspace/tools/get-process-output.ts
@@ -29,11 +29,6 @@ Use this after starting a background command with execute_command (background: t
   }),
   execute: async ({ pid, tail, wait: shouldWait }, context) => {
     const { workspace, sandbox } = requireSandbox(context);
-
-    if (!sandbox.processes) {
-      throw new SandboxFeatureNotSupportedError('processes');
-    }
-
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT);
 
     const span = startWorkspaceSpan(context, workspace, {
@@ -46,6 +41,9 @@ Use this after starting a background command with execute_command (background: t
     const toolCallId = context?.agent?.toolCallId;
 
     try {
+      if (!sandbox.processes) {
+        throw new SandboxFeatureNotSupportedError('processes');
+      }
       const handle = await sandbox.processes.get(pid);
       if (!handle) {
         span.end({ success: false });
@@ -101,7 +99,7 @@ Use this after starting a background command with execute_command (background: t
       const stderr = await truncateOutput(handle.stderr, tail, tokenLimit, 'sandwich');
 
       if (!stdout && !stderr) {
-        span.end({ exitCode: handle.exitCode });
+        span.end({ success: true, exitCode: handle.exitCode });
         return '(no output yet)';
       }
 
@@ -120,7 +118,7 @@ Use this after starting a background command with execute_command (background: t
         parts.push('', `Exit code: ${handle.exitCode}`);
       }
 
-      span.end({ exitCode: handle.exitCode });
+      span.end({ success: true, exitCode: handle.exitCode });
       return parts.join('\n');
     } catch (err) {
       span.error(err);

--- a/packages/core/src/workspace/tools/get-process-output.ts
+++ b/packages/core/src/workspace/tools/get-process-output.ts
@@ -4,6 +4,7 @@ import { WORKSPACE_TOOLS } from '../constants';
 import { SandboxFeatureNotSupportedError } from '../errors';
 import { emitWorkspaceMetadata, requireSandbox } from './helpers';
 import { DEFAULT_TAIL_LINES, truncateOutput, sandboxToModelOutput } from './output-helpers';
+import { startWorkspaceSpan } from './tracing';
 
 export const getProcessOutputTool = createTool({
   id: WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT,
@@ -35,10 +36,18 @@ Use this after starting a background command with execute_command (background: t
 
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT);
 
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'sandbox',
+      operation: 'getProcessOutput',
+      input: { pid, tail, wait: shouldWait },
+      attributes: { pid: Number(pid) || undefined, sandboxProvider: sandbox.provider },
+    });
+
     const toolCallId = context?.agent?.toolCallId;
 
     const handle = await sandbox.processes.get(pid);
     if (!handle) {
+      span.end({ success: false });
       return `No background process found with PID ${pid}.`;
     }
 
@@ -109,6 +118,7 @@ Use this after starting a background command with execute_command (background: t
       parts.push('', `Exit code: ${handle.exitCode}`);
     }
 
+    span.end({ exitCode: handle.exitCode });
     return parts.join('\n');
   },
 });

--- a/packages/core/src/workspace/tools/get-process-output.ts
+++ b/packages/core/src/workspace/tools/get-process-output.ts
@@ -100,6 +100,7 @@ Use this after starting a background command with execute_command (background: t
     const stderr = await truncateOutput(handle.stderr, tail, tokenLimit, 'sandwich');
 
     if (!stdout && !stderr) {
+      span.end({ exitCode: handle.exitCode });
       return '(no output yet)';
     }
 

--- a/packages/core/src/workspace/tools/get-process-output.ts
+++ b/packages/core/src/workspace/tools/get-process-output.ts
@@ -45,81 +45,86 @@ Use this after starting a background command with execute_command (background: t
 
     const toolCallId = context?.agent?.toolCallId;
 
-    const handle = await sandbox.processes.get(pid);
-    if (!handle) {
-      span.end({ success: false });
-      return `No background process found with PID ${pid}.`;
-    }
+    try {
+      const handle = await sandbox.processes.get(pid);
+      if (!handle) {
+        span.end({ success: false });
+        return `No background process found with PID ${pid}.`;
+      }
 
-    // Emit process info so the UI can display the command
-    if (handle.command) {
-      await context?.writer?.custom({
-        type: 'data-sandbox-command',
-        data: { command: handle.command, pid, toolCallId },
-      });
-    }
+      // Emit process info so the UI can display the command
+      if (handle.command) {
+        await context?.writer?.custom({
+          type: 'data-sandbox-command',
+          data: { command: handle.command, pid, toolCallId },
+        });
+      }
 
-    // If wait requested, block until process exits with streaming callbacks
-    if (shouldWait && handle.exitCode === undefined) {
-      const result = await handle.wait({
-        onStdout: context?.writer
-          ? async (data: string) => {
-              await context.writer!.custom({
-                type: 'data-sandbox-stdout',
-                data: { output: data, timestamp: Date.now(), toolCallId },
-                transient: true,
-              });
-            }
-          : undefined,
-        onStderr: context?.writer
-          ? async (data: string) => {
-              await context.writer!.custom({
-                type: 'data-sandbox-stderr',
-                data: { output: data, timestamp: Date.now(), toolCallId },
-                transient: true,
-              });
-            }
-          : undefined,
-      });
+      // If wait requested, block until process exits with streaming callbacks
+      if (shouldWait && handle.exitCode === undefined) {
+        const result = await handle.wait({
+          onStdout: context?.writer
+            ? async (data: string) => {
+                await context.writer!.custom({
+                  type: 'data-sandbox-stdout',
+                  data: { output: data, timestamp: Date.now(), toolCallId },
+                  transient: true,
+                });
+              }
+            : undefined,
+          onStderr: context?.writer
+            ? async (data: string) => {
+                await context.writer!.custom({
+                  type: 'data-sandbox-stderr',
+                  data: { output: data, timestamp: Date.now(), toolCallId },
+                  transient: true,
+                });
+              }
+            : undefined,
+        });
 
-      await context?.writer?.custom({
-        type: 'data-sandbox-exit',
-        data: {
-          exitCode: result.exitCode,
-          success: result.success,
-          executionTimeMs: result.executionTimeMs,
-          toolCallId,
-        },
-      });
-    }
+        await context?.writer?.custom({
+          type: 'data-sandbox-exit',
+          data: {
+            exitCode: result.exitCode,
+            success: result.success,
+            executionTimeMs: result.executionTimeMs,
+            toolCallId,
+          },
+        });
+      }
 
-    const running = handle.exitCode === undefined;
+      const running = handle.exitCode === undefined;
 
-    const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT]?.maxOutputTokens;
-    const stdout = await truncateOutput(handle.stdout, tail, tokenLimit, 'sandwich');
-    const stderr = await truncateOutput(handle.stderr, tail, tokenLimit, 'sandwich');
+      const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT]?.maxOutputTokens;
+      const stdout = await truncateOutput(handle.stdout, tail, tokenLimit, 'sandwich');
+      const stderr = await truncateOutput(handle.stderr, tail, tokenLimit, 'sandwich');
 
-    if (!stdout && !stderr) {
+      if (!stdout && !stderr) {
+        span.end({ exitCode: handle.exitCode });
+        return '(no output yet)';
+      }
+
+      const parts: string[] = [];
+
+      // Only label stdout/stderr when both are present
+      if (stdout && stderr) {
+        parts.push('stdout:', stdout, '', 'stderr:', stderr);
+      } else if (stdout) {
+        parts.push(stdout);
+      } else {
+        parts.push('stderr:', stderr);
+      }
+
+      if (!running) {
+        parts.push('', `Exit code: ${handle.exitCode}`);
+      }
+
       span.end({ exitCode: handle.exitCode });
-      return '(no output yet)';
+      return parts.join('\n');
+    } catch (err) {
+      span.error(err);
+      throw err;
     }
-
-    const parts: string[] = [];
-
-    // Only label stdout/stderr when both are present
-    if (stdout && stderr) {
-      parts.push('stdout:', stdout, '', 'stderr:', stderr);
-    } else if (stdout) {
-      parts.push(stdout);
-    } else {
-      parts.push('stderr:', stderr);
-    }
-
-    if (!running) {
-      parts.push('', `Exit code: ${handle.exitCode}`);
-    }
-
-    span.end({ exitCode: handle.exitCode });
-    return parts.join('\n');
   },
 });

--- a/packages/core/src/workspace/tools/get-process-output.ts
+++ b/packages/core/src/workspace/tools/get-process-output.ts
@@ -35,7 +35,7 @@ Use this after starting a background command with execute_command (background: t
       category: 'sandbox',
       operation: 'getProcessOutput',
       input: { pid, tail, wait: shouldWait },
-      attributes: { pid: Number(pid) || undefined, sandboxProvider: sandbox.provider },
+      attributes: { sandboxProvider: sandbox.provider },
     });
 
     const toolCallId = context?.agent?.toolCallId;
@@ -99,7 +99,7 @@ Use this after starting a background command with execute_command (background: t
       const stderr = await truncateOutput(handle.stderr, tail, tokenLimit, 'sandwich');
 
       if (!stdout && !stderr) {
-        span.end({ success: true, exitCode: handle.exitCode });
+        span.end({ success: true }, { exitCode: handle.exitCode });
         return '(no output yet)';
       }
 
@@ -118,7 +118,7 @@ Use this after starting a background command with execute_command (background: t
         parts.push('', `Exit code: ${handle.exitCode}`);
       }
 
-      span.end({ success: true, exitCode: handle.exitCode });
+      span.end({ success: true }, { exitCode: handle.exitCode });
       return parts.join('\n');
     } catch (err) {
       span.error(err);

--- a/packages/core/src/workspace/tools/grep.ts
+++ b/packages/core/src/workspace/tools/grep.ts
@@ -245,7 +245,7 @@ Usage:
         workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.GREP]?.maxOutputTokens,
         'end',
       );
-      span.end({ resultCount: totalMatchCount });
+      span.end({ success: true, resultCount: totalMatchCount });
       return output;
     } catch (err) {
       span.error(err, { filePath: inputPath });

--- a/packages/core/src/workspace/tools/grep.ts
+++ b/packages/core/src/workspace/tools/grep.ts
@@ -68,14 +68,14 @@ Usage:
       category: 'filesystem',
       operation: 'grep',
       input: { pattern, path: inputPath, contextLines, maxCount },
-      attributes: { filePath: inputPath, query: pattern, filesystemProvider: filesystem.provider },
+      attributes: { filesystemProvider: filesystem.provider },
     });
 
     try {
       // Guard against excessively long patterns as a cheap ReDoS heuristic
       const MAX_PATTERN_LENGTH = 1000;
       if (pattern.length > MAX_PATTERN_LENGTH) {
-        span.end({ success: false, resultCount: 0 });
+        span.end({ success: false });
         return `Error: Pattern too long (${pattern.length} chars, max ${MAX_PATTERN_LENGTH}). Use a shorter pattern.`;
       }
 
@@ -84,7 +84,7 @@ Usage:
       try {
         regex = new RegExp(pattern, caseSensitive ? 'g' : 'gi');
       } catch (e) {
-        span.end({ success: false, resultCount: 0 });
+        span.end({ success: false });
         return `Error: Invalid regex pattern: ${(e as Error).message}`;
       }
 
@@ -245,10 +245,10 @@ Usage:
         workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.GREP]?.maxOutputTokens,
         'end',
       );
-      span.end({ success: true, resultCount: totalMatchCount });
+      span.end({ success: true }, { resultCount: totalMatchCount });
       return output;
     } catch (err) {
-      span.error(err, { filePath: inputPath });
+      span.error(err);
       throw err;
     }
   },

--- a/packages/core/src/workspace/tools/grep.ts
+++ b/packages/core/src/workspace/tools/grep.ts
@@ -7,6 +7,7 @@ import type { GlobMatcher } from '../glob';
 import { createGlobMatcher, extractGlobBase, isGlobPattern } from '../glob';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
 import { applyTokenLimit } from './output-helpers';
+import { startWorkspaceSpan } from './tracing';
 
 export const grepTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.GREP,
@@ -63,9 +64,17 @@ Usage:
     const { workspace, filesystem } = requireFilesystem(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.GREP);
 
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'grep',
+      input: { pattern, path: inputPath, contextLines, maxCount },
+      attributes: { filePath: inputPath, query: pattern, filesystemProvider: filesystem.provider },
+    });
+
     // Guard against excessively long patterns as a cheap ReDoS heuristic
     const MAX_PATTERN_LENGTH = 1000;
     if (pattern.length > MAX_PATTERN_LENGTH) {
+      span.end({ success: false, resultCount: 0 });
       return `Error: Pattern too long (${pattern.length} chars, max ${MAX_PATTERN_LENGTH}). Use a shorter pattern.`;
     }
 
@@ -74,6 +83,7 @@ Usage:
     try {
       regex = new RegExp(pattern, caseSensitive ? 'g' : 'gi');
     } catch (e) {
+      span.end({ success: false, resultCount: 0 });
       return `Error: Invalid regex pattern: ${(e as Error).message}`;
     }
 
@@ -229,10 +239,12 @@ Usage:
     const summary = summaryParts.join(' ');
     outputLines.unshift(summary, '---');
 
-    return await applyTokenLimit(
+    const output = await applyTokenLimit(
       outputLines.join('\n'),
       workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.GREP]?.maxOutputTokens,
       'end',
     );
+    span.end({ resultCount: totalMatchCount });
+    return output;
   },
 });

--- a/packages/core/src/workspace/tools/grep.ts
+++ b/packages/core/src/workspace/tools/grep.ts
@@ -71,180 +71,185 @@ Usage:
       attributes: { filePath: inputPath, query: pattern, filesystemProvider: filesystem.provider },
     });
 
-    // Guard against excessively long patterns as a cheap ReDoS heuristic
-    const MAX_PATTERN_LENGTH = 1000;
-    if (pattern.length > MAX_PATTERN_LENGTH) {
-      span.end({ success: false, resultCount: 0 });
-      return `Error: Pattern too long (${pattern.length} chars, max ${MAX_PATTERN_LENGTH}). Use a shorter pattern.`;
-    }
-
-    // Validate regex
-    let regex: RegExp;
     try {
-      regex = new RegExp(pattern, caseSensitive ? 'g' : 'gi');
-    } catch (e) {
-      span.end({ success: false, resultCount: 0 });
-      return `Error: Invalid regex pattern: ${(e as Error).message}`;
-    }
-
-    // Determine search root and glob filter from the combined path parameter
-    let searchPath: string;
-    let globMatcher: GlobMatcher | undefined;
-
-    if (isGlobPattern(inputPath)) {
-      // Path contains glob characters — extract the static base as search root
-      searchPath = extractGlobBase(inputPath);
-      globMatcher = createGlobMatcher(inputPath, { dot: includeHidden });
-    } else {
-      searchPath = inputPath;
-    }
-
-    // Load gitignore filter.
-    // If the user explicitly targets a gitignored path (e.g. "./dist"), skip
-    // filtering so they can still search there. Otherwise apply as normal.
-    const rawIgnoreFilter = await loadGitignore(filesystem);
-    const searchPathNormalized = searchPath.replace(/^\.\//, '').replace(/\/$/, '');
-    const targetIsIgnored = rawIgnoreFilter && searchPathNormalized && rawIgnoreFilter(searchPathNormalized + '/');
-    const ignoreFilter = targetIsIgnored ? undefined : rawIgnoreFilter;
-
-    // Collect files to search
-    let filePaths: string[];
-
-    // Check if searchPath is a file or directory
-    try {
-      const stat = await filesystem.stat(searchPath);
-      if (stat.type === 'file') {
-        // Single file — search it directly
-        filePaths = isTextFile(searchPath) ? [searchPath] : [];
-      } else {
-        // Directory — walk recursively
-        const collectFiles = async (dir: string): Promise<string[]> => {
-          const files: string[] = [];
-          let entries;
-          try {
-            entries = await filesystem.readdir(dir);
-          } catch {
-            return files;
-          }
-
-          for (const entry of entries) {
-            // Skip hidden files/dirs unless includeHidden is set
-            if (!includeHidden && entry.name.startsWith('.')) continue;
-
-            const fullPath = dir.endsWith('/') ? `${dir}${entry.name}` : `${dir}/${entry.name}`;
-
-            // Skip gitignored paths
-            if (ignoreFilter) {
-              const relativePath = fullPath.replace(/^\.\//, '');
-              const checkPath = entry.type === 'directory' ? `${relativePath}/` : relativePath;
-              if (ignoreFilter(checkPath)) continue;
-            }
-
-            if (entry.type === 'file') {
-              // Skip non-text files
-              if (!isTextFile(entry.name)) continue;
-              // Apply glob filter (createGlobMatcher normalizes leading slashes)
-              if (globMatcher && !globMatcher(fullPath)) continue;
-              files.push(fullPath);
-            } else if (entry.type === 'directory' && !entry.isSymlink) {
-              files.push(...(await collectFiles(fullPath)));
-            }
-          }
-          return files;
-        };
-        filePaths = await collectFiles(searchPath);
+      // Guard against excessively long patterns as a cheap ReDoS heuristic
+      const MAX_PATTERN_LENGTH = 1000;
+      if (pattern.length > MAX_PATTERN_LENGTH) {
+        span.end({ success: false, resultCount: 0 });
+        return `Error: Pattern too long (${pattern.length} chars, max ${MAX_PATTERN_LENGTH}). Use a shorter pattern.`;
       }
-    } catch {
-      // Path doesn't exist
-      filePaths = [];
-    }
 
-    const outputLines: string[] = [];
-    const filesWithMatches = new Set<string>();
-    let totalMatchCount = 0;
-    let truncated = false;
-    const MAX_LINE_LENGTH = 500;
-    const GLOBAL_CAP = 1000;
-
-    for (const filePath of filePaths) {
-      if (truncated) break;
-
-      let content: string;
+      // Validate regex
+      let regex: RegExp;
       try {
-        const raw = await filesystem.readFile(filePath, { encoding: 'utf-8' });
-        if (typeof raw !== 'string') continue;
-        content = raw;
+        regex = new RegExp(pattern, caseSensitive ? 'g' : 'gi');
+      } catch (e) {
+        span.end({ success: false, resultCount: 0 });
+        return `Error: Invalid regex pattern: ${(e as Error).message}`;
+      }
+
+      // Determine search root and glob filter from the combined path parameter
+      let searchPath: string;
+      let globMatcher: GlobMatcher | undefined;
+
+      if (isGlobPattern(inputPath)) {
+        // Path contains glob characters — extract the static base as search root
+        searchPath = extractGlobBase(inputPath);
+        globMatcher = createGlobMatcher(inputPath, { dot: includeHidden });
+      } else {
+        searchPath = inputPath;
+      }
+
+      // Load gitignore filter.
+      // If the user explicitly targets a gitignored path (e.g. "./dist"), skip
+      // filtering so they can still search there. Otherwise apply as normal.
+      const rawIgnoreFilter = await loadGitignore(filesystem);
+      const searchPathNormalized = searchPath.replace(/^\.\//, '').replace(/\/$/, '');
+      const targetIsIgnored = rawIgnoreFilter && searchPathNormalized && rawIgnoreFilter(searchPathNormalized + '/');
+      const ignoreFilter = targetIsIgnored ? undefined : rawIgnoreFilter;
+
+      // Collect files to search
+      let filePaths: string[];
+
+      // Check if searchPath is a file or directory
+      try {
+        const stat = await filesystem.stat(searchPath);
+        if (stat.type === 'file') {
+          // Single file — search it directly
+          filePaths = isTextFile(searchPath) ? [searchPath] : [];
+        } else {
+          // Directory — walk recursively
+          const collectFiles = async (dir: string): Promise<string[]> => {
+            const files: string[] = [];
+            let entries;
+            try {
+              entries = await filesystem.readdir(dir);
+            } catch {
+              return files;
+            }
+
+            for (const entry of entries) {
+              // Skip hidden files/dirs unless includeHidden is set
+              if (!includeHidden && entry.name.startsWith('.')) continue;
+
+              const fullPath = dir.endsWith('/') ? `${dir}${entry.name}` : `${dir}/${entry.name}`;
+
+              // Skip gitignored paths
+              if (ignoreFilter) {
+                const relativePath = fullPath.replace(/^\.\//, '');
+                const checkPath = entry.type === 'directory' ? `${relativePath}/` : relativePath;
+                if (ignoreFilter(checkPath)) continue;
+              }
+
+              if (entry.type === 'file') {
+                // Skip non-text files
+                if (!isTextFile(entry.name)) continue;
+                // Apply glob filter (createGlobMatcher normalizes leading slashes)
+                if (globMatcher && !globMatcher(fullPath)) continue;
+                files.push(fullPath);
+              } else if (entry.type === 'directory' && !entry.isSymlink) {
+                files.push(...(await collectFiles(fullPath)));
+              }
+            }
+            return files;
+          };
+          filePaths = await collectFiles(searchPath);
+        }
       } catch {
-        continue;
+        // Path doesn't exist
+        filePaths = [];
       }
 
-      const lines = content.split('\n');
-      let fileMatchCount = 0;
+      const outputLines: string[] = [];
+      const filesWithMatches = new Set<string>();
+      let totalMatchCount = 0;
+      let truncated = false;
+      const MAX_LINE_LENGTH = 500;
+      const GLOBAL_CAP = 1000;
 
-      for (let i = 0; i < lines.length; i++) {
-        const currentLine = lines[i]!;
-        // Reset regex lastIndex for each line since we use 'g' flag
-        regex.lastIndex = 0;
-        const lineMatch = regex.exec(currentLine);
-        if (!lineMatch) continue;
+      for (const filePath of filePaths) {
+        if (truncated) break;
 
-        filesWithMatches.add(filePath);
-
-        let lineContent = currentLine;
-        if (lineContent.length > MAX_LINE_LENGTH) {
-          lineContent = lineContent.slice(0, MAX_LINE_LENGTH) + '...';
+        let content: string;
+        try {
+          const raw = await filesystem.readFile(filePath, { encoding: 'utf-8' });
+          if (typeof raw !== 'string') continue;
+          content = raw;
+        } catch {
+          continue;
         }
 
-        // Add context lines before the match
-        if (contextLines > 0) {
-          const beforeStart = Math.max(0, i - contextLines);
-          for (let b = beforeStart; b < i; b++) {
-            outputLines.push(`${filePath}:${b + 1}- ${lines[b]}`);
+        const lines = content.split('\n');
+        let fileMatchCount = 0;
+
+        for (let i = 0; i < lines.length; i++) {
+          const currentLine = lines[i]!;
+          // Reset regex lastIndex for each line since we use 'g' flag
+          regex.lastIndex = 0;
+          const lineMatch = regex.exec(currentLine);
+          if (!lineMatch) continue;
+
+          filesWithMatches.add(filePath);
+
+          let lineContent = currentLine;
+          if (lineContent.length > MAX_LINE_LENGTH) {
+            lineContent = lineContent.slice(0, MAX_LINE_LENGTH) + '...';
           }
-        }
 
-        // Add the matching line
-        outputLines.push(`${filePath}:${i + 1}:${lineMatch.index + 1}: ${lineContent}`);
-
-        // Add context lines after the match
-        if (contextLines > 0) {
-          const afterEnd = Math.min(lines.length - 1, i + contextLines);
-          for (let a = i + 1; a <= afterEnd; a++) {
-            outputLines.push(`${filePath}:${a + 1}- ${lines[a]}`);
+          // Add context lines before the match
+          if (contextLines > 0) {
+            const beforeStart = Math.max(0, i - contextLines);
+            for (let b = beforeStart; b < i; b++) {
+              outputLines.push(`${filePath}:${b + 1}- ${lines[b]}`);
+            }
           }
-          // Separator between context groups
-          outputLines.push('--');
-        }
 
-        totalMatchCount++;
-        fileMatchCount++;
+          // Add the matching line
+          outputLines.push(`${filePath}:${i + 1}:${lineMatch.index + 1}: ${lineContent}`);
 
-        // Per-file limit (like grep -m)
-        if (maxCount !== undefined && fileMatchCount >= maxCount) break;
+          // Add context lines after the match
+          if (contextLines > 0) {
+            const afterEnd = Math.min(lines.length - 1, i + contextLines);
+            for (let a = i + 1; a <= afterEnd; a++) {
+              outputLines.push(`${filePath}:${a + 1}- ${lines[a]}`);
+            }
+            // Separator between context groups
+            outputLines.push('--');
+          }
 
-        // Global cap to protect context window
-        if (totalMatchCount >= GLOBAL_CAP) {
-          truncated = true;
-          break;
+          totalMatchCount++;
+          fileMatchCount++;
+
+          // Per-file limit (like grep -m)
+          if (maxCount !== undefined && fileMatchCount >= maxCount) break;
+
+          // Global cap to protect context window
+          if (totalMatchCount >= GLOBAL_CAP) {
+            truncated = true;
+            break;
+          }
         }
       }
-    }
 
-    // Summary line — placed at the top so it's always visible after truncation
-    const summaryParts = [`${totalMatchCount} match${totalMatchCount !== 1 ? 'es' : ''}`];
-    summaryParts.push(`across ${filesWithMatches.size} file${filesWithMatches.size !== 1 ? 's' : ''}`);
-    if (truncated) {
-      summaryParts.push(`(truncated at ${GLOBAL_CAP})`);
-    }
-    const summary = summaryParts.join(' ');
-    outputLines.unshift(summary, '---');
+      // Summary line — placed at the top so it's always visible after truncation
+      const summaryParts = [`${totalMatchCount} match${totalMatchCount !== 1 ? 'es' : ''}`];
+      summaryParts.push(`across ${filesWithMatches.size} file${filesWithMatches.size !== 1 ? 's' : ''}`);
+      if (truncated) {
+        summaryParts.push(`(truncated at ${GLOBAL_CAP})`);
+      }
+      const summary = summaryParts.join(' ');
+      outputLines.unshift(summary, '---');
 
-    const output = await applyTokenLimit(
-      outputLines.join('\n'),
-      workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.GREP]?.maxOutputTokens,
-      'end',
-    );
-    span.end({ resultCount: totalMatchCount });
-    return output;
+      const output = await applyTokenLimit(
+        outputLines.join('\n'),
+        workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.GREP]?.maxOutputTokens,
+        'end',
+      );
+      span.end({ resultCount: totalMatchCount });
+      return output;
+    } catch (err) {
+      span.error(err, { filePath: inputPath });
+      throw err;
+    }
   },
 });

--- a/packages/core/src/workspace/tools/index-content.ts
+++ b/packages/core/src/workspace/tools/index-content.ts
@@ -2,6 +2,7 @@ import { z } from 'zod/v4';
 import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { emitWorkspaceMetadata, requireWorkspace } from './helpers';
+import { startWorkspaceSpan } from './tracing';
 
 export const indexContentTool = createTool({
   id: WORKSPACE_TOOLS.SEARCH.INDEX,
@@ -15,7 +16,20 @@ export const indexContentTool = createTool({
     const workspace = requireWorkspace(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.SEARCH.INDEX);
 
-    await workspace.index(path, content, { metadata });
-    return `Indexed ${path}`;
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'search',
+      operation: 'index',
+      input: { path, contentLength: content.length },
+      attributes: { filePath: path },
+    });
+
+    try {
+      await workspace.index(path, content, { metadata });
+      span.end({ bytesTransferred: Buffer.byteLength(content, 'utf-8') });
+      return `Indexed ${path}`;
+    } catch (err) {
+      span.error(err, { filePath: path });
+      throw err;
+    }
   },
 });

--- a/packages/core/src/workspace/tools/index-content.ts
+++ b/packages/core/src/workspace/tools/index-content.ts
@@ -20,15 +20,15 @@ export const indexContentTool = createTool({
       category: 'search',
       operation: 'index',
       input: { path, contentLength: content.length },
-      attributes: { filePath: path },
+      attributes: {},
     });
 
     try {
       await workspace.index(path, content, { metadata });
-      span.end({ success: true, bytesTransferred: Buffer.byteLength(content, 'utf-8') });
+      span.end({ success: true }, { bytesTransferred: Buffer.byteLength(content, 'utf-8') });
       return `Indexed ${path}`;
     } catch (err) {
-      span.error(err, { filePath: path });
+      span.error(err);
       throw err;
     }
   },

--- a/packages/core/src/workspace/tools/index-content.ts
+++ b/packages/core/src/workspace/tools/index-content.ts
@@ -25,7 +25,7 @@ export const indexContentTool = createTool({
 
     try {
       await workspace.index(path, content, { metadata });
-      span.end({ bytesTransferred: Buffer.byteLength(content, 'utf-8') });
+      span.end({ success: true, bytesTransferred: Buffer.byteLength(content, 'utf-8') });
       return `Indexed ${path}`;
     } catch (err) {
       span.error(err, { filePath: path });

--- a/packages/core/src/workspace/tools/index.ts
+++ b/packages/core/src/workspace/tools/index.ts
@@ -36,5 +36,9 @@ export {
   DEFAULT_TAIL_LINES,
 } from './output-helpers';
 
+// Tracing
+export { startWorkspaceSpan } from './tracing';
+export type { WorkspaceSpanOptions, WorkspaceSpanHandle } from './tracing';
+
 // Tree formatter
 export * from './tree-formatter';

--- a/packages/core/src/workspace/tools/kill-process.ts
+++ b/packages/core/src/workspace/tools/kill-process.ts
@@ -25,7 +25,7 @@ Use this to stop a long-running background process that was started with execute
       category: 'sandbox',
       operation: 'killProcess',
       input: { pid },
-      attributes: { pid: Number(pid) || undefined, sandboxProvider: sandbox.provider },
+      attributes: { sandboxProvider: sandbox.provider },
     });
 
     const toolCallId = context?.agent?.toolCallId;
@@ -80,7 +80,7 @@ Use this to stop a long-running background process that was started with execute
         }
       }
 
-      span.end({ success: true, exitCode: handle?.exitCode ?? 137 });
+      span.end({ success: true }, { exitCode: handle?.exitCode ?? 137 });
       return parts.join('\n');
     } catch (err) {
       span.error(err);

--- a/packages/core/src/workspace/tools/kill-process.ts
+++ b/packages/core/src/workspace/tools/kill-process.ts
@@ -19,11 +19,6 @@ Use this to stop a long-running background process that was started with execute
   }),
   execute: async ({ pid }, context) => {
     const { workspace, sandbox } = requireSandbox(context);
-
-    if (!sandbox.processes) {
-      throw new SandboxFeatureNotSupportedError('processes');
-    }
-
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS);
 
     const span = startWorkspaceSpan(context, workspace, {
@@ -36,6 +31,9 @@ Use this to stop a long-running background process that was started with execute
     const toolCallId = context?.agent?.toolCallId;
 
     try {
+      if (!sandbox.processes) {
+        throw new SandboxFeatureNotSupportedError('processes');
+      }
       // Snapshot output before kill
       const handle = await sandbox.processes.get(pid);
 
@@ -82,7 +80,7 @@ Use this to stop a long-running background process that was started with execute
         }
       }
 
-      span.end({ exitCode: handle?.exitCode ?? 137 });
+      span.end({ success: true, exitCode: handle?.exitCode ?? 137 });
       return parts.join('\n');
     } catch (err) {
       span.error(err);

--- a/packages/core/src/workspace/tools/kill-process.ts
+++ b/packages/core/src/workspace/tools/kill-process.ts
@@ -35,49 +35,58 @@ Use this to stop a long-running background process that was started with execute
 
     const toolCallId = context?.agent?.toolCallId;
 
-    // Snapshot output before kill
-    const handle = await sandbox.processes.get(pid);
+    try {
+      // Snapshot output before kill
+      const handle = await sandbox.processes.get(pid);
 
-    // Emit command info so the UI can display the original command
-    if (handle?.command) {
-      await context?.writer?.custom({
-        type: 'data-sandbox-command',
-        data: { command: handle.command, pid, toolCallId },
-      });
-    }
+      // Emit command info so the UI can display the original command
+      if (handle?.command) {
+        await context?.writer?.custom({
+          type: 'data-sandbox-command',
+          data: { command: handle.command, pid, toolCallId },
+        });
+      }
 
-    const killed = await sandbox.processes.kill(pid);
+      const killed = await sandbox.processes.kill(pid);
 
-    if (!killed) {
+      if (!killed) {
+        await context?.writer?.custom({
+          type: 'data-sandbox-exit',
+          data: { exitCode: handle?.exitCode ?? -1, success: false, killed: false, toolCallId },
+        });
+        span.end({ success: false });
+        return `Process ${pid} was not found or had already exited.`;
+      }
+
       await context?.writer?.custom({
         type: 'data-sandbox-exit',
-        data: { exitCode: handle?.exitCode ?? -1, success: false, killed: false, toolCallId },
+        data: { exitCode: handle?.exitCode ?? 137, success: false, killed: true, toolCallId },
       });
-      span.end({ success: false });
-      return `Process ${pid} was not found or had already exited.`;
-    }
 
-    await context?.writer?.custom({
-      type: 'data-sandbox-exit',
-      data: { exitCode: handle?.exitCode ?? 137, success: false, killed: true, toolCallId },
-    });
+      const parts: string[] = [`Process ${pid} has been killed.`];
 
-    const parts: string[] = [`Process ${pid} has been killed.`];
+      if (handle) {
+        const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS]?.maxOutputTokens;
+        const stdout = handle.stdout
+          ? await truncateOutput(handle.stdout, KILL_TAIL_LINES, tokenLimit, 'sandwich')
+          : '';
+        const stderr = handle.stderr
+          ? await truncateOutput(handle.stderr, KILL_TAIL_LINES, tokenLimit, 'sandwich')
+          : '';
 
-    if (handle) {
-      const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS]?.maxOutputTokens;
-      const stdout = handle.stdout ? await truncateOutput(handle.stdout, KILL_TAIL_LINES, tokenLimit, 'sandwich') : '';
-      const stderr = handle.stderr ? await truncateOutput(handle.stderr, KILL_TAIL_LINES, tokenLimit, 'sandwich') : '';
-
-      if (stdout) {
-        parts.push('', '--- stdout (last output) ---', stdout);
+        if (stdout) {
+          parts.push('', '--- stdout (last output) ---', stdout);
+        }
+        if (stderr) {
+          parts.push('', '--- stderr (last output) ---', stderr);
+        }
       }
-      if (stderr) {
-        parts.push('', '--- stderr (last output) ---', stderr);
-      }
-    }
 
-    span.end({ exitCode: handle?.exitCode ?? 137 });
-    return parts.join('\n');
+      span.end({ exitCode: handle?.exitCode ?? 137 });
+      return parts.join('\n');
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
   },
 });

--- a/packages/core/src/workspace/tools/kill-process.ts
+++ b/packages/core/src/workspace/tools/kill-process.ts
@@ -4,6 +4,7 @@ import { WORKSPACE_TOOLS } from '../constants';
 import { SandboxFeatureNotSupportedError } from '../errors';
 import { emitWorkspaceMetadata, requireSandbox } from './helpers';
 import { truncateOutput, sandboxToModelOutput } from './output-helpers';
+import { startWorkspaceSpan } from './tracing';
 
 const KILL_TAIL_LINES = 50;
 
@@ -24,6 +25,14 @@ Use this to stop a long-running background process that was started with execute
     }
 
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'sandbox',
+      operation: 'killProcess',
+      input: { pid },
+      attributes: { pid: Number(pid) || undefined, sandboxProvider: sandbox.provider },
+    });
+
     const toolCallId = context?.agent?.toolCallId;
 
     // Snapshot output before kill
@@ -44,6 +53,7 @@ Use this to stop a long-running background process that was started with execute
         type: 'data-sandbox-exit',
         data: { exitCode: handle?.exitCode ?? -1, success: false, killed: false, toolCallId },
       });
+      span.end({ success: false });
       return `Process ${pid} was not found or had already exited.`;
     }
 
@@ -67,6 +77,7 @@ Use this to stop a long-running background process that was started with execute
       }
     }
 
+    span.end({ exitCode: handle?.exitCode ?? 137 });
     return parts.join('\n');
   },
 });

--- a/packages/core/src/workspace/tools/list-files.ts
+++ b/packages/core/src/workspace/tools/list-files.ts
@@ -83,7 +83,7 @@ To list ALL files, omit the pattern parameter — do NOT pass pattern: "*".`,
         workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]?.maxOutputTokens ?? 1_000,
         'end',
       );
-      span.end({ resultCount: result.fileCount });
+      span.end({ success: true, resultCount: result.fileCount });
       return output;
     } catch (err) {
       span.error(err, { filePath: path });

--- a/packages/core/src/workspace/tools/list-files.ts
+++ b/packages/core/src/workspace/tools/list-files.ts
@@ -3,6 +3,7 @@ import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
 import { applyTokenLimit } from './output-helpers';
+import { startWorkspaceSpan } from './tracing';
 import { formatAsTree } from './tree-formatter';
 
 export const listFilesTool = createTool({
@@ -59,20 +60,34 @@ To list ALL files, omit the pattern parameter — do NOT pass pattern: "*".`,
     const { workspace, filesystem } = requireFilesystem(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES);
 
-    const result = await formatAsTree(filesystem, path, {
-      maxDepth,
-      showHidden,
-      dirsOnly,
-      exclude: exclude || undefined,
-      extension: extension || undefined,
-      pattern: pattern || undefined,
-      respectGitignore,
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'listFiles',
+      input: { path, maxDepth, pattern },
+      attributes: { filePath: path, filesystemProvider: filesystem.provider },
     });
 
-    return await applyTokenLimit(
-      `${result.tree}\n\n${result.summary}`,
-      workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]?.maxOutputTokens ?? 1_000,
-      'end',
-    );
+    try {
+      const result = await formatAsTree(filesystem, path, {
+        maxDepth,
+        showHidden,
+        dirsOnly,
+        exclude: exclude || undefined,
+        extension: extension || undefined,
+        pattern: pattern || undefined,
+        respectGitignore,
+      });
+
+      const output = await applyTokenLimit(
+        `${result.tree}\n\n${result.summary}`,
+        workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]?.maxOutputTokens ?? 1_000,
+        'end',
+      );
+      span.end({ resultCount: result.fileCount });
+      return output;
+    } catch (err) {
+      span.error(err, { filePath: path });
+      throw err;
+    }
   },
 });

--- a/packages/core/src/workspace/tools/list-files.ts
+++ b/packages/core/src/workspace/tools/list-files.ts
@@ -64,7 +64,7 @@ To list ALL files, omit the pattern parameter — do NOT pass pattern: "*".`,
       category: 'filesystem',
       operation: 'listFiles',
       input: { path, maxDepth, pattern },
-      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+      attributes: { filesystemProvider: filesystem.provider },
     });
 
     try {
@@ -83,10 +83,10 @@ To list ALL files, omit the pattern parameter — do NOT pass pattern: "*".`,
         workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]?.maxOutputTokens ?? 1_000,
         'end',
       );
-      span.end({ success: true, resultCount: result.fileCount });
+      span.end({ success: true }, { resultCount: result.fileCount });
       return output;
     } catch (err) {
-      span.error(err, { filePath: path });
+      span.error(err);
       throw err;
     }
   },

--- a/packages/core/src/workspace/tools/lsp-inspect.ts
+++ b/packages/core/src/workspace/tools/lsp-inspect.ts
@@ -14,6 +14,7 @@ import { z } from 'zod/v4';
 import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { requireWorkspace, emitWorkspaceMetadata } from './helpers';
+import { startWorkspaceSpan } from './tracing';
 
 const CURSOR_MARKER = '<<<';
 
@@ -101,6 +102,13 @@ export const lspInspectTool = createTool({
     const workspace = requireWorkspace(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.LSP.LSP_INSPECT);
 
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'lspInspect',
+      input: { path: filePath, line },
+      attributes: { filePath },
+    });
+
     // Parse cursor position from match
     const cursorPositions = [];
     let searchStart = 0;
@@ -112,12 +120,14 @@ export const lspInspectTool = createTool({
     }
 
     if (cursorPositions.length === 0) {
+      span.end({ success: false });
       return {
         error: `No <<< cursor marker found in match`,
       };
     }
 
     if (cursorPositions.length > 1) {
+      span.end({ success: false });
       return {
         error: `Multiple <<< markers found (found ${cursorPositions.length}, expected 1)`,
       };
@@ -129,6 +139,7 @@ export const lspInspectTool = createTool({
     // Get the LSP manager
     const lspManager = workspace.lsp;
     if (!lspManager) {
+      span.end({ success: false });
       return {
         error: 'LSP is not configured for this workspace. Enable LSP in workspace config to use this tool.',
       };
@@ -152,12 +163,14 @@ export const lspInspectTool = createTool({
     try {
       queryResult = await lspManager.prepareQuery(absolutePath);
     } catch (err) {
+      span.end({ success: false });
       return {
         error: `Failed to initialize LSP client: ${err instanceof Error ? err.message : String(err)}`,
       };
     }
 
     if (!queryResult) {
+      span.end({ success: false });
       return {
         error: `No language server available for files of this type: ${filePath}`,
       };
@@ -291,6 +304,7 @@ export const lspInspectTool = createTool({
       client.notifyClose(absolutePath);
     }
 
+    span.end({ success: !result.error });
     return result;
   },
 });

--- a/packages/core/src/workspace/tools/lsp-inspect.ts
+++ b/packages/core/src/workspace/tools/lsp-inspect.ts
@@ -106,7 +106,7 @@ export const lspInspectTool = createTool({
       category: 'filesystem',
       operation: 'lspInspect',
       input: { path: filePath, line },
-      attributes: { filePath },
+      attributes: {},
     });
 
     // Parse cursor position from match

--- a/packages/core/src/workspace/tools/mkdir.ts
+++ b/packages/core/src/workspace/tools/mkdir.ts
@@ -33,7 +33,7 @@ export const mkdirTool = createTool({
       }
 
       await filesystem.mkdir(path, { recursive });
-      span.end();
+      span.end({ success: true });
       return `Created directory ${path}`;
     } catch (err) {
       span.error(err, { filePath: path });

--- a/packages/core/src/workspace/tools/mkdir.ts
+++ b/packages/core/src/workspace/tools/mkdir.ts
@@ -24,7 +24,7 @@ export const mkdirTool = createTool({
       category: 'filesystem',
       operation: 'mkdir',
       input: { path, recursive },
-      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+      attributes: { filesystemProvider: filesystem.provider },
     });
 
     try {
@@ -36,7 +36,7 @@ export const mkdirTool = createTool({
       span.end({ success: true });
       return `Created directory ${path}`;
     } catch (err) {
-      span.error(err, { filePath: path });
+      span.error(err);
       throw err;
     }
   },

--- a/packages/core/src/workspace/tools/mkdir.ts
+++ b/packages/core/src/workspace/tools/mkdir.ts
@@ -3,6 +3,7 @@ import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { WorkspaceReadOnlyError } from '../errors';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
+import { startWorkspaceSpan } from './tracing';
 
 export const mkdirTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.MKDIR,
@@ -16,14 +17,27 @@ export const mkdirTool = createTool({
       .describe('Whether to create parent directories if they do not exist'),
   }),
   execute: async ({ path, recursive }, context) => {
-    const { filesystem } = requireFilesystem(context);
+    const { workspace, filesystem } = requireFilesystem(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.MKDIR);
 
-    if (filesystem.readOnly) {
-      throw new WorkspaceReadOnlyError('mkdir');
-    }
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'mkdir',
+      input: { path, recursive },
+      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+    });
 
-    await filesystem.mkdir(path, { recursive });
-    return `Created directory ${path}`;
+    try {
+      if (filesystem.readOnly) {
+        throw new WorkspaceReadOnlyError('mkdir');
+      }
+
+      await filesystem.mkdir(path, { recursive });
+      span.end();
+      return `Created directory ${path}`;
+    } catch (err) {
+      span.error(err, { filePath: path });
+      throw err;
+    }
   },
 });

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -53,7 +53,7 @@ export const readFileTool = createTool({
           tokenLimit,
           'end',
         );
-        span.end({ bytesTransferred: stat.size }, output);
+        span.end({ success: true, bytesTransferred: stat.size });
         return output;
       }
 
@@ -63,7 +63,7 @@ export const readFileTool = createTool({
           tokenLimit,
           'end',
         );
-        span.end({ bytesTransferred: stat.size }, output);
+        span.end({ success: true, bytesTransferred: stat.size });
         return output;
       }
 
@@ -83,7 +83,7 @@ export const readFileTool = createTool({
       }
 
       const output = await applyTokenLimit(`${header}\n${formattedContent}`, tokenLimit, 'end');
-      span.end({ bytesTransferred: stat.size });
+      span.end({ success: true, bytesTransferred: stat.size });
       return output;
     } catch (err) {
       span.error(err, { filePath: path });

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -35,7 +35,7 @@ export const readFileTool = createTool({
       category: 'filesystem',
       operation: 'readFile',
       input: { path, encoding, offset, limit },
-      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+      attributes: { filesystemProvider: filesystem.provider },
     });
 
     try {
@@ -53,7 +53,7 @@ export const readFileTool = createTool({
           tokenLimit,
           'end',
         );
-        span.end({ success: true, bytesTransferred: stat.size });
+        span.end({ success: true }, { bytesTransferred: stat.size });
         return output;
       }
 
@@ -63,7 +63,7 @@ export const readFileTool = createTool({
           tokenLimit,
           'end',
         );
-        span.end({ success: true, bytesTransferred: stat.size });
+        span.end({ success: true }, { bytesTransferred: stat.size });
         return output;
       }
 
@@ -83,10 +83,10 @@ export const readFileTool = createTool({
       }
 
       const output = await applyTokenLimit(`${header}\n${formattedContent}`, tokenLimit, 'end');
-      span.end({ success: true, bytesTransferred: stat.size });
+      span.end({ success: true }, { bytesTransferred: stat.size });
       return output;
     } catch (err) {
-      span.error(err, { filePath: path });
+      span.error(err);
       throw err;
     }
   },

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -4,6 +4,7 @@ import { WORKSPACE_TOOLS } from '../constants';
 import { extractLinesWithLimit, formatWithLineNumbers } from '../line-utils';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
 import { applyTokenLimit } from './output-helpers';
+import { startWorkspaceSpan } from './tracing';
 
 export const readFileTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.READ_FILE,
@@ -30,45 +31,63 @@ export const readFileTool = createTool({
     const { workspace, filesystem } = requireFilesystem(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.READ_FILE);
 
-    const effectiveEncoding = (encoding as BufferEncoding) ?? 'utf-8';
-    const fullContent = await filesystem.readFile(path, { encoding: effectiveEncoding });
-    const stat = await filesystem.stat(path);
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'readFile',
+      input: { path, encoding, offset, limit },
+      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+    });
 
-    const isTextEncoding = !encoding || encoding === 'utf-8' || encoding === 'utf8';
+    try {
+      const effectiveEncoding = (encoding as BufferEncoding) ?? 'utf-8';
+      const fullContent = await filesystem.readFile(path, { encoding: effectiveEncoding });
+      const stat = await filesystem.stat(path);
 
-    const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]?.maxOutputTokens;
+      const isTextEncoding = !encoding || encoding === 'utf-8' || encoding === 'utf8';
 
-    if (!isTextEncoding) {
-      return await applyTokenLimit(
-        `${stat.path} (${stat.size} bytes, ${effectiveEncoding})\n${fullContent}`,
-        tokenLimit,
-        'end',
-      );
+      const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]?.maxOutputTokens;
+
+      if (!isTextEncoding) {
+        const output = await applyTokenLimit(
+          `${stat.path} (${stat.size} bytes, ${effectiveEncoding})\n${fullContent}`,
+          tokenLimit,
+          'end',
+        );
+        span.end({ bytesTransferred: stat.size }, output);
+        return output;
+      }
+
+      if (typeof fullContent !== 'string') {
+        const output = await applyTokenLimit(
+          `${stat.path} (${stat.size} bytes, base64)\n${fullContent.toString('base64')}`,
+          tokenLimit,
+          'end',
+        );
+        span.end({ bytesTransferred: stat.size }, output);
+        return output;
+      }
+
+      const hasLineRange = offset !== undefined || limit !== undefined;
+      const result = extractLinesWithLimit(fullContent, offset, limit);
+
+      const shouldShowLineNumbers = showLineNumbers !== false;
+      const formattedContent = shouldShowLineNumbers
+        ? formatWithLineNumbers(result.content, result.lines.start)
+        : result.content;
+
+      let header: string;
+      if (hasLineRange) {
+        header = `${stat.path} (lines ${result.lines.start}-${result.lines.end} of ${result.totalLines}, ${stat.size} bytes)`;
+      } else {
+        header = `${stat.path} (${stat.size} bytes)`;
+      }
+
+      const output = await applyTokenLimit(`${header}\n${formattedContent}`, tokenLimit, 'end');
+      span.end({ bytesTransferred: stat.size });
+      return output;
+    } catch (err) {
+      span.error(err, { filePath: path });
+      throw err;
     }
-
-    if (typeof fullContent !== 'string') {
-      return await applyTokenLimit(
-        `${stat.path} (${stat.size} bytes, base64)\n${fullContent.toString('base64')}`,
-        tokenLimit,
-        'end',
-      );
-    }
-
-    const hasLineRange = offset !== undefined || limit !== undefined;
-    const result = extractLinesWithLimit(fullContent, offset, limit);
-
-    const shouldShowLineNumbers = showLineNumbers !== false;
-    const formattedContent = shouldShowLineNumbers
-      ? formatWithLineNumbers(result.content, result.lines.start)
-      : result.content;
-
-    let header: string;
-    if (hasLineRange) {
-      header = `${stat.path} (lines ${result.lines.start}-${result.lines.end} of ${result.totalLines}, ${stat.size} bytes)`;
-    } else {
-      header = `${stat.path} (${stat.size} bytes)`;
-    }
-
-    return await applyTokenLimit(`${header}\n${formattedContent}`, tokenLimit, 'end');
   },
 });

--- a/packages/core/src/workspace/tools/search.ts
+++ b/packages/core/src/workspace/tools/search.ts
@@ -25,7 +25,7 @@ export const searchTool = createTool({
       category: 'search',
       operation: 'search',
       input: { query, topK, mode, minScore },
-      attributes: { query },
+      attributes: {},
     });
 
     try {
@@ -45,10 +45,10 @@ export const searchTool = createTool({
       lines.push('---');
       lines.push(`${results.length} result${results.length !== 1 ? 's' : ''} (${effectiveMode} search)`);
 
-      span.end({ success: true, resultCount: results.length });
+      span.end({ success: true }, { resultCount: results.length });
       return lines.join('\n');
     } catch (err) {
-      span.error(err, { query });
+      span.error(err);
       throw err;
     }
   },

--- a/packages/core/src/workspace/tools/search.ts
+++ b/packages/core/src/workspace/tools/search.ts
@@ -45,7 +45,7 @@ export const searchTool = createTool({
       lines.push('---');
       lines.push(`${results.length} result${results.length !== 1 ? 's' : ''} (${effectiveMode} search)`);
 
-      span.end({ resultCount: results.length });
+      span.end({ success: true, resultCount: results.length });
       return lines.join('\n');
     } catch (err) {
       span.error(err, { query });

--- a/packages/core/src/workspace/tools/search.ts
+++ b/packages/core/src/workspace/tools/search.ts
@@ -2,6 +2,7 @@ import { z } from 'zod/v4';
 import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { emitWorkspaceMetadata, requireWorkspace } from './helpers';
+import { startWorkspaceSpan } from './tracing';
 
 export const searchTool = createTool({
   id: WORKSPACE_TOOLS.SEARCH.SEARCH,
@@ -20,22 +21,35 @@ export const searchTool = createTool({
     const workspace = requireWorkspace(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.SEARCH.SEARCH);
 
-    const results = await workspace.search(query, {
-      topK,
-      mode: mode as 'bm25' | 'vector' | 'hybrid' | undefined,
-      minScore,
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'search',
+      operation: 'search',
+      input: { query, topK, mode, minScore },
+      attributes: { query },
     });
 
-    const effectiveMode = mode ?? (workspace.canHybrid ? 'hybrid' : workspace.canVector ? 'vector' : 'bm25');
+    try {
+      const results = await workspace.search(query, {
+        topK,
+        mode: mode as 'bm25' | 'vector' | 'hybrid' | undefined,
+        minScore,
+      });
 
-    const lines = results.map(r => {
-      const lineInfo = r.lineRange ? `:${r.lineRange.start}-${r.lineRange.end}` : '';
-      return `${r.id}${lineInfo}: ${r.content}`;
-    });
+      const effectiveMode = mode ?? (workspace.canHybrid ? 'hybrid' : workspace.canVector ? 'vector' : 'bm25');
 
-    lines.push('---');
-    lines.push(`${results.length} result${results.length !== 1 ? 's' : ''} (${effectiveMode} search)`);
+      const lines = results.map(r => {
+        const lineInfo = r.lineRange ? `:${r.lineRange.start}-${r.lineRange.end}` : '';
+        return `${r.id}${lineInfo}: ${r.content}`;
+      });
 
-    return lines.join('\n');
+      lines.push('---');
+      lines.push(`${results.length} result${results.length !== 1 ? 's' : ''} (${effectiveMode} search)`);
+
+      span.end({ resultCount: results.length });
+      return lines.join('\n');
+    } catch (err) {
+      span.error(err, { query });
+      throw err;
+    }
   },
 });

--- a/packages/core/src/workspace/tools/tracing.ts
+++ b/packages/core/src/workspace/tools/tracing.ts
@@ -53,7 +53,7 @@ export interface WorkspaceSpanHandle {
  * });
  * try {
  *   const result = await filesystem.readFile(path);
- *   span.end({ success: true, bytesTransferred: result.length });
+ *   span.end({ success: true, bytesTransferred: result.length }); // success must be explicit
  *   return result;
  * } catch (err) {
  *   span.error(err, { filePath: path });
@@ -94,7 +94,6 @@ export function startWorkspaceSpan(
       span?.end({
         output,
         attributes: {
-          success: true,
           durationMs: Date.now() - startTime,
           ...attrs,
         },

--- a/packages/core/src/workspace/tools/tracing.ts
+++ b/packages/core/src/workspace/tools/tracing.ts
@@ -1,0 +1,122 @@
+/**
+ * Workspace Tracing Utilities
+ *
+ * Creates and manages WORKSPACE_ACTION spans for workspace tool operations.
+ * Each workspace tool wraps its core operation in a span that captures
+ * category, operation name, and operation-specific attributes.
+ */
+
+import type { AnySpan, WorkspaceActionAttributes } from '../../observability/types/tracing';
+import { SpanType } from '../../observability/types/tracing';
+import type { ToolExecutionContext } from '../../tools/types';
+import type { Workspace } from '../workspace';
+
+/**
+ * Options for starting a workspace action span.
+ */
+export interface WorkspaceSpanOptions {
+  /** Action category */
+  category: WorkspaceActionAttributes['category'];
+  /** Operation name (e.g. 'readFile', 'executeCommand') */
+  operation: string;
+  /** Input data to record on the span */
+  input?: unknown;
+  /** Initial attributes (merged with workspace metadata at span end) */
+  attributes?: Partial<Omit<WorkspaceActionAttributes, 'category' | 'operation'>>;
+}
+
+/**
+ * Handle returned by startWorkspaceSpan for ending the span.
+ */
+export interface WorkspaceSpanHandle {
+  /** The underlying span (undefined when tracing is not active) */
+  span: AnySpan | undefined;
+  /** End the span successfully with final attributes */
+  end(attrs?: Partial<WorkspaceActionAttributes>, output?: unknown): void;
+  /** End the span with an error */
+  error(err: unknown, attrs?: Partial<WorkspaceActionAttributes>): void;
+}
+
+/**
+ * Start a WORKSPACE_ACTION child span from the tool execution context.
+ *
+ * Returns a handle with `end()` and `error()` methods. If no tracing context
+ * is available (no parent span), all operations are safe no-ops.
+ *
+ * @example
+ * ```typescript
+ * const span = startWorkspaceSpan(context, workspace, {
+ *   category: 'filesystem',
+ *   operation: 'readFile',
+ *   input: { path },
+ *   attributes: { filePath: path },
+ * });
+ * try {
+ *   const result = await filesystem.readFile(path);
+ *   span.end({ success: true, bytesTransferred: result.length });
+ *   return result;
+ * } catch (err) {
+ *   span.error(err, { filePath: path });
+ *   throw err;
+ * }
+ * ```
+ */
+export function startWorkspaceSpan(
+  context: ToolExecutionContext | undefined,
+  workspace: Workspace | undefined,
+  options: WorkspaceSpanOptions,
+): WorkspaceSpanHandle {
+  const currentSpan = context?.tracing?.currentSpan ?? context?.tracingContext?.currentSpan;
+
+  if (!currentSpan) {
+    return noOpHandle;
+  }
+
+  const { category, operation, input, attributes } = options;
+  const startTime = Date.now();
+
+  const span = currentSpan.createChildSpan<SpanType.WORKSPACE_ACTION>({
+    type: SpanType.WORKSPACE_ACTION,
+    name: `workspace:${category}:${operation}`,
+    input,
+    attributes: {
+      category,
+      operation,
+      workspaceId: workspace?.id,
+      workspaceName: workspace?.name,
+      ...attributes,
+    },
+  });
+
+  return {
+    span,
+    end(attrs?: Partial<WorkspaceActionAttributes>, output?: unknown) {
+      span?.end({
+        output,
+        attributes: {
+          success: true,
+          durationMs: Date.now() - startTime,
+          ...attrs,
+        },
+      });
+    },
+    error(err: unknown, attrs?: Partial<WorkspaceActionAttributes>) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      span?.error({
+        error,
+        attributes: {
+          success: false,
+          durationMs: Date.now() - startTime,
+          ...attrs,
+        },
+      });
+    },
+  };
+}
+
+/** No-op handle when tracing is not available */
+const noOpHandle: WorkspaceSpanHandle = {
+  span: undefined,
+  end() {},
+  error() {},
+};

--- a/packages/core/src/workspace/tools/tracing.ts
+++ b/packages/core/src/workspace/tools/tracing.ts
@@ -3,7 +3,12 @@
  *
  * Creates and manages WORKSPACE_ACTION spans for workspace tool operations.
  * Each workspace tool wraps its core operation in a span that captures
- * category, operation name, and operation-specific attributes.
+ * category, operation name, and operation-specific input/output.
+ *
+ * Data placement follows span conventions:
+ * - `input`: what the operation receives (path, command, query, etc.)
+ * - `output`: what the operation produces (results, bytes, exit codes, etc.)
+ * - `attributes`: span metadata (category, workspaceId, provider, success)
  */
 
 import type { AnySpan, WorkspaceActionAttributes } from '../../observability/types/tracing';
@@ -19,10 +24,10 @@ export interface WorkspaceSpanOptions {
   category: WorkspaceActionAttributes['category'];
   /** Operation name (e.g. 'readFile', 'executeCommand') */
   operation: string;
-  /** Input data to record on the span */
+  /** Input data to record on the span (path, command, query, etc.) */
   input?: unknown;
-  /** Initial attributes (merged with workspace metadata at span end) */
-  attributes?: Partial<Omit<WorkspaceActionAttributes, 'category' | 'operation'>>;
+  /** Initial attributes (workspace metadata, provider info) */
+  attributes?: Partial<Omit<WorkspaceActionAttributes, 'category'>>;
 }
 
 /**
@@ -31,7 +36,7 @@ export interface WorkspaceSpanOptions {
 export interface WorkspaceSpanHandle {
   /** The underlying span (undefined when tracing is not active) */
   span: AnySpan | undefined;
-  /** End the span successfully with final attributes */
+  /** End the span with final attributes and output */
   end(attrs?: Partial<WorkspaceActionAttributes>, output?: unknown): void;
   /** End the span with an error */
   error(err: unknown, attrs?: Partial<WorkspaceActionAttributes>): void;
@@ -49,14 +54,14 @@ export interface WorkspaceSpanHandle {
  *   category: 'filesystem',
  *   operation: 'readFile',
  *   input: { path },
- *   attributes: { filePath: path },
+ *   attributes: { filesystemProvider: filesystem.provider },
  * });
  * try {
  *   const result = await filesystem.readFile(path);
- *   span.end({ success: true, bytesTransferred: result.length }); // success must be explicit
+ *   span.end({ success: true }, { bytesTransferred: result.length });
  *   return result;
  * } catch (err) {
- *   span.error(err, { filePath: path });
+ *   span.error(err);
  *   throw err;
  * }
  * ```
@@ -73,7 +78,6 @@ export function startWorkspaceSpan(
   }
 
   const { category, operation, input, attributes } = options;
-  const startTime = Date.now();
 
   const span = currentSpan.createChildSpan<SpanType.WORKSPACE_ACTION>({
     type: SpanType.WORKSPACE_ACTION,
@@ -81,7 +85,6 @@ export function startWorkspaceSpan(
     input,
     attributes: {
       category,
-      operation,
       workspaceId: workspace?.id,
       workspaceName: workspace?.name,
       ...attributes,
@@ -94,7 +97,6 @@ export function startWorkspaceSpan(
       span?.end({
         output,
         attributes: {
-          durationMs: Date.now() - startTime,
           ...attrs,
         },
       });
@@ -105,7 +107,6 @@ export function startWorkspaceSpan(
         error,
         attributes: {
           success: false,
-          durationMs: Date.now() - startTime,
           ...attrs,
         },
       });

--- a/packages/core/src/workspace/tools/write-file.ts
+++ b/packages/core/src/workspace/tools/write-file.ts
@@ -37,7 +37,7 @@ export const writeFileTool = createTool({
       const size = Buffer.byteLength(content, 'utf-8');
       let output = `Wrote ${size} bytes to ${path}`;
       output += await getEditDiagnosticsText(workspace, path, content);
-      span.end({ bytesTransferred: size });
+      span.end({ success: true, bytesTransferred: size });
       return output;
     } catch (err) {
       span.error(err, { filePath: path });

--- a/packages/core/src/workspace/tools/write-file.ts
+++ b/packages/core/src/workspace/tools/write-file.ts
@@ -21,7 +21,7 @@ export const writeFileTool = createTool({
       category: 'filesystem',
       operation: 'writeFile',
       input: { path, overwrite, contentLength: content.length },
-      attributes: { filePath: path, filesystemProvider: filesystem.provider },
+      attributes: { filesystemProvider: filesystem.provider },
     });
 
     try {
@@ -37,10 +37,10 @@ export const writeFileTool = createTool({
       const size = Buffer.byteLength(content, 'utf-8');
       let output = `Wrote ${size} bytes to ${path}`;
       output += await getEditDiagnosticsText(workspace, path, content);
-      span.end({ success: true, bytesTransferred: size });
+      span.end({ success: true }, { bytesTransferred: size });
       return output;
     } catch (err) {
-      span.error(err, { filePath: path });
+      span.error(err);
       throw err;
     }
   },

--- a/packages/core/src/workspace/tools/write-file.ts
+++ b/packages/core/src/workspace/tools/write-file.ts
@@ -3,6 +3,7 @@ import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { WorkspaceReadOnlyError } from '../errors';
 import { emitWorkspaceMetadata, getEditDiagnosticsText, requireFilesystem } from './helpers';
+import { startWorkspaceSpan } from './tracing';
 
 export const writeFileTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE,
@@ -16,18 +17,31 @@ export const writeFileTool = createTool({
     const { workspace, filesystem } = requireFilesystem(context);
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE);
 
-    if (filesystem.readOnly) {
-      throw new WorkspaceReadOnlyError('write_file');
-    }
-
-    await filesystem.writeFile(path, content, {
-      overwrite,
-      expectedMtime: (context as any)?.__expectedMtime,
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'writeFile',
+      input: { path, overwrite, contentLength: content.length },
+      attributes: { filePath: path, filesystemProvider: filesystem.provider },
     });
 
-    const size = Buffer.byteLength(content, 'utf-8');
-    let output = `Wrote ${size} bytes to ${path}`;
-    output += await getEditDiagnosticsText(workspace, path, content);
-    return output;
+    try {
+      if (filesystem.readOnly) {
+        throw new WorkspaceReadOnlyError('write_file');
+      }
+
+      await filesystem.writeFile(path, content, {
+        overwrite,
+        expectedMtime: (context as any)?.__expectedMtime,
+      });
+
+      const size = Buffer.byteLength(content, 'utf-8');
+      let output = `Wrote ${size} bytes to ${path}`;
+      output += await getEditDiagnosticsText(workspace, path, content);
+      span.end({ bytesTransferred: size });
+      return output;
+    } catch (err) {
+      span.error(err, { filePath: path });
+      throw err;
+    }
   },
 });

--- a/packages/playground-ui/src/domains/experiments/components/experiment-trace-shared.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-trace-shared.tsx
@@ -1,8 +1,8 @@
 import { BrainIcon } from 'lucide-react';
 import type { ExperimentUISpanStyle } from '../types';
-import { AgentIcon, McpServerIcon, ToolsIcon, WorkflowIcon } from '@/ds/icons';
+import { AgentIcon, FolderIcon, McpServerIcon, ToolsIcon, WorkflowIcon } from '@/ds/icons';
 
-export const spanTypePrefixes = ['agent', 'workflow', 'model', 'mcp', 'tool', 'other'];
+export const spanTypePrefixes = ['agent', 'workflow', 'model', 'mcp', 'tool', 'workspace', 'other'];
 
 export function getExperimentSpanTypeUi(type: string): ExperimentUISpanStyle | null {
   const typePrefix = type?.toLowerCase().split('_')[0];
@@ -42,6 +42,13 @@ export function getExperimentSpanTypeUi(type: string): ExperimentUISpanStyle | n
       label: 'Tool',
       bgColor: 'bg-oklch(0.75 0.15 100 / 0.1)',
       typePrefix: 'tool',
+    },
+    workspace: {
+      icon: <FolderIcon />,
+      color: 'oklch(0.75 0.15 40)',
+      label: 'Workspace',
+      bgColor: 'bg-oklch(0.75 0.15 40 / 0.1)',
+      typePrefix: 'workspace',
     },
   };
 

--- a/packages/playground-ui/src/domains/observability/components/shared.tsx
+++ b/packages/playground-ui/src/domains/observability/components/shared.tsx
@@ -1,8 +1,8 @@
 import { BrainIcon } from 'lucide-react';
 import type { UISpanStyle } from '../types';
-import { AgentIcon, McpServerIcon, MemoryIcon, ToolsIcon, WorkflowIcon } from '@/ds/icons';
+import { AgentIcon, FolderIcon, McpServerIcon, MemoryIcon, ToolsIcon, WorkflowIcon } from '@/ds/icons';
 
-export const spanTypePrefixes = ['agent', 'workflow', 'model', 'mcp', 'tool', 'memory', 'other'];
+export const spanTypePrefixes = ['agent', 'workflow', 'model', 'mcp', 'tool', 'memory', 'workspace', 'other'];
 
 export function getSpanTypeUi(type: string) {
   const typePrefix = type?.toLowerCase().split('_')[0];
@@ -49,6 +49,13 @@ export function getSpanTypeUi(type: string) {
       label: 'Memory',
       bgColor: 'bg-oklch(0.75 0.15 60 / 0.1)',
       typePrefix: 'memory',
+    },
+    workspace: {
+      icon: <FolderIcon />,
+      color: 'oklch(0.75 0.15 40)',
+      label: 'Workspace',
+      bgColor: 'bg-oklch(0.75 0.15 40 / 0.1)',
+      typePrefix: 'workspace',
     },
   };
 


### PR DESCRIPTION
## Description
  <!-- Provide a brief description of the changes in this PR -->
Adds a new `WORKSPACE_ACTION` span type so workspace operations appear as dedicated spans in traces. All 13 workspace tools (filesystem, sandbox, search) now create child spans with rich metadata including category, operation, file paths, commands, exit codes, bytes transferred, and duration.

  **Core changes:**
  - Added `WORKSPACE_ACTION` to `SpanType` enum with `WorkspaceActionAttributes` interface
  - Created `startWorkspaceSpan()` utility for child span creation with no-op fallback when tracing is inactive
  - Instrumented all workspace tools: read/write/edit/delete/list/stat/mkdir/grep (filesystem), execute-command/get-process-output/kill-process (sandbox),
  search/index (search)
  - Added `workspace` span type to playground UI trace timeline with FolderIcon and amber color in both observability and experiments views

  **Span hierarchy:** `AGENT_RUN → TOOL_CALL → WORKSPACE_ACTION`

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/684dea4d-c1b1-4f63-ab38-17be91f14236" />

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/0f6999b2-e486-4452-bcd3-863c77127246" />

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/8eb6afb3-0770-4529-9ac0-8eecef7a775a" />

  ## Related Issue(s)
  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
  Fixes #14548

  ## Type of Change
  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist
  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace action tracing added across workspace tools, emitting structured spans (category, operation, workspace/file/command metadata, success, bytes, exit codes, durations, result counts).
  * Exported helper to create workspace spans that gracefully no-ops when tracing is inactive.

* **UI**
  * Observability and experiments views now recognize and display workspace span types.

* **Tests / Documentation**
  * Added tests for workspace tracing and a changeset documenting the minor release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->