### PR TITLE
feat(mongodb): add datasets and experiments storage domains

### DIFF
--- a/.changeset/all-files-hug.md
+++ b/.changeset/all-files-hug.md
@@ -1,0 +1,11 @@
+---
+'@mastra/mongodb': minor
+---
+
+Added datasets and experiments storage support to the MongoDB store.
+
+**Datasets** — Full dataset management with versioned items. Create, update, and delete datasets and their items with automatic version tracking. Supports batch insert/delete operations, time-travel queries to retrieve items at any past version, and item history tracking.
+
+**Experiments** — Run and track experiments against datasets. Full CRUD for experiments and per-item experiment results, with pagination, filtering, and cascade deletion.
+
+Both domains are automatically available when using `MongoDBStore` — no additional configuration needed.

--- a/.changeset/all-files-hug.md
+++ b/.changeset/all-files-hug.md
@@ -9,3 +9,14 @@ Added datasets and experiments storage support to the MongoDB store.
 **Experiments** — Run and track experiments against datasets. Full CRUD for experiments and per-item experiment results, with pagination, filtering, and cascade deletion.
 
 Both domains are automatically available when using `MongoDBStore` — no additional configuration needed.
+
+```ts
+const store = new MongoDBStore({ uri: 'mongodb://localhost:27017', dbName: 'my-app' });
+
+// Datasets
+const dataset = await store.getStorage('datasets').createDataset({ name: 'my-dataset' });
+await store.getStorage('datasets').addItem({ datasetId: dataset.id, input: { prompt: 'hello' } });
+
+// Experiments
+const experiment = await store.getStorage('experiments').createExperiment({ name: 'run-1', datasetId: dataset.id });
+```

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -385,7 +385,15 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         { $inc: { version: 1 } },
         { returnDocument: 'after' },
       );
-      const newVersion = result!.version as number;
+      if (!result) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'ADD_ITEM', 'DATASET_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { datasetId: args.datasetId },
+        });
+      }
+      const newVersion = result.version as number;
 
       // Insert item
       await itemsCollection.insertOne({
@@ -475,7 +483,15 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         { $inc: { version: 1 } },
         { returnDocument: 'after' },
       );
-      const newVersion = result!.version as number;
+      if (!result) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'UPDATE_ITEM', 'DATASET_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { datasetId: args.datasetId },
+        });
+      }
+      const newVersion = result.version as number;
 
       // Close old row (set validTo = newVersion)
       await itemsCollection.updateOne(
@@ -556,7 +572,15 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         { $inc: { version: 1 } },
         { returnDocument: 'after' },
       );
-      const newVersion = result!.version as number;
+      if (!result) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'DELETE_ITEM', 'DATASET_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { datasetId },
+        });
+      }
+      const newVersion = result.version as number;
 
       // Close old row
       await itemsCollection.updateOne({ id, validTo: null, isDeleted: false }, { $set: { validTo: newVersion } });
@@ -630,7 +654,15 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         { $inc: { version: 1 } },
         { returnDocument: 'after' },
       );
-      const newVersion = result!.version as number;
+      if (!result) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'BULK_ADD_ITEMS', 'DATASET_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { datasetId: input.datasetId },
+        });
+      }
+      const newVersion = result.version as number;
 
       // Batch insert items
       if (itemsWithIds.length > 0) {
@@ -719,7 +751,15 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         { $inc: { version: 1 } },
         { returnDocument: 'after' },
       );
-      const newVersion = result!.version as number;
+      if (!result) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'BULK_DELETE_ITEMS', 'DATASET_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { datasetId: input.datasetId },
+        });
+      }
+      const newVersion = result.version as number;
 
       // Close old rows
       for (const item of currentItems) {

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -769,11 +769,16 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
 
       let row;
       if (args.datasetVersion !== undefined) {
-        row = await collection.findOne({
-          id: args.id,
-          datasetVersion: args.datasetVersion,
-          isDeleted: false,
-        });
+        // SCD-2 window predicate: find the row whose version range includes the requested version
+        row = await collection.findOne(
+          {
+            id: args.id,
+            datasetVersion: { $lte: args.datasetVersion },
+            $or: [{ validTo: null }, { validTo: { $gt: args.datasetVersion } }],
+            isDeleted: false,
+          },
+          { sort: { datasetVersion: -1 } },
+        );
       } else {
         row = await collection.findOne({
           id: args.id,

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -86,6 +86,11 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         options: { name: 'idx_dataset_items_datasetid_version' },
       },
       {
+        collection: TABLE_DATASET_ITEMS,
+        keys: { datasetId: 1, validTo: 1, isDeleted: 1, createdAt: -1, id: 1 },
+        options: { name: 'idx_dataset_items_list' },
+      },
+      {
         collection: TABLE_DATASET_VERSIONS,
         keys: { datasetId: 1 },
         options: { name: 'idx_dataset_versions_datasetid' },

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -745,21 +745,24 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         });
       }
 
-      // Fetch current items (skip items not found or mismatched)
-      const currentItems: DatasetItem[] = [];
-      for (const itemId of input.itemIds) {
-        const item = await this.getItemById({ id: itemId });
-        if (item && item.datasetId === input.datasetId) {
-          currentItems.push(item);
-        }
-      }
+      const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
+
+      // Fetch current items in one query instead of sequential lookups
+      const currentRows = await itemsCollection
+        .find({
+          id: { $in: input.itemIds },
+          datasetId: input.datasetId,
+          validTo: null,
+          isDeleted: false,
+        })
+        .toArray();
+      const currentItems = currentRows.map(row => this.transformItemRow(row));
       if (currentItems.length === 0) return;
 
       const now = new Date();
       const versionId = randomUUID();
 
       const datasetsCollection = await this.getCollection(TABLE_DATASETS);
-      const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
       const versionsCollection = await this.getCollection(TABLE_DATASET_VERSIONS);
 
       // Single version bump
@@ -778,13 +781,12 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
       }
       const newVersion = result.version as number;
 
