### PR TITLE
fix: pass credentials: 'include' in MastraClient for Studio auth

### DIFF
--- a/.changeset/fuzzy-parrots-find.md
+++ b/.changeset/fuzzy-parrots-find.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Fixed session cookies not being sent on general API calls in Studio. The MastraClient created by the React provider now includes `credentials: 'include'`, ensuring authenticated endpoints work correctly when using custom servers with auth. Fixes #14770.

--- a/.changeset/fuzzy-parrots-find.md
+++ b/.changeset/fuzzy-parrots-find.md
@@ -2,4 +2,14 @@
 '@mastra/react': patch
 ---
 
-Fixed session cookies not being sent on general API calls in Studio. The MastraClient created by the React provider now includes `credentials: 'include'`, ensuring authenticated endpoints work correctly when using custom servers with auth. Fixes #14770.
+**Fixed** React UIs getting `401` from Mastra after a successful cookie login when the app and API run on different hosts or ports (for example Mastra Studio against a custom server). API calls from `MastraReactProvider` now include session cookies by default ([#14770](https://github.com/mastra-ai/mastra/issues/14770)).
+
+**Added** optional `credentials` prop when you want tighter control, for example same-origin-only requests:
+
+```tsx
+<MastraReactProvider baseUrl="http://localhost:4000" credentials="same-origin">
+  {children}
+</MastraReactProvider>
+```
+
+**Added** `MastraClientCredentials` and `MastraClientProviderProps` type exports.

--- a/client-sdks/react/src/index.ts
+++ b/client-sdks/react/src/index.ts
@@ -1,6 +1,7 @@
 export * from './mastra-react-provider';
 export * from './agent/hooks'; // Agent hooks
 export * from './agent/types';
+export type { MastraClientCredentials, MastraClientProviderProps } from './mastra-client-context';
 export { useMastraClient } from './mastra-client-context';
 export * from './lib/ai-sdk';
 export * from './ui';

--- a/client-sdks/react/src/mastra-client-context.test.tsx
+++ b/client-sdks/react/src/mastra-client-context.test.tsx
@@ -103,6 +103,27 @@ describe('createMastraClient credentials', () => {
     expect(capturedClient.options.credentials).toBe('include');
   });
 
+  it('should allow overriding credentials via prop', async () => {
+    const { createElement } = await import('react');
+    const { renderToString } = await import('react-dom/server');
+
+    let capturedClient: any;
+    function Inspector() {
+      capturedClient = useMastraClient();
+      return null;
+    }
+
+    renderToString(
+      createElement(
+        MastraClientProvider,
+        { baseUrl: 'http://localhost:4000', credentials: 'same-origin' },
+        createElement(Inspector),
+      ),
+    );
+
+    expect(capturedClient.options.credentials).toBe('same-origin');
+  });
+
   it('should pass credentials: include for remote URLs', async () => {
     const { createElement } = await import('react');
     const { renderToString } = await import('react-dom/server');

--- a/client-sdks/react/src/mastra-client-context.test.tsx
+++ b/client-sdks/react/src/mastra-client-context.test.tsx
@@ -96,9 +96,7 @@ describe('createMastraClient credentials', () => {
       return null;
     }
 
-    renderToString(
-      createElement(MastraClientProvider, { baseUrl: 'http://localhost:4000' }, createElement(Inspector)),
-    );
+    renderToString(createElement(MastraClientProvider, { baseUrl: 'http://localhost:4000' }, createElement(Inspector)));
 
     expect(capturedClient.options.credentials).toBe('include');
   });

--- a/client-sdks/react/src/mastra-client-context.test.tsx
+++ b/client-sdks/react/src/mastra-client-context.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { isLocalUrl } from './mastra-client-context';
 
@@ -60,5 +60,63 @@ describe('isLocalUrl', () => {
   it('should return false for URLs that contain localhost as a substring of a domain', () => {
     expect(isLocalUrl('https://notlocalhost.com')).toBe(false);
     expect(isLocalUrl('https://localhost.evil.com')).toBe(false);
+  });
+});
+
+// Mock MastraClient to capture construction options
+const mockMastraClientOptions: any[] = [];
+vi.mock('@mastra/client-js', () => ({
+  MastraClient: class MockMastraClient {
+    options: any;
+    constructor(options: any) {
+      this.options = options;
+      mockMastraClientOptions.push(options);
+    }
+  },
+}));
+
+// Re-import after mock is set up — need the actual createMastraClient logic
+// which is invoked inside MastraClientProvider
+const { MastraClientProvider, useMastraClient } = await import('./mastra-client-context');
+
+describe('createMastraClient credentials', () => {
+  // See: https://github.com/mastra-ai/mastra/issues/14770
+
+  beforeEach(() => {
+    mockMastraClientOptions.length = 0;
+  });
+
+  it('should pass credentials: include for local URLs so session cookies are sent', async () => {
+    const { createElement } = await import('react');
+    const { renderToString } = await import('react-dom/server');
+
+    let capturedClient: any;
+    function Inspector() {
+      capturedClient = useMastraClient();
+      return null;
+    }
+
+    renderToString(
+      createElement(MastraClientProvider, { baseUrl: 'http://localhost:4000' }, createElement(Inspector)),
+    );
+
+    expect(capturedClient.options.credentials).toBe('include');
+  });
+
+  it('should pass credentials: include for remote URLs', async () => {
+    const { createElement } = await import('react');
+    const { renderToString } = await import('react-dom/server');
+
+    let capturedClient: any;
+    function Inspector() {
+      capturedClient = useMastraClient();
+      return null;
+    }
+
+    renderToString(
+      createElement(MastraClientProvider, { baseUrl: 'https://api.example.com' }, createElement(Inspector)),
+    );
+
+    expect(capturedClient.options.credentials).toBe('include');
   });
 });

--- a/client-sdks/react/src/mastra-client-context.tsx
+++ b/client-sdks/react/src/mastra-client-context.tsx
@@ -51,5 +51,6 @@ const createMastraClient = (baseUrl?: string, mastraClientHeaders: Record<string
     baseUrl: baseUrl || '',
     headers: isLocalUrl(baseUrl) ? { ...mastraClientHeaders, 'x-mastra-dev-playground': 'true' } : mastraClientHeaders,
     apiPrefix,
+    credentials: 'include',
   });
 };

--- a/client-sdks/react/src/mastra-client-context.tsx
+++ b/client-sdks/react/src/mastra-client-context.tsx
@@ -6,16 +6,30 @@ export type MastraClientContextType = MastraClient;
 
 const MastraClientContext = createContext<MastraClientContextType>({} as MastraClientContextType);
 
+/** Passed through to `fetch` / `MastraClient`. Default `include` sends cookies on cross-origin Studio → API requests. */
+export type MastraClientCredentials = 'omit' | 'same-origin' | 'include';
+
 export interface MastraClientProviderProps {
   children: ReactNode;
   baseUrl?: string;
   headers?: Record<string, string>;
   /** API route prefix. Defaults to '/api'. Set this to match your server's apiPrefix configuration. */
   apiPrefix?: string;
+  /**
+   * Credentials mode for API requests. Defaults to `include` so session cookies reach a custom server when Studio and API differ by origin/port.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
+   */
+  credentials?: MastraClientCredentials;
 }
 
-export const MastraClientProvider = ({ children, baseUrl, headers, apiPrefix }: MastraClientProviderProps) => {
-  const client = createMastraClient(baseUrl, headers, apiPrefix);
+export const MastraClientProvider = ({
+  children,
+  baseUrl,
+  headers,
+  apiPrefix,
+  credentials = 'include',
+}: MastraClientProviderProps) => {
+  const client = createMastraClient(baseUrl, headers, apiPrefix, credentials);
 
   return <MastraClientContext.Provider value={client}>{children}</MastraClientContext.Provider>;
 };
@@ -46,11 +60,16 @@ export const isLocalUrl = (url?: string): boolean => {
   }
 };
 
-const createMastraClient = (baseUrl?: string, mastraClientHeaders: Record<string, string> = {}, apiPrefix?: string) => {
+const createMastraClient = (
+  baseUrl?: string,
+  mastraClientHeaders: Record<string, string> = {},
+  apiPrefix?: string,
+  credentials: MastraClientCredentials = 'include',
+) => {
   return new MastraClient({
     baseUrl: baseUrl || '',
     headers: isLocalUrl(baseUrl) ? { ...mastraClientHeaders, 'x-mastra-dev-playground': 'true' } : mastraClientHeaders,
     apiPrefix,
-    credentials: 'include',
+    credentials,
   });
 };

--- a/client-sdks/react/src/mastra-react-provider.tsx
+++ b/client-sdks/react/src/mastra-react-provider.tsx
@@ -2,9 +2,9 @@ import type { MastraClientProviderProps } from '@/mastra-client-context';
 import { MastraClientProvider } from '@/mastra-client-context';
 type MastraReactProviderProps = MastraClientProviderProps;
 
-export const MastraReactProvider = ({ children, baseUrl, headers, apiPrefix }: MastraReactProviderProps) => {
+export const MastraReactProvider = ({ children, baseUrl, headers, apiPrefix, credentials }: MastraReactProviderProps) => {
   return (
-    <MastraClientProvider baseUrl={baseUrl} headers={headers} apiPrefix={apiPrefix}>
+    <MastraClientProvider baseUrl={baseUrl} headers={headers} apiPrefix={apiPrefix} credentials={credentials}>
       {children}
     </MastraClientProvider>
   );

--- a/client-sdks/react/src/mastra-react-provider.tsx
+++ b/client-sdks/react/src/mastra-react-provider.tsx
@@ -2,7 +2,13 @@ import type { MastraClientProviderProps } from '@/mastra-client-context';
 import { MastraClientProvider } from '@/mastra-client-context';
 type MastraReactProviderProps = MastraClientProviderProps;
 
-export const MastraReactProvider = ({ children, baseUrl, headers, apiPrefix, credentials }: MastraReactProviderProps) => {
+export const MastraReactProvider = ({
+  children,
+  baseUrl,
+  headers,
+  apiPrefix,
+  credentials,
+}: MastraReactProviderProps) => {
   return (
     <MastraClientProvider baseUrl={baseUrl} headers={headers} apiPrefix={apiPrefix} credentials={credentials}>
       {children}

--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -4,6 +4,7 @@ description: "Learn how to set up and use the Mastra Client SDK"
 packages:
   - "@mastra/client-js"
   - "@mastra/core"
+  - "@mastra/react"
 ---
 
 # Mastra client SDK
@@ -132,6 +133,23 @@ export const mastraClient = new MastraClient({
 Visit [MastraClient](/reference/client-js/mastra-client) for more configuration options.
 
 :::
+
+## Credentials and session cookies
+
+**Authenticate Mastra API calls with session cookies** when your UI and Mastra API are not on the same origin—different host, subdomain, or port (for example Mastra Studio on one port and a custom server on another). Add **`credentials: 'include'`** to `MastraClient` so each request carries the cookies the user already has after sign-in. Skip this and you will often get **`401`** responses from Mastra even though login succeeded in the browser.
+
+```typescript title="lib/mastra-client.ts"
+import { MastraClient } from '@mastra/client-js'
+
+export const mastraClient = new MastraClient({
+  baseUrl: process.env.MASTRA_API_URL || 'http://localhost:4111',
+  credentials: 'include',
+})
+```
+
+**Allow credentialed cross-origin requests on your server**—see [CORS: requests with credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#requests_with_credentials). You need a concrete `Access-Control-Allow-Origin` (not `*`) and `Access-Control-Allow-Credentials: true`, or the browser will block the call before it reaches Mastra.
+
+**Using `@mastra/react`?** Wrap your app with `MastraReactProvider`, set `baseUrl` and `apiPrefix` to match your server, and rely on the default `credentials: 'include'`. Change `credentials` only when you deliberately want `same-origin` or `omit` behavior.
 
 ## Adding request cancelling
 


### PR DESCRIPTION
## Description

The `MastraClient` created by the React provider (`MastraClientProvider`) was not passing `credentials: 'include'` to fetch, so session cookies were never sent on general API calls (agents, workflows, tools). Auth-specific calls worked because they bypassed the client and used raw `fetch()` with `credentials: 'include'`. This one-line fix adds `credentials: 'include'` to the `MastraClient` constructor, ensuring all Studio API calls include session cookies.

## Related Issue(s)

Fixes #14770

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API requests now include session cookies by default, fixing 401s after cookie-based login when UI and API are on different hosts/ports.
* **New Features**
  * Provider gains an optional prop to control request credential behavior (can override default).
  * Provider now forwards credential setting into client initialization.
* **Documentation**
  * Added guidance on credentialed requests and CORS for session cookies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->