### PR TITLE
docs(models): clarify custom endpoint model config

### DIFF
--- a/.changeset/orange-pianos-battle.md
+++ b/.changeset/orange-pianos-battle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved custom OpenAI-compatible model configuration guidance in the models docs.

--- a/docs/src/content/en/models/index.mdx
+++ b/docs/src/content/en/models/index.mdx
@@ -304,7 +304,9 @@ Your users never experience the disruption - the response comes back with the sa
 
 Mastra also supports local models like `gpt-oss`, `Qwen3`, `DeepSeek` and many more that you run on your own hardware. The application running your local model needs to provide an OpenAI-compatible API server for Mastra to connect to. We recommend using [LMStudio](https://lmstudio.ai/) (see [Running the LMStudio server](https://lmstudio.ai/docs/developer/core/server)).
 
-For a custom provider the `id` (`${providerId}/${modelId}`) is required but it will only be used for display purposes. The `modelId` needs to be the actual model you want to use. An example would be: `custom/my-qwen3-model`.
+For custom OpenAI-compatible endpoints, `id` is the shorthand `provider/model` form. It works well when the upstream server expects a bare model name such as `llama3.2`.
+
+If the remote endpoint expects a provider-qualified model name such as `google/gemini-2.5-flash`, use `providerId` and `modelId` instead. `providerId` is used by Mastra for metadata, and `modelId` is sent upstream exactly as provided.
 
 For the `url` it's **important** that you use the base URL of the OpenAI-compatible endpoint with Mastra's `model` setting and not the individual chat endpoints.
 
@@ -316,7 +318,8 @@ const agent = new Agent({
   name: "My Agent",
   instructions: "You are a helpful assistant",
   model: {
-    id: "custom/my-qwen3-model",
+    providerId: "google",
+    modelId: "google/gemini-2.5-flash",
     url: "http://your-custom-openai-compatible-endpoint.com/v1"
   }
 })

--- a/docs/src/content/en/models/index.mdx
+++ b/docs/src/content/en/models/index.mdx
@@ -318,7 +318,23 @@ const agent = new Agent({
   name: "My Agent",
   instructions: "You are a helpful assistant",
   model: {
-    providerId: "google",
+    id: "custom/my-qwen3-model",
+    url: "http://your-custom-openai-compatible-endpoint.com/v1"
+  }
+})
+```
+
+If the remote endpoint expects a provider-qualified model name, pass that exact value in `modelId`:
+
+```typescript title="src/mastra/agents/my-agent.ts"
+import { Agent } from "@mastra/core/agent";
+
+const agent = new Agent({
+  id: "my-agent",
+  name: "My Agent",
+  instructions: "You are a helpful assistant",
+  model: {
+    providerId: "gateway",
     modelId: "google/gemini-2.5-flash",
     url: "http://your-custom-openai-compatible-endpoint.com/v1"
   }

--- a/packages/core/scripts/generate-model-docs.ts
+++ b/packages/core/scripts/generate-model-docs.ts
@@ -878,7 +878,9 @@ Your users never experience the disruption - the response comes back with the sa
 
 Mastra also supports local models like \`gpt-oss\`, \`Qwen3\`, \`DeepSeek\` and many more that you run on your own hardware. The application running your local model needs to provide an OpenAI-compatible API server for Mastra to connect to. We recommend using [LMStudio](https://lmstudio.ai/) (see [Running the LMStudio server](https://lmstudio.ai/docs/developer/core/server)).
 
-For a custom provider the \`id\` (\`$\{providerId\}/$\{modelId\}\`) is required but it will only be used for display purposes. The \`modelId\` needs to be the actual model you want to use. An example would be: \`custom/my-qwen3-model\`.
+For custom OpenAI-compatible endpoints, \`id\` is the shorthand \`provider/model\` form. It works well when the upstream server expects a bare model name such as \`llama3.2\`.
+
+If the remote endpoint expects a provider-qualified model name such as \`google/gemini-2.5-flash\`, use \`providerId\` and \`modelId\` instead. \`providerId\` is used by Mastra for metadata, and \`modelId\` is sent upstream exactly as provided.
 
 For the \`url\` it's **important** that you use the base URL of the OpenAI-compatible endpoint with Mastra's \`model\` setting and not the individual chat endpoints.
 
@@ -890,7 +892,8 @@ const agent = new Agent({
   name: "My Agent",
   instructions: "You are a helpful assistant",
   model: {
-    id: "custom/my-qwen3-model",
+    providerId: "google",
+    modelId: "google/gemini-2.5-flash",
     url: "http://your-custom-openai-compatible-endpoint.com/v1"
   }
 })

--- a/packages/core/scripts/generate-model-docs.ts
+++ b/packages/core/scripts/generate-model-docs.ts
@@ -892,7 +892,23 @@ const agent = new Agent({
   name: "My Agent",
   instructions: "You are a helpful assistant",
   model: {
-    providerId: "google",
+    id: "custom/my-qwen3-model",
+    url: "http://your-custom-openai-compatible-endpoint.com/v1"
+  }
+})
+\`\`\`
+
+If the remote endpoint expects a provider-qualified model name, pass that exact value in \`modelId\`:
+
+\`\`\`typescript title="src/mastra/agents/my-agent.ts"
+import { Agent } from "@mastra/core/agent";
+
+const agent = new Agent({
+  id: "my-agent",
+  name: "My Agent",
+  instructions: "You are a helpful assistant",
+  model: {
+    providerId: "gateway",
     modelId: "google/gemini-2.5-flash",
     url: "http://your-custom-openai-compatible-endpoint.com/v1"
   }


### PR DESCRIPTION
## Summary
- clarify when to use `id` versus `providerId`/`modelId` for custom OpenAI-compatible endpoints
- add an example for provider-qualified upstream model names like `google/gemini-2.5-flash`
- keep the LMStudio shorthand example for local servers that expect bare model names

## Testing
- regenerated model docs with `pnpm --dir packages/core generate:model-router`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how to configure custom OpenAI-compatible model endpoints, explaining when to use a shorthand provider/model id versus separate providerId and modelId fields.
  * Replaced old examples with new, clearer configuration samples including an alternate flow for upstreams that require provider-qualified model names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->