### PR TITLE
feat: prevent macOS sleep during active mastracode work

### DIFF
--- a/.changeset/fluffy-ghosts-accept.md
+++ b/.changeset/fluffy-ghosts-accept.md
@@ -1,0 +1,9 @@
+---
+'mastracode': patch
+---
+
+Added macOS sleep prevention while Mastra Code is actively running.
+
+Mastra Code now starts the built-in caffeinate utility only while an agent run is in progress, then releases it after completion, aborts, errors, or app shutdown.
+
+To opt out, set MASTRACODE_DISABLE_CAFFEINATE=1 before launching Mastra Code.

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -162,6 +162,16 @@ Once saved, provider models appear in existing selectors like `/models` and `/su
 
 Custom providers are stored in `settings.json` in the same app data directory. If you save an API key, it is stored locally in plaintext, so use a machine/user profile you trust.
 
+### macOS sleep prevention
+
+On macOS, Mastra Code starts the built-in `caffeinate` utility while the agent is actively running, then stops it as soon as the run completes, errors, aborts, or the TUI exits. Idle sessions do not keep your machine awake.
+
+To disable this behavior, set `MASTRACODE_DISABLE_CAFFEINATE=1` before launching Mastra Code:
+
+```bash
+export MASTRACODE_DISABLE_CAFFEINATE=1
+```
+
 ### Plan persistence
 
 When you approve a plan (via `submit_plan`), it is saved as a markdown file in the app data directory:

--- a/mastracode/src/tui/__tests__/mastra-tui-hooks.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-hooks.test.ts
@@ -1,11 +1,17 @@
+import { EventEmitter } from 'node:events';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  mockSpawn: vi.fn(),
   dispatchEvent: vi.fn(),
   showError: vi.fn(),
   showInfo: vi.fn(),
   showFormattedError: vi.fn(),
   notify: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: mocks.mockSpawn,
 }));
 
 vi.mock('../event-dispatch.js', () => ({
@@ -33,22 +39,31 @@ function createHookResult(overrides: Record<string, unknown> = {}) {
 function createBareTui(hookManager?: Record<string, unknown>) {
   const tui = Object.create(MastraTUI.prototype) as {
     state: Record<string, unknown>;
+    caffeinateProcess: MockChildProcess | null;
     getEventContext: ReturnType<typeof vi.fn>;
     showHookWarnings: ReturnType<typeof vi.fn>;
     runUserPromptHook: (input: string) => Promise<boolean>;
     handleEvent: (event: unknown) => Promise<void>;
+    stop: () => void;
   };
 
-  tui.state = { hookManager };
+  tui.state = { hookManager, ui: { stop: vi.fn() } };
+  tui.caffeinateProcess = null;
   tui.getEventContext = vi.fn(() => ({}));
   tui.showHookWarnings = vi.fn();
 
   return tui;
 }
 
+class MockChildProcess extends EventEmitter {
+  kill = vi.fn();
+}
+
 describe('MastraTUI hook wiring', () => {
   beforeEach(() => {
     Object.values(mocks).forEach(mockFn => mockFn.mockReset());
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it('blocks non-command prompt when UserPromptSubmit blocks', async () => {
@@ -99,5 +114,78 @@ describe('MastraTUI hook wiring', () => {
     await tui.handleEvent({ type: 'agent_start' });
 
     expect(runStop).not.toHaveBeenCalled();
+  });
+
+  it('starts caffeinate on macOS agent_start', async () => {
+    vi.stubGlobal('process', { platform: 'darwin', env: {} });
+    const child = new MockChildProcess();
+    mocks.mockSpawn.mockReturnValue(child);
+    const tui = createBareTui();
+
+    await tui.handleEvent({ type: 'agent_start' });
+
+    expect(mocks.mockSpawn).toHaveBeenCalledWith('caffeinate', ['-i', '-m'], { stdio: 'ignore' });
+    expect(tui.caffeinateProcess).toBe(child);
+  });
+
+  it('does not start duplicate caffeinate processes', async () => {
+    vi.stubGlobal('process', { platform: 'darwin', env: {} });
+    const child = new MockChildProcess();
+    mocks.mockSpawn.mockReturnValue(child);
+    const tui = createBareTui();
+
+    await tui.handleEvent({ type: 'agent_start' });
+    await tui.handleEvent({ type: 'agent_start' });
+
+    expect(mocks.mockSpawn).toHaveBeenCalledTimes(1);
+    expect(tui.caffeinateProcess).toBe(child);
+  });
+
+  it.each(['aborted', 'error', 'complete'] as const)('stops caffeinate on agent_end reason=%s', async reason => {
+    vi.stubGlobal('process', { platform: 'darwin', env: {} });
+    const child = new MockChildProcess();
+    mocks.mockSpawn.mockReturnValue(child);
+    const tui = createBareTui();
+
+    await tui.handleEvent({ type: 'agent_start' });
+    await tui.handleEvent({ type: 'agent_end', reason });
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(tui.caffeinateProcess).toBeNull();
+  });
+
+  it('cleans up caffeinate on stop()', () => {
+    vi.stubGlobal('process', { platform: 'darwin', env: {} });
+    const runSessionEnd = vi.fn().mockResolvedValue(createHookResult());
+    const child = new MockChildProcess();
+    const tui = createBareTui({ runSessionEnd });
+    tui.caffeinateProcess = child;
+
+    tui.stop();
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(runSessionEnd).toHaveBeenCalledTimes(1);
+    expect((tui.state.ui as { stop: ReturnType<typeof vi.fn> }).stop).toHaveBeenCalledTimes(1);
+    expect(tui.caffeinateProcess).toBeNull();
+  });
+
+  it('does nothing on non-darwin platforms', async () => {
+    vi.stubGlobal('process', { platform: 'linux', env: {} });
+    const tui = createBareTui();
+
+    await tui.handleEvent({ type: 'agent_start' });
+
+    expect(mocks.mockSpawn).not.toHaveBeenCalled();
+    expect(tui.caffeinateProcess).toBeNull();
+  });
+
+  it('does not start caffeinate when disabled by env var', async () => {
+    vi.stubGlobal('process', { platform: 'darwin', env: { MASTRACODE_DISABLE_CAFFEINATE: '1' } });
+    const tui = createBareTui();
+
+    await tui.handleEvent({ type: 'agent_start' });
+
+    expect(mocks.mockSpawn).not.toHaveBeenCalled();
+    expect(tui.caffeinateProcess).toBeNull();
   });
 });

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -2,6 +2,8 @@
  * Main TUI class for Mastra Code.
  * Wires the Harness to pi-tui components for a full interactive experience.
  */
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import { Spacer } from '@mariozechner/pi-tui';
 import type { Component } from '@mariozechner/pi-tui';
 import type { HarnessEvent } from '@mastra/core/harness';
@@ -73,6 +75,11 @@ export type { MastraTUIOptions } from './state.js';
 /** How often to recheck for updates during a long-running session (ms). */
 const UPDATE_RECHECK_INTERVAL_MS = 45 * 60 * 1_000; // 45 minutes
 const IMAGE_PLACEHOLDER_PATTERN = /\[image\]\s*/g;
+const CAFFEINATE_ARGS = ['-i', '-m'];
+
+function shouldUseCaffeinate(): boolean {
+  return process.platform === 'darwin' && process.env.MASTRACODE_DISABLE_CAFFEINATE !== '1';
+}
 
 export function consumePendingImages(
   text: string,
@@ -91,6 +98,7 @@ export class MastraTUI {
   private state: TUIState;
   private updateCheckTimer: ReturnType<typeof setInterval> | null = null;
   private hasShownUpdateBanner = false;
+  private caffeinateProcess: ChildProcess | null = null;
 
   private static readonly DOUBLE_CTRL_C_MS = 500;
 
@@ -262,6 +270,8 @@ export class MastraTUI {
    * Stop the TUI and clean up.
    */
   stop(): void {
+    this.stopCaffeinate();
+
     // Run SessionEnd hooks (best-effort, don't await)
     const hookMgr = this.state.hookManager;
     if (hookMgr) {
@@ -401,18 +411,66 @@ export class MastraTUI {
   }
 
   private async handleEvent(event: HarnessEvent): Promise<void> {
-    await dispatchEvent(event, this.getEventContext(), this.state);
-
-    if (event.type === 'thread_created') {
-      await this.syncThreadActivePackMetadata(event.thread);
-    } else if (event.type === 'thread_changed') {
-      await this.syncThreadActivePackMetadata();
+    if (event.type === 'agent_start') {
+      this.startCaffeinate();
     }
 
-    if (event.type === 'agent_end') {
-      const stopReason = event.reason === 'aborted' ? 'aborted' : event.reason === 'error' ? 'error' : 'complete';
-      await this.runStopHook(stopReason);
+    try {
+      await dispatchEvent(event, this.getEventContext(), this.state);
+
+      if (event.type === 'thread_created') {
+        await this.syncThreadActivePackMetadata(event.thread);
+      } else if (event.type === 'thread_changed') {
+        await this.syncThreadActivePackMetadata();
+      }
+
+      if (event.type === 'agent_end') {
+        const stopReason = event.reason === 'aborted' ? 'aborted' : event.reason === 'error' ? 'error' : 'complete';
+        await this.runStopHook(stopReason);
+      }
+    } finally {
+      if (event.type === 'agent_end') {
+        this.stopCaffeinate();
+      }
     }
+  }
+
+  private startCaffeinate(): void {
+    if (!shouldUseCaffeinate() || this.caffeinateProcess) {
+      return;
+    }
+
+    try {
+      const child = spawn('caffeinate', CAFFEINATE_ARGS, {
+        stdio: 'ignore',
+      });
+
+      child.once('error', () => {
+        if (this.caffeinateProcess === child) {
+          this.caffeinateProcess = null;
+        }
+      });
+
+      child.once('exit', () => {
+        if (this.caffeinateProcess === child) {
+          this.caffeinateProcess = null;
+        }
+      });
+
+      this.caffeinateProcess = child;
+    } catch {
+      this.caffeinateProcess = null;
+    }
+  }
+
+  private stopCaffeinate(): void {
+    const child = this.caffeinateProcess;
+    if (!child) {
+      return;
+    }
+
+    this.caffeinateProcess = null;
+    child.kill();
   }
 
   private async buildProviderAccess(): Promise<ProviderAccess> {


### PR DESCRIPTION
Mastra Code now uses macOS `caffeinate` while an agent run is active, and releases it when the run ends or the TUI exits. It stays idle when Mastra Code is waiting for input.

After:
```bash
caffeinate -i -m
```
only runs during active agent work.

I also added targeted tests for start/stop cleanup paths and documented the opt-out env var in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mastra Code now prevents macOS from sleeping during active agent runs and stops doing so when runs complete, abort, error, or the app exits.
  * Added environment variable opt-out: MASTRACODE_DISABLE_CAFFEINATE=1.

* **Documentation**
  * Added macOS sleep prevention docs and instructions for disabling the behavior.

* **Tests**
  * Expanded tests covering the macOS sleep-prevention lifecycle and gating by platform and env var.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->