### PR TITLE
EntityList NoMatch sub component for '0' search result

### DIFF
--- a/.changeset/fruity-garlics-notice.md
+++ b/.changeset/fruity-garlics-notice.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added EntityList.NoMatch component that displays a message when search filtering returns no results. Applied to all entity list pages: Agents, Workflows, Tools, Scorers, Processors, Prompts, Datasets, and MCP Servers.

--- a/packages/playground-ui/src/domains/agents/components/agent-list/agents-list.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-list/agents-list.tsx
@@ -76,6 +76,8 @@ export function AgentsList({ agents, isLoading, error, search = '' }: AgentsList
         />
       </EntityList.Top>
 
+      {filteredData.length === 0 && search ? <EntityList.NoMatch message="No Agents match your search" /> : null}
+
       {filteredData.map(agent => {
         const name = truncateString(agent.name, 50);
         const instructions = truncateString(extractPrompt(agent.instructions), 200);

--- a/packages/playground-ui/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -49,6 +49,8 @@ export function DatasetsList({ datasets, isLoading, error, search = '' }: Datase
         <EntityList.TopCell className="text-center">Created</EntityList.TopCell>
       </EntityList.Top>
 
+      {filteredData.length === 0 && search ? <EntityList.NoMatch message="No Datasets match your search" /> : null}
+
       {filteredData.map(ds => {
         const name = truncateString(ds.name, 50);
         const description = truncateString(ds.description ?? '', 200);

--- a/packages/playground-ui/src/domains/mcps/components/mcps-list/mcps-list.tsx
+++ b/packages/playground-ui/src/domains/mcps/components/mcps-list/mcps-list.tsx
@@ -85,6 +85,8 @@ export function McpServersList({ mcpServers, isLoading, error, search = '' }: Mc
         />
       </EntityList.Top>
 
+      {filteredData.length === 0 && search ? <EntityList.NoMatch message="No MCP Servers match your search" /> : null}
+
       {filteredData.map(server => (
         <McpServerRow key={server.id} server={server} />
       ))}

--- a/packages/playground-ui/src/domains/processors/components/processors-list/processors-list.tsx
+++ b/packages/playground-ui/src/domains/processors/components/processors-list/processors-list.tsx
@@ -96,6 +96,8 @@ export function ProcessorsList({ processors, isLoading, error, search = '' }: Pr
         <EntityList.TopCellSmart short="Used by" long="Used by Agents" className="text-center" />
       </EntityList.Top>
 
+      {filteredData.length === 0 && search ? <EntityList.NoMatch message="No Processors match your search" /> : null}
+
       {filteredData.map(processor => {
         const name = truncateString(processor.name || processor.id, 50);
         const description = truncateString(processor.description ?? '', 200);

--- a/packages/playground-ui/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
+++ b/packages/playground-ui/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
@@ -51,6 +51,8 @@ export function PromptsList({ promptBlocks, isLoading, error, search = '' }: Pro
         <EntityList.TopCell className="text-center">Is Published</EntityList.TopCell>
       </EntityList.Top>
 
+      {filteredData.length === 0 && search ? <EntityList.NoMatch message="No Prompts match your search" /> : null}
+
       {filteredData.map(block => {
         const name = truncateString(block.name, 50);
         const description = truncateString(block.description ?? '', 200);

--- a/packages/playground-ui/src/domains/scores/components/scorers-list/scorers-list.tsx
+++ b/packages/playground-ui/src/domains/scores/components/scorers-list/scorers-list.tsx
@@ -59,6 +59,8 @@ export function ScorersList({ scorers, isLoading, error, search = '' }: ScorersL
         <EntityList.TopCell className="text-center">Workflows</EntityList.TopCell>
       </EntityList.Top>
 
+      {filteredData.length === 0 && search ? <EntityList.NoMatch message="No Scorers match your search" /> : null}
+
       {filteredData.map(scorer => {
         const name = truncateString(scorer.scorer.config?.name ?? scorer.id, 50);
         const description = truncateString(scorer.scorer.config?.description ?? '', 200);

--- a/packages/playground-ui/src/domains/tools/components/tools-list/tools-list.tsx
+++ b/packages/playground-ui/src/domains/tools/components/tools-list/tools-list.tsx
@@ -57,6 +57,8 @@ export function ToolsList({ tools, agents, isLoading, error, search = '' }: Tool
         />
       </EntityList.Top>
 
+      {filteredData.length === 0 && search ? <EntityList.NoMatch message="No Tools match your search" /> : null}
+
       {filteredData.map(tool => {
         const name = truncateString(tool.id, 50);
         const description = truncateString(tool.description ?? '', 200);

--- a/packages/playground-ui/src/domains/workflows/components/workflows-list/workflows-list.tsx
+++ b/packages/playground-ui/src/domains/workflows/components/workflows-list/workflows-list.tsx
@@ -58,6 +58,8 @@ export function WorkflowsList({ workflows, isLoading, error, search = '' }: Work
         <EntityList.TopCell>Number of steps</EntityList.TopCell>
       </EntityList.Top>
 
+      {filteredData.length === 0 && search ? <EntityList.NoMatch message="No Workflows match your search" /> : null}
+
       {filteredData.map(wf => {
         const name = truncateString(wf.name, 50);
         const description = truncateString(wf.description ?? '', 200);

--- a/packages/playground-ui/src/ds/components/EntityList/entity-list-no-match.tsx
+++ b/packages/playground-ui/src/ds/components/EntityList/entity-list-no-match.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/lib/utils';
+
+export type EntityListNoMatchProps = {
+  message?: string;
+  className?: string;
+};
+
+export function EntityListNoMatch({ message = 'Nothing matches your search', className }: EntityListNoMatchProps) {
+  return (
+    <div className={cn('col-span-full flex flex-col items-center justify-center gap-2 py-12 text-neutral3', className)}>
+      <p className="text-ui-md">{message}</p>
+    </div>
+  );
+}

--- a/packages/playground-ui/src/ds/components/EntityList/entity-list.tsx
+++ b/packages/playground-ui/src/ds/components/EntityList/entity-list.tsx
@@ -1,4 +1,5 @@
 import { EntityListCell, EntityListTextCell, EntityListNameCell, EntityListDescriptionCell } from './entity-list-cells';
+import { EntityListNoMatch } from './entity-list-no-match';
 import { EntityListRoot } from './entity-list-root';
 import { EntityListRowLink } from './entity-list-row-link';
 import { EntityListRows } from './entity-list-rows';
@@ -16,4 +17,5 @@ export const EntityList = Object.assign(EntityListRoot, {
   TextCell: EntityListTextCell,
   NameCell: EntityListNameCell,
   DescriptionCell: EntityListDescriptionCell,
+  NoMatch: EntityListNoMatch,
 });

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -53,14 +53,7 @@ function Agents() {
           </div>
         </EntityListPageLayout.Top>
 
-        <AgentsList
-          agents={agents}
-          isLoading={isLoading}
-          error={error}
-          search={search}
-          onSearch={setSearch}
-          hideToolbar
-        />
+        <AgentsList agents={agents} isLoading={isLoading} error={error} search={search} />
       </EntityListPageLayout>
     );
   }

--- a/packages/playground/src/pages/datasets/index.tsx
+++ b/packages/playground/src/pages/datasets/index.tsx
@@ -67,14 +67,7 @@ function Datasets() {
             </div>
           </EntityListPageLayout.Top>
 
-          <DatasetsList
-            datasets={datasets}
-            isLoading={isLoading}
-            error={error}
-            onCreateClick={() => setIsCreateDialogOpen(true)}
-            search={search}
-            onSearch={setSearch}
-          />
+          <DatasetsList datasets={datasets} isLoading={isLoading} error={error} search={search} />
         </EntityListPageLayout>
 
         <CreateDatasetDialog


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

<img width="1440" height="568" alt="CleanShot 2026-03-24 at 12 40 41" src="https://github.com/user-attachments/assets/06ace2f0-3391-447e-bbe9-aa64800768de" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear "no match" messages for searches across all entity lists (Agents, Workflows, Tools, Scorers, Processors, Prompts, Datasets, and MCP Servers) so empty filtered results now show a helpful message.

* **UI Changes**
  * Simplified behavior in certain "new proposal" views so list search/create interactions are handled differently in that variant.

* **Chores**
  * Released a patch update entry for the UI package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->