### PR TITLE
chore: version studio asset uploads

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -177,6 +177,7 @@ jobs:
         run: echo "version=$(node -p \"require('./packages/cli/package.json').version\")" >> "$GITHUB_OUTPUT"
 
       - name: Upload studio assets to R2
+        if: ${{ !inputs.dry_run }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -172,6 +172,21 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
           REQUIRE_PACKAGE_DOCS: 'true'
 
+      - name: Get CLI version
+        id: cli-version
+        run: echo "version=$(node -p \"require('./packages/cli/package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload studio assets to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          STUDIO_BUCKET_NAME: ${{ secrets.STUDIO_BUCKET_NAME }}
+          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
+        run: |
+          aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
       - name: Updated alpha versions
         if: ${{ !inputs.dry_run }}
         run: node .github/scripts/publish-alpha-tags.js alpha

--- a/.github/workflows/upload-studio-r2.yml
+++ b/.github/workflows/upload-studio-r2.yml
@@ -1,0 +1,44 @@
+name: Upload Studio to R2
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'CLI version to build (e.g. 1.3.14)'
+        required: true
+        type: string
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.version }}
+
+jobs:
+  upload-studio:
+    name: Build and Upload Studio
+    if: ${{ github.repository == 'mastra-ai/mastra' }}
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_CACHE: remote:r
+    steps:
+      - name: Checkout repo at tag
+        uses: actions/checkout@v5
+        with:
+          ref: mastra@${{ inputs.version }}
+          fetch-depth: 1
+
+      - name: Setup pnpm and Node.js
+        uses: ./.github/actions/setup-pnpm-node
+
+      - name: Build packages
+        run: pnpm turbo build --filter="mastra"
+
+      - name: Upload studio assets to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          STUDIO_BUCKET_NAME: ${{ secrets.STUDIO_BUCKET_NAME }}
+          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
+        run: |
+          aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ inputs.version }}/studio/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete

--- a/.github/workflows/upload-studio-r2.yml
+++ b/.github/workflows/upload-studio-r2.yml
@@ -1,5 +1,8 @@
 name: Upload Studio to R2
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -20,11 +23,11 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
     steps:
-      - name: Checkout repo at tag
+      - name: Initial checkout
         uses: actions/checkout@v5
         with:
-          ref: mastra@${{ inputs.version }}
           fetch-depth: 1
+          ref: mastra@${{ inputs.version }}
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node


### PR DESCRIPTION
## Summary
- add a manual workflow to build a tagged CLI release and upload studio assets to Cloudflare R2
- upload studio assets to versioned prefixes in both the manual upload workflow and npm publish workflow
- source the published CLI version from packages/cli/package.json before uploading in npm-publish

## Test Plan
- pnpm prettier --check .github/workflows/upload-studio-r2.yml .github/workflows/npm-publish.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated stable-release deployment now publishes Studio static assets to R2, keeping public assets in sync and removing stale files.
  * Added a manual, version-based workflow to upload specific Studio builds to R2, enabling controlled redeployments of tagged or past versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->