### PR TITLE
fix(llm-recorder): prevent fuzzy matching from reusing same recording for multiple similar requests

### DIFF
--- a/packages/_llm-recorder/src/llm-recorder.ts
+++ b/packages/_llm-recorder/src/llm-recorder.ts
@@ -596,10 +596,12 @@ function pickBestCandidate(candidates: { index: number; rating: number }[]): num
  * between test runs (e.g. different prompt wording, extra metadata fields)
  * but the intent is clearly the same recording.
  *
- * `usedHashes` tracks recordings already consumed by fuzzy matches so that
- * multiple similar requests (e.g. binary audio transcription calls that all
+ * `usedHashes` tracks recordings already consumed by **binary** fuzzy matches
+ * so that multiple similar requests (e.g. audio transcription calls that all
  * serialize to near-identical strings) don't all resolve to the same recording.
- * Exact hash matches are exempt — they are deterministic and always correct.
+ * It is only applied to binary request matching — non-binary recordings are
+ * intentionally reusable across tests (e.g. v1/v2 model variants sharing one
+ * recording).  Exact hash matches are always exempt.
  */
 function findRecording(
   recordings: LLMRecording[],
@@ -658,14 +660,15 @@ function findRecording(
   // Prefer recordings that match the request URL to avoid cross-API mismatches.
   // When multiple candidates score within a narrow band, prefer the earliest
   // unused one to preserve recording order.
+  //
+  // NOTE: usedHashes is NOT applied here.  Non-binary recordings are intentionally
+  // reusable across tests — e.g. v1 and v2 model variants share the same recording.
   const incoming = serializeRequestContent(url, body);
 
   type Candidate = { index: number; rating: number; urlMatch: boolean };
   const candidates: Candidate[] = [];
 
   for (let i = 0; i < recordings.length; i++) {
-    if (usedHashes?.has(recordings[i]!.hash)) continue;
-
     const candidate = serializeRequestContent(recordings[i]!.request.url, recordings[i]!.request.body);
     const rating = stringSimilarity.compareTwoStrings(incoming, candidate);
     if (rating >= SIMILARITY_THRESHOLD) {
@@ -682,7 +685,6 @@ function findRecording(
   const pick = pickBestCandidate(urlCandidates) ?? pickBestCandidate(candidates);
 
   if (pick != null) {
-    usedHashes?.add(recordings[pick]!.hash);
     return recordings[pick]!;
   }
 

--- a/packages/_llm-recorder/src/llm-recorder.ts
+++ b/packages/_llm-recorder/src/llm-recorder.ts
@@ -306,6 +306,8 @@ export interface LLMRecorderInstance {
   stop(): void;
   /** Save recordings to disk (only in record mode) */
   save(): Promise<void>;
+  /** Reset fuzzy match tracking so recordings can be reused across tests */
+  resetFuzzyMatches(): void;
   /** Current test mode */
   mode: LLMTestMode;
   /** Whether we're in record mode (legacy, use .mode instead) */
@@ -616,14 +618,46 @@ function findRecording(
     return undefined;
   }
 
-  // 2. Fuzzy match via string similarity on serialized request content.
-  //    Prefer recordings that match the request URL to avoid cross-API mismatches
-  //    (e.g. /v1/chat/completions vs /v1/responses).
+  // 2. Fuzzy match fallback.
   //    Skip recordings already consumed by a previous fuzzy match.
-  //    When multiple candidates score within a narrow band (< 0.05 apart),
-  //    prefer the earliest unused one to preserve recording order — this is
-  //    critical for binary requests (e.g. audio) where serialized forms are
-  //    nearly identical and similarity scores are essentially random.
+
+  // For binary requests, string similarity is unreliable because the serialized
+  // form mainly differs in the random multipart boundary and binary digest, making
+  // all candidates score nearly identically.  Instead, match by body size proximity
+  // (replayed audio is deterministic so sizes should be very close).
+  const isBinary = typeof body === 'object' && body !== null && (body as Record<string, unknown>).__binary === true;
+
+  if (isBinary) {
+    const incomingSize = (body as Record<string, unknown>).size as number;
+    let bestIndex: number | undefined;
+    let bestSizeDiff = Infinity;
+
+    for (let i = 0; i < recordings.length; i++) {
+      if (usedHashes?.has(recordings[i]!.hash)) continue;
+      if (recordings[i]!.request.url !== url) continue;
+
+      const recBody = recordings[i]!.request.body as Record<string, unknown> | undefined;
+      if (!recBody?.__binary) continue;
+
+      const recSize = recBody.size as number;
+      const diff = Math.abs(incomingSize - recSize);
+      if (diff < bestSizeDiff) {
+        bestSizeDiff = diff;
+        bestIndex = i;
+      }
+    }
+
+    if (bestIndex != null) {
+      usedHashes?.add(recordings[bestIndex]!.hash);
+      return recordings[bestIndex]!;
+    }
+    // Fall through to string similarity if no binary match found
+  }
+
+  // For non-binary requests, use string similarity on serialized request content.
+  // Prefer recordings that match the request URL to avoid cross-API mismatches.
+  // When multiple candidates score within a narrow band, prefer the earliest
+  // unused one to preserve recording order.
   const incoming = serializeRequestContent(url, body);
 
   type Candidate = { index: number; rating: number; urlMatch: boolean };
@@ -733,6 +767,9 @@ export function setupLLMRecording(options: LLMRecorderOptions): LLMRecorderInsta
       },
       async save() {
         // no-op
+      },
+      resetFuzzyMatches() {
+        // no-op in live mode
       },
     };
     return instance;
@@ -1035,6 +1072,10 @@ export function setupLLMRecording(options: LLMRecorderOptions): LLMRecorderInsta
           (deduped > 0 ? ` (${deduped} duplicates removed)` : ''),
       );
     },
+
+    resetFuzzyMatches() {
+      fuzzyUsedHashes.clear();
+    },
   };
 
   return instance;
@@ -1060,6 +1101,10 @@ export function useLLMRecording(name: string, options: Omit<LLMRecorderOptions, 
 
   beforeAll(() => {
     recorder.start();
+  });
+
+  beforeEach(() => {
+    recorder.resetFuzzyMatches();
   });
 
   afterAll(async () => {

--- a/packages/_llm-recorder/src/llm-recorder.ts
+++ b/packages/_llm-recorder/src/llm-recorder.ts
@@ -570,15 +570,43 @@ function createStreamingResponse(
 /** Minimum similarity score to accept a fuzzy match */
 const SIMILARITY_THRESHOLD = 0.6;
 
+/** When candidates score within this band of the top score, prefer the earliest one */
+const SIMILARITY_TIE_BAND = 0.05;
+
+/**
+ * From a list of candidates, pick the earliest one whose score is within
+ * SIMILARITY_TIE_BAND of the best score.  Returns the recording index or
+ * undefined if the list is empty.
+ */
+function pickBestCandidate(candidates: { index: number; rating: number }[]): number | undefined {
+  if (candidates.length === 0) return undefined;
+  const best = Math.max(...candidates.map(c => c.rating));
+  const tied = candidates.filter(c => best - c.rating < SIMILARITY_TIE_BAND);
+  // Earliest index wins among tied candidates
+  tied.sort((a, b) => a.index - b.index);
+  return tied[0]!.index;
+}
+
 /**
  * Find a matching recording — first by exact hash, then by string similarity.
  *
  * The fuzzy fallback handles cases where the request body changed slightly
  * between test runs (e.g. different prompt wording, extra metadata fields)
  * but the intent is clearly the same recording.
+ *
+ * `usedHashes` tracks recordings already consumed by fuzzy matches so that
+ * multiple similar requests (e.g. binary audio transcription calls that all
+ * serialize to near-identical strings) don't all resolve to the same recording.
+ * Exact hash matches are exempt — they are deterministic and always correct.
  */
-function findRecording(recordings: LLMRecording[], hash: string, url: string, body: unknown): LLMRecording | undefined {
-  // 1. Exact hash match (fast path)
+function findRecording(
+  recordings: LLMRecording[],
+  hash: string,
+  url: string,
+  body: unknown,
+  usedHashes?: Set<string>,
+): LLMRecording | undefined {
+  // 1. Exact hash match (fast path) — always valid regardless of used set
   const exact = recordings.find(r => r.hash === hash);
   if (exact) {
     return exact;
@@ -591,32 +619,37 @@ function findRecording(recordings: LLMRecording[], hash: string, url: string, bo
   // 2. Fuzzy match via string similarity on serialized request content.
   //    Prefer recordings that match the request URL to avoid cross-API mismatches
   //    (e.g. /v1/chat/completions vs /v1/responses).
+  //    Skip recordings already consumed by a previous fuzzy match.
+  //    When multiple candidates score within a narrow band (< 0.05 apart),
+  //    prefer the earliest unused one to preserve recording order — this is
+  //    critical for binary requests (e.g. audio) where serialized forms are
+  //    nearly identical and similarity scores are essentially random.
   const incoming = serializeRequestContent(url, body);
-  let bestRating = -1;
-  let bestIndex = -1;
-  let bestUrlMatchRating = -1;
-  let bestUrlMatchIndex = -1;
+
+  type Candidate = { index: number; rating: number; urlMatch: boolean };
+  const candidates: Candidate[] = [];
 
   for (let i = 0; i < recordings.length; i++) {
+    if (usedHashes?.has(recordings[i]!.hash)) continue;
+
     const candidate = serializeRequestContent(recordings[i]!.request.url, recordings[i]!.request.body);
     const rating = stringSimilarity.compareTwoStrings(incoming, candidate);
-    if (rating > bestRating) {
-      bestRating = rating;
-      bestIndex = i;
-    }
-    if (recordings[i]!.request.url === url && rating > bestUrlMatchRating) {
-      bestUrlMatchRating = rating;
-      bestUrlMatchIndex = i;
+    if (rating >= SIMILARITY_THRESHOLD) {
+      candidates.push({ index: i, rating, urlMatch: recordings[i]!.request.url === url });
     }
   }
 
-  // Prefer URL-matching recording when available and above threshold
-  if (bestUrlMatchRating >= SIMILARITY_THRESHOLD && bestUrlMatchIndex >= 0) {
-    return recordings[bestUrlMatchIndex]!;
+  if (candidates.length === 0) {
+    return undefined;
   }
 
-  if (bestRating >= SIMILARITY_THRESHOLD && bestIndex >= 0) {
-    return recordings[bestIndex]!;
+  // Among URL-matching candidates, pick the earliest one within 0.05 of the top score
+  const urlCandidates = candidates.filter(c => c.urlMatch);
+  const pick = pickBestCandidate(urlCandidates) ?? pickBestCandidate(candidates);
+
+  if (pick != null) {
+    usedHashes?.add(recordings[pick]!.hash);
+    return recordings[pick]!;
   }
 
   return undefined;
@@ -707,6 +740,7 @@ export function setupLLMRecording(options: LLMRecorderOptions): LLMRecorderInsta
 
   const recordings: LLMRecording[] = [];
   const isRecordMode = mode === 'record';
+  const fuzzyUsedHashes = new Set<string>();
   let saved = false;
 
   // Create handlers for each LLM API host (or a filtered subset)
@@ -860,7 +894,7 @@ export function setupLLMRecording(options: LLMRecorderOptions): LLMRecorderInsta
           console.log(`[llm-recorder]   Available hashes: ${savedRecordings.map(r => r.hash).join(', ')}`);
         }
 
-        const recording = findRecording(savedRecordings, hash, url, body);
+        const recording = findRecording(savedRecordings, hash, url, body, fuzzyUsedHashes);
 
         if (!recording) {
           console.error(`[llm-recorder] No recording found for: ${url}${model ? ` (model: ${model})` : ''}`);

--- a/packages/_llm-recorder/src/llm-recorder.ts
+++ b/packages/_llm-recorder/src/llm-recorder.ts
@@ -572,23 +572,6 @@ function createStreamingResponse(
 /** Minimum similarity score to accept a fuzzy match */
 const SIMILARITY_THRESHOLD = 0.6;
 
-/** When candidates score within this band of the top score, prefer the earliest one */
-const SIMILARITY_TIE_BAND = 0.05;
-
-/**
- * From a list of candidates, pick the earliest one whose score is within
- * SIMILARITY_TIE_BAND of the best score.  Returns the recording index or
- * undefined if the list is empty.
- */
-function pickBestCandidate(candidates: { index: number; rating: number }[]): number | undefined {
-  if (candidates.length === 0) return undefined;
-  const best = Math.max(...candidates.map(c => c.rating));
-  const tied = candidates.filter(c => best - c.rating < SIMILARITY_TIE_BAND);
-  // Earliest index wins among tied candidates
-  tied.sort((a, b) => a.index - b.index);
-  return tied[0]!.index;
-}
-
 /**
  * Find a matching recording — first by exact hash, then by string similarity.
  *
@@ -643,6 +626,13 @@ function findRecording(
 
       const recSize = recBody.size as number;
       const diff = Math.abs(incomingSize - recSize);
+
+      // Reject candidates whose size diverges too much — the same TTS output
+      // varies by only a few bytes across runs, so a 10% relative tolerance
+      // is generous while still preventing clearly-wrong matches.
+      const maxSize = Math.max(incomingSize, recSize) || 1;
+      if (diff / maxSize > 0.1) continue;
+
       if (diff < bestSizeDiff) {
         bestSizeDiff = diff;
         bestIndex = i;
@@ -657,35 +647,37 @@ function findRecording(
   }
 
   // For non-binary requests, use string similarity on serialized request content.
-  // Prefer recordings that match the request URL to avoid cross-API mismatches.
-  // When multiple candidates score within a narrow band, prefer the earliest
-  // unused one to preserve recording order.
+  // Prefer recordings that match the request URL to avoid cross-API mismatches
+  // (e.g. /v1/chat/completions vs /v1/responses).
   //
   // NOTE: usedHashes is NOT applied here.  Non-binary recordings are intentionally
   // reusable across tests — e.g. v1 and v2 model variants share the same recording.
   const incoming = serializeRequestContent(url, body);
-
-  type Candidate = { index: number; rating: number; urlMatch: boolean };
-  const candidates: Candidate[] = [];
+  let bestRating = -1;
+  let bestIndex = -1;
+  let bestUrlMatchRating = -1;
+  let bestUrlMatchIndex = -1;
 
   for (let i = 0; i < recordings.length; i++) {
     const candidate = serializeRequestContent(recordings[i]!.request.url, recordings[i]!.request.body);
     const rating = stringSimilarity.compareTwoStrings(incoming, candidate);
-    if (rating >= SIMILARITY_THRESHOLD) {
-      candidates.push({ index: i, rating, urlMatch: recordings[i]!.request.url === url });
+    if (rating > bestRating) {
+      bestRating = rating;
+      bestIndex = i;
+    }
+    if (recordings[i]!.request.url === url && rating > bestUrlMatchRating) {
+      bestUrlMatchRating = rating;
+      bestUrlMatchIndex = i;
     }
   }
 
-  if (candidates.length === 0) {
-    return undefined;
+  // Prefer URL-matching recording when available and above threshold
+  if (bestUrlMatchRating >= SIMILARITY_THRESHOLD && bestUrlMatchIndex >= 0) {
+    return recordings[bestUrlMatchIndex]!;
   }
 
-  // Among URL-matching candidates, pick the earliest one within 0.05 of the top score
-  const urlCandidates = candidates.filter(c => c.urlMatch);
-  const pick = pickBestCandidate(urlCandidates) ?? pickBestCandidate(candidates);
-
-  if (pick != null) {
-    return recordings[pick]!;
+  if (bestRating >= SIMILARITY_THRESHOLD && bestIndex >= 0) {
+    return recordings[bestIndex]!;
   }
 
   return undefined;

--- a/packages/core/src/voice/aisdk/__tests__/aisdk-voice.e2e.test.ts
+++ b/packages/core/src/voice/aisdk/__tests__/aisdk-voice.e2e.test.ts
@@ -228,13 +228,11 @@ describe('AI SDK Voice Integration Tests', () => {
 
       expect(transcribedText).toBeTruthy();
       expect(typeof transcribedText).toBe('string');
-      // Check for either "round trip" or "round-trip"
+      // Exact match not expected due to speech synthesis variations
+      // but key words should be present
       expect(transcribedText.toLowerCase()).toMatch(/round.?trip/);
       console.log('Original:', originalText);
       console.log('Transcribed:', transcribedText);
-
-      // Note: Exact match not expected due to speech synthesis variations
-      // but key words should be present
     }, 20000);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the e2e test failure in `aisdk-voice.e2e.test.ts` where the round-trip transcription test received `"this is a transcription test."` instead of the expected `"round trip"` text.

## Root Cause

When multiple requests serialize to near-identical strings (e.g. binary audio transcription calls with `multipart/form-data` bodies), the fuzzy matcher returned the **same** best-scoring recording for all of them. All transcription requests share the same URL and their serialized form differs only in boundary strings, digests, and sizes — making similarity scores essentially random among candidates.

## Fix

Two changes to `findRecording()` in `packages/_llm-recorder/src/llm-recorder.ts`:

1. **Consumed-recording tracking**: A session-scoped `Set<string>` tracks which recordings have been matched by fuzzy lookups. Already-consumed recordings are skipped in subsequent fuzzy searches. Exact hash matches are exempt (they're deterministic and always correct).

2. **Tie-breaking by recording order**: When multiple candidates score within 0.05 of each other, the earliest unused recording wins. This preserves the original recording order for requests with near-identical serialized forms.

Also restored the original `/round.?trip/` assertion in the test (minor comment cleanup only).

## Test Plan

- `OPENAI_API_KEY=sk-dummy npx vitest run src/voice/aisdk/__tests__/aisdk-voice.e2e.test.ts` — **16/16 tests pass** (was 15/16 before fix)
- Round-trip test correctly transcribes: `"Hello, this is a round-trip test using AI SDK voice models."`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public reset for per-test fuzzy-match tracking so replay state is cleared between runs (automatically invoked per test).

* **Bug Fixes**
  * Exact matches remain prioritized for lookups.
  * Deterministic fuzzy selection for binary payloads now prefers recordings by payload size and prevents reusing the same binary recording.
  * Non-binary fuzzy matching reuse behavior unchanged.

* **Tests**
  * Clarified voice transcription test expectations to account for speech variation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->