### PR TITLE
fix: harden OM repro capture serialization

### DIFF
--- a/.changeset/bright-emus-fail.md
+++ b/.changeset/bright-emus-fail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed OM repro capture so recordings keep writing usable artifacts even when live state contains circular values.

--- a/packages/memory/src/processors/observational-memory/repro-capture.ts
+++ b/packages/memory/src/processors/observational-memory/repro-capture.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { inspect } from 'node:util';
 import type { MastraDBMessage, MessageList } from '@mastra/core/agent';
 import { parseMemoryRequestContext } from '@mastra/core/memory';
 import type { ProcessInputStepArgs } from '@mastra/core/processors';
@@ -25,10 +26,154 @@ export function safeCaptureJson(value: unknown): unknown {
     JSON.stringify(value, (_key, current) => {
       if (typeof current === 'bigint') return current.toString();
       if (typeof current === 'function') return '[function]';
+      if (typeof current === 'symbol') return current.toString();
       if (current instanceof Error) return { name: current.name, message: current.message, stack: current.stack };
       if (current instanceof Set) return { __type: 'Set', values: Array.from(current.values()) };
       if (current instanceof Map) return { __type: 'Map', entries: Array.from(current.entries()) };
       return current;
+    }),
+  );
+}
+
+function safeCaptureJsonOrError(value: unknown): { ok: true; value: unknown } | { ok: false; error: unknown } {
+  try {
+    return { ok: true, value: safeCaptureJson(value) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: safeCaptureJson({
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        inspected: inspect(value, { depth: 3, maxArrayLength: 20, breakLength: 120 }),
+      }),
+    };
+  }
+}
+
+function formatCaptureDate(value: unknown): string | undefined {
+  if (!value) return undefined;
+  if (value instanceof Date) return value.toISOString();
+
+  try {
+    return new Date(value as string | number | Date).toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
+function summarizeOmTurn(value: unknown): unknown {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const turn = value as {
+    threadId?: string;
+    resourceId?: string;
+    _started?: boolean;
+    _ended?: boolean;
+    _generationCountAtStart?: number;
+    _record?: {
+      id?: string;
+      scope?: string;
+      threadId?: string;
+      resourceId?: string;
+      createdAt?: unknown;
+      updatedAt?: unknown;
+      lastObservedAt?: unknown;
+      generationCount?: number;
+      observationTokenCount?: number;
+      pendingMessageTokens?: number;
+      isBufferingObservation?: boolean;
+      isBufferingReflection?: boolean;
+    };
+    _context?: {
+      messages?: unknown[];
+      systemMessage?: unknown;
+      continuation?: { id?: string };
+      otherThreadsContext?: unknown;
+      record?: { id?: string };
+    };
+    _currentStep?: {
+      stepNumber?: number;
+      _prepared?: boolean;
+      _context?: {
+        activated?: boolean;
+        observed?: boolean;
+        buffered?: boolean;
+        reflected?: boolean;
+        didThresholdCleanup?: boolean;
+        messages?: unknown[];
+        systemMessage?: unknown[];
+      };
+    };
+  };
+
+  return {
+    __type: 'ObservationTurn',
+    threadId: turn.threadId,
+    resourceId: turn.resourceId,
+    started: turn._started,
+    ended: turn._ended,
+    generationCountAtStart: turn._generationCountAtStart,
+    record: turn._record
+      ? {
+          id: turn._record.id,
+          scope: turn._record.scope,
+          threadId: turn._record.threadId,
+          resourceId: turn._record.resourceId,
+          createdAt: formatCaptureDate(turn._record.createdAt),
+          updatedAt: formatCaptureDate(turn._record.updatedAt),
+          lastObservedAt: formatCaptureDate(turn._record.lastObservedAt),
+          generationCount: turn._record.generationCount,
+          observationTokenCount: turn._record.observationTokenCount,
+          pendingMessageTokens: turn._record.pendingMessageTokens,
+          isBufferingObservation: turn._record.isBufferingObservation,
+          isBufferingReflection: turn._record.isBufferingReflection,
+        }
+      : undefined,
+    context: turn._context
+      ? {
+          messageCount: Array.isArray(turn._context.messages) ? turn._context.messages.length : undefined,
+          hasSystemMessage: Array.isArray(turn._context.systemMessage)
+            ? turn._context.systemMessage.length > 0
+            : Boolean(turn._context.systemMessage),
+          continuationId: turn._context.continuation?.id,
+          hasOtherThreadsContext: Boolean(turn._context.otherThreadsContext),
+          recordId: turn._context.record?.id,
+        }
+      : undefined,
+    currentStep: turn._currentStep
+      ? {
+          stepNumber: turn._currentStep.stepNumber,
+          prepared: turn._currentStep._prepared,
+          context: turn._currentStep._context
+            ? {
+                activated: turn._currentStep._context.activated,
+                observed: turn._currentStep._context.observed,
+                buffered: turn._currentStep._context.buffered,
+                reflected: turn._currentStep._context.reflected,
+                didThresholdCleanup: turn._currentStep._context.didThresholdCleanup,
+                messageCount: Array.isArray(turn._currentStep._context.messages)
+                  ? turn._currentStep._context.messages.length
+                  : undefined,
+                systemMessageCount: Array.isArray(turn._currentStep._context.systemMessage)
+                  ? turn._currentStep._context.systemMessage.length
+                  : undefined,
+              }
+            : undefined,
+        }
+      : undefined,
+  };
+}
+
+function sanitizeCaptureState(rawState: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(rawState).map(([key, value]) => {
+      if (key === '__omTurn') {
+        return [key, summarizeOmTurn(value)];
+      }
+
+      return [key, value];
     }),
   );
 }
@@ -129,60 +274,89 @@ export function writeProcessInputStepReproCapture(params: {
     const idRemap = inferReproIdRemap(params.preMessages, contextMessages);
 
     const rawState = (params.args.state as Record<string, unknown>) ?? {};
-    const inputPayload = safeCaptureJson({
-      stepNumber: params.stepNumber,
-      threadId: params.threadId,
-      resourceId: params.resourceId,
-      readOnly: memoryContext?.memoryConfig?.readOnly,
-      messageCount: contextMessages.length,
-      messageIds: contextMessages.map(message => message.id),
-      stateKeys: Object.keys(rawState),
-      state: rawState,
-      args: {
-        messages: params.args.messages,
-        steps: params.args.steps,
-        systemMessages: params.args.systemMessages,
-        retryCount: params.args.retryCount,
-        tools: params.args.tools,
-        toolChoice: params.args.toolChoice,
-        activeTools: params.args.activeTools,
-        providerOptions: params.args.providerOptions,
-        modelSettings: params.args.modelSettings,
-        structuredOutput: params.args.structuredOutput,
+    const sanitizedState = sanitizeCaptureState(rawState);
+    const payloads = [
+      {
+        fileName: 'input.json',
+        data: {
+          stepNumber: params.stepNumber,
+          threadId: params.threadId,
+          resourceId: params.resourceId,
+          readOnly: memoryContext?.memoryConfig?.readOnly,
+          messageCount: contextMessages.length,
+          messageIds: contextMessages.map(message => message.id),
+          stateKeys: Object.keys(rawState),
+          state: sanitizedState,
+          args: {
+            messages: params.args.messages,
+            steps: params.args.steps,
+            systemMessages: params.args.systemMessages,
+            retryCount: params.args.retryCount,
+            toolChoice: params.args.toolChoice,
+            activeTools: params.args.activeTools,
+            modelSettings: params.args.modelSettings,
+            structuredOutput: params.args.structuredOutput,
+          },
+        },
       },
-    });
-
-    const preStatePayload = safeCaptureJson({
-      record: params.preRecord,
-      bufferedChunks: params.preBufferedChunks,
-      contextTokenCount: params.preContextTokenCount,
-      messages: params.preMessages,
-      messageList: params.preSerializedMessageList,
-    });
-
-    const outputPayload = safeCaptureJson({
-      details: params.details,
-      messageDiff: {
-        removedMessageIds,
-        addedMessageIds,
-        idRemap,
+      {
+        fileName: 'pre-state.json',
+        data: {
+          record: params.preRecord,
+          bufferedChunks: params.preBufferedChunks,
+          contextTokenCount: params.preContextTokenCount,
+          messages: params.preMessages,
+          messageList: params.preSerializedMessageList,
+        },
       },
-    });
+      {
+        fileName: 'output.json',
+        data: {
+          details: params.details,
+          messageDiff: {
+            removedMessageIds,
+            addedMessageIds,
+            idRemap,
+          },
+        },
+      },
+      {
+        fileName: 'post-state.json',
+        data: {
+          record: params.postRecord,
+          bufferedChunks: params.postBufferedChunks,
+          contextTokenCount: params.postContextTokenCount,
+          messageCount: contextMessages.length,
+          messageIds: contextMessages.map(message => message.id),
+          messages: contextMessages,
+          messageList: params.messageList.serialize(),
+        },
+      },
+    ] as const;
 
-    const postStatePayload = safeCaptureJson({
-      record: params.postRecord,
-      bufferedChunks: params.postBufferedChunks,
-      contextTokenCount: params.postContextTokenCount,
-      messageCount: contextMessages.length,
-      messageIds: contextMessages.map(message => message.id),
-      messages: contextMessages,
-      messageList: params.messageList.serialize(),
-    });
+    const captureErrors: Array<{ fileName: string; error: unknown }> = [];
 
-    writeFileSync(join(captureDir, 'input.json'), `${JSON.stringify(inputPayload, null, 2)}\n`);
-    writeFileSync(join(captureDir, 'pre-state.json'), `${JSON.stringify(preStatePayload, null, 2)}\n`);
-    writeFileSync(join(captureDir, 'output.json'), `${JSON.stringify(outputPayload, null, 2)}\n`);
-    writeFileSync(join(captureDir, 'post-state.json'), `${JSON.stringify(postStatePayload, null, 2)}\n`);
+    for (const payload of payloads) {
+      const serialized = safeCaptureJsonOrError(payload.data);
+      if (serialized.ok) {
+        writeFileSync(join(captureDir, payload.fileName), `${JSON.stringify(serialized.value, null, 2)}\n`);
+        continue;
+      }
+
+      captureErrors.push({ fileName: payload.fileName, error: serialized.error });
+      writeFileSync(
+        join(captureDir, payload.fileName),
+        `${JSON.stringify({ __captureError: serialized.error }, null, 2)}\n`,
+      );
+    }
+
+    if (captureErrors.length > 0) {
+      writeFileSync(join(captureDir, 'capture-error.json'), `${JSON.stringify(captureErrors, null, 2)}\n`);
+      params.debug?.(
+        `[OM:repro-capture] wrote processInputStep capture with ${captureErrors.length} serialization error(s) to ${captureDir}`,
+      );
+      return;
+    }
 
     params.debug?.(`[OM:repro-capture] wrote processInputStep capture to ${captureDir}`);
   } catch (error) {


### PR DESCRIPTION
This keeps OM repro capture useful when live state includes circular values or other non-serializable data.

Before, a bad payload could leave a step directory empty after `mkdirSync(...)` succeeded but snapshot writing failed.

```ts
// before
step-dir/
```

Now we still write artifacts, and any payload-specific failure is recorded instead of dropping the whole snapshot.

```ts
// after
step-dir/
  input.json
  pre-state.json
  output.json
  post-state.json
  capture-error.json
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed observational memory recording capture to properly handle complex state values including circular references and special types, ensuring usable artifacts are always generated.
  * Enhanced error handling for serialization failures with detailed error logging, fallback artifact generation, and comprehensive error reporting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->