### PR TITLE
feat(storage): add @mastra/storage package for shared adapter utilities

### DIFF
--- a/.changeset/bright-mails-bow.md
+++ b/.changeset/bright-mails-bow.md
@@ -1,0 +1,31 @@
+---
+'@internal/storage-test-utils': patch
+'@mastra/astra': patch
+'@mastra/chroma': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/cloudflare-d1': patch
+'@mastra/convex': patch
+'@mastra/couchbase': patch
+'@mastra/duckdb': patch
+'@mastra/dynamodb': patch
+'@mastra/elasticsearch': patch
+'@mastra/lance': patch
+'@mastra/libsql': patch
+'@mastra/mongodb': patch
+'@mastra/mssql': patch
+'@mastra/opensearch': patch
+'@mastra/pg': patch
+'@mastra/pinecone': patch
+'@mastra/qdrant': patch
+'@mastra/s3vectors': patch
+'@mastra/turbopuffer': patch
+'@mastra/upstash': patch
+'@mastra/vectorize': patch
+---
+
+Updated storage adapters to use `@mastra/storage` for shared schemas and utilities.
+
+- Added `@mastra/storage` as a peer dependency for storage and vector adapter packages
+- Moved shared table constants, pagination helpers, SQL identifier parsing, and storage utility imports out of `@mastra/core/storage`
+- Kept adapter runtime classes based on `@mastra/core/storage` so existing storage APIs continue to work

--- a/.changeset/fresh-walls-smile.md
+++ b/.changeset/fresh-walls-smile.md
@@ -1,0 +1,15 @@
+---
+'@mastra/storage': minor
+---
+
+Added the new `@mastra/storage` package for shared storage adapter utilities.
+
+- Added shared table constants, schema definitions, pagination helpers, SQL identifier utilities, and storage data types for adapter packages
+- Kept `MastraCompositeStore`, storage interfaces, and domain base classes in `@mastra/core/storage`
+
+**Example**
+
+```ts
+import { TABLE_SCHEMAS, createStorageErrorId } from '@mastra/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
+```

--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -42,6 +42,8 @@ This configures instance-level storage, which all agents share by default. You c
 
 Mastra automatically initializes the necessary storage structures on first interaction. See [Storage Overview](/reference/storage/overview) for domain coverage and the schema used by the built-in database-backed domains.
 
+If you're implementing a custom storage adapter package, install `@mastra/storage` for shared table constants, schema definitions, pagination helpers, and SQL utilities. Keep the runtime storage classes and interfaces imported from `@mastra/core/storage`.
+
 ## Supported providers
 
 Each provider page includes installation instructions, configuration parameters, and usage examples:

--- a/docs/src/content/en/reference/storage/overview.mdx
+++ b/docs/src/content/en/reference/storage/overview.mdx
@@ -3,6 +3,7 @@ title: "Reference: Storage overview | Storage"
 description: Core data schema and table structure for Mastra's storage system.
 packages:
   - "@mastra/core"
+  - "@mastra/storage"
 ---
 
 import { SchemaTable } from "@site/src/components/SchemaTable";
@@ -29,6 +30,8 @@ Not every storage adapter implements every domain. Composite storage lets you mi
 | `experiments` | Experiment runs and per-item experiment results. |
 
 The schema definitions below cover the built-in database-backed tables documented for `memory`, `workflows`, `scores`, and `observability`. Other domains, and non-database adapters, use implementation-specific storage structures.
