### PR TITLE
fix(convex): use keyed lookups for workflow snapshot queries instead of full table scans

### DIFF
--- a/.changeset/fix-convex-workflow-keyed-lookups.md
+++ b/.changeset/fix-convex-workflow-keyed-lookups.md
@@ -2,8 +2,6 @@
 '@mastra/convex': patch
 ---
 
-fix(convex): use keyed lookups for workflow snapshot queries instead of full table scans
+Fixed workflow query performance in Convex storage
 
-- `getWorkflowRunById`: uses `load()` with composite keys when `workflowName` is provided (O(1)), falls back to filtered `queryTable` when omitted
-- `getRun`: uses `load()` with composite keys (both params required)
-- `listWorkflowRuns`: passes `workflowName`/`resourceId` as server-side filters instead of fetching all rows and filtering in JavaScript
+Workflow snapshot queries (`getWorkflowRunById`, `listWorkflowRuns`) now use indexed lookups and server-side filtering instead of fetching all rows. This significantly improves performance for deployments with large workflow histories and avoids hitting Convex's 16MB read limit with growing datasets.

--- a/.changeset/fix-convex-workflow-keyed-lookups.md
+++ b/.changeset/fix-convex-workflow-keyed-lookups.md
@@ -1,0 +1,9 @@
+---
+'@mastra/convex': patch
+---
+
+fix(convex): use keyed lookups for workflow snapshot queries instead of full table scans
+
+- `getWorkflowRunById`: uses `load()` with composite keys when `workflowName` is provided (O(1)), falls back to filtered `queryTable` when omitted
+- `getRun`: uses `load()` with composite keys (both params required)
+- `listWorkflowRuns`: passes `workflowName`/`resourceId` as server-side filters instead of fetching all rows and filtering in JavaScript

