### PR TITLE
fix(cli): Skip git question if already in git repo

### DIFF
--- a/.changeset/large-apes-juggle.md
+++ b/.changeset/large-apes-juggle.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+During `create-mastra`, skip the git initialization question if the current directory is already a git repository.

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -12,7 +12,7 @@ import { getPackageManagerAddCommand } from '../../utils/package-manager.js';
 import type { PackageManager } from '../../utils/package-manager.js';
 import { interactivePrompt } from '../init/utils.js';
 import type { LLMProvider } from '../init/utils.js';
-import { getPackageManager } from '../utils.js';
+import { getPackageManager, isGitInitialized } from '../utils.js';
 
 const exec = util.promisify(child_process.exec);
 
@@ -195,6 +195,8 @@ export const createMastraProject = async ({
   let result: Awaited<ReturnType<typeof interactivePrompt>> | undefined = undefined;
 
   if (needsInteractive) {
+    const skipGitInit = await isGitInitialized({ cwd: process.cwd() });
+
     result = await interactivePrompt({
       options: { showBanner: false },
       skip: {
@@ -203,6 +205,7 @@ export const createMastraProject = async ({
         skills: skills !== undefined && skills.length > 0,
         mcpServer: mcpServer !== undefined,
         directory: true,
+        gitInit: skipGitInit,
       },
     });
   }


### PR DESCRIPTION
## Description

We were missing the `.git` check during create-mastra, which caused the interactive prompt to ask about git initialization even if the directory was already a git repository. This PR adds a check for an existing git repository and skips the git initialization question if one is found.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `create-mastra` command now skips the git initialization prompt when git is already initialized in the current working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->