### PR TITLE
fix: strip Anthropic thinking block signatures from LLM prompt history

### DIFF
--- a/.changeset/early-crews-clap.md
+++ b/.changeset/early-crews-clap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Anthropic thinking block signatures being replayed to the LLM, causing 'Invalid signature in thinking block' API errors. Anthropic reasoning parts with cryptographic signatures are now stripped from LLM prompts (matching the existing OpenAI reasoning stripping pattern), while being preserved in database storage and UI display.

--- a/packages/core/src/agent/message-list/conversion/output-converter-anthropic-reasoning.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-anthropic-reasoning.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { AIV5Type } from '../types';
+import { sanitizeV5UIMessages } from './output-converter';
+
+/**
+ * Tests for Anthropic reasoning (thinking block) stripping in sanitizeV5UIMessages.
+ *
+ * Anthropic thinking blocks contain cryptographic signatures that are model-specific
+ * and ephemeral. Replaying them from thread history causes 'Invalid signature in
+ * thinking block' errors. These parts are stripped when building a prompt TO the LLM
+ * (filterIncompleteToolCalls=true) but preserved for UI display and DB storage.
+ *
+ * See: https://github.com/mastra-ai/mastra/issues/14559
+ */
+describe('sanitizeV5UIMessages — Anthropic reasoning stripping', () => {
+  const makeMessage = (parts: AIV5Type.UIMessage['parts']): AIV5Type.UIMessage => ({
+    id: 'msg-1',
+    role: 'assistant',
+    parts,
+  });
+
+  it('should strip Anthropic reasoning parts from LLM prompt', () => {
+    const msg = makeMessage([
+      {
+        type: 'reasoning',
+        reasoning: 'thinking...',
+        providerMetadata: {
+          anthropic: { signature: 'sig_abc123' },
+        },
+      } as AIV5Type.UIMessage['parts'][number],
+      { type: 'text', text: 'Hello world' },
+    ]);
+
+    const result = sanitizeV5UIMessages([msg], true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].parts).toHaveLength(1);
+    expect(result[0].parts[0].type).toBe('text');
+  });
+
+  it('should preserve text parts alongside stripped reasoning', () => {
+    const msg = makeMessage([
+      {
+        type: 'reasoning',
+        reasoning: 'deep thought',
+        providerMetadata: {
+          anthropic: { signature: 'sig_xyz' },
+        },
+      } as AIV5Type.UIMessage['parts'][number],
+      { type: 'text', text: 'The answer is 42' },
+    ]);
+
+    const result = sanitizeV5UIMessages([msg], true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].parts).toHaveLength(1);
+    expect(result[0].parts[0]).toMatchObject({ type: 'text', text: 'The answer is 42' });
+  });
+
+  it('should remove message entirely when only Anthropic reasoning parts remain', () => {
+    const msg = makeMessage([
+      {
+        type: 'reasoning',
+        reasoning: 'only thinking here',
+        providerMetadata: {
+          anthropic: { signature: 'sig_only' },
+        },
+      } as AIV5Type.UIMessage['parts'][number],
+    ]);
+
+    const result = sanitizeV5UIMessages([msg], true);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('should not strip reasoning parts without Anthropic providerMetadata', () => {
+    const msg = makeMessage([
+      {
+        type: 'reasoning',
+        reasoning: 'generic reasoning',
+      } as AIV5Type.UIMessage['parts'][number],
+      { type: 'text', text: 'response' },
+    ]);
+
+    const result = sanitizeV5UIMessages([msg], true);
+
+    expect(result).toHaveLength(1);
+    // Both parts should be preserved
+    expect(result[0].parts).toHaveLength(2);
+    expect(result[0].parts[0].type).toBe('reasoning');
+    expect(result[0].parts[1].type).toBe('text');
+  });
+
+  it('should preserve Anthropic reasoning parts for UI display (filterIncompleteToolCalls=false)', () => {
+    const msg = makeMessage([
+      {
+        type: 'reasoning',
+        reasoning: 'thinking...',
+        providerMetadata: {
+          anthropic: { signature: 'sig_ui' },
+        },
+      } as AIV5Type.UIMessage['parts'][number],
+      { type: 'text', text: 'response' },
+    ]);
+
+    const result = sanitizeV5UIMessages([msg], false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].parts).toHaveLength(2);
+    expect(result[0].parts[0].type).toBe('reasoning');
+  });
+});

