### PR TITLE
feat(memory): allow disabling filterIncompleteToolCalls for suspended tool call visibility

### DIFF
--- a/.changeset/soft-pets-battle.md
+++ b/.changeset/soft-pets-battle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added `filterIncompleteToolCalls` option to memory config. When set to `false`, suspended tool calls remain visible in the agent's prompt context, allowing the agent to see its own pending interactions in thread history. Defaults to `true` (current behavior). Useful for suspend/resume patterns with providers that support incomplete tool calls (e.g. Anthropic).

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -633,7 +633,7 @@ const response = await agent.generate('Help me organize my day', {
                     type: 'MemoryConfig',
                     isOptional: true,
                     description:
-                      'Additional memory configuration options including lastMessages, readOnly, semanticRecall, and workingMemory.',
+                      'Additional memory configuration options including lastMessages, readOnly, semanticRecall, workingMemory, and filterIncompleteToolCalls.',
                   },
                 ],
               },

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -509,7 +509,7 @@ const stream = await agent.stream('message for agent')
                     type: 'MemoryConfig',
                     isOptional: true,
                     description:
-                      'Configuration for memory behavior including lastMessages, readOnly, semanticRecall, and workingMemory.',
+                      'Configuration for memory behavior including lastMessages, readOnly, semanticRecall, workingMemory, and filterIncompleteToolCalls.',
                   },
                 ],
               },

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -80,6 +80,7 @@ export class MessageList {
 
   private generateMessageId?: (context?: IdGeneratorContext) => string;
   private _agentNetworkAppend = false;
+  private filterIncompleteToolCalls: boolean;
   private logger?: IMastraLogger;
 
   // Event recording for observability
@@ -99,6 +100,7 @@ export class MessageList {
     resourceId,
     generateMessageId,
     logger,
+    filterIncompleteToolCalls,
     // @ts-expect-error Flag for agent network messages
     _agentNetworkAppend,
   }: {
@@ -106,12 +108,14 @@ export class MessageList {
     resourceId?: string;
     generateMessageId?: (context?: IdGeneratorContext) => string;
     logger?: IMastraLogger;
+    filterIncompleteToolCalls?: boolean;
   } = {}) {
     if (threadId) {
       this.memoryInfo = { threadId, resourceId };
     }
     this.generateMessageId = generateMessageId;
     this.logger = logger;
+    this.filterIncompleteToolCalls = filterIncompleteToolCalls ?? true;
     this._agentNetworkAppend = _agentNetworkAppend || false;
   }
 
@@ -362,8 +366,11 @@ export class MessageList {
           this.createAdapterContext(),
           this.messages,
         );
-        // Filter incomplete tool calls when sending messages TO the LLM
-        const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true);
+        const modelMessages = convertAIV5UIToModelMessages(
+          this.all.aiV5.ui(),
+          this.messages,
+          this.filterIncompleteToolCalls,
+        );
 
         const messages = [...systemMessages, ...modelMessages];
 
@@ -381,8 +388,11 @@ export class MessageList {
           downloadRetries: 3,
         },
       ): Promise<LanguageModelV2Prompt> => {
-        // Filter incomplete tool calls when sending messages TO the LLM
-        const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true);
+        const modelMessages = convertAIV5UIToModelMessages(
+          this.all.aiV5.ui(),
+          this.messages,
+          this.filterIncompleteToolCalls,
+        );
 
         const storedModelOutputs = new Map<string, unknown>();
         for (const dbMsg of this.messages) {
@@ -419,7 +429,6 @@ export class MessageList {
             }
           }
         }
-
         const systemMessages = convertAIV4CoreToAIV5ModelMessages(
           [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat()],
           `system`,

--- a/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
@@ -71,6 +71,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
         resourceId,
         generateMessageId: capabilities.generateMessageId,
         logger: capabilities.logger,
+        filterIncompleteToolCalls: memoryConfig?.filterIncompleteToolCalls,
         // @ts-expect-error Flag for agent network messages
         _agentNetworkAppend: capabilities._agentNetworkAppend,
       });

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -942,6 +942,25 @@ type BaseMemoryConfig = {
       };
 
   /**
+   * Whether to filter out incomplete (suspended) tool calls when sending messages to the LLM.
+   * When true, tool calls in `input-available` state are stripped from the prompt,
+   * preventing the agent from seeing its own suspended tool calls in thread history.
+   *
+   * Set to false to allow the agent to see suspended tool calls in context.
+   * This is useful for suspend/resume patterns where the agent should be aware of pending interactions.
+   *
+   * Note: Some providers (e.g. OpenAI) may return errors when incomplete tool calls are included.
+   * Anthropic handles incomplete tool calls without issues.
+   *
+   * @default true
+   * @example
+   * ```typescript
+   * filterIncompleteToolCalls: false // Keep suspended tool calls visible in context
+   * ```
+   */
+  filterIncompleteToolCalls?: boolean;
+
+  /**
    * Thread management configuration.
    * @deprecated The `threads` object is deprecated. Use top-level `generateTitle` instead of `threads.generateTitle`.
    */


### PR DESCRIPTION
## Description

  <!-- Provide a brief description of the changes in this PR -->
Added `filterIncompleteToolCalls` option to `BaseMemoryConfig` that controls whether suspended tool calls (`input-available` state) are stripped from the agent's prompt context.

When using the suspend/resume pattern, suspended tool calls are stored in thread memory. Since #9749, these are always filtered out when building the prompt for a new `agent.stream()` or `agent.generate()` call to avoid OpenAI Responses API errors. This means the agent cannot see its own suspended tool calls in thread history during follow-up messages.

Setting `filterIncompleteToolCalls: false` keeps suspended tool calls visible in context. Defaults to `true` (current behavior, safe for all providers). Providers like Anthropic handle incomplete tool calls without issues, while OpenAI requires them to be filtered.

  ## Related Issue(s)

  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

  Fixes #14361

  ## Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: This change adds a switch that lets agents either hide or keep in-progress (suspended) tool calls visible in their conversation history; by default they remain hidden to preserve current provider compatibility, but you can turn visibility on for suspend/resume flows.

Summary
- New feature: Adds an optional BaseMemoryConfig property filterIncompleteToolCalls?: boolean (default: true).
- Behavior: When true (default) suspended/incomplete tool calls (e.g., state "input-available") are filtered out of prompts; when false they remain visible in the agent's prompt/context so agents can see their own suspended tool calls.
- Motivation: Makes the filtering behavior configurable so providers that tolerate incomplete tool calls (e.g., Anthropic) can keep them visible while providers requiring filtering (e.g., OpenAI) keep the existing behavior.
- Docs: Updated Agent.generate() and Agent.stream() memory.options docs; added changeset describing the option.
- Code changes:
  - packages/core/src/memory/types.ts: added filterIncompleteToolCalls?: boolean to BaseMemoryConfig (default documented true).
  - packages/core/src/agent/message-list/message-list.ts: MessageList now accepts and stores filterIncompleteToolCalls and forwards it into message-to-model conversions.
  - packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts: passes memoryConfig?.filterIncompleteToolCalls into MessageList.
  - packages/core/src/agent/message-list/conversion/output-converter.ts: conversion/sanitization respects filterIncompleteToolCalls.
- Tests/Changelog: Tests updated for provider-executed/tool filtering behavior; CHANGELOG updated.
- Classification: new feature + documentation update.
- Related issue: addresses the need described in the linked issue about making incomplete tool-call filtering configurable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->