### PR TITLE
fix(core): reconcile client-side tool results to prevent duplicate assistant messages in memory

### DIFF
--- a/.changeset/chatty-eggs-tap.md
+++ b/.changeset/chatty-eggs-tap.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed duplicate assistant messages when client-side tools send results back from the browser. The MessageHistory processor now matches input and DB messages by toolCallId instead of message ID, updates the DB tool state from 'call' to 'result', and removes the duplicate. This prevents exponential token growth across round-trips. (Fixes #14602)
+Fixed an issue where browser/client-side tool results created duplicate assistant messages in memory on every round-trip, causing prompt size to grow exponentially (20K → 54K → 118K → 147K tokens). Assistant messages now remain deduplicated and tool results are correctly persisted, so prompt size stays stable across round-trips. (Fixes #14602)

--- a/.changeset/chatty-eggs-tap.md
+++ b/.changeset/chatty-eggs-tap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed duplicate assistant messages when client-side tools send results back from the browser. The MessageHistory processor now matches input and DB messages by toolCallId instead of message ID, updates the DB tool state from 'call' to 'result', and removes the duplicate. This prevents exponential token growth across round-trips. (Fixes #14602)

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -78,6 +78,15 @@ class MockStorage extends MemoryStorage {
   }
   async deleteThread(_args: { threadId: string }) {}
   async saveMessages(args: { messages: MastraDBMessage[] }) {
+    // Upsert: update existing messages by ID, append new ones
+    for (const msg of args.messages) {
+      const idx = this.messages.findIndex(m => m.id === msg.id);
+      if (idx !== -1) {
+        this.messages[idx] = msg;
+      } else {
+        this.messages.push(msg);
+      }
+    }
     return { messages: args.messages };
   }
   async updateMessages(args: any) {
@@ -741,6 +750,79 @@ describe('MessageHistory', () => {
       // call-2 still in 'call' state
       expect(parts[1].toolInvocation.state).toBe('call');
       expect(parts[1].toolInvocation.result).toBeUndefined();
+    });
+
+    it('should persist updated state so subsequent reads return result', async () => {
+      const toolCallId = 'call-1';
+
+      const dbMessage: MastraDBMessage = {
+        id: 'server-111',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: { state: 'call', toolCallId, toolName: 'renderGame', args: { x: 1 } },
+            },
+          ],
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(Date.now() - 5000),
+      };
+
+      mockStorage.setMessages([dbMessage]);
+      processor = new MessageHistory({ storage: mockStorage });
+
+      const browserMessage: MastraDBMessage = {
+        id: 'browser-222',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId,
+                toolName: 'renderGame',
+                args: { x: 1 },
+                result: { ok: true },
+              },
+            },
+          ],
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(Date.now() - 4000),
+      };
+
+      // First call: reconciles and persists
+      const messageList1 = new MessageList();
+      messageList1.add(browserMessage, 'input');
+      await processor.processInput({
+        messages: [browserMessage],
+        messageList: messageList1,
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      // Second call: fresh messageList, no input — reads only from storage
+      const messageList2 = new MessageList();
+      const result2 = await processor.processInput({
+        messages: [],
+        messageList: messageList2,
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const allMessages = result2 instanceof MessageList ? result2.get.all.db() : result2;
+      const assistantMessages = allMessages.filter(m => m.role === 'assistant');
+
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0].id).toBe('server-111');
+      const toolPart = assistantMessages[0].content.parts?.[0] as any;
+      expect(toolPart.toolInvocation.state).toBe('result');
+      expect(toolPart.toolInvocation.result).toEqual({ ok: true });
     });
   });
 

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -458,6 +458,292 @@ describe('MessageHistory', () => {
     });
   });
 
