### PR TITLE
fix(core): fix Harness stateSchema typing for Zod schemas with .default(), .optional(), .transform()

### DIFF
--- a/.changeset/ready-dingos-raise.md
+++ b/.changeset/ready-dingos-raise.md
@@ -1,27 +1,5 @@
 ---
-'@mastra/longmemeval': patch
-'@mastra/mcp-docs-server': patch
-'@mastra/express': patch
-'@mastra/fastify': patch
-'create-mastra': patch
-'@mastra/playground-ui': patch
-'@mastra/client-js': patch
-'@mastra/opencode': patch
-'@mastra/datadog': patch
-'@mastra/hono': patch
-'@mastra/koa': patch
-'@mastra/daytona': patch
-'@mastra/react': patch
-'@mastra/deployer': patch
-'@mastra/deployer-vercel': patch
-'@mastra/deployer-cloud': patch
-'@mastra/server': patch
-'@mastra/mongodb': patch
 '@mastra/core': patch
-'@mastra/libsql': patch
-'mastra': patch
-'mastracode': patch
-'@mastra/pg': patch
 ---
 
-Fixed Harness stateSchema typing to accept Zod schemas with .default(), .optional(), and .transform() modifiers. Previously, these modifiers caused TypeScript errors because the type system forced schema Input and Output types to be identical. Now stateSchema correctly accepts any schema regardless of input type divergence.
+Fixed Harness `stateSchema` typing to accept Zod schemas with `.default()`, `.optional()`, and `.transform()` modifiers. Previously, these modifiers caused TypeScript errors because the type system forced schema Input and Output types to be identical. Now `stateSchema` correctly accepts any schema regardless of input type divergence.

--- a/.changeset/ready-dingos-raise.md
+++ b/.changeset/ready-dingos-raise.md
@@ -1,0 +1,27 @@
+---
+'@mastra/longmemeval': patch
+'@mastra/mcp-docs-server': patch
+'@mastra/express': patch
+'@mastra/fastify': patch
+'create-mastra': patch
+'@mastra/playground-ui': patch
+'@mastra/client-js': patch
+'@mastra/opencode': patch
+'@mastra/datadog': patch
+'@mastra/hono': patch
+'@mastra/koa': patch
+'@mastra/daytona': patch
+'@mastra/react': patch
+'@mastra/deployer': patch
+'@mastra/deployer-vercel': patch
+'@mastra/deployer-cloud': patch
+'@mastra/server': patch
+'@mastra/mongodb': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'mastra': patch
+'mastracode': patch
+'@mastra/pg': patch
+---
+
+Fixed Harness stateSchema typing to accept Zod schemas with .default(), .optional(), and .transform() modifiers. Previously, these modifiers caused TypeScript errors because the type system forced schema Input and Output types to be identical. Now stateSchema correctly accepts any schema regardless of input type divergence.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -6,7 +6,7 @@ import type { StorageThreadType } from '../memory/types';
 import type { TracingContext, TracingOptions } from '../observability';
 import { RequestContext } from '../request-context';
 import { toStandardSchema } from '../schema';
-import type { InferPublicSchema, StandardSchemaWithJSON } from '../schema';
+import type { StandardSchemaWithJSON } from '../schema';
 import type { MemoryStorage } from '../storage/domains/memory/base';
 import type { ObservationalMemoryRecord } from '../storage/types';
 import { Workspace } from '../workspace/workspace';
