### PR TITLE
fix(core): use Cloudflare API token for Workers AI auth

### DIFF
--- a/.changeset/few-bikes-divide.md
+++ b/.changeset/few-bikes-divide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the Cloudflare Workers AI model provider configuration to use `CLOUDFLARE_API_TOKEN` for authentication instead of incorrectly reusing `CLOUDFLARE_ACCOUNT_ID`.

--- a/docs/src/content/en/models/providers/cloudflare-workers-ai.mdx
+++ b/docs/src/content/en/models/providers/cloudflare-workers-ai.mdx
@@ -7,12 +7,13 @@ description: "Use Cloudflare Workers AI models with Mastra. 42 models available.
 
 # <img src="https://models.dev/logos/cloudflare-workers-ai.svg" alt="Cloudflare Workers AI logo" className="inline w-8 h-8 mr-2 align-middle dark:invert dark:brightness-0 dark:contrast-200" />Cloudflare Workers AI
 
-Access 42 Cloudflare Workers AI models through Mastra's model router. Authentication is handled automatically using the `CLOUDFLARE_ACCOUNT_ID` environment variable.
+Access 42 Cloudflare Workers AI models through Mastra's model router. Authentication is handled automatically using the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` environment variables.
 
 Learn more in the [Cloudflare Workers AI documentation](https://developers.cloudflare.com/workers-ai/models/).
 
 ```bash title=".env"
-CLOUDFLARE_ACCOUNT_ID=your-api-key
+CLOUDFLARE_ACCOUNT_ID=your-account-id
+CLOUDFLARE_API_TOKEN=your-api-token
 ```
 
 ```typescript title="src/mastra/agents/my-agent.ts" {7}
@@ -563,7 +564,7 @@ const agent = new Agent({
   model: {
     url: "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
     id: "cloudflare-workers-ai/@cf/ai4bharat/indictrans2-en-indic-1B",
-    apiKey: process.env.CLOUDFLARE_ACCOUNT_ID,
+    apiKey: process.env.CLOUDFLARE_API_TOKEN,
     headers: {
       "X-Custom-Header": "value"
     }
@@ -585,5 +586,4 @@ const agent = new Agent({
   }
 });
 ```
-
 

--- a/packages/core/src/llm/model/gateways/models-dev.test.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.test.ts
@@ -61,6 +61,16 @@ describe('ModelsDevGateway', () => {
         api: 'https://api.fireworks.ai/inference/v1',
         npm: '@ai-sdk/openai-compatible',
       },
+      'cloudflare-workers-ai': {
+        id: 'cloudflare-workers-ai',
+        name: 'Cloudflare Workers AI',
+        models: {
+          '@cf/meta/llama-3.1-8b-instruct': { name: 'Llama 3.1 8B Instruct' },
+        },
+        env: ['CLOUDFLARE_ACCOUNT_ID'],
+        api: 'https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1',
+        npm: '@ai-sdk/openai-compatible',
+      },
       'unknown-provider': {
         id: 'unknown-provider',
         name: 'Unknown',
@@ -125,6 +135,21 @@ describe('ModelsDevGateway', () => {
       expect(providers['fireworks-ai'].name).toBe('Fireworks AI');
       // But env var should use underscores
       expect(providers['fireworks-ai'].apiKeyEnvVar).toBe('FIREWORKS_API_KEY');
+    });
+
+    it('should override cloudflare-workers-ai auth to use CLOUDFLARE_API_TOKEN', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockApiResponse,
+      });
+
+      const providers = await gateway.fetchProviders();
+
+      expect(providers['cloudflare-workers-ai']).toBeDefined();
+      expect(providers['cloudflare-workers-ai'].apiKeyEnvVar).toBe('CLOUDFLARE_API_TOKEN');
+      expect(providers['cloudflare-workers-ai'].url).toBe(
+        'https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1',
+      );
     });
 
     it('should filter out deprecated models', async () => {

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -43,6 +43,9 @@ const PROVIDER_OVERRIDES: Record<string, Partial<ProviderConfig>> = {
   groq: {
     url: 'https://api.groq.com/openai/v1',
   },
+  'cloudflare-workers-ai': {
+    apiKeyEnvVar: 'CLOUDFLARE_API_TOKEN',
+  },
   // moonshotai uses Anthropic-compatible API, not OpenAI-compatible
   moonshotai: {
     url: 'https://api.moonshot.ai/anthropic/v1',
@@ -115,7 +118,10 @@ export class ModelsDevGateway extends MastraModelGateway {
 
         // Get the API key env var from the provider info
         // Convert hyphens to underscores for env var naming convention
-        const apiKeyEnvVar = providerInfo.env?.[0] || `${normalizedId.toUpperCase().replace(/-/g, '_')}_API_KEY`;
+        const apiKeyEnvVar =
+          PROVIDER_OVERRIDES[normalizedId]?.apiKeyEnvVar ||
+          providerInfo.env?.[0] ||
+          `${normalizedId.toUpperCase().replace(/-/g, '_')}_API_KEY`;
 
         // Determine the API key header (special case for Anthropic)
         const apiKeyHeader = !hasInstalledPackage

--- a/packages/core/src/llm/model/provider-registry.json
+++ b/packages/core/src/llm/model/provider-registry.json
@@ -1149,7 +1149,7 @@
     },
     "cloudflare-workers-ai": {
       "url": "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
-      "apiKeyEnvVar": "CLOUDFLARE_ACCOUNT_ID",
+      "apiKeyEnvVar": "CLOUDFLARE_API_TOKEN",
       "apiKeyHeader": "Authorization",
       "name": "Cloudflare Workers AI",
       "models": [

--- a/packages/core/src/llm/model/provider-registry.test.ts
+++ b/packages/core/src/llm/model/provider-registry.test.ts
@@ -626,6 +626,21 @@ describe('GatewayRegistry Auto-Refresh', () => {
   });
 });
 
+describe('provider registry static overrides', () => {
+  it('uses CLOUDFLARE_API_TOKEN for cloudflare-workers-ai authentication', () => {
+    // @ts-expect-error - accessing private property for testing
+    GatewayRegistry['instance'] = undefined;
+
+    const registry = GatewayRegistry.getInstance({ useDynamicLoading: false });
+
+    expect(registry.getProviders()['cloudflare-workers-ai']).toMatchObject({
+      url: 'https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1',
+      apiKeyEnvVar: 'CLOUDFLARE_API_TOKEN',
+      apiKeyHeader: 'Authorization',
+    });
+  });
+});
+
 describe('Corrupted JSON recovery', () => {
   const originalReadFileSync = fs.readFileSync.bind(fs);
   const originalWriteFileSync = fs.writeFileSync.bind(fs);


### PR DESCRIPTION
## Summary
- fix the Cloudflare Workers AI provider registry entry to use `CLOUDFLARE_API_TOKEN` for authentication while keeping `CLOUDFLARE_ACCOUNT_ID` in the base URL
- add a models.dev override so gateway sync does not reintroduce the wrong env var from upstream metadata
- update the generated provider doc and add regression coverage for both the static registry and models.dev gateway path

Fixes #14510

## Testing
- `pnpm --filter @mastra/core exec vitest run src/llm/model/provider-registry.test.ts src/llm/model/gateways/models-dev.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Cloudflare Workers AI provider authentication configuration to use the correct API token environment variable instead of account ID.

* **Documentation**
  * Updated Cloudflare Workers AI provider documentation with corrected authentication setup and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->