### PR TITLE
fit: catch errors from persistMessages in runAsyncBufferedObservation

### DIFF
--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -2,7 +2,7 @@ import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import type { MastraDBMessage, MastraMessageContentV2 } from '@mastra/core/agent';
 import { coreFeatures } from '@mastra/core/features';
 import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { injectAnchorIds, parseAnchorId, stripEphemeralAnchorIds } from '../anchor-ids';
 import { ModelByInputTokens } from '../model-by-input-tokens';
@@ -6600,6 +6600,46 @@ describe('Async Buffering Processor Logic', () => {
       // Should not throw
       (om as any).sealMessagesForBuffering([msg]);
       expect(msg.content.metadata).toBeUndefined();
+    });
+  });
+
+  describe('runAsyncBufferedObservation — persist failure', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+      (ObservationalMemory as any).sealedMessageIds.clear();
+    });
+
+    it('should return early and not track sealed IDs when persistMessages fails', async () => {
+      const storage = createInMemoryStorage();
+      const om = new ObservationalMemory({
+        storage,
+        scope: 'thread',
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
+        observation: {
+          messageTokens: 50000,
+          bufferTokens: 10000,
+        },
+        reflection: { observationTokens: 20000 },
+      });
+
+      const threadId = 'thread-1';
+      await storage.initializeObservationalMemory({
+        threadId,
+        resourceId: 'resource-1',
+        scope: 'thread',
+        config: {},
+      });
+      const record = await storage.getObservationalMemory(threadId, 'resource-1');
+
+      const messages = createTestMessages(20);
+
+      vi.spyOn((om as any).messageHistory, 'persistMessages').mockRejectedValue(new Error('Storage write failed'));
+      const doBufferedSpy = vi.spyOn(om as any, 'doAsyncBufferedObservation');
+
+      await (om as any).runAsyncBufferedObservation(record, threadId, messages, `obs:thread:${threadId}`);
+
+      expect((ObservationalMemory as any).sealedMessageIds.has(threadId)).toBe(false);
+      expect(doBufferedSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -4863,11 +4863,16 @@ ${formattedMessages}
     // 2. When MessageList creates new messages for streaming content after the seal,
     //    those new messages have their own IDs and don't overwrite the sealed messages
     // 3. The sealed messages remain intact with their content at the time of buffering
-    await this.messageHistory.persistMessages({
-      messages: messagesToBuffer,
-      threadId,
-      resourceId: freshRecord.resourceId ?? undefined,
-    });
+    try {
+      await this.messageHistory.persistMessages({
+        messages: messagesToBuffer,
+        threadId,
+        resourceId: freshRecord.resourceId ?? undefined,
+      });
+    } catch (error) {
+      omError('[OM] Failed to persist messages for buffering', error);
+      return;
+    }
 
     // Track sealed message IDs in the static map so saveMessagesWithSealedIdTracking
     // generates new IDs for any future saves of these messages.


### PR DESCRIPTION
## Description

The `persistMessages` call in `runAsyncBufferedObservation` that saves sealed messages to storage had no error handling. Since this method runs as a background async operation, a storage failure would surface as an unhandled promise rejection. This wraps the call in a try/catch with an early return so the method logs the error and bails out before registering sealed IDs or starting the observation cycle, preventing a state inconsistency where in-memory state diverges from storage. Includes a regression test verifying that neither sealed ID tracking nor the observation cycle runs when the persist fails.

## Related Issue(s)

Fixes #14651 
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for message persistence failures. The system now gracefully exits and prevents subsequent operations when message persistence encounters errors, ensuring data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->