@@ -26,7 +26,6 @@ import type {
   HarnessMode,
   HarnessRequestContext,
   HarnessSession,
-  HarnessStateSchema,
   HarnessThread,
   ModelAuthStatus,
   PermissionPolicy,
@@ -60,12 +59,12 @@ import type {
  * await harness.sendMessage({ content: "Hello!" })
  * ```
  */
-export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema<{}>> {
+export class Harness<TState = {}> {
   readonly id: string;
 
   private config: HarnessConfig<TState>;
   private stateSchema: StandardSchemaWithJSON | undefined;
-  private state: InferPublicSchema<TState>;
+  private state: TState;
   private currentModeId: string;
   private currentThreadId: string | null = null;
   private resourceId: string;
@@ -116,7 +115,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
     this.state = {
       ...this.getSchemaDefaults(),
       ...config.initialState,
-    } as InferPublicSchema<TState>;
+    } as TState;
 
     // Find default mode
     const defaultMode = config.modes.find(m => m.default) ?? config.modes[0];
@@ -135,9 +134,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
     // Seed model from mode default if not set
     const currentModel = (this.state as any).currentModelId;
     if (!currentModel && defaultMode.defaultModelId) {
-      void this.setState({ currentModelId: defaultMode.defaultModelId } as unknown as Partial<
-        InferPublicSchema<TState>
-      >);
+      void this.setState({ currentModelId: defaultMode.defaultModelId } as unknown as Partial<TState>);
     }
   }
 
@@ -246,7 +243,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
   /**
    * Get current harness state (read-only snapshot).
    */
-  getState(): Readonly<InferPublicSchema<TState>> {
+  getState(): Readonly<TState> {
     return { ...this.state };
   }
 
@@ -254,7 +251,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
    * Update harness state. Validates against schema if provided.
    * Emits state_changed event.
    */
-  async setState(updates: Partial<InferPublicSchema<TState>>): Promise<void> {
+  async setState(updates: Partial<TState>): Promise<void> {
     const changedKeys = Object.keys(updates);
     const newState = { ...this.state, ...updates };
 
@@ -264,15 +261,15 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
         const messages = result.issues.map(i => i.message).join('; ');
         throw new Error(`Invalid state update: ${messages}`);
       }
-      this.state = result.value as InferPublicSchema<TState>;
+      this.state = result.value as TState;
     } else {
-      this.state = newState as InferPublicSchema<TState>;
+      this.state = newState as TState;
     }
 
-    this.emit({ type: 'state_changed', state: this.state, changedKeys });
+    this.emit({ type: 'state_changed', state: this.state as Record<string, unknown>, changedKeys });
   }
 
-  private getSchemaDefaults(): Partial<InferPublicSchema<TState>> {
+  private getSchemaDefaults(): Partial<TState> {
     if (!this.stateSchema) return {};
 
     const defaults: Record<string, unknown> = {};
@@ -293,7 +290,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
       // Schema doesn't support JSON Schema extraction — skip defaults
     }
 
-    return defaults as Partial<InferPublicSchema<TState>>;
+    return defaults as Partial<TState>;
   }
 
   // ===========================================================================
@@ -342,7 +339,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
     // Load the incoming mode's model
     const modeModelId = await this.loadModeModelId(modeId);
     if (modeModelId) {
-      void this.setState({ currentModelId: modeModelId } as unknown as Partial<InferPublicSchema<TState>>);
+      void this.setState({ currentModelId: modeModelId } as unknown as Partial<TState>);
       this.emit({ type: 'model_changed', modelId: modeModelId } as HarnessEvent);
     }
 
@@ -415,7 +412,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
     const targetModeId = modeId ?? this.currentModeId;
 
     if (targetModeId === this.currentModeId) {
-      void this.setState({ currentModelId: modelId } as unknown as Partial<InferPublicSchema<TState>>);
+      void this.setState({ currentModelId: modelId } as unknown as Partial<TState>);
     }
 
     if (scope === 'thread') {
@@ -687,7 +684,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
     this.currentThreadId = thread.id;
 
     if (modelId && !currentStateModel) {
-      void this.setState({ currentModelId: modelId } as unknown as Partial<InferPublicSchema<TState>>);
+      void this.setState({ currentModelId: modelId } as unknown as Partial<TState>);
     }
 
     this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
@@ -958,7 +955,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
       }
 
       if (Object.keys(updates).length > 0) {
-        void this.setState(updates as unknown as Partial<InferPublicSchema<TState>>);
+        void this.setState(updates as unknown as Partial<TState>);
       }
     } catch {
       this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
@@ -1146,7 +1143,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
    * Switch the Observer model.
    */
   async switchObserverModel({ modelId }: { modelId: string }): Promise<void> {
-    void this.setState({ observerModelId: modelId } as unknown as Partial<InferPublicSchema<TState>>);
+    void this.setState({ observerModelId: modelId } as unknown as Partial<TState>);
     await this.setThreadSetting({ key: 'observerModelId', value: modelId });
     this.emit({ type: 'om_model_changed', role: 'observer', modelId } as HarnessEvent);
   }
@@ -1155,7 +1152,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
    * Switch the Reflector model.
    */
   async switchReflectorModel({ modelId }: { modelId: string }): Promise<void> {
-    void this.setState({ reflectorModelId: modelId } as unknown as Partial<InferPublicSchema<TState>>);
+    void this.setState({ reflectorModelId: modelId } as unknown as Partial<TState>);
     await this.setThreadSetting({ key: 'reflectorModelId', value: modelId });
     this.emit({ type: 'om_model_changed', role: 'reflector', modelId } as HarnessEvent);
   }
@@ -1176,7 +1173,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
 
   async setSubagentModelId({ modelId, agentType }: { modelId: string; agentType?: string }): Promise<void> {
     const key = agentType ? `subagentModelId_${agentType}` : 'subagentModelId';
-    void this.setState({ [key]: modelId } as unknown as Partial<InferPublicSchema<TState>>);
+    void this.setState({ [key]: modelId } as unknown as Partial<TState>);
     await this.setThreadSetting({ key, value: modelId });
     this.emit({ type: 'subagent_model_changed', modelId, scope: 'thread', agentType } as HarnessEvent);
   }
@@ -1207,13 +1204,13 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
   setPermissionForCategory({ category, policy }: { category: ToolCategory; policy: PermissionPolicy }): void {
     const rules = this.getPermissionRules();
     rules.categories[category] = policy;
-    void this.setState({ permissionRules: rules } as unknown as Partial<InferPublicSchema<TState>>);
+    void this.setState({ permissionRules: rules } as unknown as Partial<TState>);
   }
 
   setPermissionForTool({ toolName, policy }: { toolName: string; policy: PermissionPolicy }): void {
     const rules = this.getPermissionRules();
     rules.tools[toolName] = policy;
-    void this.setState({ permissionRules: rules } as unknown as Partial<InferPublicSchema<TState>>);
+    void this.setState({ permissionRules: rules } as unknown as Partial<TState>);
   }
 
   getPermissionRules(): PermissionRules {
@@ -2831,7 +2828,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
    */
   private async buildRequestContext(requestContext?: RequestContext): Promise<RequestContext> {
     requestContext ??= new RequestContext();
-    const harnessContext: HarnessRequestContext<Readonly<InferPublicSchema<TState>>> = {
+    const harnessContext: HarnessRequestContext<Readonly<TState>> = {
       harnessId: this.id,
       state: this.getState(),
       getState: () => this.getState(),

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -115,14 +115,7 @@ export interface HarnessSubagent {
 }
 
 /**
- * Resolves to the state data type for the Harness generic parameter.
- *
- * @example
- * ```ts
- * // Both forms are equivalent:
- * new Harness<HarnessStateSchema<z.infer<typeof mySchema>>>({...})
- * new Harness<z.infer<typeof mySchema>>({...})
- * ```
+ * State data type for the Harness generic parameter.
  */
 export type HarnessStateSchema<T> = T;
 

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -115,10 +115,16 @@ export interface HarnessSubagent {
 }
 
 /**
- * Schema type for harness state.
- * Accepts any PublicSchema variant: Zod v4, JSON Schema, AI SDK Schema, or Standard Schema.
+ * Resolves to the state data type for the Harness generic parameter.
+ *
+ * @example
+ * ```ts
+ * // Both forms are equivalent:
+ * new Harness<HarnessStateSchema<z.infer<typeof mySchema>>>({...})
+ * new Harness<z.infer<typeof mySchema>>({...})
+ * ```
  */
-export type HarnessStateSchema<T> = PublicSchema<T>;
+export type HarnessStateSchema<T> = T;
 
 /**
  * Configuration for creating a Harness instance.
@@ -137,7 +143,7 @@ export interface HarnessConfig<TState = {}> {
   storage?: MastraCompositeStore;
 
   /** Schema defining the shape of harness state (Zod, JSON Schema, Standard Schema, etc.) */
-  stateSchema?: TState;
+  stateSchema?: PublicSchema<TState, any>;
 
   /** Initial state values (must conform to schema) */
   initialState?: Partial<TState>;


### PR DESCRIPTION
## Description

`HarnessConfig<TState>` used a single generic `TState` for both the schema object type and the state data type. This broke when Zod schemas had `.default()`, `.optional()`, or `.transform()` modifiers because these create Input/Output type divergence, and the old types forced Input = Output.

This was introduced during the Standard Schema migration (`17c4145166`) which replaced `z.infer<TState>` with plain `TState` but didn't account for the changed meaning of `TState`.

The fix makes `TState` consistently represent the output data shape. `stateSchema` now accepts `PublicSchema<TState, any>` — any schema that produces `TState` as output, regardless of input type. `HarnessStateSchema<T>` becomes an identity type so existing user code like `Harness<HarnessStateSchema<z.infer<typeof mySchema>>>` continues to work.

  ## Related Issue(s)

  Fixes #14603

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist

  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript validation for harness state schemas so Zod schemas using .default(), .optional(), or .transform() no longer cause type errors, even when input/output types differ.

* **Chores**
  * Added a changeset to publish a patch release for the core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->