### PR TITLE
fix(observability): propagate model/provider to MODEL_STEP spans 

### DIFF
--- a/.changeset/eighty-parents-sort.md
+++ b/.changeset/eighty-parents-sort.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': patch
+---
+
+Fixed Datadog LLM Observability showing `model_name: custom` and missing model provider by correcting the span type mapping. `MODEL_GENERATION` now correctly maps to Datadog kind `llm` (was `workflow`), and `MODEL_STEP` falls back to `task` (was `llm`). This aligns with all other Mastra observability exporters and ensures Datadog receives model name, provider, and accurate cost estimation on the correct span. Fixes #14623.

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -214,8 +214,8 @@ describe('DatadogExporter', () => {
   describe('span type mapping', () => {
     it.each([
       [SpanType.AGENT_RUN, 'agent'],
-      [SpanType.MODEL_GENERATION, 'workflow'],
-      [SpanType.MODEL_STEP, 'llm'],
+      [SpanType.MODEL_GENERATION, 'llm'],
+      [SpanType.MODEL_STEP, 'task'],
       [SpanType.MODEL_CHUNK, 'task'],
       [SpanType.TOOL_CALL, 'tool'],
       [SpanType.MCP_TOOL_CALL, 'tool'],
@@ -1046,7 +1046,7 @@ describe('DatadogExporter', () => {
     it('includes modelName and modelProvider for llm spans', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({
-        type: SpanType.MODEL_STEP,
+        type: SpanType.MODEL_GENERATION,
         attributes: {
           model: 'gpt-4',
           provider: 'openai',
@@ -1220,7 +1220,7 @@ describe('DatadogExporter', () => {
     it('excludes known LLM fields from attribute forwarding', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({
-        type: SpanType.MODEL_STEP,
+        type: SpanType.MODEL_GENERATION,
         metadata: { userKey: 'userValue' },
         attributes: {
           model: 'gpt-4', // Should be excluded (used for modelName)

--- a/observability/datadog/src/utils.test.ts
+++ b/observability/datadog/src/utils.test.ts
@@ -9,8 +9,8 @@ import { formatInput, formatOutput, kindFor, toDate, safeStringify, SPAN_TYPE_TO
 describe('kindFor', () => {
   it.each([
     [SpanType.AGENT_RUN, 'agent'],
-    [SpanType.MODEL_GENERATION, 'workflow'],
-    [SpanType.MODEL_STEP, 'llm'],
+    [SpanType.MODEL_GENERATION, 'llm'],
+    [SpanType.MODEL_STEP, 'task'],
     [SpanType.MODEL_CHUNK, 'task'],
     [SpanType.TOOL_CALL, 'tool'],
     [SpanType.MCP_TOOL_CALL, 'tool'],
@@ -47,8 +47,7 @@ describe('SPAN_TYPE_TO_KIND mapping', () => {
     // Verify that only the expected span types have explicit mappings
     const expectedMappings = {
       [SpanType.AGENT_RUN]: 'agent',
-      [SpanType.MODEL_GENERATION]: 'workflow',
-      [SpanType.MODEL_STEP]: 'llm',
+      [SpanType.MODEL_GENERATION]: 'llm',
       [SpanType.TOOL_CALL]: 'tool',
       [SpanType.MCP_TOOL_CALL]: 'tool',
       [SpanType.WORKFLOW_RUN]: 'workflow',
@@ -64,6 +63,7 @@ describe('SPAN_TYPE_TO_KIND mapping', () => {
   it('defaults unmapped types to task', () => {
     // These should not have explicit mappings and should fall back to 'task'
     const taskTypes = [
+      SpanType.MODEL_STEP,
       SpanType.MODEL_CHUNK,
       SpanType.WORKFLOW_STEP,
       SpanType.WORKFLOW_CONDITIONAL,

--- a/observability/datadog/src/utils.ts
+++ b/observability/datadog/src/utils.ts
@@ -16,8 +16,7 @@ export type DatadogSpanKind = 'llm' | 'agent' | 'workflow' | 'tool' | 'task' | '
  */
 export const SPAN_TYPE_TO_KIND: Partial<Record<SpanType, DatadogSpanKind>> = {
   [SpanType.AGENT_RUN]: 'agent',
-  [SpanType.MODEL_GENERATION]: 'workflow',
-  [SpanType.MODEL_STEP]: 'llm',
+  [SpanType.MODEL_GENERATION]: 'llm',
   [SpanType.TOOL_CALL]: 'tool',
   [SpanType.MCP_TOOL_CALL]: 'tool',
   [SpanType.WORKFLOW_RUN]: 'workflow',


### PR DESCRIPTION
## Description
The Datadog exporter had `MODEL_GENERATION` mapped to Datadog kind `workflow` and `MODEL_STEP`
mapped to `llm`. This is the reverse of every other Mastra observability exporter (LangSmith, Braintrust, Langfuse, PostHog, Sentry, Laminar) — all of which treat `MODEL_GENERATION` as the LLM span.

This caused Datadog LLM Observability to show `model_name: custom`, miss `model_provider` entirely, and report `Estimated Cost: N/A` — because `MODEL_STEP` (mapped to `llm`) never had `model` or `provider` attributes, while `MODEL_GENERATION` (which has them) was mapped to `workflow` where Datadog ignores model info.

**Fix:** Swap the mapping so `MODEL_GENERATION` maps to `llm` and `MODEL_STEP` falls back to `task`.

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/b6da0b28-9a6d-4efc-a091-1aded57a8c12" />

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/3510cc19-f7ca-46f7-ae6e-00063606973a" />

  ## Related Issue(s)

  Fixes #14623

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist

  - [ ] I have made corresponding changes to the documentation (if
  applicable)
  - [x] I have added tests that prove my fix is effective or that my
  feature works
  - [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model step spans to properly inherit model and provider attributes from their parent spans, improving LLM observability reporting in Datadog and other exporters for accurate model-level filtering and cost estimation.

* **Tests**
  * Updated trace snapshots to reflect new model identification attributes in step-level spans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->