### PR TITLE
feat(playground): add create agent and edit agent buttons

### DIFF
--- a/.changeset/violet-zoos-stop.md
+++ b/.changeset/violet-zoos-stop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added 'Create Agent' and 'Edit Agent' buttons to the playground, gated behind the MASTRA_EXPERIMENTAL_UI environment variable. When enabled, a 'Create Agent' button appears on the agents list page and an 'Edit' button appears on the agent detail header for stored agents.

--- a/packages/playground-ui/src/domains/agents/components/agent-entity-header.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-entity-header.tsx
@@ -26,14 +26,15 @@ export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
   });
   const agentName = agent?.name || '';
   const isStoredAgent = agent?.source === 'stored';
-  const showEditButton = canCreateAgent && isStoredAgent;
+  const editPath = paths.cmsAgentEditLink(agentId);
+  const showEditButton = canCreateAgent && isStoredAgent && Boolean(editPath);
 
   return (
     <TooltipProvider>
       <EntityHeader icon={<AgentIcon />} title={agentName} isLoading={isLoading}>
         <div className="flex flex-wrap items-center gap-x-2 gap-y-3">
           {showEditButton && (
-            <Button variant="outline" size="sm" as={FrameworkLink} to={paths.cmsAgentEditLink(agentId)}>
+            <Button variant="outline" size="sm" as={FrameworkLink} to={editPath}>
               <Icon size="sm">
                 <Pencil />
               </Icon>

--- a/packages/playground-ui/src/domains/agents/components/agent-entity-header.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-entity-header.tsx
@@ -4,9 +4,9 @@ import { useCanCreateAgent } from '../hooks/use-can-create-agent';
 import { Badge } from '@/ds/components/Badge';
 import { Button } from '@/ds/components/Button';
 import { EntityHeader } from '@/ds/components/EntityHeader';
-import { Icon } from '@/ds/icons/Icon';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/ds/components/Tooltip';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
+import { Icon } from '@/ds/icons/Icon';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { useLinkComponent } from '@/lib/framework';
 

--- a/packages/playground-ui/src/domains/agents/components/agent-entity-header.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-entity-header.tsx
@@ -1,10 +1,14 @@
-import { CopyIcon, Link2, Check } from 'lucide-react';
+import { CopyIcon, Link2, Check, Pencil } from 'lucide-react';
 import { useAgent } from '../hooks/use-agent';
+import { useCanCreateAgent } from '../hooks/use-can-create-agent';
 import { Badge } from '@/ds/components/Badge';
+import { Button } from '@/ds/components/Button';
 import { EntityHeader } from '@/ds/components/EntityHeader';
+import { Icon } from '@/ds/icons/Icon';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/ds/components/Tooltip';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
+import { useLinkComponent } from '@/lib/framework';
 
 export interface AgentEntityHeaderProps {
   agentId: string;
@@ -13,17 +17,29 @@ export interface AgentEntityHeaderProps {
 export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
   const { data: agent, isLoading } = useAgent(agentId);
   const { handleCopy } = useCopyToClipboard({ text: agentId });
+  const { canCreateAgent } = useCanCreateAgent();
+  const { Link: FrameworkLink, paths } = useLinkComponent();
   const sessionUrl = `${window.location.origin}/agents/${agentId}/session`;
   const { handleCopy: handleShareLink, isCopied: isShareCopied } = useCopyToClipboard({
     text: sessionUrl,
     copyMessage: 'Session URL copied to clipboard!',
   });
   const agentName = agent?.name || '';
+  const isStoredAgent = agent?.source === 'stored';
+  const showEditButton = canCreateAgent && isStoredAgent;
 
   return (
     <TooltipProvider>
       <EntityHeader icon={<AgentIcon />} title={agentName} isLoading={isLoading}>
         <div className="flex flex-wrap items-center gap-x-2 gap-y-3">
+          {showEditButton && (
+            <Button variant="outline" size="sm" as={FrameworkLink} to={paths.cmsAgentEditLink(agentId)}>
+              <Icon size="sm">
+                <Pencil />
+              </Icon>
+              Edit
+            </Button>
+          )}
           <Tooltip>
             <TooltipTrigger asChild>
               <button onClick={handleCopy} className="h-badge-default shrink-0">

--- a/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
@@ -3,6 +3,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { BookOpen, Plus } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
+import { useCanCreateAgent } from '../../hooks/use-can-create-agent';
 import { getColumns } from './columns';
 import type { AgentTableData } from './types';
 import { Button } from '@/ds/components/Button';
@@ -18,7 +19,6 @@ import { Icon } from '@/ds/icons/Icon';
 
 import { useLinkComponent } from '@/lib/framework';
 import { is403ForbiddenError } from '@/lib/query-utils';
-import { useCanCreateAgent } from '../../hooks/use-can-create-agent';
 
 export interface AgentsTableProps {
   agents: Record<string, GetAgentResponse>;
@@ -145,7 +145,11 @@ const EmptyAgentsTable = () => {
       <EmptyState
         iconSlot={<AgentCoinIcon />}
         titleSlot="No Agents Yet"
-        descriptionSlot={canCreateAgent ? 'Create your first agent or configure agents in code.' : 'Configure agents in code to get started.'}
+        descriptionSlot={
+          canCreateAgent
+            ? 'Create your first agent or configure agents in code.'
+            : 'Configure agents in code to get started.'
+        }
         actionSlot={
           <div className="flex flex-col sm:flex-row gap-2">
             {canCreateAgent && (

--- a/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
@@ -1,7 +1,7 @@
 import type { GetAgentResponse } from '@mastra/client-js';
 import type { ColumnDef } from '@tanstack/react-table';
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
-import { BookOpen } from 'lucide-react';
+import { BookOpen, Plus } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
 import { getColumns } from './columns';
 import type { AgentTableData } from './types';
@@ -18,6 +18,7 @@ import { Icon } from '@/ds/icons/Icon';
 
 import { useLinkComponent } from '@/lib/framework';
 import { is403ForbiddenError } from '@/lib/query-utils';
+import { useCanCreateAgent } from '../../hooks/use-can-create-agent';
 
 export interface AgentsTableProps {
   agents: Record<string, GetAgentResponse>;
@@ -135,29 +136,42 @@ const AgentsTableSkeleton = () => (
   </Table>
 );
 
-const EmptyAgentsTable = () => (
-  <div className="flex h-full items-center justify-center">
-    <EmptyState
-      iconSlot={<AgentCoinIcon />}
-      titleSlot="No Agents Yet"
-      descriptionSlot="Configure agents in code to get started."
-      actionSlot={
-        <div className="flex flex-col sm:flex-row gap-2">
-          <Button
-            size="lg"
-            variant="outline"
-            as="a"
-            href="https://mastra.ai/docs/agents/overview"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Icon>
-              <BookOpen />
-            </Icon>
-            Documentation
-          </Button>
-        </div>
-      }
-    />
-  </div>
-);
+const EmptyAgentsTable = () => {
+  const { canCreateAgent } = useCanCreateAgent();
+  const { Link: FrameworkLink, paths } = useLinkComponent();
+
+  return (
+    <div className="flex h-full items-center justify-center">
+      <EmptyState
+        iconSlot={<AgentCoinIcon />}
+        titleSlot="No Agents Yet"
+        descriptionSlot={canCreateAgent ? 'Create your first agent or configure agents in code.' : 'Configure agents in code to get started.'}
+        actionSlot={
+          <div className="flex flex-col sm:flex-row gap-2">
+            {canCreateAgent && (
+              <Button size="lg" variant="primary" as={FrameworkLink} to={paths.cmsAgentCreateLink()}>
+                <Icon>
+                  <Plus />
+                </Icon>
+                Create an agent
+              </Button>
+            )}
+            <Button
+              size="lg"
+              variant="outline"
+              as="a"
+              href="https://mastra.ai/docs/agents/overview"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Icon>
+                <BookOpen />
+              </Icon>
+              Documentation
+            </Button>
+          </div>
+        }
+      />
+    </div>
+  );
+};

--- a/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
@@ -139,6 +139,8 @@ const AgentsTableSkeleton = () => (
 const EmptyAgentsTable = () => {
   const { canCreateAgent } = useCanCreateAgent();
   const { Link: FrameworkLink, paths } = useLinkComponent();
+  const createAgentPath = paths.cmsAgentCreateLink();
+  const showCreateCta = canCreateAgent && Boolean(createAgentPath);
 
   return (
     <div className="flex h-full items-center justify-center">
@@ -146,14 +148,14 @@ const EmptyAgentsTable = () => {
         iconSlot={<AgentCoinIcon />}
         titleSlot="No Agents Yet"
         descriptionSlot={
-          canCreateAgent
+          showCreateCta
             ? 'Create your first agent or configure agents in code.'
             : 'Configure agents in code to get started.'
         }
         actionSlot={
           <div className="flex flex-col sm:flex-row gap-2">
-            {canCreateAgent && (
-              <Button size="lg" variant="primary" as={FrameworkLink} to={paths.cmsAgentCreateLink()}>
+            {showCreateCta && (
+              <Button size="lg" variant="primary" as={FrameworkLink} to={createAgentPath}>
                 <Icon>
                   <Plus />
                 </Icon>

--- a/packages/playground-ui/src/domains/agents/hooks/use-can-create-agent.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-can-create-agent.ts
@@ -1,0 +1,7 @@
+export const useCanCreateAgent = () => {
+  const canCreateAgent =
+    typeof window !== 'undefined' &&
+    (window as unknown as Record<string, unknown>).MASTRA_EXPERIMENTAL_UI === 'true';
+
+  return { canCreateAgent };
+};

--- a/packages/playground-ui/src/domains/agents/hooks/use-can-create-agent.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-can-create-agent.ts
@@ -1,7 +1,6 @@
 export const useCanCreateAgent = () => {
   const canCreateAgent =
-    typeof window !== 'undefined' &&
-    (window as unknown as Record<string, unknown>).MASTRA_EXPERIMENTAL_UI === 'true';
+    typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).MASTRA_EXPERIMENTAL_UI === 'true';
 
   return { canCreateAgent };
 };

--- a/packages/playground-ui/src/domains/agents/index.tsx
+++ b/packages/playground-ui/src/domains/agents/index.tsx
@@ -38,5 +38,6 @@ export * from './components/agent-playground';
 export * from './components/agent-page-tabs';
 export * from './components/agent-top-bar-controls';
 export * from './hooks/use-agent-experiments';
+export * from './hooks/use-can-create-agent';
 export * from './components/agent-traces-panel';
 export * from './components/agent-list/agents-list';

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -29,6 +29,8 @@ function Agents() {
   const [search, setSearch] = useState('');
   const { canCreateAgent } = useCanCreateAgent();
   const { Link: FrameworkLink, paths } = useLinkComponent();
+  const createAgentPath = paths.cmsAgentCreateLink();
+  const showCreateCta = canCreateAgent && Boolean(createAgentPath);
 
   if (variant === 'new-proposal') {
     return (
@@ -41,8 +43,8 @@ function Agents() {
               </MainHeader.Title>
             </MainHeader.Column>
             <MainHeader.Column className="flex justify-end gap-2">
-              {canCreateAgent && (
-                <ButtonWithTooltip as={FrameworkLink} to={paths.cmsAgentCreateLink()} tooltipContent="Create an agent">
+              {showCreateCta && (
+                <ButtonWithTooltip as={FrameworkLink} to={createAgentPath} tooltipContent="Create an agent">
                   <Plus />
                 </ButtonWithTooltip>
               )}
@@ -78,8 +80,8 @@ function Agents() {
         </HeaderTitle>
 
         <HeaderAction>
-          {canCreateAgent && (
-            <Button variant="light" as={FrameworkLink} to={paths.cmsAgentCreateLink()}>
+          {showCreateCta && (
+            <Button variant="light" as={FrameworkLink} to={createAgentPath}>
               <Icon>
                 <Plus />
               </Icon>

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -15,16 +15,20 @@ import {
   ListSearch,
   MainHeader,
   EntityListPageLayout,
+  useCanCreateAgent,
+  useLinkComponent,
 } from '@mastra/playground-ui';
-import { useExperimentalUI } from '@/domains/experimental-ui/experimental-ui-context';
-import { BookIcon } from 'lucide-react';
+import { BookIcon, Plus } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';
+import { useExperimentalUI } from '@/domains/experimental-ui/experimental-ui-context';
 
 function Agents() {
   const { data: agents = {}, isLoading, error } = useAgents();
   const { variant } = useExperimentalUI('entity-list-page');
   const [search, setSearch] = useState('');
+  const { canCreateAgent } = useCanCreateAgent();
+  const { Link: FrameworkLink, paths } = useLinkComponent();
 
   if (variant === 'new-proposal') {
     return (
@@ -37,6 +41,11 @@ function Agents() {
               </MainHeader.Title>
             </MainHeader.Column>
             <MainHeader.Column className="flex justify-end gap-2">
+              {canCreateAgent && (
+                <ButtonWithTooltip as={FrameworkLink} to={paths.cmsAgentCreateLink()} tooltipContent="Create an agent">
+                  <Plus />
+                </ButtonWithTooltip>
+              )}
               <ButtonWithTooltip
                 as="a"
                 href="https://mastra.ai/en/docs/agents/overview"
@@ -69,6 +78,14 @@ function Agents() {
         </HeaderTitle>
 
         <HeaderAction>
+          {canCreateAgent && (
+            <Button variant="light" as={FrameworkLink} to={paths.cmsAgentCreateLink()}>
+              <Icon>
+                <Plus />
+              </Icon>
+              Create an agent
+            </Button>
+          )}
           <Button variant="ghost" size="md" as={Link} to="https://mastra.ai/en/docs/agents/overview" target="_blank">
             <DocsIcon />
             Agents documentation


### PR DESCRIPTION
Re-adds the 'Create Agent' and 'Edit Agent' buttons to the playground, gated behind the `MASTRA_EXPERIMENTAL_UI` environment variable.

When `MASTRA_EXPERIMENTAL_UI=true`:
- A 'Create Agent' button appears on the agents list page (both UI variants) and in the empty agents table state
- An 'Edit' button appears on the agent detail header for stored agents

Uses a new `useCanCreateAgent` hook in `playground-ui` that reads `window.MASTRA_EXPERIMENTAL_UI`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Create Agent" button added to the agents list page for quick agent creation.
  * "Edit" button added to agent detail headers for stored agents.
  * Both controls are only shown when the experimental UI flag is active, preserving the current experience for other users.
  * Empty-state and header areas updated to surface the new CTAs where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->