### PR TITLE
feat(mastracode): expose observational memory toggle

### DIFF
--- a/.changeset/green-mice-repair.md
+++ b/.changeset/green-mice-repair.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Expose `createMastraCode({ observationalMemory: false })` so embedded mastracode consumers can fully disable observational memory.

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -72,6 +72,20 @@ Type `@` followed by a partial filename to fuzzy-search project files and refere
 
 Select a suggestion with arrow keys and press Tab to insert it.
 
+### Programmatic usage
+
+If you embed `mastracode` in another app, `createMastraCode()` accepts a config object:
+
+```ts
+import { createMastraCode } from 'mastracode';
+
+const { harness } = await createMastraCode({
+  observationalMemory: false,
+});
+```
+
+Set `observationalMemory: false` to fully disable observational memory, including background observation buffering and reflection.
+
 ### Slash commands
 
 | Command             | Description                                      |

--- a/mastracode/src/agents/__tests__/memory.test.ts
+++ b/mastracode/src/agents/__tests__/memory.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const memoryInstances = vi.hoisted(() => [] as Array<{ config: unknown }>);
+const mockMemory = vi.hoisted(() =>
+  vi.fn(function (this: { config: unknown }, config: unknown) {
+    this.config = config;
+    memoryInstances.push(this);
+  }),
+);
+const mockGetOmScope = vi.hoisted(() => vi.fn(() => 'thread'));
+const mockResolveModel = vi.hoisted(() => vi.fn((modelId: string) => ({ modelId })));
+
+vi.mock('@mastra/memory', () => ({
+  Memory: mockMemory,
+}));
+
+vi.mock('../../utils/project.js', () => ({
+  getOmScope: mockGetOmScope,
+}));
+
+vi.mock('../model.js', () => ({
+  resolveModel: mockResolveModel,
+}));
+
+type MockMemoryConfig =
+  | {
+      storage: Record<string, string>;
+      options: {
+        observationalMemory: false;
+      };
+    }
+  | {
+      storage: Record<string, string>;
+      options: {
+        observationalMemory: {
+          enabled: true;
+          scope: 'thread' | 'resource';
+        };
+      };
+    };
+
+describe('getDynamicMemory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    memoryInstances.length = 0;
+  });
+
+  it('disables observational memory when requested', async () => {
+    const { getDynamicMemory } = await import('../memory.js');
+    const storage = { id: 'storage' };
+
+    const memory = getDynamicMemory(
+      storage,
+      false,
+    )({
+      requestContext: { get: vi.fn().mockReturnValue(undefined) } as unknown as { get: ReturnType<typeof vi.fn> },
+    });
+
+    expect(mockMemory).toHaveBeenCalledTimes(1);
+    expect(mockMemory).toHaveBeenCalledWith({
+      storage,
+      options: {
+        observationalMemory: false,
+      },
+    });
+    expect(mockGetOmScope).not.toHaveBeenCalled();
+    expect(memory).toBe(memoryInstances[0]);
+  });
+
+  it('keeps the enabled and disabled memory caches separate', async () => {
+    const { getDynamicMemory } = await import('../memory.js');
+    const storage = { id: 'storage' };
+    const requestContext = {
+      get: vi.fn().mockReturnValue(undefined),
+    } as unknown as { get: ReturnType<typeof vi.fn> };
+
+    const enabledMemory = getDynamicMemory(storage)({ requestContext });
+    const disabledMemory = getDynamicMemory(storage, false)({ requestContext });
+
+    expect(mockMemory).toHaveBeenCalledTimes(2);
+    expect(enabledMemory).not.toBe(disabledMemory);
+    const enabledConfig = mockMemory.mock.calls[0]?.[0] as MockMemoryConfig;
+    const disabledConfig = mockMemory.mock.calls[1]?.[0] as MockMemoryConfig;
+
+    expect(enabledConfig.options.observationalMemory).toMatchObject({
+      enabled: true,
+      scope: 'thread',
+    });
+    expect(disabledConfig.options.observationalMemory).toBe(false);
+  });
+});

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -38,18 +38,34 @@ function getReflectorModel({ requestContext }: { requestContext: RequestContext 
 
 /**
  * Dynamic memory factory function.
- * Reads OM thresholds from harness state via requestContext.
- * Model functions also read from requestContext (no mutable bridge needed).
+ * Reads OM thresholds from harness state via requestContext when observational
+ * memory is enabled. Model functions also read from requestContext (no mutable
+ * bridge needed).
  */
-export function getDynamicMemory(storage: MastraCompositeStore) {
+export function getDynamicMemory(storage: MastraCompositeStore, observationalMemory = true) {
   return ({ requestContext }: { requestContext: RequestContext }) => {
+    if (!observationalMemory) {
+      const cacheKey = `${observationalMemory}`;
+      if (cachedMemory && cachedMemoryKey === cacheKey) {
+        return cachedMemory;
+      }
+
+      cachedMemory = new Memory({
+        storage,
+        options: {
+          observationalMemory: false,
+        },
+      });
+      cachedMemoryKey = cacheKey;
+
+      return cachedMemory;
+    }
+
     const state = getHarnessState(requestContext);
     const omScope = getOmScope(state?.projectPath);
-
     const obsThreshold = state?.observationThreshold ?? DEFAULT_OBS_THRESHOLD;
     const refThreshold = state?.reflectionThreshold ?? DEFAULT_REF_THRESHOLD;
-
-    const cacheKey = `${obsThreshold}:${refThreshold}:${omScope}`;
+    const cacheKey = `${observationalMemory}:${obsThreshold}:${refThreshold}:${omScope}`;
     if (cachedMemory && cachedMemoryKey === cacheKey) {
       return cachedMemory;
     }

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -81,6 +81,8 @@ export interface MastraCodeConfig {
   disabledTools?: string[];
   /** Custom storage config instead of auto-detected default */
   storage?: StorageConfig;
+  /** Enable or disable observational memory. Default: true */
+  observationalMemory?: boolean;
   /** Initial state overrides (yolo, thinkingLevel, etc.) */
   initialState?: Record<string, unknown>;
   /** Override heartbeat handlers. Default: gateway-sync */
@@ -124,7 +126,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   const storage = storageResult.storage;
   const storageWarning = storageResult.warning;
 
-  const memory = getDynamicMemory(storage);
+  const memory = getDynamicMemory(storage, config?.observationalMemory);
 
   // MCP
   const mcpManager = config?.disableMcp ? undefined : createMcpManager(project.rootPath);
@@ -296,7 +298,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
 
   // Build initial state with global preferences
   const globalInitialState: Record<string, unknown> = {};
-  if (effectiveOmModel) {
+  if (config?.observationalMemory !== false && effectiveOmModel) {
     globalInitialState.observerModelId = effectiveOmModel;
     globalInitialState.reflectorModelId = effectiveOmModel;
   }


### PR DESCRIPTION
## Summary
- add an `observationalMemory` boolean to `createMastraCode()`
- disable observational memory in `getDynamicMemory()` when that flag is `false`
- document the new programmatic option and add focused coverage

## Testing
- focused verification run in the fork checkout with the same package layout: `pnpm exec vitest run src/agents/__tests__/memory.test.ts --config vitest.config.ts`
- focused import check in the fork checkout with the same package layout: `pnpm exec tsx -e "import('./src/index.ts'); import('./src/agents/memory.ts');"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to disable observational memory when embedding mastracode in other applications via `createMastraCode()`
* **Documentation**
  * Added "Programmatic usage" section to README with embedding examples and configuration details
* **Tests**
  * Added test suite to verify memory configuration behavior with observational memory enabled and disabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->