### PR TITLE
docs(models): clarify gateway-style custom endpoint ids

### DIFF
--- a/docs/src/content/en/models/index.mdx
+++ b/docs/src/content/en/models/index.mdx
@@ -304,9 +304,11 @@ Your users never experience the disruption - the response comes back with the sa
 
 Mastra also supports local models like `gpt-oss`, `Qwen3`, `DeepSeek` and many more that you run on your own hardware. The application running your local model needs to provide an OpenAI-compatible API server for Mastra to connect to. We recommend using [LMStudio](https://lmstudio.ai/) (see [Running the LMStudio server](https://lmstudio.ai/docs/developer/core/server)).
 
-For custom OpenAI-compatible endpoints, `id` is the shorthand `provider/model` form. It works well when the upstream server expects a bare model name such as `llama3.2`.
+For custom OpenAI-compatible endpoints, `id` is the routing form that Mastra sends through the model router.
 
-If the remote endpoint expects a provider-qualified model name such as `google/gemini-2.5-flash`, use `providerId` and `modelId` instead. `providerId` is used by Mastra for metadata, and `modelId` is sent upstream exactly as provided.
+Use `provider/model` when the remote behaves like a direct provider and expects a bare model name such as `llama3.2`.
+
+Use `gateway/provider/model` when the remote behaves like a model gateway and the upstream model namespace includes the provider, such as `mastra/google/gemini-2.5-flash` or `openrouter/google/gemini-2.5-flash`.
 
 For the `url` it's **important** that you use the base URL of the OpenAI-compatible endpoint with Mastra's `model` setting and not the individual chat endpoints.
 
@@ -324,8 +326,7 @@ const agent = new Agent({
 })
 ```
 
-If the remote endpoint expects a provider-qualified model name, pass that exact value in `modelId`:
-
+If the remote behaves like a model gateway, include the gateway prefix in `id`:
 ```typescript title="src/mastra/agents/my-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
@@ -334,8 +335,7 @@ const agent = new Agent({
   name: "My Agent",
   instructions: "You are a helpful assistant",
   model: {
-    providerId: "gateway",
-    modelId: "google/gemini-2.5-flash",
+    id: "mastra/google/gemini-2.5-flash",
     url: "http://your-custom-openai-compatible-endpoint.com/v1"
   }
 })

--- a/packages/core/scripts/generate-model-docs.ts
+++ b/packages/core/scripts/generate-model-docs.ts
@@ -878,9 +878,11 @@ Your users never experience the disruption - the response comes back with the sa
 
 Mastra also supports local models like \`gpt-oss\`, \`Qwen3\`, \`DeepSeek\` and many more that you run on your own hardware. The application running your local model needs to provide an OpenAI-compatible API server for Mastra to connect to. We recommend using [LMStudio](https://lmstudio.ai/) (see [Running the LMStudio server](https://lmstudio.ai/docs/developer/core/server)).
 
-For custom OpenAI-compatible endpoints, \`id\` is the shorthand \`provider/model\` form. It works well when the upstream server expects a bare model name such as \`llama3.2\`.
+For custom OpenAI-compatible endpoints, \`id\` is the routing form that Mastra sends through the model router.
 
-If the remote endpoint expects a provider-qualified model name such as \`google/gemini-2.5-flash\`, use \`providerId\` and \`modelId\` instead. \`providerId\` is used by Mastra for metadata, and \`modelId\` is sent upstream exactly as provided.
+Use \`provider/model\` when the remote behaves like a direct provider and expects a bare model name such as \`llama3.2\`.
+
+Use \`gateway/provider/model\` when the remote behaves like a model gateway and the upstream model namespace includes the provider, such as \`mastra/google/gemini-2.5-flash\` or \`openrouter/google/gemini-2.5-flash\`.
 
 For the \`url\` it's **important** that you use the base URL of the OpenAI-compatible endpoint with Mastra's \`model\` setting and not the individual chat endpoints.
 
@@ -898,8 +900,7 @@ const agent = new Agent({
 })
 \`\`\`
 
-If the remote endpoint expects a provider-qualified model name, pass that exact value in \`modelId\`:
-
+If the remote behaves like a model gateway, include the gateway prefix in \`id\`:
 \`\`\`typescript title="src/mastra/agents/my-agent.ts"
 import { Agent } from "@mastra/core/agent";
 
@@ -908,8 +909,7 @@ const agent = new Agent({
   name: "My Agent",
   instructions: "You are a helpful assistant",
   model: {
-    providerId: "gateway",
-    modelId: "google/gemini-2.5-flash",
+    id: "mastra/google/gemini-2.5-flash",
     url: "http://your-custom-openai-compatible-endpoint.com/v1"
   }
 })


### PR DESCRIPTION
## Summary
- clarify that `id` is the routing form used for custom OpenAI-compatible endpoints
- explain the difference between `provider/model` and `gateway/provider/model`
- add a gateway-style example using `mastra/google/gemini-2.5-flash`

## Testing
- regenerated the main models page from `packages/core/scripts/generate-model-docs.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for configuring custom OpenAI-compatible model endpoints
  * Clarified how to format model IDs for direct provider connections versus gateway-based routing
  * Simplified configuration by consolidating provider and model settings into a unified ID format
  * Included updated examples demonstrating the revised endpoint setup specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->