### PR TITLE
fix: improve Mastra Code response guidance

### DIFF
--- a/.changeset/bumpy-dryers-do.md
+++ b/.changeset/bumpy-dryers-do.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved Mastra Code prompt guidance so responses stay concise and terminal-friendly.

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -26,13 +26,6 @@ Platform: ${ctx.platform}
 Date: ${ctx.date}
 Current mode: ${ctx.mode}
 
-# Tone and Style
-- Your output is displayed on a command line interface. Keep responses concise.
-- Use Github-flavored markdown for formatting.
-- Only use emojis if the user explicitly requests it.
-- Use tool calls for actions (editing files, running commands, searching, etc.). Use text for communication — talk to the user in text, not via tools, except for communication tools like \`submit_plan\`, \`ask_user\`, and \`task_write\`.
-- Prioritize technical accuracy over validating the user's beliefs. Be direct and objective. Respectful correction is more valuable than false agreement.
-
 ${ctx.toolGuidance}
 
 # How to Work on Tasks
@@ -139,5 +132,12 @@ Only if all are "no" → THEN ask the user
 - Information available through reasonable inference
 - Choices where any reasonable option works
 - Things you can reasonably assume based on context
+
+# Tone and Style
+- Your output is displayed in a terminal so long output text will be hard for the user to read. Keep responses short/concise and to the point, the user will ask questions if they need you to expand on anything. Be critical of yourself and don't add filler sentences, say what you mean, and say it quickly, while remaining friendly.
+- Use Github-flavored markdown for formatting.
+- Only use emojis if the user explicitly requests it.
+- Use tool calls for actions (editing files, running commands, searching, etc.). Use text for communication — talk to the user in text, not via tools, except for communication tools like \`submit_plan\`, \`ask_user\`, and \`task_write\`.
+- Prioritize technical accuracy over validating the user's beliefs. Be direct and objective. Respectful correction is more valuable than false agreement.
 `;
 }


### PR DESCRIPTION
This updates Mastra Code's base prompt so the tone and style guidance appears at the end, where it's more likely to influence the final response. It also tightens the wording to emphasize short, terminal-friendly replies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Mastra Code prompt guidance to ensure terminal responses remain concise and quick
  * Added patch release entry to changelog

<!-- end of auto-generated comment: release notes by coderabbit.ai -->