### PR TITLE
fix(memory): prevent OM rate-limit errors from blocking agent response

### DIFF
--- a/.changeset/om-rate-limit-graceful-degradation.md
+++ b/.changeset/om-rate-limit-graceful-degradation.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory errors (e.g. rate limits) blocking the entire agent response. Previously, if the OM model failed, the agent would abort with a tripwire — even if the main model was working fine. Now OM errors degrade gracefully: the agent continues without observations, a non-blocking warning is shown, and a circuit breaker temporarily disables OM after repeated failures to avoid spamming a broken API.

--- a/mastracode/src/tui/components/om-marker.ts
+++ b/mastracode/src/tui/components/om-marker.ts
@@ -105,6 +105,10 @@ function formatMarker(data: OMMarkerData): string {
     }
     case 'om_observation_failed': {
       const tokens = data.tokensAttempted ? ` (${formatTokens(data.tokensAttempted)} tokens)` : '';
+      // Non-blocking failures show as warnings — the agent continues without memory
+      if ((data as any).nonBlocking) {
+        return theme.fg('warning', `  ⚠ Memory temporarily unavailable: ${data.error}`);
+      }
       return theme.fg('error', `  ✗ ${label} failed${tokens}: ${data.error}`);
     }
     case 'om_buffering_start': {
@@ -126,7 +130,8 @@ function formatMarker(data: OMMarkerData): string {
       return theme.fg('success', `  ✓ Buffered ${label.toLowerCase()}: ${input} → ${output} tokens${ratio}`);
     }
     case 'om_buffering_failed': {
-      return theme.fg('error', `  ✗ Buffering ${label.toLowerCase()} failed: ${data.error}`);
+      // Buffering failures are always non-blocking (fire-and-forget) — show as warning
+      return theme.fg('warning', `  ⚠ Buffering ${label.toLowerCase()} skipped: ${data.error}`);
     }
     case 'om_activation': {
       const kind = data.operationType === 'reflection' ? 'reflection' : 'observations';

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -11834,7 +11834,7 @@ describe('Processor behavioral regressions', () => {
   // was replaced with message-level flag checking (metadata.mastra.sealed). Storage adapters
   // handle dedup via upserts (INSERT ON CONFLICT DO UPDATE).
 
-  it('should map threshold observation errors through abort instead of bubbling raw errors', async () => {
+  it('should gracefully degrade on threshold observation errors instead of aborting', async () => {
     const { MessageList } = await import('@mastra/core/agent');
     const { RequestContext } = await import('@mastra/core/di');
 
@@ -11906,27 +11906,27 @@ describe('Processor behavioral regressions', () => {
       throw new Error(`abort-called:${message}`);
     }) as any;
 
-    try {
-      await processor.processInputStep({
-        messageList,
-        messages: [],
-        requestContext: ctx,
-        stepNumber: 1,
-        state,
-        steps: [],
-        systemMessages: [],
-        model: mockModel as any,
-        retryCount: 0,
-        abort,
-      });
-      throw new Error('expected abort to throw');
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      expect(msg).toContain('abort-called:');
-      expect(abortCalled).toBe(true);
-    } finally {
-      engine.observe = originalObserve;
-    }
+    // With graceful degradation, observation errors no longer trigger abort.
+    // The processor returns the messageList as-is, without observations.
+    const result = await processor.processInputStep({
+      messageList,
+      messages: [],
+      requestContext: ctx,
+      stepNumber: 1,
+      state,
+      steps: [],
+      systemMessages: [],
+      model: mockModel as any,
+      retryCount: 0,
+      abort,
+    });
+
+    // abort should NOT be called — errors are handled gracefully
+    expect(abortCalled).toBe(false);
+    // messageList is returned as-is
+    expect(result).toBe(messageList);
+
+    engine.observe = originalObserve;
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/om-error-and-persistence.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/om-error-and-persistence.test.ts
@@ -337,12 +337,9 @@ describe('OM Error State', { timeout: 30_000 }, () => {
     });
   });
 
-  // TODO: The OM refactor regressed this error-path behavior. Re-enable in a follow-up PR.
-  it.skip('should return empty text when observer fails', async () => {
-    // When observation fails, OM calls abort() which triggers a TripWire.
-    // The agent architecture converts TripWire to a successful result with empty text,
-    // not a thrown error. This is by design - the tripwire mechanism returns early
-    // with empty text rather than propagating the error.
+  it('should gracefully degrade when observer fails — agent still returns response', async () => {
+    // When observation fails, OM degrades gracefully — the agent continues
+    // without observations rather than aborting with a tripwire.
     const result = await agent.generate('Hello, I need help.', {
       memory: {
         thread: 'test-error-thread',
@@ -350,16 +347,15 @@ describe('OM Error State', { timeout: 30_000 }, () => {
       },
     });
 
-    // Agent returns empty text when tripwire is triggered (observation failure)
-    expect(result.text).toBe('');
-    expect(result.tripwire).toBeDefined();
-    expect(result.tripwire?.reason).toContain('Encountered error during memory observation');
+    // Agent returns a normal response — OM failure doesn't block it
+    expect(result.text).toBeTruthy();
+    // No tripwire — the agent continues normally
+    expect(result.tripwire).toBeUndefined();
   });
 
-  // TODO: The OM refactor regressed this error-path behavior. Re-enable in a follow-up PR.
-  it.skip('should emit tripwire in response when observer fails during streaming', async () => {
-    // When observation fails, OM calls abort() which triggers a TripWire.
-    // The stream completes with a tripwire part, not an error throw.
+  it('should gracefully degrade when observer fails during streaming', async () => {
+    // When observation fails, OM degrades gracefully — the stream continues
+    // without observations rather than emitting a tripwire.
     const response = await agent.stream('Hello, I need help.', {
       memory: {
         thread: 'test-error-stream',
@@ -367,76 +363,29 @@ describe('OM Error State', { timeout: 30_000 }, () => {
       },
     });
 
-    const reader = response.fullStream.getReader();
-    let tripwireEmitted = false;
     let textContent = '';
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        if (value.type === 'tripwire') {
-          tripwireEmitted = true;
-          expect(value.payload?.reason).toBeDefined();
-          expect(value.payload?.reason).toContain('Encountered error during memory observation');
-        }
-        if (value.type === 'text-delta') {
-          textContent += (value as any).delta || (value.payload as any)?.delta || '';
-        }
-      }
-    } finally {
-      reader.releaseLock();
+    for await (const chunk of response.textStream) {
+      textContent += chunk;
     }
 
-    // Tripwire should be emitted in the stream
-    expect(tripwireEmitted).toBe(true);
-    // Text content should be empty when tripwire is triggered
-    expect(textContent).toBe('');
+    // Agent streams normally — OM failure doesn't block it
+    expect(textContent).toBeTruthy();
   });
 
-  // TODO: The OM refactor regressed this error-path behavior. Re-enable in a follow-up PR.
-  it.skip('should emit tripwire when observer fails and no observation marker parts are persisted', async () => {
-    // When observation fails, OM calls abort() which triggers a TripWire.
-    // The stream completes with a tripwire part, not an error throw.
-    const threadId = 'test-error-persist';
-    const resourceId = 'test-resource';
-
+  it('should complete streaming successfully when observer fails', async () => {
     const response = await agent.stream('Hello, I need help with something important.', {
       memory: {
-        thread: threadId,
-        resource: resourceId,
+        thread: 'test-error-persist',
+        resource: 'test-resource',
       },
     });
 
-    const reader = response.fullStream.getReader();
-    let tripwireEmitted = false;
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        if (value.type === 'tripwire') {
-          tripwireEmitted = true;
-        }
-      }
-    } finally {
-      reader.releaseLock();
+    let textContent = '';
+    for await (const chunk of response.textStream) {
+      textContent += chunk;
     }
 
-    // Tripwire should be emitted (not an error thrown)
-    expect(tripwireEmitted).toBe(true);
-
-    const memoryStore = await store.getStore('memory');
-    const result = await memoryStore!.listMessages({ threadId });
-    const persistedObservationMarkerParts = result.messages.flatMap((message: any) => {
-      const parts = message.content?.parts || [];
-      return parts.filter(
-        (part: any) => typeof part.type === 'string' && /^data-om-(observation|reflection)-/.test(part.type),
-      );
-    });
-
-    expect(persistedObservationMarkerParts).toHaveLength(0);
+    expect(textContent).toBeTruthy();
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/om-rate-limit-graceful-degradation.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/om-rate-limit-graceful-degradation.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests that a rate-limited OM model does not block the main agent response.
+ *
+ * When the observational memory model fails (e.g. rate limit from the provider),
+ * the agent should continue normally without observations rather than aborting
+ * the entire response.
+ */
+
+import { Agent } from '@mastra/core/agent';
+import { InMemoryStore } from '@mastra/core/storage';
+import { createTool } from '@mastra/core/tools';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { z } from 'zod';
+
+import { Memory } from '../../../..';
+
+// =============================================================================
+// Mock Models
+// =============================================================================
+
+type StreamPart =
+  | { type: 'stream-start'; warnings: unknown[] }
+  | { type: 'response-metadata'; id: string; modelId: string; timestamp: Date }
+  | { type: 'text-start'; id: string }
+  | { type: 'text-delta'; id?: string; delta: string }
+  | { type: 'text-end'; id: string }
+  | { type: 'tool-call'; toolCallId: string; toolName: string; input: string }
+  | {
+      type: 'finish';
+      finishReason: 'stop' | 'tool-calls';
+      usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+    };
+
+/** Main agent model that works fine — uses tool call first to generate multi-step interaction */
+function createWorkingAgentModel(responseText: string) {
+  let callCount = 0;
+
+  return {
+    specificationVersion: 'v2' as const,
+    provider: 'mock-main',
+    modelId: 'mock-main-model',
+    defaultObjectGenerationMode: undefined,
+    supportsImageUrls: false,
+    supportedUrls: {},
+
+    async doGenerate() {
+      const firstCall = callCount === 0;
+      callCount++;
+
+      if (firstCall) {
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'tool-calls' as const,
+          usage: { inputTokens: 50, outputTokens: 20, totalTokens: 70 },
+          content: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: `call-${Date.now()}`,
+              toolName: 'test',
+              input: JSON.stringify({ action: 'trigger' }),
+            },
+          ],
+          warnings: [],
+        };
+      }
+
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+        content: [{ type: 'text' as const, text: responseText }],
+        warnings: [],
+      };
+    },
+
+    async doStream() {
+      const firstCall = callCount === 0;
+      callCount++;
+
+      const parts: StreamPart[] = firstCall
+        ? [
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-main-model', timestamp: new Date() },
+            {
+              type: 'tool-call',
+              toolCallId: `call-${Date.now()}`,
+              toolName: 'test',
+              input: JSON.stringify({ action: 'trigger' }),
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 50, outputTokens: 20, totalTokens: 70 },
+            },
+          ]
+        : [
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-1', modelId: 'mock-main-model', timestamp: new Date() },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: responseText },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+            },
+          ];
+
+      const stream = new ReadableStream<StreamPart>({
+        async start(controller) {
+          for (const part of parts) {
+            controller.enqueue(part);
+            await new Promise(resolve => setTimeout(resolve, 2));
+          }
+          controller.close();
+        },
+      });
+
+      return {
+        stream,
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    },
+  };
+}
+
+/**
+ * OM observer model that throws a rate-limit error.
+ * Simulates what happens when the provider (e.g. Anthropic) rate-limits
+ * the OM model while the main agent model has been switched to a different provider.
+ */
+function createRateLimitedObserverModel() {
+  return {
+    specificationVersion: 'v2' as const,
+    provider: 'mock-rate-limited',
+    modelId: 'mock-rate-limited-observer',
+    defaultObjectGenerationMode: undefined,
+    supportsImageUrls: false,
+    supportedUrls: {},
+
+    async doGenerate() {
+      throw new Error("This request would exceed your account's rate limit. Please try again later.");
+    },
+
+    async doStream() {
+      throw new Error("This request would exceed your account's rate limit. Please try again later.");
+    },
+  };
+}
+
+/** OM reflector model (working) */
+function createWorkingReflectorModel() {
+  return {
+    specificationVersion: 'v2' as const,
+    provider: 'mock-reflector',
+    modelId: 'mock-reflector-model',
+    defaultObjectGenerationMode: undefined,
+    supportsImageUrls: false,
+    supportedUrls: {},
+
+    async doGenerate() {
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+        content: [
+          {
+            type: 'text' as const,
+            text: `<observations>\n## Condensed\n- User needs help\n</observations>`,
+          },
+        ],
+        warnings: [],
+      };
+    },
+
+    async doStream() {
+      const text = `<observations>\n## Condensed\n- User needs help\n</observations>`;
+      const stream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue({ type: 'stream-start', warnings: [] });
+          controller.enqueue({
+            type: 'response-metadata',
+            id: 'ref-1',
+            modelId: 'mock-reflector-model',
+            timestamp: new Date(),
+          });
+          controller.enqueue({ type: 'text-start', id: 'text-1' });
+          controller.enqueue({ type: 'text-delta', id: 'text-1', delta: text });
+          controller.enqueue({ type: 'text-end', id: 'text-1' });
+          controller.enqueue({
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+          });
+          controller.close();
+        },
+      });
+
+      return {
+        stream,
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    },
+  };
+}
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+const dummyTool = createTool({
+  id: 'test',
+  description: 'Trigger tool for OM testing',
+  inputSchema: z.object({
+    action: z.string().optional(),
+  }),
+  execute: async () => {
+    return { success: true, message: 'Tool executed' };
+  },
+});
+
+const longResponseText =
+  'I understand your request completely. Let me provide you with a comprehensive and detailed response ' +
+  'that covers all the important aspects of what you asked about. Here are my thoughts and recommendations ' +
+  'based on the information you provided. I hope this detailed explanation helps clarify everything you need ' +
+  'to know about the topic at hand. Please let me know if you have any follow-up questions or need additional ' +
+  'clarification on any of these points.';
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Rate-limited OM model should not block agent response', { timeout: 30_000 }, () => {
+  let store: InMemoryStore;
+
+  beforeEach(() => {
+    store = new InMemoryStore();
+  });
+
+  it('should return agent response even when OM model is rate-limited (generate)', async () => {
+    const memory = new Memory({
+      storage: store,
+      options: {
+        observationalMemory: {
+          enabled: true,
+          observation: {
+            model: createRateLimitedObserverModel() as any,
+            messageTokens: 20,
+            bufferTokens: false,
+          },
+          reflection: {
+            model: createWorkingReflectorModel() as any,
+            observationTokens: 50000,
+          },
+        },
+      },
+    });
+
+    const threadId = 'test-rate-limit-thread';
+    const resource = 'test-resource';
+
+    // Seed conversation history
+    const seedAgent = new Agent({
+      id: 'test-om-ratelimit-seed',
+      name: 'Seed Agent',
+      instructions: 'You are a helpful assistant. Always use the test tool first.',
+      model: createWorkingAgentModel(longResponseText) as any,
+      tools: { test: dummyTool },
+      memory,
+    });
+    await seedAgent.generate('Hello, I need help with something important. ' + longResponseText, {
+      memory: { thread: threadId, resource },
+    });
+
+    // Second call with fresh agent — OM model will fail, but agent should succeed
+    const agent = new Agent({
+      id: 'test-om-ratelimit',
+      name: 'Test Agent',
+      instructions: 'You are a helpful assistant. Always use the test tool first.',
+      model: createWorkingAgentModel(longResponseText) as any,
+      tools: { test: dummyTool },
+      memory,
+    });
+
+    const result = await agent.generate('Can you tell me more? ' + longResponseText, {
+      memory: { thread: threadId, resource },
+    });
+
+    // The agent should succeed — OM failure degrades gracefully
+    // The response should contain text from the main model, NOT be killed by tripwire
+    expect(result.text).toBeTruthy();
+    expect(result.text).toContain('understand your request');
+    // No tripwire — the agent continues normally
+    expect(result.tripwire).toBeUndefined();
+  });
+
+  it('should stream agent response even when OM model is rate-limited', async () => {
+    const memory = new Memory({
+      storage: store,
+      options: {
+        observationalMemory: {
+          enabled: true,
+          observation: {
+            model: createRateLimitedObserverModel() as any,
+            messageTokens: 20,
+            bufferTokens: false,
+          },
+          reflection: {
+            model: createWorkingReflectorModel() as any,
+            observationTokens: 50000,
+          },
+        },
+      },
+    });
+
+    const threadId = 'test-rate-limit-stream';
+    const resource = 'test-resource';
+
+    // Seed conversation history
+    const seedAgent = new Agent({
+      id: 'test-om-ratelimit-seed-stream',
+      name: 'Seed Agent',
+      instructions: 'You are a helpful assistant. Always use the test tool first.',
+      model: createWorkingAgentModel(longResponseText) as any,
+      tools: { test: dummyTool },
+      memory,
+    });
+    await seedAgent.generate('Hello, I need help with something important. ' + longResponseText, {
+      memory: { thread: threadId, resource },
+    });
+
+    // Stream with fresh agent — OM fails, but stream should work
+    const streamAgent = new Agent({
+      id: 'test-om-ratelimit-stream',
+      name: 'Test Agent Stream',
+      instructions: 'You are a helpful assistant. Always use the test tool first.',
+      model: createWorkingAgentModel(longResponseText) as any,
+      tools: { test: dummyTool },
+      memory,
+    });
+
+    const response = await streamAgent.stream('Tell me about TypeScript. ' + longResponseText, {
+      memory: { thread: threadId, resource },
+    });
+
+    // Consume the text stream to get the full response
+    let textContent = '';
+    for await (const chunk of response.textStream) {
+      textContent += chunk;
+    }
+
+    // Agent response streams normally — OM failure is gracefully degraded
+    expect(textContent).toContain('understand your request');
+  });
+});

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -4,11 +4,54 @@ import type { Processor, ProcessInputStepArgs, ProcessOutputResultArgs } from '@
 import type { ObservationalMemoryRecord } from '@mastra/core/storage';
 
 import { OBSERVATION_CONTINUATION_HINT } from './constants';
-import { omDebug } from './debug';
+import { omDebug, omError } from './debug';
 import type { ObservationTurn } from './observation-turn/index';
 import type { ObservationalMemory } from './observational-memory';
 import { isOmReproCaptureEnabled, safeCaptureJson, writeProcessInputStepReproCapture } from './repro-capture';
 import type { TokenCounterModelContext } from './token-counter';
+
+// ── Circuit breaker for OM observation failures ──────────────────────────────
+// After consecutive failures (e.g. rate limits), temporarily skip OM to avoid
+// spamming a broken API and blocking the user experience.
+const OM_CIRCUIT_BREAKER_THRESHOLD = 3; // failures before opening the circuit
+const OM_CIRCUIT_BREAKER_COOLDOWN_MS = 60_000; // 60 seconds cooldown
+
+class ObservationCircuitBreaker {
+  private consecutiveFailures = 0;
+  private openedAt: number | null = null;
+
+  /** Record a failure. Returns true if the circuit just opened. */
+  recordFailure(): boolean {
+    this.consecutiveFailures++;
+    if (this.consecutiveFailures >= OM_CIRCUIT_BREAKER_THRESHOLD && !this.openedAt) {
+      this.openedAt = Date.now();
+      return true;
+    }
+    return false;
+  }
+
+  /** Record a success — resets the breaker. */
+  recordSuccess(): void {
+    this.consecutiveFailures = 0;
+    this.openedAt = null;
+  }
+
+  /** Returns true if the circuit is open (should skip OM). */
+  isOpen(): boolean {
+    if (!this.openedAt) return false;
+    if (Date.now() - this.openedAt > OM_CIRCUIT_BREAKER_COOLDOWN_MS) {
+      // Cooldown expired — move to half-open (allow one attempt)
+      this.openedAt = null;
+      this.consecutiveFailures = OM_CIRCUIT_BREAKER_THRESHOLD - 1; // one more failure re-opens
+      return false;
+    }
+    return true;
+  }
+
+  get failures(): number {
+    return this.consecutiveFailures;
+  }
+}
 
 /** Subset of Memory that the processor needs — avoids circular imports. */
 export interface MemoryContextProvider {
@@ -48,6 +91,9 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
 
   /** Active turn — created on first processInputStep, ended on processOutputResult. */
   private turn?: ObservationTurn;
+
+  /** Circuit breaker to skip OM after consecutive failures. */
+  private circuitBreaker = new ObservationCircuitBreaker();
 
   constructor(engine: ObservationalMemory, memory: MemoryContextProvider) {
     this.engine = engine;
@@ -105,6 +151,14 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
         return messageList;
       }
 
+      // ── Circuit breaker: skip OM if it has been failing repeatedly ──
+      if (this.circuitBreaker.isOpen()) {
+        omDebug(
+          `[OM:processInputStep:CIRCUIT-OPEN] Skipping OM — circuit breaker open after ${this.circuitBreaker.failures} consecutive failures. Will retry after cooldown.`,
+        );
+        return messageList;
+      }
+
       // ── Create turn on first step (or when state is reset) ──
       // The turn is stashed in customState so that the output processor instance
       // (which is a separate ObservationalMemoryProcessor) can retrieve it in
@@ -137,16 +191,52 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
         try {
           ctx = await step.prepare();
         } catch (error) {
-          // Map observation errors through abort (processor-specific concern)
-          const err = error instanceof Error ? error : new Error(String(error));
-          const abortMessage = abortSignal?.aborted
-            ? 'Agent execution was aborted'
-            : `Encountered error during memory observation: ${err.message}`;
-          if (typeof abort === 'function') {
-            abort(abortMessage);
+          // If the agent was explicitly aborted, propagate as before.
+          if (abortSignal?.aborted) {
+            const err = error instanceof Error ? error : new Error(String(error));
+            if (typeof abort === 'function') {
+              abort('Agent execution was aborted');
+            }
+            throw err;
           }
-          throw err;
+
+          // For all other OM errors (rate limits, model failures, network issues):
+          // degrade gracefully — log the error, emit a warning via the stream
+          // writer, and let the agent continue without observations.
+          // This prevents a failing OM model from blocking the main agent response.
+          const err = error instanceof Error ? error : new Error(String(error));
+          omError(`[OM] Observation failed during step preparation, continuing without observations: ${err.message}`);
+
+          // Track failure in circuit breaker
+          const circuitJustOpened = this.circuitBreaker.recordFailure();
+
+          // Emit a non-blocking warning event so the UI can display it
+          if (writer) {
+            const warningMessage = circuitJustOpened
+              ? `${err.message} (memory temporarily disabled after ${this.circuitBreaker.failures} failures, will retry in ${OM_CIRCUIT_BREAKER_COOLDOWN_MS / 1000}s)`
+              : err.message;
+            void writer
+              .custom({
+                type: 'data-om-observation-failed',
+                data: {
+                  cycleId: `processor-error-${Date.now()}`,
+                  operationType: 'observation',
+                  startedAt: new Date().toISOString(),
+                  error: warningMessage,
+                  recordId: '',
+                  threadId,
+                  nonBlocking: true,
+                },
+              })
+              .catch(() => {});
+          }
+
+          // Return messageList as-is — the agent proceeds without OM context
+          return messageList;
         }
+
+        // OM step preparation succeeded — reset circuit breaker
+        this.circuitBreaker.recordSuccess();
 
         // Inject system messages (one per cache-stable chunk) + continuation
         if (ctx.systemMessage) {


### PR DESCRIPTION
## Description
When the observational memory model hits a rate limit, it triggered a tripwire that killed the entire agent response — even after switching to a different working main model. The app became completely unusable until the rate limit expired. This change catches OM errors gracefully so the agent continues without observations, shows a non-blocking warning in the UI,
and adds a circuit breaker to stop retrying after repeated failures.

  ## Related Issue(s)

  Fixes #14737

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observational memory failures (rate limits, API errors) no longer block agent responses.
  * Added circuit breaker mechanism to prevent repeated error spam by temporarily disabling memory operations after consecutive failures.
  * Non-blocking warnings displayed for memory unavailability instead of response-blocking errors.

* **Bug Fixes**
  * Agent execution no longer aborted by observational memory errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->