-      // Close old rows
-      for (const item of currentItems) {
-        await itemsCollection.updateOne(
-          { id: item.id, validTo: null, isDeleted: false },
-          { $set: { validTo: newVersion } },
-        );
-      }
+      // Close old rows in batch
+      const currentIds = currentItems.map(i => i.id);
+      await itemsCollection.updateMany(
+        { id: { $in: currentIds }, validTo: null, isDeleted: false },
+        { $set: { validTo: newVersion } },
+      );
 
       // Insert tombstones in batch
       const tombstones = currentItems.map(item => ({

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -62,6 +62,8 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
 
   getDefaultIndexDefinitions(): MongoDBIndexConfig[] {
     return [
+      { collection: TABLE_DATASETS, keys: { id: 1 }, options: { name: 'idx_datasets_id', unique: true } },
+      { collection: TABLE_DATASETS, keys: { createdAt: -1, id: 1 }, options: { name: 'idx_datasets_createdat_id' } },
       { collection: TABLE_DATASET_ITEMS, keys: { datasetId: 1 }, options: { name: 'idx_dataset_items_datasetid' } },
       {
         collection: TABLE_DATASET_ITEMS,

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -1064,8 +1064,23 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
     const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
     const versionsCollection = await this.getCollection(TABLE_DATASET_VERSIONS);
 
-    await datasetsCollection.deleteMany({});
-    await itemsCollection.deleteMany({});
-    await versionsCollection.deleteMany({});
+    const results = await Promise.allSettled([
+      datasetsCollection.deleteMany({}),
+      itemsCollection.deleteMany({}),
+      versionsCollection.deleteMany({}),
+    ]);
+
+    const failures = results.filter(r => r.status === 'rejected');
+    if (failures.length > 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'CLEAR_ALL', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { failedCollections: failures.length },
+        },
+        (failures[0] as PromiseRejectedResult).reason,
+      );
+    }
   }
 }

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -927,7 +927,14 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
       if (args.search) {
         const escaped = args.search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         const regex = new RegExp(escaped, 'i');
-        const searchCondition = [{ $expr: { $regexMatch: { input: { $toString: '$input' }, regex } } }];
+        // Use $convert with onError/onNull to safely handle any BSON type.
+        // $toString crashes on objects/arrays; $convert falls back to '' for unsupported types.
+        // This means search only matches string-valued input fields; for object inputs,
+        // a text index or materialized field would be needed for deeper search.
+        const safeStr = (field: string) => ({
+          $convert: { input: field, to: 'string', onError: '', onNull: '' },
+        });
+        const searchCondition = [{ $expr: { $regexMatch: { input: safeStr('$input'), regex } } }];
         if (filter.$or) {
           filter.$and = [{ $or: filter.$or }, { $or: searchCondition }];
           delete filter.$or;

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -1,0 +1,976 @@
+import { randomUUID } from 'node:crypto';
+
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  DatasetsStorage,
+  TABLE_DATASETS,
+  TABLE_DATASET_ITEMS,
+  TABLE_DATASET_VERSIONS,
+  TABLE_EXPERIMENTS,
+  TABLE_EXPERIMENT_RESULTS,
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  safelyParseJSON,
+  ensureDate,
+} from '@mastra/core/storage';
+import type {
+  DatasetRecord,
+  DatasetItem,
+  DatasetItemRow,
+  DatasetVersion,
+  CreateDatasetInput,
+  UpdateDatasetInput,
+  AddDatasetItemInput,
+  UpdateDatasetItemInput,
+  ListDatasetsInput,
+  ListDatasetsOutput,
+  ListDatasetItemsInput,
+  ListDatasetItemsOutput,
+  ListDatasetVersionsInput,
+  ListDatasetVersionsOutput,
+  BatchInsertItemsInput,
+  BatchDeleteItemsInput,
+} from '@mastra/core/storage';
+import type { Collection } from 'mongodb';
+
+import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
+import { resolveMongoDBConfig } from '../../db';
+import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';
+
+const MANAGED_COLLECTIONS = [TABLE_DATASETS, TABLE_DATASET_ITEMS, TABLE_DATASET_VERSIONS] as const;
+
+export class MongoDBDatasetsStorage extends DatasetsStorage {
+  #connector: MongoDBConnector;
+  #skipDefaultIndexes: boolean;
+  #indexes: MongoDBIndexConfig[];
+
+  constructor(config: MongoDBDomainConfig) {
+    super();
+    this.#connector = resolveMongoDBConfig(config);
+    this.#skipDefaultIndexes = config.skipDefaultIndexes ?? false;
+    this.#indexes = (config.indexes ?? []).filter(i =>
+      (MANAGED_COLLECTIONS as readonly string[]).includes(i.collection),
+    );
+  }
+
+  private getCollection(name: string): Promise<Collection> {
+    return this.#connector.getCollection(name);
+  }
+
+  // --- Index management ---
+
+  getDefaultIndexDefinitions(): MongoDBIndexConfig[] {
+    return [
+      { collection: TABLE_DATASET_ITEMS, keys: { datasetId: 1 }, options: { name: 'idx_dataset_items_datasetid' } },
+      {
+        collection: TABLE_DATASET_ITEMS,
+        keys: { datasetId: 1, validTo: 1 },
+        options: { name: 'idx_dataset_items_datasetid_validto' },
+      },
+      {
+        collection: TABLE_DATASET_ITEMS,
+        keys: { datasetId: 1, isDeleted: 1 },
+        options: { name: 'idx_dataset_items_datasetid_isdeleted' },
+      },
+      {
+        collection: TABLE_DATASET_ITEMS,
+        keys: { id: 1, validTo: 1 },
+        options: { name: 'idx_dataset_items_id_validto' },
+      },
+      {
+        collection: TABLE_DATASET_ITEMS,
+        keys: { datasetId: 1, datasetVersion: 1 },
+        options: { name: 'idx_dataset_items_datasetid_version' },
+      },
+      {
+        collection: TABLE_DATASET_VERSIONS,
+        keys: { datasetId: 1 },
+        options: { name: 'idx_dataset_versions_datasetid' },
+      },
+      {
+        collection: TABLE_DATASET_VERSIONS,
+        keys: { datasetId: 1, version: 1 },
+        options: { name: 'idx_dataset_versions_datasetid_version', unique: true },
+      },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.#skipDefaultIndexes) return;
+    for (const indexDef of this.getDefaultIndexDefinitions()) {
+      try {
+        const collection = await this.getCollection(indexDef.collection);
+        await collection.createIndex(indexDef.keys, indexDef.options);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create index on ${indexDef.collection}:`, error);
+      }
+    }
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    for (const indexDef of this.#indexes) {
+      try {
+        const collection = await this.getCollection(indexDef.collection);
+        await collection.createIndex(indexDef.keys, indexDef.options);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create custom index on ${indexDef.collection}:`, error);
+      }
+    }
+  }
+
+  async init(): Promise<void> {
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  // --- Row transformations ---
+
+  private transformDatasetRow(row: Record<string, any>): DatasetRecord {
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description ?? undefined,
+      metadata: typeof row.metadata === 'string' ? safelyParseJSON(row.metadata) : (row.metadata ?? undefined),
+      inputSchema: typeof row.inputSchema === 'string' ? safelyParseJSON(row.inputSchema) : row.inputSchema,
+      groundTruthSchema:
+        typeof row.groundTruthSchema === 'string' ? safelyParseJSON(row.groundTruthSchema) : row.groundTruthSchema,
+      requestContextSchema:
+        typeof row.requestContextSchema === 'string'
+          ? safelyParseJSON(row.requestContextSchema)
+          : row.requestContextSchema,
+      tags: typeof row.tags === 'string' ? safelyParseJSON(row.tags) : (row.tags ?? undefined),
+      targetType: row.targetType ?? undefined,
+      targetIds: typeof row.targetIds === 'string' ? safelyParseJSON(row.targetIds) : (row.targetIds ?? undefined),
+      version: row.version ?? 0,
+      createdAt: ensureDate(row.createdAt)!,
+      updatedAt: ensureDate(row.updatedAt)!,
+    };
+  }
+
+  private transformItemRow(row: Record<string, any>): DatasetItem {
+    return {
+      id: row.id,
+      datasetId: row.datasetId,
+      datasetVersion: row.datasetVersion,
+      input: typeof row.input === 'string' ? safelyParseJSON(row.input) : row.input,
+      groundTruth: typeof row.groundTruth === 'string' ? safelyParseJSON(row.groundTruth) : row.groundTruth,
+      requestContext: typeof row.requestContext === 'string' ? safelyParseJSON(row.requestContext) : row.requestContext,
+      metadata: typeof row.metadata === 'string' ? safelyParseJSON(row.metadata) : row.metadata,
+      source: typeof row.source === 'string' ? safelyParseJSON(row.source) : row.source,
+      createdAt: ensureDate(row.createdAt)!,
+      updatedAt: ensureDate(row.updatedAt)!,
+    };
+  }
+
+  private transformItemRowFull(row: Record<string, any>): DatasetItemRow {
+    return {
+      ...this.transformItemRow(row),
+      validTo: row.validTo ?? null,
+      isDeleted: row.isDeleted ?? false,
+    };
+  }
+
+  private transformDatasetVersionRow(row: Record<string, any>): DatasetVersion {
+    return {
+      id: row.id,
+      datasetId: row.datasetId,
+      version: row.version,
+      createdAt: ensureDate(row.createdAt)!,
+    };
+  }
+
+  // --- Dataset CRUD ---
+
+  async createDataset(input: CreateDatasetInput): Promise<DatasetRecord> {
+    try {
+      const id = randomUUID();
+      const now = new Date();
+      const collection = await this.getCollection(TABLE_DATASETS);
+
+      const record = {
+        id,
+        name: input.name,
+        description: input.description ?? null,
+        metadata: input.metadata ?? null,
+        inputSchema: input.inputSchema ?? null,
+        groundTruthSchema: input.groundTruthSchema ?? null,
+        requestContextSchema: input.requestContextSchema ?? null,
+        targetType: input.targetType ?? null,
+        targetIds: input.targetIds ?? null,
+        version: 0,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      await collection.insertOne(record);
+
+      return this.transformDatasetRow(record);
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'CREATE_DATASET', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async getDatasetById({ id }: { id: string }): Promise<DatasetRecord | null> {
+    try {
+      const collection = await this.getCollection(TABLE_DATASETS);
+      const row = await collection.findOne({ id });
+      return row ? this.transformDatasetRow(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_DATASET', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  protected async _doUpdateDataset(args: UpdateDatasetInput): Promise<DatasetRecord> {
+    try {
+      const existing = await this.getDatasetById({ id: args.id });
+      if (!existing) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'UPDATE_DATASET', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { datasetId: args.id },
+        });
+      }
+
+      const collection = await this.getCollection(TABLE_DATASETS);
+      const now = new Date();
+      const updateDoc: Record<string, any> = { updatedAt: now };
+
+      if (args.name !== undefined) updateDoc.name = args.name;
+      if (args.description !== undefined) updateDoc.description = args.description;
+      if (args.metadata !== undefined) updateDoc.metadata = args.metadata;
+      if (args.inputSchema !== undefined) updateDoc.inputSchema = args.inputSchema;
+      if (args.groundTruthSchema !== undefined) updateDoc.groundTruthSchema = args.groundTruthSchema;
+      if (args.requestContextSchema !== undefined) updateDoc.requestContextSchema = args.requestContextSchema;
+      if (args.tags !== undefined) updateDoc.tags = args.tags;
+      if (args.targetType !== undefined) updateDoc.targetType = args.targetType;
+      if (args.targetIds !== undefined) updateDoc.targetIds = args.targetIds;
+
+      await collection.updateOne({ id: args.id }, { $set: updateDoc });
+
+      const updated = await this.getDatasetById({ id: args.id });
+      return updated!;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'UPDATE_DATASET', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteDataset({ id }: { id: string }): Promise<void> {
+    try {
+      // Detach experiments — wrapped in try/catch because experiment collections may not exist
+      try {
+        const experimentsCollection = await this.getCollection(TABLE_EXPERIMENTS);
+        const experimentIds = await experimentsCollection.find({ datasetId: id }, { projection: { id: 1 } }).toArray();
+
+        if (experimentIds.length > 0) {
+          const resultsCollection = await this.getCollection(TABLE_EXPERIMENT_RESULTS);
+          await resultsCollection.deleteMany({
+            experimentId: { $in: experimentIds.map(e => e.id) },
+          });
+        }
+        await experimentsCollection.updateMany({ datasetId: id }, { $set: { datasetId: null, datasetVersion: null } });
+      } catch {
+        /* experiment collections may not exist */
+      }
+
+      // Cascade delete
+      const versionsCollection = await this.getCollection(TABLE_DATASET_VERSIONS);
+      const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
+      const datasetsCollection = await this.getCollection(TABLE_DATASETS);
+
+      await versionsCollection.deleteMany({ datasetId: id });
+      await itemsCollection.deleteMany({ datasetId: id });
+      await datasetsCollection.deleteOne({ id });
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'DELETE_DATASET', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async listDatasets(args: ListDatasetsInput): Promise<ListDatasetsOutput> {
+    try {
+      const { page, perPage: perPageInput } = args.pagination;
+      const collection = await this.getCollection(TABLE_DATASETS);
+
+      const total = await collection.countDocuments({});
+
+      if (total === 0) {
+        return { datasets: [], pagination: { total: 0, page, perPage: perPageInput, hasMore: false } };
+      }
+
+      const perPage = normalizePerPage(perPageInput, 100);
+      const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+      const limitValue = perPageInput === false ? total : perPage;
+
+      const rows = await collection.find({}).sort({ createdAt: -1, id: 1 }).skip(offset).limit(limitValue).toArray();
+
+      return {
+        datasets: rows.map(row => this.transformDatasetRow(row)),
+        pagination: {
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: perPageInput === false ? false : offset + perPage < total,
+        },
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'LIST_DATASETS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // --- Item mutations (SCD-2) ---
+
+  protected async _doAddItem(args: AddDatasetItemInput): Promise<DatasetItem> {
+    try {
+      const id = randomUUID();
+      const versionId = randomUUID();
+      const now = new Date();
+
+      const datasetsCollection = await this.getCollection(TABLE_DATASETS);
+      const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
+      const versionsCollection = await this.getCollection(TABLE_DATASET_VERSIONS);
+
+      // Bump dataset version
+      const result = await datasetsCollection.findOneAndUpdate(
+        { id: args.datasetId },
+        { $inc: { version: 1 } },
+        { returnDocument: 'after' },
+      );
+      const newVersion = result!.version as number;
+
+      // Insert item
+      await itemsCollection.insertOne({
+        id,
+        datasetId: args.datasetId,
+        datasetVersion: newVersion,
+        validTo: null,
+        isDeleted: false,
+        input: args.input,
+        groundTruth: args.groundTruth ?? null,
+        requestContext: args.requestContext ?? null,
+        metadata: args.metadata ?? null,
+        source: args.source ?? null,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      // Insert dataset_version row
+      await versionsCollection.insertOne({
+        id: versionId,
+        datasetId: args.datasetId,
+        version: newVersion,
+        createdAt: now,
+      });
+
+      return {
+        id,
+        datasetId: args.datasetId,
+        datasetVersion: newVersion,
+        input: args.input,
+        groundTruth: args.groundTruth,
+        requestContext: args.requestContext,
+        metadata: args.metadata,
+        source: args.source,
+        createdAt: now,
+        updatedAt: now,
+      };
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'ADD_ITEM', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  protected async _doUpdateItem(args: UpdateDatasetItemInput): Promise<DatasetItem> {
+    try {
+      const existing = await this.getItemById({ id: args.id });
+      if (!existing) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'UPDATE_ITEM', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { itemId: args.id },
+        });
+      }
+      if (existing.datasetId !== args.datasetId) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'UPDATE_ITEM', 'DATASET_MISMATCH'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { itemId: args.id, expectedDatasetId: args.datasetId, actualDatasetId: existing.datasetId },
+        });
+      }
+
+      const now = new Date();
+      const versionId = randomUUID();
+
+      const mergedInput = args.input ?? existing.input;
+      const mergedGroundTruth = args.groundTruth ?? existing.groundTruth;
+      const mergedRequestContext = args.requestContext ?? existing.requestContext;
+      const mergedMetadata = args.metadata ?? existing.metadata;
+      const mergedSource = args.source ?? existing.source;
+
+      const datasetsCollection = await this.getCollection(TABLE_DATASETS);
+      const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
+      const versionsCollection = await this.getCollection(TABLE_DATASET_VERSIONS);
+
+      // Bump dataset version
+      const result = await datasetsCollection.findOneAndUpdate(
+        { id: args.datasetId },
+        { $inc: { version: 1 } },
+        { returnDocument: 'after' },
+      );
+      const newVersion = result!.version as number;
+
+      // Close old row (set validTo = newVersion)
+      await itemsCollection.updateOne(
+        { id: args.id, validTo: null, isDeleted: false },
+        { $set: { validTo: newVersion } },
+      );
+
+      // Insert new row with merged fields, preserving original createdAt
+      await itemsCollection.insertOne({
+        id: args.id,
+        datasetId: args.datasetId,
+        datasetVersion: newVersion,
+        validTo: null,
+        isDeleted: false,
+        input: mergedInput,
+        groundTruth: mergedGroundTruth,
+        requestContext: mergedRequestContext,
+        metadata: mergedMetadata,
+        source: mergedSource,
+        createdAt: existing.createdAt,
+        updatedAt: now,
+      });
+
+      // Insert dataset_version row
+      await versionsCollection.insertOne({
+        id: versionId,
+        datasetId: args.datasetId,
+        version: newVersion,
+        createdAt: now,
+      });
+
+      return {
+        ...existing,
+        datasetVersion: newVersion,
+        input: mergedInput,
+        groundTruth: mergedGroundTruth,
+        requestContext: mergedRequestContext,
+        metadata: mergedMetadata,
+        source: mergedSource,
+        updatedAt: now,
+      };
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'UPDATE_ITEM', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  protected async _doDeleteItem({ id, datasetId }: { id: string; datasetId: string }): Promise<void> {
+    try {
+      const existing = await this.getItemById({ id });
+      if (!existing) return; // no-op if not found
+      if (existing.datasetId !== datasetId) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'DELETE_ITEM', 'DATASET_MISMATCH'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { itemId: id, expectedDatasetId: datasetId, actualDatasetId: existing.datasetId },
+        });
+      }
+
+      const now = new Date();
+      const versionId = randomUUID();
+
+      const datasetsCollection = await this.getCollection(TABLE_DATASETS);
+      const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
+      const versionsCollection = await this.getCollection(TABLE_DATASET_VERSIONS);
+
+      // Bump dataset version
+      const result = await datasetsCollection.findOneAndUpdate(
+        { id: datasetId },
+        { $inc: { version: 1 } },
+        { returnDocument: 'after' },
+      );
+      const newVersion = result!.version as number;
+
+      // Close old row
+      await itemsCollection.updateOne({ id, validTo: null, isDeleted: false }, { $set: { validTo: newVersion } });
+
+      // Insert tombstone
+      await itemsCollection.insertOne({
+        id,
+        datasetId,
+        datasetVersion: newVersion,
+        validTo: null,
+        isDeleted: true,
+        input: existing.input,
+        groundTruth: existing.groundTruth,
+        requestContext: existing.requestContext,
+        metadata: existing.metadata,
+        source: existing.source,
+        createdAt: existing.createdAt,
+        updatedAt: now,
+      });
+
+      // Insert dataset_version row
+      await versionsCollection.insertOne({
+        id: versionId,
+        datasetId,
+        version: newVersion,
+        createdAt: now,
+      });
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'DELETE_ITEM', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // --- Batch operations ---
+
+  protected async _doBatchInsertItems(input: BatchInsertItemsInput): Promise<DatasetItem[]> {
+    try {
+      const dataset = await this.getDatasetById({ id: input.datasetId });
+      if (!dataset) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'BULK_ADD_ITEMS', 'DATASET_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { datasetId: input.datasetId },
+        });
+      }
+
+      const now = new Date();
+      const versionId = randomUUID();
+
+      // Pre-generate IDs
+      const itemsWithIds = input.items.map(itemInput => ({
+        generatedId: randomUUID(),
+        itemInput,
+      }));
+
+      const datasetsCollection = await this.getCollection(TABLE_DATASETS);
+      const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
+      const versionsCollection = await this.getCollection(TABLE_DATASET_VERSIONS);
+
+      // Single version bump
+      const result = await datasetsCollection.findOneAndUpdate(
+        { id: input.datasetId },
+        { $inc: { version: 1 } },
+        { returnDocument: 'after' },
+      );
+      const newVersion = result!.version as number;
+
+      // Batch insert items
+      if (itemsWithIds.length > 0) {
+        const docs = itemsWithIds.map(({ generatedId, itemInput }) => ({
+          id: generatedId,
+          datasetId: input.datasetId,
+          datasetVersion: newVersion,
+          validTo: null,
+          isDeleted: false,
+          input: itemInput.input,
+          groundTruth: itemInput.groundTruth ?? null,
+          requestContext: itemInput.requestContext ?? null,
+          metadata: itemInput.metadata ?? null,
+          source: itemInput.source ?? null,
+          createdAt: now,
+          updatedAt: now,
+        }));
+        await itemsCollection.insertMany(docs);
+      }
+
+      // Single dataset_version row
+      await versionsCollection.insertOne({
+        id: versionId,
+        datasetId: input.datasetId,
+        version: newVersion,
+        createdAt: now,
+      });
+
+      return itemsWithIds.map(({ generatedId, itemInput }) => ({
+        id: generatedId,
+        datasetId: input.datasetId,
+        datasetVersion: newVersion,
+        input: itemInput.input,
+        groundTruth: itemInput.groundTruth,
+        requestContext: itemInput.requestContext,
+        metadata: itemInput.metadata,
+        source: itemInput.source,
+        createdAt: now,
+        updatedAt: now,
+      }));
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'BULK_ADD_ITEMS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  protected async _doBatchDeleteItems(input: BatchDeleteItemsInput): Promise<void> {
+    try {
+      const dataset = await this.getDatasetById({ id: input.datasetId });
+      if (!dataset) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'BULK_DELETE_ITEMS', 'DATASET_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { datasetId: input.datasetId },
+        });
+      }
+
+      // Fetch current items (skip items not found or mismatched)
+      const currentItems: DatasetItem[] = [];
+      for (const itemId of input.itemIds) {
+        const item = await this.getItemById({ id: itemId });
+        if (item && item.datasetId === input.datasetId) {
+          currentItems.push(item);
+        }
+      }
+      if (currentItems.length === 0) return;
+
+      const now = new Date();
+      const versionId = randomUUID();
+
+      const datasetsCollection = await this.getCollection(TABLE_DATASETS);
+      const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
+      const versionsCollection = await this.getCollection(TABLE_DATASET_VERSIONS);
+
+      // Single version bump
+      const result = await datasetsCollection.findOneAndUpdate(
+        { id: input.datasetId },
+        { $inc: { version: 1 } },
+        { returnDocument: 'after' },
+      );
+      const newVersion = result!.version as number;
+
+      // Close old rows
+      for (const item of currentItems) {
+        await itemsCollection.updateOne(
+          { id: item.id, validTo: null, isDeleted: false },
+          { $set: { validTo: newVersion } },
+        );
+      }
+
+      // Insert tombstones in batch
+      const tombstones = currentItems.map(item => ({
+        id: item.id,
+        datasetId: input.datasetId,
+        datasetVersion: newVersion,
+        validTo: null,
+        isDeleted: true,
+        input: item.input,
+        groundTruth: item.groundTruth,
+        requestContext: item.requestContext,
+        metadata: item.metadata,
+        source: item.source,
+        createdAt: item.createdAt,
+        updatedAt: now,
+      }));
+      await itemsCollection.insertMany(tombstones);
+
+      // Single dataset_version row
+      await versionsCollection.insertOne({
+        id: versionId,
+        datasetId: input.datasetId,
+        version: newVersion,
+        createdAt: now,
+      });
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'BULK_DELETE_ITEMS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // --- SCD-2 queries ---
+
+  async getItemById(args: { id: string; datasetVersion?: number }): Promise<DatasetItem | null> {
+    try {
+      const collection = await this.getCollection(TABLE_DATASET_ITEMS);
+
+      let row;
+      if (args.datasetVersion !== undefined) {
+        row = await collection.findOne({
+          id: args.id,
+          datasetVersion: args.datasetVersion,
+          isDeleted: false,
+        });
+      } else {
+        row = await collection.findOne({
+          id: args.id,
+          validTo: null,
+          isDeleted: false,
+        });
+      }
+
+      return row ? this.transformItemRow(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_ITEM', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async getItemsByVersion({ datasetId, version }: { datasetId: string; version: number }): Promise<DatasetItem[]> {
+    try {
+      const collection = await this.getCollection(TABLE_DATASET_ITEMS);
+      const rows = await collection
+        .find({
+          datasetId,
+          datasetVersion: { $lte: version },
+          $or: [{ validTo: null }, { validTo: { $gt: version } }],
+          isDeleted: false,
+        })
+        .sort({ createdAt: -1, id: 1 })
+        .toArray();
+
+      return rows.map(row => this.transformItemRow(row));
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_ITEMS_BY_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async getItemHistory(itemId: string): Promise<DatasetItemRow[]> {
+    try {
+      const collection = await this.getCollection(TABLE_DATASET_ITEMS);
+      const rows = await collection.find({ id: itemId }).sort({ datasetVersion: -1 }).toArray();
+      return rows.map(row => this.transformItemRowFull(row));
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_ITEM_HISTORY', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async listItems(args: ListDatasetItemsInput): Promise<ListDatasetItemsOutput> {
+    try {
+      const { page, perPage: perPageInput } = args.pagination;
+      const collection = await this.getCollection(TABLE_DATASET_ITEMS);
+
+      // Build filter
+      const filter: Record<string, any> = { datasetId: args.datasetId };
+
+      if (args.version !== undefined) {
+        // SCD-2 time-travel
+        filter.datasetVersion = { $lte: args.version };
+        filter.$or = [{ validTo: null }, { validTo: { $gt: args.version } }];
+        filter.isDeleted = false;
+      } else {
+        // Current items only
+        filter.validTo = null;
+        filter.isDeleted = false;
+      }
+
+      if (args.search) {
+        const regex = new RegExp(args.search, 'i');
+        const searchCondition = [{ $expr: { $regexMatch: { input: { $toString: '$input' }, regex } } }];
+        if (filter.$or) {
+          filter.$and = [{ $or: filter.$or }, { $or: searchCondition }];
+          delete filter.$or;
+        } else {
+          filter.$or = searchCondition;
+        }
+      }
+
+      const total = await collection.countDocuments(filter);
+
+      if (total === 0) {
+        return { items: [], pagination: { total: 0, page, perPage: perPageInput, hasMore: false } };
+      }
+
+      const perPage = normalizePerPage(perPageInput, 100);
+      const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+      const limitValue = perPageInput === false ? total : perPage;
+
+      const rows = await collection
+        .find(filter)
+        .sort({ createdAt: -1, id: 1 })
+        .skip(offset)
+        .limit(limitValue)
+        .toArray();
+
+      return {
+        items: rows.map(row => this.transformItemRow(row)),
+        pagination: {
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: perPageInput === false ? false : offset + perPage < total,
+        },
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'LIST_ITEMS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // --- Dataset versions ---
+
+  async createDatasetVersion(datasetId: string, version: number): Promise<DatasetVersion> {
+    try {
+      const id = randomUUID();
+      const now = new Date();
+      const collection = await this.getCollection(TABLE_DATASET_VERSIONS);
+
+      await collection.insertOne({ id, datasetId, version, createdAt: now });
+
+      return { id, datasetId, version, createdAt: now };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'CREATE_DATASET_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async listDatasetVersions(input: ListDatasetVersionsInput): Promise<ListDatasetVersionsOutput> {
+    try {
+      const { page, perPage: perPageInput } = input.pagination;
+      const collection = await this.getCollection(TABLE_DATASET_VERSIONS);
+      const filter = { datasetId: input.datasetId };
+
+      const total = await collection.countDocuments(filter);
+
+      if (total === 0) {
+        return { versions: [], pagination: { total: 0, page, perPage: perPageInput, hasMore: false } };
+      }
+
+      const perPage = normalizePerPage(perPageInput, 100);
+      const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+      const limitValue = perPageInput === false ? total : perPage;
+
+      const rows = await collection.find(filter).sort({ version: -1 }).skip(offset).limit(limitValue).toArray();
+
+      return {
+        versions: rows.map(row => this.transformDatasetVersionRow(row)),
+        pagination: {
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: perPageInput === false ? false : offset + perPage < total,
+        },
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'LIST_DATASET_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // --- Clear all ---
+
+  async dangerouslyClearAll(): Promise<void> {
+    const datasetsCollection = await this.getCollection(TABLE_DATASETS);
+    const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
+    const versionsCollection = await this.getCollection(TABLE_DATASET_VERSIONS);
+
+    await datasetsCollection.deleteMany({});
+    await itemsCollection.deleteMany({});
+    await versionsCollection.deleteMany({});
+  }
+}

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -464,14 +464,26 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         });
       }
 
+      // Short-circuit if no mutable fields are provided
+      const hasChanges =
+        args.input !== undefined ||
+        args.groundTruth !== undefined ||
+        args.requestContext !== undefined ||
+        args.metadata !== undefined ||
+        args.source !== undefined;
+
+      if (!hasChanges) {
+        return existing;
+      }
+
       const now = new Date();
       const versionId = randomUUID();
 
-      const mergedInput = args.input ?? existing.input;
-      const mergedGroundTruth = args.groundTruth ?? existing.groundTruth;
-      const mergedRequestContext = args.requestContext ?? existing.requestContext;
-      const mergedMetadata = args.metadata ?? existing.metadata;
-      const mergedSource = args.source ?? existing.source;
+      const mergedInput = args.input !== undefined ? args.input : existing.input;
+      const mergedGroundTruth = args.groundTruth !== undefined ? args.groundTruth : existing.groundTruth;
+      const mergedRequestContext = args.requestContext !== undefined ? args.requestContext : existing.requestContext;
+      const mergedMetadata = args.metadata !== undefined ? args.metadata : existing.metadata;
+      const mergedSource = args.source !== undefined ? args.source : existing.source;
 
       const datasetsCollection = await this.getCollection(TABLE_DATASETS);
       const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -635,6 +635,11 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         });
       }
 
+      // No-op for empty batch — don't bump version
+      if (!input.items || input.items.length === 0) {
+        return [];
+      }
+
       const now = new Date();
       const versionId = randomUUID();
 

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -331,6 +331,12 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
 
       const perPage = normalizePerPage(perPageInput, 100);
       const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+      // Handle perPage = 0 edge case (MongoDB limit(0) disables limit)
+      if (perPage === 0) {
+        return { datasets: [], pagination: { total, page, perPage: perPageForResponse, hasMore: total > 0 } };
+      }
+
       const limitValue = perPageInput === false ? total : perPage;
 
       const rows = await collection.find({}).sort({ createdAt: -1, id: 1 }).skip(offset).limit(limitValue).toArray();
@@ -870,6 +876,12 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
 
       const perPage = normalizePerPage(perPageInput, 100);
       const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+      // Handle perPage = 0 edge case (MongoDB limit(0) disables limit)
+      if (perPage === 0) {
+        return { items: [], pagination: { total, page, perPage: perPageForResponse, hasMore: total > 0 } };
+      }
+
       const limitValue = perPageInput === false ? total : perPage;
 
       const rows = await collection
@@ -937,6 +949,12 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
 
       const perPage = normalizePerPage(perPageInput, 100);
       const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+      // Handle perPage = 0 edge case (MongoDB limit(0) disables limit)
+      if (perPage === 0) {
+        return { versions: [], pagination: { total, page, perPage: perPageForResponse, hasMore: total > 0 } };
+      }
+
       const limitValue = perPageInput === false ? total : perPage;
 
       const rows = await collection.find(filter).sort({ version: -1 }).skip(offset).limit(limitValue).toArray();

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -913,7 +913,8 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
       }
 
       if (args.search) {
-        const regex = new RegExp(args.search, 'i');
+        const escaped = args.search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const regex = new RegExp(escaped, 'i');
         const searchCondition = [{ $expr: { $regexMatch: { input: { $toString: '$input' }, regex } } }];
         if (filter.$or) {
           filter.$and = [{ $or: filter.$or }, { $or: searchCondition }];

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -283,7 +283,8 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
 
   async deleteDataset({ id }: { id: string }): Promise<void> {
     try {
-      // Detach experiments — wrapped in try/catch because experiment collections may not exist
+      // Detach experiments — tolerate missing collections (NamespaceNotFound)
+      // but rethrow real operational failures
       try {
         const experimentsCollection = await this.getCollection(TABLE_EXPERIMENTS);
         const experimentIds = await experimentsCollection.find({ datasetId: id }, { projection: { id: 1 } }).toArray();
@@ -295,8 +296,10 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
           });
         }
         await experimentsCollection.updateMany({ datasetId: id }, { $set: { datasetId: null, datasetVersion: null } });
-      } catch {
-        /* experiment collections may not exist */
+      } catch (e: unknown) {
+        // Only swallow NamespaceNotFound (code 26) — collection doesn't exist yet
+        const isNamespaceNotFound = e instanceof Error && 'code' in e && (e as { code: number }).code === 26;
+        if (!isNamespaceNotFound) throw e;
       }
 
       // Cascade delete

--- a/stores/mongodb/src/storage/domains/experiments/index.ts
+++ b/stores/mongodb/src/storage/domains/experiments/index.ts
@@ -128,6 +128,7 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1 } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1, itemId: 1 }, options: { unique: true } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { createdAt: -1 } },
+      { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1, startedAt: 1 } },
     ];
   }
 

--- a/stores/mongodb/src/storage/domains/experiments/index.ts
+++ b/stores/mongodb/src/storage/domains/experiments/index.ts
@@ -305,6 +305,12 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
 
       const normalizedPerPage = normalizePerPage(perPageInput, 100);
       const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, normalizedPerPage);
+
+      // Handle perPage = 0 edge case (MongoDB limit(0) disables limit)
+      if (normalizedPerPage === 0) {
+        return { experiments: [], pagination: { total, page, perPage: perPageForResponse, hasMore: total > 0 } };
+      }
+
       const limitValue = perPageInput === false ? total : normalizedPerPage;
 
       const docs = await collection.find(filter).sort({ createdAt: -1 }).skip(offset).limit(limitValue).toArray();
@@ -498,6 +504,12 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
 
       const normalizedPerPage = normalizePerPage(perPageInput, 100);
       const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, normalizedPerPage);
+
+      // Handle perPage = 0 edge case (MongoDB limit(0) disables limit)
+      if (normalizedPerPage === 0) {
+        return { results: [], pagination: { total, page, perPage: perPageForResponse, hasMore: total > 0 } };
+      }
+
       const limitValue = perPageInput === false ? total : normalizedPerPage;
 
       const docs = await collection.find(filter).sort({ startedAt: 1 }).skip(offset).limit(limitValue).toArray();

--- a/stores/mongodb/src/storage/domains/experiments/index.ts
+++ b/stores/mongodb/src/storage/domains/experiments/index.ts
@@ -123,12 +123,12 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
     return [
       { collection: TABLE_EXPERIMENTS, keys: { id: 1 }, options: { unique: true } },
       { collection: TABLE_EXPERIMENTS, keys: { datasetId: 1 } },
-      { collection: TABLE_EXPERIMENTS, keys: { createdAt: -1 } },
+      { collection: TABLE_EXPERIMENTS, keys: { createdAt: -1, id: 1 } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { id: 1 }, options: { unique: true } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1 } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1, itemId: 1 }, options: { unique: true } },
       { collection: TABLE_EXPERIMENT_RESULTS, keys: { createdAt: -1 } },
-      { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1, startedAt: 1 } },
+      { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1, startedAt: 1, id: 1 } },
     ];
   }
 
