### PR TITLE
fix(duckdb): fix "Cannot create values of type ANY" error in metrics queries

### DIFF
--- a/.changeset/large-yaks-shout.md
+++ b/.changeset/large-yaks-shout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/duckdb': patch
+---
+
+Fixed 'Cannot create values of type ANY' error when querying metrics endpoints with DuckDB. Parameter binding now uses explicit typed methods instead of relying on DuckDB's type inference, which fails for certain SQL contexts like json_extract_string.

--- a/stores/duckdb/src/storage/db/index.ts
+++ b/stores/duckdb/src/storage/db/index.ts
@@ -1,6 +1,38 @@
-import { DuckDBInstance, DuckDBTimestampValue } from '@duckdb/node-api';
-import type { DuckDBValue } from '@duckdb/node-api';
+import { DuckDBInstance, DuckDBTimestampValue, DuckDBTimestampTZValue } from '@duckdb/node-api';
+import type { DuckDBPreparedStatement } from '@duckdb/node-api';
 import { MastraBase } from '@mastra/core/base';
+
+/**
+ * Bind a single parameter to a prepared statement using explicit typed methods.
+ * This avoids the "Cannot create values of type ANY" error that occurs when
+ * DuckDB cannot infer parameter types from SQL context (e.g. json_extract_string).
+ */
+export function bindParam(stmt: DuckDBPreparedStatement, index: number, value: unknown): void {
+  if (value === null || value === undefined) {
+    stmt.bindNull(index);
+  } else if (typeof value === 'string') {
+    stmt.bindVarchar(index, value);
+  } else if (typeof value === 'number') {
+    if (Number.isInteger(value) && value >= -2147483648 && value <= 2147483647) {
+      stmt.bindInteger(index, value);
+    } else {
+      stmt.bindDouble(index, value);
+    }
+  } else if (typeof value === 'boolean') {
+    stmt.bindBoolean(index, value);
+  } else if (typeof value === 'bigint') {
+    stmt.bindBigInt(index, value);
+  } else if (value instanceof Date) {
+    stmt.bindTimestamp(index, new DuckDBTimestampValue(BigInt(value.getTime()) * 1000n));
+  } else if (value instanceof DuckDBTimestampValue) {
+    stmt.bindTimestamp(index, value);
+  } else if (value instanceof DuckDBTimestampTZValue) {
+    stmt.bindTimestampTZ(index, value);
+  } else {
+    // Fallback: serialize to JSON string
+    stmt.bindVarchar(index, JSON.stringify(value));
+  }
+}
 
 /** Convert DuckDB-specific return types to plain JS types */
 function toJsValue(val: unknown): unknown {
@@ -122,7 +154,9 @@ export class DuckDBConnection extends MastraBase {
       let paramIndex = 0;
       const preparedSql = sql.replace(/\?/g, () => `$${++paramIndex}`);
       const stmt = await connection.prepare(preparedSql);
-      stmt.bind(params as DuckDBValue[]);
+      for (let i = 0; i < params.length; i++) {
+        bindParam(stmt, i + 1, params[i]);
+      }
       const result = await stmt.run();
       const rows = await result.getRows();
       const columns = result.columnNames();
@@ -151,7 +185,9 @@ export class DuckDBConnection extends MastraBase {
       let paramIndex = 0;
       const preparedSql = sql.replace(/\?/g, () => `$${++paramIndex}`);
       const stmt = await connection.prepare(preparedSql);
-      stmt.bind(params as DuckDBValue[]);
+      for (let i = 0; i < params.length; i++) {
+        bindParam(stmt, i + 1, params[i]);
+      }
       await stmt.run();
     } finally {
       this.closeConnection(connection);

--- a/stores/duckdb/src/vector/index.ts
+++ b/stores/duckdb/src/vector/index.ts
@@ -1,5 +1,5 @@
 import { DuckDBInstance } from '@duckdb/node-api';
-import type { DuckDBValue } from '@duckdb/node-api';
+
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector, validateUpsertInput, validateTopK } from '@mastra/core/vector';
@@ -15,6 +15,7 @@ import type {
   UpdateVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import { bindParam } from '../storage/db/index';
 import { buildFilterClause } from './filter-builder';
 import type { DuckDBVectorConfig, DuckDBVectorFilter } from './types';
 
@@ -119,8 +120,9 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
       const preparedSql = sql.replace(/\?/g, () => `$${++paramIndex}`);
 
       const stmt = await connection.prepare(preparedSql);
-      // Bind parameters as array - DuckDB Node API bind() accepts array
-      stmt.bind(params as DuckDBValue[]);
+      for (let i = 0; i < params.length; i++) {
+        bindParam(stmt, i + 1, params[i]);
+      }
       const result = await stmt.run();
       const rows = await result.getRows();
 
@@ -152,8 +154,9 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
         const preparedSql = sql.replace(/\?/g, () => `$${++paramIndex}`);
 
         const stmt = await connection.prepare(preparedSql);
-        // Bind parameters as array - DuckDB Node API bind() accepts array
-        stmt.bind(params as DuckDBValue[]);
+        for (let i = 0; i < params.length; i++) {
+          bindParam(stmt, i + 1, params[i]);
+        }
         await stmt.run();
       }
     } finally {


### PR DESCRIPTION
## Summary

- Fixed "Cannot create values of type ANY" error when querying DuckDB metrics endpoints (e.g. `/observability/metrics/percentiles`)
- Replaced `stmt.bind(params)` with explicit typed bind calls (`bindVarchar`, `bindInteger`, `bindDouble`, etc.) based on JS value types
- Applied fix to both `DuckDBConnection` (storage) and `DuckDBVector` (vector) query/execute methods

## Root Cause

DuckDB's `stmt.bind()` internally calls `createValue()` which needs to determine the parameter type from the prepared statement's type inference. When DuckDB can't infer the type from SQL context (e.g. parameters in `json_extract_string(col, ?)` or other function calls), it assigns type `ANY`, and `createValue` throws:

```
Error: Cannot create values of type ANY. Specify a specific type.
```

## Fix

Instead of relying on DuckDB's type inference via `stmt.bind(params)`, we now bind each parameter individually using explicit typed methods:

- `string` → `bindVarchar`
- `number` (integer) → `bindInteger`
- `number` (float) → `bindDouble`
- `boolean` → `bindBoolean`
- `bigint` → `bindBigInt`
- `Date` → `bindTimestamp`
- `null`/`undefined` → `bindNull`
- fallback → `bindVarchar` (JSON serialized)

## Test plan

- [ ] Verify metrics percentiles endpoint works with DuckDB store
- [ ] Verify observability queries with filters (labels, tags, metadata) work
- [ ] Verify vector store queries still work correctly

https://claude.ai/code/session_01B8WW898wZJzoPmfZGc92ki

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error occurring when querying metrics endpoints with DuckDB, improving parameter handling to ensure compatibility with SQL functions like `json_extract_string`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->