### PR TITLE
fix(pg): sanitize invalid JSON escape sequences for workflow snapshots

### DIFF
--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -36,8 +36,8 @@ function getTableName({ indexName, schemaName }: { indexName: string; schemaName
 function sanitizeJsonForPg(jsonString: string): string {
   return (
     jsonString
-      // Fix invalid JSON escape sequences like \v, \k, \g
-      .replace(/\\(?!["\\/bfnrtu])/g, '\\\\')
+      // Fix invalid JSON escape sequences safely (respect existing escapes)
+      .replace(/(^|[^\\])(\\(?!["\\/bfnrtu]))/g, '$1\\\\')
       // Remove problematic Unicode sequences
       .replace(/\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g, '')
   );

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -27,13 +27,20 @@ function getTableName({ indexName, schemaName }: { indexName: string; schemaName
 }
 
 /**
- * Sanitizes JSON string by removing problematic Unicode sequences that PostgreSQL jsonb rejects.
- * Removes:
- * - \u0000 (null character) - causes error 22P05 "unsupported Unicode escape sequence"
- * - \uD800-\uDFFF (unpaired surrogates) - causes "Unicode low surrogate must follow a high surrogate"
+ * Sanitizes JSON string for PostgreSQL jsonb:
+ * - Escapes invalid JSON escape sequences (e.g. \v, \k → \\v, \\k)
+ * - Removes problematic Unicode sequences:
+ *   - \u0000 (null character) - causes error 22P05 "unsupported Unicode escape sequence"
+ *   - \uD800-\uDFFF (unpaired surrogates) - causes "Unicode low surrogate must follow a high surrogate"
  */
 function sanitizeJsonForPg(jsonString: string): string {
-  return jsonString.replace(/\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g, '');
+  return (
+    jsonString
+      // Fix invalid JSON escape sequences like \v, \k, \g
+      .replace(/\\(?!["\\/bfnrtu])/g, '\\\\')
+      // Remove problematic Unicode sequences
+      .replace(/\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g, '')
+  );
 }
 
 export class WorkflowsPG extends WorkflowsStorage {

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -36,9 +36,9 @@ function getTableName({ indexName, schemaName }: { indexName: string; schemaName
 function sanitizeJsonForPg(jsonString: string): string {
   return (
     jsonString
-      // Fix invalid JSON escape sequences safely (respect existing escapes)
+      // Fix invalid JSON escape sequences safely without rewriting already-escaped backslashes.
       .replace(/(^|[^\\])(\\(?!["\\/bfnrtu]))/g, '$1\\\\')
-      // Remove problematic Unicode sequences
+      // Remove problematic Unicode sequences.
       .replace(/\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g, '')
   );
 }

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -345,3 +345,25 @@ describe('PostgresStore pool integration', () => {
     await expect(store.pool.query('SELECT 1')).rejects.toThrow();
   });
 });
+
+// handles invalid JSON escape sequences in workflow snapshot persistence
+describe('sanitizeJsonForPg - invalid escape handling', () => {
+  it('should handle invalid JSON escape sequences like \\v without throwing', async () => {
+    const pool = createTestPool();
+    const workflows = new WorkflowsPG({ pool });
+
+    const snapshot = {
+      text: 'bad \\v escape',
+    };
+
+    await expect(
+      workflows.persistWorkflowSnapshot({
+        workflowName: 'test-workflow',
+        runId: 'run-1',
+        snapshot: snapshot as any,
+      }),
+    ).resolves.not.toThrow();
+
+    await pool.end();
+  });
+});

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -348,22 +348,26 @@ describe('PostgresStore pool integration', () => {
 
 // handles invalid JSON escape sequences in workflow snapshot persistence
 describe('sanitizeJsonForPg - invalid escape handling', () => {
-  it('should handle invalid JSON escape sequences like \\v without throwing', async () => {
+  it('should handle invalid JSON escape sequences without throwing', async () => {
     const pool = createTestPool();
     const workflows = new WorkflowsPG({ pool });
 
-    const snapshot = {
-      text: 'bad \\v escape',
-    };
+    try {
+      await workflows.init();
 
-    await expect(
-      workflows.persistWorkflowSnapshot({
-        workflowName: 'test-workflow',
-        runId: 'run-1',
-        snapshot: snapshot as any,
-      }),
-    ).resolves.not.toThrow();
+      const snapshot = {
+        text: 'bad \\v escape',
+      };
 
-    await pool.end();
+      await expect(
+        workflows.persistWorkflowSnapshot({
+          workflowName: 'test-workflow',
+          runId: 'run-1',
+          snapshot: snapshot as any,
+        }),
+      ).resolves.not.toThrow();
+    } finally {
+      await pool.end();
+    }
   });
 });

--- a/stores/pg/src/storage/index.test.ts
+++ b/stores/pg/src/storage/index.test.ts
@@ -6,9 +6,12 @@ import {
   createStoreIndexTests,
   createDomainIndexTests,
 } from '@internal/storage-test-utils';
+import { Mastra } from '@mastra/core/mastra';
 import { TABLE_THREADS } from '@mastra/core/storage';
+import { createStep, createWorkflow } from '@mastra/core/workflows';
 import { Pool } from 'pg';
 import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod/v4';
 
 import { DatasetsPG } from './domains/datasets';
 import { ExperimentsPG } from './domains/experiments';
@@ -346,26 +349,113 @@ describe('PostgresStore pool integration', () => {
   });
 });
 
-// handles invalid JSON escape sequences in workflow snapshot persistence
-describe('sanitizeJsonForPg - invalid escape handling', () => {
-  it('should handle invalid JSON escape sequences without throwing', async () => {
+describe('WorkflowsPG snapshot sanitization', () => {
+  it('round-trips workflow-executed backslash content and strips null characters', async () => {
     const pool = createTestPool();
-    const workflows = new WorkflowsPG({ pool });
+    const store = new PostgresStore({ id: `pg-sanitize-${Date.now()}`, pool });
+    const workflowName = `sanitize-roundtrip-${Date.now()}`;
+    const runId = `run-${Date.now()}`;
+
+    const captureStep = createStep({
+      id: 'capture-special-strings',
+      inputSchema: z.object({
+        invalidEscapeV: z.string(),
+        invalidEscapeK: z.string(),
+        backslashSpace: z.string(),
+        validEscape: z.string(),
+        nullCharContent: z.string(),
+      }),
+      outputSchema: z.object({
+        invalidEscapeV: z.string(),
+        invalidEscapeK: z.string(),
+        backslashSpace: z.string(),
+        validEscape: z.string(),
+        nullCharContent: z.string(),
+      }),
+      execute: async ({ inputData }) => inputData,
+    });
+
+    const workflow = createWorkflow({
+      id: workflowName,
+      inputSchema: z.object({
+        invalidEscapeV: z.string(),
+        invalidEscapeK: z.string(),
+        backslashSpace: z.string(),
+        validEscape: z.string(),
+        nullCharContent: z.string(),
+      }),
+      outputSchema: z.object({
+        invalidEscapeV: z.string(),
+        invalidEscapeK: z.string(),
+        backslashSpace: z.string(),
+        validEscape: z.string(),
+        nullCharContent: z.string(),
+      }),
+    })
+      .then(captureStep)
+      .commit();
+
+    const inputData = {
+      invalidEscapeV: 'Omschr\\vijving',
+      invalidEscapeK: 'Toepassel\\k',
+      backslashSpace: 'hello\\ world',
+      validEscape: 'line1\nline2',
+      nullCharContent: 'prefix\u0000suffix',
+    };
 
     try {
-      await workflows.init();
+      await store.init();
 
-      const snapshot = {
-        text: 'bad \\v escape',
-      };
+      const mastra = new Mastra({
+        logger: false,
+        storage: store,
+        workflows: { [workflowName]: workflow },
+      });
 
-      await expect(
-        workflows.persistWorkflowSnapshot({
-          workflowName: 'test-workflow',
-          runId: 'run-1',
-          snapshot: snapshot as any,
-        }),
-      ).resolves.not.toThrow();
+      workflow.__registerMastra(mastra);
+
+      const run = await workflow.createRun({ runId });
+      const result = await run.start({ inputData });
+
+      expect(result.status).toBe('success');
+      expect(result.steps['capture-special-strings']).toMatchObject({
+        status: 'success',
+        output: {
+          invalidEscapeV: 'Omschr\\vijving',
+          invalidEscapeK: 'Toepassel\\k',
+          backslashSpace: 'hello\\ world',
+          validEscape: 'line1\nline2',
+          nullCharContent: 'prefix\u0000suffix',
+        },
+      });
+
+      const workflows = await store.getStore('workflows');
+      const loadedSnapshot = await workflows?.loadWorkflowSnapshot({ workflowName, runId });
+      expect(loadedSnapshot).toBeDefined();
+      expect((loadedSnapshot as any)?.context['capture-special-strings']).toMatchObject({
+        status: 'success',
+        output: {
+          invalidEscapeV: 'Omschr\\vijving',
+          invalidEscapeK: 'Toepassel\\k',
+          backslashSpace: 'hello\\ world',
+          validEscape: 'line1\nline2',
+          nullCharContent: 'prefixsuffix',
+        },
+      });
+
+      const { runs } = await workflows!.listWorkflowRuns({ workflowName, status: 'success' });
+      const storedRun = runs.find(run => run.runId === runId);
+      expect(storedRun).toBeDefined();
+      expect((storedRun?.snapshot as any)?.context['capture-special-strings']).toMatchObject({
+        status: 'success',
+        output: {
+          invalidEscapeV: 'Omschr\\vijving',
+          invalidEscapeK: 'Toepassel\\k',
+          backslashSpace: 'hello\\ world',
+          validEscape: 'line1\nline2',
+          nullCharContent: 'prefixsuffix',
+        },
+      });
     } finally {
       await pool.end();
     }


### PR DESCRIPTION
## Description

Fixes an issue where PostgreSQL `jsonb` operations fail when workflow snapshots contain invalid JSON escape sequences (e.g. `\v`, `\k`).

This change:
- Escapes invalid JSON escape sequences before persistence
- Continues to sanitize problematic Unicode sequences (`\u0000`, unpaired surrogates)
- Ensures snapshots can be safely stored and queried in PostgreSQL

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/14689

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed JSON escapes in workflow snapshots so stored snapshots no longer fail and retain intended backslash escape content while stripping embedded null characters.
* **Tests**
  * Added a test validating snapshot sanitization preserves backslashes and standard escapes but removes null characters before persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->