### PR TITLE
fix: remove thread selector preview lookup

### DIFF
--- a/mastracode/src/tui/commands/__tests__/threads.test.ts
+++ b/mastracode/src/tui/commands/__tests__/threads.test.ts
@@ -147,7 +147,9 @@ describe('handleThreadsCommand thread listing', () => {
       updatedAt: new Date('2026-03-17T15:10:00.000Z').getTime(),
     });
     state.attemptedThreadPreviewIds.add('thread-1');
-    state.harness.getFirstUserMessagesForThreads = vi.fn(async () => new Map([['thread-1', createMessage('message-1', 'slow')]]));
+    state.harness.getFirstUserMessagesForThreads = vi.fn(
+      async () => new Map([['thread-1', createMessage('message-1', 'slow')]]),
+    );
 
     const commandPromise = handleThreadsCommand(ctx);
     await Promise.resolve();

--- a/mastracode/src/tui/commands/__tests__/threads.test.ts
+++ b/mastracode/src/tui/commands/__tests__/threads.test.ts
@@ -1,4 +1,4 @@
-import type { HarnessThread } from '@mastra/core/harness';
+import type { HarnessMessage, HarnessThread } from '@mastra/core/harness';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { handleThreadsCommand } from '../threads.js';
 import type { SlashCommandContext } from '../types.js';
@@ -42,6 +42,15 @@ function createThread(id: string, updatedAtIso: string): HarnessThread {
     updatedAt,
     metadata: {},
     tokenUsage: { totalTokens: 0, promptTokens: 0, completionTokens: 0 },
+  };
+}
+
+function createMessage(id: string, text: string): HarnessMessage {
+  return {
+    id,
+    role: 'user',
+    createdAt: new Date('2026-03-17T15:00:00.000Z'),
+    content: [{ type: 'text', text }],
   };
 }
 
@@ -130,23 +139,15 @@ describe('handleThreadsCommand thread listing', () => {
     await commandPromise;
   });
 
-  it('fetches and caches uncached previews from the harness', async () => {
+  it('returns only cached previews and never requests uncached ones from the harness', async () => {
     const threads = [createThread('thread-1', '2026-03-17T15:10:00.000Z')];
     const { ctx, state, showOverlay } = createContext(threads);
-    state.harness.getFirstUserMessagesForThreads = vi.fn(
-      async () =>
-        new Map([
-          [
-            'thread-1',
-            {
-              id: 'message-1',
-              role: 'user',
-              createdAt: new Date('2026-03-17T15:00:00.000Z'),
-              content: [{ type: 'text', text: 'This is a long preview message that should be truncated for display.' }],
-            },
-          ],
-        ]),
-    );
+    state.threadPreviewCache.set('thread-1', {
+      preview: 'Cached preview',
+      updatedAt: new Date('2026-03-17T15:10:00.000Z').getTime(),
+    });
+    state.attemptedThreadPreviewIds.add('thread-1');
+    state.harness.getFirstUserMessagesForThreads = vi.fn(async () => new Map([['thread-1', createMessage('message-1', 'slow')]]));
 
     const commandPromise = handleThreadsCommand(ctx);
     await Promise.resolve();
@@ -154,15 +155,16 @@ describe('handleThreadsCommand thread listing', () => {
 
     const selector = selectorInstances[0];
     expect(typeof selector.options.getMessagePreviews).toBe('function');
-    await expect(selector.options.getMessagePreviews(['thread-1'])).resolves.toEqual(
-      new Map([['thread-1', 'This is a long preview message that should be t...']]),
+    await expect(selector.options.getMessagePreviews(['thread-1', 'thread-2'])).resolves.toEqual(
+      new Map([['thread-1', 'Cached preview']]),
     );
-    expect(state.harness.getFirstUserMessagesForThreads).toHaveBeenCalledWith({ threadIds: ['thread-1'] });
+    expect(state.harness.getFirstUserMessagesForThreads).not.toHaveBeenCalled();
     expect(state.threadPreviewCache.get('thread-1')).toEqual({
-      preview: 'This is a long preview message that should be t...',
+      preview: 'Cached preview',
       updatedAt: new Date('2026-03-17T15:10:00.000Z').getTime(),
     });
     expect(state.attemptedThreadPreviewIds.has('thread-1')).toBe(true);
+    expect(state.attemptedThreadPreviewIds.has('thread-2')).toBe(false);
 
     selector.options.onCancel();
     await commandPromise;

--- a/mastracode/src/tui/commands/threads.ts
+++ b/mastracode/src/tui/commands/threads.ts
@@ -1,23 +1,9 @@
 import { Spacer } from '@mariozechner/pi-tui';
-import type { HarnessMessage } from '@mastra/core/harness';
 import { ThreadLockError } from '../../utils/thread-lock.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
 import { ThreadSelectorComponent } from '../components/thread-selector.js';
 import { askCloneName, confirmClone, resetUIAfterClone } from './clone.js';
 import type { SlashCommandContext } from './types.js';
-
-function extractTextContent(message: HarnessMessage): string {
-  return message.content
-    .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
-    .map(c => c.text)
-    .join(' ')
-    .trim();
-}
-
-function truncatePreview(text: string, maxLength = 50): string {
-  if (text.length <= maxLength) return text;
-  return text.slice(0, maxLength - 3) + '...';
-}
 
 export function showThreadLockPrompt(
   ctx: SlashCommandContext,
@@ -126,38 +112,6 @@ export async function handleThreadsCommand(ctx: SlashCommandContext): Promise<vo
         state.attemptedThreadPreviewIds = attemptedThreadIds;
       },
       getMessagePreviews: async (threadIds: string[]) => {
-        const uncachedThreadIds = threadIds.filter(
-          threadId => !state.threadPreviewCache.has(threadId) && !state.attemptedThreadPreviewIds.has(threadId),
-        );
-
-        if (uncachedThreadIds.length > 0) {
-          const firstUserMessages = await state.harness.getFirstUserMessagesForThreads({
-            threadIds: uncachedThreadIds,
-          });
-
-          for (const threadId of uncachedThreadIds) {
-            state.attemptedThreadPreviewIds.add(threadId);
-          }
-
-          for (const [threadId, message] of firstUserMessages.entries()) {
-            const text = extractTextContent(message);
-            if (!text) {
-              continue;
-            }
-
-            const thread = threadById.get(threadId);
-            if (!thread) {
-              continue;
-            }
-
-            const preview = truncatePreview(text);
-            state.threadPreviewCache.set(threadId, {
-              preview,
-              updatedAt: thread.updatedAt.getTime(),
-            });
-          }
-        }
-
         return new Map(
           threadIds.flatMap(threadId => {
             const preview = state.threadPreviewCache.get(threadId)?.preview;


### PR DESCRIPTION
This removes the uncached first-message preview lookup from the thread selector again so the popup stays fast and still shows any previews we already have cached.

Before:
```ts
const firstUserMessages = await state.harness.getFirstUserMessagesForThreads({ threadIds: uncachedThreadIds });
```

After:
```ts
return new Map(
  threadIds.flatMap(threadId => {
    const preview = state.threadPreviewCache.get(threadId)?.preview;
    return preview ? [[threadId, preview] as const] : [];
  }),
);
```

Also updates the targeted test so uncached previews are not fetched from the harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Thread previews now display only from cache. Automatic fetching of uncached thread previews has been removed from the preview retrieval process.

* **Tests**
  * Updated thread listing test scenarios to validate cached preview behavior, including handling of previously attempted and new threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->