### PR TITLE
fix: create observability spans for tool input validation failures

### DIFF
--- a/.changeset/shy-mugs-retire.md
+++ b/.changeset/shy-mugs-retire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool input validation failures not producing observability spans. When input schema validation failed, no TOOL_CALL span was created because span creation happened inside the execution function that ran after validation. Moved span creation before input validation so validation errors are now captured in spans and visible in observability backends like Datadog.

--- a/packages/core/src/tools/tool-builder/builder.e2e.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.e2e.test.ts
@@ -789,6 +789,181 @@ describe('Tool Tracing Context Injection', () => {
     expect(mockToolSpan.end).not.toHaveBeenCalled(); // Should not call end() when error() is called
   });
 
+  it('should create and end span with error when input validation fails', async () => {
+    const testTool = createTool({
+      id: 'input-validation-span-tool',
+      description: 'Tool with strict input validation',
+      inputSchema: z.object({
+        name: z.string().min(3, 'Name must be at least 3 characters'),
+        age: z.number().min(0, 'Age must be positive'),
+      }),
+      execute: async inputData => ({ result: `Hello ${inputData.name}` }),
+    });
+
+    // Mock agent span
+    const mockToolSpan = {
+      end: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const mockAgentSpan = {
+      createChildSpan: vi.fn().mockReturnValue(mockToolSpan),
+    } as unknown as AnySpan;
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'input-validation-span-tool',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        description: 'Tool with strict input validation',
+        requestContext: new RequestContext(),
+        tracingContext: { currentSpan: mockAgentSpan },
+      },
+    });
+
+    const builtTool = builder.build();
+
+    // Execute with invalid input (name too short)
+    const result: any = await builtTool.execute!({ name: 'A', age: 25 }, { toolCallId: 'test-call-id', messages: [] });
+
+    // Verify the result is a validation error
+    expect(result).toHaveProperty('error', true);
+    expect(result.message).toContain('Tool input validation failed');
+
+    // Verify tool span was still created despite validation failure
+    expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: SpanType.TOOL_CALL,
+        name: "tool: 'input-validation-span-tool'",
+        input: { name: 'A', age: 25 },
+      }),
+    );
+
+    // Verify span was ended with failure attributes
+    expect(mockToolSpan.end).toHaveBeenCalledWith({
+      output: result,
+      attributes: { success: false },
+    });
+
+    // execute function's error path should NOT have been called
+    expect(mockToolSpan.error).not.toHaveBeenCalled();
+  });
+
+  it('should create and end span with error when input has missing required fields', async () => {
+    const testTool = createTool({
+      id: 'missing-fields-span-tool',
+      description: 'Tool that requires specific fields',
+      inputSchema: z.object({
+        required_field: z.string(),
+      }),
+      execute: async inputData => ({ result: inputData.required_field }),
+    });
+
+    const mockToolSpan = {
+      end: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const mockAgentSpan = {
+      createChildSpan: vi.fn().mockReturnValue(mockToolSpan),
+    } as unknown as AnySpan;
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'missing-fields-span-tool',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        description: 'Tool that requires specific fields',
+        requestContext: new RequestContext(),
+        tracingContext: { currentSpan: mockAgentSpan },
+      },
+    });
+
+    const builtTool = builder.build();
+
+    // Execute with empty object (missing required field)
+    const result: any = await builtTool.execute!({}, { toolCallId: 'test-call-id', messages: [] });
+
+    expect(result).toHaveProperty('error', true);
+
+    // Span was created and ended with error
+    expect(mockAgentSpan.createChildSpan).toHaveBeenCalled();
+    expect(mockToolSpan.end).toHaveBeenCalledWith({
+      output: result,
+      attributes: { success: false },
+    });
+  });
+
+  it('should end span with error when Vercel tool output validation fails', async () => {
+    // Mock Vercel tool that returns data not matching its output schema
+    const vercelTool = {
+      description: 'Vercel tool with output schema',
+      parameters: z.object({ input: z.string() }),
+      outputSchema: z.object({
+        count: z.number(),
+        label: z.string(),
+      }),
+      execute: async () => {
+        // Return data that doesn't match the output schema
+        return { count: 'not-a-number', label: 123 };
+      },
+    };
+
+    const mockToolSpan = {
+      end: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const mockAgentSpan = {
+      createChildSpan: vi.fn().mockReturnValue(mockToolSpan),
+    } as unknown as AnySpan;
+
+    const mockLogger = {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trackException: vi.fn(),
+    };
+
+    const builder = new CoreToolBuilder({
+      originalTool: vercelTool as any,
+      options: {
+        name: 'vercel-output-fail-tool',
+        logger: mockLogger as any,
+        description: 'Vercel tool with output schema',
+        requestContext: new RequestContext(),
+        tracingContext: { currentSpan: mockAgentSpan },
+      },
+    });
+
+    const builtTool = builder.build();
+    const result: any = await builtTool.execute!({ input: 'test' }, { toolCallId: 'test-call-id', messages: [] });
+
+    // Verify result is a validation error
+    expect(result).toHaveProperty('error', true);
+    expect(result.message).toContain('Tool output validation failed');
+
+    // Verify span was created
+    expect(mockAgentSpan.createChildSpan).toHaveBeenCalled();
+
+    // Verify span was ended with failure (not error, since output validation is a soft failure)
+    expect(mockToolSpan.end).toHaveBeenCalledWith({
+      output: result,
+      attributes: { success: false },
+    });
+    expect(mockToolSpan.error).not.toHaveBeenCalled();
+  });
+
   it('should create child span with correct logType attribute', async () => {
     const testTool = createTool({
       id: 'toolset-tool',

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -22,6 +22,7 @@ import {
   getOrCreateSpan,
   createObservabilityContext,
 } from '../../observability';
+import type { AnySpan } from '../../observability';
 import { RequestContext } from '../../request-context';
 import { isStandardSchemaWithJSON, toStandardSchema, standardSchemaToJSONSchema } from '../../schema';
 import { isVercelTool } from '../../tools/toolchecks';
@@ -331,40 +332,11 @@ export class CoreToolBuilder extends MastraBase {
       type: logType,
     });
 
-    const execFunction = async (args: unknown, execOptions: MastraToolInvocationOptions) => {
-      // Prefer execution-time tracingContext (passed at runtime for VNext methods)
-      // Fall back to build-time context for Legacy methods (AI SDK v4 doesn't support passing custom options)
-      const tracingContext = execOptions.tracingContext || options.tracingContext;
+    // Extract MCP metadata once with proper typing to avoid repeated unsafe casts
+    const mcpMeta =
+      !isVercelTool(tool) && 'mcpMetadata' in tool ? (tool as { mcpMetadata?: McpMetadata }).mcpMetadata : undefined;
 
-      // Extract MCP metadata once with proper typing to avoid repeated unsafe casts
-      const mcpMeta =
-        !isVercelTool(tool) && 'mcpMetadata' in tool ? (tool as { mcpMetadata?: McpMetadata }).mcpMetadata : undefined;
-
-      // Create tool span - either as child of existing span or as new root span (e.g. MCP tools)
-      const toolRequestContext = execOptions.requestContext ?? options.requestContext;
-      const toolSpan = getOrCreateSpan({
-        type: mcpMeta ? SpanType.MCP_TOOL_CALL : SpanType.TOOL_CALL,
-        name: mcpMeta ? `mcp_tool: '${options.name}' on '${mcpMeta.serverName}'` : `tool: '${options.name}'`,
-        input: args,
-        entityType: EntityType.TOOL,
-        entityId: options.name,
-        entityName: options.name,
-        attributes: mcpMeta
-          ? {
-              mcpServer: mcpMeta.serverName,
-              serverVersion: mcpMeta.serverVersion,
-              toolDescription: options.description,
-            }
-          : {
-              toolDescription: options.description,
-              toolType: logType || 'tool',
-            },
-        tracingPolicy: options.tracingPolicy,
-        tracingContext: tracingContext,
-        requestContext: toolRequestContext,
-        mastra: options.mastra && 'observability' in options.mastra ? (options.mastra as Mastra) : undefined,
-      });
-
+    const execFunction = async (args: unknown, execOptions: MastraToolInvocationOptions, toolSpan?: AnySpan) => {
       try {
         let result;
         let suspendData = null;
@@ -548,6 +520,35 @@ export class CoreToolBuilder extends MastraBase {
 
     return async (args: unknown, execOptions?: MastraToolInvocationOptions) => {
       let logger = options.logger || this.logger;
+
+      // Create tool span early so validation failures are always observable.
+      // Prefer execution-time tracingContext (passed at runtime for VNext methods)
+      // Fall back to build-time context for Legacy methods (AI SDK v4 doesn't support passing custom options)
+      const tracingContext = execOptions?.tracingContext || options.tracingContext;
+      const toolRequestContext = execOptions?.requestContext ?? options.requestContext;
+      const toolSpan = getOrCreateSpan({
+        type: mcpMeta ? SpanType.MCP_TOOL_CALL : SpanType.TOOL_CALL,
+        name: mcpMeta ? `mcp_tool: '${options.name}' on '${mcpMeta.serverName}'` : `tool: '${options.name}'`,
+        input: args,
+        entityType: EntityType.TOOL,
+        entityId: options.name,
+        entityName: options.name,
+        attributes: mcpMeta
+          ? {
+              mcpServer: mcpMeta.serverName,
+              serverVersion: mcpMeta.serverVersion,
+              toolDescription: options.description,
+            }
+          : {
+              toolDescription: options.description,
+              toolType: logType || 'tool',
+            },
+        tracingPolicy: options.tracingPolicy,
+        tracingContext: tracingContext,
+        requestContext: toolRequestContext,
+        mastra: options.mastra && 'observability' in options.mastra ? (options.mastra as Mastra) : undefined,
+      });
+
       try {
         logger.debug(start, { ...rest, model: logModelObject, args });
 
@@ -560,6 +561,7 @@ export class CoreToolBuilder extends MastraBase {
           error?.message?.includes('suspendedToolRunId: Required') && !(args as Record<string, unknown>)?.resumeData;
         if (error && !suspendedToolRunIdErrToIgnore) {
           logger.warn(error.message);
+          toolSpan?.end({ output: error, attributes: { success: false } });
           return error;
         }
         // Use validated/transformed data
@@ -569,7 +571,7 @@ export class CoreToolBuilder extends MastraBase {
         return await new Promise((resolve, reject) => {
           setImmediate(async () => {
             try {
-              const result = await execFunction(args, execOptions!);
+              const result = await execFunction(args, execOptions!, toolSpan);
               resolve(result);
             } catch (err) {
               reject(err);
@@ -590,6 +592,7 @@ export class CoreToolBuilder extends MastraBase {
           },
           err,
         );
+        toolSpan?.error({ error: mastraError, attributes: { success: false } });
         logger.trackException(mastraError);
         logger.error(error, { ...rest, model: logModelObject, error: mastraError, args });
         throw mastraError;


### PR DESCRIPTION
When tool input schema validation fails, no `TOOL_CALL` span was created — making these failures invisible in observability backends like Datadog.

The issue was that `getOrCreateSpan()` was called inside `execFunction`, which only runs *after* `validateToolInput()` passes. If validation failed, we returned an error object early and never entered the span-creating code path.

**Before:** validation fails → error returned → no span
**After:** span created → validation fails → span ended with `{ success: false }` → error returned

The fix moves span creation in `builder.ts` to before input validation in the outer wrapper. On validation failure, the span is ended with error attributes. The outer catch block also ends the span on unexpected errors.

Added tests for input validation span creation and Vercel tool output validation span creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool validation errors are now properly captured and emitted to observability backends, ensuring validation failures are visible in monitoring systems instead of being silently dropped.

* **Tests**
  * Added end-to-end tests covering input and output validation error scenarios to ensure proper error tracking and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->