### PR TITLE
Add chat-with-elasticsearch template

### DIFF
--- a/templates/template-chat-with-elasticsearch/.env.example
+++ b/templates/template-chat-with-elasticsearch/.env.example
@@ -1,0 +1,9 @@
+OPENAI_API_KEY=
+ELASTICSEARCH_URL=http://localhost:9200
+# API key for authenticating with Elasticsearch and Kibana MCP server
+ELASTICSEARCH_API_KEY=
+
+# Optional: Kibana MCP Server URL for additional Elasticsearch tools via MCP
+# If configured, the agent will also use tools from Kibana's MCP server
+# Note: Authentication uses the ELASTICSEARCH_API_KEY from above
+KIBANA_MCP_URL=

--- a/templates/template-chat-with-elasticsearch/.env.example
+++ b/templates/template-chat-with-elasticsearch/.env.example
@@ -1,5 +1,5 @@
-# Choose which embedder to use for memory and semantic recall
-# Options: 'openai' (default) or 'elastic'
+# Options: 'openai' or 'elastic'
+# Leave empty to disable memory
 EMBEDDER_PROVIDER=
 
 # Required when EMBEDDER_PROVIDER=openai
@@ -7,7 +7,7 @@ OPENAI_API_KEY=
 OPENAI_EMBEDDING_MODEL=openai/text-embedding-3-small
 
 # Required when EMBEDDER_PROVIDER=elastic
-ELASTIC_INFERENCE_ID=
+ELASTIC_INFERENCE_ID=jina-embeddings-v5-text-small
 
 ELASTICSEARCH_URL=http://localhost:9200
 ELASTICSEARCH_API_KEY=

--- a/templates/template-chat-with-elasticsearch/.env.example
+++ b/templates/template-chat-with-elasticsearch/.env.example
@@ -1,9 +1,21 @@
+# Choose which embedder to use for memory and semantic recall
+# Options: 'openai' (default) or 'elastic'
+EMBEDDER_PROVIDER=
+
+# Required when EMBEDDER_PROVIDER=openai
 OPENAI_API_KEY=
+OPENAI_EMBEDDING_MODEL=openai/text-embedding-3-small
+
+# Required when EMBEDDER_PROVIDER=elastic
+ELASTIC_INFERENCE_ID=
+
 ELASTICSEARCH_URL=http://localhost:9200
-# API key for authenticating with Elasticsearch and Kibana MCP server
 ELASTICSEARCH_API_KEY=
 
-# Optional: Kibana MCP Server URL for additional Elasticsearch tools via MCP
 # If configured, the agent will also use tools from Kibana's MCP server
-# Note: Authentication uses the ELASTICSEARCH_API_KEY from above
 KIBANA_MCP_URL=
+
+# Elastic APM Server endpoint for OpenTelemetry trace export
+ELASTIC_APM_ENDPOINT=
+# Required if APM Server has authentication enabled
+ELASTIC_APM_SECRET_TOKEN=

--- a/templates/template-chat-with-elasticsearch/.gitignore
+++ b/templates/template-chat-with-elasticsearch/.gitignore
@@ -1,0 +1,10 @@
+output.txt
+node_modules
+dist
+.mastra
+.env.development
+.env
+*.db
+*.db-*
+.netlify
+.vercel