+
+If you are building a storage adapter, import table constants, schema definitions, pagination helpers, SQL identifier parsers, and shared storage data types from `@mastra/storage`. Keep `MastraCompositeStore`, storage domain base classes, and storage interfaces imported from `@mastra/core/storage`.
 
 ## Core schema
 

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@mastra/storage",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "packages/storage"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./sql": {
+      "import": {
+        "types": "./dist/sql.d.ts",
+        "default": "./dist/sql.js"
+      },
+      "require": {
+        "types": "./dist/sql.d.ts",
+        "default": "./dist/sql.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "build:lib": "pnpm check && tsup --silent --config tsup.config.ts",
+    "prepack": "pnpx tsx ../../scripts/generate-package-docs.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "test": "vitest run",
+    "lint": "eslint ."
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "zod": "^3.25.0 || ^4.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@types/node": "22.19.15",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "eslint": "^9.39.4",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/packages/storage/src/constants.ts
+++ b/packages/storage/src/constants.ts
@@ -1,0 +1,558 @@
+import { spanRecordSchema } from './domains/observability';
+import { buildStorageSchema } from './types';
+import type { StorageColumn, StorageTableConfig } from './types';
+
+export const TABLE_WORKFLOW_SNAPSHOT = 'mastra_workflow_snapshot';
+export const TABLE_MESSAGES = 'mastra_messages';
+export const TABLE_THREADS = 'mastra_threads';
+export const TABLE_TRACES = 'mastra_traces';
+export const TABLE_RESOURCES = 'mastra_resources';
+export const TABLE_SCORERS = 'mastra_scorers';
+export const TABLE_SPANS = 'mastra_ai_spans';
+export const TABLE_AGENTS = 'mastra_agents';
+export const TABLE_AGENT_VERSIONS = 'mastra_agent_versions';
+export const TABLE_OBSERVATIONAL_MEMORY = 'mastra_observational_memory';
+export const TABLE_PROMPT_BLOCKS = 'mastra_prompt_blocks';
+export const TABLE_PROMPT_BLOCK_VERSIONS = 'mastra_prompt_block_versions';
+export const TABLE_SCORER_DEFINITIONS = 'mastra_scorer_definitions';
+export const TABLE_SCORER_DEFINITION_VERSIONS = 'mastra_scorer_definition_versions';
+export const TABLE_MCP_CLIENTS = 'mastra_mcp_clients';
+export const TABLE_MCP_CLIENT_VERSIONS = 'mastra_mcp_client_versions';
+export const TABLE_MCP_SERVERS = 'mastra_mcp_servers';
+export const TABLE_MCP_SERVER_VERSIONS = 'mastra_mcp_server_versions';
+export const TABLE_WORKSPACES = 'mastra_workspaces';
+export const TABLE_WORKSPACE_VERSIONS = 'mastra_workspace_versions';
+export const TABLE_SKILLS = 'mastra_skills';
+export const TABLE_SKILL_VERSIONS = 'mastra_skill_versions';
+export const TABLE_SKILL_BLOBS = 'mastra_skill_blobs';
+
+// Dataset tables
+export const TABLE_DATASETS = 'mastra_datasets';
+export const TABLE_DATASET_ITEMS = 'mastra_dataset_items';
+export const TABLE_DATASET_VERSIONS = 'mastra_dataset_versions';
+
+// Experiment tables
+export const TABLE_EXPERIMENTS = 'mastra_experiments';
+export const TABLE_EXPERIMENT_RESULTS = 'mastra_experiment_results';
+
+/** Union of all core table name constants. */
+export type TABLE_NAMES =
+  | typeof TABLE_WORKFLOW_SNAPSHOT
+  | typeof TABLE_MESSAGES
+  | typeof TABLE_THREADS
+  | typeof TABLE_TRACES
+  | typeof TABLE_RESOURCES
+  | typeof TABLE_SCORERS
+  | typeof TABLE_SPANS
+  | typeof TABLE_AGENTS
+  | typeof TABLE_AGENT_VERSIONS
+  | typeof TABLE_PROMPT_BLOCKS
+  | typeof TABLE_PROMPT_BLOCK_VERSIONS
+  | typeof TABLE_SCORER_DEFINITIONS
+  | typeof TABLE_SCORER_DEFINITION_VERSIONS
+  | typeof TABLE_MCP_CLIENTS
+  | typeof TABLE_MCP_CLIENT_VERSIONS
+  | typeof TABLE_MCP_SERVERS
+  | typeof TABLE_MCP_SERVER_VERSIONS
+  | typeof TABLE_WORKSPACES
+  | typeof TABLE_WORKSPACE_VERSIONS
+  | typeof TABLE_SKILLS
+  | typeof TABLE_SKILL_VERSIONS
+  | typeof TABLE_SKILL_BLOBS
+  | typeof TABLE_DATASETS
+  | typeof TABLE_DATASET_ITEMS
+  | typeof TABLE_DATASET_VERSIONS
+  | typeof TABLE_EXPERIMENTS
+  | typeof TABLE_EXPERIMENT_RESULTS;
+
+export const SCORERS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  scorerId: { type: 'text' },
+  traceId: { type: 'text', nullable: true },
+  spanId: { type: 'text', nullable: true },
+  runId: { type: 'text' },
+  scorer: { type: 'jsonb' },
+  preprocessStepResult: { type: 'jsonb', nullable: true },
+  extractStepResult: { type: 'jsonb', nullable: true },
+  analyzeStepResult: { type: 'jsonb', nullable: true },
+  score: { type: 'float' },
+  reason: { type: 'text', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  preprocessPrompt: { type: 'text', nullable: true },
+  extractPrompt: { type: 'text', nullable: true },
+  generateScorePrompt: { type: 'text', nullable: true },
+  generateReasonPrompt: { type: 'text', nullable: true },
+  analyzePrompt: { type: 'text', nullable: true },
+
+  // Deprecated
+  reasonPrompt: { type: 'text', nullable: true },
+  input: { type: 'jsonb' },
+  output: { type: 'jsonb' }, // MESSAGE OUTPUT
+  additionalContext: { type: 'jsonb', nullable: true }, // DATA FROM THE CONTEXT PARAM ON AN AGENT
+  requestContext: { type: 'jsonb', nullable: true }, // THE EVALUATE Request Context FOR THE RUN
+  /**
+   * Things you can evaluate
+   */
+  entityType: { type: 'text', nullable: true }, // WORKFLOW, AGENT, TOOL, STEP, NETWORK
+  entity: { type: 'jsonb', nullable: true }, // MINIMAL JSON DATA ABOUT WORKFLOW, AGENT, TOOL, STEP, NETWORK
+  entityId: { type: 'text', nullable: true },
+  source: { type: 'text' },
+  resourceId: { type: 'text', nullable: true },
+  threadId: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp' },
+  updatedAt: { type: 'timestamp' },
+};
+
+export const SPAN_SCHEMA = buildStorageSchema(spanRecordSchema);
+
+/**
+ * @deprecated Use SPAN_SCHEMA instead. This legacy schema is retained only for migration purposes.
+ * @internal
+ */
+export const OLD_SPAN_SCHEMA: Record<string, StorageColumn> = {
+  // Composite primary key of traceId and spanId
+  traceId: { type: 'text', nullable: false },
+  spanId: { type: 'text', nullable: false },
+  parentSpanId: { type: 'text', nullable: true },
+  name: { type: 'text', nullable: false },
+  scope: { type: 'jsonb', nullable: true }, // Mastra package info {"core-version": "0.1.0"}
+  spanType: { type: 'text', nullable: false }, // WORKFLOW_RUN, WORKFLOW_STEP, AGENT_RUN, AGENT_STEP, TOOL_RUN, TOOL_STEP, etc.
+  attributes: { type: 'jsonb', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  links: { type: 'jsonb', nullable: true },
+  input: { type: 'jsonb', nullable: true },
+  output: { type: 'jsonb', nullable: true },
+  error: { type: 'jsonb', nullable: true },
+  startedAt: { type: 'timestamp', nullable: false }, // When the span started
+  endedAt: { type: 'timestamp', nullable: true }, // When the span ended
+  createdAt: { type: 'timestamp', nullable: false }, // The time the database record was created
+  updatedAt: { type: 'timestamp', nullable: true }, // The time the database record was last updated
+  isEvent: { type: 'boolean', nullable: false },
+};
+
+export const AGENTS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  status: { type: 'text', nullable: false }, // 'draft' or 'published'
+  activeVersionId: { type: 'text', nullable: true }, // FK to agent_versions.id
+  authorId: { type: 'text', nullable: true }, // Author identifier for multi-tenant filtering
+  metadata: { type: 'jsonb', nullable: true }, // Additional metadata for the agent
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const AGENT_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true }, // UUID
+  agentId: { type: 'text', nullable: false },
+  versionNumber: { type: 'integer', nullable: false },
+  // Agent config fields
+  name: { type: 'text', nullable: false }, // Agent display name
+  description: { type: 'text', nullable: true },
+  instructions: { type: 'text', nullable: false },
+  model: { type: 'jsonb', nullable: false },
+  tools: { type: 'jsonb', nullable: true },
+  defaultOptions: { type: 'jsonb', nullable: true },
+  workflows: { type: 'jsonb', nullable: true },
+  agents: { type: 'jsonb', nullable: true },
+  integrationTools: { type: 'jsonb', nullable: true },
+  inputProcessors: { type: 'jsonb', nullable: true },
+  outputProcessors: { type: 'jsonb', nullable: true },
+  memory: { type: 'jsonb', nullable: true },
+  scorers: { type: 'jsonb', nullable: true },
+  mcpClients: { type: 'jsonb', nullable: true },
+  requestContextSchema: { type: 'jsonb', nullable: true },
+  workspace: { type: 'jsonb', nullable: true },
+  skills: { type: 'jsonb', nullable: true },
+  skillsFormat: { type: 'text', nullable: true },
+  // Version metadata
+  changedFields: { type: 'jsonb', nullable: true }, // Array of field names
+  changeMessage: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
+export const PROMPT_BLOCKS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  status: { type: 'text', nullable: false }, // 'draft', 'published', or 'archived'
+  activeVersionId: { type: 'text', nullable: true }, // FK to prompt_block_versions.id
+  authorId: { type: 'text', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const PROMPT_BLOCK_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  blockId: { type: 'text', nullable: false },
+  versionNumber: { type: 'integer', nullable: false },
+  name: { type: 'text', nullable: false },
+  description: { type: 'text', nullable: true },
+  content: { type: 'text', nullable: false },
+  rules: { type: 'jsonb', nullable: true },
+  requestContextSchema: { type: 'jsonb', nullable: true },
+  changedFields: { type: 'jsonb', nullable: true },
+  changeMessage: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
+export const SCORER_DEFINITIONS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  status: { type: 'text', nullable: false }, // 'draft', 'published', or 'archived'
+  activeVersionId: { type: 'text', nullable: true }, // FK to scorer_definition_versions.id
+  authorId: { type: 'text', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const SCORER_DEFINITION_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  scorerDefinitionId: { type: 'text', nullable: false },
+  versionNumber: { type: 'integer', nullable: false },
+  name: { type: 'text', nullable: false },
+  description: { type: 'text', nullable: true },
+  type: { type: 'text', nullable: false }, // 'llm-judge', 'bias', 'toxicity', etc.
+  model: { type: 'jsonb', nullable: true },
+  instructions: { type: 'text', nullable: true },
+  scoreRange: { type: 'jsonb', nullable: true },
+  presetConfig: { type: 'jsonb', nullable: true },
+  defaultSampling: { type: 'jsonb', nullable: true },
+  changedFields: { type: 'jsonb', nullable: true },
+  changeMessage: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
+export const MCP_CLIENTS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  status: { type: 'text', nullable: false }, // 'draft', 'published', or 'archived'
+  activeVersionId: { type: 'text', nullable: true }, // FK to mcp_client_versions.id
+  authorId: { type: 'text', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const MCP_CLIENT_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  mcpClientId: { type: 'text', nullable: false },
+  versionNumber: { type: 'integer', nullable: false },
+  name: { type: 'text', nullable: false },
+  description: { type: 'text', nullable: true },
+  servers: { type: 'jsonb', nullable: false },
+  changedFields: { type: 'jsonb', nullable: true },
+  changeMessage: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
+export const MCP_SERVERS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  status: { type: 'text', nullable: false }, // 'draft', 'published', or 'archived'
+  activeVersionId: { type: 'text', nullable: true }, // FK to mcp_server_versions.id
+  authorId: { type: 'text', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const MCP_SERVER_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  mcpServerId: { type: 'text', nullable: false },
+  versionNumber: { type: 'integer', nullable: false },
+  name: { type: 'text', nullable: false },
+  version: { type: 'text', nullable: false },
+  description: { type: 'text', nullable: true },
+  instructions: { type: 'text', nullable: true },
+  repository: { type: 'jsonb', nullable: true },
+  releaseDate: { type: 'text', nullable: true },
+  isLatest: { type: 'boolean', nullable: true },
+  packageCanonical: { type: 'text', nullable: true },
+  tools: { type: 'jsonb', nullable: true },
+  agents: { type: 'jsonb', nullable: true },
+  workflows: { type: 'jsonb', nullable: true },
+  changedFields: { type: 'jsonb', nullable: true },
+  changeMessage: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
+export const WORKSPACES_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  status: { type: 'text', nullable: false }, // 'draft', 'published', or 'archived'
+  activeVersionId: { type: 'text', nullable: true }, // FK to workspace_versions.id
+  authorId: { type: 'text', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const WORKSPACE_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  workspaceId: { type: 'text', nullable: false },
+  versionNumber: { type: 'integer', nullable: false },
+  name: { type: 'text', nullable: false },
+  description: { type: 'text', nullable: true },
+  filesystem: { type: 'jsonb', nullable: true },
+  sandbox: { type: 'jsonb', nullable: true },
+  mounts: { type: 'jsonb', nullable: true },
+  search: { type: 'jsonb', nullable: true },
+  skills: { type: 'jsonb', nullable: true },
+  tools: { type: 'jsonb', nullable: true },
+  autoSync: { type: 'boolean', nullable: true },
+  operationTimeout: { type: 'integer', nullable: true },
+  changedFields: { type: 'jsonb', nullable: true },
+  changeMessage: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
+export const SKILLS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  status: { type: 'text', nullable: false }, // 'draft', 'published', or 'archived'
+  activeVersionId: { type: 'text', nullable: true }, // FK to skill_versions.id
+  authorId: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const SKILL_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  skillId: { type: 'text', nullable: false },
+  versionNumber: { type: 'integer', nullable: false },
+  name: { type: 'text', nullable: false },
+  description: { type: 'text', nullable: false },
+  instructions: { type: 'text', nullable: false },
+  license: { type: 'text', nullable: true },
+  compatibility: { type: 'jsonb', nullable: true },
+  source: { type: 'jsonb', nullable: true },
+  references: { type: 'jsonb', nullable: true },
+  scripts: { type: 'jsonb', nullable: true },
+  assets: { type: 'jsonb', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  tree: { type: 'jsonb', nullable: true },
+  changedFields: { type: 'jsonb', nullable: true },
+  changeMessage: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
+export const SKILL_BLOBS_SCHEMA: Record<string, StorageColumn> = {
+  hash: { type: 'text', nullable: false, primaryKey: true },
+  content: { type: 'text', nullable: false },
+  size: { type: 'integer', nullable: false },
+  mimeType: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
+export const OBSERVATIONAL_MEMORY_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  lookupKey: { type: 'text', nullable: false }, // 'resource:{resourceId}' or 'thread:{threadId}'
+  scope: { type: 'text', nullable: false }, // 'resource' or 'thread'
+  resourceId: { type: 'text', nullable: true },
+  threadId: { type: 'text', nullable: true },
+  activeObservations: { type: 'text', nullable: false }, // JSON array of observations
+  activeObservationsPendingUpdate: { type: 'text', nullable: true }, // JSON array, used during updates
+  originType: { type: 'text', nullable: false }, // 'initialization', 'observation', or 'reflection'
+  config: { type: 'text', nullable: false }, // JSON object
+  generationCount: { type: 'integer', nullable: false },
+  lastObservedAt: { type: 'timestamp', nullable: true },
+  lastReflectionAt: { type: 'timestamp', nullable: true },
+  pendingMessageTokens: { type: 'integer', nullable: false }, // Token count
+  totalTokensObserved: { type: 'integer', nullable: false }, // Running total of all observed tokens
+  observationTokenCount: { type: 'integer', nullable: false }, // Current observation size in tokens
+  isObserving: { type: 'boolean', nullable: false },
+  isReflecting: { type: 'boolean', nullable: false },
+  observedMessageIds: { type: 'jsonb', nullable: true }, // JSON array of message IDs already observed
+  observedTimezone: { type: 'text', nullable: true }, // Timezone used for Observer date formatting (e.g., "America/Los_Angeles")
+  // Async buffering columns
+  bufferedObservations: { type: 'text', nullable: true }, // JSON string of buffered observation content
+  bufferedObservationTokens: { type: 'integer', nullable: true }, // Token count of buffered observations
+  bufferedMessageIds: { type: 'jsonb', nullable: true }, // JSON array of message IDs in the buffer
+  bufferedReflection: { type: 'text', nullable: true }, // JSON string of buffered reflection content
+  bufferedReflectionTokens: { type: 'integer', nullable: true }, // Token count of buffered reflection (post-compression)
+  bufferedReflectionInputTokens: { type: 'integer', nullable: true }, // Token count of observations fed to reflector (pre-compression)
+  reflectedObservationLineCount: { type: 'integer', nullable: true }, // Number of observation lines that were reflected on during async buffering
+  bufferedObservationChunks: { type: 'jsonb', nullable: true }, // JSON array of BufferedObservationChunk objects
+  isBufferingObservation: { type: 'boolean', nullable: false },
+  isBufferingReflection: { type: 'boolean', nullable: false },
+  lastBufferedAtTokens: { type: 'integer', nullable: false },
+  lastBufferedAtTime: { type: 'timestamp', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+// Dataset schemas
+export const DATASETS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  name: { type: 'text', nullable: false },
+  description: { type: 'text', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  inputSchema: { type: 'jsonb', nullable: true },
+  groundTruthSchema: { type: 'jsonb', nullable: true },
+  requestContextSchema: { type: 'jsonb', nullable: true },
+  tags: { type: 'jsonb', nullable: true },
+  targetType: { type: 'text', nullable: true },
+  targetIds: { type: 'jsonb', nullable: true },
+  version: { type: 'integer', nullable: false },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const DATASET_ITEMS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false },
+  datasetId: { type: 'text', nullable: false, references: { table: 'mastra_datasets', column: 'id' } },
+  datasetVersion: { type: 'integer', nullable: false },
+  validTo: { type: 'integer', nullable: true },
+  isDeleted: { type: 'boolean', nullable: false },
+  input: { type: 'jsonb', nullable: false },
+  groundTruth: { type: 'jsonb', nullable: true },
+  requestContext: { type: 'jsonb', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  source: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const DATASET_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  datasetId: { type: 'text', nullable: false, references: { table: 'mastra_datasets', column: 'id' } },
+  version: { type: 'integer', nullable: false },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
+// Experiment schemas
+export const EXPERIMENTS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  name: { type: 'text', nullable: true },
+  description: { type: 'text', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  datasetId: { type: 'text', nullable: true, references: { table: 'mastra_datasets', column: 'id' } },
+  datasetVersion: { type: 'integer', nullable: true },
+  targetType: { type: 'text', nullable: false },
+  targetId: { type: 'text', nullable: false },
+  status: { type: 'text', nullable: false },
+  totalItems: { type: 'integer', nullable: false },
+  succeededCount: { type: 'integer', nullable: false },
+  failedCount: { type: 'integer', nullable: false },
+  skippedCount: { type: 'integer', nullable: false },
+  startedAt: { type: 'timestamp', nullable: true },
+  completedAt: { type: 'timestamp', nullable: true },
+  agentVersion: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const EXPERIMENT_RESULTS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  experimentId: { type: 'text', nullable: false, references: { table: 'mastra_experiments', column: 'id' } },
+  itemId: { type: 'text', nullable: false, references: { table: 'mastra_dataset_items', column: 'id' } },
+  itemDatasetVersion: { type: 'integer', nullable: true },
+  input: { type: 'jsonb', nullable: false },
+  output: { type: 'jsonb', nullable: true },
+  groundTruth: { type: 'jsonb', nullable: true },
+  error: { type: 'jsonb', nullable: true },
+  startedAt: { type: 'timestamp', nullable: false },
+  completedAt: { type: 'timestamp', nullable: false },
+  retryCount: { type: 'integer', nullable: false },
+  traceId: { type: 'text', nullable: true },
+  status: { type: 'text', nullable: true },
+  tags: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
+/**
+ * Schema definitions for all core tables.
+ */
+export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> = {
+  [TABLE_WORKFLOW_SNAPSHOT]: {
+    workflow_name: {
+      type: 'text',
+    },
+    run_id: {
+      type: 'text',
+    },
+    resourceId: { type: 'text', nullable: true },
+    snapshot: {
+      type: 'jsonb',
+    },
+    createdAt: {
+      type: 'timestamp',
+    },
+    updatedAt: {
+      type: 'timestamp',
+    },
+  },
+  [TABLE_SCORERS]: SCORERS_SCHEMA,
+  [TABLE_THREADS]: {
+    id: { type: 'text', nullable: false, primaryKey: true },
+    resourceId: { type: 'text', nullable: false },
+    title: { type: 'text', nullable: false },
+    metadata: { type: 'jsonb', nullable: true },
+    createdAt: { type: 'timestamp', nullable: false },
+    updatedAt: { type: 'timestamp', nullable: false },
+  },
+  [TABLE_MESSAGES]: {
+    id: { type: 'text', nullable: false, primaryKey: true },
+    thread_id: { type: 'text', nullable: false },
+    content: { type: 'text', nullable: false },
+    role: { type: 'text', nullable: false },
+    type: { type: 'text', nullable: false },
+    createdAt: { type: 'timestamp', nullable: false },
+    resourceId: { type: 'text', nullable: true },
+  },
+  [TABLE_SPANS]: SPAN_SCHEMA,
+  [TABLE_TRACES]: {
+    id: { type: 'text', nullable: false, primaryKey: true },
+    parentSpanId: { type: 'text', nullable: true },
+    name: { type: 'text', nullable: false },
+    traceId: { type: 'text', nullable: false },
+    scope: { type: 'text', nullable: false },
+    kind: { type: 'integer', nullable: false },
+    attributes: { type: 'jsonb', nullable: true },
+    status: { type: 'jsonb', nullable: true },
+    events: { type: 'jsonb', nullable: true },
+    links: { type: 'jsonb', nullable: true },
+    other: { type: 'text', nullable: true },
+    startTime: { type: 'bigint', nullable: false },
+    endTime: { type: 'bigint', nullable: false },
+    createdAt: { type: 'timestamp', nullable: false },
+  },
+  [TABLE_RESOURCES]: {
+    id: { type: 'text', nullable: false, primaryKey: true },
+    workingMemory: { type: 'text', nullable: true },
+    metadata: { type: 'jsonb', nullable: true },
+    createdAt: { type: 'timestamp', nullable: false },
+    updatedAt: { type: 'timestamp', nullable: false },
+  },
+  [TABLE_AGENTS]: AGENTS_SCHEMA,
+  [TABLE_AGENT_VERSIONS]: AGENT_VERSIONS_SCHEMA,
+  [TABLE_PROMPT_BLOCKS]: PROMPT_BLOCKS_SCHEMA,
+  [TABLE_PROMPT_BLOCK_VERSIONS]: PROMPT_BLOCK_VERSIONS_SCHEMA,
+  [TABLE_SCORER_DEFINITIONS]: SCORER_DEFINITIONS_SCHEMA,
+  [TABLE_SCORER_DEFINITION_VERSIONS]: SCORER_DEFINITION_VERSIONS_SCHEMA,
+  [TABLE_MCP_CLIENTS]: MCP_CLIENTS_SCHEMA,
+  [TABLE_MCP_CLIENT_VERSIONS]: MCP_CLIENT_VERSIONS_SCHEMA,
+  [TABLE_MCP_SERVERS]: MCP_SERVERS_SCHEMA,
+  [TABLE_MCP_SERVER_VERSIONS]: MCP_SERVER_VERSIONS_SCHEMA,
+  [TABLE_WORKSPACES]: WORKSPACES_SCHEMA,
+  [TABLE_WORKSPACE_VERSIONS]: WORKSPACE_VERSIONS_SCHEMA,
+  [TABLE_SKILLS]: SKILLS_SCHEMA,
+  [TABLE_SKILL_VERSIONS]: SKILL_VERSIONS_SCHEMA,
+  [TABLE_SKILL_BLOBS]: SKILL_BLOBS_SCHEMA,
+  [TABLE_DATASETS]: DATASETS_SCHEMA,
+  [TABLE_DATASET_ITEMS]: DATASET_ITEMS_SCHEMA,
+  [TABLE_DATASET_VERSIONS]: DATASET_VERSIONS_SCHEMA,
+  [TABLE_EXPERIMENTS]: EXPERIMENTS_SCHEMA,
+  [TABLE_EXPERIMENT_RESULTS]: EXPERIMENT_RESULTS_SCHEMA,
+};
+
+/**
+ * Table-level config for tables that need composite primary keys or other table-level settings.
+ * Keyed by table name. Tables not listed here use single-column PKs from their schema.
+ */
+export const TABLE_CONFIGS: Partial<Record<TABLE_NAMES, StorageTableConfig>> = {
+  [TABLE_DATASET_ITEMS]: { columns: DATASET_ITEMS_SCHEMA, compositePrimaryKey: ['id', 'datasetVersion'] },
+};
+
+/**
+ * Schema for the observational memory table.
+ * Exported separately as OM is optional and not part of TABLE_NAMES.
+ */
+export const OBSERVATIONAL_MEMORY_TABLE_SCHEMA = {
+  [TABLE_OBSERVATIONAL_MEMORY]: OBSERVATIONAL_MEMORY_SCHEMA,
+};

--- a/packages/storage/src/domains/observability/index.ts
+++ b/packages/storage/src/domains/observability/index.ts
@@ -1,0 +1,1 @@
+export * from './tracing';

--- a/packages/storage/src/domains/observability/tracing.ts
+++ b/packages/storage/src/domains/observability/tracing.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod/v4';
+import { SpanType } from '../../observability';
+import { contextFields, dbTimestamps, metadataField, tagsField, traceIdField, spanIdField } from '../shared';
+
+export { traceIdField, spanIdField };
+
+const createOmitKeys = <T extends z.ZodRawShape>(shape: T): { [K in keyof T]: true } =>
+  Object.fromEntries(Object.keys(shape).map(k => [k, true])) as { [K in keyof T]: true };
+
+const spanNameField = z.string().describe('Human-readable span name');
+const parentSpanIdField = z.string().describe('Parent span reference (null = root span)');
+const spanTypeField = z.nativeEnum(SpanType).describe('Span type (e.g., WORKFLOW_RUN, AGENT_RUN, TOOL_CALL, etc.)');
+const attributesField = z.record(z.string(), z.unknown()).describe('Span-type specific attributes (e.g., model, tokens, tools)');
+const linksField = z.array(z.unknown()).describe('References to related spans in other traces');
+const inputField = z.unknown().describe('Input data passed to the span');
+const outputField = z.unknown().describe('Output data returned from the span');
+const errorField = z.unknown().describe('Error info - presence indicates failure (status derived from this)');
+const isEventField = z.boolean().describe('Whether this is an event (point-in-time) vs a span (duration)');
+const startedAtField = z.date().describe('When the span started');
+const endedAtField = z.date().describe('When the span ended (null = running, status derived from this)');
+
+export enum TraceStatus {
+  SUCCESS = 'success',
+  ERROR = 'error',
+  RUNNING = 'running',
+}
+
+const traceStatusField = z.nativeEnum(TraceStatus).describe('Current status of the trace');
+
+const sharedFields = {
+  ...contextFields,
+  metadata: metadataField.nullish(),
+  tags: tagsField.nullish(),
+} as const;
+
+export const spanIds = {
+  traceId: traceIdField,
+  spanId: spanIdField,
+} as const satisfies z.ZodRawShape;
+
+export const spanIdsSchema = z.object({
+  ...spanIds,
+});
+
+export type SpanIds = z.infer<typeof spanIdsSchema>;
+
+const omitDbTimestamps = createOmitKeys(dbTimestamps);
+const omitSpanIds = createOmitKeys(spanIds);
+void omitDbTimestamps;
+void omitSpanIds;
+
+export const spanRecordSchema = z
+  .object({
+    ...spanIds,
+    name: spanNameField,
+    spanType: spanTypeField,
+    isEvent: isEventField,
+    startedAt: startedAtField,
+    parentSpanId: parentSpanIdField.nullish(),
+    ...sharedFields,
+    experimentId: z.string().nullish().describe('Experiment or eval run identifier'),
+    attributes: attributesField.nullish(),
+    links: linksField.nullish(),
+    input: inputField.nullish(),
+    output: outputField.nullish(),
+    error: errorField.nullish(),
+    endedAt: endedAtField.nullish(),
+    requestContext: z.record(z.string(), z.unknown()).nullish().describe('Request context data'),
+    ...dbTimestamps,
+  })
+  .describe('Span record data');
+
+export type SpanRecord = z.infer<typeof spanRecordSchema>;
+
+export function computeTraceStatus(span: SpanRecord): TraceStatus {
+  if (span.error != null) return TraceStatus.ERROR;
+  if (span.endedAt == null) return TraceStatus.RUNNING;
+  return TraceStatus.SUCCESS;
+}
+
+export const traceSpanSchema = spanRecordSchema.extend({
+  status: traceStatusField,
+});
+
+export type TraceSpan = z.infer<typeof traceSpanSchema>;

--- a/packages/storage/src/domains/shared.ts
+++ b/packages/storage/src/domains/shared.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod/v4';
+import { EntityType } from '../observability';
+
+export { EntityType };
+
+export const createdAtField = z.date().describe('Database record creation time');
+export const updatedAtField = z.date().describe('Database record last update time');
+
+export const dbTimestamps = {
+  createdAt: createdAtField,
+  updatedAt: updatedAtField.nullable(),
+} as const satisfies z.ZodRawShape;
+
+export const paginationArgsSchema = z
+  .object({
+    page: z.coerce.number().int().min(0).optional().default(0).describe('Zero-indexed page number'),
+    perPage: z.coerce.number().int().min(1).max(100).optional().default(10).describe('Number of items per page'),
+  })
+  .describe('Pagination options for list queries');
+
+export type PaginationArgs = z.input<typeof paginationArgsSchema>;
+
+export const paginationInfoSchema = z.object({
+  total: z.number().describe('Total number of items available'),
+  page: z.number().describe('Current page'),
+  perPage: z.union([z.number(), z.literal(false)]).describe('Number of items per page, or false if pagination is disabled'),
+  hasMore: z.boolean().describe('True if more pages are available'),
+});
+
+export const dateRangeSchema = z
+  .object({
+    start: z.coerce.date().optional().describe('Start of date range (inclusive by default)'),
+    end: z.coerce.date().optional().describe('End of date range (inclusive by default)'),
+    startExclusive: z.boolean().optional().describe('When true, excludes the start date from results (uses > instead of >=)'),
+    endExclusive: z.boolean().optional().describe('When true, excludes the end date from results (uses < instead of <=)'),
+  })
+  .describe('Date range filter for timestamps');
+
+export type DateRange = z.input<typeof dateRangeSchema>;
+
+export const sortDirectionSchema = z.enum(['ASC', 'DESC']).describe("Sort direction: 'ASC' | 'DESC'");
+
+export const entityTypeField = z.nativeEnum(EntityType).describe(`Entity type (e.g., 'agent' | 'processor' | 'tool' | 'workflow')`);
+export const entityIdField = z.string().describe('ID of the entity (e.g., "weatherAgent", "orderWorkflow")');
+export const entityNameField = z.string().describe('Name of the entity');
+export const userIdField = z.string().describe('Human end-user who triggered execution');
+export const organizationIdField = z.string().describe('Multi-tenant organization/account');
+export const resourceIdField = z.string().describe('Broader resource context (Mastra memory compatibility)');
+export const runIdField = z.string().describe('Unique execution run identifier');
+export const sessionIdField = z.string().describe('Session identifier for grouping traces');
+export const threadIdField = z.string().describe('Conversation thread identifier');
+export const requestIdField = z.string().describe('HTTP request ID for log correlation');
+export const environmentField = z.string().describe(`Environment (e.g., "production" | "staging" | "development")`);
+export const sourceField = z.string().describe(`Source of execution (e.g., "local" | "cloud" | "ci")`);
+export const serviceNameField = z.string().describe('Name of the service');
+export const parentEntityTypeField = z.nativeEnum(EntityType).describe('Entity type of the parent entity');
+export const parentEntityIdField = z.string().describe('ID of the parent entity');
+export const parentEntityNameField = z.string().describe('Name of the parent entity');
+export const rootEntityTypeField = z.nativeEnum(EntityType).describe('Entity type of the root entity');
+export const rootEntityIdField = z.string().describe('ID of the root entity');
+export const rootEntityNameField = z.string().describe('Name of the root entity');
+export const experimentIdField = z.string().describe('Experiment or eval run identifier');
+
+export const scopeField = z.record(z.string(), z.unknown()).describe('Arbitrary package/app version info (e.g., {"core": "1.0.0", "memory": "1.0.0", "gitSha": "abcd1234"})');
+export const metadataField = z.record(z.string(), z.unknown()).describe('User-defined metadata for custom filtering');
+export const tagsField = z.array(z.string()).describe('Labels for filtering');
+
+export const contextFields = {
+  entityType: entityTypeField.nullish(),
+  entityId: entityIdField.nullish(),
+  entityName: entityNameField.nullish(),
+  parentEntityType: parentEntityTypeField.nullish(),
+  parentEntityId: parentEntityIdField.nullish(),
+  parentEntityName: parentEntityNameField.nullish(),
+  rootEntityType: rootEntityTypeField.nullish(),
+  rootEntityId: rootEntityIdField.nullish(),
+  rootEntityName: rootEntityNameField.nullish(),
+  userId: userIdField.nullish(),
+  organizationId: organizationIdField.nullish(),
+  resourceId: resourceIdField.nullish(),
+  runId: runIdField.nullish(),
+  sessionId: sessionIdField.nullish(),
+  threadId: threadIdField.nullish(),
+  requestId: requestIdField.nullish(),
+  environment: environmentField.nullish(),
+  source: sourceField.nullish(),
+  serviceName: serviceNameField.nullish(),
+  scope: scopeField.nullish(),
+  experimentId: experimentIdField.nullish(),
+} as const;
+
+export const commonFilterFields = {
+  timestamp: dateRangeSchema.optional().describe('Filter by timestamp range'),
+  traceId: z.string().optional().describe('Filter by trace ID'),
+  spanId: z.string().optional().describe('Filter by span ID'),
+  entityType: entityTypeField.optional(),
+  entityName: entityNameField.optional(),
+  userId: userIdField.optional(),
+  organizationId: organizationIdField.optional(),
+  experimentId: experimentIdField.optional(),
+  serviceName: serviceNameField.optional(),
+  environment: environmentField.optional(),
+} as const;
+
+export const traceIdField = z.string().describe('Unique trace identifier');
+export const spanIdField = z.string().describe('Unique span identifier within a trace');

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,0 +1,7 @@
+export * from './constants';
+export * from './types';
+export * from './utils';
+export * from './sql';
+export * from './observability';
+export * from './domains/observability';
+export * from './domains/shared';

--- a/packages/storage/src/observability.ts
+++ b/packages/storage/src/observability.ts
@@ -1,0 +1,30 @@
+export enum EntityType {
+  AGENT = 'agent',
+  EVAL = 'eval',
+  INPUT_PROCESSOR = 'input_processor',
+  INPUT_STEP_PROCESSOR = 'input_step_processor',
+  OUTPUT_PROCESSOR = 'output_processor',
+  OUTPUT_STEP_PROCESSOR = 'output_step_processor',
+  TOOL = 'tool',
+  WORKFLOW_RUN = 'workflow_run',
+  WORKFLOW_STEP = 'workflow_step',
+}
+
+export enum SpanType {
+  AGENT_RUN = 'agent_run',
+  GENERIC = 'generic',
+  MODEL_GENERATION = 'model_generation',
+  MODEL_STEP = 'model_step',
+  MODEL_CHUNK = 'model_chunk',
+  MCP_TOOL_CALL = 'mcp_tool_call',
+  PROCESSOR_RUN = 'processor_run',
+  TOOL_CALL = 'tool_call',
+  WORKFLOW_RUN = 'workflow_run',
+  WORKFLOW_STEP = 'workflow_step',
+  WORKFLOW_CONDITIONAL = 'workflow_conditional',
+  WORKFLOW_CONDITIONAL_EVAL = 'workflow_conditional_eval',
+  WORKFLOW_PARALLEL = 'workflow_parallel',
+  WORKFLOW_LOOP = 'workflow_loop',
+  WORKFLOW_SLEEP = 'workflow_sleep',
+  WORKFLOW_WAIT_EVENT = 'workflow_wait_event',
+}

--- a/packages/storage/src/sql.ts
+++ b/packages/storage/src/sql.ts
@@ -1,0 +1,24 @@
+export type SqlIdentifier = string & { __brand: 'SqlIdentifier' };
+export type FieldKey = string & { __brand: 'FieldKey' };
+
+export const SQL_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+export function parseSqlIdentifier(name: string, kind = 'identifier'): SqlIdentifier {
+  if (!SQL_IDENTIFIER_PATTERN.test(name) || name.length > 63) {
+    throw new Error(
+      `Invalid ${kind}: ${name}. Must start with a letter or underscore, contain only letters, numbers, or underscores, and be at most 63 characters long.`,
+    );
+  }
+  return name as SqlIdentifier;
+}
+
+export function parseFieldKey(key: string): FieldKey {
+  if (!key) throw new Error('Field key cannot be empty');
+  const segments = key.split('.');
+  for (const segment of segments) {
+    if (!SQL_IDENTIFIER_PATTERN.test(segment) || segment.length > 63) {
+      throw new Error(`Invalid field key segment: ${segment} in ${key}`);
+    }
+  }
+  return key as FieldKey;
+}

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -1,0 +1,328 @@
+import { z } from 'zod/v4';
+
+export type StoragePagination = {
+  page: number;
+  perPage: number | false;
+};
+
+export type StorageColumnType = 'text' | 'timestamp' | 'uuid' | 'jsonb' | 'integer' | 'float' | 'bigint' | 'boolean';
+
+export interface StorageColumn {
+  type: StorageColumnType;
+  primaryKey?: boolean;
+  nullable?: boolean;
+  references?: {
+    table: string;
+    column: string;
+  };
+}
+
+export interface StorageTableConfig {
+  columns: Record<string, StorageColumn>;
+  compositePrimaryKey?: string[];
+}
+
+export interface WorkflowRuns {
+  runs: WorkflowRun[];
+  total: number;
+}
+
+export interface StorageWorkflowRun {
+  workflow_name: string;
+  run_id: string;
+  resourceId?: string;
+  snapshot: unknown | string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface WorkflowRun {
+  workflowName: string;
+  runId: string;
+  snapshot: unknown | string;
+  createdAt: Date;
+  updatedAt: Date;
+  resourceId?: string;
+}
+
+export type PaginationInfo = {
+  total: number;
+  page: number;
+  perPage: number | false;
+  hasMore: boolean;
+};
+
+export type MastraMessageFormat = 'v1' | 'v2';
+
+export type StorageListWorkflowRunsInput = {
+  workflowName?: string;
+  fromDate?: Date;
+  toDate?: Date;
+  perPage?: number | false;
+  page?: number;
+  resourceId?: string;
+  status?: string;
+};
+
+export type StorageResourceType = {
+  id: string;
+  workingMemory?: string;
+  metadata?: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type StorageMessageType = {
+  id: string;
+  thread_id: string;
+  content: string;
+  role: string;
+  type: string;
+  createdAt: Date;
+  resourceId: string | null;
+};
+
+export interface StorageOrderBy<TField extends ThreadOrderBy = ThreadOrderBy> {
+  field?: TField;
+  direction?: ThreadSortDirection;
+}
+
+export interface ThreadSortOptions {
+  orderBy?: ThreadOrderBy;
+  sortDirection?: ThreadSortDirection;
+}
+
+export type ThreadOrderBy = 'createdAt' | 'updatedAt';
+
+export type ThreadSortDirection = 'ASC' | 'DESC';
+
+export interface CreateIndexOptions {
+  name: string;
+  table: string;
+  columns: string[];
+  unique?: boolean;
+  concurrent?: boolean;
+  where?: string;
+  method?: string;
+  opclass?: Record<string, string>;
+  storage?: Record<string, string>;
+  tablespace?: string;
+}
+
+export interface IndexInfo {
+  name: string;
+  table: string;
+  columns: string[];
+  unique: boolean;
+  size?: string;
+  definition?: string;
+}
+
+export interface StorageIndexStats extends IndexInfo {
+  scans?: number;
+  tuples_read?: number;
+  tuples_fetched?: number;
+  last_used?: Date;
+  method?: string;
+}
+
+export type TargetType = 'agent' | 'workflow' | 'scorer' | 'processor';
+
+export interface DatasetRecord {
+  id: string;
+  name: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  inputSchema?: Record<string, unknown>;
+  groundTruthSchema?: Record<string, unknown>;
+  requestContextSchema?: Record<string, unknown>;
+  tags?: string[] | null;
+  targetType?: TargetType | null;
+  targetIds?: string[] | null;
+  version: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface DatasetItemSource {
+  type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result';
+  referenceId?: string;
+}
+
+export interface DatasetItem {
+  id: string;
+  datasetId: string;
+  datasetVersion: number;
+  input: unknown;
+  groundTruth?: unknown;
+  requestContext?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  source?: DatasetItemSource;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface DatasetItemRow {
+  id: string;
+  datasetId: string;
+  datasetVersion: number;
+  validTo: number | null;
+  isDeleted: boolean;
+  input: unknown;
+  groundTruth?: unknown;
+  requestContext?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  source?: DatasetItemSource;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface DatasetVersion {
+  id: string;
+  datasetId: string;
+  version: number;
+  createdAt: Date;
+}
+
+export function unwrapSchema(schema: z.ZodTypeAny): { base: z.ZodTypeAny; nullable: boolean } {
+  let current = schema;
+  let nullable = false;
+
+  while (true) {
+    const typeName = getZodTypeName(current);
+    if (!typeName) break;
+
+    if (typeName === 'ZodNullable' || typeName === 'ZodOptional') {
+      nullable = true;
+    }
+
+    const inner = getZodInnerType(current, typeName);
+    if (!inner) break;
+    current = inner;
+  }
+
+  return { base: current, nullable };
+}
+
+export function getZodChecks(schema: z.ZodTypeAny): Array<{ kind: string }> {
+  if ('_zod' in schema) {
+    const zodV4 = schema as { _zod?: { def?: { checks?: unknown[] } } };
+    const checks = zodV4._zod?.def?.checks;
+
+    if (checks && Array.isArray(checks)) {
+      return checks.map((check: unknown) => {
+        if (
+          typeof check === 'object' &&
+          check !== null &&
+          'def' in check &&
+          typeof check.def === 'object' &&
+          check.def !== null
+        ) {
+          const def = check.def as Record<string, unknown>;
+
+          if (def.check === 'number_format' && def.format === 'safeint') {
+            return { kind: 'int' };
+          }
+
+          if (def.check === 'string_format' && typeof def.format === 'string') {
+            return { kind: def.format };
+          }
+
+          return { kind: typeof def.check === 'string' ? def.check : 'unknown' };
+        }
+
+        return { kind: 'unknown' };
+      });
+    }
+  }
+
+  if ('_def' in schema) {
+    const zodV3 = schema as unknown as { _def?: { checks?: Array<{ kind: string }> } };
+    const checks = zodV3._def?.checks;
+
+    if (checks && Array.isArray(checks)) {
+      return checks;
+    }
+  }
+
+  return [];
+}
+
+export function zodToStorageType(schema: z.ZodTypeAny): StorageColumnType {
+  const typeName = getZodTypeName(schema);
+
+  if (typeName === 'ZodString') {
+    const checks = getZodChecks(schema);
+    if (checks.some(c => c.kind === 'uuid')) {
+      return 'uuid';
+    }
+    return 'text';
+  }
+  if (typeName === 'ZodNativeEnum' || typeName === 'ZodEnum') {
+    return 'text';
+  }
+  if (typeName === 'ZodNumber') {
+    const checks = getZodChecks(schema);
+    return checks.some(c => c.kind === 'int') ? 'integer' : 'float';
+  }
+  if (typeName === 'ZodBigInt' || typeName === 'ZodBigint') {
+    return 'bigint';
+  }
+  if (typeName === 'ZodDate') {
+    return 'timestamp';
+  }
+  if (typeName === 'ZodBoolean') {
+    return 'boolean';
+  }
+  return 'jsonb';
+}
+
+export function buildStorageSchema<Shape extends z.ZodRawShape>(
+  zObject: z.ZodObject<Shape>,
+): Record<keyof Shape & string, StorageColumn> {
+  const shape = zObject.shape;
+  const result: Record<string, StorageColumn> = {};
+
+  for (const [key, field] of Object.entries(shape)) {
+    const { base, nullable } = unwrapSchema(field as z.ZodTypeAny);
+    result[key] = {
+      type: zodToStorageType(base),
+      nullable,
+    };
+  }
+
+  return result as Record<keyof Shape & string, StorageColumn>;
+}
+
+export function getZodTypeName(schema: z.ZodTypeAny): string | undefined {
+  const schemaAny = schema as any;
+
+  if (schemaAny._def?.typeName) {
+    return schemaAny._def.typeName;
+  }
+
+  const zod4Type = schemaAny._def?.type;
+  if (typeof zod4Type === 'string' && zod4Type) {
+    return 'Zod' + zod4Type.charAt(0).toUpperCase() + zod4Type.slice(1);
+  }
+
+  return undefined;
+}
+
+export function getZodInnerType(schema: z.ZodTypeAny, typeName: string): z.ZodTypeAny | undefined {
+  const schemaAny = schema as any;
+
+  if (typeName === 'ZodNullable' || typeName === 'ZodOptional' || typeName === 'ZodDefault') {
+    return schemaAny._zod?.def?.innerType ?? schemaAny._def?.innerType;
+  }
+
+  if (typeName === 'ZodEffects') {
+    return schemaAny._zod?.def?.schema ?? schemaAny._def?.schema;
+  }
+
+  if (typeName === 'ZodBranded') {
+    return schemaAny._zod?.def?.type ?? schemaAny._def?.type;
+  }
+
+  return undefined;
+}

--- a/packages/storage/src/utils.ts
+++ b/packages/storage/src/utils.ts
@@ -1,0 +1,235 @@
+import { TABLE_SCHEMAS, TABLE_SCORERS } from './constants';
+import type { TABLE_NAMES } from './constants';
+import type { StorageColumn } from './types';
+
+export type StoreName =
+  | 'PG'
+  | 'MSSQL'
+  | 'LIBSQL'
+  | 'MONGODB'
+  | 'CLICKHOUSE'
+  | 'CLOUDFLARE'
+  | 'CLOUDFLARE_D1'
+  | 'DYNAMODB'
+  | 'LANCE'
+  | 'UPSTASH'
+  | 'ASTRA'
+  | 'CHROMA'
+  | 'COUCHBASE'
+  | 'OPENSEARCH'
+  | 'PINECONE'
+  | 'QDRANT'
+  | 'S3'
+  | 'TURBOPUFFER'
+  | 'VECTORIZE'
+  | (string & {});
+
+export function safelyParseJSON(input: any): any {
+  if (input && typeof input === 'object') return input;
+  if (input == null) return {};
+  if (typeof input === 'string') {
+    try {
+      return JSON.parse(input);
+    } catch {
+      return input;
+    }
+  }
+  return {};
+}
+
+export interface TransformRowOptions {
+  preferredTimestampFields?: Record<string, string>;
+  convertTimestamps?: boolean;
+  nullValuePattern?: string;
+  fieldMappings?: Record<string, string>;
+}
+
+export function transformRow<T = Record<string, any>>(
+  row: Record<string, any>,
+  tableName: TABLE_NAMES,
+  options: TransformRowOptions = {},
+): T {
+  const { preferredTimestampFields = {}, convertTimestamps = false, nullValuePattern, fieldMappings = {} } = options;
+
+  const tableSchema = TABLE_SCHEMAS[tableName];
+  const result: Record<string, any> = {};
+
+  for (const [key, columnSchema] of Object.entries(tableSchema)) {
+    const sourceKey = fieldMappings[key] ?? key;
+    let value = row[sourceKey];
+
+    if (preferredTimestampFields[key]) {
+      value = row[preferredTimestampFields[key]] ?? value;
+    }
+
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (nullValuePattern && value === nullValuePattern) {
+      continue;
+    }
+
+    if (columnSchema.type === 'jsonb') {
+      if (typeof value === 'string') {
+        result[key] = safelyParseJSON(value);
+      } else if (typeof value === 'object') {
+        result[key] = value;
+      } else {
+        result[key] = value;
+      }
+    } else if (columnSchema.type === 'timestamp' && convertTimestamps && typeof value === 'string') {
+      result[key] = new Date(value);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result as T;
+}
+
+export function transformScoreRow<T = Record<string, any>>(row: Record<string, any>, options: TransformRowOptions = {}): T {
+  return transformRow<T>(row, TABLE_SCORERS, options);
+}
+
+export function toUpperSnakeCase(str: string): string {
+  return str
+    .replace(/([a-z])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1_$2')
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function createStoreErrorId(
+  kind: 'storage' | 'vector',
+  store: StoreName,
+  operation: string,
+  status: string,
+): Uppercase<string> {
+  return `MASTRA_${kind.toUpperCase()}_${toUpperSnakeCase(store)}_${toUpperSnakeCase(operation)}_${toUpperSnakeCase(status)}` as Uppercase<string>;
+}
+
+export function createStorageErrorId(store: StoreName, operation: string, status: string): Uppercase<string> {
+  return createStoreErrorId('storage', store, operation, status);
+}
+
+export function createVectorErrorId(store: StoreName, operation: string, status: string): Uppercase<string> {
+  return createStoreErrorId('vector', store, operation, status);
+}
+
+export const generateStorageErrorId = createStorageErrorId;
+
+export function getSqlType(type: StorageColumn['type']): string {
+  switch (type) {
+    case 'text':
+      return 'TEXT';
+    case 'timestamp':
+      return 'TIMESTAMP';
+    case 'float':
+      return 'FLOAT';
+    case 'integer':
+      return 'INTEGER';
+    case 'bigint':
+      return 'BIGINT';
+    case 'jsonb':
+      return 'JSONB';
+    case 'boolean':
+      return 'BOOLEAN';
+    default:
+      return 'TEXT';
+  }
+}
+
+export function getDefaultValue(type: StorageColumn['type']): string {
+  switch (type) {
+    case 'text':
+    case 'uuid':
+      return "DEFAULT ''";
+    case 'timestamp':
+      return "DEFAULT '1970-01-01 00:00:00'";
+    case 'integer':
+    case 'bigint':
+    case 'float':
+      return 'DEFAULT 0';
+    case 'jsonb':
+      return "DEFAULT '{}'";
+    case 'boolean':
+      return 'DEFAULT FALSE';
+    default:
+      return "DEFAULT ''";
+  }
+}
+
+export function ensureDate(date: Date | string | number): Date {
+  return date instanceof Date ? date : new Date(date);
+}
+
+export function serializeDate(date: Date | string | number): string {
+  return ensureDate(date).toISOString();
+}
+
+export interface DateRangeFilter {
+  start?: Date | string;
+  end?: Date | string;
+  startExclusive?: boolean;
+  endExclusive?: boolean;
+}
+
+export function filterByDateRange<T>(items: T[], getDate: (item: T) => Date | string | undefined, range?: DateRangeFilter): T[] {
+  if (!range?.start && !range?.end) {
+    return items;
+  }
+
+  const start = range.start ? ensureDate(range.start) : undefined;
+  const end = range.end ? ensureDate(range.end) : undefined;
+
+  return items.filter(item => {
+    const value = getDate(item);
+    if (!value) return false;
+
+    const date = ensureDate(value);
+
+    if (start) {
+      if (range.startExclusive ? date <= start : date < start) {
+        return false;
+      }
+    }
+
+    if (end) {
+      if (range.endExclusive ? date >= end : date > end) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+export function jsonValueEquals(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function normalizePerPage(perPageInput: number | false | undefined, defaultValue: number): number {
+  if (perPageInput === false) {
+    return Number.MAX_SAFE_INTEGER;
+  } else if (perPageInput === 0) {
+    return 0;
+  } else if (typeof perPageInput === 'number' && perPageInput > 0) {
+    return perPageInput;
+  } else if (typeof perPageInput === 'number' && perPageInput < 0) {
+    throw new Error('perPage must be >= 0');
+  }
+  return defaultValue;
+}
+
+export function calculatePagination(
+  page: number,
+  perPageInput: number | false | undefined,
+  normalizedPerPage: number,
+): { offset: number; perPage: number | false } {
+  return {
+    offset: perPageInput === false ? 0 : page * normalizedPerPage,
+    perPage: perPageInput === false ? false : normalizedPerPage,
+  };
+}

--- a/packages/storage/tsconfig.build.json
+++ b/packages/storage/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+}

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/storage/tsup.config.ts
+++ b/packages/storage/tsup.config.ts
@@ -1,0 +1,20 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    sql: 'src/sql.ts',
+  },
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4268,6 +4268,39 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
 
+  packages/storage:
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../_types-builder
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.0.18(vitest@4.0.18)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.0.18(vitest@4.0.18)
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+
   pubsub/google-cloud-pubsub:
     dependencies:
       '@google-cloud/pubsub':
@@ -4631,6 +4664,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18)
@@ -4653,6 +4689,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -4693,6 +4732,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -4733,6 +4775,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -4776,6 +4821,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -4825,6 +4873,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -4871,6 +4922,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -4914,6 +4968,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -4954,6 +5011,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5003,6 +5063,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5043,6 +5106,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5086,6 +5152,9 @@ importers:
       '@mastra/core':
         specifier: workspace:^
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5126,6 +5195,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5172,6 +5244,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5212,6 +5287,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/mssql':
         specifier: ^9.1.9
         version: 9.1.9
@@ -5255,6 +5333,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5301,6 +5382,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5344,6 +5428,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5387,6 +5474,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5430,6 +5520,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5473,6 +5566,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5519,6 +5615,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -5559,6 +5658,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@mastra/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15

--- a/stores/_test-utils/package.json
+++ b/stores/_test-utils/package.json
@@ -16,11 +16,13 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@mastra/core": "*",
-    "vitest": "*"
+    "vitest": "*",
+    "@mastra/storage": "*"
   },
   "devDependencies": {
     "@mastra/core": "workspace:*",
     "@vitest/coverage-v8": "catalog:",
-    "@vitest/ui": "catalog:"
+    "@vitest/ui": "catalog:",
+    "@mastra/storage": "workspace:*"
   }
 }

--- a/stores/_test-utils/src/domains/datasets/index.ts
+++ b/stores/_test-utils/src/domains/datasets/index.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
-import type { MastraStorage, DatasetsStorage, DatasetRecord, DatasetItem } from '@mastra/core/storage';
+import type { MastraStorage, DatasetsStorage } from '@mastra/core/storage';
+import type { DatasetRecord, DatasetItem } from '@mastra/storage';
 
 export function createDatasetsTests({ storage }: { storage: MastraStorage }) {
   // Skip tests if storage doesn't have datasets domain

--- a/stores/_test-utils/src/domains/memory/data.ts
+++ b/stores/_test-utils/src/domains/memory/data.ts
@@ -1,7 +1,7 @@
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
-import type { StorageResourceType } from '@mastra/core/storage';
 import { randomUUID } from 'node:crypto';
+import type { StorageResourceType } from '@mastra/storage';
 
 let role: 'assistant' | 'user' = 'assistant';
 export const getRole = () => {

--- a/stores/_test-utils/src/domains/observability/data.ts
+++ b/stores/_test-utils/src/domains/observability/data.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { SpanType, EntityType } from '@mastra/core/observability';
-import type { CreateSpanRecord, SpanRecord } from '@mastra/core/storage';
+import type { CreateSpanRecord } from '@mastra/core/storage';
+import type { SpanRecord } from '@mastra/storage';
 
 /**
  * Default base date for testing - can be overridden

--- a/stores/_test-utils/src/domains/observability/index.ts
+++ b/stores/_test-utils/src/domains/observability/index.ts
@@ -1,5 +1,7 @@
-import { MastraStorage, TraceStatus } from '@mastra/core/storage';
-import type { ObservabilityStorage, SpanRecord, TraceSpan } from '@mastra/core/storage';
+import { MastraStorage } from '@mastra/core/storage';
+import { TraceStatus } from '@mastra/storage';
+import type { ObservabilityStorage } from '@mastra/core/storage';
+import type { SpanRecord, TraceSpan } from '@mastra/storage';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { createSpan, createChildSpan, SpanType, EntityType, DEFAULT_BASE_DATE } from './data';
 

--- a/stores/astra/package.json
+++ b/stores/astra/package.json
@@ -43,10 +43,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/astra/src/vector/index.ts
+++ b/stores/astra/src/vector/index.ts
@@ -1,7 +1,6 @@
 import type { Db } from '@datastax/astra-db-ts';
 import { DataAPIClient, UUID } from '@datastax/astra-db-ts';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';
 import type {
   QueryResult,
@@ -15,6 +14,7 @@ import type {
   UpdateVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import type { AstraVectorFilter } from './filter';
 import { AstraFilterTranslator } from './filter';
 

--- a/stores/chroma/package.json
+++ b/stores/chroma/package.json
@@ -42,10 +42,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/chroma/src/vector/index.ts
+++ b/stores/chroma/src/vector/index.ts
@@ -1,5 +1,4 @@
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector, validateUpsert, validateTopK } from '@mastra/core/vector';
 import type {
   QueryResult,
@@ -13,6 +12,7 @@ import type {
   UpdateVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import { ChromaClient, CloudClient } from 'chromadb';
 import type { ChromaClientArgs, RecordSet, Where, WhereDocument, Collection, Metadata, Search } from 'chromadb';
 import type { ChromaVectorFilter } from './filter';

--- a/stores/clickhouse/package.json
+++ b/stores/clickhouse/package.json
@@ -45,10 +45,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/clickhouse/src/storage/db/index.ts
+++ b/stores/clickhouse/src/storage/db/index.ts
@@ -9,8 +9,8 @@ import {
   TABLE_SPANS,
   TABLE_SCHEMAS,
   getDefaultValue,
-} from '@mastra/core/storage';
-import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/storage';
 import type { ClickhouseConfig } from './utils';
 import { TABLE_ENGINES, transformRow } from './utils';
 

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -1,4 +1,4 @@
-import type { TABLE_NAMES, TABLE_SCHEMAS, StorageColumn } from '@mastra/core/storage';
+import type { TABLE_NAMES, TABLE_SCHEMAS, StorageColumn } from '@mastra/storage';
 import {
   TABLE_MESSAGES,
   TABLE_RESOURCES,
@@ -27,7 +27,7 @@ import {
   TABLE_SKILLS,
   TABLE_SKILL_VERSIONS,
   TABLE_SKILL_BLOBS,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   [TABLE_MESSAGES]: `MergeTree()`,

--- a/stores/clickhouse/src/storage/domains/memory/index.ts
+++ b/stores/clickhouse/src/storage/domains/memory/index.ts
@@ -4,22 +4,22 @@ import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type {
-  StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesOutput,
   StorageListThreadsInput,
   StorageListThreadsOutput,
 } from '@mastra/core/storage';
+import { MemoryStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  MemoryStorage,
   normalizePerPage,
   calculatePagination,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
   TABLE_SCHEMAS,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageResourceType } from '@mastra/storage';
 import { ClickhouseDB, resolveClickhouseConfig } from '../../db';
 import type { ClickhouseDomainConfig } from '../../db';
 import { transformRow, transformRows } from '../../db/utils';

--- a/stores/clickhouse/src/storage/domains/observability/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/index.ts
@@ -1,16 +1,7 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  listTracesArgsSchema,
-  ObservabilityStorage,
-  SPAN_SCHEMA,
-  TABLE_SPANS,
-  toTraceSpans,
-  TraceStatus,
-} from '@mastra/core/storage';
+import { listTracesArgsSchema, ObservabilityStorage, toTraceSpans } from '@mastra/core/storage';
 import type {
-  SpanRecord,
   ListTracesArgs,
   ListTracesResponse,
   TracingStorageStrategy,
@@ -26,6 +17,8 @@ import type {
   GetTraceArgs,
   GetTraceResponse,
 } from '@mastra/core/storage';
+import { createStorageErrorId, SPAN_SCHEMA, TABLE_SPANS, TraceStatus } from '@mastra/storage';
+import type { SpanRecord } from '@mastra/storage';
 import { ClickhouseDB, resolveClickhouseConfig } from '../../db';
 import type { ClickhouseDomainConfig } from '../../db';
 import { TABLE_ENGINES, transformRows } from '../../db/utils';

--- a/stores/clickhouse/src/storage/domains/scores/index.ts
+++ b/stores/clickhouse/src/storage/domains/scores/index.ts
@@ -2,17 +2,17 @@ import type { ClickHouseClient } from '@clickhouse/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
+import { ScoresStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  ScoresStorage,
   SCORERS_SCHEMA,
   TABLE_SCORERS,
   calculatePagination,
   normalizePerPage,
   transformScoreRow as coreTransformScoreRow,
   TABLE_SCHEMAS,
-} from '@mastra/core/storage';
-import type { StoragePagination } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StoragePagination } from '@mastra/storage';
 import { ClickhouseDB, resolveClickhouseConfig } from '../../db';
 import type { ClickhouseDomainConfig } from '../../db';
 

--- a/stores/clickhouse/src/storage/domains/workflows/index.ts
+++ b/stores/clickhouse/src/storage/domains/workflows/index.ts
@@ -1,19 +1,10 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  normalizePerPage,
-  TABLE_WORKFLOW_SNAPSHOT,
-  TABLE_SCHEMAS,
-  WorkflowsStorage,
-} from '@mastra/core/storage';
-import type {
-  WorkflowRun,
-  WorkflowRuns,
-  StorageListWorkflowRunsInput,
-  UpdateWorkflowStateOptions,
-} from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { createStorageErrorId, normalizePerPage, TABLE_WORKFLOW_SNAPSHOT, TABLE_SCHEMAS } from '@mastra/storage';
+import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/storage';
 import { ClickhouseDB, resolveClickhouseConfig } from '../../db';
 import type { ClickhouseDomainConfig } from '../../db';
 import { TABLE_ENGINES } from '../../db/utils';

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -1,8 +1,10 @@
 import type { ClickHouseClient, ClickHouseClientConfigOptions } from '@clickhouse/client';
 import { createClient } from '@clickhouse/client';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
-import type { TABLE_NAMES, StorageDomains, TABLE_SCHEMAS } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
+import type { StorageDomains } from '@mastra/core/storage';
+import { createStorageErrorId } from '@mastra/storage';
+import type { TABLE_NAMES, TABLE_SCHEMAS } from '@mastra/storage';
 import { MemoryStorageClickhouse } from './domains/memory';
 import { ObservabilityStorageClickhouse } from './domains/observability';
 import { ScoresStorageClickhouse } from './domains/scores';

--- a/stores/clickhouse/src/storage/migration.test.ts
+++ b/stores/clickhouse/src/storage/migration.test.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@clickhouse/client';
 import type { ClickHouseClient } from '@clickhouse/client';
 import { MastraError } from '@mastra/core/error';
-import { TABLE_SPANS, SPAN_SCHEMA } from '@mastra/core/storage';
+import { TABLE_SPANS, SPAN_SCHEMA } from '@mastra/storage';
 import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
 
 import { ClickhouseDB } from './db';

--- a/stores/cloudflare-d1/package.json
+++ b/stores/cloudflare-d1/package.json
@@ -46,10 +46,12 @@
     "miniflare": "^4.20260312.0",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/cloudflare-d1/src/storage/db/index.ts
+++ b/stores/cloudflare-d1/src/storage/db/index.ts
@@ -1,8 +1,8 @@
 import type { D1Database } from '@cloudflare/workers-types';
 import { MastraBase } from '@mastra/core/base';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createStorageErrorId, getDefaultValue, getSqlType, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
-import type { TABLE_NAMES, StorageColumn } from '@mastra/core/storage';
+import { createStorageErrorId, getDefaultValue, getSqlType, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/storage';
+import type { TABLE_NAMES, StorageColumn } from '@mastra/storage';
 import Cloudflare from 'cloudflare';
 import { deserializeValue } from '../domains/utils';
 import { createSqlBuilder } from '../sql-builder';

--- a/stores/cloudflare-d1/src/storage/domains/memory/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/memory/index.ts
@@ -2,10 +2,16 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
+import { MemoryStorage } from '@mastra/core/storage';
+import type {
+  StorageListMessagesInput,
+  StorageListMessagesOutput,
+  StorageListThreadsInput,
+  StorageListThreadsOutput,
+} from '@mastra/core/storage';
 import {
   createStorageErrorId,
   ensureDate,
-  MemoryStorage,
   serializeDate,
   TABLE_MESSAGES,
   TABLE_THREADS,
@@ -13,14 +19,8 @@ import {
   TABLE_SCHEMAS,
   normalizePerPage,
   calculatePagination,
-} from '@mastra/core/storage';
-import type {
-  StorageResourceType,
-  StorageListMessagesInput,
-  StorageListMessagesOutput,
-  StorageListThreadsInput,
-  StorageListThreadsOutput,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageResourceType } from '@mastra/storage';
 import { D1DB, resolveD1Config } from '../../db';
 import type { D1DomainConfig } from '../../db';
 import { createSqlBuilder } from '../../sql-builder';

--- a/stores/cloudflare-d1/src/storage/domains/scores/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/scores/index.ts
@@ -1,16 +1,16 @@
 import { ErrorDomain, ErrorCategory, MastraError } from '@mastra/core/error';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
+import { ScoresStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  ScoresStorage,
   TABLE_SCORERS,
   TABLE_SCHEMAS,
   calculatePagination,
   normalizePerPage,
   transformScoreRow as coreTransformScoreRow,
-} from '@mastra/core/storage';
-import type { StoragePagination } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StoragePagination } from '@mastra/storage';
 import { D1DB, resolveD1Config } from '../../db';
 import type { D1DomainConfig } from '../../db';
 import { createSqlBuilder } from '../../sql-builder';

--- a/stores/cloudflare-d1/src/storage/domains/workflows/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/workflows/index.ts
@@ -1,18 +1,9 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import type {
-  WorkflowRun,
-  WorkflowRuns,
-  StorageListWorkflowRunsInput,
-  UpdateWorkflowStateOptions,
-} from '@mastra/core/storage';
-import {
-  createStorageErrorId,
-  ensureDate,
-  TABLE_WORKFLOW_SNAPSHOT,
-  TABLE_SCHEMAS,
-  WorkflowsStorage,
-} from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { createStorageErrorId, ensureDate, TABLE_WORKFLOW_SNAPSHOT, TABLE_SCHEMAS } from '@mastra/storage';
+import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/storage';
 import { D1DB, resolveD1Config } from '../../db';
 import type { D1DomainConfig } from '../../db';
 import { createSqlBuilder } from '../../sql-builder';

--- a/stores/cloudflare-d1/src/storage/index.ts
+++ b/stores/cloudflare-d1/src/storage/index.ts
@@ -1,7 +1,8 @@
 import type { D1Database } from '@cloudflare/workers-types';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
 import type { StorageDomains } from '@mastra/core/storage';
+import { createStorageErrorId } from '@mastra/storage';
 import Cloudflare from 'cloudflare';
 import { MemoryStorageD1 } from './domains/memory';
 import { ScoresStorageD1 } from './domains/scores';

--- a/stores/cloudflare-d1/src/storage/rest-api.test.ts
+++ b/stores/cloudflare-d1/src/storage/rest-api.test.ts
@@ -8,9 +8,9 @@ import {
   checkWorkflowSnapshot,
 } from '@internal/storage-test-utils';
 import type { StorageThreadType } from '@mastra/core/memory';
-import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
-import { TABLE_MESSAGES, TABLE_THREADS, TABLE_WORKFLOW_SNAPSHOT, TABLE_TRACES } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/storage';
+import { TABLE_MESSAGES, TABLE_THREADS, TABLE_WORKFLOW_SNAPSHOT, TABLE_TRACES } from '@mastra/storage';
 import dotenv from 'dotenv';
 import { describe, it, expect, beforeAll, beforeEach, afterAll, vi, afterEach } from 'vitest';
 

--- a/stores/cloudflare-d1/src/storage/sql-builder.ts
+++ b/stores/cloudflare-d1/src/storage/sql-builder.ts
@@ -1,4 +1,4 @@
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 
 /**
  * Type definition for SQL query parameters

--- a/stores/cloudflare/package.json
+++ b/stores/cloudflare/package.json
@@ -67,11 +67,13 @@
     "miniflare": "^4.20260312.0",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.20240919.0",
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/cloudflare/src/do/index.ts
+++ b/stores/cloudflare/src/do/index.ts
@@ -1,7 +1,8 @@
 import type { SqlStorage } from '@cloudflare/workers-types';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
 import type { StorageDomains } from '@mastra/core/storage';
+import { createStorageErrorId } from '@mastra/storage';
 
 import { MemoryStorageDO } from './storage/domains/memory';
 import { ScoresStorageDO } from './storage/domains/scores';

--- a/stores/cloudflare/src/do/storage/db/index.ts
+++ b/stores/cloudflare/src/do/storage/db/index.ts
@@ -1,8 +1,8 @@
 import type { SqlStorage } from '@cloudflare/workers-types';
 import { MastraBase } from '@mastra/core/base';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createStorageErrorId, getDefaultValue, getSqlType, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
-import type { TABLE_NAMES, StorageColumn } from '@mastra/core/storage';
+import { createStorageErrorId, getDefaultValue, getSqlType, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/storage';
+import type { TABLE_NAMES, StorageColumn } from '@mastra/storage';
 
 import { deserializeValue } from '../domains/utils';
 import { createSqlBuilder } from '../sql-builder';

--- a/stores/cloudflare/src/do/storage/domains/memory/index.ts
+++ b/stores/cloudflare/src/do/storage/domains/memory/index.ts
@@ -2,10 +2,16 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
+import { MemoryStorage } from '@mastra/core/storage';
+import type {
+  StorageListMessagesInput,
+  StorageListMessagesOutput,
+  StorageListThreadsInput,
+  StorageListThreadsOutput,
+} from '@mastra/core/storage';
 import {
   createStorageErrorId,
   ensureDate,
-  MemoryStorage,
   serializeDate,
   TABLE_MESSAGES,
   TABLE_THREADS,
@@ -13,14 +19,8 @@ import {
   TABLE_SCHEMAS,
   normalizePerPage,
   calculatePagination,
-} from '@mastra/core/storage';
-import type {
-  StorageResourceType,
-  StorageListMessagesInput,
-  StorageListMessagesOutput,
-  StorageListThreadsInput,
-  StorageListThreadsOutput,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageResourceType } from '@mastra/storage';
 
 import { DODB } from '../../db';
 import type { DODomainConfig } from '../../db';

--- a/stores/cloudflare/src/do/storage/domains/scores/index.ts
+++ b/stores/cloudflare/src/do/storage/domains/scores/index.ts
@@ -1,16 +1,16 @@
 import { ErrorDomain, ErrorCategory, MastraError } from '@mastra/core/error';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
+import { ScoresStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  ScoresStorage,
   TABLE_SCORERS,
   TABLE_SCHEMAS,
   calculatePagination,
   normalizePerPage,
   transformScoreRow as coreTransformScoreRow,
-} from '@mastra/core/storage';
-import type { StoragePagination } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StoragePagination } from '@mastra/storage';
 
 import { DODB } from '../../db';
 import type { DODomainConfig } from '../../db';

--- a/stores/cloudflare/src/do/storage/domains/workflows/index.ts
+++ b/stores/cloudflare/src/do/storage/domains/workflows/index.ts
@@ -1,18 +1,9 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import type {
-  WorkflowRun,
-  WorkflowRuns,
-  StorageListWorkflowRunsInput,
-  UpdateWorkflowStateOptions,
-} from '@mastra/core/storage';
-import {
-  createStorageErrorId,
-  ensureDate,
-  TABLE_WORKFLOW_SNAPSHOT,
-  TABLE_SCHEMAS,
-  WorkflowsStorage,
-} from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { createStorageErrorId, ensureDate, TABLE_WORKFLOW_SNAPSHOT, TABLE_SCHEMAS } from '@mastra/storage';
+import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/storage';
 
 import { DODB } from '../../db';
 import type { DODomainConfig } from '../../db';

--- a/stores/cloudflare/src/do/storage/sql-builder.ts
+++ b/stores/cloudflare/src/do/storage/sql-builder.ts
@@ -1,4 +1,4 @@
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 
 /**
  * Type definition for SQL query parameters

--- a/stores/cloudflare/src/kv/index.ts
+++ b/stores/cloudflare/src/kv/index.ts
@@ -1,14 +1,15 @@
 import type { KVNamespace } from '@cloudflare/workers-types';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { MastraCompositeStore } from '@mastra/core/storage';
+import type { StorageDomains } from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  MastraCompositeStore,
   TABLE_MESSAGES,
   TABLE_THREADS,
   TABLE_WORKFLOW_SNAPSHOT,
   TABLE_SCORERS,
-} from '@mastra/core/storage';
-import type { TABLE_NAMES, StorageDomains } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { TABLE_NAMES } from '@mastra/storage';
 import Cloudflare from 'cloudflare';
 import { MemoryStorageCloudflare } from './storage/domains/memory';
 import { ScoresStorageCloudflare } from './storage/domains/scores';

--- a/stores/cloudflare/src/kv/storage/binding-api.test.ts
+++ b/stores/cloudflare/src/kv/storage/binding-api.test.ts
@@ -14,7 +14,7 @@ import {
   TABLE_THREADS,
   TABLE_TRACES,
   TABLE_WORKFLOW_SNAPSHOT,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
 import dotenv from 'dotenv';
 import { Miniflare } from 'miniflare';
 import { vi } from 'vitest';

--- a/stores/cloudflare/src/kv/storage/db/index.ts
+++ b/stores/cloudflare/src/kv/storage/db/index.ts
@@ -8,8 +8,8 @@ import {
   TABLE_THREADS,
   TABLE_TRACES,
   TABLE_WORKFLOW_SNAPSHOT,
-} from '@mastra/core/storage';
-import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/storage';
 import Cloudflare from 'cloudflare';
 import type { CloudflareDomainConfig, ListOptions, RecordTypes } from '../types';
 

--- a/stores/cloudflare/src/kv/storage/domains/memory/index.ts
+++ b/stores/cloudflare/src/kv/storage/domains/memory/index.ts
@@ -3,24 +3,24 @@ import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type {
-  StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesOutput,
   StorageListThreadsInput,
   StorageListThreadsOutput,
 } from '@mastra/core/storage';
+import { MemoryStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
   ensureDate,
   filterByDateRange,
-  MemoryStorage,
   normalizePerPage,
   calculatePagination,
   serializeDate,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageResourceType } from '@mastra/storage';
 import { CloudflareKVDB, resolveCloudflareConfig } from '../../db';
 import type { CloudflareDomainConfig } from '../../types';
 

--- a/stores/cloudflare/src/kv/storage/domains/scores/index.ts
+++ b/stores/cloudflare/src/kv/storage/domains/scores/index.ts
@@ -1,15 +1,15 @@
 import { ErrorDomain, ErrorCategory, MastraError } from '@mastra/core/error';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
+import { ScoresStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  ScoresStorage,
   TABLE_SCORERS,
   calculatePagination,
   normalizePerPage,
   transformScoreRow as coreTransformScoreRow,
-} from '@mastra/core/storage';
-import type { StoragePagination } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StoragePagination } from '@mastra/storage';
 import { CloudflareKVDB, resolveCloudflareConfig } from '../../db';
 import type { CloudflareDomainConfig } from '../../types';
 

--- a/stores/cloudflare/src/kv/storage/domains/workflows/index.ts
+++ b/stores/cloudflare/src/kv/storage/domains/workflows/index.ts
@@ -1,18 +1,9 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  TABLE_WORKFLOW_SNAPSHOT,
-  ensureDate,
-  WorkflowsStorage,
-  normalizePerPage,
-} from '@mastra/core/storage';
-import type {
-  WorkflowRun,
-  WorkflowRuns,
-  StorageListWorkflowRunsInput,
-  UpdateWorkflowStateOptions,
-} from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { createStorageErrorId, TABLE_WORKFLOW_SNAPSHOT, ensureDate, normalizePerPage } from '@mastra/storage';
+import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/storage';
 import { CloudflareKVDB, resolveCloudflareConfig } from '../../db';
 import type { CloudflareDomainConfig } from '../../types';
 

--- a/stores/cloudflare/src/kv/storage/logger-verification.test.ts
+++ b/stores/cloudflare/src/kv/storage/logger-verification.test.ts
@@ -9,7 +9,7 @@ import {
   TABLE_THREADS,
   TABLE_TRACES,
   TABLE_WORKFLOW_SNAPSHOT,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
 import { Miniflare } from 'miniflare';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CloudflareStore } from '..';

--- a/stores/cloudflare/src/kv/storage/rest-api.test.ts
+++ b/stores/cloudflare/src/kv/storage/rest-api.test.ts
@@ -1,8 +1,8 @@
 import { createSampleMessageV1, createSampleThread, checkWorkflowSnapshot } from '@internal/storage-test-utils';
 import type { MastraMessageV1, StorageThreadType } from '@mastra/core/memory';
-import type { TABLE_NAMES } from '@mastra/core/storage';
-import { TABLE_MESSAGES, TABLE_THREADS, TABLE_WORKFLOW_SNAPSHOT, TABLE_TRACES } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
+import type { TABLE_NAMES } from '@mastra/storage';
+import { TABLE_MESSAGES, TABLE_THREADS, TABLE_WORKFLOW_SNAPSHOT, TABLE_TRACES } from '@mastra/storage';
 import dotenv from 'dotenv';
 import { describe, it, expect, beforeAll, beforeEach, afterAll, vi, afterEach } from 'vitest';
 

--- a/stores/cloudflare/src/kv/storage/types.ts
+++ b/stores/cloudflare/src/kv/storage/types.ts
@@ -2,13 +2,30 @@ import type { KVNamespace } from '@cloudflare/workers-types';
 import type { ScoreRowData } from '@mastra/core/evals';
 import type { StorageThreadType, MastraDBMessage } from '@mastra/core/memory';
 import type {
+  StorageAgentType,
+  StoragePromptBlockType,
+  StorageScorerDefinitionType,
+  StorageMCPClientType,
+  StorageMCPServerType,
+  StorageWorkspaceType,
+  StorageSkillType,
+  StorageBlobEntry,
+} from '@mastra/core/storage';
+import type { AgentVersion } from '@mastra/core/storage/domains/agents';
+import type { MCPClientVersion } from '@mastra/core/storage/domains/mcp-clients';
+import type { MCPServerVersion } from '@mastra/core/storage/domains/mcp-servers';
+import type { PromptBlockVersion } from '@mastra/core/storage/domains/prompt-blocks';
+import type { ScorerDefinitionVersion } from '@mastra/core/storage/domains/scorer-definitions';
+import type { SkillVersion } from '@mastra/core/storage/domains/skills';
+import type { WorkspaceVersion } from '@mastra/core/storage/domains/workspaces';
+import type { WorkflowRunState } from '@mastra/core/workflows';
+import type {
   TABLE_MESSAGES,
   TABLE_THREADS,
   TABLE_WORKFLOW_SNAPSHOT,
   TABLE_TRACES,
   TABLE_RESOURCES,
   TABLE_NAMES,
-  StorageResourceType,
   TABLE_SCORERS,
   TABLE_SPANS,
   TABLE_AGENTS,
@@ -32,23 +49,8 @@ import type {
   TABLE_SKILL_VERSIONS,
   TABLE_SKILL_BLOBS,
   SpanRecord,
-  StorageAgentType,
-  StoragePromptBlockType,
-  StorageScorerDefinitionType,
-  StorageMCPClientType,
-  StorageMCPServerType,
-  StorageWorkspaceType,
-  StorageSkillType,
-  StorageBlobEntry,
-} from '@mastra/core/storage';
-import type { AgentVersion } from '@mastra/core/storage/domains/agents';
-import type { MCPClientVersion } from '@mastra/core/storage/domains/mcp-clients';
-import type { MCPServerVersion } from '@mastra/core/storage/domains/mcp-servers';
-import type { PromptBlockVersion } from '@mastra/core/storage/domains/prompt-blocks';
-import type { ScorerDefinitionVersion } from '@mastra/core/storage/domains/scorer-definitions';
-import type { SkillVersion } from '@mastra/core/storage/domains/skills';
-import type { WorkspaceVersion } from '@mastra/core/storage/domains/workspaces';
-import type { WorkflowRunState } from '@mastra/core/workflows';
+  StorageResourceType,
+} from '@mastra/storage';
 import type Cloudflare from 'cloudflare';
 
 /**

--- a/stores/convex/package.json
+++ b/stores/convex/package.json
@@ -61,10 +61,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/convex/src/schema.ts
+++ b/stores/convex/src/schema.ts
@@ -2,9 +2,9 @@
  * Convex schema definitions for Mastra tables.
  *
  * This file dynamically builds Convex table definitions from the canonical
- * TABLE_SCHEMAS in @mastra/core/storage/constants to ensure they stay in sync.
+ * TABLE_SCHEMAS in @mastra/storage to ensure they stay in sync.
  *
- * The import path @mastra/core/storage/constants is specifically designed to
+ * The import path @mastra/storage is specifically designed to
  * avoid pulling in Node.js dependencies, making it safe to use in Convex's
  * sandboxed schema evaluation environment.
  */
@@ -15,7 +15,7 @@ import {
   TABLE_THREADS,
   TABLE_RESOURCES,
   TABLE_SCORERS,
-} from '@mastra/core/storage/constants';
+} from '@mastra/storage';
 import { defineTable } from 'convex/server';
 import { v } from 'convex/values';
 

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -4,7 +4,7 @@ import {
   TABLE_THREADS,
   TABLE_RESOURCES,
   TABLE_SCORERS,
-} from '@mastra/core/storage/constants';
+} from '@mastra/storage';
 import type { GenericMutationCtx as MutationCtx } from 'convex/server';
 import { mutationGeneric } from 'convex/server';
 

--- a/stores/convex/src/storage/db/index.ts
+++ b/stores/convex/src/storage/db/index.ts
@@ -1,8 +1,8 @@
 import crypto from 'node:crypto';
 
 import { MastraBase } from '@mastra/core/base';
-import { TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
-import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
+import { TABLE_WORKFLOW_SNAPSHOT } from '@mastra/storage';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/storage';
 
 import { ConvexAdminClient } from '../client';
 import type { EqualityFilter, IndexHint } from '../types';

--- a/stores/convex/src/storage/domains/memory/index.ts
+++ b/stores/convex/src/storage/domains/memory/index.ts
@@ -2,9 +2,15 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
+import { MemoryStorage } from '@mastra/core/storage';
+import type {
+  StorageListMessagesInput,
+  StorageListMessagesOutput,
+  StorageListThreadsInput,
+  StorageListThreadsOutput,
+} from '@mastra/core/storage';
 import {
   filterByDateRange,
-  MemoryStorage,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
@@ -12,14 +18,8 @@ import {
   createStorageErrorId,
   normalizePerPage,
   safelyParseJSON,
-} from '@mastra/core/storage';
-import type {
-  StorageListMessagesInput,
-  StorageListMessagesOutput,
-  StorageListThreadsInput,
-  StorageListThreadsOutput,
-  StorageResourceType,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageResourceType } from '@mastra/storage';
 
 import { ConvexDB, resolveConvexConfig } from '../../db';
 import type { ConvexDomainConfig } from '../../db';

--- a/stores/convex/src/storage/domains/scores/index.ts
+++ b/stores/convex/src/storage/domains/scores/index.ts
@@ -8,8 +8,9 @@ import type {
   ScoringEntityType,
   ScoringSource,
 } from '@mastra/core/evals';
-import { TABLE_SCORERS, ScoresStorage, createStorageErrorId } from '@mastra/core/storage';
-import type { StoragePagination } from '@mastra/core/storage';
+import { ScoresStorage } from '@mastra/core/storage';
+import { TABLE_SCORERS, createStorageErrorId } from '@mastra/storage';
+import type { StoragePagination } from '@mastra/storage';
 
 import { ConvexDB, resolveConvexConfig } from '../../db';
 import type { ConvexDomainConfig } from '../../db';

--- a/stores/convex/src/storage/domains/workflows/index.ts
+++ b/stores/convex/src/storage/domains/workflows/index.ts
@@ -1,12 +1,8 @@
-import { TABLE_WORKFLOW_SNAPSHOT, normalizePerPage, WorkflowsStorage } from '@mastra/core/storage';
-import type {
-  StorageListWorkflowRunsInput,
-  StorageWorkflowRun,
-  WorkflowRun,
-  WorkflowRuns,
-  UpdateWorkflowStateOptions,
-} from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { TABLE_WORKFLOW_SNAPSHOT, normalizePerPage } from '@mastra/storage';
+import type { StorageListWorkflowRunsInput, StorageWorkflowRun, WorkflowRun, WorkflowRuns } from '@mastra/storage';
 
 import { ConvexDB, resolveConvexConfig } from '../../db';
 import type { ConvexDomainConfig } from '../../db';

--- a/stores/convex/src/storage/index.test.ts
+++ b/stores/convex/src/storage/index.test.ts
@@ -106,7 +106,7 @@ if (!deploymentUrl || !adminKey) {
 describe('Convex Schema Sync', () => {
   it('mastraThreadsTable should include all fields from TABLE_SCHEMAS[TABLE_THREADS]', async () => {
     // Import the core schema - this defines the canonical field list
-    const { TABLE_SCHEMAS, TABLE_THREADS } = await import('@mastra/core/storage');
+    const { TABLE_SCHEMAS, TABLE_THREADS } = await import('@mastra/storage');
     // Import the Convex schema - this is what users actually use
     const { mastraThreadsTable } = await import('../schema');
 
@@ -125,7 +125,7 @@ describe('Convex Schema Sync', () => {
   });
 
   it('mastraMessagesTable should include all fields from TABLE_SCHEMAS[TABLE_MESSAGES]', async () => {
-    const { TABLE_SCHEMAS, TABLE_MESSAGES } = await import('@mastra/core/storage');
+    const { TABLE_SCHEMAS, TABLE_MESSAGES } = await import('@mastra/storage');
     const { mastraMessagesTable } = await import('../schema');
 
     const coreSchema = TABLE_SCHEMAS[TABLE_MESSAGES];
@@ -140,7 +140,7 @@ describe('Convex Schema Sync', () => {
   });
 
   it('mastraResourcesTable should include all fields from TABLE_SCHEMAS[TABLE_RESOURCES]', async () => {
-    const { TABLE_SCHEMAS, TABLE_RESOURCES } = await import('@mastra/core/storage');
+    const { TABLE_SCHEMAS, TABLE_RESOURCES } = await import('@mastra/storage');
     const { mastraResourcesTable } = await import('../schema');
 
     const coreSchema = TABLE_SCHEMAS[TABLE_RESOURCES];

--- a/stores/convex/src/storage/types.ts
+++ b/stores/convex/src/storage/types.ts
@@ -1,4 +1,4 @@
-import type { TABLE_NAMES } from '@mastra/core/storage';
+import type { TABLE_NAMES } from '@mastra/storage';
 
 export type EqualityFilter = {
   field: string;

--- a/stores/convex/src/vector/index.ts
+++ b/stores/convex/src/vector/index.ts
@@ -1,7 +1,6 @@
 import crypto from 'node:crypto';
 
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';
 import type {
   CreateIndexParams,
@@ -15,6 +14,7 @@ import type {
   UpdateVectorParams,
   UpsertVectorParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 
 import type { ConvexAdminClientConfig } from '../storage/client';
 import { ConvexAdminClient } from '../storage/client';

--- a/stores/couchbase/package.json
+++ b/stores/couchbase/package.json
@@ -42,10 +42,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/couchbase/src/vector/index.ts
+++ b/stores/couchbase/src/vector/index.ts
@@ -1,5 +1,4 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';
 import type {
   QueryResult,
@@ -13,6 +12,7 @@ import type {
   UpdateVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import type { Bucket, Cluster, Collection, Scope } from 'couchbase';
 import { MutateInSpec, connect, SearchRequest, VectorQuery, VectorSearch } from 'couchbase';
 

--- a/stores/duckdb/package.json
+++ b/stores/duckdb/package.json
@@ -42,10 +42,12 @@
     "rimraf": "^5.0.10",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/duckdb/src/vector/index.ts
+++ b/stores/duckdb/src/vector/index.ts
@@ -1,7 +1,6 @@
 import { DuckDBInstance } from '@duckdb/node-api';
 import type { DuckDBValue } from '@duckdb/node-api';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector, validateUpsertInput, validateTopK } from '@mastra/core/vector';
 import type {
   IndexStats,
@@ -15,6 +14,7 @@ import type {
   UpdateVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import { buildFilterClause } from './filter-builder.js';
 import type { DuckDBVectorConfig, DuckDBVectorFilter } from './types.js';
 

--- a/stores/dynamodb/package.json
+++ b/stores/dynamodb/package.json
@@ -42,7 +42,8 @@
     "electrodb": "^3.7.2"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",
@@ -55,7 +56,8 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/dynamodb/src/storage/domains/memory/index.ts
+++ b/stores/dynamodb/src/storage/domains/memory/index.ts
@@ -2,23 +2,23 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { StorageThreadType, MastraMessageV1, MastraDBMessage } from '@mastra/core/memory';
-import {
-  createStorageErrorId,
-  filterByDateRange,
-  MemoryStorage,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_THREADS,
-  TABLE_MESSAGES,
-  TABLE_RESOURCES,
-} from '@mastra/core/storage';
+import { MemoryStorage } from '@mastra/core/storage';
 import type {
-  StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesOutput,
   StorageListThreadsInput,
   StorageListThreadsOutput,
 } from '@mastra/core/storage';
+import {
+  createStorageErrorId,
+  filterByDateRange,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_THREADS,
+  TABLE_MESSAGES,
+  TABLE_RESOURCES,
+} from '@mastra/storage';
+import type { StorageResourceType } from '@mastra/storage';
 import type { Service } from 'electrodb';
 import type { ThreadEntityData, MessageEntityData, ResourceEntityData } from '../../../entities/utils';
 import { resolveDynamoDBConfig } from '../../db';

--- a/stores/dynamodb/src/storage/domains/scores/index.ts
+++ b/stores/dynamodb/src/storage/domains/scores/index.ts
@@ -1,15 +1,15 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
+import { ScoresStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
   SCORERS_SCHEMA,
-  ScoresStorage,
   calculatePagination,
   normalizePerPage,
   TABLE_SCORERS,
-} from '@mastra/core/storage';
-import type { StoragePagination } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StoragePagination } from '@mastra/storage';
 import type { Service } from 'electrodb';
 import { resolveDynamoDBConfig } from '../../db';
 import type { DynamoDBDomainConfig } from '../../db';

--- a/stores/dynamodb/src/storage/domains/utils.ts
+++ b/stores/dynamodb/src/storage/domains/utils.ts
@@ -4,8 +4,8 @@ import {
   TABLE_RESOURCES,
   TABLE_WORKFLOW_SNAPSHOT,
   TABLE_SCORERS,
-} from '@mastra/core/storage';
-import type { TABLE_NAMES } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { TABLE_NAMES } from '@mastra/storage';
 import type { Service } from 'electrodb';
 
 /**

--- a/stores/dynamodb/src/storage/domains/workflows/index.ts
+++ b/stores/dynamodb/src/storage/domains/workflows/index.ts
@@ -1,17 +1,9 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  normalizePerPage,
-  TABLE_WORKFLOW_SNAPSHOT,
-  WorkflowsStorage,
-} from '@mastra/core/storage';
-import type {
-  WorkflowRun,
-  WorkflowRuns,
-  StorageListWorkflowRunsInput,
-  UpdateWorkflowStateOptions,
-} from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { createStorageErrorId, normalizePerPage, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/storage';
+import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/storage';
 import type { Service } from 'electrodb';
 import type { WorkflowSnapshotEntityData } from '../../../entities/utils';
 import { resolveDynamoDBConfig } from '../../db';

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -2,7 +2,8 @@ import { DynamoDBClient, DescribeTableCommand } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { StorageDomains } from '@mastra/core/storage';
-import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
+import { createStorageErrorId } from '@mastra/storage';
 
 import type { Service } from 'electrodb';
 import { getElectroDbService } from '../entities';

--- a/stores/elasticsearch/package.json
+++ b/stores/elasticsearch/package.json
@@ -44,10 +44,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/elasticsearch/src/vector/index.ts
+++ b/stores/elasticsearch/src/vector/index.ts
@@ -1,6 +1,5 @@
 import { Client as ElasticSearchClient } from '@elastic/elasticsearch';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import type {
   CreateIndexParams,
   DeleteIndexParams,
@@ -14,6 +13,7 @@ import type {
   DeleteVectorsParams,
 } from '@mastra/core/vector';
 import { MastraVector, validateUpsert, validateTopK } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 
 import packageJson from '../../package.json';
 import { ElasticSearchFilterTranslator } from './filter';

--- a/stores/lance/package.json
+++ b/stores/lance/package.json
@@ -41,10 +41,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/lance/src/storage/db/index.ts
+++ b/stores/lance/src/storage/db/index.ts
@@ -1,8 +1,8 @@
 import type { Connection } from '@lancedb/lancedb';
 import { MastraBase } from '@mastra/core/base';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createStorageErrorId, getDefaultValue } from '@mastra/core/storage';
-import type { TABLE_NAMES, StorageColumn } from '@mastra/core/storage';
+import { createStorageErrorId, getDefaultValue } from '@mastra/storage';
+import type { TABLE_NAMES, StorageColumn } from '@mastra/storage';
 import { Utf8, Int32, Float32, Binary, Schema, Field, Float64 } from 'apache-arrow';
 import type { DataType } from 'apache-arrow';
 import { getPrimaryKeys, getTableSchema, processResultWithTypeConversion, validateKeyTypes } from './utils';

--- a/stores/lance/src/storage/db/utils.ts
+++ b/stores/lance/src/storage/db/utils.ts
@@ -1,7 +1,7 @@
 import type { Connection, FieldLike, SchemaLike } from '@lancedb/lancedb';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createStorageErrorId, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
-import type { TABLE_NAMES } from '@mastra/core/storage';
+import { createStorageErrorId, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/storage';
+import type { TABLE_NAMES } from '@mastra/storage';
 
 export function getPrimaryKeys(tableName: TABLE_NAMES): string[] {
   let primaryId: string[] = ['id'];

--- a/stores/lance/src/storage/domains/memory/index.ts
+++ b/stores/lance/src/storage/domains/memory/index.ts
@@ -3,23 +3,23 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
+import { MemoryStorage } from '@mastra/core/storage';
+import type {
+  StorageListMessagesInput,
+  StorageListMessagesOutput,
+  StorageListThreadsInput,
+  StorageListThreadsOutput,
+} from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  MemoryStorage,
   normalizePerPage,
   calculatePagination,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
   TABLE_SCHEMAS,
-} from '@mastra/core/storage';
-import type {
-  StorageResourceType,
-  StorageListMessagesInput,
-  StorageListMessagesOutput,
-  StorageListThreadsInput,
-  StorageListThreadsOutput,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageResourceType } from '@mastra/storage';
 import { LanceDB, resolveLanceConfig } from '../../db';
 import type { LanceDomainConfig } from '../../db';
 import { getTableSchema, processResultWithTypeConversion } from '../../db/utils';

--- a/stores/lance/src/storage/domains/scores/index.ts
+++ b/stores/lance/src/storage/domains/scores/index.ts
@@ -2,15 +2,15 @@ import type { Connection } from '@lancedb/lancedb';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
+import { ScoresStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  ScoresStorage,
   TABLE_SCORERS,
   SCORERS_SCHEMA,
   calculatePagination,
   normalizePerPage,
-} from '@mastra/core/storage';
-import type { StoragePagination } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StoragePagination } from '@mastra/storage';
 import { LanceDB, resolveLanceConfig } from '../../db';
 import type { LanceDomainConfig } from '../../db';
 import { getTableSchema, processResultWithTypeConversion } from '../../db/utils';

--- a/stores/lance/src/storage/domains/workflows/index.ts
+++ b/stores/lance/src/storage/domains/workflows/index.ts
@@ -1,20 +1,16 @@
 import type { Connection } from '@lancedb/lancedb';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import type {
-  WorkflowRun,
-  StorageListWorkflowRunsInput,
-  WorkflowRuns,
-  UpdateWorkflowStateOptions,
-} from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
+import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import {
   createStorageErrorId,
   ensureDate,
   normalizePerPage,
   TABLE_WORKFLOW_SNAPSHOT,
   TABLE_SCHEMAS,
-  WorkflowsStorage,
-} from '@mastra/core/storage';
-import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+} from '@mastra/storage';
+import type { WorkflowRun, StorageListWorkflowRunsInput, WorkflowRuns } from '@mastra/storage';
 import { LanceDB, resolveLanceConfig } from '../../db';
 import type { LanceDomainConfig } from '../../db';
 

--- a/stores/lance/src/storage/index.ts
+++ b/stores/lance/src/storage/index.ts
@@ -1,8 +1,9 @@
 import { connect } from '@lancedb/lancedb';
 import type { Connection, ConnectionOptions } from '@lancedb/lancedb';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
 import type { StorageDomains } from '@mastra/core/storage';
+import { createStorageErrorId } from '@mastra/storage';
 import { StoreMemoryLance } from './domains/memory';
 import { StoreScoresLance } from './domains/scores';
 import { StoreWorkflowsLance } from './domains/workflows';

--- a/stores/lance/src/vector/index.ts
+++ b/stores/lance/src/vector/index.ts
@@ -2,7 +2,6 @@ import { connect, Index } from '@lancedb/lancedb';
 import type { Connection, ConnectionOptions, CreateTableOptions, Table, TableLike } from '@lancedb/lancedb';
 
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import type {
   CreateIndexParams,
   DeleteIndexParams,
@@ -17,6 +16,7 @@ import type {
 } from '@mastra/core/vector';
 
 import { MastraVector } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import type { LanceVectorFilter } from './filter';
 import { LanceFilterTranslator } from './filter';
 import type { IndexConfig } from './types';

--- a/stores/libsql/package.json
+++ b/stores/libsql/package.json
@@ -40,10 +40,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/libsql/src/storage/db/index.ts
+++ b/stores/libsql/src/storage/db/index.ts
@@ -2,15 +2,9 @@ import { createClient } from '@libsql/client';
 import type { Client, InValue } from '@libsql/client';
 import { MastraBase } from '@mastra/core/base';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  getSqlType,
-  TABLE_WORKFLOW_SNAPSHOT,
-  TABLE_SPANS,
-  TABLE_SCHEMAS,
-} from '@mastra/core/storage';
-import type { TABLE_NAMES, StorageColumn } from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import { createStorageErrorId, getSqlType, TABLE_WORKFLOW_SNAPSHOT, TABLE_SPANS, TABLE_SCHEMAS } from '@mastra/storage';
+import type { TABLE_NAMES, StorageColumn } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import {
   buildSelectColumns,
   createExecuteWriteOperationWithRetry,

--- a/stores/libsql/src/storage/db/resilient-columns.test.ts
+++ b/stores/libsql/src/storage/db/resilient-columns.test.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@libsql/client';
-import { TABLE_SCHEMAS } from '@mastra/core/storage';
-import type { TABLE_NAMES, StorageColumn } from '@mastra/core/storage';
+import { TABLE_SCHEMAS } from '@mastra/storage';
+import type { TABLE_NAMES, StorageColumn } from '@mastra/storage';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { LibSQLDB } from './index';

--- a/stores/libsql/src/storage/db/utils.ts
+++ b/stores/libsql/src/storage/db/utils.ts
@@ -1,8 +1,8 @@
 import type { InValue } from '@libsql/client';
 import type { IMastraLogger } from '@mastra/core/logger';
-import { safelyParseJSON, TABLE_SCHEMAS } from '@mastra/core/storage';
-import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import { safelyParseJSON, TABLE_SCHEMAS } from '@mastra/storage';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 
 /**
  * Builds a SQL column list for SELECT statements, wrapping JSONB columns with json()

--- a/stores/libsql/src/storage/domains/agents/index.ts
+++ b/stores/libsql/src/storage/domains/agents/index.ts
@@ -1,15 +1,6 @@
 import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  AgentsStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_AGENTS,
-  TABLE_AGENT_VERSIONS,
-  AGENTS_SCHEMA,
-  AGENT_VERSIONS_SCHEMA,
-} from '@mastra/core/storage';
+import { AgentsStorage } from '@mastra/core/storage';
 import type {
   StorageAgentType,
   StorageCreateAgentInput,
@@ -22,6 +13,15 @@ import type {
   ListVersionsOutput,
   AgentInstructionBlock,
 } from '@mastra/core/storage';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
+  AGENTS_SCHEMA,
+  AGENT_VERSIONS_SCHEMA,
+} from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';

--- a/stores/libsql/src/storage/domains/blobs/index.ts
+++ b/stores/libsql/src/storage/domains/blobs/index.ts
@@ -1,6 +1,7 @@
 import type { Client } from '@libsql/client';
-import { BlobStore, TABLE_SKILL_BLOBS, SKILL_BLOBS_SCHEMA } from '@mastra/core/storage';
+import { BlobStore } from '@mastra/core/storage';
 import type { StorageBlobEntry } from '@mastra/core/storage';
+import { TABLE_SKILL_BLOBS, SKILL_BLOBS_SCHEMA } from '@mastra/storage';
 
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';

--- a/stores/libsql/src/storage/domains/datasets/index.ts
+++ b/stores/libsql/src/storage/domains/datasets/index.ts
@@ -1,27 +1,7 @@
 import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  TABLE_DATASETS,
-  TABLE_DATASET_ITEMS,
-  TABLE_DATASET_VERSIONS,
-  TABLE_EXPERIMENTS,
-  TABLE_EXPERIMENT_RESULTS,
-  DATASETS_SCHEMA,
-  DATASET_ITEMS_SCHEMA,
-  DATASET_VERSIONS_SCHEMA,
-  DatasetsStorage,
-  calculatePagination,
-  normalizePerPage,
-  safelyParseJSON,
-  ensureDate,
-} from '@mastra/core/storage';
+import { DatasetsStorage } from '@mastra/core/storage';
 import type {
-  DatasetRecord,
-  DatasetItem,
-  DatasetItemRow,
-  DatasetVersion,
-  TargetType,
   CreateDatasetInput,
   UpdateDatasetInput,
   AddDatasetItemInput,
@@ -35,6 +15,22 @@ import type {
   BatchInsertItemsInput,
   BatchDeleteItemsInput,
 } from '@mastra/core/storage';
+import {
+  createStorageErrorId,
+  TABLE_DATASETS,
+  TABLE_DATASET_ITEMS,
+  TABLE_DATASET_VERSIONS,
+  TABLE_EXPERIMENTS,
+  TABLE_EXPERIMENT_RESULTS,
+  DATASETS_SCHEMA,
+  DATASET_ITEMS_SCHEMA,
+  DATASET_VERSIONS_SCHEMA,
+  calculatePagination,
+  normalizePerPage,
+  safelyParseJSON,
+  ensureDate,
+} from '@mastra/storage';
+import type { DatasetRecord, DatasetItem, DatasetItemRow, DatasetVersion, TargetType } from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';
@@ -121,7 +117,7 @@ export class DatasetsLibSQL extends DatasetsStorage {
       tags: row.tags ? safelyParseJSON(row.tags) : undefined,
       targetType: (row.targetType as TargetType) || undefined,
       targetIds: row.targetIds ? safelyParseJSON(row.targetIds) : undefined,
-      version: row.version as number,
+      version: Number(row.version),
       createdAt: ensureDate(row.createdAt)!,
       updatedAt: ensureDate(row.updatedAt)!,
     };
@@ -131,7 +127,7 @@ export class DatasetsLibSQL extends DatasetsStorage {
     return {
       id: row.id as string,
       datasetId: row.datasetId as string,
-      datasetVersion: row.datasetVersion as number,
+      datasetVersion: Number(row.datasetVersion),
       input: safelyParseJSON(row.input),
       groundTruth: row.groundTruth ? safelyParseJSON(row.groundTruth) : undefined,
       requestContext: row.requestContext ? safelyParseJSON(row.requestContext) : undefined,
@@ -146,8 +142,8 @@ export class DatasetsLibSQL extends DatasetsStorage {
     return {
       id: row.id as string,
       datasetId: row.datasetId as string,
-      datasetVersion: row.datasetVersion as number,
-      validTo: row.validTo as number | null,
+      datasetVersion: Number(row.datasetVersion),
+      validTo: row.validTo != null ? Number(row.validTo) : null,
       isDeleted: Boolean(row.isDeleted),
       input: safelyParseJSON(row.input),
       groundTruth: row.groundTruth ? safelyParseJSON(row.groundTruth) : undefined,
@@ -163,7 +159,7 @@ export class DatasetsLibSQL extends DatasetsStorage {
     return {
       id: row.id as string,
       datasetId: row.datasetId as string,
-      version: row.version as number,
+      version: Number(row.version),
       createdAt: ensureDate(row.createdAt)!,
     };
   }

--- a/stores/libsql/src/storage/domains/experiments/index.ts
+++ b/stores/libsql/src/storage/domains/experiments/index.ts
@@ -1,17 +1,6 @@
 import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  TABLE_EXPERIMENTS,
-  TABLE_EXPERIMENT_RESULTS,
-  EXPERIMENTS_SCHEMA,
-  EXPERIMENT_RESULTS_SCHEMA,
-  ExperimentsStorage,
-  calculatePagination,
-  normalizePerPage,
-  safelyParseJSON,
-  ensureDate,
-} from '@mastra/core/storage';
+import { ExperimentsStorage } from '@mastra/core/storage';
 import type {
   Experiment,
   ExperimentResult,
@@ -24,6 +13,17 @@ import type {
   ListExperimentResultsInput,
   ListExperimentResultsOutput,
 } from '@mastra/core/storage';
+import {
+  createStorageErrorId,
+  TABLE_EXPERIMENTS,
+  TABLE_EXPERIMENT_RESULTS,
+  EXPERIMENTS_SCHEMA,
+  EXPERIMENT_RESULTS_SCHEMA,
+  calculatePagination,
+  normalizePerPage,
+  safelyParseJSON,
+  ensureDate,
+} from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';
@@ -71,7 +71,7 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
     return {
       id: row.id as string,
       datasetId: (row.datasetId as string | null) ?? null,
-      datasetVersion: row.datasetVersion != null ? (row.datasetVersion as number) : null,
+      datasetVersion: row.datasetVersion != null ? Number(row.datasetVersion) : null,
       agentVersion: (row.agentVersion as string | null) ?? null,
       targetType: row.targetType as Experiment['targetType'],
       targetId: row.targetId as string,
@@ -79,10 +79,10 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       description: (row.description as string) ?? undefined,
       metadata: row.metadata ? safelyParseJSON(row.metadata as string) : undefined,
       status: row.status as Experiment['status'],
-      totalItems: row.totalItems as number,
-      succeededCount: row.succeededCount as number,
-      failedCount: row.failedCount as number,
-      skippedCount: (row.skippedCount as number) ?? 0,
+      totalItems: Number(row.totalItems),
+      succeededCount: Number(row.succeededCount),
+      failedCount: Number(row.failedCount),
+      skippedCount: row.skippedCount != null ? Number(row.skippedCount) : 0,
       startedAt: row.startedAt ? ensureDate(row.startedAt as string | Date)! : null,
       completedAt: row.completedAt ? ensureDate(row.completedAt as string | Date)! : null,
       createdAt: ensureDate(row.createdAt as string | Date)!,
@@ -96,14 +96,14 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       id: row.id as string,
       experimentId: row.experimentId as string,
       itemId: row.itemId as string,
-      itemDatasetVersion: row.itemDatasetVersion != null ? (row.itemDatasetVersion as number) : null,
+      itemDatasetVersion: row.itemDatasetVersion != null ? Number(row.itemDatasetVersion) : null,
       input: safelyParseJSON(row.input as string),
       output: row.output ? safelyParseJSON(row.output as string) : null,
       groundTruth: row.groundTruth ? safelyParseJSON(row.groundTruth as string) : null,
       error: row.error ? safelyParseJSON(row.error as string) : null,
       startedAt: ensureDate(row.startedAt as string | Date)!,
       completedAt: ensureDate(row.completedAt as string | Date)!,
-      retryCount: row.retryCount as number,
+      retryCount: Number(row.retryCount),
       traceId: (row.traceId as string | null) ?? null,
       status: (row.status as ExperimentResult['status']) ?? null,
       tags: row.tags ? safelyParseJSON(row.tags as string) : null,

--- a/stores/libsql/src/storage/domains/mcp-clients/index.ts
+++ b/stores/libsql/src/storage/domains/mcp-clients/index.ts
@@ -1,15 +1,6 @@
 import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  MCPClientsStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_MCP_CLIENTS,
-  TABLE_MCP_CLIENT_VERSIONS,
-  MCP_CLIENTS_SCHEMA,
-  MCP_CLIENT_VERSIONS_SCHEMA,
-} from '@mastra/core/storage';
+import { MCPClientsStorage } from '@mastra/core/storage';
 import type {
   StorageMCPClientType,
   StorageCreateMCPClientInput,
@@ -23,6 +14,15 @@ import type {
   ListMCPClientVersionsInput,
   ListMCPClientVersionsOutput,
 } from '@mastra/core/storage/domains/mcp-clients';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_MCP_CLIENTS,
+  TABLE_MCP_CLIENT_VERSIONS,
+  MCP_CLIENTS_SCHEMA,
+  MCP_CLIENT_VERSIONS_SCHEMA,
+} from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';

--- a/stores/libsql/src/storage/domains/mcp-servers/index.ts
+++ b/stores/libsql/src/storage/domains/mcp-servers/index.ts
@@ -1,15 +1,6 @@
 import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  MCPServersStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_MCP_SERVERS,
-  TABLE_MCP_SERVER_VERSIONS,
-  MCP_SERVERS_SCHEMA,
-  MCP_SERVER_VERSIONS_SCHEMA,
-} from '@mastra/core/storage';
+import { MCPServersStorage } from '@mastra/core/storage';
 import type {
   StorageMCPServerType,
   StorageCreateMCPServerInput,
@@ -23,6 +14,15 @@ import type {
   ListMCPServerVersionsInput,
   ListMCPServerVersionsOutput,
 } from '@mastra/core/storage/domains/mcp-servers';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_MCP_SERVERS,
+  TABLE_MCP_SERVER_VERSIONS,
+  MCP_SERVERS_SCHEMA,
+  MCP_SERVER_VERSIONS_SCHEMA,
+} from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -5,7 +5,6 @@ import { MessageList } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type {
-  StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesByResourceIdInput,
   StorageListMessagesOutput,
@@ -25,16 +24,17 @@ import type {
   SwapBufferedReflectionToActiveInput,
   CreateReflectionGenerationInput,
 } from '@mastra/core/storage';
+import { MemoryStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  MemoryStorage,
   normalizePerPage,
   calculatePagination,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
   TABLE_SCHEMAS,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageResourceType } from '@mastra/storage';
 
 /**
  * Local constant for the observational memory table name.
@@ -42,7 +42,7 @@ import {
  * versions that don't export TABLE_OBSERVATIONAL_MEMORY.
  */
 const OM_TABLE = 'mastra_observational_memory' as const;
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';
@@ -65,13 +65,13 @@ export class MemoryLibSQL extends MemoryStorage {
     await this.#db.createTable({ tableName: TABLE_MESSAGES, schema: TABLE_SCHEMAS[TABLE_MESSAGES] });
     await this.#db.createTable({ tableName: TABLE_RESOURCES, schema: TABLE_SCHEMAS[TABLE_RESOURCES] });
 
-    // Dynamically import OM schema to avoid crashing on older @mastra/core versions
+    // Dynamically import OM schema to keep the static dependency surface minimal.
     let omSchema: Record<string, any> | undefined;
     try {
-      const { OBSERVATIONAL_MEMORY_TABLE_SCHEMA } = await import('@mastra/core/storage');
+      const { OBSERVATIONAL_MEMORY_TABLE_SCHEMA } = await import('@mastra/storage');
       omSchema = OBSERVATIONAL_MEMORY_TABLE_SCHEMA?.[OM_TABLE];
     } catch {
-      // Older @mastra/core without OM support
+      // OM schema not available
     }
 
     if (omSchema) {

--- a/stores/libsql/src/storage/domains/observability/index.ts
+++ b/stores/libsql/src/storage/domains/observability/index.ts
@@ -1,15 +1,6 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  listTracesArgsSchema,
-  ObservabilityStorage,
-  SPAN_SCHEMA,
-  TABLE_SPANS,
-  toTraceSpans,
-  TraceStatus,
-} from '@mastra/core/storage';
+import { listTracesArgsSchema, ObservabilityStorage, toTraceSpans } from '@mastra/core/storage';
 import type {
-  SpanRecord,
   ListTracesArgs,
   ListTracesResponse,
   TracingStorageStrategy,
@@ -25,7 +16,9 @@ import type {
   GetTraceArgs,
   GetTraceResponse,
 } from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import { createStorageErrorId, SPAN_SCHEMA, TABLE_SPANS, TraceStatus } from '@mastra/storage';
+import type { SpanRecord } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { transformFromSqlRow } from '../../db/utils';

--- a/stores/libsql/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/libsql/src/storage/domains/prompt-blocks/index.ts
@@ -1,15 +1,6 @@
 import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  PromptBlocksStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_PROMPT_BLOCKS,
-  TABLE_PROMPT_BLOCK_VERSIONS,
-  PROMPT_BLOCKS_SCHEMA,
-  PROMPT_BLOCK_VERSIONS_SCHEMA,
-} from '@mastra/core/storage';
+import { PromptBlocksStorage } from '@mastra/core/storage';
 import type {
   StoragePromptBlockType,
   StorageCreatePromptBlockInput,
@@ -21,6 +12,15 @@ import type {
   ListPromptBlockVersionsInput,
   ListPromptBlockVersionsOutput,
 } from '@mastra/core/storage';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_PROMPT_BLOCKS,
+  TABLE_PROMPT_BLOCK_VERSIONS,
+  PROMPT_BLOCKS_SCHEMA,
+  PROMPT_BLOCK_VERSIONS_SCHEMA,
+} from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';

--- a/stores/libsql/src/storage/domains/scorer-definitions/index.ts
+++ b/stores/libsql/src/storage/domains/scorer-definitions/index.ts
@@ -1,15 +1,6 @@
 import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  ScorerDefinitionsStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_SCORER_DEFINITIONS,
-  TABLE_SCORER_DEFINITION_VERSIONS,
-  SCORER_DEFINITIONS_SCHEMA,
-  SCORER_DEFINITION_VERSIONS_SCHEMA,
-} from '@mastra/core/storage';
+import { ScorerDefinitionsStorage } from '@mastra/core/storage';
 import type {
   StorageScorerDefinitionType,
   StorageCreateScorerDefinitionInput,
@@ -23,6 +14,15 @@ import type {
   ListScorerDefinitionVersionsInput,
   ListScorerDefinitionVersionsOutput,
 } from '@mastra/core/storage/domains/scorer-definitions';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_SCORER_DEFINITIONS,
+  TABLE_SCORER_DEFINITION_VERSIONS,
+  SCORER_DEFINITIONS_SCHEMA,
+  SCORER_DEFINITION_VERSIONS_SCHEMA,
+} from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';

--- a/stores/libsql/src/storage/domains/scores/index.ts
+++ b/stores/libsql/src/storage/domains/scores/index.ts
@@ -2,16 +2,16 @@ import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
+import { ScoresStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
   TABLE_SCORERS,
   SCORERS_SCHEMA,
-  ScoresStorage,
   calculatePagination,
   normalizePerPage,
   transformScoreRow as coreTransformScoreRow,
-} from '@mastra/core/storage';
-import type { StoragePagination } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StoragePagination } from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';

--- a/stores/libsql/src/storage/domains/skills/index.ts
+++ b/stores/libsql/src/storage/domains/skills/index.ts
@@ -1,15 +1,6 @@
 import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  SkillsStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_SKILLS,
-  TABLE_SKILL_VERSIONS,
-  SKILLS_SCHEMA,
-  SKILL_VERSIONS_SCHEMA,
-} from '@mastra/core/storage';
+import { SkillsStorage } from '@mastra/core/storage';
 import type {
   StorageSkillType,
   StorageCreateSkillInput,
@@ -23,6 +14,15 @@ import type {
   ListSkillVersionsInput,
   ListSkillVersionsOutput,
 } from '@mastra/core/storage/domains/skills';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_SKILLS,
+  TABLE_SKILL_VERSIONS,
+  SKILLS_SCHEMA,
+  SKILL_VERSIONS_SCHEMA,
+} from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';

--- a/stores/libsql/src/storage/domains/workflows/index.ts
+++ b/stores/libsql/src/storage/domains/workflows/index.ts
@@ -1,19 +1,10 @@
 import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import type {
-  WorkflowRun,
-  WorkflowRuns,
-  StorageListWorkflowRunsInput,
-  UpdateWorkflowStateOptions,
-} from '@mastra/core/storage';
-import {
-  createStorageErrorId,
-  normalizePerPage,
-  TABLE_WORKFLOW_SNAPSHOT,
-  TABLE_SCHEMAS,
-  WorkflowsStorage,
-} from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
 import type { WorkflowRunState, StepResult } from '@mastra/core/workflows';
+import { createStorageErrorId, normalizePerPage, TABLE_WORKFLOW_SNAPSHOT, TABLE_SCHEMAS } from '@mastra/storage';
+import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { createExecuteWriteOperationWithRetry } from '../../db/utils';

--- a/stores/libsql/src/storage/domains/workspaces/index.ts
+++ b/stores/libsql/src/storage/domains/workspaces/index.ts
@@ -1,15 +1,6 @@
 import type { Client, InValue } from '@libsql/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  WorkspacesStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_WORKSPACES,
-  TABLE_WORKSPACE_VERSIONS,
-  WORKSPACES_SCHEMA,
-  WORKSPACE_VERSIONS_SCHEMA,
-} from '@mastra/core/storage';
+import { WorkspacesStorage } from '@mastra/core/storage';
 import type {
   StorageWorkspaceType,
   StorageCreateWorkspaceInput,
@@ -23,6 +14,15 @@ import type {
   ListWorkspaceVersionsInput,
   ListWorkspaceVersionsOutput,
 } from '@mastra/core/storage/domains/workspaces';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_WORKSPACES,
+  TABLE_WORKSPACE_VERSIONS,
+  WORKSPACES_SCHEMA,
+  WORKSPACE_VERSIONS_SCHEMA,
+} from '@mastra/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';

--- a/stores/libsql/src/storage/migration.test.ts
+++ b/stores/libsql/src/storage/migration.test.ts
@@ -1,13 +1,7 @@
 import { createClient } from '@libsql/client';
 import type { Client } from '@libsql/client';
 import { MastraError } from '@mastra/core/error';
-import {
-  OLD_SPAN_SCHEMA,
-  TABLE_SPANS,
-  TABLE_SCHEMAS,
-  TABLE_THREADS,
-  TABLE_WORKFLOW_SNAPSHOT,
-} from '@mastra/core/storage';
+import { OLD_SPAN_SCHEMA, TABLE_SPANS, TABLE_SCHEMAS, TABLE_THREADS, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/storage';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { LibSQLDB } from './db';
 import { LibSQLStore } from './index';

--- a/stores/libsql/src/vector/index.ts
+++ b/stores/libsql/src/vector/index.ts
@@ -2,8 +2,6 @@ import { createClient } from '@libsql/client';
 import type { Client as TursoClient, InValue } from '@libsql/client';
 
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
 import { MastraVector, validateUpsertInput, validateTopK } from '@mastra/core/vector';
 import type {
   IndexStats,
@@ -17,6 +15,8 @@ import type {
   UpdateVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import type { LibSQLVectorFilter } from './filter';
 import { LibSQLFilterTranslator } from './filter';
 import { buildFilterQuery } from './sql-builder';

--- a/stores/libsql/src/vector/sql-builder.ts
+++ b/stores/libsql/src/vector/sql-builder.ts
@@ -1,5 +1,4 @@
 import type { InValue } from '@libsql/client';
-import { parseFieldKey } from '@mastra/core/utils';
 import type {
   BasicOperator,
   NumericOperator,
@@ -7,6 +6,7 @@ import type {
   ElementOperator,
   LogicalOperator,
 } from '@mastra/core/vector/filter';
+import { parseFieldKey } from '@mastra/storage/sql';
 import type { LibSQLVectorFilter } from './filter';
 
 type OperatorType =

--- a/stores/mongodb/package.json
+++ b/stores/mongodb/package.json
@@ -46,10 +46,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/mongodb/src/storage/db/index.ts
+++ b/stores/mongodb/src/storage/db/index.ts
@@ -1,5 +1,5 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createStorageErrorId } from '@mastra/core/storage';
+import { createStorageErrorId } from '@mastra/storage';
 import { MongoDBConnector } from '../connectors/MongoDBConnector';
 import type { MongoDBConfig, MongoDBDomainConfig } from '../types';
 

--- a/stores/mongodb/src/storage/domains/agents/index.ts
+++ b/stores/mongodb/src/storage/domains/agents/index.ts
@@ -1,14 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  AgentsStorage,
-  createStorageErrorId,
-  TABLE_AGENTS,
-  TABLE_AGENT_VERSIONS,
-  normalizePerPage,
-  calculatePagination,
-} from '@mastra/core/storage';
+import { AgentsStorage } from '@mastra/core/storage';
 import type {
   StorageAgentType,
   StorageCreateAgentInput,
@@ -22,6 +15,13 @@ import type {
   ListVersionsInput,
   ListVersionsOutput,
 } from '@mastra/core/storage/domains/agents';
+import {
+  createStorageErrorId,
+  TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
+  normalizePerPage,
+  calculatePagination,
+} from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/blobs/index.ts
+++ b/stores/mongodb/src/storage/domains/blobs/index.ts
@@ -1,6 +1,7 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { BlobStore, createStorageErrorId, TABLE_SKILL_BLOBS } from '@mastra/core/storage';
+import { BlobStore } from '@mastra/core/storage';
 import type { StorageBlobEntry } from '@mastra/core/storage';
+import { createStorageErrorId, TABLE_SKILL_BLOBS } from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/mcp-clients/index.ts
+++ b/stores/mongodb/src/storage/domains/mcp-clients/index.ts
@@ -1,14 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  MCPClientsStorage,
-  createStorageErrorId,
-  TABLE_MCP_CLIENTS,
-  TABLE_MCP_CLIENT_VERSIONS,
-  normalizePerPage,
-  calculatePagination,
-} from '@mastra/core/storage';
+import { MCPClientsStorage } from '@mastra/core/storage';
 import type {
   StorageMCPClientType,
   StorageCreateMCPClientInput,
@@ -22,6 +15,13 @@ import type {
   ListMCPClientVersionsInput,
   ListMCPClientVersionsOutput,
 } from '@mastra/core/storage/domains/mcp-clients';
+import {
+  createStorageErrorId,
+  TABLE_MCP_CLIENTS,
+  TABLE_MCP_CLIENT_VERSIONS,
+  normalizePerPage,
+  calculatePagination,
+} from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/mcp-servers/index.ts
+++ b/stores/mongodb/src/storage/domains/mcp-servers/index.ts
@@ -1,14 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  MCPServersStorage,
-  createStorageErrorId,
-  TABLE_MCP_SERVERS,
-  TABLE_MCP_SERVER_VERSIONS,
-  normalizePerPage,
-  calculatePagination,
-} from '@mastra/core/storage';
+import { MCPServersStorage } from '@mastra/core/storage';
 import type {
   StorageMCPServerType,
   StorageCreateMCPServerInput,
@@ -22,6 +15,13 @@ import type {
   ListMCPServerVersionsInput,
   ListMCPServerVersionsOutput,
 } from '@mastra/core/storage/domains/mcp-servers';
+import {
+  createStorageErrorId,
+  TABLE_MCP_SERVERS,
+  TABLE_MCP_SERVER_VERSIONS,
+  normalizePerPage,
+  calculatePagination,
+} from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -4,25 +4,8 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
-import {
-  createStorageErrorId,
-  MemoryStorage,
-  normalizePerPage,
-  calculatePagination,
-  safelyParseJSON,
-  TABLE_MESSAGES,
-  TABLE_RESOURCES,
-  TABLE_THREADS,
-} from '@mastra/core/storage';
-
-/**
- * Local constant for the observational memory table name.
- * Defined locally to avoid a static import that crashes on older @mastra/core
- * versions that don't export TABLE_OBSERVATIONAL_MEMORY.
- */
-const OM_TABLE = 'mastra_observational_memory' as const;
+import { MemoryStorage } from '@mastra/core/storage';
 import type {
-  StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesByResourceIdInput,
   StorageListMessagesOutput,
@@ -42,6 +25,23 @@ import type {
   SwapBufferedReflectionToActiveInput,
   CreateReflectionGenerationInput,
 } from '@mastra/core/storage';
+import type { StorageResourceType } from '@mastra/storage';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  safelyParseJSON,
+  TABLE_MESSAGES,
+  TABLE_RESOURCES,
+  TABLE_THREADS,
+} from '@mastra/storage';
+
+/**
+ * Local constant for the observational memory table name.
+ * Defined locally to avoid a static import that crashes on older @mastra/core
+ * versions that don't export TABLE_OBSERVATIONAL_MEMORY.
+ */
+const OM_TABLE = 'mastra_observational_memory' as const;
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/observability/index.ts
+++ b/stores/mongodb/src/storage/domains/observability/index.ts
@@ -1,14 +1,6 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  listTracesArgsSchema,
-  ObservabilityStorage,
-  TABLE_SPANS,
-  toTraceSpans,
-  TraceStatus,
-} from '@mastra/core/storage';
+import { listTracesArgsSchema, ObservabilityStorage, toTraceSpans } from '@mastra/core/storage';
 import type {
-  SpanRecord,
   UpdateSpanRecord,
   ListTracesArgs,
   ListTracesResponse,
@@ -25,6 +17,8 @@ import type {
   GetTraceArgs,
   GetTraceResponse,
 } from '@mastra/core/storage';
+import { createStorageErrorId, TABLE_SPANS, TraceStatus } from '@mastra/storage';
+import type { SpanRecord } from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/mongodb/src/storage/domains/prompt-blocks/index.ts
@@ -1,14 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  PromptBlocksStorage,
-  createStorageErrorId,
-  TABLE_PROMPT_BLOCKS,
-  TABLE_PROMPT_BLOCK_VERSIONS,
-  normalizePerPage,
-  calculatePagination,
-} from '@mastra/core/storage';
+import { PromptBlocksStorage } from '@mastra/core/storage';
 import type {
   StoragePromptBlockType,
   StorageCreatePromptBlockInput,
@@ -22,6 +15,13 @@ import type {
   ListPromptBlockVersionsInput,
   ListPromptBlockVersionsOutput,
 } from '@mastra/core/storage/domains/prompt-blocks';
+import {
+  createStorageErrorId,
+  TABLE_PROMPT_BLOCKS,
+  TABLE_PROMPT_BLOCK_VERSIONS,
+  normalizePerPage,
+  calculatePagination,
+} from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/scorer-definitions/index.ts
+++ b/stores/mongodb/src/storage/domains/scorer-definitions/index.ts
@@ -1,14 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  ScorerDefinitionsStorage,
-  createStorageErrorId,
-  TABLE_SCORER_DEFINITIONS,
-  TABLE_SCORER_DEFINITION_VERSIONS,
-  normalizePerPage,
-  calculatePagination,
-} from '@mastra/core/storage';
+import { ScorerDefinitionsStorage } from '@mastra/core/storage';
 import type {
   StorageScorerDefinitionType,
   StorageCreateScorerDefinitionInput,
@@ -22,6 +15,13 @@ import type {
   ListScorerDefinitionVersionsInput,
   ListScorerDefinitionVersionsOutput,
 } from '@mastra/core/storage/domains/scorer-definitions';
+import {
+  createStorageErrorId,
+  TABLE_SCORER_DEFINITIONS,
+  TABLE_SCORER_DEFINITION_VERSIONS,
+  normalizePerPage,
+  calculatePagination,
+} from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/scores/index.ts
+++ b/stores/mongodb/src/storage/domains/scores/index.ts
@@ -3,16 +3,16 @@ import { randomUUID } from 'node:crypto';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
+import { ScoresStorage } from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  ScoresStorage,
   TABLE_SCORERS,
   calculatePagination,
   normalizePerPage,
   safelyParseJSON,
   transformScoreRow as coreTransformScoreRow,
-} from '@mastra/core/storage';
-import type { StoragePagination } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StoragePagination } from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/skills/index.ts
+++ b/stores/mongodb/src/storage/domains/skills/index.ts
@@ -1,14 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  SkillsStorage,
-  createStorageErrorId,
-  TABLE_SKILLS,
-  TABLE_SKILL_VERSIONS,
-  normalizePerPage,
-  calculatePagination,
-} from '@mastra/core/storage';
+import { SkillsStorage } from '@mastra/core/storage';
 import type {
   StorageSkillType,
   StorageCreateSkillInput,
@@ -22,6 +15,13 @@ import type {
   ListSkillVersionsInput,
   ListSkillVersionsOutput,
 } from '@mastra/core/storage/domains/skills';
+import {
+  createStorageErrorId,
+  TABLE_SKILLS,
+  TABLE_SKILL_VERSIONS,
+  normalizePerPage,
+  calculatePagination,
+} from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/utils.ts
+++ b/stores/mongodb/src/storage/domains/utils.ts
@@ -1,6 +1,6 @@
 import type { IMastraLogger } from '@mastra/core/logger';
-import { safelyParseJSON, TABLE_SCHEMAS } from '@mastra/core/storage';
-import type { TABLE_NAMES } from '@mastra/core/storage';
+import { safelyParseJSON, TABLE_SCHEMAS } from '@mastra/storage';
+import type { TABLE_NAMES } from '@mastra/storage';
 
 export function formatDateForMongoDB(date: Date | string): Date {
   return typeof date === 'string' ? new Date(date) : date;

--- a/stores/mongodb/src/storage/domains/workflows/index.ts
+++ b/stores/mongodb/src/storage/domains/workflows/index.ts
@@ -1,18 +1,9 @@
 import { ErrorDomain, ErrorCategory, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  WorkflowsStorage,
-  TABLE_WORKFLOW_SNAPSHOT,
-  safelyParseJSON,
-  normalizePerPage,
-} from '@mastra/core/storage';
-import type {
-  WorkflowRun,
-  WorkflowRuns,
-  StorageListWorkflowRunsInput,
-  UpdateWorkflowStateOptions,
-} from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { createStorageErrorId, TABLE_WORKFLOW_SNAPSHOT, safelyParseJSON, normalizePerPage } from '@mastra/storage';
+import type { WorkflowRun, WorkflowRuns, StorageListWorkflowRunsInput } from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/domains/workspaces/index.ts
+++ b/stores/mongodb/src/storage/domains/workspaces/index.ts
@@ -1,14 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  WorkspacesStorage,
-  createStorageErrorId,
-  TABLE_WORKSPACES,
-  TABLE_WORKSPACE_VERSIONS,
-  normalizePerPage,
-  calculatePagination,
-} from '@mastra/core/storage';
+import { WorkspacesStorage } from '@mastra/core/storage';
 import type {
   StorageWorkspaceType,
   StorageCreateWorkspaceInput,
@@ -22,6 +15,13 @@ import type {
   ListWorkspaceVersionsInput,
   ListWorkspaceVersionsOutput,
 } from '@mastra/core/storage/domains/workspaces';
+import {
+  createStorageErrorId,
+  TABLE_WORKSPACES,
+  TABLE_WORKSPACE_VERSIONS,
+  normalizePerPage,
+  calculatePagination,
+} from '@mastra/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';

--- a/stores/mongodb/src/storage/index.test.ts
+++ b/stores/mongodb/src/storage/index.test.ts
@@ -7,7 +7,7 @@ import {
   createDomainIndexTests,
 } from '@internal/storage-test-utils';
 import { SpanType } from '@mastra/core/observability';
-import { TABLE_THREADS } from '@mastra/core/storage';
+import { TABLE_THREADS } from '@mastra/storage';
 import { MongoClient } from 'mongodb';
 import { describe, expect, it, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -1,6 +1,7 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { StorageDomains } from '@mastra/core/storage';
-import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
+import { createStorageErrorId } from '@mastra/storage';
 import type { MongoDBConnector } from './connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from './db';
 import { MongoDBAgentsStorage } from './domains/agents';

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -1,5 +1,4 @@
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector, validateUpsertInput, validateVectorValues } from '@mastra/core/vector';
 import type {
   QueryResult,
@@ -13,6 +12,7 @@ import type {
   UpdateVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import { MongoClient } from 'mongodb';
 import type { MongoClientOptions, Document, Db, Collection } from 'mongodb';
 import { v4 as uuidv4 } from 'uuid';

--- a/stores/mssql/package.json
+++ b/stores/mssql/package.json
@@ -45,10 +45,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/mssql/src/index.ts
+++ b/stores/mssql/src/index.ts
@@ -1,3 +1,3 @@
 // Entry point for mastra-mssql store
 export * from './storage';
-export type { CreateIndexOptions, IndexInfo } from '@mastra/core/storage';
+export type { CreateIndexOptions, IndexInfo } from '@mastra/storage';

--- a/stores/mssql/src/storage/db/index.ts
+++ b/stores/mssql/src/storage/db/index.ts
@@ -6,15 +6,9 @@ import {
   TABLE_SPANS,
   TABLE_SCHEMAS,
   getDefaultValue,
-} from '@mastra/core/storage';
-import type {
-  StorageColumn,
-  TABLE_NAMES,
-  CreateIndexOptions,
-  IndexInfo,
-  StorageIndexStats,
-} from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+} from '@mastra/storage';
+import type { StorageColumn, TABLE_NAMES, CreateIndexOptions, IndexInfo, StorageIndexStats } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import sql from 'mssql';
 import { getSchemaName, getTableName } from './utils';
 

--- a/stores/mssql/src/storage/db/utils.ts
+++ b/stores/mssql/src/storage/db/utils.ts
@@ -1,6 +1,6 @@
-import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
-import { TABLE_SCHEMAS } from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/storage';
+import { TABLE_SCHEMAS } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 
 export function getSchemaName(schema?: string) {
   return schema ? `[${parseSqlIdentifier(schema, 'schema name')}]` : undefined;

--- a/stores/mssql/src/storage/domains/memory/index.ts
+++ b/stores/mssql/src/storage/domains/memory/index.ts
@@ -2,24 +2,23 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
+import { MemoryStorage } from '@mastra/core/storage';
+import type {
+  StorageListMessagesInput,
+  StorageListMessagesOutput,
+  StorageListThreadsInput,
+  StorageListThreadsOutput,
+} from '@mastra/core/storage';
 import {
   createStorageErrorId,
-  MemoryStorage,
   normalizePerPage,
   calculatePagination,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
   TABLE_SCHEMAS,
-} from '@mastra/core/storage';
-import type {
-  StorageResourceType,
-  StorageListMessagesInput,
-  StorageListMessagesOutput,
-  StorageListThreadsInput,
-  StorageListThreadsOutput,
-  CreateIndexOptions,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { CreateIndexOptions, StorageResourceType } from '@mastra/storage';
 import sql from 'mssql';
 import { MssqlDB, resolveMssqlConfig } from '../../db';
 import type { MssqlDomainConfig } from '../../db';

--- a/stores/mssql/src/storage/domains/observability/index.ts
+++ b/stores/mssql/src/storage/domains/observability/index.ts
@@ -1,15 +1,6 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  listTracesArgsSchema,
-  ObservabilityStorage,
-  SPAN_SCHEMA,
-  TABLE_SPANS,
-  toTraceSpans,
-  TraceStatus,
-} from '@mastra/core/storage';
+import { listTracesArgsSchema, ObservabilityStorage, toTraceSpans } from '@mastra/core/storage';
 import type {
-  SpanRecord,
   ListTracesArgs,
   ListTracesResponse,
   TracingStorageStrategy,
@@ -24,8 +15,9 @@ import type {
   GetRootSpanArgs,
   GetRootSpanResponse,
   CreateSpanArgs,
-  CreateIndexOptions,
 } from '@mastra/core/storage';
+import { createStorageErrorId, SPAN_SCHEMA, TABLE_SPANS, TraceStatus } from '@mastra/storage';
+import type { SpanRecord, CreateIndexOptions } from '@mastra/storage';
 import type { ConnectionPool } from 'mssql';
 import { MssqlDB, resolveMssqlConfig } from '../../db';
 import type { MssqlDomainConfig } from '../../db';

--- a/stores/mssql/src/storage/domains/scores/index.ts
+++ b/stores/mssql/src/storage/domains/scores/index.ts
@@ -2,16 +2,16 @@ import { randomUUID } from 'node:crypto';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
-import type { StoragePagination, CreateIndexOptions } from '@mastra/core/storage';
+import { ScoresStorage } from '@mastra/core/storage';
+import type { StoragePagination, CreateIndexOptions } from '@mastra/storage';
 import {
   createStorageErrorId,
-  ScoresStorage,
   TABLE_SCORERS,
   TABLE_SCHEMAS,
   calculatePagination,
   normalizePerPage,
   transformScoreRow as coreTransformScoreRow,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
 import type { ConnectionPool } from 'mssql';
 import { MssqlDB, resolveMssqlConfig } from '../../db';
 import type { MssqlDomainConfig } from '../../db';

--- a/stores/mssql/src/storage/domains/utils.ts
+++ b/stores/mssql/src/storage/domains/utils.ts
@@ -1,6 +1,6 @@
-import type { StorageColumn, TABLE_NAMES, DateRange } from '@mastra/core/storage';
-import { TABLE_SCHEMAS } from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import type { DateRange, StorageColumn, TABLE_NAMES } from '@mastra/storage';
+import { TABLE_SCHEMAS } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 
 export function getSchemaName(schema?: string) {
   return schema ? `[${parseSqlIdentifier(schema, 'schema name')}]` : undefined;

--- a/stores/mssql/src/storage/domains/workflows/index.ts
+++ b/stores/mssql/src/storage/domains/workflows/index.ts
@@ -1,19 +1,9 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  WorkflowsStorage,
-  TABLE_WORKFLOW_SNAPSHOT,
-  TABLE_SCHEMAS,
-  normalizePerPage,
-} from '@mastra/core/storage';
-import type {
-  StorageListWorkflowRunsInput,
-  WorkflowRun,
-  WorkflowRuns,
-  UpdateWorkflowStateOptions,
-  CreateIndexOptions,
-} from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { createStorageErrorId, TABLE_WORKFLOW_SNAPSHOT, TABLE_SCHEMAS, normalizePerPage } from '@mastra/storage';
+import type { CreateIndexOptions, StorageListWorkflowRunsInput, WorkflowRun, WorkflowRuns } from '@mastra/storage';
 import sql from 'mssql';
 import { MssqlDB, resolveMssqlConfig } from '../../db';
 import type { MssqlDomainConfig } from '../../db';

--- a/stores/mssql/src/storage/index.test.ts
+++ b/stores/mssql/src/storage/index.test.ts
@@ -6,7 +6,7 @@ import {
   createStoreIndexTests,
   createDomainIndexTests,
 } from '@internal/storage-test-utils';
-import { TABLE_THREADS } from '@mastra/core/storage';
+import { TABLE_THREADS } from '@mastra/storage';
 import sql from 'mssql';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/stores/mssql/src/storage/index.ts
+++ b/stores/mssql/src/storage/index.ts
@@ -1,6 +1,8 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
-import type { StorageDomains, CreateIndexOptions } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
+import type { StorageDomains } from '@mastra/core/storage';
+import { createStorageErrorId } from '@mastra/storage';
+import type { CreateIndexOptions } from '@mastra/storage';
 
 import sql from 'mssql';
 import { MemoryMSSQL } from './domains/memory';

--- a/stores/mssql/src/storage/migration.test.ts
+++ b/stores/mssql/src/storage/migration.test.ts
@@ -1,5 +1,5 @@
 import { MastraError } from '@mastra/core/error';
-import { OLD_SPAN_SCHEMA, TABLE_SPANS, TABLE_SCHEMAS } from '@mastra/core/storage';
+import { OLD_SPAN_SCHEMA, TABLE_SPANS, TABLE_SCHEMAS } from '@mastra/storage';
 import sql from 'mssql';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { MssqlDB } from './db';

--- a/stores/opensearch/package.json
+++ b/stores/opensearch/package.json
@@ -44,10 +44,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/opensearch/src/vector/index.ts
+++ b/stores/opensearch/src/vector/index.ts
@@ -1,5 +1,4 @@
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import type {
   CreateIndexParams,
   DeleteIndexParams,
@@ -13,6 +12,7 @@ import type {
   DeleteVectorsParams,
 } from '@mastra/core/vector';
 import { MastraVector, validateUpsert, validateTopK } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import { Client as OpenSearchClient } from '@opensearch-project/opensearch';
 import type { ClientOptions } from '@opensearch-project/opensearch';
 import { OpenSearchFilterTranslator } from './filter';

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -51,10 +51,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.4.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.4.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/pg/src/shared/config.ts
+++ b/stores/pg/src/shared/config.ts
@@ -1,5 +1,5 @@
 import type { ConnectionOptions } from 'node:tls';
-import type { CreateIndexOptions } from '@mastra/core/storage';
+import type { CreateIndexOptions } from '@mastra/storage';
 import type { ClientConfig, Pool, PoolConfig } from 'pg';
 
 /**

--- a/stores/pg/src/storage/db/constraint-utils.test.ts
+++ b/stores/pg/src/storage/db/constraint-utils.test.ts
@@ -1,4 +1,4 @@
-import { TABLE_WORKFLOW_SNAPSHOT, TABLE_SCHEMAS } from '@mastra/core/storage';
+import { TABLE_WORKFLOW_SNAPSHOT, TABLE_SCHEMAS } from '@mastra/storage';
 import { describe, it, expect } from 'vitest';
 
 import { POSTGRES_IDENTIFIER_MAX_LENGTH, truncateIdentifier, buildConstraintName } from './constraint-utils';

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -8,15 +8,9 @@ import {
   TABLE_SCHEMAS,
   getSqlType,
   getDefaultValue,
-} from '@mastra/core/storage';
-import type {
-  StorageColumn,
-  TABLE_NAMES,
-  CreateIndexOptions,
-  IndexInfo,
-  StorageIndexStats,
-} from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+} from '@mastra/storage';
+import type { StorageColumn, TABLE_NAMES, CreateIndexOptions, IndexInfo, StorageIndexStats } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import { Pool } from 'pg';
 import type { DbClient } from '../client';
 import { PoolAdapter } from '../client';

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -1,20 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  AgentsStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_AGENTS,
-  TABLE_AGENT_VERSIONS,
-  TABLE_SCHEMAS,
-} from '@mastra/core/storage';
+import { AgentsStorage } from '@mastra/core/storage';
 import type {
   StorageAgentType,
   StorageCreateAgentInput,
   StorageUpdateAgentInput,
   StorageListAgentsInput,
   StorageListAgentsOutput,
-  CreateIndexOptions,
   AgentInstructionBlock,
 } from '@mastra/core/storage';
 import type {
@@ -23,6 +14,15 @@ import type {
   ListVersionsInput,
   ListVersionsOutput,
 } from '@mastra/core/storage/domains/agents';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
+  TABLE_SCHEMAS,
+} from '@mastra/storage';
+import type { CreateIndexOptions } from '@mastra/storage';
 import { PgDB, resolvePgConfig, generateTableSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getTableName, getSchemaName } from '../utils';

--- a/stores/pg/src/storage/domains/blobs/index.ts
+++ b/stores/pg/src/storage/domains/blobs/index.ts
@@ -1,5 +1,6 @@
-import { BlobStore, TABLE_SKILL_BLOBS, TABLE_SCHEMAS } from '@mastra/core/storage';
+import { BlobStore } from '@mastra/core/storage';
 import type { StorageBlobEntry } from '@mastra/core/storage';
+import { TABLE_SKILL_BLOBS, TABLE_SCHEMAS } from '@mastra/storage';
 
 import { PgDB, resolvePgConfig } from '../../db';
 import type { PgDomainConfig } from '../../db';

--- a/stores/pg/src/storage/domains/datasets/index.ts
+++ b/stores/pg/src/storage/domains/datasets/index.ts
@@ -1,27 +1,6 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  TABLE_DATASETS,
-  TABLE_DATASET_ITEMS,
-  TABLE_DATASET_VERSIONS,
-  TABLE_EXPERIMENTS,
-  TABLE_EXPERIMENT_RESULTS,
-  TABLE_CONFIGS,
-  TABLE_SCHEMAS,
-  DATASETS_SCHEMA,
-  DATASET_ITEMS_SCHEMA,
-  DATASET_VERSIONS_SCHEMA,
-  DatasetsStorage,
-  calculatePagination,
-  normalizePerPage,
-  safelyParseJSON,
-  ensureDate,
-} from '@mastra/core/storage';
+import { DatasetsStorage } from '@mastra/core/storage';
 import type {
-  DatasetRecord,
-  DatasetItem,
-  DatasetItemRow,
-  DatasetVersion,
   CreateDatasetInput,
   UpdateDatasetInput,
   AddDatasetItemInput,
@@ -34,9 +13,32 @@ import type {
   ListDatasetVersionsOutput,
   BatchInsertItemsInput,
   BatchDeleteItemsInput,
-  CreateIndexOptions,
-  TargetType,
 } from '@mastra/core/storage';
+import {
+  createStorageErrorId,
+  TABLE_DATASETS,
+  TABLE_DATASET_ITEMS,
+  TABLE_DATASET_VERSIONS,
+  TABLE_EXPERIMENTS,
+  TABLE_EXPERIMENT_RESULTS,
+  TABLE_CONFIGS,
+  TABLE_SCHEMAS,
+  DATASETS_SCHEMA,
+  DATASET_ITEMS_SCHEMA,
+  DATASET_VERSIONS_SCHEMA,
+  calculatePagination,
+  normalizePerPage,
+  safelyParseJSON,
+  ensureDate,
+} from '@mastra/storage';
+import type {
+  DatasetRecord,
+  DatasetItem,
+  DatasetItemRow,
+  DatasetVersion,
+  TargetType,
+  CreateIndexOptions,
+} from '@mastra/storage';
 import { PgDB, resolvePgConfig, generateTableSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getTableName, getSchemaName } from '../utils';
@@ -89,10 +91,12 @@ export class DatasetsPG extends DatasetsStorage {
     await this.#db.createTable({ tableName: TABLE_DATASET_VERSIONS, schema: DATASET_VERSIONS_SCHEMA });
 
     // Migrate: add new columns to existing tables
+    await this.#addColumnIfNotExists(TABLE_DATASETS, 'version', 'INTEGER NOT NULL DEFAULT 0');
     await this.#addColumnIfNotExists(TABLE_DATASETS, 'requestContextSchema', 'JSONB');
     await this.#addColumnIfNotExists(TABLE_DATASETS, 'tags', 'JSONB');
     await this.#addColumnIfNotExists(TABLE_DATASETS, 'targetType', 'TEXT');
     await this.#addColumnIfNotExists(TABLE_DATASETS, 'targetIds', 'JSONB');
+    await this.#addColumnIfNotExists(TABLE_DATASET_ITEMS, 'datasetVersion', 'INTEGER NOT NULL DEFAULT 0');
     await this.#addColumnIfNotExists(TABLE_DATASET_ITEMS, 'requestContext', 'JSONB');
     await this.#addColumnIfNotExists(TABLE_DATASET_ITEMS, 'source', 'JSONB');
 
@@ -102,9 +106,26 @@ export class DatasetsPG extends DatasetsStorage {
 
   async #addColumnIfNotExists(table: string, column: string, sqlType: string): Promise<void> {
     const exists = await this.#db.hasColumn(table, column);
+    const fullTableName = getTableName({ indexName: table, schemaName: getSchemaName(this.#schema) });
+
     if (!exists) {
-      const fullTableName = getTableName({ indexName: table, schemaName: getSchemaName(this.#schema) });
       await this.#db.client.none(`ALTER TABLE ${fullTableName} ADD COLUMN "${column}" ${sqlType}`);
+    }
+
+    if (table === TABLE_DATASETS && column === 'version') {
+      await this.#db.client.none(`
+        ALTER TABLE ${fullTableName}
+        ALTER COLUMN "version" TYPE INTEGER
+        USING "version"::integer
+      `);
+    }
+
+    if (table === TABLE_DATASET_ITEMS && column === 'datasetVersion') {
+      await this.#db.client.none(`
+        ALTER TABLE ${fullTableName}
+        ALTER COLUMN "datasetVersion" TYPE INTEGER
+        USING "datasetVersion"::integer
+      `);
     }
   }
 
@@ -171,7 +192,7 @@ export class DatasetsPG extends DatasetsStorage {
       tags: row.tags ? safelyParseJSON(row.tags) : undefined,
       targetType: (row.targetType as TargetType) || null,
       targetIds: row.targetIds || null,
-      version: row.version as number,
+      version: Number(row.version),
       createdAt: ensureDate(row.createdAtZ || row.createdAt)!,
       updatedAt: ensureDate(row.updatedAtZ || row.updatedAt)!,
     };
@@ -181,7 +202,7 @@ export class DatasetsPG extends DatasetsStorage {
     return {
       id: row.id as string,
       datasetId: row.datasetId as string,
-      datasetVersion: row.datasetVersion as number,
+      datasetVersion: Number(row.datasetVersion),
       input: safelyParseJSON(row.input),
       groundTruth: row.groundTruth ? safelyParseJSON(row.groundTruth) : undefined,
       requestContext: row.requestContext ? safelyParseJSON(row.requestContext) : undefined,
@@ -196,8 +217,8 @@ export class DatasetsPG extends DatasetsStorage {
     return {
       id: row.id as string,
       datasetId: row.datasetId as string,
-      datasetVersion: row.datasetVersion as number,
-      validTo: row.validTo as number | null,
+      datasetVersion: Number(row.datasetVersion),
+      validTo: row.validTo != null ? Number(row.validTo) : null,
       isDeleted: Boolean(row.isDeleted),
       input: safelyParseJSON(row.input),
       groundTruth: row.groundTruth ? safelyParseJSON(row.groundTruth) : undefined,
@@ -213,7 +234,7 @@ export class DatasetsPG extends DatasetsStorage {
     return {
       id: row.id as string,
       datasetId: row.datasetId as string,
-      version: row.version as number,
+      version: Number(row.version),
       createdAt: ensureDate(row.createdAtZ || row.createdAt)!,
     };
   }
@@ -493,7 +514,7 @@ export class DatasetsPG extends DatasetsStorage {
           `UPDATE ${datasetsTable} SET "version" = "version" + 1 WHERE "id" = $1 RETURNING "version"`,
           [args.datasetId],
         );
-        newVersion = row.version as number;
+        newVersion = Number(row.version);
 
         await t.none(
           `INSERT INTO ${itemsTable} ("id","datasetId","datasetVersion","validTo","isDeleted","input","groundTruth","requestContext","metadata","source","createdAt","createdAtZ","updatedAt","updatedAtZ") VALUES ($1,$2,$3,NULL,false,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
@@ -590,7 +611,7 @@ export class DatasetsPG extends DatasetsStorage {
           `UPDATE ${datasetsTable} SET "version" = "version" + 1 WHERE "id" = $1 RETURNING "version"`,
           [args.datasetId],
         );
-        newVersion = row.version as number;
+        newVersion = Number(row.version);
 
         // 2. Close old row (set validTo = newVersion)
         await t.none(
@@ -676,7 +697,7 @@ export class DatasetsPG extends DatasetsStorage {
           `UPDATE ${datasetsTable} SET "version" = "version" + 1 WHERE "id" = $1 RETURNING "version"`,
           [datasetId],
         );
-        const newVersion = row.version as number;
+        const newVersion = Number(row.version);
 
         // 2. Close old row
         await t.none(
@@ -756,7 +777,7 @@ export class DatasetsPG extends DatasetsStorage {
           `UPDATE ${datasetsTable} SET "version" = "version" + 1 WHERE "id" = $1 RETURNING "version"`,
           [input.datasetId],
         );
-        newVersion = row.version as number;
+        newVersion = Number(row.version);
 
         // 2. N item inserts
         for (const { id, input: itemInput } of itemsWithIds) {
@@ -849,7 +870,7 @@ export class DatasetsPG extends DatasetsStorage {
           `UPDATE ${datasetsTable} SET "version" = "version" + 1 WHERE "id" = $1 RETURNING "version"`,
           [input.datasetId],
         );
-        const newVersion = row.version as number;
+        const newVersion = Number(row.version);
 
         // 2. For each item: close old row + insert tombstone
         for (const item of currentItems) {

--- a/stores/pg/src/storage/domains/experiments/index.ts
+++ b/stores/pg/src/storage/domains/experiments/index.ts
@@ -1,17 +1,5 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  TABLE_EXPERIMENTS,
-  TABLE_EXPERIMENT_RESULTS,
-  TABLE_SCHEMAS,
-  EXPERIMENTS_SCHEMA,
-  EXPERIMENT_RESULTS_SCHEMA,
-  ExperimentsStorage,
-  calculatePagination,
-  normalizePerPage,
-  safelyParseJSON,
-  ensureDate,
-} from '@mastra/core/storage';
+import { ExperimentsStorage } from '@mastra/core/storage';
 import type {
   Experiment,
   ExperimentResult,
@@ -23,8 +11,20 @@ import type {
   ListExperimentsOutput,
   ListExperimentResultsInput,
   ListExperimentResultsOutput,
-  CreateIndexOptions,
 } from '@mastra/core/storage';
+import {
+  createStorageErrorId,
+  TABLE_EXPERIMENTS,
+  TABLE_EXPERIMENT_RESULTS,
+  TABLE_SCHEMAS,
+  EXPERIMENTS_SCHEMA,
+  EXPERIMENT_RESULTS_SCHEMA,
+  calculatePagination,
+  normalizePerPage,
+  safelyParseJSON,
+  ensureDate,
+} from '@mastra/storage';
+import type { CreateIndexOptions } from '@mastra/storage';
 import { PgDB, resolvePgConfig, generateTableSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getTableName, getSchemaName } from '../utils';
@@ -112,15 +112,15 @@ export class ExperimentsPG extends ExperimentsStorage {
       description: (row.description as string) ?? undefined,
       metadata: row.metadata ? safelyParseJSON(row.metadata) : undefined,
       datasetId: (row.datasetId as string | null) ?? null,
-      datasetVersion: row.datasetVersion != null ? (row.datasetVersion as number) : null,
+      datasetVersion: row.datasetVersion != null ? Number(row.datasetVersion) : null,
       agentVersion: (row.agentVersion as string | null) ?? null,
       targetType: row.targetType as Experiment['targetType'],
       targetId: row.targetId as string,
       status: row.status as Experiment['status'],
-      totalItems: row.totalItems as number,
-      succeededCount: row.succeededCount as number,
-      failedCount: row.failedCount as number,
-      skippedCount: (row.skippedCount as number) ?? 0,
+      totalItems: Number(row.totalItems),
+      succeededCount: Number(row.succeededCount),
+      failedCount: Number(row.failedCount),
+      skippedCount: row.skippedCount != null ? Number(row.skippedCount) : 0,
       startedAt: row.startedAt ? ensureDate(row.startedAtZ || row.startedAt)! : null,
       completedAt: row.completedAt ? ensureDate(row.completedAtZ || row.completedAt)! : null,
       createdAt: ensureDate(row.createdAtZ || row.createdAt)!,
@@ -133,14 +133,14 @@ export class ExperimentsPG extends ExperimentsStorage {
       id: row.id as string,
       experimentId: row.experimentId as string,
       itemId: row.itemId as string,
-      itemDatasetVersion: row.itemDatasetVersion != null ? (row.itemDatasetVersion as number) : null,
+      itemDatasetVersion: row.itemDatasetVersion != null ? Number(row.itemDatasetVersion) : null,
       input: safelyParseJSON(row.input),
       output: row.output ? safelyParseJSON(row.output) : null,
       groundTruth: row.groundTruth ? safelyParseJSON(row.groundTruth) : null,
       error: row.error ? safelyParseJSON(row.error) : null,
       startedAt: ensureDate(row.startedAtZ || row.startedAt)!,
       completedAt: ensureDate(row.completedAtZ || row.completedAt)!,
-      retryCount: row.retryCount as number,
+      retryCount: Number(row.retryCount),
       traceId: (row.traceId as string | null) ?? null,
       status: (row.status as ExperimentResult['status']) ?? null,
       tags: row.tags ? safelyParseJSON(row.tags) : null,

--- a/stores/pg/src/storage/domains/mcp-clients/index.ts
+++ b/stores/pg/src/storage/domains/mcp-clients/index.ts
@@ -1,20 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  MCPClientsStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_MCP_CLIENTS,
-  TABLE_MCP_CLIENT_VERSIONS,
-  TABLE_SCHEMAS,
-} from '@mastra/core/storage';
+import { MCPClientsStorage } from '@mastra/core/storage';
 import type {
   StorageMCPClientType,
   StorageCreateMCPClientInput,
   StorageUpdateMCPClientInput,
   StorageListMCPClientsInput,
   StorageListMCPClientsOutput,
-  CreateIndexOptions,
 } from '@mastra/core/storage';
 import type {
   MCPClientVersion,
@@ -22,6 +13,15 @@ import type {
   ListMCPClientVersionsInput,
   ListMCPClientVersionsOutput,
 } from '@mastra/core/storage/domains/mcp-clients';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_MCP_CLIENTS,
+  TABLE_MCP_CLIENT_VERSIONS,
+  TABLE_SCHEMAS,
+} from '@mastra/storage';
+import type { CreateIndexOptions } from '@mastra/storage';
 import { PgDB, resolvePgConfig } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getTableName, getSchemaName } from '../utils';

--- a/stores/pg/src/storage/domains/mcp-servers/index.ts
+++ b/stores/pg/src/storage/domains/mcp-servers/index.ts
@@ -1,20 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  MCPServersStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_MCP_SERVERS,
-  TABLE_MCP_SERVER_VERSIONS,
-  TABLE_SCHEMAS,
-} from '@mastra/core/storage';
+import { MCPServersStorage } from '@mastra/core/storage';
 import type {
   StorageMCPServerType,
   StorageCreateMCPServerInput,
   StorageUpdateMCPServerInput,
   StorageListMCPServersInput,
   StorageListMCPServersOutput,
-  CreateIndexOptions,
 } from '@mastra/core/storage';
 import type {
   MCPServerVersion,
@@ -22,6 +13,15 @@ import type {
   ListMCPServerVersionsInput,
   ListMCPServerVersionsOutput,
 } from '@mastra/core/storage/domains/mcp-servers';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_MCP_SERVERS,
+  TABLE_MCP_SERVER_VERSIONS,
+  TABLE_SCHEMAS,
+} from '@mastra/storage';
+import type { CreateIndexOptions } from '@mastra/storage';
 import { PgDB, resolvePgConfig } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getTableName, getSchemaName } from '../utils';

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -4,8 +4,28 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
+import { MemoryStorage } from '@mastra/core/storage';
+import type {
+  StorageListMessagesInput,
+  StorageListMessagesByResourceIdInput,
+  StorageListMessagesOutput,
+  StorageListThreadsInput,
+  StorageListThreadsOutput,
+  StorageCloneThreadInput,
+  StorageCloneThreadOutput,
+  ThreadCloneMetadata,
+  ObservationalMemoryRecord,
+  BufferedObservationChunk,
+  CreateObservationalMemoryInput,
+  UpdateActiveObservationsInput,
+  UpdateBufferedObservationsInput,
+  SwapBufferedToActiveInput,
+  SwapBufferedToActiveResult,
+  UpdateBufferedReflectionInput,
+  SwapBufferedReflectionToActiveInput,
+  CreateReflectionGenerationInput,
+} from '@mastra/core/storage';
 import {
-  MemoryStorage,
   normalizePerPage,
   calculatePagination,
   TABLE_MESSAGES,
@@ -13,7 +33,8 @@ import {
   TABLE_THREADS,
   TABLE_SCHEMAS,
   createStorageErrorId,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageResourceType, CreateIndexOptions } from '@mastra/storage';
 
 /**
  * Local constant for the observational memory table name.
@@ -35,29 +56,7 @@ try {
 } catch {
   // OM not available in this version of core
 }
-import type {
-  StorageResourceType,
-  StorageListMessagesInput,
-  StorageListMessagesByResourceIdInput,
-  StorageListMessagesOutput,
-  StorageListThreadsInput,
-  StorageListThreadsOutput,
-  CreateIndexOptions,
-  StorageCloneThreadInput,
-  StorageCloneThreadOutput,
-  ThreadCloneMetadata,
-  ObservationalMemoryRecord,
-  BufferedObservationChunk,
-  CreateObservationalMemoryInput,
-  UpdateActiveObservationsInput,
-  UpdateBufferedObservationsInput,
-  SwapBufferedToActiveInput,
-  SwapBufferedToActiveResult,
-  UpdateBufferedReflectionInput,
-  SwapBufferedReflectionToActiveInput,
-  CreateReflectionGenerationInput,
-} from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import {
   PgDB,
   resolvePgConfig,
@@ -125,13 +124,13 @@ export class MemoryPG extends MemoryStorage {
     await this.#db.createTable({ tableName: TABLE_MESSAGES, schema: TABLE_SCHEMAS[TABLE_MESSAGES] });
     await this.#db.createTable({ tableName: TABLE_RESOURCES, schema: TABLE_SCHEMAS[TABLE_RESOURCES] });
 
-    // Dynamically import OM schema to avoid breaking older @mastra/core versions
+    // Dynamically import OM schema to keep the static dependency surface minimal.
     let omSchema: Record<string, any> | undefined;
     try {
-      const { OBSERVATIONAL_MEMORY_TABLE_SCHEMA } = await import('@mastra/core/storage');
+      const { OBSERVATIONAL_MEMORY_TABLE_SCHEMA } = await import('@mastra/storage');
       omSchema = OBSERVATIONAL_MEMORY_TABLE_SCHEMA?.[OM_TABLE];
     } catch {
-      // OM not available in this version of core
+      // OM schema not available
     }
 
     if (omSchema) {
@@ -160,6 +159,7 @@ export class MemoryPG extends MemoryStorage {
           'metadata',
         ],
       });
+      await this.#migrateObservationalMemorySchema();
     }
     await this.#db.alterTable({
       tableName: TABLE_MESSAGES,
@@ -176,6 +176,74 @@ export class MemoryPG extends MemoryStorage {
     }
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
+  }
+
+  async #migrateObservationalMemorySchema(): Promise<void> {
+    const tableName = getTableName({
+      indexName: OM_TABLE,
+      schemaName: getSchemaName(this.#schema),
+    });
+
+    const columns = await this.#db.client.manyOrNone<{ column_name: string; data_type: string; udt_name: string }>(
+      `SELECT column_name, data_type, udt_name
+       FROM information_schema.columns
+       WHERE table_schema = $1 AND table_name = $2`,
+      [this.#schema, OM_TABLE],
+    );
+
+    const columnMap = new Map(columns.map(column => [column.column_name, column]));
+    const migrations: string[] = [];
+
+    const integerColumns = [
+      'totalTokensObserved',
+      'pendingMessageTokens',
+      'observationTokenCount',
+      'bufferedReflectionTokens',
+      'bufferedReflectionInputTokens',
+      'reflectedObservationLineCount',
+      'lastBufferedAtTokens',
+    ] as const;
+
+    for (const columnName of integerColumns) {
+      const column = columnMap.get(columnName);
+      if (column && column.data_type !== 'integer') {
+        migrations.push(`
+        ALTER COLUMN "${columnName}" TYPE integer
+        USING COALESCE(NULLIF("${columnName}"::text, ''), '0')::integer
+      `);
+      }
+    }
+
+    const bufferedObservationChunks = columnMap.get('bufferedObservationChunks');
+    if (bufferedObservationChunks && bufferedObservationChunks.data_type !== 'jsonb') {
+      migrations.push(`
+        ALTER COLUMN "bufferedObservationChunks" TYPE jsonb
+        USING CASE
+          WHEN "bufferedObservationChunks" IS NULL OR "bufferedObservationChunks"::text = '' THEN NULL
+          ELSE "bufferedObservationChunks"::jsonb
+        END
+      `);
+    }
+
+    const metadata = columnMap.get('metadata');
+    if (metadata && metadata.data_type !== 'jsonb') {
+      migrations.push(`
+        ALTER COLUMN "metadata" TYPE jsonb
+        USING CASE
+          WHEN "metadata" IS NULL OR "metadata"::text = '' THEN NULL
+          ELSE "metadata"::jsonb
+        END
+      `);
+    }
+
+    if (migrations.length === 0) {
+      return;
+    }
+
+    await this.#db.client.none(`
+      ALTER TABLE ${tableName}
+      ${migrations.join(',\n')}
+    `);
   }
 
   /**
@@ -873,13 +941,13 @@ export class MemoryPG extends MemoryStorage {
 
       if (filter?.dateRange?.start) {
         const startOp = filter.dateRange.startExclusive ? '>' : '>=';
-        conditions.push(`COALESCE("createdAtZ", "createdAt") ${startOp} $${paramIndex++}`);
+        conditions.push(`COALESCE("createdAtZ", "createdAt"::timestamptz) ${startOp} $${paramIndex++}::timestamptz`);
         queryParams.push(filter.dateRange.start);
       }
 
       if (filter?.dateRange?.end) {
         const endOp = filter.dateRange.endExclusive ? '<' : '<=';
-        conditions.push(`COALESCE("createdAtZ", "createdAt") ${endOp} $${paramIndex++}`);
+        conditions.push(`COALESCE("createdAtZ", "createdAt"::timestamptz) ${endOp} $${paramIndex++}::timestamptz`);
         queryParams.push(filter.dateRange.end);
       }
 
@@ -1447,10 +1515,7 @@ export class MemoryPG extends MemoryStorage {
   async saveResource({ resource }: { resource: StorageResourceType }): Promise<StorageResourceType> {
     await this.#db.insert({
       tableName: TABLE_RESOURCES,
-      record: {
-        ...resource,
-        metadata: JSON.stringify(resource.metadata),
-      },
+      record: resource,
     });
 
     return resource;
@@ -1562,11 +1627,11 @@ export class MemoryPG extends MemoryStorage {
 
         // Apply date filters
         if (options?.messageFilter?.startDate) {
-          messageQuery += ` AND COALESCE("createdAtZ", "createdAt") >= $${paramIndex++}`;
+          messageQuery += ` AND COALESCE("createdAtZ", "createdAt"::timestamptz) >= $${paramIndex++}::timestamptz`;
           messageParams.push(options.messageFilter.startDate);
         }
         if (options?.messageFilter?.endDate) {
-          messageQuery += ` AND COALESCE("createdAtZ", "createdAt") <= $${paramIndex++}`;
+          messageQuery += ` AND COALESCE("createdAtZ", "createdAt"::timestamptz) <= $${paramIndex++}::timestamptz`;
           messageParams.push(options.messageFilter.endDate);
         }
 

--- a/stores/pg/src/storage/domains/observability/index.ts
+++ b/stores/pg/src/storage/domains/observability/index.ts
@@ -1,15 +1,6 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  listTracesArgsSchema,
-  ObservabilityStorage,
-  TABLE_SCHEMAS,
-  TABLE_SPANS,
-  toTraceSpans,
-  TraceStatus,
-} from '@mastra/core/storage';
+import { listTracesArgsSchema, ObservabilityStorage, toTraceSpans } from '@mastra/core/storage';
 import type {
-  SpanRecord,
   TracingStorageStrategy,
   ListTracesArgs,
   ListTracesResponse,
@@ -24,9 +15,10 @@ import type {
   GetRootSpanResponse,
   GetTraceArgs,
   GetTraceResponse,
-  CreateIndexOptions,
 } from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import { createStorageErrorId, TABLE_SCHEMAS, TABLE_SPANS, TraceStatus } from '@mastra/storage';
+import type { SpanRecord, CreateIndexOptions } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import { PgDB, resolvePgConfig, generateTableSQL, generateIndexSQL, generateTimestampTriggerSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { transformFromSqlRow, getTableName, getSchemaName } from '../utils';

--- a/stores/pg/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/pg/src/storage/domains/prompt-blocks/index.ts
@@ -1,20 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  PromptBlocksStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_PROMPT_BLOCKS,
-  TABLE_PROMPT_BLOCK_VERSIONS,
-  TABLE_SCHEMAS,
-} from '@mastra/core/storage';
+import { PromptBlocksStorage } from '@mastra/core/storage';
 import type {
   StoragePromptBlockType,
   StorageCreatePromptBlockInput,
   StorageUpdatePromptBlockInput,
   StorageListPromptBlocksInput,
   StorageListPromptBlocksOutput,
-  CreateIndexOptions,
 } from '@mastra/core/storage';
 import type {
   PromptBlockVersion,
@@ -22,7 +13,16 @@ import type {
   ListPromptBlockVersionsInput,
   ListPromptBlockVersionsOutput,
 } from '@mastra/core/storage/domains/prompt-blocks';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_PROMPT_BLOCKS,
+  TABLE_PROMPT_BLOCK_VERSIONS,
+  TABLE_SCHEMAS,
+} from '@mastra/storage';
+import type { CreateIndexOptions } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import { PgDB, resolvePgConfig, generateTableSQL, generateIndexSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getTableName, getSchemaName } from '../utils';

--- a/stores/pg/src/storage/domains/scorer-definitions/index.ts
+++ b/stores/pg/src/storage/domains/scorer-definitions/index.ts
@@ -1,20 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  ScorerDefinitionsStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_SCORER_DEFINITIONS,
-  TABLE_SCORER_DEFINITION_VERSIONS,
-  TABLE_SCHEMAS,
-} from '@mastra/core/storage';
+import { ScorerDefinitionsStorage } from '@mastra/core/storage';
 import type {
   StorageScorerDefinitionType,
   StorageCreateScorerDefinitionInput,
   StorageUpdateScorerDefinitionInput,
   StorageListScorerDefinitionsInput,
   StorageListScorerDefinitionsOutput,
-  CreateIndexOptions,
 } from '@mastra/core/storage';
 import type {
   ScorerDefinitionVersion,
@@ -22,7 +13,16 @@ import type {
   ListScorerDefinitionVersionsInput,
   ListScorerDefinitionVersionsOutput,
 } from '@mastra/core/storage/domains/scorer-definitions';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_SCORER_DEFINITIONS,
+  TABLE_SCORER_DEFINITION_VERSIONS,
+  TABLE_SCHEMAS,
+} from '@mastra/storage';
+import type { CreateIndexOptions } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import { PgDB, resolvePgConfig, generateTableSQL, generateIndexSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getTableName, getSchemaName } from '../utils';

--- a/stores/pg/src/storage/domains/scores/index.ts
+++ b/stores/pg/src/storage/domains/scores/index.ts
@@ -1,17 +1,17 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
-import type { StoragePagination, CreateIndexOptions } from '@mastra/core/storage';
+import { ScoresStorage } from '@mastra/core/storage';
+import type { StoragePagination, CreateIndexOptions } from '@mastra/storage';
 import {
   calculatePagination,
   createStorageErrorId,
   normalizePerPage,
-  ScoresStorage,
   TABLE_SCORERS,
   TABLE_SCHEMAS,
   transformScoreRow as coreTransformScoreRow,
-} from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+} from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import { PgDB, resolvePgConfig, generateTableSQL, generateIndexSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 
@@ -303,15 +303,15 @@ export class ScoresPG extends ScoresStorage {
         record: {
           id,
           ...rest,
-          input: JSON.stringify(input) || '',
-          output: JSON.stringify(output) || '',
-          scorer: scorer ? JSON.stringify(scorer) : null,
-          preprocessStepResult: preprocessStepResult ? JSON.stringify(preprocessStepResult) : null,
-          analyzeStepResult: analyzeStepResult ? JSON.stringify(analyzeStepResult) : null,
-          metadata: metadata ? JSON.stringify(metadata) : null,
-          additionalContext: additionalContext ? JSON.stringify(additionalContext) : null,
-          requestContext: requestContext ? JSON.stringify(requestContext) : null,
-          entity: entity ? JSON.stringify(entity) : null,
+          input,
+          output,
+          scorer: scorer ?? null,
+          preprocessStepResult: preprocessStepResult ?? null,
+          analyzeStepResult: analyzeStepResult ?? null,
+          metadata: metadata ?? null,
+          additionalContext: additionalContext ?? null,
+          requestContext: requestContext ?? null,
+          entity: entity ?? null,
           createdAt: now.toISOString(),
           updatedAt: now.toISOString(),
         },

--- a/stores/pg/src/storage/domains/skills/index.ts
+++ b/stores/pg/src/storage/domains/skills/index.ts
@@ -1,20 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  SkillsStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_SKILLS,
-  TABLE_SKILL_VERSIONS,
-  TABLE_SCHEMAS,
-} from '@mastra/core/storage';
+import { SkillsStorage } from '@mastra/core/storage';
 import type {
   StorageSkillType,
   StorageCreateSkillInput,
   StorageUpdateSkillInput,
   StorageListSkillsInput,
   StorageListSkillsOutput,
-  CreateIndexOptions,
 } from '@mastra/core/storage';
 import type {
   SkillVersion,
@@ -22,6 +13,15 @@ import type {
   ListSkillVersionsInput,
   ListSkillVersionsOutput,
 } from '@mastra/core/storage/domains/skills';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_SKILLS,
+  TABLE_SKILL_VERSIONS,
+  TABLE_SCHEMAS,
+} from '@mastra/storage';
+import type { CreateIndexOptions } from '@mastra/storage';
 import { PgDB, resolvePgConfig } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getTableName, getSchemaName } from '../utils';

--- a/stores/pg/src/storage/domains/utils.ts
+++ b/stores/pg/src/storage/domains/utils.ts
@@ -1,6 +1,6 @@
-import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
-import { TABLE_SCHEMAS } from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/storage';
+import { TABLE_SCHEMAS } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 
 export function getSchemaName(schema?: string) {
   return schema ? `"${parseSqlIdentifier(schema, 'schema name')}"` : undefined;

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -1,19 +1,9 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  normalizePerPage,
-  TABLE_WORKFLOW_SNAPSHOT,
-  TABLE_SCHEMAS,
-  WorkflowsStorage,
-  createStorageErrorId,
-} from '@mastra/core/storage';
-import type {
-  UpdateWorkflowStateOptions,
-  StorageListWorkflowRunsInput,
-  WorkflowRun,
-  WorkflowRuns,
-  CreateIndexOptions,
-} from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { normalizePerPage, TABLE_WORKFLOW_SNAPSHOT, TABLE_SCHEMAS, createStorageErrorId } from '@mastra/storage';
+import type { CreateIndexOptions, StorageListWorkflowRunsInput, WorkflowRun, WorkflowRuns } from '@mastra/storage';
 import { PgDB, resolvePgConfig, generateTableSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 

--- a/stores/pg/src/storage/domains/workspaces/index.ts
+++ b/stores/pg/src/storage/domains/workspaces/index.ts
@@ -1,20 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  WorkspacesStorage,
-  createStorageErrorId,
-  normalizePerPage,
-  calculatePagination,
-  TABLE_WORKSPACES,
-  TABLE_WORKSPACE_VERSIONS,
-  TABLE_SCHEMAS,
-} from '@mastra/core/storage';
+import { WorkspacesStorage } from '@mastra/core/storage';
 import type {
   StorageWorkspaceType,
   StorageCreateWorkspaceInput,
   StorageUpdateWorkspaceInput,
   StorageListWorkspacesInput,
   StorageListWorkspacesOutput,
-  CreateIndexOptions,
 } from '@mastra/core/storage';
 import type {
   WorkspaceVersion,
@@ -22,6 +13,15 @@ import type {
   ListWorkspaceVersionsInput,
   ListWorkspaceVersionsOutput,
 } from '@mastra/core/storage/domains/workspaces';
+import {
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_WORKSPACES,
+  TABLE_WORKSPACE_VERSIONS,
+  TABLE_SCHEMAS,
+} from '@mastra/storage';
+import type { CreateIndexOptions } from '@mastra/storage';
 import { PgDB, resolvePgConfig } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getTableName, getSchemaName } from '../utils';

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -6,7 +6,7 @@ import {
   createStoreIndexTests,
   createDomainIndexTests,
 } from '@internal/storage-test-utils';
-import { TABLE_THREADS } from '@mastra/core/storage';
+import { TABLE_THREADS } from '@mastra/storage';
 import { Pool } from 'pg';
 import { describe, it, expect, vi } from 'vitest';
 

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -1,7 +1,8 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
 import type { StorageDomains } from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
+import { createStorageErrorId } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import { Pool } from 'pg';
 import {
   validateConfig,

--- a/stores/pg/src/storage/migration.test.ts
+++ b/stores/pg/src/storage/migration.test.ts
@@ -1,12 +1,6 @@
 import { MastraError } from '@mastra/core/error';
 import { SpanType } from '@mastra/core/observability';
-import {
-  OLD_SPAN_SCHEMA,
-  TABLE_SPANS,
-  TABLE_SCHEMAS,
-  TABLE_THREADS,
-  TABLE_WORKFLOW_SNAPSHOT,
-} from '@mastra/core/storage';
+import { OLD_SPAN_SCHEMA, TABLE_SPANS, TABLE_SCHEMAS, TABLE_THREADS, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/storage';
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { PgDB } from './db';

--- a/stores/pg/src/storage/test-utils.ts
+++ b/stores/pg/src/storage/test-utils.ts
@@ -1,5 +1,6 @@
 import { createSampleThread } from '@internal/storage-test-utils';
-import type { MemoryStorage, StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
+import type { MemoryStorage } from '@mastra/core/storage';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/storage';
 import { Pool } from 'pg';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { PostgresStoreConfig } from '../shared/config';

--- a/stores/pg/src/vector/index.schema-name.test.ts
+++ b/stores/pg/src/vector/index.schema-name.test.ts
@@ -13,7 +13,7 @@ vi.mock('@mastra/core/error', () => ({
   },
 }));
 
-vi.mock('@mastra/core/utils', () => ({
+vi.mock('@mastra/storage/sql', () => ({
   parseSqlIdentifier: (name: string) => name,
 }));
 

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -1,6 +1,4 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
-import { parseSqlIdentifier } from '@mastra/core/utils';
 import { MastraVector, validateUpsertInput, validateTopK } from '@mastra/core/vector';
 import type {
   IndexStats,
@@ -14,6 +12,8 @@ import type {
   DeleteVectorsParams,
   UpdateVectorParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
+import { parseSqlIdentifier } from '@mastra/storage/sql';
 import { Mutex } from 'async-mutex';
 import * as pg from 'pg';
 import xxhash from 'xxhash-wasm';

--- a/stores/pg/src/vector/sql-builder.ts
+++ b/stores/pg/src/vector/sql-builder.ts
@@ -1,4 +1,3 @@
-import { parseFieldKey } from '@mastra/core/utils';
 import type {
   BasicOperator,
   NumericOperator,
@@ -8,6 +7,7 @@ import type {
   RegexOperator,
   VectorFilter,
 } from '@mastra/core/vector/filter';
+import { parseFieldKey } from '@mastra/storage/sql';
 import type { PGVectorFilter } from './filter';
 
 type OperatorType =

--- a/stores/pinecone/package.json
+++ b/stores/pinecone/package.json
@@ -41,10 +41,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/pinecone/src/vector/index.ts
+++ b/stores/pinecone/src/vector/index.ts
@@ -1,5 +1,4 @@
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';
 import type {
   QueryResult,
@@ -12,6 +11,7 @@ import type {
   DeleteVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import { Pinecone } from '@pinecone-database/pinecone';
 import type {
   IndexStatsDescription,

--- a/stores/qdrant/package.json
+++ b/stores/qdrant/package.json
@@ -42,10 +42,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -1,5 +1,4 @@
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector, validateUpsertInput } from '@mastra/core/vector';
 import type {
   QueryResult,
@@ -13,6 +12,7 @@ import type {
   UpdateVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import { QdrantClient } from '@qdrant/js-client-rest';
 import type { QdrantClientParams, Schemas } from '@qdrant/js-client-rest';
 

--- a/stores/s3vectors/package.json
+++ b/stores/s3vectors/package.json
@@ -46,10 +46,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/s3vectors/src/vector/index.ts
+++ b/stores/s3vectors/src/vector/index.ts
@@ -12,7 +12,6 @@ import {
 } from '@aws-sdk/client-s3vectors';
 import type { S3VectorsClientConfig } from '@aws-sdk/client-s3vectors';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';
 import type {
   QueryResult,
@@ -26,6 +25,7 @@ import type {
   DeleteVectorParams,
   UpdateVectorParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import { v4 as uuidv4 } from 'uuid';
 import { S3VectorsFilterTranslator } from './filter';
 import type { S3VectorsFilter } from './filter';

--- a/stores/turbopuffer/package.json
+++ b/stores/turbopuffer/package.json
@@ -45,10 +45,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/turbopuffer/src/vector/index.ts
+++ b/stores/turbopuffer/src/vector/index.ts
@@ -1,5 +1,4 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import type {
   CreateIndexParams,
   DeleteIndexParams,
@@ -13,6 +12,7 @@ import type {
   DeleteVectorsParams,
 } from '@mastra/core/vector';
 import { MastraVector } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import { Turbopuffer } from '@turbopuffer/turbopuffer';
 import type { DistanceMetric, QueryResults, Schema, Vector } from '@turbopuffer/turbopuffer';
 import { TurbopufferFilterTranslator } from './filter';

--- a/stores/upstash/package.json
+++ b/stores/upstash/package.json
@@ -44,10 +44,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/upstash/src/storage/db/index.ts
+++ b/stores/upstash/src/storage/db/index.ts
@@ -1,6 +1,6 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createStorageErrorId } from '@mastra/core/storage';
-import type { TABLE_NAMES } from '@mastra/core/storage';
+import { createStorageErrorId } from '@mastra/storage';
+import type { TABLE_NAMES } from '@mastra/storage';
 import { Redis } from '@upstash/redis';
 import { getKey, processRecord } from '../domains/utils';
 

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -2,8 +2,17 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
+import { MemoryStorage } from '@mastra/core/storage';
+import type {
+  StorageListMessagesInput,
+  StorageListMessagesOutput,
+  StorageListThreadsInput,
+  StorageListThreadsOutput,
+  StorageCloneThreadInput,
+  StorageCloneThreadOutput,
+  ThreadCloneMetadata,
+} from '@mastra/core/storage';
 import {
-  MemoryStorage,
   TABLE_RESOURCES,
   TABLE_THREADS,
   TABLE_MESSAGES,
@@ -12,19 +21,8 @@ import {
   createStorageErrorId,
   ensureDate,
   filterByDateRange,
-} from '@mastra/core/storage';
-import type {
-  StorageResourceType,
-  StorageListMessagesInput,
-  StorageListMessagesOutput,
-  StorageListThreadsInput,
-  StorageListThreadsOutput,
-  ThreadOrderBy,
-  ThreadSortDirection,
-  StorageCloneThreadInput,
-  StorageCloneThreadOutput,
-  ThreadCloneMetadata,
-} from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { StorageResourceType, ThreadOrderBy, ThreadSortDirection } from '@mastra/storage';
 import type { Redis } from '@upstash/redis';
 import { UpstashDB, resolveUpstashConfig } from '../../db';
 import type { UpstashDomainConfig } from '../../db';

--- a/stores/upstash/src/storage/domains/scores/index.ts
+++ b/stores/upstash/src/storage/domains/scores/index.ts
@@ -1,15 +1,15 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
+import { ScoresStorage } from '@mastra/core/storage';
 import {
   calculatePagination,
   normalizePerPage,
-  ScoresStorage,
   TABLE_SCORERS,
   transformScoreRow as coreTransformScoreRow,
   createStorageErrorId,
-} from '@mastra/core/storage';
-import type { PaginationInfo, StoragePagination } from '@mastra/core/storage';
+} from '@mastra/storage';
+import type { PaginationInfo, StoragePagination } from '@mastra/storage';
 import type { Redis } from '@upstash/redis';
 import { UpstashDB, resolveUpstashConfig } from '../../db';
 import type { UpstashDomainConfig } from '../../db';

--- a/stores/upstash/src/storage/domains/utils.ts
+++ b/stores/upstash/src/storage/domains/utils.ts
@@ -1,5 +1,5 @@
-import { serializeDate, TABLE_MESSAGES, TABLE_WORKFLOW_SNAPSHOT, TABLE_SCORERS } from '@mastra/core/storage';
-import type { TABLE_NAMES } from '@mastra/core/storage';
+import { serializeDate, TABLE_MESSAGES, TABLE_WORKFLOW_SNAPSHOT, TABLE_SCORERS } from '@mastra/storage';
+import type { TABLE_NAMES } from '@mastra/storage';
 
 export function getKey(tableName: TABLE_NAMES, keys: Record<string, any>): string {
   const keyParts = Object.entries(keys)

--- a/stores/upstash/src/storage/domains/workflows/index.ts
+++ b/stores/upstash/src/storage/domains/workflows/index.ts
@@ -1,18 +1,9 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  normalizePerPage,
-  TABLE_WORKFLOW_SNAPSHOT,
-  WorkflowsStorage,
-  ensureDate,
-} from '@mastra/core/storage';
-import type {
-  StorageListWorkflowRunsInput,
-  WorkflowRun,
-  WorkflowRuns,
-  UpdateWorkflowStateOptions,
-} from '@mastra/core/storage';
+import { WorkflowsStorage } from '@mastra/core/storage';
+import type { UpdateWorkflowStateOptions } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
+import { createStorageErrorId, normalizePerPage, TABLE_WORKFLOW_SNAPSHOT, ensureDate } from '@mastra/storage';
+import type { StorageListWorkflowRunsInput, WorkflowRun, WorkflowRuns } from '@mastra/storage';
 import type { Redis } from '@upstash/redis';
 import { UpstashDB, resolveUpstashConfig } from '../../db';
 import type { UpstashDomainConfig } from '../../db';

--- a/stores/upstash/src/vector/index.ts
+++ b/stores/upstash/src/vector/index.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';
 import type {
   CreateIndexParams,
@@ -12,6 +11,7 @@ import type {
   DeleteVectorsParams,
   UpdateVectorParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import { Index } from '@upstash/vector';
 
 import { UpstashFilterTranslator } from './filter';

--- a/stores/vectorize/package.json
+++ b/stores/vectorize/package.json
@@ -44,10 +44,12 @@
     "eslint": "^9.39.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@mastra/storage": "workspace:*"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/storage": ">=1.0.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/vectorize/src/vector/index.ts
+++ b/stores/vectorize/src/vector/index.ts
@@ -1,5 +1,4 @@
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';
 import type {
   QueryResult,
@@ -13,6 +12,7 @@ import type {
   IndexStats,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import { createVectorErrorId } from '@mastra/storage';
 import Cloudflare from 'cloudflare';
 
 import { VectorizeFilterTranslator } from './filter';


### PR DESCRIPTION
## Summary
- add a new `@mastra/storage` package for shared storage constants, schemas, utility types, pagination helpers, and SQL helpers
- migrate storage and vector adapters to import those shared pieces from `@mastra/storage` instead of `@mastra/core/storage` where possible
- keep runtime storage abstractions and domain base classes in `@mastra/core/storage`
- update storage docs and add changesets for the new package and adapter peer dependency updates

## Test plan
- `cd packages/storage && pnpm check && pnpm build:lib`
- `cd stores/libsql && pnpm test`
- `cd stores/pg && pnpm test`