### PR TITLE
Metrics Dashboard availability check

### DIFF
--- a/.changeset/strict-regions-return.md
+++ b/.changeset/strict-regions-return.md
@@ -4,4 +4,25 @@
 '@mastra/server': patch
 ---
 
-Added storage type detection to the Metrics Dashboard. The dashboard now shows an empty state when the observability storage does not support metrics (e.g. PostgreSQL, LibSQL), and displays a warning when using in-memory storage since metrics are not persisted across server restarts. Also added a docs link button to the Metrics page header.
+Added storage type detection to the Metrics Dashboard. The `/system/packages` endpoint now returns `observabilityStorageType`, identifying the observability storage backend. The dashboard shows an empty state when the storage does not support metrics (e.g. PostgreSQL, LibSQL), and displays a warning when using in-memory storage since metrics are not persisted across server restarts. Also added a docs link button to the Metrics page header.
+
+```ts
+import { MastraClient } from '@mastra/client-js';
+
+const client = new MastraClient();
+const system = await client.getSystemPackages();
+
+// system.observabilityStorageType contains the class name of the observability store:
+// - 'ObservabilityStorageClickhouse' → full metrics support
+// - 'ObservabilityInMemory'          → metrics work but are not persisted across restarts
+// - 'ObservabilityPG', 'ObservabilityLibSQL', etc. → metrics not supported
+
+if (system.observabilityStorageType === 'ObservabilityInMemory') {
+  console.warn('Metrics are not persisted — data will be lost on server restart.');
+}
+
+const SUPPORTED = new Set(['ObservabilityStorageClickhouse', 'ObservabilityInMemory']);
+if (!SUPPORTED.has(system.observabilityStorageType ?? '')) {
+  console.error('Metrics require ClickHouse, DuckDB, or in-memory observability storage.');
+}
+```

--- a/.changeset/strict-regions-return.md
+++ b/.changeset/strict-regions-return.md
@@ -13,16 +13,15 @@ const client = new MastraClient();
 const system = await client.getSystemPackages();
 
 // system.observabilityStorageType contains the class name of the observability store:
-// - 'ObservabilityStorageClickhouse' → full metrics support
-// - 'ObservabilityInMemory'          → metrics work but are not persisted across restarts
+// - 'ObservabilityInMemory' → metrics work but are not persisted across restarts
 // - 'ObservabilityPG', 'ObservabilityLibSQL', etc. → metrics not supported
 
 if (system.observabilityStorageType === 'ObservabilityInMemory') {
   console.warn('Metrics are not persisted — data will be lost on server restart.');
 }
 