--- a/templates/template-chat-with-elasticsearch/README.md
+++ b/templates/template-chat-with-elasticsearch/README.md
@@ -1,0 +1,40 @@
+# Elasticsearch Chat Template
+
+A Mastra template for building conversational AI agents that interact with Elasticsearch clusters using natural language.
+
+## Getting Started
+
+This template works with:
+- **[Local Elasticsearch](https://www.elastic.co/docs/deploy-manage/deploy/self-managed/local-development-installation-quickstart)** - Run Elasticsearch locally for development
+- **Serverless Elasticsearch** - Fully managed, auto-scaling projects
+- **Elastic Cloud Hosted (ECH)** - Self-managed cloud deployments
+
+[Sign up for a free Elastic Cloud trial](https://cloud.elastic.co/registration) to get started with cloud deployments.
+
+### Using Observability Projects
+
+To export traces to Elastic APM, create an **Observability** project (which includes Elasticsearch). This gives you:
+- Elasticsearch for data storage and search
+- APM for trace collection and visualization
+- Pre-configured integration for seamless observability
+
+### Free Elastic Inference Service (EIS)
+
+Trial deployments include free token limits for [Elastic Inference Service](https://www.elastic.co/docs/explore-analyze/elastic-inference/eis#rate-limits), allowing you to use hosted embedding models without additional costs during evaluation.
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| **Embedder Configuration** ||||
+| `EMBEDDER_PROVIDER` | No | - | Embedder provider: `openai` or `elastic`. Leave empty to disable memory. |
+| `OPENAI_API_KEY` | If `openai` | - | OpenAI API key for embeddings and LLM. |
+| `OPENAI_EMBEDDING_MODEL` | No | `openai/text-embedding-3-small` | OpenAI embedding model to use. |
+| `ELASTIC_INFERENCE_ID` | If `elastic` | `jina-embeddings-v5-text-small` | Elasticsearch Inference endpoint ID. |
+| **Elasticsearch Configuration** ||||
+| `ELASTICSEARCH_URL` | Yes | `http://localhost:9200` | Elasticsearch cluster endpoint. |
+| `ELASTICSEARCH_API_KEY` | No | - | API key for Elasticsearch authentication. |
+| **Optional Integrations** ||||
+| `KIBANA_MCP_URL` | No | - | Kibana MCP server URL for additional tools. |
+| `ELASTIC_APM_ENDPOINT` | No | - | Elastic APM endpoint for trace export. |
+| `ELASTIC_APM_SECRET_TOKEN` | No | - | APM authentication token (sent as `ApiKey`). |

--- a/templates/template-chat-with-elasticsearch/README.md
+++ b/templates/template-chat-with-elasticsearch/README.md
@@ -1,6 +1,7 @@
 # Elasticsearch Chat Template
 
 A Mastra template for building conversational AI agents that interact with Elasticsearch clusters using natural language.
+This template uses Elasticsearch/Elastic for querying data, agent memory (with Elastic Inference Service for embeddings), observability (Elastic APM), and enhanced tooling (Kibana MCP).
 
 ## Getting Started
 

--- a/templates/template-chat-with-elasticsearch/README.md
+++ b/templates/template-chat-with-elasticsearch/README.md
@@ -23,6 +23,30 @@ To export traces to Elastic APM, create an **Observability** project (which incl
 
 Trial deployments include free token limits for [Elastic Inference Service](https://www.elastic.co/docs/explore-analyze/elastic-inference/eis#rate-limits), allowing you to use hosted embedding models without additional costs during evaluation.
 
+## Quick Start
+
+1. **Install dependencies**
+   ```bash
+   pnpm install
+   ```
+
+2. **Configure environment**
+   - Copy `.env.example` to `.env`
+   - Set `ELASTICSEARCH_URL` to your Elasticsearch endpoint
+   - (Optional) Configure embedder, APM, and Kibana MCP settings
+
+3. **Seed sample data** (optional)
+   ```bash
+   pnpm seed
+   ```
+   This creates an `articles` index with 10 sample articles about Elasticsearch.
+
+4. **Start the dev server**
+   ```bash
+   pnpm dev
+   ```
+   Open [http://localhost:4111](http://localhost:4111) to access Mastra Studio.
+
 ## Environment Variables
 
 | Variable | Required | Default | Description |

--- a/templates/template-chat-with-elasticsearch/package.json
+++ b/templates/template-chat-with-elasticsearch/package.json
@@ -18,10 +18,15 @@
   "dependencies": {
     "@elastic/elasticsearch": "^8.17.1",
     "@mastra/core": "latest",
+    "@mastra/elasticsearch": "latest",
     "@mastra/libsql": "latest",
     "@mastra/loggers": "latest",
     "@mastra/mcp": "latest",
     "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
+    "@mastra/otel-exporter": "latest",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
+    "ai": "^4.0.42",
     "dotenv": "^16.4.5",
     "zod": "^4.3.6"
   },

--- a/templates/template-chat-with-elasticsearch/package.json
+++ b/templates/template-chat-with-elasticsearch/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "template-chat-with-elasticsearch",
+  "version": "1.0.0",
+  "description": "A Mastra template for chatting with Elasticsearch using natural language queries.",
+  "main": "index.js",
+  "scripts": {
+    "seed": "tsx src/seed.ts",
+    "dev": "mastra dev",
+    "build": "mastra build",
+    "start": "mastra start"
+  },
+  "license": "Apache-2.0",
+  "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
+  "type": "module",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "dependencies": {
+    "@elastic/elasticsearch": "^8.17.1",
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/mcp": "latest",
+    "@mastra/memory": "latest",
+    "dotenv": "^16.4.5",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.7",
+    "mastra": "latest",
+    "tsx": "^4.19.4",
+    "typescript": "^5.9.3"
+  }
+}

--- a/templates/template-chat-with-elasticsearch/package.json
+++ b/templates/template-chat-with-elasticsearch/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "template-chat-with-elasticsearch",
+  "name": "chat-with-elasticsearch",
   "version": "1.0.0",
-  "description": "A Mastra template for chatting with Elasticsearch using natural language queries.",
+  "description": "Chat with Elasticsearch using natural language. Query your data, explore indices, and get semantic search with Elastic Inference Service.",
   "main": "index.js",
   "scripts": {
     "seed": "tsx src/seed.ts",
@@ -9,6 +9,8 @@
     "build": "mastra build",
     "start": "mastra start"
   },
+  "keywords": [],
+  "author": "",
   "license": "Apache-2.0",
   "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
   "type": "module",

--- a/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
@@ -1,8 +1,11 @@
 import { Agent } from '@mastra/core/agent';
 import { Memory } from '@mastra/memory';
+import { ElasticSearchVector } from '@mastra/elasticsearch';
 import { introspectIndices } from '../tools/introspect-indices';
 import { executeSearch } from '../tools/execute-search';
 import { getKibanaMcpTools } from '../mcp/kibana-mcp-client';
+import { esClient } from '../lib/elasticsearch-client';
+import { createEmbedder } from '../lib/embedder-config';
 
 const localTools = { introspectIndices, executeSearch };
 
@@ -21,6 +24,13 @@ You also have access to additional tools from Kibana's MCP server. These may inc
 
 Use these tools when they provide functionality not covered by the built-in tools.`
   : '';
+
+const elasticsearchVector = new ElasticSearchVector({
+  id: 'elasticsearch-memory-vector',
+  client: esClient,
+});
+
+const embedder = createEmbedder();
 
 export const elasticsearchAgent = new Agent({
   id: 'elasticsearch-agent',
@@ -75,5 +85,12 @@ For summaries across multiple documents:
 - Explain your search strategy when relevant.
 - If no results are found, suggest alternative queries or filters.`,
   tools: { ...localTools, ...kibanaMcpTools },
-  memory: new Memory(),
+  memory: new Memory({
+    vector: elasticsearchVector,
+    embedder,
+    options: {
+      semanticRecall: true,
+      lastMessages: 10,
+    },
+  }),
 });

--- a/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
@@ -51,6 +51,10 @@ const memory = embedder
     })
   : undefined;
 
+/**
+ * AI agent for querying Elasticsearch clusters using natural language.
+ * Includes schema introspection, hybrid search, and optional Kibana MCP tools.
+ */
 export const elasticsearchAgent = new Agent({
   id: 'elasticsearch-agent',
   name: 'Elasticsearch Agent',

--- a/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
@@ -1,0 +1,79 @@
+import { Agent } from '@mastra/core/agent';
+import { Memory } from '@mastra/memory';
+import { introspectIndices } from '../tools/introspect-indices';
+import { executeSearch } from '../tools/execute-search';
+import { getKibanaMcpTools } from '../mcp/kibana-mcp-client';
+
+const localTools = { introspectIndices, executeSearch };
+
+const kibanaMcpTools = await getKibanaMcpTools();
+const hasKibanaTools = Object.keys(kibanaMcpTools).length > 0;
+
+const kibanaToolsInstruction = hasKibanaTools
+  ? `
+
+## Kibana MCP Tools
+
+You also have access to additional tools from Kibana's MCP server. These may include tools for:
+- Running ES|QL queries
+- Managing indices
+- Accessing Kibana features
+
+Use these tools when they provide functionality not covered by the built-in tools.`
+  : '';
+
+export const elasticsearchAgent = new Agent({
+  id: 'elasticsearch-agent',
+  name: 'Elasticsearch Agent',
+  model: 'openai/gpt-5.2',
+  instructions: `You are an Elasticsearch assistant that helps users explore and query their Elasticsearch cluster using natural language.
+
+## Tools
+
+You have the following tools:
+
+- **introspect-indices**: Returns information about all indices in the cluster, including field mappings (names and types) and stats (document count, size). Use an optional indexPattern to filter specific indices.
+
+- **execute-search**: Executes hybrid search queries combining full-text (BM25) and semantic search using RRF fusion. Returns documents with _id, _index, _score, and source fields.
+${kibanaToolsInstruction}
+
+## Workflow
+
+1. When the user asks about the cluster or available data, call introspect-indices to understand what indices and fields exist.
+2. Before searching, identify the correct index and field names from the schema.
+3. For searches, determine the appropriate textField (and optionally vectorField for semantic search).
+4. Execute the search and present results with proper citations.
+
+## Search Guidelines
+
+- Always call introspect-indices first if you don't know the schema.
+- Use the textField parameter for the main searchable text field (e.g., "message", "content", "title").
+- If a semantic_text field exists, use it as vectorField for hybrid search.
+- Apply filters for narrowing results (e.g., status, category, date ranges).
+
+## Citation Format
+
+When presenting search results, ALWAYS cite the source documents:
+
+1. Include the document _id for each piece of information
+2. Reference the specific field the data came from
+3. Include the index name for context
+
+Example citation format:
+> "The server returned a timeout error" (index: logs-2024.01, _id: abc123, field: message)
+
+For summaries across multiple documents:
+> Found 3 errors related to timeouts:
+> - "Connection timeout after 30s" [logs-2024.01/_id:abc123]
+> - "Request timeout exceeded" [logs-2024.01/_id:def456]
+> - "Gateway timeout" [logs-2024.01/_id:ghi789]
+
+## Response Guidelines
+
+- Be concise but informative.
+- Always cite sources when presenting data from search results.
+- Explain your search strategy when relevant.
+- If no results are found, suggest alternative queries or filters.`,
+  tools: { ...localTools, ...kibanaMcpTools },
+  memory: new Memory(),
+});

--- a/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
@@ -54,7 +54,7 @@ const memory = embedder
 export const elasticsearchAgent = new Agent({
   id: 'elasticsearch-agent',
   name: 'Elasticsearch Agent',
-  model: 'openai/gpt-5.2',
+  model: 'openai/gpt-5.4',
   instructions: `You are an Elasticsearch assistant that helps users explore and query their Elasticsearch cluster using natural language.
 
 ## Tools

--- a/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
@@ -12,6 +12,14 @@ const localTools = { introspectIndices, executeSearch };
 const kibanaMcpTools = await getKibanaMcpTools();
 const hasKibanaTools = Object.keys(kibanaMcpTools).length > 0;
 
+// Log Kibana MCP status
+if (hasKibanaTools) {
+  const toolCount = Object.keys(kibanaMcpTools).length;
+  console.log(`[Kibana MCP] Enabled with ${toolCount} tool${toolCount !== 1 ? 's' : ''}: ${Object.keys(kibanaMcpTools).join(', ')}`);
+} else {
+  console.log('[Kibana MCP] Not configured. Set KIBANA_MCP_URL to enable additional tools.');
+}
+
 const kibanaToolsInstruction = hasKibanaTools
   ? `
 
@@ -21,6 +29,7 @@ You also have access to additional tools from Kibana's MCP server. These may inc
 - Running ES|QL queries
 - Managing indices
 - Accessing Kibana features
+- Accessing O11y or Security features depending on the Elastic project type
 
 Use these tools when they provide functionality not covered by the built-in tools.`
   : '';

--- a/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/agents/elasticsearch-agent.ts
@@ -25,12 +25,22 @@ You also have access to additional tools from Kibana's MCP server. These may inc
 Use these tools when they provide functionality not covered by the built-in tools.`
   : '';
 
-const elasticsearchVector = new ElasticSearchVector({
-  id: 'elasticsearch-memory-vector',
-  client: esClient,
-});
-
 const embedder = createEmbedder();
+
+// Only configure memory if embedder is available
+const memory = embedder
+  ? new Memory({
+      vector: new ElasticSearchVector({
+        id: 'elasticsearch-memory-vector',
+        client: esClient,
+      }),
+      embedder,
+      options: {
+        semanticRecall: true,
+        lastMessages: 10,
+      },
+    })
+  : undefined;
 
 export const elasticsearchAgent = new Agent({
   id: 'elasticsearch-agent',
@@ -85,12 +95,5 @@ For summaries across multiple documents:
 - Explain your search strategy when relevant.
 - If no results are found, suggest alternative queries or filters.`,
   tools: { ...localTools, ...kibanaMcpTools },
-  memory: new Memory({
-    vector: elasticsearchVector,
-    embedder,
-    options: {
-      semanticRecall: true,
-      lastMessages: 10,
-    },
-  }),
+  memory,
 });

--- a/templates/template-chat-with-elasticsearch/src/mastra/index.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/index.ts
@@ -33,6 +33,9 @@ if (process.env.ELASTIC_APM_ENDPOINT) {
   console.log('[Observability] Elastic APM not configured. Set ELASTIC_APM_ENDPOINT to enable.');
 }
 
+/**
+ * Mastra instance configured with Elasticsearch agent, LibSQL storage, and observability.
+ */
 export const mastra = new Mastra({
   agents: { elasticsearchAgent },
   storage: new LibSQLStore({

--- a/templates/template-chat-with-elasticsearch/src/mastra/index.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/index.ts
@@ -1,0 +1,16 @@
+import { Mastra } from '@mastra/core/mastra';
+import { PinoLogger } from '@mastra/loggers';
+import { LibSQLStore } from '@mastra/libsql';
+import { elasticsearchAgent } from './agents/elasticsearch-agent';
+
+export const mastra = new Mastra({
+  agents: { elasticsearchAgent },
+  storage: new LibSQLStore({
+    id: 'mastra-storage',
+    url: 'file:./mastra.db',
+  }),
+  logger: new PinoLogger({
+    name: 'Mastra',
+    level: 'info',
+  }),
+});

--- a/templates/template-chat-with-elasticsearch/src/mastra/index.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/index.ts
@@ -7,7 +7,6 @@ import { elasticsearchAgent } from './agents/elasticsearch-agent';
 
 const exporters = [
   new DefaultExporter(), // For local Mastra Playground UI
-  new CloudExporter(), // For Mastra Cloud (optional)
 ];
 
 if (process.env.ELASTIC_APM_ENDPOINT) {

--- a/templates/template-chat-with-elasticsearch/src/mastra/index.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/index.ts
@@ -1,7 +1,38 @@
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { LibSQLStore } from '@mastra/libsql';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+import { OtelExporter } from '@mastra/otel-exporter';
 import { elasticsearchAgent } from './agents/elasticsearch-agent';
+
+const exporters = [
+  new DefaultExporter(), // For local Mastra Playground UI
+  new CloudExporter(), // For Mastra Cloud (optional)
+];
+
+if (process.env.ELASTIC_APM_ENDPOINT) {
+  const endpoint = process.env.ELASTIC_APM_ENDPOINT.endsWith('/v1/traces')
+    ? process.env.ELASTIC_APM_ENDPOINT
+    : `${process.env.ELASTIC_APM_ENDPOINT}/v1/traces`;
+
+  console.log(`[Observability] Elastic APM enabled: ${endpoint}`);
+
+  exporters.push(
+    new OtelExporter({
+      provider: {
+        custom: {
+          endpoint,
+          protocol: 'http/protobuf',
+          headers: process.env.ELASTIC_APM_SECRET_TOKEN
+            ? { Authorization: `ApiKey ${process.env.ELASTIC_APM_SECRET_TOKEN}` }
+            : {},
+        },
+      },
+    })
+  );
+} else {
+  console.log('[Observability] Elastic APM not configured. Set ELASTIC_APM_ENDPOINT to enable.');
+}
 
 export const mastra = new Mastra({
   agents: { elasticsearchAgent },
@@ -12,5 +43,14 @@ export const mastra = new Mastra({
   logger: new PinoLogger({
     name: 'Mastra',
     level: 'info',
+  }),
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'chat-with-elasticsearch',
+        exporters,
+        spanOutputProcessors: [new SensitiveDataFilter()],
+      },
+    },
   }),
 });

--- a/templates/template-chat-with-elasticsearch/src/mastra/lib/elasticsearch-client.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/lib/elasticsearch-client.ts
@@ -1,4 +1,5 @@
 import { Client } from '@elastic/elasticsearch';
+import packageJson from '../../../package.json';
 
 if (!process.env.ELASTICSEARCH_URL) {
   throw new Error('ELASTICSEARCH_URL environment variable is required');
@@ -7,4 +8,6 @@ if (!process.env.ELASTICSEARCH_URL) {
 export const esClient = new Client({
   node: process.env.ELASTICSEARCH_URL,
   auth: process.env.ELASTICSEARCH_API_KEY ? { apiKey: process.env.ELASTICSEARCH_API_KEY } : undefined,
+  name: 'mastra-elasticsearch-chat',
+  headers: { 'user-agent': `mastra-elasticsearch-chat/${packageJson.version}` },
 });

--- a/templates/template-chat-with-elasticsearch/src/mastra/lib/elasticsearch-client.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/lib/elasticsearch-client.ts
@@ -5,6 +5,9 @@ if (!process.env.ELASTICSEARCH_URL) {
   throw new Error('ELASTICSEARCH_URL environment variable is required');
 }
 
+/**
+ * Elasticsearch client configured with connection URL, authentication, and user-agent tracking.
+ */
 export const esClient = new Client({
   node: process.env.ELASTICSEARCH_URL,
   auth: process.env.ELASTICSEARCH_API_KEY ? { apiKey: process.env.ELASTICSEARCH_API_KEY } : undefined,

--- a/templates/template-chat-with-elasticsearch/src/mastra/lib/elasticsearch-client.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/lib/elasticsearch-client.ts
@@ -1,0 +1,10 @@
+import { Client } from '@elastic/elasticsearch';
+
+if (!process.env.ELASTICSEARCH_URL) {
+  throw new Error('ELASTICSEARCH_URL environment variable is required');
+}
+
+export const esClient = new Client({
+  node: process.env.ELASTICSEARCH_URL,
+  auth: process.env.ELASTICSEARCH_API_KEY ? { apiKey: process.env.ELASTICSEARCH_API_KEY } : undefined,
+});

--- a/templates/template-chat-with-elasticsearch/src/mastra/lib/elasticsearch-embedder.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/lib/elasticsearch-embedder.ts
@@ -1,0 +1,88 @@
+import { customProvider } from 'ai';
+import { esClient } from './elasticsearch-client';
+
+/**
+ * Configuration for Elasticsearch Inference Service embedder
+ */
+export interface ElasticsearchInferenceConfig {
+  /**
+   * The inference ID configured in Elasticsearch (e.g., 'jina-embeddings-v3')
+   * This should match an inference endpoint you've created in Elasticsearch or which is already available off-the-shelf.
+   */
+  inferenceId: string;
+
+  /**
+   * Maximum number of texts to embed in a single batch
+   * @default 16
+   */
+  maxBatchSize?: number;
+}
+
+/**
+ * Creates an Elastic Inference Service embedder that uses EIS for generating embeddings.
+ *
+ * Prerequisites:
+ *
+ *    Create an inference endpoint using EIS (Elastic Inference Service) or use one of the preconfigured ones:
+ *    ```
+ *    PUT _inference/text_embedding/jina-embeddings-v3
+ *    {
+ *      "service": "elastic",
+ *      "service_settings": {
+ *        "model_id": ".jina-embeddings-v3"
+ *      }
+ *    }
+ *    ```
+ *
+ * @param config Configuration for the Elasticsearch inference embedder
+ * @returns An AI SDK compatible embedding model
+ */
+export function createElasticsearchInferenceEmbedder(
+  config: ElasticsearchInferenceConfig
+) {
+  const maxBatchSize = config.maxBatchSize ?? 16;
+
+  const provider = customProvider({
+    textEmbeddingModels: {
+      [config.inferenceId]: {
+        specificationVersion: 'v3',
+        provider: 'elastic',
+        modelId: config.inferenceId,
+        maxEmbeddingsPerCall: maxBatchSize,
+        supportsParallelCalls: true,
+        async doEmbed({ values }) {
+          try {
+            const response = await esClient.inference.inference({
+              inference_id: config.inferenceId,
+              input: values,
+              task_type: 'text_embedding',
+            });
+
+            let embeddings: number[][];
+
+            if (response.text_embedding) {
+              embeddings = response.text_embedding.map((result: any) => {
+                return result.embedding;
+              });
+            } else {
+              throw new Error(
+                `Unexpected response format from Elasticsearch Inference API. Response: ${JSON.stringify(response)}`
+              );
+            }
+
+            return {
+              embeddings,
+              warnings: [],
+            };
+          } catch (error) {
+            throw new Error(
+              `Elasticsearch Inference API error: ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        },
+      },
+    },
+  });
+
+  return provider.textEmbeddingModel(config.inferenceId);
+}

--- a/templates/template-chat-with-elasticsearch/src/mastra/lib/embedder-config.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/lib/embedder-config.ts
@@ -17,7 +17,8 @@ export interface EmbedderConfig {
 }
 
 /**
- * Reads embedder configuration from environment variables
+ * Reads embedder configuration from environment variables.
+ * @returns Configuration object with provider and model settings.
  */
 export function getEmbedderConfig(): EmbedderConfig {
   const provider = (process.env.EMBEDDER_PROVIDER || 'openai') as EmbedderProvider;
@@ -30,13 +31,9 @@ export function getEmbedderConfig(): EmbedderConfig {
 }
 
 /**
- * Creates an embedder based on the configuration
- *
- * Supports two providers:
- * - 'openai': Uses OpenAI's embedding models (requires OPENAI_API_KEY)
- * - 'elastic': Uses Elastic Inference Service with models like Jina
- *
- * @returns Configured embedding model, model string, or null if no valid configuration
+ * Creates an embedder based on environment configuration.
+ * Supports OpenAI (requires OPENAI_API_KEY) and Elastic Inference Service providers.
+ * @returns Configured embedding model, model string, or null if unconfigured.
  */
 export function createEmbedder() {
   if (!process.env.EMBEDDER_PROVIDER) {

--- a/templates/template-chat-with-elasticsearch/src/mastra/lib/embedder-config.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/lib/embedder-config.ts
@@ -1,0 +1,79 @@
+import { createElasticsearchInferenceEmbedder } from './elasticsearch-embedder';
+
+/**
+ * Supported embedder providers
+ */
+export type EmbedderProvider = 'openai' | 'elastic';
+
+/**
+ * Configuration for the embedder based on environment variables
+ */
+export interface EmbedderConfig {
+  provider: EmbedderProvider;
+  // OpenAI specific
+  openaiModel?: string;
+  // Elasticsearch Inference specific
+  elasticInferenceId?: string;
+}
+
+/**
+ * Reads embedder configuration from environment variables
+ */
+export function getEmbedderConfig(): EmbedderConfig {
+  const provider = (process.env.EMBEDDER_PROVIDER || 'openai') as EmbedderProvider;
+
+  return {
+    provider,
+    openaiModel: process.env.OPENAI_EMBEDDING_MODEL || 'openai/text-embedding-3-small',
+    elasticInferenceId: process.env.ELASTIC_INFERENCE_ID || 'jina-embeddings-v5-text-small',
+  };
+}
+
+/**
+ * Creates an embedder based on the configuration
+ *
+ * Supports two providers:
+ * - 'openai': Uses OpenAI's embedding models (requires OPENAI_API_KEY)
+ * - 'elastic': Uses Elastic Inference Service with models like Jina
+ *
+ * @returns Configured embedding model or model string
+ */
+export function createEmbedder() {
+  const config = getEmbedderConfig();
+
+  switch (config.provider) {
+    case 'elastic': {
+      if (!config.elasticInferenceId) {
+        throw new Error(
+          'ELASTIC_INFERENCE_ID is required when EMBEDDER_PROVIDER=elastic.\n' +
+          'Example: ELASTIC_INFERENCE_ID=jina-embeddings-v5-text-small.'
+        );
+      }
+
+      console.log(`[Embedder] Using Elastic Inference Service: ${config.elasticInferenceId}`);
+      return createElasticsearchInferenceEmbedder({
+        inferenceId: config.elasticInferenceId,
+      });
+    }
+
+    case 'openai': {
+      if (!process.env.OPENAI_API_KEY) {
+        throw new Error(
+          'OPENAI_API_KEY is required when EMBEDDER_PROVIDER=openai.\n' +
+          'Set OPENAI_API_KEY in your .env file.'
+        );
+      }
+
+      console.log(`[Embedder] Using OpenAI: ${config.openaiModel}`);
+      return config.openaiModel!;
+    }
+
+    default: {
+      throw new Error(
+        `Unknown embedder provider: ${config.provider}.\n` +
+        'Supported providers: openai, elastic\n' +
+        'Set EMBEDDER_PROVIDER=openai or EMBEDDER_PROVIDER=elastic\n'
+      );
+    }
+  }
+}

--- a/templates/template-chat-with-elasticsearch/src/mastra/lib/embedder-config.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/lib/embedder-config.ts
@@ -36,18 +36,26 @@ export function getEmbedderConfig(): EmbedderConfig {
  * - 'openai': Uses OpenAI's embedding models (requires OPENAI_API_KEY)
  * - 'elastic': Uses Elastic Inference Service with models like Jina
  *
- * @returns Configured embedding model or model string
+ * @returns Configured embedding model, model string, or null if no valid configuration
  */
 export function createEmbedder() {
+  if (!process.env.EMBEDDER_PROVIDER) {
+    console.log('[Embedder] No embedder configured. Memory and semantic recall disabled.');
+    console.log('[Embedder] To enable memory, set EMBEDDER_PROVIDER=openai or EMBEDDER_PROVIDER=elastic and configure an embedding model');
+    return null;
+  }
+
   const config = getEmbedderConfig();
 
   switch (config.provider) {
     case 'elastic': {
       if (!config.elasticInferenceId) {
-        throw new Error(
-          'ELASTIC_INFERENCE_ID is required when EMBEDDER_PROVIDER=elastic.\n' +
-          'Example: ELASTIC_INFERENCE_ID=jina-embeddings-v5-text-small.'
+        console.warn(
+          '[Embedder] ELASTIC_INFERENCE_ID is required when EMBEDDER_PROVIDER=elastic.\n' +
+          '[Embedder] Example: ELASTIC_INFERENCE_ID=jina-embeddings-v5-text-small.\n' +
+          '[Embedder] Memory disabled.'
         );
+        return null;
       }
 
       console.log(`[Embedder] Using Elastic Inference Service: ${config.elasticInferenceId}`);
@@ -58,10 +66,12 @@ export function createEmbedder() {
 
     case 'openai': {
       if (!process.env.OPENAI_API_KEY) {
-        throw new Error(
-          'OPENAI_API_KEY is required when EMBEDDER_PROVIDER=openai.\n' +
-          'Set OPENAI_API_KEY in your .env file.'
+        console.warn(
+          '[Embedder] OPENAI_API_KEY is required when EMBEDDER_PROVIDER=openai.\n' +
+          '[Embedder] Set OPENAI_API_KEY in your .env file.\n' +
+          '[Embedder] Memory disabled.'
         );
+        return null;
       }
 
       console.log(`[Embedder] Using OpenAI: ${config.openaiModel}`);
@@ -69,11 +79,12 @@ export function createEmbedder() {
     }
 
     default: {
-      throw new Error(
-        `Unknown embedder provider: ${config.provider}.\n` +
-        'Supported providers: openai, elastic\n' +
-        'Set EMBEDDER_PROVIDER=openai or EMBEDDER_PROVIDER=elastic\n'
+      console.warn(
+        `[Embedder] Unknown embedder provider: ${config.provider}.\n` +
+        '[Embedder] Supported providers: openai, elastic\n' +
+        '[Embedder] Memory disabled.'
       );
+      return null;
     }
   }
 }

--- a/templates/template-chat-with-elasticsearch/src/mastra/lib/embedder-config.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/lib/embedder-config.ts
@@ -49,15 +49,6 @@ export function createEmbedder() {
 
   switch (config.provider) {
     case 'elastic': {
-      if (!config.elasticInferenceId) {
-        console.warn(
-          '[Embedder] ELASTIC_INFERENCE_ID is required when EMBEDDER_PROVIDER=elastic.\n' +
-          '[Embedder] Example: ELASTIC_INFERENCE_ID=jina-embeddings-v5-text-small.\n' +
-          '[Embedder] Memory disabled.'
-        );
-        return null;
-      }
-
       console.log(`[Embedder] Using Elastic Inference Service: ${config.elasticInferenceId}`);
       return createElasticsearchInferenceEmbedder({
         inferenceId: config.elasticInferenceId,

--- a/templates/template-chat-with-elasticsearch/src/mastra/mcp/kibana-mcp-client.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/mcp/kibana-mcp-client.ts
@@ -1,0 +1,35 @@
+import { MCPClient } from '@mastra/mcp';
+
+const KIBANA_MCP_URL = process.env.KIBANA_MCP_URL;
+const ELASTICSEARCH_API_KEY = process.env.ELASTICSEARCH_API_KEY;
+
+export const kibanaMcpClient = KIBANA_MCP_URL
+  ? new MCPClient({
+      servers: {
+        kibana: {
+          url: new URL(KIBANA_MCP_URL),
+          requestInit: ELASTICSEARCH_API_KEY
+            ? {
+                headers: {
+                  Authorization: `ApiKey ${ELASTICSEARCH_API_KEY}`,
+                },
+              }
+            : undefined,
+        },
+      },
+    })
+  : null;
+
+export async function getKibanaMcpTools(): Promise<Record<string, unknown>> {
+  if (!kibanaMcpClient) {
+    return {};
+  }
+
+  try {
+    const tools = await kibanaMcpClient.listTools();
+    return tools;
+  } catch (error) {
+    console.warn('Failed to connect to Kibana MCP server:', error);
+    return {};
+  }
+}

--- a/templates/template-chat-with-elasticsearch/src/mastra/mcp/kibana-mcp-client.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/mcp/kibana-mcp-client.ts
@@ -3,6 +3,9 @@ import { MCPClient } from '@mastra/mcp';
 const KIBANA_MCP_URL = process.env.KIBANA_MCP_URL;
 const ELASTICSEARCH_API_KEY = process.env.ELASTICSEARCH_API_KEY;
 
+/**
+ * MCP client for connecting to Kibana's MCP server, or null if not configured.
+ */
 export const kibanaMcpClient = KIBANA_MCP_URL
   ? new MCPClient({
       servers: {
@@ -20,6 +23,10 @@ export const kibanaMcpClient = KIBANA_MCP_URL
     })
   : null;
 
+/**
+ * Retrieves available tools from the Kibana MCP server.
+ * @returns Object mapping tool names to tool definitions, or empty object if unavailable.
+ */
 export async function getKibanaMcpTools(): Promise<Record<string, unknown>> {
   if (!kibanaMcpClient) {
     return {};

--- a/templates/template-chat-with-elasticsearch/src/mastra/tools/execute-search.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/tools/execute-search.ts
@@ -1,0 +1,100 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+import { esClient } from '../lib/elasticsearch-client';
+
+const MAX_RESULTS = 100;
+
+export const executeSearch = createTool({
+  id: 'execute-search',
+  description: `Executes a hybrid search query against Elasticsearch using retrievers.
+Combines full-text (BM25) search with semantic/vector search using RRF (Reciprocal Rank Fusion) for optimal results.
+
+Use this tool when:
+- Searching for documents by content
+- Combining keyword and semantic search
+- Finding relevant documents for a user query
+
+The tool returns document IDs, scores, and source fields for citation purposes.`,
+  inputSchema: z.object({
+    index: z.string().describe('The index or index pattern to search (e.g., "logs-*", "products")'),
+    query: z.string().describe('The search query in natural language'),
+    textField: z.string().describe('The field to search for text/keyword matches (e.g., "message", "title", "content")'),
+    vectorField: z
+      .string()
+      .optional()
+      .describe('The semantic_text or dense_vector field for semantic search. If not provided, only text search is performed.'),
+    size: z.number().optional().describe('Number of results to return (max 100, default: 10)'),
+    filters: z
+      .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+      .optional()
+      .describe('Optional filters as field-value pairs (e.g., {"status": "active", "category": "electronics"})'),
+  }),
+  execute: async ({ index, query, textField, vectorField, size, filters }) => {
+    const resultSize = size ?? 10;
+    const limitedSize = Math.min(resultSize, MAX_RESULTS);
+
+    const filterClauses = filters
+      ? Object.entries(filters).map(([field, value]) => ({
+          term: { [field]: value },
+        }))
+      : [];
+
+    const searchRequest: Record<string, unknown> = {
+      index,
+      size: limitedSize,
+    };
+
+    if (vectorField) {
+      searchRequest.retriever = {
+        rrf: {
+          retrievers: [
+            {
+              standard: {
+                query: {
+                  bool: {
+                    must: [{ match: { [textField]: query } }],
+                    ...(filterClauses.length > 0 && { filter: filterClauses }),
+                  },
+                },
+              },
+            },
+            {
+              standard: {
+                query: {
+                  bool: {
+                    must: [{ semantic: { field: vectorField, query } }],
+                    ...(filterClauses.length > 0 && { filter: filterClauses }),
+                  },
+                },
+              },
+            },
+          ],
+        },
+      };
+    } else {
+      searchRequest.query = {
+        bool: {
+          must: [{ match: { [textField]: query } }],
+          ...(filterClauses.length > 0 && { filter: filterClauses }),
+        },
+      };
+    }
+
+    const response = await esClient.search(searchRequest);
+
+    const hits = response.hits.hits.map((hit) => ({
+      _id: hit._id,
+      _index: hit._index,
+      _score: hit._score ?? null,
+      fields: (hit._source as Record<string, unknown>) || {},
+    }));
+
+    const total = typeof response.hits.total === 'number' ? response.hits.total : response.hits.total?.value ?? 0;
+
+    return {
+      hits,
+      total,
+      took: response.took,
+    };
+  },
+});

--- a/templates/template-chat-with-elasticsearch/src/mastra/tools/introspect-indices.ts
+++ b/templates/template-chat-with-elasticsearch/src/mastra/tools/introspect-indices.ts
@@ -1,0 +1,80 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+import { esClient } from '../lib/elasticsearch-client';
+
+export const introspectIndices = createTool({
+  id: 'introspect-indices',
+  description:
+    'Introspects the Elasticsearch cluster and returns a description of all indices, their mappings (field names and types), and stats (document count, size).',
+  inputSchema: z.object({
+    indexPattern: z
+      .string()
+      .optional()
+      .describe('Optional index pattern to filter indices (e.g., "logs-*"). Defaults to all non-system indices.'),
+  }),
+  execute: async ({ indexPattern }) => {
+    const indices = await esClient.cat.indices({
+      format: 'json',
+      h: 'index,docs.count,store.size',
+      index: indexPattern,
+    });
+
+    const visibleIndices = indices.filter(
+      (idx) => idx.index && !idx.index.startsWith('.'),
+    );
+
+    if (visibleIndices.length === 0) {
+      return { schema: 'No indices found.' };
+    }
+
+    const indexNames = visibleIndices.map((idx) => idx.index as string);
+
+    const mappings = await esClient.indices.getMapping({
+      index: indexNames,
+    });
+
+    const lines: string[] = ['# Elasticsearch Indices', ''];
+
+    for (const idx of visibleIndices) {
+      const indexName = idx.index as string;
+      const docCount = idx['docs.count'] ?? '0';
+      const storeSize = idx['store.size'] ?? 'N/A';
+
+      lines.push(`## ${indexName}`);
+      lines.push(`- Documents: ${docCount}`);
+      lines.push(`- Size: ${storeSize}`);
+      lines.push('');
+
+      const indexMapping = mappings[indexName];
+      if (indexMapping?.mappings?.properties) {
+        lines.push('### Fields');
+        lines.push('');
+        lines.push('| Field | Type | Additional Info |');
+        lines.push('|-------|------|-----------------|');
+
+        const formatFields = (properties: Record<string, any>, prefix = '') => {
+          for (const [fieldName, fieldDef] of Object.entries(properties)) {
+            const fullName = prefix ? `${prefix}.${fieldName}` : fieldName;
+            const fieldType = fieldDef.type || 'object';
+            const additionalInfo: string[] = [];
+
+            if (fieldDef.analyzer) additionalInfo.push(`analyzer: ${fieldDef.analyzer}`);
+            if (fieldDef.index === false) additionalInfo.push('not indexed');
+            if (fieldDef.fields) additionalInfo.push(`multi-field: ${Object.keys(fieldDef.fields).join(', ')}`);
+
+            lines.push(`| ${fullName} | ${fieldType} | ${additionalInfo.join(', ') || '-'} |`);
+
+            if (fieldDef.properties) {
+              formatFields(fieldDef.properties, fullName);
+            }
+          }
+        };
+
+        formatFields(indexMapping.mappings.properties);
+        lines.push('');
+      }
+    }
+
+    return { schema: lines.join('\n') };
+  },
+});

--- a/templates/template-chat-with-elasticsearch/src/seed.ts
+++ b/templates/template-chat-with-elasticsearch/src/seed.ts
@@ -156,6 +156,10 @@ Consider denormalization. Unlike relational databases, Elasticsearch works best 
   },
 ];
 
+/**
+ * Seeds the Elasticsearch cluster with sample articles about Elasticsearch topics.
+ * Creates the 'articles' index and indexes 10 sample documents.
+ */
 async function seed() {
   console.log('Connecting to Elasticsearch...');
 

--- a/templates/template-chat-with-elasticsearch/src/seed.ts
+++ b/templates/template-chat-with-elasticsearch/src/seed.ts
@@ -1,0 +1,238 @@
+import 'dotenv/config';
+import { esClient } from './mastra/lib/elasticsearch-client';
+
+const INDEX_NAME = 'articles';
+
+const articles = [
+  {
+    title: 'Getting Started with Elasticsearch',
+    content: `Elasticsearch is a distributed, RESTful search and analytics engine capable of addressing a growing number of use cases. As the heart of the Elastic Stack, it centrally stores your data for lightning fast search, fine‑tuned relevancy, and powerful analytics that scale with ease.
+
+This guide will walk you through the basics of setting up Elasticsearch, creating your first index, and running your first queries. We'll cover the fundamental concepts like documents, indices, and mappings.
+
+Elasticsearch uses an inverted index structure that allows for very fast full-text searches. When you index a document, Elasticsearch breaks down the text fields into individual terms and creates a mapping of which documents contain each term.`,
+    author: 'Sarah Chen',
+    category: 'Technology',
+    tags: ['elasticsearch', 'search', 'tutorial', 'beginner'],
+    published_date: '2024-01-15',
+    views: 15420,
+  },
+  {
+    title: 'Understanding Vector Search and Embeddings',
+    content: `Vector search represents a paradigm shift in how we approach information retrieval. Unlike traditional keyword-based search, vector search uses machine learning models to convert text into dense numerical representations called embeddings.
+
+These embeddings capture semantic meaning, allowing searches to find conceptually similar content even when exact keywords don't match. For example, a search for "automobile" can find documents about "cars" and "vehicles" because their embeddings are close in vector space.
+
+Elasticsearch supports dense vector fields and k-nearest neighbor (kNN) search, making it possible to build powerful semantic search applications. Combined with traditional BM25 scoring, you can create hybrid search systems that leverage both keyword matching and semantic understanding.`,
+    author: 'Michael Rodriguez',
+    category: 'Technology',
+    tags: ['vectors', 'embeddings', 'machine-learning', 'semantic-search'],
+    published_date: '2024-02-20',
+    views: 8930,
+  },
+  {
+    title: 'Building Production-Ready Search Applications',
+    content: `Moving from a prototype to a production search system requires careful consideration of several factors: performance, relevance, reliability, and maintainability.
+
+Performance optimization starts with proper index design. Consider your query patterns and design your mappings accordingly. Use appropriate field types - keyword fields for exact matching and filtering, text fields for full-text search. Implement pagination using search_after for deep pagination scenarios.
+
+Relevance tuning is an ongoing process. Start with Elasticsearch's default BM25 scoring, then iterate based on user feedback. Consider using function_score queries to boost documents based on business logic like recency or popularity.
+
+For reliability, implement proper error handling, circuit breakers, and fallback mechanisms. Monitor your cluster health and set up alerts for key metrics like search latency and indexing throughput.`,
+    author: 'Emily Watson',
+    category: 'Engineering',
+    tags: ['production', 'best-practices', 'performance', 'elasticsearch'],
+    published_date: '2024-03-10',
+    views: 12150,
+  },
+  {
+    title: 'Introduction to ES|QL: The New Query Language',
+    content: `ES|QL (Elasticsearch Query Language) is a new piped query language designed to make data exploration and analysis more intuitive. Unlike the JSON-based Query DSL, ES|QL uses a familiar pipe syntax similar to SQL and SPL.
+
+With ES|QL, you can filter, aggregate, and transform data using a series of commands connected by pipes. For example: FROM logs | WHERE status == "error" | STATS count = COUNT(*) BY service | SORT count DESC
+
+Key features include native support for time-series data, built-in statistical functions, and the ability to chain multiple operations in a single query. ES|QL queries are also optimized by Elasticsearch's query planner for efficient execution.
+
+The language continues to evolve with new features like FORK and FUSE for hybrid search, making it increasingly powerful for complex search and analytics use cases.`,
+    author: 'David Kim',
+    category: 'Technology',
+    tags: ['esql', 'query-language', 'analytics', 'elasticsearch'],
+    published_date: '2024-04-05',
+    views: 6540,
+  },
+  {
+    title: 'Securing Your Elasticsearch Cluster',
+    content: `Security should be a top priority when deploying Elasticsearch in any environment. A properly secured cluster protects sensitive data and prevents unauthorized access.
+
+Start with the basics: enable TLS for all communications, both between nodes (transport layer) and for client connections (HTTP layer). Use strong authentication - Elasticsearch supports native realm, LDAP, Active Directory, SAML, and OIDC.
+
+Implement role-based access control (RBAC) to limit what users can see and do. Create roles with specific index privileges and field-level security to ensure users only access data they're authorized to see. Document-level security adds another layer by filtering documents based on user attributes.
+
+Audit logging helps you track who accessed what and when. Enable audit logs to maintain compliance and investigate security incidents. Regular security reviews and penetration testing help identify vulnerabilities before attackers do.`,
+    author: 'James Thompson',
+    category: 'Security',
+    tags: ['security', 'authentication', 'rbac', 'tls', 'elasticsearch'],
+    published_date: '2024-04-22',
+    views: 9870,
+  },
+  {
+    title: 'Optimizing Elasticsearch for Log Analytics',
+    content: `Log analytics is one of the most common use cases for Elasticsearch. With proper optimization, Elasticsearch can handle millions of log events per second while providing fast search and aggregation capabilities.
+
+Index lifecycle management (ILM) is essential for log data. Configure policies to automatically roll over indices based on size or age, move older data to cheaper storage tiers, and delete data past its retention period. This keeps your cluster performant and cost-effective.
+
+For high-volume ingestion, use bulk indexing and tune your refresh interval. A longer refresh interval (e.g., 30 seconds instead of 1 second) reduces indexing overhead at the cost of slightly delayed search visibility.
+
+Design your mappings with log analysis in mind. Use keyword fields for log levels, service names, and other categorical data you'll filter on. Consider using runtime fields for infrequently accessed computed values to save storage space.`,
+    author: 'Lisa Park',
+    category: 'Operations',
+    tags: ['logging', 'observability', 'ilm', 'performance', 'elasticsearch'],
+    published_date: '2024-05-18',
+    views: 11200,
+  },
+  {
+    title: 'Machine Learning Anomaly Detection with Elasticsearch',
+    content: `Elasticsearch's machine learning capabilities enable automatic detection of anomalies in your data without requiring extensive data science expertise. The unsupervised algorithms learn normal patterns and alert you when deviations occur.
+
+Anomaly detection jobs analyze time-series data to find unusual patterns. You define the data to analyze, the time buckets, and what constitutes an anomaly. Elasticsearch handles the rest - building models, scoring data, and generating alerts.
+
+Common use cases include detecting unusual traffic patterns in web logs, identifying fraudulent transactions in payment data, and spotting infrastructure issues before they cause outages. Multi-metric jobs can correlate anomalies across multiple measurements for more accurate detection.
+
+Integration with alerting allows you to automatically notify teams when anomalies are detected. Combine with Kibana's ML features for visualization and investigation of detected anomalies.`,
+    author: 'Robert Martinez',
+    category: 'Data Science',
+    tags: ['machine-learning', 'anomaly-detection', 'observability', 'elasticsearch'],
+    published_date: '2024-06-03',
+    views: 7650,
+  },
+  {
+    title: 'Migrating from Solr to Elasticsearch',
+    content: `Many organizations are migrating from Apache Solr to Elasticsearch to take advantage of its modern architecture, richer ecosystem, and better operational tooling. While both are built on Lucene, there are important differences to consider.
+
+Schema design differs between the two. Solr's schema.xml becomes Elasticsearch mappings. Dynamic fields in Solr translate to dynamic templates in Elasticsearch. Take time to review and optimize your mappings during migration rather than doing a 1:1 translation.
+
+Query syntax translation requires attention. Solr's query parsers (edismax, standard) map to Elasticsearch's query types, but the syntax is different. The bool query in Elasticsearch provides similar functionality to Solr's boolean operators.
+
+Plan for a parallel running period where both systems serve traffic. This allows you to validate search relevance and performance before fully cutting over. Tools like Rally can help benchmark Elasticsearch performance against your expected workload.`,
+    author: 'Amanda Foster',
+    category: 'Engineering',
+    tags: ['migration', 'solr', 'elasticsearch', 'search'],
+    published_date: '2024-06-25',
+    views: 5430,
+  },
+  {
+    title: 'Real-time Analytics with Elasticsearch Aggregations',
+    content: `Elasticsearch aggregations provide powerful real-time analytics capabilities. From simple metrics like averages and sums to complex multi-level aggregations, you can analyze your data in countless ways.
+
+Bucket aggregations group documents into buckets based on field values, ranges, or other criteria. Terms aggregations show top values, histogram aggregations create distribution charts, and date_histogram is perfect for time-series analysis.
+
+Metric aggregations compute statistics over sets of documents - min, max, avg, sum, percentiles, and more. Combine them with bucket aggregations to compute metrics per group.
+
+Pipeline aggregations operate on the output of other aggregations. Calculate moving averages, derivatives, or cumulative sums to identify trends. The bucket_script aggregation lets you perform custom calculations across sibling buckets.
+
+For large datasets, use sampling or composite aggregations to maintain performance. The composite aggregation is particularly useful for paginating through all buckets in an aggregation.`,
+    author: 'Kevin O\'Brien',
+    category: 'Analytics',
+    tags: ['aggregations', 'analytics', 'real-time', 'elasticsearch'],
+    published_date: '2024-07-12',
+    views: 8920,
+  },
+  {
+    title: 'Elasticsearch Index Design Patterns',
+    content: `Good index design is fundamental to Elasticsearch performance and functionality. The decisions you make about how to structure your indices impact query speed, storage efficiency, and operational complexity.
+
+The time-based index pattern works well for log and event data. Create indices per time period (daily, weekly, monthly) and use index aliases for querying. This makes data retention simple - just delete old indices.
+
+For entity-centric data like products or users, consider your access patterns. If you always query by a specific field (like tenant_id), that field should probably be in your index name or used for routing to ensure related documents are co-located.
+
+Mapping design matters. Use appropriate field types - keyword for exact matching and aggregations, text for full-text search. Don't index fields you won't search on. Use doc_values: false for text fields you only search (not sort or aggregate) to save disk space.
+
+Consider denormalization. Unlike relational databases, Elasticsearch works best with denormalized data. Duplicating data across documents often performs better than using joins or nested objects.`,
+    author: 'Jennifer Walsh',
+    category: 'Engineering',
+    tags: ['index-design', 'mappings', 'patterns', 'elasticsearch'],
+    published_date: '2024-08-01',
+    views: 10340,
+  },
+];
+
+async function seed() {
+  console.log('Connecting to Elasticsearch...');
+
+  const indexExists = await esClient.indices.exists({ index: INDEX_NAME });
+
+  if (indexExists) {
+    console.log(`Index "${INDEX_NAME}" already exists. Deleting...`);
+    await esClient.indices.delete({ index: INDEX_NAME });
+  }
+
+  console.log(`Creating index "${INDEX_NAME}"...`);
+  await esClient.indices.create({
+    index: INDEX_NAME,
+    mappings: {
+      properties: {
+        title: {
+          type: 'text',
+          analyzer: 'english',
+          fields: {
+            keyword: { type: 'keyword' },
+          },
+        },
+        content: {
+          type: 'text',
+          analyzer: 'english',
+        },
+        author: {
+          type: 'keyword',
+        },
+        category: {
+          type: 'keyword',
+        },
+        tags: {
+          type: 'keyword',
+        },
+        published_date: {
+          type: 'date',
+        },
+        views: {
+          type: 'integer',
+        },
+      },
+    },
+  });
+
+  console.log('Indexing articles...');
+  const operations = articles.flatMap((doc) => [{ index: { _index: INDEX_NAME } }, doc]);
+
+  const bulkResponse = await esClient.bulk({ refresh: true, operations });
+
+  if (bulkResponse.errors) {
+    const erroredDocuments: Array<{ status: number; error: unknown; document: unknown }> = [];
+    bulkResponse.items.forEach((action, i) => {
+      const operation = Object.values(action)[0];
+      if (operation?.error) {
+        erroredDocuments.push({
+          status: operation.status,
+          error: operation.error,
+          document: articles[i],
+        });
+      }
+    });
+    console.error('Failed to index some documents:', erroredDocuments);
+  }
+
+  const count = await esClient.count({ index: INDEX_NAME });
+  console.log(`\nSeeding complete!`);
+  console.log(`Index: ${INDEX_NAME}`);
+  console.log(`Documents indexed: ${count.count}`);
+  console.log(`\nSample queries to try:`);
+  console.log(`- "What articles discuss Elasticsearch security?"`);
+  console.log(`- "Find tutorials for beginners"`);
+  console.log(`- "Articles about machine learning and anomaly detection"`);
+  console.log(`- "What did Sarah Chen write about?"`);
+}
+
+seed().catch((err) => {
+  console.error('Failed to seed Elasticsearch:', err);
+  process.exit(1);
+});

--- a/templates/template-chat-with-elasticsearch/tsconfig.json
+++ b/templates/template-chat-with-elasticsearch/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/templates/template-chat-with-elasticsearch/tsconfig.json
+++ b/templates/template-chat-with-elasticsearch/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Description

This PR adds a new template to chat with data residing inside elasticsearch. Elasticsearch is also used for agent memory (using `ElasticSearchStore`), generating embeddings (using Elastic Inference Service) and Observability (using Elastic APM), if configured appropriately. You can also configure Kibana's MCP server for additional tools.

Some initial data is also available via the `pnpm seed` command

## Related Issue(s)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Elasticsearch-backed chat template with configurable embedding providers (OpenAI or Elastic Inference Service).
  * Semantic and hybrid search support, optional agent memory, Kibana MCP tool integrations, and optional Elastic APM trace exporting.
  * Sample data seeding and developer scripts for quick setup.

* **Documentation**
  * Added a README and example environment configuration documenting setup, env vars, and quick-start steps.

* **Chores**
  * Added project manifest and ignore rules for local/dev artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->