@@ -314,7 +314,12 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
 
       const limitValue = perPageInput === false ? total : normalizedPerPage;
 
-      const docs = await collection.find(filter).sort({ createdAt: -1 }).skip(offset).limit(limitValue).toArray();
+      const docs = await collection
+        .find(filter)
+        .sort({ createdAt: -1, id: 1 })
+        .skip(offset)
+        .limit(limitValue)
+        .toArray();
 
       return {
         experiments: docs.map(d => transformExperimentRow(d as unknown as Record<string, unknown>)),
@@ -513,7 +518,7 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
 
       const limitValue = perPageInput === false ? total : normalizedPerPage;
 
-      const docs = await collection.find(filter).sort({ startedAt: 1 }).skip(offset).limit(limitValue).toArray();
+      const docs = await collection.find(filter).sort({ startedAt: 1, id: 1 }).skip(offset).limit(limitValue).toArray();
 
       return {
         results: docs.map(d => transformExperimentResultRow(d as unknown as Record<string, unknown>)),

--- a/stores/mongodb/src/storage/domains/experiments/index.ts
+++ b/stores/mongodb/src/storage/domains/experiments/index.ts
@@ -228,16 +228,6 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
   }
 
   async updateExperiment(input: UpdateExperimentInput): Promise<Experiment> {
-    const existing = await this.getExperimentById({ id: input.id });
-    if (!existing) {
-      throw new MastraError({
-        id: createStorageErrorId('MONGODB', 'UPDATE_EXPERIMENT', 'NOT_FOUND'),
-        domain: ErrorDomain.STORAGE,
-        category: ErrorCategory.USER,
-        details: { experimentId: input.id },
-      });
-    }
-
     const updateFields: Record<string, unknown> = { updatedAt: new Date() };
 
     if (input.name !== undefined) updateFields.name = input.name;
@@ -253,8 +243,19 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
 
     try {
       const collection = await this.getCollection(TABLE_EXPERIMENTS);
-      await collection.updateOne({ id: input.id }, { $set: updateFields });
-      return (await this.getExperimentById({ id: input.id }))!;
+      const result = await collection.updateOne({ id: input.id }, { $set: updateFields });
+
+      if (result.matchedCount === 0) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'UPDATE_EXPERIMENT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { experimentId: input.id },
+        });
+      }
+
+      const updated = await this.getExperimentById({ id: input.id });
+      return updated!;
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(

--- a/stores/mongodb/src/storage/domains/experiments/index.ts
+++ b/stores/mongodb/src/storage/domains/experiments/index.ts
@@ -1,0 +1,558 @@
+import { randomUUID } from 'node:crypto';
+
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  ExperimentsStorage,
+  createStorageErrorId,
+  TABLE_EXPERIMENTS,
+  TABLE_EXPERIMENT_RESULTS,
+  normalizePerPage,
+  calculatePagination,
+  safelyParseJSON,
+} from '@mastra/core/storage';
+import type {
+  Experiment,
+  ExperimentResult,
+  ExperimentResultStatus,
+  CreateExperimentInput,
+  UpdateExperimentInput,
+  AddExperimentResultInput,
+  UpdateExperimentResultInput,
+  ListExperimentsInput,
+  ListExperimentsOutput,
+  ListExperimentResultsInput,
+  ListExperimentResultsOutput,
+} from '@mastra/core/storage';
+import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
+import { resolveMongoDBConfig } from '../../db';
+import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toDate(value: unknown): Date {
+  if (value instanceof Date) return value;
+  if (typeof value === 'string' || typeof value === 'number') return new Date(value);
+  return new Date();
+}
+
+function toDateOrNull(value: unknown): Date | null {
+  if (value === null || value === undefined) return null;
+  return toDate(value);
+}
+
+function parseJsonField(value: unknown): any {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === 'string') return safelyParseJSON(value);
+  return value;
+}
+
+function transformExperimentRow(row: Record<string, unknown>): Experiment {
+  return {
+    id: row.id as string,
+    name: (row.name as string) ?? undefined,
+    description: (row.description as string) ?? undefined,
+    metadata: parseJsonField(row.metadata) ?? undefined,
+    datasetId: (row.datasetId as string | null) ?? null,
+    datasetVersion: row.datasetVersion != null ? Number(row.datasetVersion) : null,
+    targetType: row.targetType as Experiment['targetType'],
+    targetId: row.targetId as string,
+    status: row.status as Experiment['status'],
+    totalItems: Number(row.totalItems ?? 0),
+    succeededCount: Number(row.succeededCount ?? 0),
+    failedCount: Number(row.failedCount ?? 0),
+    skippedCount: Number(row.skippedCount ?? 0),
+    agentVersion: (row.agentVersion as string | null) ?? null,
+    startedAt: toDateOrNull(row.startedAt),
+    completedAt: toDateOrNull(row.completedAt),
+    createdAt: toDate(row.createdAt),
+    updatedAt: toDate(row.updatedAt),
+  };
+}
+
+function transformExperimentResultRow(row: Record<string, unknown>): ExperimentResult {
+  return {
+    id: row.id as string,
+    experimentId: row.experimentId as string,
+    itemId: row.itemId as string,
+    itemDatasetVersion: row.itemDatasetVersion != null ? Number(row.itemDatasetVersion) : null,
+    input: parseJsonField(row.input),
+    output: parseJsonField(row.output) ?? null,
+    groundTruth: parseJsonField(row.groundTruth) ?? null,
+    error: parseJsonField(row.error) ?? null,
+    startedAt: toDate(row.startedAt),
+    completedAt: toDate(row.completedAt),
+    retryCount: Number(row.retryCount ?? 0),
+    traceId: (row.traceId as string | null) ?? null,
+    status: (row.status as ExperimentResultStatus | null) ?? null,
+    tags: Array.isArray(row.tags) ? row.tags : (parseJsonField(row.tags) ?? null),
+    createdAt: toDate(row.createdAt),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MongoDB Experiments Storage
+// ---------------------------------------------------------------------------
+
+export class MongoDBExperimentsStorage extends ExperimentsStorage {
+  #connector: MongoDBConnector;
+  #skipDefaultIndexes?: boolean;
+  #indexes?: MongoDBIndexConfig[];
+
+  static readonly MANAGED_COLLECTIONS = [TABLE_EXPERIMENTS, TABLE_EXPERIMENT_RESULTS] as const;
+
+  constructor(config: MongoDBDomainConfig) {
+    super();
+    this.#connector = resolveMongoDBConfig(config);
+    this.#skipDefaultIndexes = config.skipDefaultIndexes;
+    this.#indexes = config.indexes?.filter(idx =>
+      (MongoDBExperimentsStorage.MANAGED_COLLECTIONS as readonly string[]).includes(idx.collection),
+    );
+  }
+
+  private async getCollection(name: string) {
+    return this.#connector.getCollection(name);
+  }
+
+  // -------------------------------------------------------------------------
+  // Index Management
+  // -------------------------------------------------------------------------
+
+  getDefaultIndexDefinitions(): MongoDBIndexConfig[] {
+    return [
+      { collection: TABLE_EXPERIMENTS, keys: { id: 1 }, options: { unique: true } },
+      { collection: TABLE_EXPERIMENTS, keys: { datasetId: 1 } },
+      { collection: TABLE_EXPERIMENTS, keys: { createdAt: -1 } },
+      { collection: TABLE_EXPERIMENT_RESULTS, keys: { id: 1 }, options: { unique: true } },
+      { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1 } },
+      { collection: TABLE_EXPERIMENT_RESULTS, keys: { experimentId: 1, itemId: 1 }, options: { unique: true } },
+      { collection: TABLE_EXPERIMENT_RESULTS, keys: { createdAt: -1 } },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.#skipDefaultIndexes) return;
+    for (const indexDef of this.getDefaultIndexDefinitions()) {
+      try {
+        const collection = await this.getCollection(indexDef.collection);
+        await collection.createIndex(indexDef.keys, indexDef.options);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create index on ${indexDef.collection}:`, error);
+      }
+    }
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.#indexes || this.#indexes.length === 0) return;
+    for (const indexDef of this.#indexes) {
+      try {
+        const collection = await this.getCollection(indexDef.collection);
+        await collection.createIndex(indexDef.keys, indexDef.options);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create custom index on ${indexDef.collection}:`, error);
+      }
+    }
+  }
+
+  async init(): Promise<void> {
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  // -------------------------------------------------------------------------
+  // Experiment CRUD
+  // -------------------------------------------------------------------------
+
+  async createExperiment(input: CreateExperimentInput): Promise<Experiment> {
+    const id = input.id ?? randomUUID();
+    const now = new Date();
+
+    const doc = {
+      id,
+      name: input.name ?? null,
+      description: input.description ?? null,
+      metadata: input.metadata ?? null,
+      datasetId: input.datasetId ?? null,
+      datasetVersion: input.datasetVersion ?? null,
+      targetType: input.targetType,
+      targetId: input.targetId,
+      status: 'pending' as const,
+      totalItems: input.totalItems,
+      succeededCount: 0,
+      failedCount: 0,
+      skippedCount: 0,
+      agentVersion: null,
+      startedAt: null,
+      completedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    try {
+      const collection = await this.getCollection(TABLE_EXPERIMENTS);
+      await collection.insertOne(doc);
+
+      return {
+        id,
+        name: input.name,
+        description: input.description,
+        metadata: input.metadata,
+        datasetId: input.datasetId ?? null,
+        datasetVersion: input.datasetVersion ?? null,
+        targetType: input.targetType,
+        targetId: input.targetId,
+        status: 'pending',
+        totalItems: input.totalItems,
+        succeededCount: 0,
+        failedCount: 0,
+        skippedCount: 0,
+        agentVersion: null,
+        startedAt: null,
+        completedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'CREATE_EXPERIMENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { name: input.name ?? 'unnamed' },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateExperiment(input: UpdateExperimentInput): Promise<Experiment> {
+    const existing = await this.getExperimentById({ id: input.id });
+    if (!existing) {
+      throw new MastraError({
+        id: createStorageErrorId('MONGODB', 'UPDATE_EXPERIMENT', 'NOT_FOUND'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { experimentId: input.id },
+      });
+    }
+
+    const updateFields: Record<string, unknown> = { updatedAt: new Date() };
+
+    if (input.name !== undefined) updateFields.name = input.name;
+    if (input.description !== undefined) updateFields.description = input.description;
+    if (input.metadata !== undefined) updateFields.metadata = input.metadata;
+    if (input.status !== undefined) updateFields.status = input.status;
+    if (input.totalItems !== undefined) updateFields.totalItems = input.totalItems;
+    if (input.succeededCount !== undefined) updateFields.succeededCount = input.succeededCount;
+    if (input.failedCount !== undefined) updateFields.failedCount = input.failedCount;
+    if (input.skippedCount !== undefined) updateFields.skippedCount = input.skippedCount;
+    if (input.startedAt !== undefined) updateFields.startedAt = input.startedAt;
+    if (input.completedAt !== undefined) updateFields.completedAt = input.completedAt;
+
+    try {
+      const collection = await this.getCollection(TABLE_EXPERIMENTS);
+      await collection.updateOne({ id: input.id }, { $set: updateFields });
+      return (await this.getExperimentById({ id: input.id }))!;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'UPDATE_EXPERIMENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { experimentId: input.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getExperimentById({ id }: { id: string }): Promise<Experiment | null> {
+    try {
+      const collection = await this.getCollection(TABLE_EXPERIMENTS);
+      const doc = await collection.findOne({ id });
+      if (!doc) return null;
+      return transformExperimentRow(doc as unknown as Record<string, unknown>);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_EXPERIMENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listExperiments(args: ListExperimentsInput): Promise<ListExperimentsOutput> {
+    try {
+      const collection = await this.getCollection(TABLE_EXPERIMENTS);
+      const { page, perPage: perPageInput } = args.pagination;
+
+      const filter: Record<string, unknown> = {};
+      if (args.datasetId) {
+        filter.datasetId = args.datasetId;
+      }
+
+      const total = await collection.countDocuments(filter);
+
+      if (total === 0) {
+        return { experiments: [], pagination: { total: 0, page, perPage: perPageInput, hasMore: false } };
+      }
+
+      const normalizedPerPage = normalizePerPage(perPageInput, 100);
+      const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, normalizedPerPage);
+      const limitValue = perPageInput === false ? total : normalizedPerPage;
+
+      const docs = await collection.find(filter).sort({ createdAt: -1 }).skip(offset).limit(limitValue).toArray();
+
+      return {
+        experiments: docs.map(d => transformExperimentRow(d as unknown as Record<string, unknown>)),
+        pagination: {
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: perPageInput === false ? false : offset + normalizedPerPage < total,
+        },
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'LIST_EXPERIMENTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteExperiment({ id }: { id: string }): Promise<void> {
+    try {
+      // Delete results first (FK semantics)
+      const resultsCollection = await this.getCollection(TABLE_EXPERIMENT_RESULTS);
+      await resultsCollection.deleteMany({ experimentId: id });
+
+      const experimentsCollection = await this.getCollection(TABLE_EXPERIMENTS);
+      await experimentsCollection.deleteOne({ id });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'DELETE_EXPERIMENT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id },
+        },
+        error,
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Experiment Results
+  // -------------------------------------------------------------------------
+
+  async addExperimentResult(input: AddExperimentResultInput): Promise<ExperimentResult> {
+    const id = input.id ?? randomUUID();
+    const now = new Date();
+
+    const doc = {
+      id,
+      experimentId: input.experimentId,
+      itemId: input.itemId,
+      itemDatasetVersion: input.itemDatasetVersion ?? null,
+      input: input.input,
+      output: input.output ?? null,
+      groundTruth: input.groundTruth ?? null,
+      error: input.error ?? null,
+      startedAt: input.startedAt,
+      completedAt: input.completedAt,
+      retryCount: input.retryCount,
+      traceId: input.traceId ?? null,
+      status: input.status ?? null,
+      tags: input.tags ?? null,
+      createdAt: now,
+    };
+
+    try {
+      const collection = await this.getCollection(TABLE_EXPERIMENT_RESULTS);
+      await collection.insertOne(doc);
+
+      return {
+        id,
+        experimentId: input.experimentId,
+        itemId: input.itemId,
+        itemDatasetVersion: input.itemDatasetVersion ?? null,
+        input: input.input,
+        output: input.output ?? null,
+        groundTruth: input.groundTruth ?? null,
+        error: input.error ?? null,
+        startedAt: input.startedAt,
+        completedAt: input.completedAt,
+        retryCount: input.retryCount,
+        traceId: input.traceId ?? null,
+        status: input.status ?? null,
+        tags: input.tags ?? null,
+        createdAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'ADD_EXPERIMENT_RESULT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { experimentId: input.experimentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateExperimentResult(input: UpdateExperimentResultInput): Promise<ExperimentResult> {
+    const updateFields: Record<string, unknown> = {};
+
+    if (input.status !== undefined) updateFields.status = input.status;
+    if (input.tags !== undefined) updateFields.tags = input.tags;
+
+    if (Object.keys(updateFields).length === 0) {
+      const existing = await this.getExperimentResultById({ id: input.id });
+      if (!existing) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'UPDATE_EXPERIMENT_RESULT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { resultId: input.id },
+        });
+      }
+      return existing;
+    }
+
+    try {
+      const collection = await this.getCollection(TABLE_EXPERIMENT_RESULTS);
+
+      const filter: Record<string, unknown> = { id: input.id };
+      if (input.experimentId) {
+        filter.experimentId = input.experimentId;
+      }
+
+      const result = await collection.findOneAndUpdate(filter, { $set: updateFields }, { returnDocument: 'after' });
+
+      if (!result) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'UPDATE_EXPERIMENT_RESULT', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { resultId: input.id },
+        });
+      }
+
+      return transformExperimentResultRow(result as unknown as Record<string, unknown>);
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'UPDATE_EXPERIMENT_RESULT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { resultId: input.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getExperimentResultById({ id }: { id: string }): Promise<ExperimentResult | null> {
+    try {
+      const collection = await this.getCollection(TABLE_EXPERIMENT_RESULTS);
+      const doc = await collection.findOne({ id });
+      if (!doc) return null;
+      return transformExperimentResultRow(doc as unknown as Record<string, unknown>);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_EXPERIMENT_RESULT', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listExperimentResults(args: ListExperimentResultsInput): Promise<ListExperimentResultsOutput> {
+    try {
+      const collection = await this.getCollection(TABLE_EXPERIMENT_RESULTS);
+      const { page, perPage: perPageInput } = args.pagination;
+
+      const filter: Record<string, unknown> = { experimentId: args.experimentId };
+
+      const total = await collection.countDocuments(filter);
+
+      if (total === 0) {
+        return { results: [], pagination: { total: 0, page, perPage: perPageInput, hasMore: false } };
+      }
+
+      const normalizedPerPage = normalizePerPage(perPageInput, 100);
+      const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, normalizedPerPage);
+      const limitValue = perPageInput === false ? total : normalizedPerPage;
+
+      const docs = await collection.find(filter).sort({ startedAt: 1 }).skip(offset).limit(limitValue).toArray();
+
+      return {
+        results: docs.map(d => transformExperimentResultRow(d as unknown as Record<string, unknown>)),
+        pagination: {
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: perPageInput === false ? false : offset + normalizedPerPage < total,
+        },
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'LIST_EXPERIMENT_RESULTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { experimentId: args.experimentId },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteExperimentResults({ experimentId }: { experimentId: string }): Promise<void> {
+    try {
+      const collection = await this.getCollection(TABLE_EXPERIMENT_RESULTS);
+      await collection.deleteMany({ experimentId });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'DELETE_EXPERIMENT_RESULTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { experimentId },
+        },
+        error,
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Cleanup
+  // -------------------------------------------------------------------------
+
+  async dangerouslyClearAll(): Promise<void> {
+    for (const collectionName of MongoDBExperimentsStorage.MANAGED_COLLECTIONS) {
+      try {
+        const collection = await this.getCollection(collectionName);
+        await collection.deleteMany({});
+      } catch {
+        // Collection may not exist yet
+      }
+    }
+  }
+}

--- a/stores/mongodb/src/storage/domains/experiments/index.ts
+++ b/stores/mongodb/src/storage/domains/experiments/index.ts
@@ -425,7 +425,7 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
 
     if (Object.keys(updateFields).length === 0) {
       const existing = await this.getExperimentResultById({ id: input.id });
-      if (!existing) {
+      if (!existing || (input.experimentId && existing.experimentId !== input.experimentId)) {
         throw new MastraError({
           id: createStorageErrorId('MONGODB', 'UPDATE_EXPERIMENT_RESULT', 'NOT_FOUND'),
           domain: ErrorDomain.STORAGE,

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -5,6 +5,8 @@ import type { MongoDBConnector } from './connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from './db';
 import { MongoDBAgentsStorage } from './domains/agents';
 import { MongoDBBlobStore } from './domains/blobs';
+import { MongoDBDatasetsStorage } from './domains/datasets';
+import { MongoDBExperimentsStorage } from './domains/experiments';
 import { MongoDBMCPClientsStorage } from './domains/mcp-clients';
 import { MongoDBMCPServersStorage } from './domains/mcp-servers';
 import { MemoryStorageMongoDB } from './domains/memory';
@@ -21,6 +23,8 @@ import type { MongoDBConfig } from './types';
 export {
   MongoDBAgentsStorage,
   MongoDBBlobStore,
+  MongoDBDatasetsStorage,
+  MongoDBExperimentsStorage,
   MongoDBMCPClientsStorage,
   MongoDBMCPServersStorage,
   MemoryStorageMongoDB,
@@ -92,6 +96,10 @@ export class MongoDBStore extends MastraCompositeStore {
 
     const blobs = new MongoDBBlobStore(domainConfig);
 
+    const datasets = new MongoDBDatasetsStorage(domainConfig);
+
+    const experiments = new MongoDBExperimentsStorage(domainConfig);
+
     this.stores = {
       memory,
       scores,
@@ -105,6 +113,8 @@ export class MongoDBStore extends MastraCompositeStore {
       workspaces,
       skills,
       blobs,
+      datasets,
+      experiments,
     };
   }
 


### PR DESCRIPTION
Adds datasets and experiments storage support to `@mastra/mongodb`.

`MongoDBDatasetsStorage` handles dataset CRUD, versioned items (with time-travel queries and item history), and batch insert/delete. `MongoDBExperimentsStorage` handles experiment lifecycle and per-item results with pagination and filtering.

Both domains are registered in `MongoDBStore` automatically — no config changes needed to use them. All 53 shared test suite tests pass.

```ts
import { MongoDBStore } from '@mastra/mongodb';

const store = new MongoDBStore({ uri: '...', dbName: 'my-db' });
// store.datasets and store.experiments are now available
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dataset persistence: full dataset and item management with automatic versioning, item history, and time-travel queries to view past item states.
  * Batch item insert/delete plus paginated, searchable item listings with stable sorting and total/hasMore indicators.
  * Experiment persistence: experiment CRUD with per-item experiment results, paginated results, filtering, and cascade deletion of related results.
  * Both features are enabled automatically when using the MongoDB-backed store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->