### PR TITLE
fix: insert step-start between consecutive loop iterations

### DIFF
--- a/.changeset/loud-turtles-fly.md
+++ b/.changeset/loud-turtles-fly.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix consecutive tool-only loop iterations being merged into a single assistant message block. When the agentic loop runs multiple iterations that each produce only tool calls, the LLM would misinterpret them as parallel calls from a single turn. A `step-start` boundary is now inserted between iterations to ensure they are treated as sequential steps.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -699,25 +699,30 @@ export class MessageList {
    * source so the updated content is re-saved.
    */
   public stepStart(): boolean {
-    for (let m = this.messages.length - 1; m >= 0; m--) {
-      const msg = this.messages[m]!;
-      if (msg.role !== 'assistant' || !msg.content?.parts) continue;
-
-      if (MessageMerger.isSealed(msg)) {
-        return false;
-      }
-
-      msg.content.parts.push({ type: 'step-start' as const });
-
-      // Ensure the mutated message is persisted
-      if (!this.stateManager.isResponseMessage(msg)) {
-        this.stateManager.removeMessage(msg);
-        this.stateManager.addToSource(msg, 'response');
-      }
-
-      return true;
+    const lastMsg = this.messages[this.messages.length - 1];
+    if (!lastMsg || lastMsg.role !== 'assistant' || !lastMsg.content?.parts) {
+      return false;
     }
-    return false;
+
+    if (MessageMerger.isSealed(lastMsg)) {
+      return false;
+    }
+
+    // Don't add a duplicate step-start
+    const lastPart = lastMsg.content.parts[lastMsg.content.parts.length - 1];
+    if (lastPart?.type === 'step-start') {
+      return false;
+    }
+
+    lastMsg.content.parts.push({ type: 'step-start' as const });
+
+    // Ensure the mutated message is persisted
+    if (!this.stateManager.isResponseMessage(lastMsg)) {
+      this.stateManager.removeMessage(lastMsg);
+      this.stateManager.addToSource(lastMsg, 'response');
+    }
+
+    return true;
   }
 
   public getSystemMessages(tag?: string): CoreMessageV4[] {

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -686,6 +686,40 @@ export class MessageList {
     return false;
   }
 
+  /**
+   * Append a `step-start` boundary to the last assistant message.
+   * This marks the beginning of a new loop iteration so that
+   * `convertToModelMessages` splits sequential tool-call turns into
+   * separate message blocks instead of collapsing them into one.
+   *
+   * Respects sealed messages (post-observation) — if the last assistant
+   * message is sealed, the step-start is not added.
+   *
+   * If the message was loaded from memory it is moved to the response
+   * source so the updated content is re-saved.
+   */
+  public stepStart(): boolean {
+    for (let m = this.messages.length - 1; m >= 0; m--) {
+      const msg = this.messages[m]!;
+      if (msg.role !== 'assistant' || !msg.content?.parts) continue;
+
+      if (MessageMerger.isSealed(msg)) {
+        return false;
+      }
+
+      msg.content.parts.push({ type: 'step-start' as const });
+
+      // Ensure the mutated message is persisted
+      if (!this.stateManager.isResponseMessage(msg)) {
+        this.stateManager.removeMessage(msg);
+        this.stateManager.addToSource(msg, 'response');
+      }
+
+      return true;
+    }
+    return false;
+  }
+
   public getSystemMessages(tag?: string): CoreMessageV4[] {
     if (tag) {
       return this.taggedSystemMessages[tag] || [];

--- a/packages/core/src/agent/message-list/tests/step-start.test.ts
+++ b/packages/core/src/agent/message-list/tests/step-start.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { MastraDBMessage } from '../';
+import { MessageList } from '../index';
+
+function makeAssistantMessage(parts: MastraDBMessage['content']['parts'], id?: string): MastraDBMessage {
+  return {
+    id: id ?? `msg-${Math.random().toString(36).slice(2)}`,
+    role: 'assistant',
+    content: { format: 2, parts },
+    createdAt: new Date(),
+  };
+}
+
+function makeUserMessage(text: string): MastraDBMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2)}`,
+    role: 'user',
+    content: { format: 2, parts: [{ type: 'text', text }] },
+    createdAt: new Date(),
+  };
+}
+
+describe('MessageList.stepStart', () => {
+  it('should append step-start to the last assistant message', () => {
+    const messageList = new MessageList();
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'tc-1',
+          toolName: 'weather',
+          args: { city: 'London' },
+          result: { temp: 72 },
+        },
+      },
+    ]);
+    messageList.add(msg, 'response');
+
+    const result = messageList.stepStart();
+
+    expect(result).toBe(true);
+    const parts = messageList.get.all.db()[0]?.content?.parts ?? [];
+    expect(parts[parts.length - 1]).toEqual({ type: 'step-start' });
+  });
+
+  it('should return false when the last message is a user message', () => {
+    const messageList = new MessageList();
+    messageList.add(makeUserMessage('hello'), 'response');
+
+    const result = messageList.stepStart();
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when there are no messages', () => {
+    const messageList = new MessageList();
+
+    const result = messageList.stepStart();
+
+    expect(result).toBe(false);
+  });
+
+  it('should not add a duplicate step-start', () => {
+    const messageList = new MessageList();
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'tc-1',
+          toolName: 'weather',
+          args: { city: 'London' },
+          result: { temp: 72 },
+        },
+      },
+    ]);
+    messageList.add(msg, 'response');
+
+    messageList.stepStart();
+    const secondResult = messageList.stepStart();
+
+    expect(secondResult).toBe(false);
+    const parts = messageList.get.all.db()[0]?.content?.parts ?? [];
+    const stepStarts = parts.filter(p => p.type === 'step-start');
+    expect(stepStarts).toHaveLength(1);
+  });
+
+  it('should not add step-start to a sealed message', () => {
+    const messageList = new MessageList();
+    const msg = makeAssistantMessage([{ type: 'text', text: 'hello' }]);
+    // Seal the message
+    msg.content.metadata = { mastra: { sealed: true } };
+    messageList.add(msg, 'response');
+
+    const result = messageList.stepStart();
+
+    expect(result).toBe(false);
+    const parts = messageList.get.all.db()[0]?.content?.parts ?? [];
+    expect(parts.find(p => p.type === 'step-start')).toBeUndefined();
+  });
+
+  it('should move a memory message to response source for persistence', () => {
+    const messageList = new MessageList();
+    const msg = makeAssistantMessage([{ type: 'text', text: 'hello' }]);
+    messageList.add(msg, 'memory');
+
+    const result = messageList.stepStart();
+
+    expect(result).toBe(true);
+    // The message should now be in the response source (drainable for saving)
+    const unsaved = messageList.drainUnsavedMessages();
+    expect(unsaved.length).toBeGreaterThan(0);
+    expect(unsaved.find(m => m.id === msg.id)).toBeDefined();
+  });
+});

--- a/packages/core/src/agent/message-list/tests/step-start.test.ts
+++ b/packages/core/src/agent/message-list/tests/step-start.test.ts
@@ -111,6 +111,8 @@ describe('MessageList.stepStart', () => {
     // The message should now be in the response source (drainable for saving)
     const unsaved = messageList.drainUnsavedMessages();
     expect(unsaved.length).toBeGreaterThan(0);
-    expect(unsaved.find(m => m.id === msg.id)).toBeDefined();
+    const drained = unsaved.find(m => m.id === msg.id);
+    expect(drained).toBeDefined();
+    expect(drained?.content.parts.at(-1)).toEqual({ type: 'step-start' });
   });
 });

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -2592,6 +2592,9 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                         },
                         "type": "tool-invocation",
                       },
+                      {
+                        "type": "step-start",
+                      },
                     ],
                   },
                   "createdAt": 2024-01-01T00:00:00.003Z,

--- a/packages/core/src/loop/test-utils/tools.ts
+++ b/packages/core/src/loop/test-utils/tools.ts
@@ -1390,4 +1390,132 @@ export function toolsTests({ loopFn, runId }: { loopFn: typeof loop; runId: stri
       expect(meaningful).toEqual(['text', 'tool:web_search', 'text']);
     });
   });
+
+  describe('step-start between consecutive tool-only loop iterations', () => {
+    it('should insert step-start between tool calls from different loop iterations', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      let responseCount = 0;
+      const result = await loopFn({
+        methodType: 'stream',
+        runId,
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async () => {
+                switch (responseCount++) {
+                  case 0:
+                    // Iteration 1: tool call only
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'response-metadata',
+                          id: 'id-0',
+                          modelId: 'mock-model-id',
+                          timestamp: new Date(0),
+                        },
+                        {
+                          type: 'tool-call',
+                          id: 'call-1',
+                          toolCallId: 'call-1',
+                          toolName: 'weather',
+                          input: '{ "city": "London" }',
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 1:
+                    // Iteration 2: another tool call only
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'response-metadata',
+                          id: 'id-1',
+                          modelId: 'mock-model-id',
+                          timestamp: new Date(100),
+                        },
+                        {
+                          type: 'tool-call',
+                          id: 'call-2',
+                          toolCallId: 'call-2',
+                          toolName: 'weather',
+                          input: '{ "city": "Paris" }',
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 2:
+                    // Iteration 3: text response (ends the loop)
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'response-metadata',
+                          id: 'id-2',
+                          modelId: 'mock-model-id',
+                          timestamp: new Date(200),
+                        },
+                        { type: 'text-start', id: 'text-1' },
+                        { type: 'text-delta', id: 'text-1', delta: 'Both cities are nice.' },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  default:
+                    throw new Error(`Unexpected response count: ${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          weather: {
+            inputSchema: z.object({ city: z.string() }),
+            execute: async ({ city }: { city: string }) => ({
+              city,
+              temperature: 72,
+            }),
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(4),
+        ...defaultSettings(),
+        _internal: {
+          now: mockValues(0, 50, 100, 150, 200, 250, 300),
+          generateId: mockId({ prefix: 'id' }),
+        },
+      });
+
+      await result.consumeStream();
+
+      // Get the single merged assistant message
+      const assistantMessages = messageList.get.all.db().filter(m => m.role === 'assistant');
+      const parts = assistantMessages.flatMap(m => m.content.parts ?? []);
+
+      const partTypes = parts.map((p: any) =>
+        p.type === 'tool-invocation' ? `tool:${p.toolInvocation.toolName}:${p.toolInvocation.toolCallId}` : p.type,
+      );
+
+      // There must be a step-start between the two tool calls from different iterations
+      // Without the fix, consecutive tool-only turns would be merged without a boundary,
+      // causing the LLM to see them as parallel calls from a single turn.
+      const call1Idx = partTypes.findIndex((t: string) => t.includes('call-1'));
+      const call2Idx = partTypes.findIndex((t: string) => t.includes('call-2'));
+      const stepStartsBetween = partTypes.slice(call1Idx, call2Idx).filter((t: string) => t === 'step-start');
+      expect(stepStartsBetween.length).toBeGreaterThanOrEqual(1);
+    });
+  });
 }

