### PR TITLE
Update MetricsCard to let a user customize the <h> element level 

### DIFF
--- a/.changeset/cuddly-bats-camp.md
+++ b/.changeset/cuddly-bats-camp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added `as` prop to `MetricsCardTitle` and `titleAs` prop to `MetricsCardTitleAndDescription` to customize the heading level (h2, h3, h4). Defaults to h2.

--- a/packages/playground-ui/src/ds/components/MetricsCard/metrics-card-title-and-description.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsCard/metrics-card-title-and-description.tsx
@@ -6,6 +6,7 @@ import { MetricsCardTitle } from './metrics-card-title';
 type PropsWithTitleDescription = {
   title: string;
   description?: string;
+  titleAs?: 'h2' | 'h3' | 'h4';
   children?: never;
   className?: string;
 };
@@ -22,11 +23,11 @@ export function MetricsCardTitleAndDescription(props: PropsWithTitleDescription 
     return <div className={props.className}>{props.children}</div>;
   }
 
-  const { title, description } = props;
+  const { title, description, titleAs } = props;
 
   return (
     <div className={props.className}>
-      <MetricsCardTitle>{title}</MetricsCardTitle>
+      <MetricsCardTitle as={titleAs}>{title}</MetricsCardTitle>
       {description && <MetricsCardDescription>{description}</MetricsCardDescription>}
     </div>
   );

--- a/packages/playground-ui/src/ds/components/MetricsCard/metrics-card-title.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsCard/metrics-card-title.tsx
@@ -1,5 +1,13 @@
 import { cn } from '@/lib/utils';
 
-export function MetricsCardTitle({ children, className }: { children: string; className?: string }) {
-  return <h3 className={cn('text-ui-md font-normal text-neutral4', className)}>{children}</h3>;
+export function MetricsCardTitle({
+  children,
+  className,
+  as: Tag = 'h2',
+}: {
+  children: string;
+  className?: string;
+  as?: 'h2' | 'h3' | 'h4';
+}) {
+  return <Tag className={cn('text-ui-md font-normal text-neutral4', className)}>{children}</Tag>;
 }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics cards now support flexible heading level customization (h2, h3, h4) with h2 as the default, enabling improved semantic HTML structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->