### PR TITLE
fix(client-sdks): `MastraClientProvider` credentials configuration

### DIFF
--- a/.changeset/react-provider-credentials.md
+++ b/.changeset/react-provider-credentials.md
@@ -7,7 +7,9 @@
 **Added** optional `credentials` when you want tighter control, for example same-origin-only requests:
 
 ```tsx
-<MastraReactProvider baseUrl="http://localhost:4000" credentials="same-origin" />
+<MastraReactProvider baseUrl="http://localhost:4000" credentials="same-origin">
+  {children}
+</MastraReactProvider>
 ```
 
 **Added** `MastraClientCredentials` and `MastraClientProviderProps` so you can type provider props explicitly.

--- a/.changeset/react-provider-credentials.md
+++ b/.changeset/react-provider-credentials.md
@@ -1,0 +1,13 @@
+---
+'@mastra/react': patch
+---
+
+**Fixed** React UIs getting `401` from Mastra after a successful cookie login when the app and API run on different hosts or ports (for example Mastra Studio against a custom server). API calls from `MastraReactProvider` now include session cookies by default ([#14770](https://github.com/mastra-ai/mastra/issues/14770)).
+
+**Added** optional `credentials` when you want tighter control, for example same-origin-only requests:
+
+```tsx
+<MastraReactProvider baseUrl="http://localhost:4000" credentials="same-origin" />
+```
+
+**Added** `MastraClientCredentials` and `MastraClientProviderProps` so you can type provider props explicitly.

--- a/client-sdks/react/src/index.ts
+++ b/client-sdks/react/src/index.ts
@@ -1,6 +1,7 @@
 export * from './mastra-react-provider';
 export * from './agent/hooks'; // Agent hooks
 export * from './agent/types';
+export type { MastraClientCredentials, MastraClientProviderProps } from './mastra-client-context';
 export { useMastraClient } from './mastra-client-context';
 export * from './lib/ai-sdk';
 export * from './ui';

--- a/client-sdks/react/src/mastra-client-context.tsx
+++ b/client-sdks/react/src/mastra-client-context.tsx
@@ -6,16 +6,30 @@ export type MastraClientContextType = MastraClient;
 
 const MastraClientContext = createContext<MastraClientContextType>({} as MastraClientContextType);
 
+/** Passed through to `fetch` / `MastraClient`. Default `include` sends cookies on cross-origin Studio → API requests. */
+export type MastraClientCredentials = 'omit' | 'same-origin' | 'include';
+
 export interface MastraClientProviderProps {
   children: ReactNode;
   baseUrl?: string;
   headers?: Record<string, string>;
   /** API route prefix. Defaults to '/api'. Set this to match your server's apiPrefix configuration. */
   apiPrefix?: string;
+  /**
+   * Credentials mode for API requests. Defaults to `include` so session cookies reach a custom server when Studio and API differ by origin/port.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
+   */
+  credentials?: MastraClientCredentials;
 }
 
-export const MastraClientProvider = ({ children, baseUrl, headers, apiPrefix }: MastraClientProviderProps) => {
-  const client = createMastraClient(baseUrl, headers, apiPrefix);
+export const MastraClientProvider = ({
+  children,
+  baseUrl,
+  headers,
+  apiPrefix,
+  credentials = 'include',
+}: MastraClientProviderProps) => {
+  const client = createMastraClient(baseUrl, headers, apiPrefix, credentials);
 
   return <MastraClientContext.Provider value={client}>{children}</MastraClientContext.Provider>;
 };
@@ -46,10 +60,16 @@ export const isLocalUrl = (url?: string): boolean => {
   }
 };
 
-const createMastraClient = (baseUrl?: string, mastraClientHeaders: Record<string, string> = {}, apiPrefix?: string) => {
+const createMastraClient = (
+  baseUrl?: string,
+  mastraClientHeaders: Record<string, string> = {},
+  apiPrefix?: string,
+  credentials: MastraClientCredentials = 'include',
+) => {
   return new MastraClient({
     baseUrl: baseUrl || '',
     headers: isLocalUrl(baseUrl) ? { ...mastraClientHeaders, 'x-mastra-dev-playground': 'true' } : mastraClientHeaders,
     apiPrefix,
+    credentials,
   });
 };

--- a/client-sdks/react/src/mastra-react-provider.tsx
+++ b/client-sdks/react/src/mastra-react-provider.tsx
@@ -1,10 +1,11 @@
 import type { MastraClientProviderProps } from '@/mastra-client-context';
 import { MastraClientProvider } from '@/mastra-client-context';
+
 type MastraReactProviderProps = MastraClientProviderProps;
 
-export const MastraReactProvider = ({ children, baseUrl, headers, apiPrefix }: MastraReactProviderProps) => {
+export const MastraReactProvider = ({ children, baseUrl, headers, apiPrefix, credentials }: MastraReactProviderProps) => {
   return (
-    <MastraClientProvider baseUrl={baseUrl} headers={headers} apiPrefix={apiPrefix}>
+    <MastraClientProvider baseUrl={baseUrl} headers={headers} apiPrefix={apiPrefix} credentials={credentials}>
       {children}
     </MastraClientProvider>
   );

--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -4,6 +4,7 @@ description: "Learn how to set up and use the Mastra Client SDK"
 packages:
   - "@mastra/client-js"
   - "@mastra/core"
+  - "@mastra/react"
 ---
 
 # Mastra client SDK
@@ -132,6 +133,23 @@ export const mastraClient = new MastraClient({
 Visit [MastraClient](/reference/client-js/mastra-client) for more configuration options.
 
 :::
+
+## Credentials and session cookies
+
+**Authenticate Mastra API calls with session cookies** when your UI and Mastra API are not on the same origin—different host, subdomain, or port (for example Mastra Studio on one port and a custom server on another). Add **`credentials: 'include'`** to `MastraClient` so each request carries the cookies the user already has after sign-in. Skip this and you will often get **`401`** responses from Mastra even though login succeeded in the browser.
+
+```typescript title="lib/mastra-client.ts"
+import { MastraClient } from '@mastra/client-js'
+
+export const mastraClient = new MastraClient({
+  baseUrl: process.env.MASTRA_API_URL || 'http://localhost:4111',
+  credentials: 'include',
+})
+```
+
+**Allow credentialed cross-origin requests on your server**—see [CORS: requests with credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#requests_with_credentials). You need a concrete `Access-Control-Allow-Origin` (not `*`) and `Access-Control-Allow-Credentials: true`, or the browser will block the call before it reaches Mastra.
+
+**Using `@mastra/react`?** Wrap your app with `MastraReactProvider`, set `baseUrl` and `apiPrefix` to match your server, and rely on the default `credentials: 'include'`. Change `credentials` only when you deliberately want `same-origin` or `omit` behavior.
 
 ## Adding request cancelling
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Adds optional  `credentials` prop to `MastraReactProvider` and `MastraClientProvider`, defaults to `'include'` to fix React UIs getting `401` from Mastra after a successful cookie login when the app and API run on different hosts or ports.

## Related Issue(s)
Fixes #14770 
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
N/A test coverage already present in `client-sdks/client-js/src/client.test.ts`
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 401 errors in React UI requests after cookie-based login across different hosts/ports by including session cookies by default.

* **New Features**
  * Optional credentials prop for the React provider (defaults to include).
  * Exported types to allow explicit typing of provider props.

* **Documentation**
  * Added guidance on credentials/session cookies and CORS for cross-origin setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->