### PR TITLE
fix(schema-compat): remove createRequire usage

### DIFF
--- a/.changeset/rare-bats-pick.md
+++ b/.changeset/rare-bats-pick.md
@@ -1,0 +1,7 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed schema-compat ESM imports for Zod JSON Schema helpers.
+
+@mastra/schema-compat no longer uses createRequire in its Zod v4 adapter or runtime eval tests, which avoids createRequire-related ESM issues while preserving support for zod/v3 and zod/v4.

--- a/packages/schema-compat/src/json-to-zod.test.ts
+++ b/packages/schema-compat/src/json-to-zod.test.ts
@@ -1,5 +1,5 @@
-import { createRequire } from 'node:module';
 import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
 import type { JsonSchema } from './json-to-zod';
 import { jsonSchemaToZod } from './json-to-zod';
 
@@ -1089,8 +1089,6 @@ describe('jsonSchemaToZod', () => {
       const result = jsonSchemaToZod(schema);
 
       // Should be valid JavaScript that can be evaluated with Function()
-      const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
-      const { z } = __require('zod');
       expect(() => {
         Function('z', `"use strict";return (${result});`)(z);
       }).not.toThrow();
@@ -1105,8 +1103,6 @@ describe('jsonSchemaToZod', () => {
       };
 
       const result = jsonSchemaToZod(schema);
-      const __require = typeof require === 'function' ? require : createRequire(import.meta.url);
-      const { z } = __require('zod');
       const zodSchema = Function('z', `"use strict";return (${result});`)(z);
 
       // Valid data (strings only - matches exactly one schema)

--- a/packages/schema-compat/src/standard-schema/adapters/zod-v4.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/zod-v4.ts
@@ -1,5 +1,5 @@
-import { createRequire } from 'node:module';
 import type { StandardSchemaV1, StandardJSONSchemaV1 } from '@standard-schema/spec';
+import { toJSONSchema } from 'zod/v4';
 import type { StandardSchemaWithJSON, StandardSchemaWithJSONProps } from '../standard-schema.types';
 
 /**
@@ -38,11 +38,6 @@ function convertToJsonSchema(
   options: StandardJSONSchemaV1.Options,
   adapterOptions: ZodV4AdapterOptions,
 ): Record<string, unknown> {
-  const toJSONSchema = getToJSONSchema();
-  if (!toJSONSchema) {
-    throw new Error('z.toJSONSchema is not available. Ensure zod >= 3.25.0 is installed.');
-  }
-
   const target = SUPPORTED_TARGETS.has(options.target) ? options.target : 'draft-07';
 
   const jsonSchemaOptions: Record<string, unknown> = {
@@ -58,67 +53,7 @@ function convertToJsonSchema(
     jsonSchemaOptions.override = adapterOptions.override;
   }
 
-  return toJSONSchema(zodSchema, jsonSchemaOptions) as Record<string, unknown>;
-}
-
-/**
- * Cached reference to z.toJSONSchema.
- */
-let _toJSONSchema: ((schema: unknown, options?: unknown) => unknown) | null = null;
-let _toJSONSchemaResolved = false;
-
-let __require: ReturnType<typeof createRequire>;
-
-function getRequire(): ReturnType<typeof createRequire> {
-  if (!__require) {
-    __require = createRequire(import.meta.url);
-  }
-  return __require;
-}
-function pickToJSONSchema(mod: unknown): ((schema: unknown, options?: unknown) => unknown) | null {
-  const candidate = mod as {
-    toJSONSchema?: unknown;
-    z?: { toJSONSchema?: unknown };
-    default?: { toJSONSchema?: unknown; z?: { toJSONSchema?: unknown } };
-  };
-
-  const picks = [
-    candidate?.toJSONSchema,
-    candidate?.z?.toJSONSchema,
-    candidate?.default?.toJSONSchema,
-    candidate?.default?.z?.toJSONSchema,
-  ];
-
-  const toJSONSchema = picks.find(fn => typeof fn === 'function');
-  return (toJSONSchema as ((schema: unknown, options?: unknown) => unknown) | undefined) ?? null;
-}
-
-function resolveToJSONSchema(
-  loadModule: (moduleName: 'zod/v4' | 'zod') => unknown,
-): ((schema: unknown, options?: unknown) => unknown) | null {
-  for (const moduleName of ['zod/v4', 'zod'] as const) {
-    try {
-      const zodModule = loadModule(moduleName);
-      const toJSONSchema = pickToJSONSchema(zodModule);
-      if (toJSONSchema) {
-        return toJSONSchema;
-      }
-    } catch {
-      // Try next module path.
-    }
-  }
-
-  return null;
-}
-
-function getToJSONSchema(): ((schema: unknown, options?: unknown) => unknown) | null {
-  if (_toJSONSchemaResolved) {
-    return _toJSONSchema;
-  }
-
-  _toJSONSchema = resolveToJSONSchema(moduleName => getRequire()(moduleName));
-  _toJSONSchemaResolved = true;
-  return _toJSONSchema;
+  return toJSONSchema(zodSchema as Parameters<typeof toJSONSchema>[0], jsonSchemaOptions) as Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove `createRequire` from `@mastra/schema-compat` Zod v4 adapter
- replace runtime `createRequire` usage in json-to-zod tests with static Zod imports
- add a patch changeset for `@mastra/schema-compat`

## Test plan
- pnpm test --dir packages/schema-compat
- pnpm build --dir packages/schema-compat
- pnpm exec tsc --noEmit -p packages/schema-compat/tsconfig.json

Fixes https://github.com/mastra-ai/mastra/issues/14440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ESM import compatibility issues in the schema-compat package for Zod JSON Schema utilities.
  * Maintained support for both Zod v3 and v4 versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->