--- a/packages/core/src/agent/message-list/conversion/output-converter-anthropic-reasoning.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-anthropic-reasoning.test.ts
@@ -91,6 +91,32 @@ describe('sanitizeV5UIMessages — Anthropic reasoning stripping', () => {
     expect(result[0].parts[1].type).toBe('text');
   });
 
+  it('should strip both OpenAI and Anthropic reasoning parts from same message', () => {
+    const msg = makeMessage([
+      {
+        type: 'reasoning',
+        reasoning: 'anthropic thinking',
+        providerMetadata: {
+          anthropic: { signature: 'sig_abc' },
+        },
+      } as AIV5Type.UIMessage['parts'][number],
+      {
+        type: 'reasoning',
+        reasoning: 'openai reasoning',
+        providerMetadata: {
+          openai: { itemId: 'rs_123' },
+        },
+      } as AIV5Type.UIMessage['parts'][number],
+      { type: 'text', text: 'final response' },
+    ]);
+
+    const result = sanitizeV5UIMessages([msg], true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].parts).toHaveLength(1);
+    expect(result[0].parts[0].type).toBe('text');
+  });
+
   it('should preserve Anthropic reasoning parts for UI display (filterIncompleteToolCalls=false)', () => {
     const msg = makeMessage([
       {

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -71,6 +71,23 @@ export function sanitizeV5UIMessages(
             'openai' in (p.providerMetadata as Record<string, unknown>),
         );
 
+      // When building a prompt TO the LLM (filterIncompleteToolCalls=true),
+      // check if this message contains Anthropic reasoning parts (thinking blocks with signatures).
+      // Anthropic thinking block signatures are cryptographic and model-specific. Replaying them
+      // from thread history causes 'Invalid signature in thinking block' errors.
+      // Reasoning data is preserved in the database — only stripped from LLM input.
+      // See: https://github.com/mastra-ai/mastra/issues/14559
+      const hasAnthropicReasoning =
+        filterIncompleteToolCalls &&
+        m.parts.some(
+          p =>
+            p.type === 'reasoning' &&
+            'providerMetadata' in p &&
+            p.providerMetadata &&
+            typeof p.providerMetadata === 'object' &&
+            'anthropic' in (p.providerMetadata as Record<string, unknown>),
+        );
+
       // Filter out streaming states and optionally input-available (which aren't supported by convertToModelMessages)
       const safeParts = m.parts.filter(p => {
         // Filter out data-* parts (custom streaming data from writer.custom())
@@ -90,6 +107,15 @@ export function sanitizeV5UIMessages(
         // Reasoning data is preserved in the database — only stripped from LLM input.
         // See: https://github.com/mastra-ai/mastra/issues/12980
         if (p.type === 'reasoning' && hasOpenAIReasoning) {
+          return false;
+        }
+
+        // Strip Anthropic reasoning parts (thinking blocks with signatures) when building a prompt TO the LLM.
+        // Anthropic thinking block signatures are cryptographic and model-specific. Replaying them from
+        // thread history causes 'Invalid signature in thinking block' errors, especially after model changes.
+        // Reasoning data is preserved in the database — only stripped from LLM input.
+        // See: https://github.com/mastra-ai/mastra/issues/14559
+        if (p.type === 'reasoning' && hasAnthropicReasoning) {
           return false;
         }
 


### PR DESCRIPTION
## Description

Strip Anthropic reasoning parts (thinking blocks with cryptographic signatures) from LLM prompt history in `sanitizeV5UIMessages()`, matching the established OpenAI reasoning stripping pattern.

When Anthropic thinking blocks with `providerMetadata.anthropic.signature` are stored in thread history and later replayed as input to the Anthropic API, the signatures fail validation (they are cryptographic, model-specific, and ephemeral), causing `Invalid signature in thinking block` errors. If all parts in a message were thinking blocks, stripping them can leave an empty message causing `text content blocks must be non-empty` errors.

The fix adds `hasAnthropicReasoning` detection alongside the existing `hasOpenAIReasoning` check, and filters out Anthropic reasoning parts when `filterIncompleteToolCalls=true` (i.e., when building prompts TO the LLM). Reasoning data is preserved in the database and UI output — only stripped from LLM input. The existing empty-message removal (`if (!safeParts.length) return false`) handles the edge case where all parts were reasoning blocks.

## Related Issue(s)

Fixes #14559

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Invalid signature in thinking block" errors with Anthropic: signed reasoning blocks are now removed from prompts sent to the LLM, preventing replayed signatures from causing API errors while keeping those reasoning blocks visible in the UI and stored in the database, matching the existing behavior for other providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->