### PR TITLE
fix(mastracode): speed up loading and show all threads in thread selector

### DIFF
--- a/.changeset/fuzzy-facts-burn.md
+++ b/.changeset/fuzzy-facts-burn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `Harness.listThreads()` so callers can request threads across all resources.

--- a/.changeset/shaky-ears-dance.md
+++ b/.changeset/shaky-ears-dance.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed the thread selector so it shows all threads consistently and opens faster.

--- a/.changeset/two-glasses-report.md
+++ b/.changeset/two-glasses-report.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastracode': patch
+---
+
+Fixed the thread selector so it shows all available threads and opens faster by avoiding the extra first-message preview lookup.

--- a/.changeset/two-glasses-report.md
+++ b/.changeset/two-glasses-report.md
@@ -1,6 +1,0 @@
----
-'@mastra/core': patch
-'mastracode': patch
----
-
-Fixed the thread selector so it shows all available threads and opens faster by avoiding the extra first-message preview lookup.

--- a/mastracode/src/tui/commands/__tests__/threads.test.ts
+++ b/mastracode/src/tui/commands/__tests__/threads.test.ts
@@ -64,6 +64,7 @@ function createContext(threads: HarnessThread[]) {
       listThreads: vi.fn(async () => threads),
       getCurrentThreadId: vi.fn(() => null),
       getResourceId: vi.fn(() => 'resource-1'),
+      getFirstUserMessagesForThreads: vi.fn(async () => new Map()),
       setResourceId: vi.fn(),
       switchThread: vi.fn(),
       cloneThread: vi.fn(),
@@ -129,9 +130,22 @@ describe('handleThreadsCommand thread listing', () => {
     await commandPromise;
   });
 
-  it('does not request message previews from the harness', async () => {
+  it('fetches and caches uncached previews from the harness', async () => {
     const threads = [createThread('thread-1', '2026-03-17T15:10:00.000Z')];
     const { ctx, state, showOverlay } = createContext(threads);
+    state.harness.getFirstUserMessagesForThreads = vi.fn(async () =>
+      new Map([
+        [
+          'thread-1',
+          {
+            id: 'message-1',
+            role: 'user',
+            createdAt: new Date('2026-03-17T15:00:00.000Z'),
+            content: [{ type: 'text', text: 'This is a long preview message that should be truncated for display.' }],
+          },
+        ],
+      ]),
+    );
 
     const commandPromise = handleThreadsCommand(ctx);
     await Promise.resolve();
@@ -139,9 +153,15 @@ describe('handleThreadsCommand thread listing', () => {
 
     const selector = selectorInstances[0];
     expect(typeof selector.options.getMessagePreviews).toBe('function');
-    await expect(selector.options.getMessagePreviews(['thread-1'])).resolves.toEqual(new Map());
-    expect(state.threadPreviewCache.size).toBe(0);
-    expect(state.attemptedThreadPreviewIds.size).toBe(0);
+    await expect(selector.options.getMessagePreviews(['thread-1'])).resolves.toEqual(
+      new Map([['thread-1', 'This is a long preview message that should be t...']]),
+    );
+    expect(state.harness.getFirstUserMessagesForThreads).toHaveBeenCalledWith({ threadIds: ['thread-1'] });
+    expect(state.threadPreviewCache.get('thread-1')).toEqual({
+      preview: 'This is a long preview message that should be t...',
+      updatedAt: new Date('2026-03-17T15:10:00.000Z').getTime(),
+    });
+    expect(state.attemptedThreadPreviewIds.has('thread-1')).toBe(true);
 
     selector.options.onCancel();
     await commandPromise;

--- a/mastracode/src/tui/commands/__tests__/threads.test.ts
+++ b/mastracode/src/tui/commands/__tests__/threads.test.ts
@@ -64,7 +64,6 @@ function createContext(threads: HarnessThread[]) {
       listThreads: vi.fn(async () => threads),
       getCurrentThreadId: vi.fn(() => null),
       getResourceId: vi.fn(() => 'resource-1'),
-      getFirstUserMessagesForThreads: vi.fn(async () => new Map()),
       setResourceId: vi.fn(),
       switchThread: vi.fn(),
       cloneThread: vi.fn(),
@@ -81,7 +80,7 @@ function createContext(threads: HarnessThread[]) {
   return { ctx, state, showOverlay };
 }
 
-describe('handleThreadsCommand preview cache invalidation', () => {
+describe('handleThreadsCommand thread listing', () => {
   beforeEach(() => {
     selectorInstances.length = 0;
   });
@@ -125,6 +124,24 @@ describe('handleThreadsCommand preview cache invalidation', () => {
     expect(selector.options.initialMessagePreviews.get('thread-1')).toBe('Fresh preview');
     expect(state.threadPreviewCache.get('thread-1')?.preview).toBe('Fresh preview');
     expect(state.attemptedThreadPreviewIds.has('thread-1')).toBe(true);
+
+    selector.options.onCancel();
+    await commandPromise;
+  });
+
+  it('does not request message previews from the harness', async () => {
+    const threads = [createThread('thread-1', '2026-03-17T15:10:00.000Z')];
+    const { ctx, state, showOverlay } = createContext(threads);
+
+    const commandPromise = handleThreadsCommand(ctx);
+    await Promise.resolve();
+    expect(showOverlay).toHaveBeenCalledTimes(1);
+
+    const selector = selectorInstances[0];
+    expect(typeof selector.options.getMessagePreviews).toBe('function');
+    await expect(selector.options.getMessagePreviews(['thread-1'])).resolves.toEqual(new Map());
+    expect(state.threadPreviewCache.size).toBe(0);
+    expect(state.attemptedThreadPreviewIds.size).toBe(0);
 
     selector.options.onCancel();
     await commandPromise;

--- a/mastracode/src/tui/commands/__tests__/threads.test.ts
+++ b/mastracode/src/tui/commands/__tests__/threads.test.ts
@@ -133,18 +133,19 @@ describe('handleThreadsCommand thread listing', () => {
   it('fetches and caches uncached previews from the harness', async () => {
     const threads = [createThread('thread-1', '2026-03-17T15:10:00.000Z')];
     const { ctx, state, showOverlay } = createContext(threads);
-    state.harness.getFirstUserMessagesForThreads = vi.fn(async () =>
-      new Map([
-        [
-          'thread-1',
-          {
-            id: 'message-1',
-            role: 'user',
-            createdAt: new Date('2026-03-17T15:00:00.000Z'),
-            content: [{ type: 'text', text: 'This is a long preview message that should be truncated for display.' }],
-          },
-        ],
-      ]),
+    state.harness.getFirstUserMessagesForThreads = vi.fn(
+      async () =>
+        new Map([
+          [
+            'thread-1',
+            {
+              id: 'message-1',
+              role: 'user',
+              createdAt: new Date('2026-03-17T15:00:00.000Z'),
+              content: [{ type: 'text', text: 'This is a long preview message that should be truncated for display.' }],
+            },
+          ],
+        ]),
     );
 
     const commandPromise = handleThreadsCommand(ctx);

--- a/mastracode/src/tui/commands/threads.ts
+++ b/mastracode/src/tui/commands/threads.ts
@@ -131,7 +131,9 @@ export async function handleThreadsCommand(ctx: SlashCommandContext): Promise<vo
         );
 
         if (uncachedThreadIds.length > 0) {
-          const firstUserMessages = await state.harness.getFirstUserMessagesForThreads({ threadIds: uncachedThreadIds });
+          const firstUserMessages = await state.harness.getFirstUserMessagesForThreads({
+            threadIds: uncachedThreadIds,
+          });
 
           for (const threadId of uncachedThreadIds) {
             state.attemptedThreadPreviewIds.add(threadId);

--- a/mastracode/src/tui/commands/threads.ts
+++ b/mastracode/src/tui/commands/threads.ts
@@ -1,23 +1,9 @@
 import { Spacer } from '@mariozechner/pi-tui';
-import type { HarnessMessage } from '@mastra/core/harness';
 import { ThreadLockError } from '../../utils/thread-lock.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
 import { ThreadSelectorComponent } from '../components/thread-selector.js';
 import { askCloneName, confirmClone, resetUIAfterClone } from './clone.js';
 import type { SlashCommandContext } from './types.js';
-
-function extractTextContent(message: HarnessMessage): string {
-  return message.content
-    .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
-    .map(c => c.text)
-    .join(' ')
-    .trim();
-}
-
-function truncatePreview(text: string, maxLength = 50): string {
-  if (text.length <= maxLength) return text;
-  return text.slice(0, maxLength - 3) + '...';
-}
 
 export function showThreadLockPrompt(
   ctx: SlashCommandContext,
@@ -126,41 +112,9 @@ export async function handleThreadsCommand(ctx: SlashCommandContext): Promise<vo
         state.attemptedThreadPreviewIds = attemptedThreadIds;
       },
       getMessagePreviews: async (threadIds: string[]) => {
-        const uncachedThreadIds = threadIds.filter(
-          threadId => !state.threadPreviewCache.has(threadId) && !state.attemptedThreadPreviewIds.has(threadId),
-        );
-
-        if (uncachedThreadIds.length === 0) {
-          return new Map(
-            threadIds.flatMap(threadId => {
-              const preview = state.threadPreviewCache.get(threadId)?.preview;
-              return preview ? [[threadId, preview] as const] : [];
-            }),
-          );
-        }
-
-        const firstUserMessages = await state.harness.getFirstUserMessagesForThreads({ threadIds: uncachedThreadIds });
-        const previews = new Map<string, string>();
-
-        for (const threadId of uncachedThreadIds) {
-          state.attemptedThreadPreviewIds.add(threadId);
-        }
-
-        for (const [threadId, message] of firstUserMessages.entries()) {
-          const text = extractTextContent(message);
-          if (text) {
-            const preview = truncatePreview(text);
-            previews.set(threadId, preview);
-            const thread = threadById.get(threadId);
-            if (thread) {
-              state.threadPreviewCache.set(threadId, { preview, updatedAt: thread.updatedAt.getTime() });
-            }
-          }
-        }
-
         return new Map(
           threadIds.flatMap(threadId => {
-            const preview = previews.get(threadId) ?? state.threadPreviewCache.get(threadId)?.preview;
+            const preview = state.threadPreviewCache.get(threadId)?.preview;
             return preview ? [[threadId, preview] as const] : [];
           }),
         );

--- a/mastracode/src/tui/commands/threads.ts
+++ b/mastracode/src/tui/commands/threads.ts
@@ -1,9 +1,23 @@
 import { Spacer } from '@mariozechner/pi-tui';
+import type { HarnessMessage } from '@mastra/core/harness';
 import { ThreadLockError } from '../../utils/thread-lock.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
 import { ThreadSelectorComponent } from '../components/thread-selector.js';
 import { askCloneName, confirmClone, resetUIAfterClone } from './clone.js';
 import type { SlashCommandContext } from './types.js';
+
+function extractTextContent(message: HarnessMessage): string {
+  return message.content
+    .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+    .map(c => c.text)
+    .join(' ')
+    .trim();
+}
+
+function truncatePreview(text: string, maxLength = 50): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - 3) + '...';
+}
 
 export function showThreadLockPrompt(
   ctx: SlashCommandContext,
@@ -112,6 +126,36 @@ export async function handleThreadsCommand(ctx: SlashCommandContext): Promise<vo
         state.attemptedThreadPreviewIds = attemptedThreadIds;
       },
       getMessagePreviews: async (threadIds: string[]) => {
+        const uncachedThreadIds = threadIds.filter(
+          threadId => !state.threadPreviewCache.has(threadId) && !state.attemptedThreadPreviewIds.has(threadId),
+        );
+
+        if (uncachedThreadIds.length > 0) {
+          const firstUserMessages = await state.harness.getFirstUserMessagesForThreads({ threadIds: uncachedThreadIds });
+
+          for (const threadId of uncachedThreadIds) {
+            state.attemptedThreadPreviewIds.add(threadId);
+          }
+
+          for (const [threadId, message] of firstUserMessages.entries()) {
+            const text = extractTextContent(message);
+            if (!text) {
+              continue;
+            }
+
+            const thread = threadById.get(threadId);
+            if (!thread) {
+              continue;
+            }
+
+            const preview = truncatePreview(text);
+            state.threadPreviewCache.set(threadId, {
+              preview,
+              updatedAt: thread.updatedAt.getTime(),
+            });
+          }
+        }
+
         return new Map(
           threadIds.flatMap(threadId => {
             const preview = state.threadPreviewCache.get(threadId)?.preview;

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -844,7 +844,7 @@ export class Harness<TState extends HarnessStateSchema<any> = HarnessStateSchema
       ? undefined
       : { resourceId: this.resourceId };
 
-    const result = await memoryStorage.listThreads({ filter });
+    const result = await memoryStorage.listThreads({ filter, perPage: false });
 
     return result.threads.map((thread: StorageThreadType) => ({
       id: thread.id,


### PR DESCRIPTION
This tightens up the thread popup so it shows all threads consistently and opens faster.

Before, some threads could be hidden by the selector's project-path filtering and the popup would spend time fetching first-message previews. After this change, the selector shows the full thread list and relies on the thread data it already has instead of doing the extra preview lookup, which makes it dramatically faster to load/use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thread selector now consistently shows all threads in the UI.
  * Thread listing correctly requests and retrieves threads across all resources.
  * Thread selector opens and initializes faster.
  * Thread previews load more reliably and are cached for snappier browsing.
  * Preview text is truncated appropriately for concise display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->