### PR TITLE
feat(playground): add infinite scroll pagination to datasets list

### DIFF
--- a/.changeset/datasets-infinite-scroll.md
+++ b/.changeset/datasets-infinite-scroll.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added infinite scroll pagination to the datasets list page. Datasets now load progressively as you scroll, instead of only showing the first 10 results.

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-datasets.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-datasets.tsx
@@ -19,9 +19,8 @@ export function AgentPlaygroundDatasets({ agentId }: AgentPlaygroundDatasetsProp
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [generateDatasetId, setGenerateDatasetId] = useState<string | null>(null);
 
-  const { data: datasetsData, isLoading: isDatasetsLoading } = useDatasets();
+  const { data: datasets = [], isLoading: isDatasetsLoading } = useDatasets();
   const { data: experiments } = useAgentExperiments(agentId);
-  const datasets = datasetsData?.datasets ?? [];
 
   // Build a map of dataset ID → latest experiment for this agent
   const latestExperimentByDataset = useMemo(() => {

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
@@ -92,7 +92,7 @@ export function AgentPlaygroundEvaluate({
     }
   }, [pendingScorerItems, onPendingScorerItemsConsumed]);
 
-  const { data: datasetsData, isLoading: datasetsLoading } = useDatasets();
+  const { data: allDatasets = [], isLoading: datasetsLoading } = useDatasets();
   const { data: scorers } = useScorers();
   const { form } = useAgentEditFormContext();
   const agentScorers = useWatch({ control: form.control, name: 'scorers' }) || {};
@@ -113,7 +113,7 @@ export function AgentPlaygroundEvaluate({
     [agentDescription, agentInstructions, agentTools],
   );
 
-  const allDatasets = datasetsData?.datasets || [];
+  // allDatasets is already set from useDatasets() above
   // targetIds may come as a JSON string from some storage backends — normalize
   const parseTargetIds = (ids: unknown): string[] => {
     if (Array.isArray(ids)) return ids;

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-review.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-review.tsx
@@ -59,7 +59,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
   const { data: completedItems, refetch: refetchCompleted } = useCompletedItems(agentId);
   const client = useMastraClient();
   const { provider, model } = usePlaygroundModel();
-  const { data: allDatasets } = useDatasets();
+  const { data: allDatasets = [] } = useDatasets();
   const { updateDataset } = useDatasetMutations();
 
   // Load persisted review items on mount / when data changes
@@ -91,7 +91,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
   const [analysisModelId, setAnalysisModelId] = useState<string | null>(null);
 
   // Collect tag vocabulary from datasets that items belong to
-  const datasets = allDatasets?.datasets;
+  const datasets = allDatasets;
   const datasetTagVocabulary = useMemo(() => {
     if (!datasets) return [] as string[];
     const datasetIds = new Set(items.map(i => i.datasetId).filter(Boolean));

--- a/packages/playground-ui/src/domains/agents/components/agent-traces-panel.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-traces-panel.tsx
@@ -219,8 +219,7 @@ function BulkAddToDatasetBar({
   isPending: boolean;
 }) {
   const [datasetId, setDatasetId] = useState('');
-  const { data, isLoading: isDatasetsLoading } = useDatasets();
-  const datasets = data?.datasets ?? [];
+  const { data: datasets = [], isLoading: isDatasetsLoading } = useDatasets();
 
   return (
     <div className="flex items-center gap-3 px-4 py-2 border-b border-border1 bg-surface2 shrink-0">

--- a/packages/playground-ui/src/domains/agents/hooks/use-agent-experiments.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-agent-experiments.ts
@@ -24,8 +24,7 @@ interface AgentExperiment {
  */
 export const useAgentExperiments = (agentId: string, attachedScorerIds: string[] = []) => {
   const client = useMastraClient();
-  const { data: datasetsData } = useDatasets();
-  const datasets = datasetsData?.datasets ?? [];
+  const { data: datasets = [] } = useDatasets();
 
   return useQuery({
     queryKey: ['agent-experiments', agentId, attachedScorerIds, datasets.map(d => d.id)],

--- a/packages/playground-ui/src/domains/datasets/components/add-items-to-dataset-dialog.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/add-items-to-dataset-dialog.tsx
@@ -29,11 +29,8 @@ export function AddItemsToDatasetDialog({
   const [isAdding, setIsAdding] = useState(false);
   const [progress, setProgress] = useState(0);
 
-  const { data, isLoading: isDatasetsLoading } = useDatasets();
+  const { data: datasets = [], isLoading: isDatasetsLoading } = useDatasets();
   const { addItem } = useDatasetMutations();
-
-  // Extract datasets array from response
-  const datasets: DatasetRecord[] = (data as { datasets: DatasetRecord[] } | undefined)?.datasets ?? [];
 
   // Filter out the current dataset from the list
   const availableDatasets = datasets.filter((d: DatasetRecord) => d.id !== currentDatasetId);

--- a/packages/playground-ui/src/domains/datasets/components/dataset-combobox.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/dataset-combobox.tsx
@@ -28,7 +28,7 @@ export function DatasetCombobox({
   disabled = false,
   variant = 'inputLike',
 }: DatasetComboboxProps) {
-  const { data, isLoading, isError, error } = useDatasets();
+  const { data: datasets = [], isLoading, isError, error } = useDatasets();
   const { navigate, paths } = useLinkComponent();
 
   useEffect(() => {
@@ -37,8 +37,6 @@ export function DatasetCombobox({
       toast.error(`Error loading datasets: ${errorMessage}`);
     }
   }, [isError, error]);
-
-  const datasets = data?.datasets ?? [];
   const datasetOptions = datasets.map(d => ({
     label: d.name,
     value: d.id,

--- a/packages/playground-ui/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns';
 import { useMemo } from 'react';
 import { NoDatasetsInfo } from './no-datasets-info';
 import { EntityList, EntityListSkeleton } from '@/ds/components/EntityList';
+import { ItemListNextPageLoading } from '@/ds/components/ItemList/item-list-next-page-loading';
 import { ErrorState } from '@/ds/components/ErrorState';
 import { PermissionDenied } from '@/ds/components/PermissionDenied';
 import { useLinkComponent } from '@/lib/framework';
@@ -14,9 +15,20 @@ export interface DatasetsListProps {
   isLoading: boolean;
   error?: Error | null;
   search?: string;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  setEndOfListElement?: (element: HTMLDivElement | null) => void;
 }
 
-export function DatasetsList({ datasets, isLoading, error, search = '' }: DatasetsListProps) {
+export function DatasetsList({
+  datasets,
+  isLoading,
+  error,
+  search = '',
+  hasNextPage,
+  isFetchingNextPage,
+  setEndOfListElement,
+}: DatasetsListProps) {
   const { paths } = useLinkComponent();
 
   const filteredData = useMemo(() => {
@@ -65,6 +77,14 @@ export function DatasetsList({ datasets, isLoading, error, search = '' }: Datase
           </EntityList.RowLink>
         );
       })}
+
+      <ItemListNextPageLoading
+        isLoading={isFetchingNextPage}
+        hasMore={hasNextPage}
+        setEndOfListElement={setEndOfListElement}
+        loadingText="Loading more datasets..."
+        noMoreDataText="No more datasets to load"
+      />
     </EntityList>
   );
 }

--- a/packages/playground-ui/src/domains/datasets/components/datasets-table/datasets-table.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/datasets-table/datasets-table.tsx
@@ -94,16 +94,15 @@ export function DatasetsTable({
               ))}
             </Tbody>
           </Table>
+          <ItemListNextPageLoading
+            isLoading={isFetchingNextPage}
+            hasMore={hasNextPage}
+            setEndOfListElement={setEndOfListElement}
+            loadingText="Loading more datasets..."
+            noMoreDataText="No more datasets to load"
+          />
         </ScrollableContainer>
       )}
-
-      <ItemListNextPageLoading
-        isLoading={isFetchingNextPage}
-        hasMore={hasNextPage}
-        setEndOfListElement={setEndOfListElement}
-        loadingText="Loading more datasets..."
-        noMoreDataText="No more datasets to load"
-      />
     </div>
   );
 }

--- a/packages/playground-ui/src/domains/datasets/components/datasets-table/datasets-table.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/datasets-table/datasets-table.tsx
@@ -6,6 +6,7 @@ import React, { useMemo, useState } from 'react';
 import { EmptyDatasetsTable } from '../empty-datasets-table';
 import type { DatasetTableColumn } from './columns';
 import { columns } from './columns';
+import { ItemListNextPageLoading } from '@/ds/components/ItemList/item-list-next-page-loading';
 import { PermissionDenied } from '@/ds/components/PermissionDenied';
 import { ScrollableContainer } from '@/ds/components/ScrollableContainer';
 import { Searchbar, SearchbarWrapper } from '@/ds/components/Searchbar';
@@ -19,9 +20,20 @@ export interface DatasetsTableProps {
   isLoading: boolean;
   error?: Error | null;
   onCreateClick?: () => void;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  setEndOfListElement?: (element: HTMLDivElement | null) => void;
 }
 
-export function DatasetsTable({ datasets, isLoading, error, onCreateClick }: DatasetsTableProps) {
+export function DatasetsTable({
+  datasets,
+  isLoading,
+  error,
+  onCreateClick,
+  hasNextPage,
+  isFetchingNextPage,
+  setEndOfListElement,
+}: DatasetsTableProps) {
   const [search, setSearch] = useState('');
   const { navigate, paths } = useLinkComponent();
   const tableData: DatasetTableColumn[] = useMemo(() => datasets, [datasets]);
@@ -84,6 +96,14 @@ export function DatasetsTable({ datasets, isLoading, error, onCreateClick }: Dat
           </Table>
         </ScrollableContainer>
       )}
+
+      <ItemListNextPageLoading
+        isLoading={isFetchingNextPage}
+        hasMore={hasNextPage}
+        setEndOfListElement={setEndOfListElement}
+        loadingText="Loading more datasets..."
+        noMoreDataText="No more datasets to load"
+      />
     </div>
   );
 }

--- a/packages/playground-ui/src/domains/datasets/components/save-as-dataset-item-dialog.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/save-as-dataset-item-dialog.tsx
@@ -38,10 +38,8 @@ export function SaveAsDatasetItemDialog({
   const [groundTruth, setGroundTruth] = useState('');
   // source is passed through — not editable in the UI
 
-  const { data, isLoading: isDatasetsLoading } = useDatasets();
+  const { data: datasets = [], isLoading: isDatasetsLoading } = useDatasets();
   const { addItem } = useDatasetMutations();
-
-  const datasets = data?.datasets ?? [];
 
   useEffect(() => {
     if (isOpen) {

--- a/packages/playground-ui/src/domains/datasets/hooks/use-dataset-experiments.ts
+++ b/packages/playground-ui/src/domains/datasets/hooks/use-dataset-experiments.ts
@@ -1,9 +1,8 @@
 import type { ClientScoreRowData } from '@mastra/client-js';
 import type { ExperimentStatus } from '@mastra/core/storage';
 import { useMastraClient } from '@mastra/react';
-import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
-import { useInView } from '@/hooks/use-in-view';
+import { useQuery } from '@tanstack/react-query';
+import { useInfiniteScrollQuery } from '@/hooks/use-infinite-scroll-query';
 
 export interface DatasetExperimentsFilters {
   status?: string;
@@ -58,8 +57,6 @@ export const useDatasetExperiment = (datasetId: string, experimentId: string) =>
   });
 };
 
-const RESULTS_PER_PAGE = 100;
-
 interface UseDatasetExperimentResultsParams {
   datasetId: string;
   experimentId: string;
@@ -76,42 +73,16 @@ export const useDatasetExperimentResults = ({
   experimentStatus,
 }: UseDatasetExperimentResultsParams) => {
   const client = useMastraClient();
-  const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
 
-  const query = useInfiniteQuery({
+  return useInfiniteScrollQuery({
     queryKey: ['dataset-experiment-results', datasetId, experimentId, experimentStatus],
-    queryFn: async ({ pageParam }) => {
-      return client.listDatasetExperimentResults(datasetId, experimentId, {
-        page: pageParam,
-        perPage: RESULTS_PER_PAGE,
-      });
-    },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, _, lastPageParam) => {
-      if (!lastPage?.results?.length) {
-        return undefined;
-      }
-      const totalFetched = (lastPageParam + 1) * RESULTS_PER_PAGE;
-      const total = lastPage?.pagination?.total ?? 0;
-      if (totalFetched >= total) {
-        return undefined;
-      }
-      return lastPageParam + 1;
-    },
+    queryFn: page => client.listDatasetExperimentResults(datasetId, experimentId, { page, perPage: 100 }),
+    getItems: page => page?.results ?? [],
+    getTotal: page => page?.pagination?.total ?? 0,
     enabled: Boolean(datasetId) && Boolean(experimentId),
+    perPage: 100,
     refetchInterval: experimentStatus === 'running' || experimentStatus === 'pending' ? 2000 : false,
-    select: data => {
-      return data.pages.flatMap(page => page?.results ?? []);
-    },
   });
-
-  useEffect(() => {
-    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
-      void query.fetchNextPage();
-    }
-  }, [isEndOfListInView, query.hasNextPage, query.isFetchingNextPage]);
-
-  return { ...query, setEndOfListElement };
 };
 
 /**

--- a/packages/playground-ui/src/domains/datasets/hooks/use-dataset-items.ts
+++ b/packages/playground-ui/src/domains/datasets/hooks/use-dataset-items.ts
@@ -1,7 +1,6 @@
 import { useMastraClient } from '@mastra/react';
-import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
-import { useInView } from '@/hooks/use-in-view';
+import { useQuery } from '@tanstack/react-query';
+import { useInfiniteScrollQuery } from '@/hooks/use-infinite-scroll-query';
 
 /**
  * Hook to fetch a single dataset item by ID
@@ -16,51 +15,24 @@ export const useDatasetItem = (datasetId: string, itemId: string) => {
   });
 };
 
-const PER_PAGE = 10;
-
 /**
  * Hook to list items in a dataset with infinite scroll pagination and optional search
  * @param version - Optional version timestamp to view historical snapshot
  */
 export const useDatasetItems = (datasetId: string, search?: string, version?: number | null) => {
   const client = useMastraClient();
-  const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
 
-  const query = useInfiniteQuery({
+  return useInfiniteScrollQuery({
     queryKey: ['dataset-items', datasetId, search, version],
-    queryFn: async ({ pageParam }) => {
-      const res = await client.listDatasetItems(datasetId, {
-        page: pageParam,
-        perPage: PER_PAGE,
+    queryFn: page =>
+      client.listDatasetItems(datasetId, {
+        page,
+        perPage: 10,
         search: search || undefined,
         version: version || undefined,
-      });
-      return res;
-    },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, _, lastPageParam) => {
-      if (!lastPage?.items?.length) {
-        return undefined;
-      }
-      const totalFetched = (lastPageParam + 1) * PER_PAGE;
-      const total = lastPage?.pagination?.total ?? 0;
-      if (totalFetched >= total) {
-        return undefined;
-      }
-      return lastPageParam + 1;
-    },
+      }),
+    getItems: page => page?.items ?? [],
+    getTotal: page => page?.pagination?.total ?? 0,
     enabled: Boolean(datasetId),
-    select: data => {
-      return data.pages.flatMap(page => page?.items ?? []);
-    },
-    retry: false,
   });
-
-  useEffect(() => {
-    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
-      void query.fetchNextPage();
-    }
-  }, [isEndOfListInView, query.hasNextPage, query.isFetchingNextPage]);
-
-  return { ...query, setEndOfListElement };
 };

--- a/packages/playground-ui/src/domains/datasets/hooks/use-datasets.ts
+++ b/packages/playground-ui/src/domains/datasets/hooks/use-datasets.ts
@@ -1,51 +1,19 @@
 import { useMastraClient } from '@mastra/react';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
-import { useInView } from '@/hooks/use-in-view';
-
-const PER_PAGE = 10;
+import { useQuery } from '@tanstack/react-query';
+import { useInfiniteScrollQuery } from '@/hooks/use-infinite-scroll-query';
 
 /**
  * Hook to list all datasets with infinite scroll pagination
  */
 export const useDatasets = () => {
   const client = useMastraClient();
-  const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
 
-  const query = useInfiniteQuery({
+  return useInfiniteScrollQuery({
     queryKey: ['datasets'],
-    queryFn: async ({ pageParam }) => {
-      const res = await client.listDatasets({
-        page: pageParam,
-        perPage: PER_PAGE,
-      });
-      return res;
-    },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, _, lastPageParam) => {
-      if (!lastPage?.datasets?.length) {
-        return undefined;
-      }
-      const totalFetched = (lastPageParam + 1) * PER_PAGE;
-      const total = lastPage?.pagination?.total ?? 0;
-      if (totalFetched >= total) {
-        return undefined;
-      }
-      return lastPageParam + 1;
-    },
-    select: data => {
-      return data.pages.flatMap(page => page?.datasets ?? []);
-    },
-    retry: false,
+    queryFn: page => client.listDatasets({ page, perPage: 10 }),
+    getItems: page => page?.datasets ?? [],
+    getTotal: page => page?.pagination?.total ?? 0,
   });
-
-  useEffect(() => {
-    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
-      void query.fetchNextPage();
-    }
-  }, [isEndOfListInView, query.hasNextPage, query.isFetchingNextPage]);
-
-  return { ...query, setEndOfListElement };
 };
 
 /**

--- a/packages/playground-ui/src/domains/datasets/hooks/use-datasets.ts
+++ b/packages/playground-ui/src/domains/datasets/hooks/use-datasets.ts
@@ -1,15 +1,51 @@
 import { useMastraClient } from '@mastra/react';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useInView } from '@/hooks/use-in-view';
+
+const PER_PAGE = 10;
 
 /**
- * Hook to list all datasets with optional pagination
+ * Hook to list all datasets with infinite scroll pagination
  */
-export const useDatasets = (pagination?: { page?: number; perPage?: number }) => {
+export const useDatasets = () => {
   const client = useMastraClient();
-  return useQuery({
-    queryKey: ['datasets', pagination],
-    queryFn: () => client.listDatasets(pagination),
+  const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
+
+  const query = useInfiniteQuery({
+    queryKey: ['datasets'],
+    queryFn: async ({ pageParam }) => {
+      const res = await client.listDatasets({
+        page: pageParam,
+        perPage: PER_PAGE,
+      });
+      return res;
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      if (!lastPage?.datasets?.length) {
+        return undefined;
+      }
+      const totalFetched = (lastPageParam + 1) * PER_PAGE;
+      const total = lastPage?.pagination?.total ?? 0;
+      if (totalFetched >= total) {
+        return undefined;
+      }
+      return lastPageParam + 1;
+    },
+    select: data => {
+      return data.pages.flatMap(page => page?.datasets ?? []);
+    },
+    retry: false,
   });
+
+  useEffect(() => {
+    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
+      void query.fetchNextPage();
+    }
+  }, [isEndOfListInView, query.hasNextPage, query.isFetchingNextPage]);
+
+  return { ...query, setEndOfListElement };
 };
 
 /**

--- a/packages/playground-ui/src/hooks/use-infinite-scroll-query.ts
+++ b/packages/playground-ui/src/hooks/use-infinite-scroll-query.ts
@@ -1,0 +1,61 @@
+import type { QueryKey } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useInView } from '@/hooks/use-in-view';
+
+interface UseInfiniteScrollQueryOptions<TPage, TItem> {
+  queryKey: QueryKey;
+  queryFn: (pageParam: number) => Promise<TPage>;
+  getItems: (page: TPage) => TItem[];
+  getTotal?: (page: TPage) => number;
+  enabled?: boolean;
+  perPage?: number;
+  refetchInterval?: number | false;
+}
+
+/**
+ * Generic infinite scroll hook that combines useInfiniteQuery with useInView
+ * for automatic next-page fetching when the end of the list becomes visible.
+ */
+export function useInfiniteScrollQuery<TPage, TItem>({
+  queryKey,
+  queryFn,
+  getItems,
+  getTotal = () => 0,
+  enabled = true,
+  perPage = 10,
+  refetchInterval,
+}: UseInfiniteScrollQueryOptions<TPage, TItem>) {
+  const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
+
+  const query = useInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam }) => queryFn(pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      if (!getItems(lastPage)?.length) {
+        return undefined;
+      }
+      const totalFetched = (lastPageParam + 1) * perPage;
+      const total = getTotal(lastPage);
+      if (totalFetched >= total) {
+        return undefined;
+      }
+      return lastPageParam + 1;
+    },
+    enabled,
+    refetchInterval,
+    select: data => {
+      return data.pages.flatMap(page => getItems(page));
+    },
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
+      void query.fetchNextPage();
+    }
+  }, [isEndOfListInView, query.hasNextPage, query.isFetchingNextPage]);
+
+  return { ...query, setEndOfListElement };
+}

--- a/packages/playground-ui/src/hooks/use-infinite-scroll-query.ts
+++ b/packages/playground-ui/src/hooks/use-infinite-scroll-query.ts
@@ -55,7 +55,7 @@ export function useInfiniteScrollQuery<TPage, TItem>({
     if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
       void query.fetchNextPage();
     }
-  }, [isEndOfListInView, query.hasNextPage, query.isFetchingNextPage]);
+  }, [isEndOfListInView, query.hasNextPage, query.isFetchingNextPage, query.fetchNextPage]);
 
   return { ...query, setEndOfListElement };
 }

--- a/packages/playground-ui/src/lib/ai-ui/messages/dataset-save-action.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/messages/dataset-save-action.tsx
@@ -57,9 +57,8 @@ function DatasetSaveDialog({
     }
   }, [open, initialGroundTruth]);
 
-  const { data, isLoading: isDatasetsLoading } = useDatasets();
+  const { data: datasets = [], isLoading: isDatasetsLoading } = useDatasets();
   const { addItem } = useDatasetMutations();
-  const datasets = data?.datasets ?? [];
 
   const handleSubmit = useCallback(async () => {
     if (!selectedDatasetId) {

--- a/packages/playground/src/pages/datasets/index.tsx
+++ b/packages/playground/src/pages/datasets/index.tsx
@@ -17,18 +17,17 @@ import {
   MainHeader,
   EntityListPageLayout,
 } from '@mastra/playground-ui';
-import { useExperimentalUI } from '@/domains/experimental-ui/experimental-ui-context';
 import { BookIcon, Database, Plus } from 'lucide-react';
 import { useState } from 'react';
+import { useExperimentalUI } from '@/domains/experimental-ui/experimental-ui-context';
 
 function Datasets() {
   const { Link: FrameworkLink } = useLinkComponent();
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const { navigate, paths } = useLinkComponent();
-  const { data, isLoading, error } = useDatasets();
+  const { data: datasets = [], isLoading, error, hasNextPage, isFetchingNextPage, setEndOfListElement } = useDatasets();
   const { variant } = useExperimentalUI('entity-list-page');
   const [search, setSearch] = useState('');
-  const datasets = data?.datasets ?? [];
 
   const handleDatasetCreated = (datasetId: string) => {
     setIsCreateDialogOpen(false);
@@ -67,7 +66,15 @@ function Datasets() {
             </div>
           </EntityListPageLayout.Top>
 
-          <DatasetsList datasets={datasets} isLoading={isLoading} error={error} search={search} />
+          <DatasetsList
+            datasets={datasets}
+            isLoading={isLoading}
+            error={error}
+            search={search}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            setEndOfListElement={setEndOfListElement}
+          />
         </EntityListPageLayout>
 
         <CreateDatasetDialog
@@ -114,6 +121,9 @@ function Datasets() {
           isLoading={isLoading}
           error={error}
           onCreateClick={() => setIsCreateDialogOpen(true)}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          setEndOfListElement={setEndOfListElement}
         />
       </MainContentContent>
 


### PR DESCRIPTION
## Description

The datasets page only showed the first 10 datasets because the API returns paginated results (default page size 10) but the UI fetched a single page without requesting more. This converts the `useDatasets` hook from `useQuery` to `useInfiniteQuery` with `useInView`-based auto-fetching, reusing the same infinite scroll pattern already used for dataset items (`use-dataset-items.ts`).

Changes:
- Convert `useDatasets` hook to use `useInfiniteQuery` with automatic next-page fetching
- Extract shared infinite scroll logic into a reusable `useInfiniteScrollQuery` hook
- Add `ItemListNextPageLoading` indicator to both `DatasetsList` and `DatasetsTable` components
- Update all 10 consumers of `useDatasets` to use the new flat array return shape

## Related Issue(s)

Fixes #14631

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Datasets list now uses infinite scroll pagination with a next-page loading indicator, progressively loading more items as you scroll.

* **Improvements**
  * More consistent and reliable dataset loading across dataset-related screens and dialogs, reducing empty-state glitches and improving scrolling/loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->