### PR TITLE
fixed cost extimate summaries

### DIFF
--- a/.changeset/lemon-donuts-serve.md
+++ b/.changeset/lemon-donuts-serve.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed model cost reporting on total token metrics. `mastra_model_total_input_tokens` and `mastra_model_total_output_tokens` now include estimated cost for the full input and output totals, which makes dashboard and aggregate cost queries return the expected values.

--- a/.changeset/lemon-donuts-serve.md
+++ b/.changeset/lemon-donuts-serve.md
@@ -2,4 +2,4 @@
 '@mastra/observability': patch
 ---
 
-Fixed model cost reporting on total token metrics. `mastra_model_total_input_tokens` and `mastra_model_total_output_tokens` now include estimated cost for the full input and output totals, which makes dashboard and aggregate cost queries return the expected values.
+Improved model usage normalization and total cost reporting. Model generation spans now populate input and output text detail buckets from the reported totals when providers do not supply a full breakdown, and `mastra_model_total_input_tokens` / `mastra_model_total_output_tokens` now include estimated cost based on the successfully priced detail buckets for those totals.

--- a/observability/mastra/src/__snapshots__/agent-processors-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace.json
@@ -165,7 +165,13 @@
                       "completionStartTime": "<date>",
                       "usage": {
                         "inputTokens": 15,
-                        "outputTokens": 25
+                        "outputTokens": 25,
+                        "inputDetails": {
+                          "text": 15
+                        },
+                        "outputDetails": {
+                          "text": 25
+                        }
                       }
                     },
                     "metadata": {
@@ -216,7 +222,13 @@
                           "messageId": "<messageId-1>",
                           "usage": {
                             "inputTokens": 15,
-                            "outputTokens": 25
+                            "outputTokens": 25,
+                            "inputDetails": {
+                              "text": 15
+                            },
+                            "outputDetails": {
+                              "text": 25
+                            }
                           },
                           "isContinued": false,
                           "finishReason": "stop"
@@ -297,7 +309,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 15,
-                "outputTokens": 25
+                "outputTokens": 25,
+                "inputDetails": {
+                  "text": 15
+                },
+                "outputDetails": {
+                  "text": 25
+                }
               }
             },
             "metadata": {
@@ -348,7 +366,13 @@
                   "messageId": "<messageId-2>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"
@@ -548,7 +572,13 @@
                       "completionStartTime": "<date>",
                       "usage": {
                         "inputTokens": 15,
-                        "outputTokens": 25
+                        "outputTokens": 25,
+                        "inputDetails": {
+                          "text": 15
+                        },
+                        "outputDetails": {
+                          "text": 25
+                        }
                       }
                     },
                     "metadata": {
@@ -601,7 +631,13 @@
                           "messageId": "<messageId-3>",
                           "usage": {
                             "inputTokens": 15,
-                            "outputTokens": 25
+                            "outputTokens": 25,
+                            "inputDetails": {
+                              "text": 15
+                            },
+                            "outputDetails": {
+                              "text": 25
+                            }
                           },
                           "isContinued": false,
                           "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
@@ -67,7 +67,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 15,
-                "outputTokens": 25
+                "outputTokens": 25,
+                "inputDetails": {
+                  "text": 15
+                },
+                "outputDetails": {
+                  "text": 25
+                }
               }
             },
             "metadata": {
@@ -121,7 +127,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"
@@ -295,7 +307,13 @@
                       "completionStartTime": "<date>",
                       "usage": {
                         "inputTokens": 15,
-                        "outputTokens": 25
+                        "outputTokens": 25,
+                        "inputDetails": {
+                          "text": 15
+                        },
+                        "outputDetails": {
+                          "text": 25
+                        }
                       }
                     },
                     "metadata": {
@@ -352,7 +370,13 @@
                           "messageId": "<messageId-2>",
                           "usage": {
                             "inputTokens": 15,
-                            "outputTokens": 25
+                            "outputTokens": 25,
+                            "inputDetails": {
+                              "text": 15
+                            },
+                            "outputDetails": {
+                              "text": 25
+                            }
                           },
                           "isContinued": false,
                           "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/agent-tool-call-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-tool-call-trace.json
@@ -65,7 +65,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 30,
-                "outputTokens": 35
+                "outputTokens": 35,
+                "inputDetails": {
+                  "text": 30
+                },
+                "outputDetails": {
+                  "text": 35
+                }
               }
             },
             "metadata": {
@@ -117,7 +123,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 10
+                    "outputTokens": 10,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 10
+                    }
                   },
                   "isContinued": true,
                   "finishReason": "tool-calls"
