### PR TITLE
fix(datadog): move error.message from tags to metadata to avoid normalization

### DIFF
--- a/.changeset/chatty-tires-juggle.md
+++ b/.changeset/chatty-tires-juggle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': patch
+---
+
+Fixed error messages in Datadog being mangled by tag normalization (colons splitting into key/value pairs, spaces becoming underscores, truncation). Error message text is now stored in span metadata instead of tags, which preserves the original content. Structured error fields (error status, id, domain, category) remain as tags.

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -240,7 +240,7 @@ describe('DatadogExporter', () => {
   });
 
   describe('error handling', () => {
-    it('includes error tags for error spans', async () => {
+    it('includes error tags and error message in metadata for error spans', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({
         errorInfo: {
@@ -255,9 +255,11 @@ describe('DatadogExporter', () => {
       expect(mockAnnotate).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
+          metadata: expect.objectContaining({
+            'error.message': 'Something went wrong',
+          }),
           tags: expect.objectContaining({
             error: true,
-            'error.message': 'Something went wrong',
             'error.id': 'err-123',
             'error.category': 'validation',
           }),
@@ -325,7 +327,7 @@ describe('DatadogExporter', () => {
       );
     });
 
-    it('merges span.tags with error tags when both present', async () => {
+    it('merges span.tags with error tags when both present, error message in metadata', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({
         tags: ['production', 'critical'],
@@ -340,11 +342,13 @@ describe('DatadogExporter', () => {
       expect(mockAnnotate).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
+          metadata: expect.objectContaining({
+            'error.message': 'Something failed',
+          }),
           tags: {
             production: true,
             critical: true,
             error: true,
-            'error.message': 'Something failed',
             'error.category': 'runtime',
           },
         }),

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -287,10 +287,15 @@ export class DatadogExporter extends BaseExporter {
     const otherAttributes = omitKeys((span.attributes ?? {}) as Record<string, any>, knownFields);
 
     // Merge span.metadata + remaining attributes into metadata
-    const combinedMetadata = {
+    // Error message goes into metadata (not tags) because tags get normalized/truncated
+    // which mangles free-form error text (e.g. colons split into key/value, spaces become underscores)
+    const combinedMetadata: Record<string, any> = {
       ...span.metadata,
       ...otherAttributes,
     };
+    if (span.errorInfo) {
+      combinedMetadata['error.message'] = span.errorInfo.message;
+    }
     if (Object.keys(combinedMetadata).length > 0) {
       annotations.metadata = combinedMetadata;
     }
@@ -314,10 +319,10 @@ export class DatadogExporter extends BaseExporter {
       }
     }
 
-    // Add error info as flattened tags (dd-trace requires primitive tag values)
+    // Add error status and structured error fields as tags (short, structured values that survive normalization)
+    // The error message itself is in metadata above to avoid tag normalization/truncation
     if (span.errorInfo) {
       tags.error = true;
-      tags['error.message'] = span.errorInfo.message;
       if (span.errorInfo.id) {
         tags['error.id'] = span.errorInfo.id;
       }


### PR DESCRIPTION
Follow-up to #14570 — error messages like `mcp_error_-32000: connection closed` were getting mangled by Datadog tag normalization (colons split into key/value pairs, spaces become underscores, truncation). For example, an error with two colons would produce multiple split tags, one without a proper key/value.

Moves `error.message` from annotation tags to annotation metadata, which doesn't get transformed. Structured error fields (`error` boolean, `error.id`, `error.domain`, `error.category`) stay as tags since they're short values that survive normalization fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Datadog error message handling to preserve full error messages without normalization. Error messages are now retained in their original form while structured error attributes continue to be emitted as tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->