-const SUPPORTED = new Set(['ObservabilityStorageClickhouse', 'ObservabilityInMemory']);
+const SUPPORTED = new Set(['ObservabilityInMemory']);
 if (!SUPPORTED.has(system.observabilityStorageType ?? '')) {
-  console.error('Metrics require ClickHouse, DuckDB, or in-memory observability storage.');
+  console.error('Metrics require in-memory observability storage.');
 }
 ```

--- a/.changeset/strict-regions-return.md
+++ b/.changeset/strict-regions-return.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/client-js': patch
+'@mastra/server': patch
+---
+
+Added storage type detection to the Metrics Dashboard. The dashboard now shows an empty state when the observability storage does not support metrics (e.g. PostgreSQL, LibSQL), and displays a warning when using in-memory storage since metrics are not persisted across server restarts. Also added a docs link button to the Metrics page header.

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -1350,6 +1350,8 @@ export interface GetSystemPackagesResponse {
   packages: MastraPackage[];
   isDev: boolean;
   cmsEnabled: boolean;
+  storageType?: string;
+  observabilityStorageType?: string;
 }
 
 // ============================================================================

--- a/packages/playground-ui/src/domains/metrics/components/metrics-dashboard.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/metrics-dashboard.tsx
@@ -11,7 +11,11 @@ import { Button } from '@/ds/components/Button';
 import { EmptyState } from '@/ds/components/EmptyState';
 import { MetricsFlexGrid } from '@/ds/components/MetricsFlexGrid';
 
-const ANALYTICS_OBSERVABILITY_TYPES = new Set(['ObservabilityStorageClickhouse', 'ObservabilityInMemory']);
+const ANALYTICS_OBSERVABILITY_TYPES = new Set([
+  // 'ObservabilityStorageClickhouse',
+  // 'ObservabilityStorageDuckDB',
+  'ObservabilityInMemory',
+]);
 
 export function MetricsDashboard() {
   const { data, isLoading } = useMastraPackages();
@@ -29,7 +33,7 @@ export function MetricsDashboard() {
         <EmptyState
           iconSlot={<CircleSlashIcon />}
           titleSlot="Metrics are not available with your current storage"
-          descriptionSlot="Metrics require ClickHouse, DuckDB, or in-memory storage for observability. Relational databases (PostgreSQL, LibSQL) do not support metrics collection. To enable metrics on an existing project, switch the observability storage in the Mastra configuration."
+          descriptionSlot="Metrics currently require in-memory storage for observability. ClickHouse and DuckDB support is coming soon. Relational databases (PostgreSQL, LibSQL) do not support metrics collection. To enable metrics on an existing project, switch the observability storage in the Mastra configuration."
           actionSlot={
             <Button
               variant="ghost"

--- a/packages/playground-ui/src/domains/metrics/components/metrics-dashboard.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/metrics-dashboard.tsx
@@ -1,23 +1,62 @@
+import { CircleSlashIcon, ExternalLinkIcon } from 'lucide-react';
 import { LatencyCard } from './latency-card';
 import { AgentRunsKpiCard, TotalTokensKpiCard, AvgScoreKpiCard } from './metrics-kpi-cards';
 import { ModelUsageCostCard } from './model-usage-cost-card';
 import { ScoresCard } from './scores-card';
 import { TokenUsageByAgentCard } from './token-usage-by-agent-card';
 import { TracesVolumeCard } from './traces-volume-card';
+import { useMastraPackages } from '@/domains/configuration/hooks/use-mastra-packages';
 import { Alert, AlertTitle, AlertDescription } from '@/ds/components/Alert';
+import { Button } from '@/ds/components/Button';
+import { EmptyState } from '@/ds/components/EmptyState';
 import { MetricsFlexGrid } from '@/ds/components/MetricsFlexGrid';
 
+const ANALYTICS_OBSERVABILITY_TYPES = new Set(['ObservabilityStorageClickhouse', 'ObservabilityInMemory']);
+
 export function MetricsDashboard() {
+  const { data, isLoading } = useMastraPackages();
+  const observabilityType = data?.observabilityStorageType;
+  const supportsMetrics = observabilityType ? ANALYTICS_OBSERVABILITY_TYPES.has(observabilityType) : false;
+  const isInMemory = observabilityType === 'ObservabilityInMemory';
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (!supportsMetrics) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<CircleSlashIcon />}
+          titleSlot="Metrics are not available with your current storage"
+          descriptionSlot="Metrics require ClickHouse, DuckDB, or in-memory storage for observability. Relational databases (PostgreSQL, LibSQL) do not support metrics collection. To enable metrics on an existing project, switch the observability storage in the Mastra configuration."
+          actionSlot={
+            <Button
+              variant="ghost"
+              as="a"
+              href="https://mastra.ai/en/docs/observability/metrics"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Metrics Documentation <ExternalLinkIcon />
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="grid gap-8 content-start pb-10">
-      <Alert variant="warning">
-        <AlertTitle>Metrics are not available with your current storage</AlertTitle>
-        <AlertDescription as="p">
-          Metrics require ClickHouse or DuckDB for observability. Relational databases (PostgreSQL, LibSQL) do not
-          support metrics collection. To enable metrics on an existing project, switch your observability storage to
-          ClickHouse or DuckDB in your Mastra configuration.
-        </AlertDescription>
-      </Alert>
+      {isInMemory && (
+        <Alert variant="info">
+          <AlertTitle>Metrics are not persisted</AlertTitle>
+          <AlertDescription as="p">
+            This project uses in-memory storage for observability. Metrics will be lost on every server restart. For
+            persistent metrics, switch the observability storage to ClickHouse or DuckDB.
+          </AlertDescription>
+        </Alert>
+      )}
 
       <MetricsFlexGrid>
         <AgentRunsKpiCard />

--- a/packages/playground/src/pages/metrics/index.tsx
+++ b/packages/playground/src/pages/metrics/index.tsx
@@ -18,9 +18,6 @@ export default function Metrics() {
   const { experimentalFeaturesEnabled } = useExperimentalFeatures();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  if (!experimentalFeaturesEnabled) {
-    return null;
-  }
   const urlPreset = searchParams.get(PERIOD_PARAM);
   const initialPreset: DatePreset = isValidPreset(urlPreset) ? urlPreset : '24h';
 
@@ -41,6 +38,10 @@ export default function Metrics() {
     },
     [setSearchParams],
   );
+
+  if (!experimentalFeaturesEnabled) {
+    return null;
+  }
 
   return (
     <MetricsProvider initialPreset={initialPreset} onPresetChange={handlePresetChange}>

--- a/packages/playground/src/pages/metrics/index.tsx
+++ b/packages/playground/src/pages/metrics/index.tsx
@@ -5,6 +5,7 @@ import {
   MainHeader,
   isValidPreset,
   ButtonWithTooltip,
+  useExperimentalFeatures,
 } from '@mastra/playground-ui';
 import type { DatePreset } from '@mastra/playground-ui';
 import { BarChart3Icon, BookIcon } from 'lucide-react';
@@ -14,7 +15,12 @@ import { useSearchParams } from 'react-router';
 const PERIOD_PARAM = 'period';
 
 export default function Metrics() {
+  const { experimentalFeaturesEnabled } = useExperimentalFeatures();
   const [searchParams, setSearchParams] = useSearchParams();
+
+  if (!experimentalFeaturesEnabled) {
+    return null;
+  }
   const urlPreset = searchParams.get(PERIOD_PARAM);
   const initialPreset: DatePreset = isValidPreset(urlPreset) ? urlPreset : '24h';
 

--- a/packages/playground/src/pages/metrics/index.tsx
+++ b/packages/playground/src/pages/metrics/index.tsx
@@ -1,8 +1,15 @@
-import { MetricsDashboard, DateRangeSelector, MetricsProvider, MainHeader, isValidPreset } from '@mastra/playground-ui';
+import {
+  MetricsDashboard,
+  DateRangeSelector,
+  MetricsProvider,
+  MainHeader,
+  isValidPreset,
+  ButtonWithTooltip,
+} from '@mastra/playground-ui';
 import type { DatePreset } from '@mastra/playground-ui';
-import { BarChart3Icon } from 'lucide-react';
-import { useSearchParams } from 'react-router';
+import { BarChart3Icon, BookIcon } from 'lucide-react';
 import { useCallback } from 'react';
+import { useSearchParams } from 'react-router';
 
 const PERIOD_PARAM = 'period';
 
@@ -38,8 +45,17 @@ export default function Metrics() {
               <BarChart3Icon /> Metrics
             </MainHeader.Title>
           </MainHeader.Column>
-          <MainHeader.Column>
+          <MainHeader.Column className="flex justify-end gap-2">
             <DateRangeSelector />
+            <ButtonWithTooltip
+              as="a"
+              href="https://mastra.ai/en/docs/observability/overview"
+              target="_blank"
+              rel="noopener noreferrer"
+              tooltipContent="Go to Metrics documentation"
+            >
+              <BookIcon />
+            </ButtonWithTooltip>
           </MainHeader.Column>
         </MainHeader>
 

--- a/packages/server/src/server/handlers/system.test.ts
+++ b/packages/server/src/server/handlers/system.test.ts
@@ -7,6 +7,7 @@ import { GET_SYSTEM_PACKAGES_ROUTE } from './system';
 const createMockMastra = (hasEditor: boolean) =>
   ({
     getEditor: () => (hasEditor ? {} : undefined),
+    getStorage: () => undefined,
   }) as any;
 
 describe('System Handlers', () => {
@@ -41,7 +42,13 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({ mastra: createMockMastra(false) } as any);
 
-      expect(result).toEqual({ packages, isDev: false, cmsEnabled: false });
+      expect(result).toEqual({
+        packages,
+        isDev: false,
+        cmsEnabled: false,
+        storageType: undefined,
+        observabilityStorageType: undefined,
+      });
     });
 
     it('should return empty array when MASTRA_PACKAGES_FILE is not set', async () => {
@@ -49,7 +56,13 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({ mastra: createMockMastra(false) } as any);
 
-      expect(result).toEqual({ packages: [], isDev: false, cmsEnabled: false });
+      expect(result).toEqual({
+        packages: [],
+        isDev: false,
+        cmsEnabled: false,
+        storageType: undefined,
+        observabilityStorageType: undefined,
+      });
     });
 
     it('should return empty array when MASTRA_PACKAGES_FILE points to invalid JSON', async () => {
@@ -58,7 +71,13 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({ mastra: createMockMastra(false) } as any);
 
-      expect(result).toEqual({ packages: [], isDev: false, cmsEnabled: false });
+      expect(result).toEqual({
+        packages: [],
+        isDev: false,
+        cmsEnabled: false,
+        storageType: undefined,
+        observabilityStorageType: undefined,
+      });
     });
 
     it('should return empty array when MASTRA_PACKAGES_FILE points to non-existent file', async () => {
@@ -66,7 +85,13 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({ mastra: createMockMastra(false) } as any);
 
-      expect(result).toEqual({ packages: [], isDev: false, cmsEnabled: false });
+      expect(result).toEqual({
+        packages: [],
+        isDev: false,
+        cmsEnabled: false,
+        storageType: undefined,
+        observabilityStorageType: undefined,
+      });
     });
 
     it('should return isDev true when MASTRA_DEV is set', async () => {
@@ -75,7 +100,13 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({ mastra: createMockMastra(false) } as any);
 
-      expect(result).toEqual({ packages: [], isDev: true, cmsEnabled: false });
+      expect(result).toEqual({
+        packages: [],
+        isDev: true,
+        cmsEnabled: false,
+        storageType: undefined,
+        observabilityStorageType: undefined,
+      });
     });
 
     it('should return cmsEnabled true when editor is configured', async () => {
@@ -83,7 +114,13 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({ mastra: createMockMastra(true) } as any);
 
-      expect(result).toEqual({ packages: [], isDev: false, cmsEnabled: true });
+      expect(result).toEqual({
+        packages: [],
+        isDev: false,
+        cmsEnabled: true,
+        storageType: undefined,
+        observabilityStorageType: undefined,
+      });
     });
 
     it('should return cmsEnabled false when editor is not configured', async () => {
@@ -91,7 +128,13 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({ mastra: createMockMastra(false) } as any);
 
-      expect(result).toEqual({ packages: [], isDev: false, cmsEnabled: false });
+      expect(result).toEqual({
+        packages: [],
+        isDev: false,
+        cmsEnabled: false,
+        storageType: undefined,
+        observabilityStorageType: undefined,
+      });
     });
   });
 });

--- a/packages/server/src/server/handlers/system.ts
+++ b/packages/server/src/server/handlers/system.ts
@@ -29,7 +29,17 @@ export const GET_SYSTEM_PACKAGES_ROUTE = createRoute({
         }
       }
 
-      return { packages, isDev: process.env.MASTRA_DEV === 'true', cmsEnabled: !!mastra.getEditor() };
+      const storage = mastra.getStorage();
+      const storageType = storage?.name;
+      const observabilityStorageType = storage?.stores?.observability?.constructor.name;
+
+      return {
+        packages,
+        isDev: process.env.MASTRA_DEV === 'true',
+        cmsEnabled: !!mastra.getEditor(),
+        storageType,
+        observabilityStorageType,
+      };
     } catch (error) {
       return handleError(error, 'Error getting system packages');
     }

--- a/packages/server/src/server/schemas/system.ts
+++ b/packages/server/src/server/schemas/system.ts
@@ -9,6 +9,8 @@ export const systemPackagesResponseSchema = z.object({
   packages: z.array(mastraPackageSchema),
   isDev: z.boolean(),
   cmsEnabled: z.boolean(),
+  storageType: z.string().optional(),
+  observabilityStorageType: z.string().optional(),
 });
 
 export type MastraPackage = z.infer<typeof mastraPackageSchema>;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

! Metrics Dashboard is an experimental feature, hidden behind the `EXPERIMENTAL_FEATURES=true` flag

If project storage does not support metrics we show Empty State

<img width="1439" height="856" alt="CleanShot 2026-03-24 at 11 01 23" src="https://github.com/user-attachments/assets/c76f30a8-dfb4-4020-a9f9-b500785dc330" />

If project uses In Memory storage we print Alert 

<img width="1436" height="671" alt="CleanShot 2026-03-24 at 11 04 45" src="https://github.com/user-attachments/assets/443e0a6b-749f-4fa8-a6ad-9fb1a3e74bc1" />



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics Dashboard shows an empty state when the configured observability storage does not support metrics.
  * Shows an informational warning when observability uses in-memory storage (metrics not persisted across restarts).
  * Adds a documentation link button to the Metrics page header.
  * System info now reports the configured storage and observability storage types.

* **Chores**
  * Added release metadata entry for patch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->