--- a/packages/core/src/loop/test-utils/tools.ts
+++ b/packages/core/src/loop/test-utils/tools.ts
@@ -1514,7 +1514,11 @@ export function toolsTests({ loopFn, runId }: { loopFn: typeof loop; runId: stri
       // causing the LLM to see them as parallel calls from a single turn.
       const call1Idx = partTypes.findIndex((t: string) => t.includes('call-1'));
       const call2Idx = partTypes.findIndex((t: string) => t.includes('call-2'));
-      const stepStartsBetween = partTypes.slice(call1Idx, call2Idx).filter((t: string) => t === 'step-start');
+      expect(call1Idx).toBeGreaterThanOrEqual(0);
+      expect(call2Idx).toBeGreaterThanOrEqual(0);
+      expect(call2Idx).toBeGreaterThan(call1Idx);
+
+      const stepStartsBetween = partTypes.slice(call1Idx + 1, call2Idx).filter((t: string) => t === 'step-start');
       expect(stepStartsBetween.length).toBeGreaterThanOrEqual(1);
     });
   });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -642,6 +642,14 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
     execute: async ({ inputData, bail, tracingContext }) => {
       currentIteration++;
 
+      // Insert a step-start boundary between loop iterations so that
+      // consecutive tool-only turns are not collapsed into a single block
+      // by convertToModelMessages. This ensures the LLM sees them as
+      // sequential steps rather than parallel tool calls.
+      if (currentIteration > 1) {
+        messageList.stepStart();
+      }
+
       let currentMessageId = inputData.isTaskCompleteCheckFailed
         ? `${messageIdPassed}-${currentIteration}`
         : inputData.messageId || messageIdPassed;


### PR DESCRIPTION
## Problem

When the agentic loop runs multiple iterations that each produce only tool calls, they get merged into a single assistant message with no boundary. The LLM then misinterprets sequential tool calls as parallel calls from a single turn.

This was reported in [#14124](https://github.com/mastra-ai/mastra/issues/14124).

## Root cause

`MessageMerger` merges consecutive assistant messages that share the same `messageId`. Since `messageId` is generated once per `agent.stream()` call and reused across all loop iterations, tool-only turns from different iterations collapse into a single message block.

## Fix

- Add `messageList.stepStart()` — finds the most recent unsealed assistant message and appends a `{ type: 'step-start' }` part, handling source migration for persistence.
- Call `messageList.stepStart()` at the start of each loop iteration after the first in `llm-execution-step.ts`.

This ensures `convertToModelMessages` splits them into separate blocks, so the LLM sees sequential steps rather than parallel tool calls.

## Changes

- `message-list.ts`: Added `stepStart()` method
- `llm-execution-step.ts`: Call `stepStart()` when `currentIteration > 1`
- `tools.ts`: Test with 3-iteration mock (tool → tool → text) verifying `step-start` boundary
- `options.ts`: Updated inline snapshot

## Test plan

```bash
cd packages/core
pnpm vitest run src/loop/loop.test.ts -t "step-start"
pnpm vitest run src/agent/__tests__/supervisor-integration.test.ts
pnpm vitest run --project unit:packages/core  # full suite: 5696 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented consecutive tool-only iterations from being merged into a single assistant response by inserting explicit step-start boundaries, preserving sequential tool-call ordering.

* **Tests**
  * Added tests to verify step-start boundaries are inserted between consecutive tool-only iterations and that insertion is idempotent and respects sealed/invalid states.

* **Chores**
  * Added release metadata for a patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->