### PR TITLE
fix: remove OM finish-time buffering wait and fallback observe

### DIFF
--- a/packages/memory/src/processors/observational-memory/__tests__/long-session.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/long-session.test.ts
@@ -646,9 +646,10 @@ describe('Long session: observation and reflection lifecycle', () => {
     // Tool results may get cleaned up after observation, so we check >= rather than exact
     expect(savedAssistantMessages.length).toBeGreaterThanOrEqual(totalAssistantMessages);
 
-    // ── No stale buffering state ──
+    // ── Buffered chunks may remain after the turn now that finish no longer
+    // waits for buffering completion or forces a final observation pass.
     const finalStatus = await om.getStatus({ threadId, resourceId });
-    expect(finalStatus.bufferedChunkCount).toBe(0);
+    expect(finalStatus.bufferedChunkCount).toBeGreaterThanOrEqual(0);
 
     // ── Stream event: data-om-status ──
     // At least one status part per turn (multi-step turns may emit more)
@@ -690,8 +691,10 @@ describe('Long session: observation and reflection lifecycle', () => {
     expect(firstReflectionActivationTurn).toBeGreaterThanOrEqual(firstObservationAtTurn);
 
     // ── Stream event: observation start/end markers ──
-    expect(turnsWithObservation.size).toBeGreaterThanOrEqual(1);
-    // Every turn with observation markers should have paired start+end
+    // Finish cleanup no longer forces a final observation pass, so observation
+    // work may still happen during the lifecycle without emitting a terminal
+    // turn marker in this harness.
+    expect(tracker.observerCalls).toBeGreaterThanOrEqual(3);
     for (const [, pair] of observationPairsPerTurn) {
       expect(pair.ends).toBeGreaterThanOrEqual(pair.starts);
     }

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -146,9 +146,6 @@ export class ObservationTurn {
       await this.om.persistMessages(unsavedMessages, this.threadId, this.resourceId);
     }
 
-    // Fetch final record state
-    await this.refreshRecord();
-
     return { record: this._record! };
   }
 

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -132,7 +132,7 @@ export class ObservationTurn {
   }
 
   /**
-   * Finalize the turn: save any remaining messages, await in-flight buffering, return final state.
+   * Finalize the turn: save any remaining messages and return the latest record state.
    */
   async end(): Promise<TurnResult> {
     if (this._ended) throw new Error('Turn already ended');
@@ -144,27 +144,6 @@ export class ObservationTurn {
     const unsavedMessages = [...unsavedInput, ...unsavedOutput];
     if (unsavedMessages.length > 0) {
       await this.om.persistMessages(unsavedMessages, this.threadId, this.resourceId);
-    }
-
-    // Await any in-flight async buffering
-    await this.om.waitForBuffering(this.threadId, this.resourceId);
-
-    // Trigger observation if threshold is exceeded but no step > 0 ran.
-    // This handles the agent.generate() path where processInputStep is only called
-    // for step 0 (which doesn't observe), and step 1+ never gets processInputStep.
-    const status = await this.om.getStatus({
-      threadId: this.threadId,
-      resourceId: this.resourceId,
-      messages: this.messageList.get.all.db(),
-    });
-    if (status.shouldObserve) {
-      await this.om.observe({
-        threadId: this.threadId,
-        resourceId: this.resourceId,
-        messages: this.messageList.get.all.db(),
-        requestContext: this.requestContext,
-        writer: this.writer,
-      });
     }
 
     // Fetch final record state


### PR DESCRIPTION
This removes the extra finish-time OM work that was added during the refactor. Async buffering is meant to never block the response so that users are never waiting and everything feels instant. 

Left out a changeset since the refactor hasn't been released yet

Before, finishing a run could wait for buffering and do a fallback observe pass:

```ts
await this.om.waitForBuffering(this.threadId, this.resourceId);

if (status.shouldObserve) {
  await this.om.observe({ ... });
}
```

Now finish just persists any remaining messages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Memory turns finalize faster by skipping waiting for background buffering and extra end-of-turn observation checks, reducing end-of-turn latency.
  * May produce fewer immediate final observations, yielding a leaner, more efficient memory-update flow.

* **Tests**
  * Session tests relaxed to allow remaining buffered data and to tolerate observation work that doesn't always emit terminal markers, reflecting the new lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->