### PR TITLE
feat(playground): attach scorers to datasets

### DIFF
--- a/.changeset/attach-scorer-ui.md
+++ b/.changeset/attach-scorer-ui.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added a Scorers section to the dataset detail view for attaching and detaching scorers. Fixed a crash on page refresh in the evaluate tab caused by `ReviewQueueProvider` not being mounted during loading states.

--- a/.changeset/calm-bags-sit.md
+++ b/.changeset/calm-bags-sit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added support for attaching scorers to datasets. Scorers attached to a dataset automatically run when an experiment is triggered, alongside any scorers specified at trigger time. New `scorerIds` field on `DatasetRecord`, `CreateDatasetInput`, and `UpdateDatasetInput` types.

--- a/.changeset/five-insects-scream.md
+++ b/.changeset/five-insects-scream.md
@@ -1,0 +1,6 @@
+---
+'@mastra/server': patch
+'@mastra/client-js': patch
+---
+
+Added `scorerIds` to dataset API schemas and handlers, allowing scorers to be attached to datasets via CREATE and UPDATE endpoints.

--- a/.changeset/rich-dancers-sort.md
+++ b/.changeset/rich-dancers-sort.md
@@ -1,0 +1,7 @@
+---
+'@mastra/libsql': patch
+'@mastra/pg': patch
+'@mastra/mongodb': patch
+---
+
+Added `scorerIds` persistence for datasets. The `scorerIds` field is now stored and retrieved correctly when creating or updating datasets.

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -2063,6 +2063,7 @@ export interface DatasetRecord {
   tags?: string[] | null;
   targetType?: string | null;
   targetIds?: string[] | null;
+  scorerIds?: string[] | null;
   version: number;
   createdAt: string | Date;
   updatedAt: string | Date;
@@ -2127,6 +2128,7 @@ export interface CreateDatasetParams {
   requestContextSchema?: Record<string, unknown> | null;
   targetType?: string;
   targetIds?: string[];
+  scorerIds?: string[];
 }
 
 export interface UpdateDatasetParams {
@@ -2140,6 +2142,7 @@ export interface UpdateDatasetParams {
   tags?: string[];
   targetType?: string;
   targetIds?: string[];
+  scorerIds?: string[] | null;
 }
 
 export interface AddDatasetItemParams {

--- a/packages/core/src/datasets/dataset.ts
+++ b/packages/core/src/datasets/dataset.ts
@@ -343,21 +343,12 @@ export class Dataset {
 
     const experimentId = run.id;
 
-    // Merge dataset-attached scorers with any experiment-specified scorers
-    const mergedConfig = { ...config };
-    if (dataset.scorerIds?.length) {
-      const existingStringIds = new Set((mergedConfig.scorers ?? []).filter((s): s is string => typeof s === 'string'));
-      const newIds = dataset.scorerIds.filter(id => !existingStringIds.has(id));
-      if (newIds.length > 0) {
-        mergedConfig.scorers = [...(mergedConfig.scorers ?? []), ...newIds];
-      }
-    }
-
-    // Fire-and-forget — update experiment to failed on unexpected errors
+    // Fire-and-forget — runExperiment merges dataset-attached scorers automatically
     void runExperiment(this.#mastra, {
       datasetId: this.id,
       experimentId,
-      ...mergedConfig,
+      ...config,
+      version: targetVersion,
     } as ExperimentConfig).catch(async err => {
       await experimentsStore
         .updateExperiment({

--- a/packages/core/src/datasets/dataset.ts
+++ b/packages/core/src/datasets/dataset.ts
@@ -125,6 +125,7 @@ export class Dataset {
     tags?: string[] | null;
     targetType?: TargetType | null;
     targetIds?: string[] | null;
+    scorerIds?: string[] | null;
   }): Promise<DatasetRecord> {
     const store = await this.#getDatasetsStore();
 
@@ -342,11 +343,21 @@ export class Dataset {
 
     const experimentId = run.id;
 
+    // Merge dataset-attached scorers with any experiment-specified scorers
+    const mergedConfig = { ...config };
+    if (dataset.scorerIds?.length) {
+      const existingStringIds = new Set((mergedConfig.scorers ?? []).filter((s): s is string => typeof s === 'string'));
+      const newIds = dataset.scorerIds.filter(id => !existingStringIds.has(id));
+      if (newIds.length > 0) {
+        mergedConfig.scorers = [...(mergedConfig.scorers ?? []), ...newIds];
+      }
+    }
+
     // Fire-and-forget — update experiment to failed on unexpected errors
     void runExperiment(this.#mastra, {
       datasetId: this.id,
       experimentId,
-      ...config,
+      ...mergedConfig,
     } as ExperimentConfig).catch(async err => {
       await experimentsStore
         .updateExperiment({

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -215,13 +215,23 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
     throw err; // unreachable, but satisfies TS control flow
   }
 
-  // Merge dataset-attached scorers with explicitly provided scorers
+  // Merge dataset-attached scorers with explicitly provided scorers, then deduplicate
   let mergedScorerInput = scorerInput;
   const datasetScorerIds = datasetRecord?.scorerIds ?? [];
   if (datasetScorerIds.length > 0) {
-    const existingIds = new Set((scorerInput ?? []).filter((s): s is string => typeof s === 'string'));
-    const newIds = datasetScorerIds.filter(id => !existingIds.has(id));
-    mergedScorerInput = [...(scorerInput ?? []), ...newIds];
+    mergedScorerInput = [...(scorerInput ?? []), ...datasetScorerIds];
+  }
+  if (mergedScorerInput && mergedScorerInput.length > 0) {
+    const seen = new Set<string>();
+    mergedScorerInput = mergedScorerInput.filter(entry => {
+      if (typeof entry === 'string') {
+        if (seen.has(entry)) return false;
+        seen.add(entry);
+        return true;
+      }
+      // Keep all scorer instances — they are resolved by reference, not by ID
+      return true;
+    });
   }
 
   // Resolve scorers

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -10,6 +10,7 @@ type ExperimentItem = {
   requestContext?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
 };
+import type { DatasetRecord } from '../../storage/types';
 import { executeTarget } from './executor';
 import type { Target, ExecutionResult } from './executor';
 import { resolveScorers, runScorersForItem } from './scorer';
@@ -102,6 +103,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
   // Phase A — Resolve items
   let items: ExperimentItem[];
   let datasetVersion: number | null;
+  let datasetRecord: DatasetRecord | null | undefined;
 
   try {
     if (config.data) {
@@ -124,8 +126,8 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
         throw new Error('DatasetsStorage not configured. Configure storage in Mastra instance.');
       }
 
-      const dataset = await datasetsStore.getDatasetById({ id: datasetId });
-      if (!dataset) {
+      datasetRecord = await datasetsStore.getDatasetById({ id: datasetId });
+      if (!datasetRecord) {
         throw new MastraError({
           id: 'DATASET_NOT_FOUND',
           text: `Dataset not found: ${datasetId}`,
@@ -134,7 +136,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
         });
       }
 
-      datasetVersion = version ?? dataset.version;
+      datasetVersion = version ?? datasetRecord.version;
       const versionItems = await datasetsStore.getItemsByVersion({
         datasetId,
         version: datasetVersion,
@@ -213,8 +215,17 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
     throw err; // unreachable, but satisfies TS control flow
   }
 
+  // Merge dataset-attached scorers with explicitly provided scorers
+  let mergedScorerInput = scorerInput;
+  const datasetScorerIds = datasetRecord?.scorerIds ?? [];
+  if (datasetScorerIds.length > 0) {
+    const existingIds = new Set((scorerInput ?? []).filter((s): s is string => typeof s === 'string'));
+    const newIds = datasetScorerIds.filter(id => !existingIds.has(id));
+    mergedScorerInput = [...(scorerInput ?? []), ...newIds];
+  }
+
   // Resolve scorers
-  const scorers = resolveScorers(mastra, scorerInput);
+  const scorers = resolveScorers(mastra, mergedScorerInput);
 
   // 5. Create experiment record (if storage available and not pre-created)
   if (experimentsStore) {

--- a/packages/core/src/datasets/manager.ts
+++ b/packages/core/src/datasets/manager.ts
@@ -98,6 +98,7 @@ export class DatasetsManager {
     metadata?: Record<string, unknown>;
     targetType?: TargetType;
     targetIds?: string[];
+    scorerIds?: string[];
   }): Promise<Dataset> {
     const store = await this.#getDatasetsStore();
 

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -388,6 +388,7 @@ export const DATASETS_SCHEMA: Record<string, StorageColumn> = {
   tags: { type: 'jsonb', nullable: true },
   targetType: { type: 'text', nullable: true },
   targetIds: { type: 'jsonb', nullable: true },
+  scorerIds: { type: 'jsonb', nullable: true },
   version: { type: 'integer', nullable: false },
   createdAt: { type: 'timestamp', nullable: false },
   updatedAt: { type: 'timestamp', nullable: false },

--- a/packages/core/src/storage/domains/datasets/inmemory.ts
+++ b/packages/core/src/storage/domains/datasets/inmemory.ts
@@ -81,6 +81,7 @@ export class DatasetsInMemory extends DatasetsStorage {
       requestContextSchema: input.requestContextSchema,
       targetType: input.targetType,
       targetIds: input.targetIds,
+      scorerIds: input.scorerIds ?? null,
       version: 0,
       createdAt: now,
       updatedAt: now,
@@ -112,6 +113,7 @@ export class DatasetsInMemory extends DatasetsStorage {
       tags: args.tags !== undefined ? args.tags : existing.tags,
       targetType: args.targetType !== undefined ? args.targetType : existing.targetType,
       targetIds: args.targetIds !== undefined ? args.targetIds : existing.targetIds,
+      scorerIds: args.scorerIds !== undefined ? args.scorerIds : existing.scorerIds,
       updatedAt: new Date(),
     } as DatasetRecord;
     this.db.datasets.set(args.id, updated);

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -2154,6 +2154,7 @@ export interface DatasetRecord {
   tags?: string[] | null;
   targetType?: TargetType | null;
   targetIds?: string[] | null;
+  scorerIds?: string[] | null;
   version: number;
   createdAt: Date;
   updatedAt: Date;
@@ -2212,6 +2213,7 @@ export interface CreateDatasetInput {
   requestContextSchema?: Record<string, unknown> | null;
   targetType?: TargetType;
   targetIds?: string[];
+  scorerIds?: string[];
 }
 
 export interface UpdateDatasetInput {
@@ -2225,6 +2227,7 @@ export interface UpdateDatasetInput {
   tags?: string[] | null;
   targetType?: TargetType | null;
   targetIds?: string[] | null;
+  scorerIds?: string[] | null;
 }
 
 export interface AddDatasetItemInput {

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
@@ -514,6 +514,7 @@ export function AgentPlaygroundEvaluate({
                 datasetTargetType={viewDs?.targetType}
                 datasetTargetIds={viewDs?.targetIds}
                 activeScorers={Object.keys(agentScorers)}
+                datasetScorerIds={viewDs?.scorerIds ?? []}
                 onGenerate={() => setGenerateDatasetId(view.id)}
                 onViewExperiment={(experimentId: string) =>
                   setView({ type: 'experiment', id: experimentId, datasetId: view.id })
@@ -532,7 +533,8 @@ export function AgentPlaygroundEvaluate({
               .filter(
                 ds =>
                   (ds.targetType === 'scorer' && parseTargetIds(ds.targetIds).includes(view.id)) ||
-                  (legacyDatasetId && ds.id === legacyDatasetId),
+                  (legacyDatasetId && ds.id === legacyDatasetId) ||
+                  (ds.scorerIds && ds.scorerIds.includes(view.id)),
               )
               .map(ds => ({ id: ds.id, name: ds.name }));
             return (

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
@@ -115,7 +115,8 @@ export function AgentPlaygroundEvaluate({
 
   const allDatasets = datasetsData?.datasets || [];
   // targetIds may come as a JSON string from some storage backends — normalize
-  const parseTargetIds = (ids: unknown): string[] => {
+  // Some backends may return JSON-stringified id arrays — normalize before use
+  const parseIdList = (ids: unknown): string[] => {
     if (Array.isArray(ids)) return ids;
     if (typeof ids === 'string') {
       try {
@@ -129,12 +130,12 @@ export function AgentPlaygroundEvaluate({
   };
   // Show only datasets explicitly attached to this agent
   const datasets = allDatasets.filter(ds => {
-    const ids = parseTargetIds(ds.targetIds);
+    const ids = parseIdList(ds.targetIds);
     return ids.includes(agentId);
   });
   // Datasets that are not attached to this agent (for "Attach Existing" dialog)
   const unattachedDatasets = allDatasets.filter(ds => {
-    const ids = parseTargetIds(ds.targetIds);
+    const ids = parseIdList(ds.targetIds);
     return !ids.includes(agentId);
   });
 
@@ -514,7 +515,7 @@ export function AgentPlaygroundEvaluate({
                 datasetTargetType={viewDs?.targetType}
                 datasetTargetIds={viewDs?.targetIds}
                 activeScorers={Object.keys(agentScorers)}
-                datasetScorerIds={viewDs?.scorerIds ?? []}
+                datasetScorerIds={parseIdList(viewDs?.scorerIds)}
                 onGenerate={() => setGenerateDatasetId(view.id)}
                 onViewExperiment={(experimentId: string) =>
                   setView({ type: 'experiment', id: experimentId, datasetId: view.id })
@@ -532,9 +533,9 @@ export function AgentPlaygroundEvaluate({
             const scorerLinkedDatasets = allDatasets
               .filter(
                 ds =>
-                  (ds.targetType === 'scorer' && parseTargetIds(ds.targetIds).includes(view.id)) ||
+                  (ds.targetType === 'scorer' && parseIdList(ds.targetIds).includes(view.id)) ||
                   (legacyDatasetId && ds.id === legacyDatasetId) ||
-                  (ds.scorerIds && ds.scorerIds.includes(view.id)),
+                  parseIdList(ds.scorerIds).includes(view.id),
               )
               .map(ds => ({ id: ds.id, name: ds.name }));
             return (
@@ -648,7 +649,7 @@ export function AgentPlaygroundEvaluate({
                       className="w-full text-left px-3 py-2 rounded hover:bg-surface4 transition-colors"
                       onClick={async () => {
                         try {
-                          const existingIds = parseTargetIds(ds.targetIds);
+                          const existingIds = parseIdList(ds.targetIds);
                           await updateDataset.mutateAsync({
                             datasetId: ds.id,
                             targetType: ds.targetType || 'agent',

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -363,7 +363,8 @@ export function DatasetDetailView({
                         <button
                           type="button"
                           onClick={() => handleDetachScorer(id)}
-                          className="opacity-0 group-hover:opacity-100 transition-opacity text-neutral3 hover:text-red-500 p-0.5"
+                          aria-label={`Detach "${name}" from this dataset`}
+                          className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity text-neutral3 hover:text-red-500 p-0.5"
                           title="Detach scorer"
                         >
                           <Icon size="sm">

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -107,8 +107,9 @@ export function DatasetDetailView({
       const newScorerIds = [...(datasetScorerIds ?? []), scorerId];
       try {
         await updateDataset.mutateAsync({ datasetId, scorerIds: newScorerIds });
-      } catch {
+      } catch (error) {
         toast.error('Failed to attach scorer');
+        throw error;
       }
     },
     [datasetId, datasetScorerIds, updateDataset],
@@ -533,9 +534,13 @@ export function DatasetDetailView({
                         type="button"
                         className="w-full text-left px-3 py-2 rounded hover:bg-surface4 transition-colors"
                         onClick={async () => {
-                          await handleAttachScorer(id);
-                          toast.success(`Attached "${name}" to this dataset`);
-                          setShowAttachScorerDialog(false);
+                          try {
+                            await handleAttachScorer(id);
+                            toast.success(`Attached "${name}" to this dataset`);
+                            setShowAttachScorerDialog(false);
+                          } catch {
+                            // error toast already shown by handleAttachScorer
+                          }
                         }}
                       >
                         <Txt variant="ui-sm" className="font-medium">

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { Play, Sparkles, Clock, ChevronRight, ChevronDown, Pencil, Save, X, Trash2 } from 'lucide-react';
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { formatVersionLabel } from './format-version-label';
 import { useAgentVersions } from '@/domains/agents/hooks/use-agent-versions';
 import { useDatasetExperiments } from '@/domains/datasets/hooks/use-dataset-experiments';
@@ -8,10 +8,12 @@ import { useDatasetItems } from '@/domains/datasets/hooks/use-dataset-items';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
 import { useDatasetVersions } from '@/domains/datasets/hooks/use-dataset-versions';
 import { useMergedRequestContext } from '@/domains/request-context/context/schema-request-context';
+import { useScorers } from '@/domains/scores/hooks/use-scorers';
 import { Button } from '@/ds/components/Button';
 import { Chip } from '@/ds/components/Chip';
 import { Combobox } from '@/ds/components/Combobox';
 import { CopyButton } from '@/ds/components/CopyButton';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '@/ds/components/Dialog';
 import { ScrollArea } from '@/ds/components/ScrollArea';
 import { Spinner } from '@/ds/components/Spinner';
 import { Textarea } from '@/ds/components/Textarea';
@@ -29,6 +31,7 @@ interface DatasetDetailViewProps {
   datasetTargetType?: string | null;
   datasetTargetIds?: string[] | null;
   activeScorers?: string[];
+  datasetScorerIds?: string[] | null;
   onGenerate: () => void;
   onViewExperiment: (experimentId: string) => void;
 }
@@ -68,6 +71,7 @@ export function DatasetDetailView({
   datasetTargetType,
   datasetTargetIds,
   activeScorers = [],
+  datasetScorerIds = [],
   onGenerate,
   onViewExperiment,
 }: DatasetDetailViewProps) {
@@ -76,8 +80,51 @@ export function DatasetDetailView({
   const [expandedItemId, setExpandedItemId] = useState<string | null>(null);
   const [itemsCollapsed, setItemsCollapsed] = useState(false);
   const [runsCollapsed, setRunsCollapsed] = useState(false);
+  const [scorersCollapsed, setScorersCollapsed] = useState(false);
+  const [showAttachScorerDialog, setShowAttachScorerDialog] = useState(false);
+  const [attachScorerSearch, setAttachScorerSearch] = useState('');
   const [selectedDatasetVersion, setSelectedDatasetVersion] = useState<string>('');
   const [selectedAgentVersion, setSelectedAgentVersion] = useState<string>('');
+
+  // Scorers for dataset attachment
+  const { data: allScorers } = useScorers();
+  const { updateDataset } = useDatasetMutations();
+
+  const attachedScorerIds = useMemo(() => new Set(datasetScorerIds ?? []), [datasetScorerIds]);
+
+  const attachedScorerEntries = useMemo(() => {
+    if (!allScorers) return [];
+    return Object.entries(allScorers).filter(([id]) => attachedScorerIds.has(id));
+  }, [allScorers, attachedScorerIds]);
+
+  const unattachedScorerEntries = useMemo(() => {
+    if (!allScorers) return [];
+    return Object.entries(allScorers).filter(([id]) => !attachedScorerIds.has(id));
+  }, [allScorers, attachedScorerIds]);
+
+  const handleAttachScorer = useCallback(
+    async (scorerId: string) => {
+      const newScorerIds = [...(datasetScorerIds ?? []), scorerId];
+      try {
+        await updateDataset.mutateAsync({ datasetId, scorerIds: newScorerIds });
+      } catch {
+        toast.error('Failed to attach scorer');
+      }
+    },
+    [datasetId, datasetScorerIds, updateDataset],
+  );
+
+  const handleDetachScorer = useCallback(
+    async (scorerId: string) => {
+      const newScorerIds = (datasetScorerIds ?? []).filter(id => id !== scorerId);
+      try {
+        await updateDataset.mutateAsync({ datasetId, scorerIds: newScorerIds });
+      } catch {
+        toast.error('Failed to detach scorer');
+      }
+    },
+    [datasetId, datasetScorerIds, updateDataset],
+  );
 
   const { data: items = [], setEndOfListElement, isFetchingNextPage } = useDatasetItems(datasetId);
   const { data: experimentsData, refetch: refetchExperiments } = useDatasetExperiments(datasetId);
@@ -260,9 +307,76 @@ export function DatasetDetailView({
         </div>
       </div>
 
-      {/* Items + Past runs */}
+      {/* Scorers + Items + Past runs */}
       <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
         <ScrollArea className="flex-1 min-h-0">
+          {/* Scorers section (collapsible) */}
+          <div className="border-b border-border1">
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setScorersCollapsed(prev => !prev)}
+                className="flex-1 px-4 py-2 flex items-center gap-1 hover:bg-surface3 transition-colors"
+              >
+                <Icon size="sm" className="text-neutral3">
+                  {scorersCollapsed ? <ChevronRight /> : <ChevronDown />}
+                </Icon>
+                <Txt variant="ui-xs" className="text-neutral3 font-semibold uppercase tracking-wider">
+                  Scorers ({attachedScorerEntries.length})
+                </Txt>
+              </button>
+              {unattachedScorerEntries.length > 0 && (
+                <div className="pr-2">
+                  <Button variant="ghost" size="sm" onClick={() => setShowAttachScorerDialog(true)}>
+                    Attach
+                  </Button>
+                </div>
+              )}
+            </div>
+            {!scorersCollapsed &&
+              (attachedScorerEntries.length === 0 ? (
+                <div className="px-4 py-4 text-center">
+                  <Txt variant="ui-xs" className="text-neutral3">
+                    No scorers attached to this dataset.
+                  </Txt>
+                  {unattachedScorerEntries.length > 0 && (
+                    <div className="mt-2">
+                      <Button variant="outline" size="sm" onClick={() => setShowAttachScorerDialog(true)}>
+                        Attach a scorer
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="divide-y divide-border1">
+                  {attachedScorerEntries.map(([id, scorer]) => {
+                    const name =
+                      (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
+                    return (
+                      <div
+                        key={id}
+                        className="flex items-center justify-between px-4 py-1.5 hover:bg-surface3 transition-colors group"
+                      >
+                        <Txt variant="ui-xs" className="text-neutral5 truncate">
+                          {name}
+                        </Txt>
+                        <button
+                          type="button"
+                          onClick={() => handleDetachScorer(id)}
+                          className="opacity-0 group-hover:opacity-100 transition-opacity text-neutral3 hover:text-red-500 p-0.5"
+                          title="Detach scorer"
+                        >
+                          <Icon size="sm">
+                            <X />
+                          </Icon>
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+          </div>
+
           {/* Items section (collapsible) */}
           <div className="border-b border-border1">
             <button
@@ -376,6 +490,65 @@ export function DatasetDetailView({
           </div>
         </ScrollArea>
       </div>
+
+      {/* Attach Scorer Dialog */}
+      <Dialog
+        open={showAttachScorerDialog}
+        onOpenChange={open => {
+          setShowAttachScorerDialog(open);
+          if (!open) setAttachScorerSearch('');
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Attach Scorer to Dataset</DialogTitle>
+          </DialogHeader>
+          <DialogBody className="max-h-[50vh] overflow-y-auto">
+            {unattachedScorerEntries.length === 0 ? (
+              <Txt variant="ui-sm" className="text-neutral3 py-4 text-center">
+                No scorers available to attach.
+              </Txt>
+            ) : (
+              <div className="space-y-2">
+                <input
+                  type="text"
+                  placeholder="Search scorers..."
+                  value={attachScorerSearch}
+                  onChange={e => setAttachScorerSearch(e.target.value)}
+                  className="w-full px-3 py-1.5 text-sm rounded border border-border1 bg-surface2 text-text1 placeholder:text-neutral3 focus:outline-none focus:ring-1 focus:ring-accent1"
+                />
+                {unattachedScorerEntries
+                  .filter(([id, scorer]) => {
+                    if (!attachScorerSearch) return true;
+                    const name =
+                      (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
+                    return name.toLowerCase().includes(attachScorerSearch.toLowerCase());
+                  })
+                  .map(([id, scorer]) => {
+                    const name =
+                      (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
+                    return (
+                      <button
+                        key={id}
+                        type="button"
+                        className="w-full text-left px-3 py-2 rounded hover:bg-surface4 transition-colors"
+                        onClick={async () => {
+                          await handleAttachScorer(id);
+                          toast.success(`Attached "${name}" to this dataset`);
+                          setShowAttachScorerDialog(false);
+                        }}
+                      >
+                        <Txt variant="ui-sm" className="font-medium">
+                          {name}
+                        </Txt>
+                      </button>
+                    );
+                  })}
+              </div>
+            )}
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -351,7 +351,7 @@ export function DatasetDetailView({
               ) : (
                 <div className="divide-y divide-border1">
                   {attachedScorerEntries.map(([id, scorer]) => {
-                    const name = (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
+                    const name = (scorer as { scorer?: { name?: string } }).scorer?.name || id;
                     return (
                       <div
                         key={id}
@@ -520,11 +520,11 @@ export function DatasetDetailView({
                 {unattachedScorerEntries
                   .filter(([id, scorer]) => {
                     if (!attachScorerSearch) return true;
-                    const name = (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
+                    const name = (scorer as { scorer?: { name?: string } }).scorer?.name || id;
                     return name.toLowerCase().includes(attachScorerSearch.toLowerCase());
                   })
                   .map(([id, scorer]) => {
-                    const name = (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
+                    const name = (scorer as { scorer?: { name?: string } }).scorer?.name || id;
                     return (
                       <button
                         key={id}

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -351,8 +351,7 @@ export function DatasetDetailView({
               ) : (
                 <div className="divide-y divide-border1">
                   {attachedScorerEntries.map(([id, scorer]) => {
-                    const name =
-                      (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
+                    const name = (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
                     return (
                       <div
                         key={id}
@@ -521,13 +520,11 @@ export function DatasetDetailView({
                 {unattachedScorerEntries
                   .filter(([id, scorer]) => {
                     if (!attachScorerSearch) return true;
-                    const name =
-                      (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
+                    const name = (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
                     return name.toLowerCase().includes(attachScorerSearch.toLowerCase());
                   })
                   .map(([id, scorer]) => {
-                    const name =
-                      (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
+                    const name = (scorer as { scorer?: { config?: { name?: string } } }).scorer?.config?.name || id;
                     return (
                       <button
                         key={id}

--- a/packages/playground/src/domains/agents/agent-layout.tsx
+++ b/packages/playground/src/domains/agents/agent-layout.tsx
@@ -61,10 +61,6 @@ export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
     </MainContentLayout>
   );
 
-  if (!showPlayground && !showObservability) {
-    return content;
-  }
-
   return (
     <SchemaRequestContextProvider>
       <PlaygroundModelProvider defaultProvider={defaultProvider} defaultModel={defaultModel}>

--- a/packages/server/src/server/handlers/datasets.ts
+++ b/packages/server/src/server/handlers/datasets.ts
@@ -150,6 +150,7 @@ export const CREATE_DATASET_ROUTE = createRoute({
         requestContextSchema,
         targetType,
         targetIds,
+        scorerIds,
       } = params as {
         name: string;
         description?: string;
@@ -159,6 +160,7 @@ export const CREATE_DATASET_ROUTE = createRoute({
         requestContextSchema?: Record<string, unknown> | null;
         targetType?: TargetType;
         targetIds?: string[];
+        scorerIds?: string[];
       };
       const ds = await mastra.datasets.create({
         name,
@@ -169,6 +171,7 @@ export const CREATE_DATASET_ROUTE = createRoute({
         requestContextSchema,
         targetType,
         targetIds,
+        scorerIds,
       });
       const details = await ds.getDetails();
       return details as any;
@@ -229,6 +232,7 @@ export const UPDATE_DATASET_ROUTE = createRoute({
         tags,
         targetType,
         targetIds,
+        scorerIds,
       } = params as {
         name?: string;
         description?: string;
@@ -239,6 +243,7 @@ export const UPDATE_DATASET_ROUTE = createRoute({
         tags?: string[];
         targetType?: TargetType;
         targetIds?: string[];
+        scorerIds?: string[] | null;
       };
       const ds = await mastra.datasets.get({ id: datasetId });
       const result = await ds.update({
@@ -251,6 +256,7 @@ export const UPDATE_DATASET_ROUTE = createRoute({
         tags,
         targetType,
         targetIds,
+        scorerIds,
       });
       return result as any;
     } catch (error) {

--- a/packages/server/src/server/schemas/datasets.ts
+++ b/packages/server/src/server/schemas/datasets.ts
@@ -81,6 +81,7 @@ export const createDatasetBodySchema = z.object({
   requestContextSchema: jsonSchemaField.describe('JSON Schema describing expected request context shape'),
   targetType: z.string().optional().describe('Target entity type (e.g. agent, workflow, scorer)'),
   targetIds: z.array(z.string()).optional().describe('IDs of target entities this dataset is attached to'),
+  scorerIds: z.array(z.string()).optional().describe('IDs of scorers attached to this dataset'),
 });
 
 export const updateDatasetBodySchema = z.object({
@@ -93,6 +94,7 @@ export const updateDatasetBodySchema = z.object({
   tags: z.array(z.string()).optional().describe('Tag definitions for categorizing experiment results'),
   targetType: z.string().optional().describe('Target entity type (e.g. agent, workflow, scorer)'),
   targetIds: z.array(z.string()).optional().describe('IDs of target entities this dataset is attached to'),
+  scorerIds: z.array(z.string()).optional().nullable().describe('IDs of scorers attached to this dataset'),
 });
 
 export const addItemBodySchema = z.object({
@@ -142,6 +144,7 @@ export const datasetResponseSchema = z.object({
   tags: z.array(z.string()).optional().nullable(),
   targetType: z.string().optional().nullable(),
   targetIds: z.array(z.string()).optional().nullable(),
+  scorerIds: z.array(z.string()).optional().nullable(),
   version: z.number().int(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),

--- a/stores/libsql/src/storage/domains/datasets/index.ts
+++ b/stores/libsql/src/storage/domains/datasets/index.ts
@@ -66,6 +66,7 @@ export class DatasetsLibSQL extends DatasetsStorage {
     await this.#addColumnIfNotExists(TABLE_DATASETS, 'tags', 'TEXT');
     await this.#addColumnIfNotExists(TABLE_DATASETS, 'targetType', 'TEXT');
     await this.#addColumnIfNotExists(TABLE_DATASETS, 'targetIds', 'TEXT');
+    await this.#addColumnIfNotExists(TABLE_DATASETS, 'scorerIds', 'TEXT');
     await this.#addColumnIfNotExists(TABLE_DATASET_ITEMS, 'requestContext', 'TEXT');
     await this.#addColumnIfNotExists(TABLE_DATASET_ITEMS, 'source', 'TEXT');
 
@@ -121,6 +122,7 @@ export class DatasetsLibSQL extends DatasetsStorage {
       tags: row.tags ? safelyParseJSON(row.tags) : undefined,
       targetType: (row.targetType as TargetType) || undefined,
       targetIds: row.targetIds ? safelyParseJSON(row.targetIds) : undefined,
+      scorerIds: row.scorerIds ? safelyParseJSON(row.scorerIds) : undefined,
       version: row.version as number,
       createdAt: ensureDate(row.createdAt)!,
       updatedAt: ensureDate(row.updatedAt)!,
@@ -188,6 +190,7 @@ export class DatasetsLibSQL extends DatasetsStorage {
           requestContextSchema: input.requestContextSchema ?? null,
           targetType: input.targetType ?? null,
           targetIds: input.targetIds ? JSON.stringify(input.targetIds) : null,
+          scorerIds: input.scorerIds ? JSON.stringify(input.scorerIds) : null,
           version: 0,
           createdAt: nowIso,
           updatedAt: nowIso,
@@ -204,6 +207,7 @@ export class DatasetsLibSQL extends DatasetsStorage {
         requestContextSchema: input.requestContextSchema ?? undefined,
         targetType: input.targetType ?? undefined,
         targetIds: input.targetIds ?? undefined,
+        scorerIds: input.scorerIds ?? undefined,
         version: 0,
         createdAt: now,
         updatedAt: now,
@@ -291,6 +295,10 @@ export class DatasetsLibSQL extends DatasetsStorage {
         updates.push('targetIds = ?');
         values.push(args.targetIds === null ? null : JSON.stringify(args.targetIds));
       }
+      if (args.scorerIds !== undefined) {
+        updates.push('scorerIds = ?');
+        values.push(args.scorerIds === null ? null : JSON.stringify(args.scorerIds));
+      }
 
       values.push(args.id);
 
@@ -313,6 +321,7 @@ export class DatasetsLibSQL extends DatasetsStorage {
         tags: (args.tags !== undefined ? args.tags : existing.tags) ?? undefined,
         targetType: (args.targetType !== undefined ? args.targetType : existing.targetType) ?? undefined,
         targetIds: (args.targetIds !== undefined ? args.targetIds : existing.targetIds) ?? undefined,
+        scorerIds: (args.scorerIds !== undefined ? args.scorerIds : existing.scorerIds) ?? undefined,
         updatedAt: new Date(now),
       };
     } catch (error) {

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -149,6 +149,7 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
       tags: typeof row.tags === 'string' ? safelyParseJSON(row.tags) : (row.tags ?? undefined),
       targetType: row.targetType ?? undefined,
       targetIds: typeof row.targetIds === 'string' ? safelyParseJSON(row.targetIds) : (row.targetIds ?? undefined),
+      scorerIds: typeof row.scorerIds === 'string' ? safelyParseJSON(row.scorerIds) : (row.scorerIds ?? undefined),
       version: row.version ?? 0,
       createdAt: ensureDate(row.createdAt)!,
       updatedAt: ensureDate(row.updatedAt)!,
@@ -205,6 +206,7 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         requestContextSchema: input.requestContextSchema ?? null,
         targetType: input.targetType ?? null,
         targetIds: input.targetIds ?? null,
+        scorerIds: input.scorerIds ?? null,
         version: 0,
         createdAt: now,
         updatedAt: now,
@@ -268,6 +270,7 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
       if (args.tags !== undefined) updateDoc.tags = args.tags;
       if (args.targetType !== undefined) updateDoc.targetType = args.targetType;
       if (args.targetIds !== undefined) updateDoc.targetIds = args.targetIds;
+      if (args.scorerIds !== undefined) updateDoc.scorerIds = args.scorerIds;
 
       await collection.updateOne({ id: args.id }, { $set: updateDoc });
 

--- a/stores/pg/src/storage/domains/datasets/index.ts
+++ b/stores/pg/src/storage/domains/datasets/index.ts
@@ -93,6 +93,7 @@ export class DatasetsPG extends DatasetsStorage {
     await this.#addColumnIfNotExists(TABLE_DATASETS, 'tags', 'JSONB');
     await this.#addColumnIfNotExists(TABLE_DATASETS, 'targetType', 'TEXT');
     await this.#addColumnIfNotExists(TABLE_DATASETS, 'targetIds', 'JSONB');
+    await this.#addColumnIfNotExists(TABLE_DATASETS, 'scorerIds', 'JSONB');
     await this.#addColumnIfNotExists(TABLE_DATASET_ITEMS, 'requestContext', 'JSONB');
     await this.#addColumnIfNotExists(TABLE_DATASET_ITEMS, 'source', 'JSONB');
 
@@ -171,6 +172,7 @@ export class DatasetsPG extends DatasetsStorage {
       tags: row.tags ? safelyParseJSON(row.tags) : undefined,
       targetType: (row.targetType as TargetType) || null,
       targetIds: row.targetIds || null,
+      scorerIds: row.scorerIds || null,
       version: row.version as number,
       createdAt: ensureDate(row.createdAtZ || row.createdAt)!,
       updatedAt: ensureDate(row.updatedAtZ || row.updatedAt)!,
@@ -238,6 +240,7 @@ export class DatasetsPG extends DatasetsStorage {
           requestContextSchema: input.requestContextSchema ?? null,
           targetType: input.targetType ?? null,
           targetIds: input.targetIds !== undefined ? JSON.stringify(input.targetIds) : null,
+          scorerIds: input.scorerIds ? JSON.stringify(input.scorerIds) : null,
           version: 0,
           createdAt: nowIso,
           updatedAt: nowIso,
@@ -254,6 +257,7 @@ export class DatasetsPG extends DatasetsStorage {
         requestContextSchema: input.requestContextSchema ?? undefined,
         targetType: input.targetType ?? null,
         targetIds: input.targetIds ?? null,
+        scorerIds: input.scorerIds ?? null,
         version: 0,
         createdAt: now,
         updatedAt: now,
@@ -341,6 +345,10 @@ export class DatasetsPG extends DatasetsStorage {
         setClauses.push(`"targetIds" = $${paramIndex++}`);
         values.push(args.targetIds === null ? null : JSON.stringify(args.targetIds));
       }
+      if (args.scorerIds !== undefined) {
+        setClauses.push(`"scorerIds" = $${paramIndex++}`);
+        values.push(args.scorerIds === null ? null : JSON.stringify(args.scorerIds));
+      }
 
       values.push(args.id);
       await this.#db.client.none(
@@ -362,6 +370,7 @@ export class DatasetsPG extends DatasetsStorage {
         tags: (args.tags !== undefined ? args.tags : existing.tags) ?? undefined,
         targetType: (args.targetType !== undefined ? args.targetType : existing.targetType) ?? null,
         targetIds: (args.targetIds !== undefined ? args.targetIds : existing.targetIds) ?? null,
+        scorerIds: (args.scorerIds !== undefined ? args.scorerIds : existing.scorerIds) ?? null,
         updatedAt: new Date(now),
       };
     } catch (error) {


### PR DESCRIPTION
Adds persistent scorer attachment to datasets. When scorers are attached to a dataset, they automatically run alongside any scorers specified at experiment trigger time.

**Core/Storage:** New `scorerIds` field on `DatasetRecord`, `CreateDatasetInput`, and `UpdateDatasetInput`. Added to `DATASETS_SCHEMA` and all storage backends (InMemory, LibSQL, PostgreSQL, MongoDB). At experiment time, dataset-attached scorers are merged with explicitly-provided scorers and deduplicated.

**Server/Client SDK:** `scorerIds` flows through CREATE/UPDATE handlers and request/response schemas. Client types updated to match.

**Playground UI:** New collapsible "Scorers" section in the dataset detail view with attach/detach via a dialog picker. `ScorerDetailView` now also shows datasets where the scorer is attached via `scorerIds`.

Also fixes a crash on page refresh in the evaluate tab — `ReviewQueueProvider` was conditionally unmounted during loading states, causing `useReviewQueue` to throw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Datasets can store associated scorer IDs; create/update responses include scorer lists.
  - Experiments now merge dataset-attached scorers with user-configured scorers (string IDs deduplicated).
  - UI: attach/detach scorers from a dataset via the Dataset detail view, with an attach dialog and per-scorer controls.

* **Bug Fixes**
  - Prevented a crash on refresh in the evaluate tab by ensuring required providers render during loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->