@@ -256,7 +268,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/agent-workflow-direct-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-direct-trace.json
@@ -64,7 +64,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 30,
-                "outputTokens": 35
+                "outputTokens": 35,
+                "inputDetails": {
+                  "text": 30
+                },
+                "outputDetails": {
+                  "text": 35
+                }
               }
             },
             "metadata": {
@@ -115,7 +121,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 10
+                    "outputTokens": 10,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 10
+                    }
                   },
                   "isContinued": true,
                   "finishReason": "tool-calls"
@@ -312,7 +324,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/agent-workflow-tool-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-tool-trace.json
@@ -66,7 +66,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 30,
-                "outputTokens": 35
+                "outputTokens": 35,
+                "inputDetails": {
+                  "text": 30
+                },
+                "outputDetails": {
+                  "text": 35
+                }
               }
             },
             "metadata": {
@@ -119,7 +125,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 10
+                    "outputTokens": 10,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 10
+                    }
                   },
                   "isContinued": true,
                   "finishReason": "tool-calls"
@@ -329,7 +341,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/model-step-timing-trace.json
+++ b/observability/mastra/src/__snapshots__/model-step-timing-trace.json
@@ -54,7 +54,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 10,
-                "outputTokens": 5
+                "outputTokens": 5,
+                "inputDetails": {
+                  "text": 10
+                },
+                "outputDetails": {
+                  "text": 5
+                }
               }
             },
             "metadata": {
@@ -103,7 +109,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 10,
-                    "outputTokens": 5
+                    "outputTokens": 5,
+                    "inputDetails": {
+                      "text": 10
+                    },
+                    "outputDetails": {
+                      "text": 5
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace.json
+++ b/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace.json
@@ -61,7 +61,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 30,
-                "outputTokens": 25
+                "outputTokens": 25,
+                "inputDetails": {
+                  "text": 30
+                },
+                "outputDetails": {
+                  "text": 25
+                }
               }
             },
             "metadata": {
@@ -110,7 +116,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 10,
-                    "outputTokens": 15
+                    "outputTokens": 15,
+                    "inputDetails": {
+                      "text": 10
+                    },
+                    "outputDetails": {
+                      "text": 15
+                    }
                   },
                   "isContinued": true,
                   "finishReason": "tool-calls"
@@ -269,7 +281,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 20,
-                    "outputTokens": 10
+                    "outputTokens": 10,
+                    "inputDetails": {
+                      "text": 20
+                    },
+                    "outputDetails": {
+                      "text": 10
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/tags-call-overrides-defaults-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-call-overrides-defaults-trace.json
@@ -57,7 +57,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 15,
-                "outputTokens": 25
+                "outputTokens": 25,
+                "inputDetails": {
+                  "text": 15
+                },
+                "outputDetails": {
+                  "text": 25
+                }
               }
             },
             "metadata": {
@@ -107,7 +113,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/tags-from-default-options-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-from-default-options-trace.json
@@ -56,7 +56,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 15,
-                "outputTokens": 25
+                "outputTokens": 25,
+                "inputDetails": {
+                  "text": 15
+                },
+                "outputDetails": {
+                  "text": 25
+                }
               }
             },
             "metadata": {
@@ -105,7 +111,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/tags-from-generate-call-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-from-generate-call-trace.json
@@ -56,7 +56,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 15,
-                "outputTokens": 25
+                "outputTokens": 25,
+                "inputDetails": {
+                  "text": 15
+                },
+                "outputDetails": {
+                  "text": 25
+                }
               }
             },
             "metadata": {
@@ -105,7 +111,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/tags-from-stream-default-options-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-from-stream-default-options-trace.json
@@ -56,7 +56,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 15,
-                "outputTokens": 25
+                "outputTokens": 25,
+                "inputDetails": {
+                  "text": 15
+                },
+                "outputDetails": {
+                  "text": 25
+                }
               }
             },
             "metadata": {
@@ -105,7 +111,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/tags-preserved-with-other-options-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-preserved-with-other-options-trace.json
@@ -57,7 +57,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 15,
-                "outputTokens": 25
+                "outputTokens": 25,
+                "inputDetails": {
+                  "text": 15
+                },
+                "outputDetails": {
+                  "text": 25
+                }
               }
             },
             "metadata": {
@@ -107,7 +113,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/tool-child-spans-trace.json
+++ b/observability/mastra/src/__snapshots__/tool-child-spans-trace.json
@@ -63,7 +63,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 30,
-                "outputTokens": 35
+                "outputTokens": 35,
+                "inputDetails": {
+                  "text": 30
+                },
+                "outputDetails": {
+                  "text": 35
+                }
               }
             },
             "metadata": {
@@ -114,7 +120,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 10
+                    "outputTokens": 10,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 10
+                    }
                   },
                   "isContinued": true,
                   "finishReason": "tool-calls"
