### PR TITLE
fix(core): make generateTitle non-blocking

### DIFF
--- a/.changeset/cold-geese-grin.md
+++ b/.changeset/cold-geese-grin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed title generation blocking stream completion. The `generateTitle` LLM call now runs in the background instead of blocking the stream from closing, removing the 2-3 second post-response delay in the UI when memory is enabled.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4393,22 +4393,22 @@ export class Agent<
         if (shouldGenerate && !thread.title) {
           const userMessage = this.getMostRecentUserMessage(messageList.get.all.ui());
           if (userMessage) {
-            const title = await this.genTitle(
-              userMessage,
-              requestContext,
-              observabilityContext,
-              titleModel,
-              titleInstructions,
+            void this.genTitle(userMessage, requestContext, observabilityContext, titleModel, titleInstructions).then(
+              async title => {
+                if (title) {
+                  await memory.createThread({
+                    threadId: thread.id,
+                    resourceId,
+                    memoryConfig,
+                    title,
+                    metadata: thread.metadata,
+                  });
+                }
+              },
+              error => {
+                this.logger.error('Error persisting generated title:', error);
+              },
             );
-            if (title) {
-              await memory.createThread({
-                threadId: thread.id,
-                resourceId,
-                memoryConfig,
-                title,
-                metadata: thread.metadata,
-              });
-            }
           }
         }
       } catch (e) {


### PR DESCRIPTION
## Description
`generateTitle` runs on the synchronous `onFinish` path of the stream, so the title generation LLM call blocks stream completion and adds 2-3 seconds of post-response latency to the UI. The user sees a loading indicator even though the LLM has already finished generating the actual response.

This PR makes the `generateTitle` call fire-and-forget using `void promise.then()`, so the stream closes immediately after the response finishes. The title is still generated and saved to the database in the background — same behavior, no user-facing delay.

  ## Related Issue(s)

  Fixes #14751

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [x] Performance improvement
  - [ ] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a 2-3 second UI delay that occurred after response completion when memory is enabled. Title generation now completes asynchronously without blocking the response stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->