### PR TITLE
Fix error info tags being recorded as [object Object] in Datadog

### DIFF
--- a/.changeset/open-dolls-listen.md
+++ b/.changeset/open-dolls-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': patch
+---
+
+Fixed error info tags being recorded as [object Object] in Datadog. Error details (message, id, domain, category) are now stored as separate flattened tags (error.message, error.id, error.domain, error.category) instead of a nested object, making error information properly visible in Datadog LLM Observability.

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -257,11 +257,9 @@ describe('DatadogExporter', () => {
         expect.objectContaining({
           tags: expect.objectContaining({
             error: true,
-            errorInfo: {
-              message: 'Something went wrong',
-              id: 'err-123',
-              category: 'validation',
-            },
+            'error.message': 'Something went wrong',
+            'error.id': 'err-123',
+            'error.category': 'validation',
           }),
         }),
       );

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -344,10 +344,8 @@ describe('DatadogExporter', () => {
             production: true,
             critical: true,
             error: true,
-            errorInfo: {
-              message: 'Something failed',
-              category: 'runtime',
-            },
+            'error.message': 'Something failed',
+            'error.category': 'runtime',
           },
         }),
       );

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -314,15 +314,19 @@ export class DatadogExporter extends BaseExporter {
       }
     }
 
-    // Add error info as consolidated tags
+    // Add error info as flattened tags (dd-trace requires primitive tag values)
     if (span.errorInfo) {
       tags.error = true;
-      tags.errorInfo = {
-        message: span.errorInfo.message,
-        ...(span.errorInfo.id ? { id: span.errorInfo.id } : {}),
-        ...(span.errorInfo.domain ? { domain: span.errorInfo.domain } : {}),
-        ...(span.errorInfo.category ? { category: span.errorInfo.category } : {}),
-      };
+      tags['error.message'] = span.errorInfo.message;
+      if (span.errorInfo.id) {
+        tags['error.id'] = span.errorInfo.id;
+      }
+      if (span.errorInfo.domain) {
+        tags['error.domain'] = span.errorInfo.domain;
+      }
+      if (span.errorInfo.category) {
+        tags['error.category'] = span.errorInfo.category;
+      }
     }
 
     if (Object.keys(tags).length > 0) {


### PR DESCRIPTION
## Description

Fixed an issue where error information was being recorded as `[object Object]` in Datadog due to nested object tag values. The Datadog tracer requires primitive tag values, so error details are now stored as separate flattened tags following Datadog's naming convention:
- `error.message` - the error message
- `error.id` - the error ID (if present)
- `error.domain` - the error domain (if present)
- `error.category` - the error category (if present)

This ensures error information is properly visible in Datadog LLM Observability instead of appearing as a stringified object.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

Updated unit tests to verify that error details are now recorded as individual flattened tags rather than a nested object. Existing test coverage validates the fix.

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

https://claude.ai/code/session_017hvfTG6ud4SWN4fZtdqgjg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error details now appear correctly in Datadog LLM Observability: message, ID, domain, and category are recorded as separate fields instead of a nested object, improving error visibility and debugging.

* **Tests**
  * Observability tests updated to align with the new flattened error-field reporting format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->