### PR TITLE
fix: improve gemini-2.5-flash reflection compression

### DIFF
--- a/.changeset/tough-ducks-peel.md
+++ b/.changeset/tough-ducks-peel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory reflection compression for `google/gemini-2.5-flash` by using stronger compression guidance and starting it at a higher compression level during reflection. `google/gemini-2.5-flash` is unusually good at generating long, faithful outputs. That made reflection retries more likely to preserve too much detail and miss the compression target, wasting tokens in the process.

--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,3 @@ om-debug.log
 om-reflector-fixture.json
 .notion
 .dev/lima
-/.issue

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ om-debug.log
 om-reflector-fixture.json
 .notion
 .dev/lima
+/.issue

--- a/packages/memory/src/processors/observational-memory/__tests__/compression-start-level.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/compression-start-level.test.ts
@@ -1,0 +1,115 @@
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { RequestContext } from '@mastra/core/di';
+import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
+import { describe, it, expect } from 'vitest';
+
+import { ObservationalMemory } from '../observational-memory';
+
+function createInMemoryStorage(): InMemoryMemory {
+  const db = new InMemoryDB();
+  return new InMemoryMemory({ db });
+}
+
+function createNoopModel(modelId: string) {
+  return new MockLanguageModelV2({
+    modelId,
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      text: '<observations>* noop</observations>',
+      content: [{ type: 'text' as const, text: '<observations>* noop</observations>' }],
+      warnings: [],
+    }),
+  });
+}
+
+describe('getCompressionStartLevel', () => {
+  it('returns level 2 for google/gemini-2.5-flash', async () => {
+    const om = new ObservationalMemory({
+      storage: createInMemoryStorage(),
+      scope: 'thread',
+      observation: {
+        model: createNoopModel('mock-observer'),
+        messageTokens: 1000,
+      },
+      reflection: {
+        model: 'google/gemini-2.5-flash',
+        observationTokens: 40000,
+      },
+    });
+
+    const level = await (om as any).getCompressionStartLevel();
+
+    expect(level).toBe(2);
+  });
+
+  it('returns level 1 for non-gemini-2.5-flash models', async () => {
+    const om = new ObservationalMemory({
+      storage: createInMemoryStorage(),
+      scope: 'thread',
+      observation: {
+        model: createNoopModel('mock-observer'),
+        messageTokens: 1000,
+      },
+      reflection: {
+        model: 'google/gemini-3.1-flash-lite-preview',
+        observationTokens: 40000,
+      },
+    });
+
+    const level = await (om as any).getCompressionStartLevel();
+
+    expect(level).toBe(1);
+  });
+
+  it('uses request-scoped model resolution when choosing the compression start level', async () => {
+    const om = new ObservationalMemory({
+      storage: createInMemoryStorage(),
+      scope: 'thread',
+      observation: {
+        model: createNoopModel('mock-observer'),
+        messageTokens: 1000,
+      },
+      reflection: {
+        model: ({ requestContext }: { requestContext: RequestContext }) => {
+          const selectedModel = requestContext.get('selectedReflectorModel');
+          return selectedModel === 'gemini-2.5-flash'
+            ? 'google/gemini-2.5-flash'
+            : 'google/gemini-3.1-flash-lite-preview';
+        },
+        observationTokens: 40000,
+      },
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('selectedReflectorModel', 'gemini-2.5-flash');
+
+    const level = await (om as any).getCompressionStartLevel(requestContext);
+
+    expect(level).toBe(2);
+  });
+
+  it('returns level 1 when model resolution fails', async () => {
+    const om = new ObservationalMemory({
+      storage: createInMemoryStorage(),
+      scope: 'thread',
+      observation: {
+        model: createNoopModel('mock-observer'),
+        messageTokens: 1000,
+      },
+      reflection: {
+        model: 'google/gemini-2.5-flash',
+        observationTokens: 40000,
+      },
+    });
+
+    (om as any).resolveModelContext = async () => {
+      throw new Error('boom');
+    };
+
+    const level = await (om as any).getCompressionStartLevel();
+
+    expect(level).toBe(1);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -91,6 +91,7 @@ import {
   parseReflectorOutput,
   validateCompression,
 } from './reflector-agent';
+import type { CompressionLevel } from './reflector-agent';
 import { isOmReproCaptureEnabled, safeCaptureJson, writeProcessInputStepReproCapture } from './repro-capture';
 import {
   calculateDynamicThreshold,
@@ -1126,6 +1127,28 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
       provider: resolved.provider,
       modelId: resolved.modelId,
     };
+  }
+
+  /**
+   * Get the default compression start level based on model behavior.
+   * gemini-2.5-flash is a faithful transcriber that needs explicit pressure to compress effectively.
+   */
+  private async getCompressionStartLevel(requestContext?: RequestContext): Promise<CompressionLevel> {
+    try {
+      const resolved = await this.resolveModelContext(this.reflectionConfig.model, requestContext);
+      const modelId = resolved?.modelId ?? '';
+
+      // gemini-2.5-flash is conservative about compression - start at level 2
+      if (modelId === 'gemini-2.5-flash' || modelId.includes('gemini-2.5-flash')) {
+        return 2;
+      }
+
+      // Default for all other models
+      return 1;
+    } catch {
+      // Silently fallback to level 1 on error - not worth disrupting the operation
+      return 1; // safe default
+    }
   }
 
   private getRuntimeModelContext(
@@ -2225,7 +2248,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     observationTokensThreshold?: number,
     abortSignal?: AbortSignal,
     skipContinuationHints?: boolean,
-    compressionStartLevel?: 0 | 1 | 2 | 3,
+    compressionStartLevel?: CompressionLevel,
     requestContext?: RequestContext,
   ): Promise<{
     observations: string;
@@ -2244,8 +2267,8 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
 
     // Attempt reflection with escalating compression levels.
     // Start at the provided level and retry up to level 3 if compression fails.
-    let currentLevel: 0 | 1 | 2 | 3 = compressionStartLevel ?? 0;
-    const maxLevel: 0 | 1 | 2 | 3 = 3;
+    let currentLevel: CompressionLevel = compressionStartLevel ?? 0;
+    const maxLevel: CompressionLevel = 3;
     let parsed: ReturnType<typeof parseReflectorOutput> = { observations: '', suggestedContinuation: undefined };
     let reflectedTokens = 0;
     let attemptNumber = 0;
@@ -2368,7 +2391,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
       }
 
       // Escalate to next compression level
-      currentLevel = Math.min(currentLevel + 1, maxLevel) as 0 | 1 | 2 | 3;
+      currentLevel = Math.min(currentLevel + 1, maxLevel) as CompressionLevel;
     }
 
     return {
@@ -5091,15 +5114,11 @@ ${formattedMessages}
     // Store cycleId so tryActivateBufferedReflection can use it for UI markers
     ObservationalMemory.reflectionBufferCycleIds.set(_bufferKey, cycleId);
 
-    // Slice activeObservations to only the first N lines that fit within the
-    // activation-point token budget. This keeps the reflector prompt small
-    // (avoiding LLM hangs on huge prompts) and matches the portion that will
-    // be replaced at activation time.
     const fullObservations = currentRecord.activeObservations ?? '';
     const allLines = fullObservations.split('\n');
     const totalLines = allLines.length;
 
-    // Calculate how many lines fit within the activation point budget
+    // Approximate tokens per line to pick a slice matching bufferActivation * threshold
     const avgTokensPerLine = totalLines > 0 ? observationTokens / totalLines : 0;
     const activationPointTokens = reflectThreshold * bufferActivation;
     const linesToReflect =
@@ -5108,20 +5127,9 @@ ${formattedMessages}
     const activeObservations = allLines.slice(0, linesToReflect).join('\n');
     const reflectedObservationLineCount = linesToReflect;
     const sliceTokenEstimate = Math.round(avgTokensPerLine * linesToReflect);
-    // Compression target: ask for 75% of the slice size. This is a modest reduction
-    // that LLMs can reliably achieve on dense observation text, unlike the more
-    // aggressive bufferActivation ratio which often fails on already-compressed content.
+    // Compression target: 75% of slice size. This gives breathing room while still making progress.
     const compressionTarget = Math.round(sliceTokenEstimate * 0.75);
 
-    omDebug(
-      `[OM:reflect] doAsyncBufferedReflection: slicing observations for reflection — totalLines=${totalLines}, avgTokPerLine=${avgTokensPerLine.toFixed(1)}, activationPointTokens=${activationPointTokens}, linesToReflect=${linesToReflect}/${totalLines}, sliceTokenEstimate=${sliceTokenEstimate}, compressionTarget=${compressionTarget}`,
-    );
-
-    omDebug(
-      `[OM:reflect] doAsyncBufferedReflection: starting reflector call, recordId=${currentRecord.id}, observationTokens=${sliceTokenEstimate}, compressionTarget=${compressionTarget} (inputTokens), activeObsLength=${activeObservations.length}, reflectedLineCount=${reflectedObservationLineCount}`,
-    );
-
-    // Emit buffering start marker (after slice so we report the actual token count)
     if (writer) {
       const startMarker = createBufferingStartMarker({
         cycleId,
@@ -5136,7 +5144,6 @@ ${formattedMessages}
     }
 
     // Call reflector with compression target.
-    // Start at compression level 1 (standard guidance), retry at level 2 (aggressive).
     const reflectResult = await this.callReflector(
       activeObservations,
       undefined, // No manual prompt
@@ -5144,7 +5151,7 @@ ${formattedMessages}
       compressionTarget,
       undefined, // No abort signal for background ops
       true, // Skip continuation hints for async buffering
-      1, // Start at compression level 1 for buffered reflection
+      await this.getCompressionStartLevel(requestContext),
       requestContext,
     );
 

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -88,6 +88,7 @@ import { registerOp, unregisterOp, isOpActiveInProcess } from './operation-regis
 import {
   buildReflectorSystemPrompt,
   buildReflectorPrompt,
+  MAX_COMPRESSION_LEVEL,
   parseReflectorOutput,
   validateCompression,
 } from './reflector-agent';
@@ -1139,7 +1140,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
       const modelId = resolved?.modelId ?? '';
 
       // gemini-2.5-flash is conservative about compression - start at level 2
-      if (modelId === 'gemini-2.5-flash' || modelId.includes('gemini-2.5-flash')) {
+      if (modelId.includes('gemini-2.5-flash')) {
         return 2;
       }
 
@@ -2266,9 +2267,11 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     let totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
 
     // Attempt reflection with escalating compression levels.
-    // Start at the provided level and retry up to level 3 if compression fails.
-    let currentLevel: CompressionLevel = compressionStartLevel ?? 0;
-    const maxLevel: CompressionLevel = 3;
+    // Start at the provided level and retry upward, but cap retries relative to the start level
+    // and never go past the highest defined compression level.
+    const startLevel: CompressionLevel = compressionStartLevel ?? 0;
+    let currentLevel: CompressionLevel = startLevel;
+    const maxLevel: CompressionLevel = Math.min(MAX_COMPRESSION_LEVEL, startLevel + 3) as CompressionLevel;
     let parsed: ReturnType<typeof parseReflectorOutput> = { observations: '', suggestedContinuation: undefined };
     let reflectedTokens = 0;
     let attemptNumber = 0;
@@ -2361,6 +2364,12 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
         break;
       }
 
+      if (currentLevel >= maxLevel) {
+        break;
+      }
+
+      const nextLevel = (currentLevel + 1) as CompressionLevel;
+
       // Emit failed marker and start marker for next retry
       if (streamContext?.writer) {
         const failedMarker = createObservationFailedMarker({
@@ -2368,7 +2377,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
           operationType: 'reflection',
           startedAt: streamContext.startedAt,
           tokensAttempted: originalTokens,
-          error: `Did not compress below threshold (${originalTokens} → ${reflectedTokens}, target: ${targetThreshold}), retrying at level ${currentLevel + 1}`,
+          error: `Did not compress below threshold (${originalTokens} → ${reflectedTokens}, target: ${targetThreshold}), retrying at level ${nextLevel}`,
           recordId: streamContext.recordId,
           threadId: streamContext.threadId,
         });
@@ -2391,7 +2400,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
       }
 
       // Escalate to next compression level
-      currentLevel = Math.min(currentLevel + 1, maxLevel) as CompressionLevel;
+      currentLevel = nextLevel;
     }
 
     return {

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -5139,6 +5139,10 @@ ${formattedMessages}
     // Compression target: 75% of slice size. This gives breathing room while still making progress.
     const compressionTarget = Math.round(sliceTokenEstimate * 0.75);
 
+    omDebug(
+      `[OM:reflect] doAsyncBufferedReflection: slicing observations for reflection — totalLines=${totalLines}, avgTokPerLine=${avgTokensPerLine.toFixed(1)}, activationPointTokens=${activationPointTokens}, linesToReflect=${linesToReflect}/${totalLines}, sliceTokenEstimate=${sliceTokenEstimate}, compressionTarget=${compressionTarget}`,
+    );
+
     if (writer) {
       const startMarker = createBufferingStartMarker({
         cycleId,
@@ -5151,6 +5155,10 @@ ${formattedMessages}
       });
       void writer.custom(startMarker).catch(() => {});
     }
+
+    omDebug(
+      `[OM:reflect] doAsyncBufferedReflection: starting reflector call, recordId=${currentRecord.id}, observationTokens=${sliceTokenEstimate}, compressionTarget=${compressionTarget} (inputTokens), activeObsLength=${activeObservations.length}, reflectedLineCount=${reflectedObservationLineCount}`,
+    );
 
     // Call reflector with compression target.
     const reflectResult = await this.callReflector(

--- a/packages/memory/src/processors/observational-memory/reflector-agent.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-agent.ts
@@ -134,12 +134,24 @@ User messages are extremely important. If the user asks a question or gives a ne
 export const REFLECTOR_SYSTEM_PROMPT = buildReflectorSystemPrompt();
 
 /**
+ * Valid compression level values (0 = no guidance, 4 = most extreme).
+ */
+export type CompressionLevel = 0 | 1 | 2 | 3 | 4;
+
+/**
+ * The highest available compression level.
+ */
+export const MAX_COMPRESSION_LEVEL: CompressionLevel = 4;
+
+/**
  * Compression guidance by level.
  * - Level 0: No compression guidance (used as first attempt for regular reflection)
- * - Level 1: Gentle compression guidance (original wording — "slightly more" goes a long way for LLMs)
- * - Level 2: Aggressive compression guidance (stronger push when level 1 didn't work)
+ * - Level 1: Gentle compression guidance
+ * - Level 2: Aggressive compression guidance
+ * - Level 3: Critical compression guidance
+ * - Level 4: Extreme compression
  */
-export const COMPRESSION_GUIDANCE: Record<0 | 1 | 2 | 3, string> = {
+export const COMPRESSION_GUIDANCE: Record<CompressionLevel, string> = {
   0: '',
   1: `
 ## COMPRESSION REQUIRED
@@ -151,11 +163,11 @@ Please re-process with slightly more compression:
 - Closer to the end, retain more fine details (recent context matters more)
 - Memory is getting long - use a more condensed style throughout
 - Combine related items more aggressively but do not lose important specific details of names, places, events, and people
+- Combine repeated similar tool calls (e.g. multiple file views, searches, or edits in the same area) into a single summary line describing what was explored/changed and the outcome
 - Preserve ✅ completion markers — they are memory signals that tell the assistant what is already resolved and help prevent repeated work
 - Preserve the concrete resolved outcome captured by ✅ markers so the assistant knows what exactly is done
-- For example if there is a long nested observation list about repeated tool calls, you can combine those into a single line and observe that the tool was called multiple times for x reason, and finally y outcome happened.
 
-Your current detail level was a 10/10, lets aim for a 8/10 detail level.
+Aim for a 8/10 detail level.
 `,
   2: `
 ## AGGRESSIVE COMPRESSION REQUIRED
@@ -167,12 +179,13 @@ Please re-process with much more aggressive compression:
 - Closer to the end, retain fine details (recent context matters more)
 - Memory is getting very long - use a significantly more condensed style throughout
 - Combine related items aggressively but do not lose important specific details of names, places, events, and people
+- Combine repeated similar tool calls (e.g. multiple file views, searches, or edits in the same area) into a single summary line describing what was explored/changed and the outcome
+- If the same file or module is mentioned across many observations, merge into one entry covering the full arc
 - Preserve ✅ completion markers — they are memory signals that tell the assistant what is already resolved and help prevent repeated work
 - Preserve the concrete resolved outcome captured by ✅ markers so the assistant knows what exactly is done
-- For example if there is a long nested observation list about repeated tool calls, you can combine those into a single line and observe that the tool was called multiple times for x reason, and finally y outcome happened.
 - Remove redundant information and merge overlapping observations
 
-Your current detail level was a 10/10, lets aim for a 6/10 detail level.
+Aim for a 6/10 detail level.
 `,
   3: `
 ## CRITICAL COMPRESSION REQUIRED
@@ -183,13 +196,32 @@ Please re-process with maximum compression:
 - Summarize the oldest observations (first 50-70%) into brief high-level paragraphs — only key facts, decisions, and outcomes
 - For the most recent observations (last 30-50%), retain important details but still use a condensed style
 - Ruthlessly merge related observations — if 10 observations are about the same topic, combine into 1-2 lines
+- Combine all tool call sequences (file views, searches, edits, builds) into outcome-only summaries — drop individual steps entirely
 - Drop procedural details (tool calls, retries, intermediate steps) — keep only final outcomes
 - Drop observations that are no longer relevant or have been superseded by newer information
 - Preserve ✅ completion markers — they are memory signals that tell the assistant what is already resolved and help prevent repeated work
 - Preserve the concrete resolved outcome captured by ✅ markers so the assistant knows what exactly is done
 - Preserve: names, dates, decisions, errors, user preferences, and architectural choices
 
-Your current detail level was a 10/10, lets aim for a 4/10 detail level.
+Aim for a 4/10 detail level.
+`,
+  4: `
+## EXTREME COMPRESSION REQUIRED
+
+Multiple compression attempts have failed. The content may already be dense from a prior reflection.
+
+You MUST dramatically reduce the number of observations while keeping the standard observation format (date groups with bullet points and priority emojis):
+- Tool call observations are the biggest source of bloat. Collapse ALL tool call sequences into outcome-only observations — e.g. 10 observations about viewing/searching/editing files become 1 observation about what was actually learned or achieved (e.g. "Investigated auth module and found token validation was skipping expiry check")
+- Never preserve individual tool calls (viewed file X, searched for Y, ran build) — only preserve what was discovered or accomplished
+- Consolidate many related observations into single, more generic observations
+- Merge all same-day date groups into at most 2-3 date groups per day
+- For older content, each topic or task should be at most 1-2 observations capturing the key outcome
+- For recent content, retain more detail but still merge related items aggressively
+- If multiple observations describe incremental progress on the same task, keep only the final state
+- Preserve ✅ completion markers and their outcomes but merge related completions into fewer lines
+- Preserve: user preferences, key decisions, architectural choices, and unresolved issues
+
+Aim for a 2/10 detail level. Fewer, more generic observations are better than many specific ones that exceed the budget.
 `,
 };
 
@@ -204,11 +236,11 @@ export const COMPRESSION_RETRY_PROMPT = COMPRESSION_GUIDANCE[1];
 export function buildReflectorPrompt(
   observations: string,
   manualPrompt?: string,
-  compressionLevel?: boolean | 0 | 1 | 2 | 3,
+  compressionLevel?: boolean | CompressionLevel,
   skipContinuationHints?: boolean,
 ): string {
   // Normalize: boolean `true` maps to level 1 for backwards compat
-  const level: 0 | 1 | 2 | 3 = typeof compressionLevel === 'number' ? compressionLevel : compressionLevel ? 1 : 0;
+  const level: CompressionLevel = typeof compressionLevel === 'number' ? compressionLevel : compressionLevel ? 1 : 0;
   const reflectionView = renderObservationGroupsForReflection(observations) ?? observations;
   const anchoredObservations = injectAnchorIds(reflectionView);
 


### PR DESCRIPTION
This fixes buffered reflection compression for `google/gemini-2.5-flash` in observational memory.

Before, `google/gemini-2.5-flash` could preserve too much detail and miss the compression target during retries.

After, it starts with stronger compression guidance, carries request-scoped model resolution through that selection, and stops retrying at the highest supported compression level.

```ts
// before
google/gemini-2.5-flash -> start at level 1
retry cap -> could drift from the defined guidance levels
```

```ts
// after
google/gemini-2.5-flash -> start at level 2
retry cap -> stays aligned with the supported levels
```

Fixes https://github.com/mastra-ai/mastra/issues/14110 (will also fix in a better way soon! with reflector editing via tool calls)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observational memory compression for Gemini 2.5 Flash with enhanced guidance and optimized compression targeting to reduce token waste and retry overhead.

* **Tests**
  * Added comprehensive test coverage for compression level selection across different AI models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->