### PR TITLE
fix(docs): rename getMemoryThreads to listMemoryThreads in client SDK reference

### DIFF
--- a/docs/src/content/en/reference/client-js/mastra-client.mdx
+++ b/docs/src/content/en/reference/client-js/mastra-client.mdx
@@ -82,7 +82,7 @@ export const mastraClient = new MastraClient({
     description: 'Retrieves a specific agent instance by ID.',
   },
   {
-    name: 'getMemoryThreads(params)',
+    name: 'listMemoryThreads(params)',
     type: 'Promise<StorageThreadType[]>',
     description:
       'Retrieves memory threads for the specified resource and agent. Requires a `resourceId` and an `agentId`.',

--- a/docs/src/content/en/reference/client-js/memory.mdx
+++ b/docs/src/content/en/reference/client-js/memory.mdx
@@ -14,7 +14,7 @@ The Memory API provides methods to manage conversation threads and message histo
 Retrieve all memory threads for a specific resource:
 
 ```typescript
-const threads = await mastraClient.getMemoryThreads({
+const threads = await mastraClient.listMemoryThreads({
   resourceId: 'resource-1',
   agentId: 'agent-1', // Optional - can be omitted if storage is configured
 })


### PR DESCRIPTION
  ## Summary
  - Updated Memory API reference to use `listMemoryThreads` instead
   of the deprecated `getMemoryThreads`
  - Updated MastraClient methods table to reflect the correct
  method name

  ## Context
  The SDK method was renamed from `getMemoryThreads` to
  `listMemoryThreads` in PR #9508, but the documentation was never
  updated to reflect this change. This caused confusion for users
  who followed the docs and got `TypeError: not a function`.

  Closes #14767


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the Memory API method from `getMemoryThreads()` to `listMemoryThreads()`. Users must update their client code to use the new method name. The method signature and return type remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->