--- a/stores/convex/src/storage/domains/workflows/index.ts
+++ b/stores/convex/src/storage/domains/workflows/index.ts
@@ -113,14 +113,19 @@ export class WorkflowsConvex extends WorkflowsStorage {
   async listWorkflowRuns(args: StorageListWorkflowRunsInput = {}): Promise<WorkflowRuns> {
     const { workflowName, fromDate, toDate, perPage, page, resourceId, status } = args;
 
-    // Use index hint if workflowName is provided - critical for performance
-    const indexHint = workflowName ? { index: 'by_workflow' as const, workflowName } : undefined;
+    // Pass known filters to queryTable for server-side filtering instead of fetching all rows
+    const filters: Array<{ field: string; value: unknown }> = [];
+    if (workflowName) {
+      filters.push({ field: 'workflow_name', value: workflowName });
+    }
+    if (resourceId) {
+      filters.push({ field: 'resourceId', value: resourceId });
+    }
 
-    let rows = await this.#db.queryTable<RawWorkflowRun>(TABLE_WORKFLOW_SNAPSHOT, undefined, indexHint);
-
-    // Apply filters in JavaScript (status requires parsing snapshot JSON)
-    if (workflowName) rows = rows.filter(run => run.workflow_name === workflowName);
-    if (resourceId) rows = rows.filter(run => run.resourceId === resourceId);
+    let rows = await this.#db.queryTable<RawWorkflowRun>(
+      TABLE_WORKFLOW_SNAPSHOT,
+      filters.length > 0 ? filters : undefined,
+    );
     if (fromDate) rows = rows.filter(run => new Date(run.createdAt).getTime() >= fromDate.getTime());
     if (toDate) rows = rows.filter(run => new Date(run.createdAt).getTime() <= toDate.getTime());
     if (status) {
@@ -158,8 +163,20 @@ export class WorkflowsConvex extends WorkflowsStorage {
     runId: string;
     workflowName?: string;
   }): Promise<WorkflowRun | null> {
-    const runs = await this.#db.queryTable<RawWorkflowRun>(TABLE_WORKFLOW_SNAPSHOT, undefined);
-    const match = runs.find(run => run.run_id === runId && (!workflowName || run.workflow_name === workflowName));
+    let match: RawWorkflowRun | null;
+    if (workflowName) {
+      // O(1) composite key lookup via by_workflow_run index
+      match = await this.#db.load<RawWorkflowRun | null>({
+        tableName: TABLE_WORKFLOW_SNAPSHOT,
+        keys: { workflow_name: workflowName, run_id: runId },
+      });
+    } else {
+      // Fallback: filter by run_id server-side (no dedicated index, but avoids full unfiltered scan)
+      const rows = await this.#db.queryTable<RawWorkflowRun>(TABLE_WORKFLOW_SNAPSHOT, [
+        { field: 'run_id', value: runId },
+      ]);
+      match = rows[0] ?? null;
+    }
     if (!match) return null;
 
     return {
@@ -177,10 +194,11 @@ export class WorkflowsConvex extends WorkflowsStorage {
   }
 
   private async getRun(workflowName: string, runId: string): Promise<RawWorkflowRun | null> {
-    const runs = await this.#db.queryTable<RawWorkflowRun>(TABLE_WORKFLOW_SNAPSHOT, [
-      { field: 'workflow_name', value: workflowName },
-    ]);
-    return runs.find(run => run.run_id === runId) ?? null;
+    // O(1) composite key lookup instead of querying by workflow_name then filtering in JS
+    return this.#db.load<RawWorkflowRun | null>({
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      keys: { workflow_name: workflowName, run_id: runId },
+    });
   }
 
   private ensureSnapshot(run: { snapshot: WorkflowRunState | string }): WorkflowRunState {

--- a/stores/convex/src/storage/domains/workflows/index.ts
+++ b/stores/convex/src/storage/domains/workflows/index.ts
@@ -114,7 +114,7 @@ export class WorkflowsConvex extends WorkflowsStorage {
     const { workflowName, fromDate, toDate, perPage, page, resourceId, status } = args;
 
     // Pass known filters to queryTable for server-side filtering instead of fetching all rows
-    const filters: Array<{ field: string; value: unknown }> = [];
+    const filters: Array<{ field: string; value: string }> = [];
     if (workflowName) {
       filters.push({ field: 'workflow_name', value: workflowName });
     }


### PR DESCRIPTION
## Description

Fixes three performance-critical methods in `WorkflowsConvex` that fetch ALL workflow snapshots into memory instead of using targeted lookups:

1. **`getWorkflowRunById`**: When `workflowName` is provided (common case), uses `this.#db.load()` with composite keys `{ workflow_name, run_id }` for O(1) lookup. When `workflowName` is omitted (rare case, type allows optional), falls back to `queryTable` with `run_id` filter — still avoids unfiltered full scan.

2. **`getRun`**: `queryTable([workflow_name])` + `.find()` → direct `this.#db.load()` with composite keys. Both params are required so `load()` always has full keys.

3. **`listWorkflowRuns`**: Was passing `undefined` filters + `indexHint` then filtering `workflowName` and `resourceId` in JavaScript → now builds filter array and passes to `queryTable()` for server-side filtering.

### Why this matters

These are O(n) full table scans that hit Convex's 16MB read limit as workflow history accumulates. The fix uses O(1) keyed lookups where possible and server-side filtered queries otherwise.


### Index coverage

The existing schema already has indexes that support these queries:
- `by_workflow_run: ["workflow_name", "run_id"]` — used by `load()` for composite key lookup
- `by_workflow: ["workflow_name"]` — available for `listWorkflowRuns` workflowName filter
- `by_resource: ["resourceId"]` — available for `listWorkflowRuns` resourceId filter

### Before / After

```typescript
// BEFORE — getWorkflowRunById (full table scan)
const runs = await this.#db.queryTable(TABLE_WORKFLOW_SNAPSHOT, undefined);
const match = runs.find(run => run.run_id === runId && (!workflowName || run.workflow_name === workflowName));

// AFTER — O(1) keyed lookup when workflowName provided
if (workflowName) {
  match = await this.#db.load({ tableName: TABLE_WORKFLOW_SNAPSHOT, keys: { workflow_name: workflowName, run_id: runId } });
} else {
  const rows = await this.#db.queryTable(TABLE_WORKFLOW_SNAPSHOT, [{ field: 'run_id', value: runId }]);
  match = rows[0] ?? null;
}
```

```typescript
// BEFORE — listWorkflowRuns (fetches all, filters in JS)
let rows = await this.#db.queryTable(TABLE_WORKFLOW_SNAPSHOT, undefined, indexHint);
if (workflowName) rows = rows.filter(run => run.workflow_name === workflowName);
if (resourceId) rows = rows.filter(run => run.resourceId === resourceId);

// AFTER — server-side filters
const filters = [];
if (workflowName) filters.push({ field: 'workflow_name', value: workflowName });
if (resourceId) filters.push({ field: 'resourceId', value: resourceId });
let rows = await this.#db.queryTable(TABLE_WORKFLOW_SNAPSHOT, filters.length > 0 ? filters : undefined);
```

## Related Issue(s)

Fixes #14633

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [ ] Made corresponding documentation changes (if applicable)
- [x] Added tests proving fix works or feature works
- [x] Addressed all Coderabbit comments