+  describe('reconcileClientToolResults', () => {
+    it('should deduplicate when browser and DB have different IDs for same tool call', async () => {
+      const toolCallId = 'call-1';
+
+      // DB has assistant message with tool in 'call' state (saved during initial stream)
+      const dbMessage: MastraDBMessage = {
+        id: 'server-111',
+        role: 'assistant',
+        content: {
+          format: 2,
+          content: 'Let me create that.',
+          parts: [
+            { type: 'text', text: 'Let me create that.' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'call',
+                toolCallId,
+                toolName: 'renderGame',
+                args: { type: 'platformer' },
+              },
+            },
+          ],
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(Date.now() - 5000),
+      };
+
+      const userMessage: MastraDBMessage = {
+        id: 'user-1',
+        role: 'user',
+        content: { format: 2, content: 'create a game', parts: [{ type: 'text', text: 'create a game' }] },
+        threadId: 'thread-1',
+        createdAt: new Date(Date.now() - 10000),
+      };
+
+      mockStorage.setMessages([userMessage, dbMessage]);
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      processor = new MessageHistory({ storage: mockStorage });
+
+      // Browser sends back assistant message with tool result — different ID
+      const browserMessage: MastraDBMessage = {
+        id: 'browser-222',
+        role: 'assistant',
+        content: {
+          format: 2,
+          content: 'Let me create that.',
+          parts: [
+            { type: 'text', text: 'Let me create that.' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId,
+                toolName: 'renderGame',
+                args: { type: 'platformer' },
+                result: { success: true, gameId: 42 },
+              },
+            },
+          ],
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(Date.now() - 4000),
+      };
+
+      const messageList = new MessageList();
+      messageList.add(browserMessage, 'input');
+
+      const result = await processor.processInput({
+        messages: [browserMessage],
+        messageList,
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const allMessages = result instanceof MessageList ? result.get.all.db() : result;
+      const assistantMessages = allMessages.filter(m => m.role === 'assistant');
+
+      // Only one assistant message (DB copy, now updated), not two
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0].id).toBe('server-111');
+
+      // Tool state updated from 'call' to 'result'
+      const toolPart = assistantMessages[0].content.parts?.find((p: any) => p.type === 'tool-invocation') as any;
+      expect(toolPart.toolInvocation.state).toBe('result');
+      expect(toolPart.toolInvocation.result).toEqual({ success: true, gameId: 42 });
+      expect(toolPart.toolInvocation.args).toEqual({ type: 'platformer' });
+
+      // DB was updated via saveMessages
+      expect(saveSpy).toHaveBeenCalledWith({
+        messages: expect.arrayContaining([expect.objectContaining({ id: 'server-111' })]),
+      });
+    });
+
+    it('should handle multiple tool calls in one assistant message', async () => {
+      const dbMessage: MastraDBMessage = {
+        id: 'server-111',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: { state: 'call', toolCallId: 'call-1', toolName: 'toolA', args: { a: 1 } },
+            },
+            {
+              type: 'tool-invocation',
+              toolInvocation: { state: 'call', toolCallId: 'call-2', toolName: 'toolB', args: { b: 2 } },
+            },
+          ],
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(Date.now() - 5000),
+      };
+
+      mockStorage.setMessages([dbMessage]);
+      processor = new MessageHistory({ storage: mockStorage });
+
+      const browserMessage: MastraDBMessage = {
+        id: 'browser-222',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-1',
+                toolName: 'toolA',
+                args: { a: 1 },
+                result: 'resultA',
+              },
+            },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-2',
+                toolName: 'toolB',
+                args: { b: 2 },
+                result: 'resultB',
+              },
+            },
+          ],
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(Date.now() - 4000),
+      };
+
+      const messageList = new MessageList();
+      messageList.add(browserMessage, 'input');
+
+      const result = await processor.processInput({
+        messages: [browserMessage],
+        messageList,
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const allMessages = result instanceof MessageList ? result.get.all.db() : result;
+      const assistantMessages = allMessages.filter(m => m.role === 'assistant');
+
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0].id).toBe('server-111');
+
+      const parts = assistantMessages[0].content.parts as any[];
+      expect(parts[0].toolInvocation.state).toBe('result');
+      expect(parts[0].toolInvocation.result).toBe('resultA');
+      expect(parts[0].toolInvocation.args).toEqual({ a: 1 });
+      expect(parts[1].toolInvocation.state).toBe('result');
+      expect(parts[1].toolInvocation.result).toBe('resultB');
+      expect(parts[1].toolInvocation.args).toEqual({ b: 2 });
+    });
+
+    it('should not modify messages when no client-side tool results are present', async () => {
+      const dbMessage: MastraDBMessage = {
+        id: 'msg-1',
+        role: 'assistant',
+        content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+        threadId: 'thread-1',
+        createdAt: new Date(Date.now() - 5000),
+      };
+
+      mockStorage.setMessages([dbMessage]);
+      const saveSpy = vi.spyOn(mockStorage, 'saveMessages');
+
+      processor = new MessageHistory({ storage: mockStorage });
+
+      const userMsg: MastraDBMessage = {
+        id: 'msg-2',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Hi' }] },
+        threadId: 'thread-1',
+        createdAt: new Date(),
+      };
+
+      const messageList = new MessageList();
+      messageList.add(userMsg, 'input');
+
+      const result = await processor.processInput({
+        messages: [userMsg],
+        messageList,
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const allMessages = result instanceof MessageList ? result.get.all.db() : result;
+      expect(allMessages).toHaveLength(2);
+
+      // saveMessages should not have been called by reconciliation
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
+    it('should only update matching tool calls and leave others unchanged', async () => {
+      const dbMessage: MastraDBMessage = {
+        id: 'server-111',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: { state: 'call', toolCallId: 'call-1', toolName: 'toolA', args: { a: 1 } },
+            },
+            {
+              type: 'tool-invocation',
+              toolInvocation: { state: 'call', toolCallId: 'call-2', toolName: 'toolB', args: { b: 2 } },
+            },
+          ],
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(Date.now() - 5000),
+      };
+
+      mockStorage.setMessages([dbMessage]);
+      processor = new MessageHistory({ storage: mockStorage });
+
+      // Browser only has result for call-1, not call-2
+      const browserMessage: MastraDBMessage = {
+        id: 'browser-222',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-1',
+                toolName: 'toolA',
+                args: { a: 1 },
+                result: 'resultA',
+              },
+            },
+          ],
+        },
+        threadId: 'thread-1',
+        createdAt: new Date(Date.now() - 4000),
+      };
+
+      const messageList = new MessageList();
+      messageList.add(browserMessage, 'input');
+
+      const result = await processor.processInput({
+        messages: [browserMessage],
+        messageList,
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const allMessages = result instanceof MessageList ? result.get.all.db() : result;
+      const assistantMessages = allMessages.filter(m => m.role === 'assistant');
+
+      expect(assistantMessages).toHaveLength(1);
+      const parts = assistantMessages[0].content.parts as any[];
+      // call-1 updated to 'result'
+      expect(parts[0].toolInvocation.state).toBe('result');
+      expect(parts[0].toolInvocation.result).toBe('resultA');
+      // call-2 still in 'call' state
+      expect(parts[1].toolInvocation.state).toBe('call');
+      expect(parts[1].toolInvocation.result).toBeUndefined();
+    });
+  });
+
   describe('processOutputResult', () => {
     it('should save user, assistant, and tool messages', async () => {
       const mockStorage = {

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -89,9 +89,22 @@ export class MessageHistory implements Processor {
 
     if (toolResultsByCallId.size === 0) return;
 
+    // Count total tool-invocation result parts per input message for completeness tracking.
+    // An input message is only removed if ALL its tool results were matched to DB calls.
+    const totalToolPartsPerMsg = new Map<string, number>();
+    for (const msg of inputMessages) {
+      if (msg.role !== 'assistant' || !msg.content?.parts) continue;
+      const count = msg.content.parts.filter(
+        p => p.type === 'tool-invocation' && p.toolInvocation?.state === 'result',
+      ).length;
+      if (count > 0) {
+        totalToolPartsPerMsg.set(msg.id, count);
+      }
+    }
+
     // Match DB messages with pending 'call' state to input results by toolCallId
     const updatedDbMessages: MastraDBMessage[] = [];
-    const inputMsgIdsToRemove = new Set<string>();
+    const matchedCountPerMsg = new Map<string, number>();
 
     for (const dbMsg of dbMessages) {
       if (dbMsg.role !== 'assistant' || !dbMsg.content?.parts) continue;
@@ -114,7 +127,7 @@ export class MessageHistory implements Processor {
           },
         } as MastraMessagePart;
 
-        inputMsgIdsToRemove.add(match.inputMsgId);
+        matchedCountPerMsg.set(match.inputMsgId, (matchedCountPerMsg.get(match.inputMsgId) ?? 0) + 1);
         dbMsgUpdated = true;
       }
 
@@ -128,9 +141,19 @@ export class MessageHistory implements Processor {
     // Persist updated DB messages (storage uses upsert — ON CONFLICT DO UPDATE)
     await this.storage.saveMessages({ messages: updatedDbMessages });
 
-    // Remove the browser's duplicate assistant messages from the messageList
-    // so only the updated DB copy (added later as 'memory' source) remains
-    messageList.removeByIds([...inputMsgIdsToRemove]);
+    // Only remove an input message if ALL its tool-invocation parts were matched.
+    // If some parts had no DB match, keep the input message to avoid losing results.
+    const inputMsgIdsToRemove: string[] = [];
+    for (const [msgId, matched] of matchedCountPerMsg) {
+      const total = totalToolPartsPerMsg.get(msgId) ?? 0;
+      if (matched === total) {
+        inputMsgIdsToRemove.push(msgId);
+      }
+    }
+
+    if (inputMsgIdsToRemove.length > 0) {
+      messageList.removeByIds(inputMsgIdsToRemove);
+    }
   }
 
   async processInput(

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -72,10 +72,13 @@ export class MessageHistory implements Processor {
   private async reconcileClientToolResults(messageList: MessageList, dbMessages: MastraDBMessage[]): Promise<void> {
     const inputMessages = messageList.get.all.db();
 
-    // Collect completed tool results from input assistant messages
+    // Collect completed tool results from input assistant messages and count
+    // total result parts per message (for completeness tracking on removal).
     const toolResultsByCallId = new Map<string, { inputMsgId: string; part: MastraMessagePart }>();
+    const totalToolPartsPerMsg = new Map<string, number>();
     for (const msg of inputMessages) {
       if (msg.role !== 'assistant' || !msg.content?.parts) continue;
+      let resultCount = 0;
       for (const part of msg.content.parts) {
         if (
           part.type === 'tool-invocation' &&
@@ -83,24 +86,15 @@ export class MessageHistory implements Processor {
           part.toolInvocation?.toolCallId
         ) {
           toolResultsByCallId.set(part.toolInvocation.toolCallId, { inputMsgId: msg.id, part });
+          resultCount++;
         }
+      }
+      if (resultCount > 0) {
+        totalToolPartsPerMsg.set(msg.id, resultCount);
       }
     }
 
     if (toolResultsByCallId.size === 0) return;
-
-    // Count total tool-invocation result parts per input message for completeness tracking.
-    // An input message is only removed if ALL its tool results were matched to DB calls.
-    const totalToolPartsPerMsg = new Map<string, number>();
-    for (const msg of inputMessages) {
-      if (msg.role !== 'assistant' || !msg.content?.parts) continue;
-      const count = msg.content.parts.filter(
-        p => p.type === 'tool-invocation' && p.toolInvocation?.state === 'result',
-      ).length;
-      if (count > 0) {
-        totalToolPartsPerMsg.set(msg.id, count);
-      }
-    }
 
     // Match DB messages with pending 'call' state to input results by toolCallId
     const updatedDbMessages: MastraDBMessage[] = [];

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -1,5 +1,5 @@
 import type { Processor } from '..';
-import type { MastraDBMessage, MessageList } from '../../agent';
+import type { MastraDBMessage, MastraMessagePart, MessageList } from '../../agent';
 import { parseMemoryRequestContext } from '../../memory';
 import { removeWorkingMemoryTags } from '../../memory/working-memory-utils';
 import type { ObservabilityContext } from '../../observability';
@@ -61,6 +61,78 @@ export class MessageHistory implements Processor {
     return null;
   }
 
+  /**
+   * Reconcile client-side tool results with DB messages.
+   *
+   * When a client-side tool (no execute function) sends results back from the browser,
+   * the input assistant message may have a different ID than the DB copy. This method
+   * matches them by toolCallId, updates the DB message state from 'call' to 'result',
+   * persists the update, and removes the browser's duplicate from the messageList.
+   */
+  private async reconcileClientToolResults(messageList: MessageList, dbMessages: MastraDBMessage[]): Promise<void> {
+    const inputMessages = messageList.get.all.db();
+
+    // Collect completed tool results from input assistant messages
+    const toolResultsByCallId = new Map<string, { inputMsgId: string; part: MastraMessagePart }>();
+    for (const msg of inputMessages) {
+      if (msg.role !== 'assistant' || !msg.content?.parts) continue;
+      for (const part of msg.content.parts) {
+        if (
+          part.type === 'tool-invocation' &&
+          part.toolInvocation?.state === 'result' &&
+          part.toolInvocation?.toolCallId
+        ) {
+          toolResultsByCallId.set(part.toolInvocation.toolCallId, { inputMsgId: msg.id, part });
+        }
+      }
+    }
+
+    if (toolResultsByCallId.size === 0) return;
+
+    // Match DB messages with pending 'call' state to input results by toolCallId
+    const updatedDbMessages: MastraDBMessage[] = [];
+    const inputMsgIdsToRemove = new Set<string>();
+
+    for (const dbMsg of dbMessages) {
+      if (dbMsg.role !== 'assistant' || !dbMsg.content?.parts) continue;
+      let dbMsgUpdated = false;
+
+      for (let i = 0; i < dbMsg.content.parts.length; i++) {
+        const dbPart = dbMsg.content.parts[i]!;
+        if (dbPart.type !== 'tool-invocation' || dbPart.toolInvocation?.state !== 'call') continue;
+
+        const match = toolResultsByCallId.get(dbPart.toolInvocation.toolCallId);
+        if (!match) continue;
+
+        // Update DB message part in-place: call → result, preserving original args
+        const matchInvocation = (match.part as Extract<MastraMessagePart, { type: 'tool-invocation' }>).toolInvocation;
+        dbMsg.content.parts[i] = {
+          ...match.part,
+          toolInvocation: {
+            ...matchInvocation,
+            args: dbPart.toolInvocation.args,
+          },
+        } as MastraMessagePart;
+
+        inputMsgIdsToRemove.add(match.inputMsgId);
+        dbMsgUpdated = true;
+      }
+
+      if (dbMsgUpdated) {
+        updatedDbMessages.push(dbMsg);
+      }
+    }
+
+    if (updatedDbMessages.length === 0) return;
+
+    // Persist updated DB messages (storage uses upsert — ON CONFLICT DO UPDATE)
+    await this.storage.saveMessages({ messages: updatedDbMessages });
+
+    // Remove the browser's duplicate assistant messages from the messageList
+    // so only the updated DB copy (added later as 'memory' source) remains
+    messageList.removeByIds([...inputMsgIdsToRemove]);
+  }
+
   async processInput(
     args: {
       messages: MastraDBMessage[];
@@ -94,7 +166,12 @@ export class MessageHistory implements Processor {
       return msg.role !== 'system';
     });
 
-    // 3. Merge with incoming messages and messages already in MessageList (avoiding duplicates by ID)
+    // 3. Reconcile client-side tool results: when the browser sends back an assistant
+    // message with completed tool results, match them to DB messages by toolCallId,
+    // update DB state from 'call' to 'result', and remove the browser duplicate.
+    await this.reconcileClientToolResults(messageList, filteredMessages);
+
+    // 4. Merge with incoming messages and messages already in MessageList (avoiding duplicates by ID)
     // This includes messages added by previous processors like SemanticRecall
     const existingMessages = messageList.get.all.db();
     const messageIds = new Set(existingMessages.map((m: MastraDBMessage) => m.id).filter(Boolean));
@@ -127,7 +204,8 @@ export class MessageHistory implements Processor {
    *
    * Note: We preserve 'call' state tool invocations because:
    * - For server-side tools, 'call' should have been converted to 'result' by the time OUTPUT is processed
-   * - For client-side tools (no execute function), 'call' is the final state from the server's perspective
+   * - For client-side tools (no execute function), 'call' is the initial state from the server's perspective.
+   *   When the browser sends back tool results, reconcileClientToolResults() updates these to 'result'.
    */
   private filterMessagesForPersistence(messages: MastraDBMessage[]): MastraDBMessage[] {
     return messages


### PR DESCRIPTION
## Description

When using `agent.stream()` with memory and client-side tools (tools without an `execute` function), each browser round-trip creates a duplicate assistant message in the database. The browser's copy has a different message ID than the server's DB copy, so `messagesAreEqual()` returns false and both survive in the prompt. This causes exponential token growth (20K → 54K → 118K → 147K) and the LLM repeating actions.

Additionally, tool results from client-side tools were never persisted to the database —
the DB always stored `state: "call"`, never `state: "result"`.

This PR adds `reconcileClientToolResults()` to `MessageHistory.processInput()` which:

1. Scans input messages for assistant messages with completed tool results (`state: "result"`)
2. Matches them to DB messages by `toolCallId` (not message ID)
3. Updates the DB message tool state from `"call"` to `"result"` with the output, preserving original args
4. Persists the update via `storage.saveMessages()` (upsert)
5. Removes the browser's duplicate assistant message from the messageList

After reconciliation, only the updated DB copy remains and is added as `source: "memory"` —  no duplicate.

### Files changed

- `packages/core/src/processors/memory/message-history.ts` — added `reconcileClientToolResults()`, called in `processInput()` between fetching DB messages and ID-based dedup
- `packages/core/src/processors/memory/message-history.test.ts` — added 4 test cases covering: different IDs same toolCallId, multiple tool calls, no-op path, partial match

## Related Issue(s)

Fixes #14602

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate assistant messages when browser-side tool results are returned; reconciles and persists tool results so messages no longer grow across round-trips.

* **Tests**
  * Added tests validating client/DB reconciliation of tool-invocation results, deduplication logic, multi-part updates, non-matching behavior, and persistence across subsequent reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->