@@ -267,7 +279,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/tool-metadata-trace.json
+++ b/observability/mastra/src/__snapshots__/tool-metadata-trace.json
@@ -62,7 +62,13 @@
               "completionStartTime": "<date>",
               "usage": {
                 "inputTokens": 30,
-                "outputTokens": 35
+                "outputTokens": 35,
+                "inputDetails": {
+                  "text": 30
+                },
+                "outputDetails": {
+                  "text": 35
+                }
               }
             },
             "metadata": {
@@ -113,7 +119,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 10
+                    "outputTokens": 10,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 10
+                    }
                   },
                   "isContinued": true,
                   "finishReason": "tool-calls"
@@ -246,7 +258,13 @@
                   "messageId": "<messageId-1>",
                   "usage": {
                     "inputTokens": 15,
-                    "outputTokens": 25
+                    "outputTokens": 25,
+                    "inputDetails": {
+                      "text": 15
+                    },
+                    "outputDetails": {
+                      "text": 25
+                    }
                   },
                   "isContinued": false,
                   "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/workflow-agent-step-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-agent-step-trace.json
@@ -115,7 +115,13 @@
                       "completionStartTime": "<date>",
                       "usage": {
                         "inputTokens": 15,
-                        "outputTokens": 25
+                        "outputTokens": 25,
+                        "inputDetails": {
+                          "text": 15
+                        },
+                        "outputDetails": {
+                          "text": 25
+                        }
                       }
                     },
                     "metadata": {
@@ -166,7 +172,13 @@
                           "messageId": "<messageId-1>",
                           "usage": {
                             "inputTokens": 15,
-                            "outputTokens": 25
+                            "outputTokens": 25,
+                            "inputDetails": {
+                              "text": 15
+                            },
+                            "outputDetails": {
+                              "text": 25
+                            }
                           },
                           "isContinued": false,
                           "finishReason": "stop"

--- a/observability/mastra/src/__snapshots__/workflow-create-step-agent-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-create-step-agent-trace.json
@@ -136,7 +136,13 @@
                       "completionStartTime": "<date>",
                       "usage": {
                         "inputTokens": 10,
-                        "outputTokens": 20
+                        "outputTokens": 20,
+                        "inputDetails": {
+                          "text": 10
+                        },
+                        "outputDetails": {
+                          "text": 20
+                        }
                       }
                     },
                     "metadata": {
@@ -185,7 +191,13 @@
                           "messageId": "<messageId-1>",
                           "usage": {
                             "inputTokens": 10,
-                            "outputTokens": 20
+                            "outputTokens": 20,
+                            "inputDetails": {
+                              "text": 10
+                            },
+                            "outputDetails": {
+                              "text": 20
+                            }
                           },
                           "isContinued": false,
                           "finishReason": "stop"

--- a/observability/mastra/src/metrics/auto-extract.test.ts
+++ b/observability/mastra/src/metrics/auto-extract.test.ts
@@ -248,8 +248,18 @@ describe('AutoExtractedMetrics', () => {
     expect(byName('mastra_model_output_reasoning_tokens')!.metric.value).toBe(30);
     expect(byName('mastra_model_output_audio_tokens')!.metric.value).toBe(10);
     expect(byName('mastra_model_output_image_tokens')!.metric.value).toBe(10);
-    expect(byName('mastra_model_total_input_tokens')!.metric.costContext).toBeUndefined();
-    expect(byName('mastra_model_total_output_tokens')!.metric.costContext).toBeUndefined();
+    expect(byName('mastra_model_total_input_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.00006375);
+    expect(byName('mastra_model_total_input_tokens')!.metric.costContext?.costMetadata).toEqual({
+      pricing_id: 'openai-gpt-4o-mini',
+      tier_index: 0,
+      error: 'partial_cost',
+    });
+    expect(byName('mastra_model_total_output_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.00009);
+    expect(byName('mastra_model_total_output_tokens')!.metric.costContext?.costMetadata).toEqual({
+      pricing_id: 'openai-gpt-4o-mini',
+      tier_index: 0,
+      error: 'partial_cost',
+    });
     expect(byName('mastra_model_input_text_tokens')!.metric.costContext).toMatchObject({
       provider: 'openai',
       model: 'gpt-4o-mini',
@@ -434,9 +444,14 @@ describe('AutoExtractedMetrics', () => {
     emitAutoExtractedMetrics(span, createMetricsContext(span));
 
     const byName = (name: string) => emittedMetrics.find(m => m.metric.name === name);
-    expect(byName('mastra_model_total_input_tokens')!.metric.costContext).toBeUndefined();
+    expect(byName('mastra_model_total_input_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.000015);
     expect(byName('mastra_model_input_text_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.000015);
-    expect(byName('mastra_model_total_output_tokens')!.metric.costContext).toBeUndefined();
+    expect(byName('mastra_model_total_output_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.00003);
+    expect(byName('mastra_model_total_output_tokens')!.metric.costContext?.costMetadata).toEqual({
+      pricing_id: 'openai-gpt-4o-mini',
+      tier_index: 0,
+      error: 'partial_cost',
+    });
     expect(byName('mastra_model_output_text_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.00003);
     expect(byName('mastra_model_output_reasoning_tokens')!.metric.costContext).toEqual({
       provider: 'openai',
@@ -476,8 +491,8 @@ describe('AutoExtractedMetrics', () => {
     emitAutoExtractedMetrics(span, createMetricsContext(span));
 
     const byName = (name: string) => emittedMetrics.find(m => m.metric.name === name);
-    expect(byName('mastra_model_total_input_tokens')!.metric.costContext).toBeUndefined();
-    expect(byName('mastra_model_total_output_tokens')!.metric.costContext).toBeUndefined();
+    expect(byName('mastra_model_total_input_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.000372);
+    expect(byName('mastra_model_total_output_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.0006);
     expect(byName('mastra_model_input_text_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.00036);
     expect(byName('mastra_model_input_cache_read_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.000012);
     expect(byName('mastra_model_output_text_tokens')!.metric.costContext?.estimatedCost).toBeCloseTo(0.0006);

--- a/observability/mastra/src/metrics/estimator.test.ts
+++ b/observability/mastra/src/metrics/estimator.test.ts
@@ -154,7 +154,7 @@ describe('estimateCosts', () => {
     });
   });
 
-  it('suppresses totals when a mode has at least one successful detail cost', () => {
+  it('adds summed detail costs onto totals when a mode has successful detail costs', () => {
     const costs = estimateCosts(
       {
         provider: 'anthropic',
@@ -174,8 +174,8 @@ describe('estimateCosts', () => {
       pricingRegistry,
     );
 
-    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toBeUndefined();
-    expect(costs.get(TokenMetrics.TOTAL_OUTPUT)).toBeUndefined();
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)?.estimatedCost).toBeCloseTo(0.000372);
+    expect(costs.get(TokenMetrics.TOTAL_OUTPUT)?.estimatedCost).toBeCloseTo(0.0006);
     expect(costs.get(TokenMetrics.INPUT_TEXT)?.estimatedCost).toBeCloseTo(0.00036);
     expect(costs.get(TokenMetrics.INPUT_CACHE_READ)?.estimatedCost).toBeCloseTo(0.000012);
     expect(costs.get(TokenMetrics.OUTPUT_TEXT)?.estimatedCost).toBeCloseTo(0.0006);

--- a/observability/mastra/src/metrics/estimator.test.ts
+++ b/observability/mastra/src/metrics/estimator.test.ts
@@ -154,6 +154,54 @@ describe('estimateCosts', () => {
     });
   });
 
+  it('sums successfully priced detail rows onto totals and marks partial coverage', () => {
+    const costs = estimateCosts(
+      {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        usage: {
+          inputTokens: 500,
+          outputTokens: 200,
+          inputDetails: {
+            text: 400,
+            cacheRead: 50,
+            cacheWrite: 30,
+            audio: 15,
+            image: 5,
+          },
+          outputDetails: {
+            text: 150,
+            reasoning: 30,
+            audio: 10,
+            image: 10,
+          },
+        },
+      },
+      pricingRegistry,
+    );
+
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)?.estimatedCost).toBeCloseTo(0.00006375);
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)?.costMetadata).toEqual({
+      pricing_id: 'openai-gpt-4o-mini',
+      tier_index: 0,
+      error: 'partial_cost',
+    });
+    expect(costs.get(TokenMetrics.TOTAL_OUTPUT)?.estimatedCost).toBeCloseTo(0.00009);
+    expect(costs.get(TokenMetrics.TOTAL_OUTPUT)?.costMetadata).toEqual({
+      pricing_id: 'openai-gpt-4o-mini',
+      tier_index: 0,
+      error: 'partial_cost',
+    });
+    expect(costs.get(TokenMetrics.INPUT_TEXT)?.estimatedCost).toBeCloseTo(0.00006);
+    expect(costs.get(TokenMetrics.INPUT_CACHE_READ)?.estimatedCost).toBeCloseTo(0.00000375);
+    expect(costs.get(TokenMetrics.OUTPUT_TEXT)?.estimatedCost).toBeCloseTo(0.00009);
+    expect(costs.get(TokenMetrics.OUTPUT_REASONING)?.costMetadata).toEqual({
+      pricing_id: 'openai-gpt-4o-mini',
+      tier_index: 0,
+      error: 'no_pricing_for_usage_type',
+    });
+  });
+
   it('adds summed detail costs onto totals when a mode has successful detail costs', () => {
     const costs = estimateCosts(
       {

--- a/observability/mastra/src/metrics/estimator.ts
+++ b/observability/mastra/src/metrics/estimator.ts
@@ -37,7 +37,7 @@ export function estimateCosts(
     costMetadata,
   };
 
-  let hasSuccessfulInputDetailCost = false;
+  const inputDetailResults: Array<{ success: boolean; costContext: CostContext }> = [];
   if (usage.inputDetails?.audio) {
     const result = estimateCostForMeter({
       meter: PricingMeter.INPUT_AUDIO_TOKENS,
@@ -45,9 +45,7 @@ export function estimateCosts(
       ...estimateFields,
     });
     results.set(TokenMetrics.INPUT_AUDIO, result.costContext);
-    if (result.success) {
-      hasSuccessfulInputDetailCost = true;
-    }
+    inputDetailResults.push(result);
   }
 
   if (usage.inputDetails?.cacheRead) {
@@ -57,9 +55,7 @@ export function estimateCosts(
       ...estimateFields,
     });
     results.set(TokenMetrics.INPUT_CACHE_READ, result.costContext);
-    if (result.success) {
-      hasSuccessfulInputDetailCost = true;
-    }
+    inputDetailResults.push(result);
   }
 
   if (usage.inputDetails?.cacheWrite) {
@@ -69,9 +65,7 @@ export function estimateCosts(
       ...estimateFields,
     });
     results.set(TokenMetrics.INPUT_CACHE_WRITE, result.costContext);
-    if (result.success) {
-      hasSuccessfulInputDetailCost = true;
-    }
+    inputDetailResults.push(result);
   }
 
   if (usage.inputDetails?.image) {
@@ -81,9 +75,7 @@ export function estimateCosts(
       ...estimateFields,
     });
     results.set(TokenMetrics.INPUT_IMAGE, result.costContext);
-    if (result.success) {
-      hasSuccessfulInputDetailCost = true;
-    }
+    inputDetailResults.push(result);
   }
 
   if (usage.inputDetails?.text) {
@@ -93,21 +85,19 @@ export function estimateCosts(
       ...estimateFields,
     });
     results.set(TokenMetrics.INPUT_TEXT, result.costContext);
-    if (result.success) {
-      hasSuccessfulInputDetailCost = true;
-    }
+    inputDetailResults.push(result);
   }
 
-  if (!hasSuccessfulInputDetailCost && usage.inputTokens != null) {
-    const result = estimateCostForMeter({
-      meter: PricingMeter.INPUT_TOKENS,
-      tokenCount: usage.inputTokens,
-      ...estimateFields,
-    });
-    results.set(TokenMetrics.TOTAL_INPUT, result.costContext);
-  }
+  setAggregateCostContext({
+    results,
+    totalMetric: TokenMetrics.TOTAL_INPUT,
+    fallbackMeter: PricingMeter.INPUT_TOKENS,
+    totalTokenCount: usage.inputTokens,
+    detailResults: inputDetailResults,
+    ...estimateFields,
+  });
 
-  let hasSuccessfulOutputDetailCost = false;
+  const outputDetailResults: Array<{ success: boolean; costContext: CostContext }> = [];
   if (usage.outputDetails?.audio) {
     const result = estimateCostForMeter({
       meter: PricingMeter.OUTPUT_AUDIO_TOKENS,
@@ -115,9 +105,7 @@ export function estimateCosts(
       ...estimateFields,
     });
     results.set(TokenMetrics.OUTPUT_AUDIO, result.costContext);
-    if (result.success) {
-      hasSuccessfulOutputDetailCost = true;
-    }
+    outputDetailResults.push(result);
   }
 
   if (usage.outputDetails?.image) {
@@ -127,9 +115,7 @@ export function estimateCosts(
       ...estimateFields,
     });
     results.set(TokenMetrics.OUTPUT_IMAGE, result.costContext);
-    if (result.success) {
-      hasSuccessfulOutputDetailCost = true;
-    }
+    outputDetailResults.push(result);
   }
 
   if (usage.outputDetails?.reasoning) {
@@ -139,9 +125,7 @@ export function estimateCosts(
       ...estimateFields,
     });
     results.set(TokenMetrics.OUTPUT_REASONING, result.costContext);
-    if (result.success) {
-      hasSuccessfulOutputDetailCost = true;
-    }
+    outputDetailResults.push(result);
   }
 
   if (usage.outputDetails?.text) {
@@ -151,19 +135,17 @@ export function estimateCosts(
       ...estimateFields,
     });
     results.set(TokenMetrics.OUTPUT_TEXT, result.costContext);
-    if (result.success) {
-      hasSuccessfulOutputDetailCost = true;
-    }
+    outputDetailResults.push(result);
   }
 
-  if (!hasSuccessfulOutputDetailCost && usage.outputTokens != null) {
-    const result = estimateCostForMeter({
-      meter: PricingMeter.OUTPUT_TOKENS,
-      tokenCount: usage.outputTokens,
-      ...estimateFields,
-    });
-    results.set(TokenMetrics.TOTAL_OUTPUT, result.costContext);
-  }
+  setAggregateCostContext({
+    results,
+    totalMetric: TokenMetrics.TOTAL_OUTPUT,
+    fallbackMeter: PricingMeter.OUTPUT_TOKENS,
+    totalTokenCount: usage.outputTokens,
+    detailResults: outputDetailResults,
+    ...estimateFields,
+  });
 
   return results;
 }
@@ -176,6 +158,57 @@ function applyErrorContextForUsage(
   for (const sample of getTokenMetricSamples(usage)) {
     results.set(sample.name, errorContext);
   }
+}
+
+function setAggregateCostContext(args: {
+  results: Map<TokenMetrics, CostContext>;
+  totalMetric: TokenMetrics;
+  fallbackMeter: PricingMeter;
+  totalTokenCount: number | undefined;
+  detailResults: Array<{ success: boolean; costContext: CostContext }>;
+  pricingModel: PricingModel;
+  pricingTier: PricingTier;
+  costMetadata: Record<string, unknown>;
+}): void {
+  const {
+    results,
+    totalMetric,
+    fallbackMeter,
+    totalTokenCount,
+    detailResults,
+    pricingModel,
+    pricingTier,
+    costMetadata,
+  } = args;
+  if (totalTokenCount == null) {
+    return;
+  }
+
+  const successfulDetailCosts = detailResults
+    .filter(result => result.success)
+    .map(result => result.costContext.estimatedCost)
+    .filter((value): value is number => typeof value === 'number');
+
+  if (successfulDetailCosts.length > 0) {
+    const hasFailedDetailCost = detailResults.some(result => !result.success);
+    results.set(totalMetric, {
+      provider: pricingModel.provider,
+      model: pricingModel.model,
+      estimatedCost: successfulDetailCosts.reduce((sum, value) => sum + value, 0),
+      costUnit: pricingModel.currency,
+      costMetadata: hasFailedDetailCost ? { ...costMetadata, error: 'partial_cost' } : { ...costMetadata },
+    });
+    return;
+  }
+
+  const fallbackResult = estimateCostForMeter({
+    meter: fallbackMeter,
+    tokenCount: totalTokenCount,
+    pricingModel,
+    pricingTier,
+    costMetadata,
+  });
+  results.set(totalMetric, fallbackResult.costContext);
 }
 
 function estimateCostForMeter(args: {

--- a/observability/mastra/src/usage.test.ts
+++ b/observability/mastra/src/usage.test.ts
@@ -19,6 +19,8 @@ describe('extractUsageMetrics', () => {
 
       expect(result.inputTokens).toBe(100);
       expect(result.outputTokens).toBe(50);
+      expect(result.inputDetails?.text).toBe(100);
+      expect(result.outputDetails?.text).toBe(50);
     });
   });
 
@@ -34,7 +36,9 @@ describe('extractUsageMetrics', () => {
 
       expect(result.inputTokens).toBe(1000);
       expect(result.outputTokens).toBe(200);
+      expect(result.inputDetails?.text).toBe(200);
       expect(result.inputDetails?.cacheRead).toBe(800);
+      expect(result.outputDetails?.text).toBe(200);
     });
 
     it('should extract reasoningTokens from usage object (OpenAI o1 models)', () => {
@@ -46,6 +50,8 @@ describe('extractUsageMetrics', () => {
 
       const result = extractUsageMetrics(usage);
 
+      expect(result.inputDetails?.text).toBe(100);
+      expect(result.outputDetails?.text).toBe(100);
       expect(result.outputDetails?.reasoning).toBe(400);
     });
 
@@ -59,6 +65,8 @@ describe('extractUsageMetrics', () => {
       const result = extractUsageMetrics(usage);
 
       expect(result.inputDetails?.cacheRead).toBe(0);
+      expect(result.inputDetails?.text).toBe(500);
+      expect(result.outputDetails?.text).toBe(100);
     });
 
     it('should handle reasoningTokens with value 0', () => {
@@ -71,6 +79,8 @@ describe('extractUsageMetrics', () => {
       const result = extractUsageMetrics(usage);
 
       expect(result.outputDetails?.reasoning).toBe(0);
+      expect(result.inputDetails?.text).toBe(100);
+      expect(result.outputDetails?.text).toBe(50);
     });
   });
 
@@ -96,6 +106,7 @@ describe('extractUsageMetrics', () => {
       expect(result.inputDetails?.text).toBe(100);
       expect(result.inputDetails?.cacheRead).toBe(800);
       expect(result.inputDetails?.cacheWrite).toBe(200);
+      expect(result.outputDetails?.text).toBe(50);
     });
 
     it('should handle Anthropic with only cache read tokens', () => {
@@ -116,6 +127,7 @@ describe('extractUsageMetrics', () => {
       expect(result.inputDetails?.text).toBe(50);
       expect(result.inputDetails?.cacheRead).toBe(500);
       expect(result.inputDetails?.cacheWrite).toBeUndefined();
+      expect(result.outputDetails?.text).toBe(100);
     });
 
     it('should handle Anthropic with only cache creation tokens', () => {
@@ -136,6 +148,7 @@ describe('extractUsageMetrics', () => {
       expect(result.inputDetails?.text).toBe(100);
       expect(result.inputDetails?.cacheWrite).toBe(1000);
       expect(result.inputDetails?.cacheRead).toBeUndefined();
+      expect(result.outputDetails?.text).toBe(50);
     });
   });
 
@@ -157,7 +170,9 @@ describe('extractUsageMetrics', () => {
       const result = extractUsageMetrics(usage, providerMetadata);
 
       expect(result.inputTokens).toBe(500);
+      expect(result.inputDetails?.text).toBe(200);
       expect(result.inputDetails?.cacheRead).toBe(300);
+      expect(result.outputDetails?.text).toBe(200);
     });
 
     it('should extract thought tokens from providerMetadata.google.usageMetadata', () => {
@@ -176,6 +191,8 @@ describe('extractUsageMetrics', () => {
 
       const result = extractUsageMetrics(usage, providerMetadata);
 
+      expect(result.inputDetails?.text).toBe(100);
+      expect(result.outputDetails?.text).toBe(200);
       expect(result.outputDetails?.reasoning).toBe(300);
     });
 
@@ -196,7 +213,9 @@ describe('extractUsageMetrics', () => {
 
       const result = extractUsageMetrics(usage, providerMetadata);
 
+      expect(result.inputDetails?.text).toBe(50);
       expect(result.inputDetails?.cacheRead).toBe(150);
+      expect(result.outputDetails?.text).toBe(150);
       expect(result.outputDetails?.reasoning).toBe(250);
     });
   });
@@ -223,8 +242,10 @@ describe('extractUsageMetrics', () => {
       const result = extractUsageMetrics(usage, providerMetadata);
 
       // Should use inputTokenDetails values (aggregated), not providerMetadata (last step)
+      expect(result.inputDetails?.text).toBe(500);
       expect(result.inputDetails?.cacheRead).toBe(10000);
       expect(result.inputDetails?.cacheWrite).toBe(5000);
+      expect(result.outputDetails?.text).toBe(100);
     });
 
     it('should use inputTokenDetails as fallback when providerMetadata has no cache data', () => {
@@ -239,8 +260,10 @@ describe('extractUsageMetrics', () => {
 
       const result = extractUsageMetrics(usage);
 
+      expect(result.inputDetails?.text).toBe(150);
       expect(result.inputDetails?.cacheRead).toBe(300);
       expect(result.inputDetails?.cacheWrite).toBe(50);
+      expect(result.outputDetails?.text).toBe(100);
     });
 
     it('should handle inputTokenDetails with zero values', () => {
@@ -257,6 +280,8 @@ describe('extractUsageMetrics', () => {
 
       expect(result.inputDetails?.cacheRead).toBe(0);
       expect(result.inputDetails?.cacheWrite).toBe(0);
+      expect(result.inputDetails?.text).toBe(500);
+      expect(result.outputDetails?.text).toBe(100);
     });
 
     it('should fall back to providerMetadata when inputTokenDetails is absent', () => {
@@ -274,9 +299,11 @@ describe('extractUsageMetrics', () => {
 
       const result = extractUsageMetrics(usage, providerMetadata);
 
+      expect(result.inputDetails?.text).toBe(100);
       expect(result.inputDetails?.cacheRead).toBe(800);
       expect(result.inputDetails?.cacheWrite).toBe(200);
       expect(result.inputTokens).toBe(1100); // Anthropic adjustment: 100 + 800 + 200
+      expect(result.outputDetails?.text).toBe(50);
     });
 
     it('should prefer inputTokenDetails over usage.cachedInputTokens', () => {
@@ -291,7 +318,9 @@ describe('extractUsageMetrics', () => {
 
       const result = extractUsageMetrics(usage);
 
+      expect(result.inputDetails?.text).toBe(200);
       expect(result.inputDetails?.cacheRead).toBe(800);
+      expect(result.outputDetails?.text).toBe(200);
     });
 
     it('should use Anthropic inputTokens adjustment with inputTokenDetails values', () => {
@@ -321,6 +350,7 @@ describe('extractUsageMetrics', () => {
       // Anthropic adjustment uses the correct aggregated values
       expect(result.inputTokens).toBe(10100); // 100 + 8000 + 2000
       expect(result.inputDetails?.text).toBe(100);
+      expect(result.outputDetails?.text).toBe(50);
     });
 
     it('should prefer inputTokenDetails over Google providerMetadata for cacheRead', () => {
@@ -343,7 +373,9 @@ describe('extractUsageMetrics', () => {
 
       const result = extractUsageMetrics(usage, providerMetadata);
 
+      expect(result.inputDetails?.text).toBe(0);
       expect(result.inputDetails?.cacheRead).toBe(7000); // inputTokenDetails wins
+      expect(result.outputDetails?.text).toBe(51);
       expect(result.outputDetails?.reasoning).toBe(49); // thoughts still extracted from Google
     });
   });
@@ -359,9 +391,11 @@ describe('extractUsageMetrics', () => {
 
       expect(result.inputTokens).toBe(0);
       expect(result.outputTokens).toBe(0);
+      expect(result.inputDetails?.text).toBe(0);
+      expect(result.outputDetails?.text).toBe(0);
     });
 
-    it('should not include inputDetails if empty', () => {
+    it('should populate text details from totals when no provider-specific breakdown is present', () => {
       const usage: LanguageModelUsage = {
         inputTokens: 100,
         outputTokens: 50,
@@ -369,8 +403,8 @@ describe('extractUsageMetrics', () => {
 
       const result = extractUsageMetrics(usage);
 
-      expect(result.inputDetails).toBeUndefined();
-      expect(result.outputDetails).toBeUndefined();
+      expect(result.inputDetails).toEqual({ text: 100 });
+      expect(result.outputDetails).toEqual({ text: 50 });
     });
 
     it('should handle empty providerMetadata', () => {
@@ -383,6 +417,8 @@ describe('extractUsageMetrics', () => {
 
       expect(result.inputTokens).toBe(100);
       expect(result.outputTokens).toBe(50);
+      expect(result.inputDetails?.text).toBe(100);
+      expect(result.outputDetails?.text).toBe(50);
     });
 
     it('should handle providerMetadata with empty anthropic object', () => {
@@ -398,7 +434,8 @@ describe('extractUsageMetrics', () => {
       const result = extractUsageMetrics(usage, providerMetadata);
 
       expect(result.inputTokens).toBe(100);
-      expect(result.inputDetails).toBeUndefined();
+      expect(result.inputDetails).toEqual({ text: 100 });
+      expect(result.outputDetails).toEqual({ text: 50 });
     });
   });
 });

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -111,7 +111,6 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
     // Per Anthropic docs: "Total input tokens is the summation of input_tokens,
     // cache_creation_input_tokens, and cache_read_input_tokens"
     if (isDefined(inputDetails.cacheRead) || isDefined(inputDetails.cacheWrite)) {
-      inputDetails.text = usage.inputTokens;
       inputTokens = (usage.inputTokens ?? 0) + (inputDetails.cacheRead ?? 0) + (inputDetails.cacheWrite ?? 0);
     }
   }
@@ -158,6 +157,6 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
   return result;
 }
 
-function sumDefinedValues<T extends Record<string, number | undefined>>(obj: T, keys: Array<keyof T>): number {
-  return keys.reduce((sum, key) => sum + (obj[key] ?? 0), 0);
+function sumDefinedValues<T extends object, K extends keyof T>(obj: T, keys: K[]): number {
+  return keys.reduce((sum, key) => sum + ((obj[key] as number | undefined) ?? 0), 0);
 }

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -130,6 +130,17 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
     }
   }
 
+  if (isDefined(inputTokens)) {
+    inputDetails.text = Math.max(
+      0,
+      inputTokens - sumDefinedValues(inputDetails, ['cacheRead', 'cacheWrite', 'audio', 'image']),
+    );
+  }
+
+  if (isDefined(outputTokens)) {
+    outputDetails.text = Math.max(0, outputTokens - sumDefinedValues(outputDetails, ['reasoning', 'audio', 'image']));
+  }
+
   // Build the final UsageStats object
   const result: UsageStats = {
     inputTokens,
@@ -145,4 +156,8 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
   }
 
   return result;
+}
+
+function sumDefinedValues<T extends Record<string, number | undefined>>(obj: T, keys: Array<keyof T>): number {
+  return keys.reduce((sum, key) => sum + (obj[key] ?? 0), 0);
 }


### PR DESCRIPTION
## Description

Fixed model cost reporting on total token metrics. `mastra_model_total_input_tokens` and `mastra_model_total_output_tokens` now include estimated cost for the full input and output totals, which makes dashboard and aggregate cost queries return the expected values.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model usage normalization now backfills input/output text detail from reported totals when providers omit breakdowns, ensuring more complete usage reporting in traces.

* **Bug Fixes**
  * Total input/output token metrics now include estimated costs derived from successfully priced detail buckets; when some detail rows fail to price, totals reflect summed successful costs and are marked as partially priced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->