### PR TITLE
fix: persist observational memory threshold settings across restarts

### DIFF
--- a/.changeset/bright-bags-jump.md
+++ b/.changeset/bright-bags-jump.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+mastracode: patch
+---
+
+Persist observational memory threshold settings across restarts and restore per-thread overrides.

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -249,6 +249,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   const builtinOmPacks = getAvailableOmPacks(startupAccess);
   const effectiveDefaults = resolveModelDefaults(globalSettings, builtinPacks);
   const effectiveOmModel = resolveOmModel(globalSettings, builtinOmPacks);
+  const effectiveObservationThreshold = globalSettings.models.omObservationThreshold ?? undefined;
+  const effectiveReflectionThreshold = globalSettings.models.omReflectionThreshold ?? undefined;
 
   // Apply resolved model defaults to modes
   const modes = (config?.modes ?? defaultModes).map(mode => {
@@ -286,6 +288,12 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   if (effectiveOmModel) {
     globalInitialState.observerModelId = effectiveOmModel;
     globalInitialState.reflectorModelId = effectiveOmModel;
+  }
+  if (effectiveObservationThreshold !== undefined) {
+    globalInitialState.observationThreshold = effectiveObservationThreshold;
+  }
+  if (effectiveReflectionThreshold !== undefined) {
+    globalInitialState.reflectionThreshold = effectiveReflectionThreshold;
   }
   if (globalSettings.preferences.yolo !== null) {
     globalInitialState.yolo = globalSettings.preferences.yolo;

--- a/mastracode/src/onboarding/settings.ts
+++ b/mastracode/src/onboarding/settings.ts
@@ -89,6 +89,10 @@ export interface GlobalSettings {
     activeOmPackId: string | null;
     /** Explicit OM model override — used for custom OM pack or /om manual changes. */
     omModelOverride: string | null;
+    /** Default OM observation threshold used for new threads unless overridden per-thread. */
+    omObservationThreshold: number | null;
+    /** Default OM reflection threshold used for new threads unless overridden per-thread. */
+    omReflectionThreshold: number | null;
     /** Per-agent-type subagent model overrides (e.g. { explore: "openai/gpt-5.1-codex-mini" }) */
     subagentModels: Record<string, string>;
   };
@@ -134,6 +138,8 @@ const DEFAULTS: GlobalSettings = {
     modeDefaults: {},
     activeOmPackId: null,
     omModelOverride: null,
+    omObservationThreshold: null,
+    omReflectionThreshold: null,
     subagentModels: {},
   },
   preferences: {

--- a/mastracode/src/tui/commands/om.ts
+++ b/mastracode/src/tui/commands/om.ts
@@ -10,6 +10,23 @@ function persistOmModelOverride(modelId: string): void {
   saveSettings(settings);
 }
 
+function persistOmThresholds({
+  observationThreshold,
+  reflectionThreshold,
+}: {
+  observationThreshold?: number;
+  reflectionThreshold?: number;
+}): void {
+  const settings = loadSettings();
+  if (observationThreshold !== undefined) {
+    settings.models.omObservationThreshold = observationThreshold;
+  }
+  if (reflectionThreshold !== undefined) {
+    settings.models.omReflectionThreshold = reflectionThreshold;
+  }
+  saveSettings(settings);
+}
+
 export async function handleOMCommand(ctx: SlashCommandContext): Promise<void> {
   const availableModels = await ctx.state.harness.listAvailableModels();
   const modelById = new Map(availableModels.map(model => [model.id, model] as const));
@@ -47,11 +64,15 @@ export async function handleOMCommand(ctx: SlashCommandContext): Promise<void> {
           persistOmModelOverride(modelId);
           ctx.showInfo(`Reflector model → ${modelId}`);
         },
-        onObservationThresholdChange: value => {
-          ctx.state.harness.setState({ observationThreshold: value } as any);
+        onObservationThresholdChange: async value => {
+          await ctx.state.harness.setState({ observationThreshold: value } as any);
+          await ctx.state.harness.setThreadSetting({ key: 'observationThreshold', value });
+          persistOmThresholds({ observationThreshold: value });
         },
-        onReflectionThresholdChange: value => {
-          ctx.state.harness.setState({ reflectionThreshold: value } as any);
+        onReflectionThresholdChange: async value => {
+          await ctx.state.harness.setState({ reflectionThreshold: value } as any);
+          await ctx.state.harness.setThreadSetting({ key: 'reflectionThreshold', value });
+          persistOmThresholds({ reflectionThreshold: value });
         },
         onClose: () => {
           ctx.state.ui.hideOverlay();

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -953,9 +953,31 @@ export class Harness<TState = {}> {
       if (meta?.reflectorModelId) {
         updates.reflectorModelId = meta.reflectorModelId;
       }
+      const hasObservationThreshold = typeof meta?.observationThreshold === 'number';
+      const hasReflectionThreshold = typeof meta?.reflectionThreshold === 'number';
+
+      if (hasObservationThreshold) {
+        updates.observationThreshold = meta.observationThreshold;
+      }
+      if (hasReflectionThreshold) {
+        updates.reflectionThreshold = meta.reflectionThreshold;
+      }
 
       if (Object.keys(updates).length > 0) {
-        void this.setState(updates as unknown as Partial<TState>);
+        await this.setState(updates as unknown as Partial<TState>);
+      }
+
+      if (!hasObservationThreshold) {
+        const observationThreshold = this.getObservationThreshold();
+        if (observationThreshold !== undefined) {
+          await this.setThreadSetting({ key: 'observationThreshold', value: observationThreshold });
+        }
+      }
+      if (!hasReflectionThreshold) {
+        const reflectionThreshold = this.getReflectionThreshold();
+        if (reflectionThreshold !== undefined) {
+          await this.setThreadSetting({ key: 'reflectionThreshold', value: reflectionThreshold });
+        }
       }
     } catch {
       this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };

--- a/packages/core/src/harness/om-threshold-persistence.test.ts
+++ b/packages/core/src/harness/om-threshold-persistence.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+
+function createHarness(storage: InMemoryStore, initialState: Record<string, unknown> = {}) {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  return new Harness({
+    id: 'test-harness',
+    storage,
+    initialState: initialState as any,
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+}
+
+describe('Harness OM threshold persistence', () => {
+  let storage: InMemoryStore;
+
+  beforeEach(() => {
+    storage = new InMemoryStore();
+  });
+
+  it('restores observation and reflection thresholds from thread metadata when switching back to a thread', async () => {
+    const harness = createHarness(storage, {
+      observationThreshold: 30000,
+      reflectionThreshold: 40000,
+    });
+    await harness.init();
+
+    const threadA = await harness.createThread();
+    await harness.setState({ observationThreshold: 12000, reflectionThreshold: 21000 } as any);
+    await harness.setThreadSetting({ key: 'observationThreshold', value: 12000 });
+    await harness.setThreadSetting({ key: 'reflectionThreshold', value: 21000 });
+
+    await harness.createThread();
+    await harness.setState({ observationThreshold: 33000, reflectionThreshold: 44000 } as any);
+
+    await harness.switchThread({ threadId: threadA.id });
+
+    expect((harness.getState() as any).observationThreshold).toBe(12000);
+    expect((harness.getState() as any).reflectionThreshold).toBe(21000);
+  });
+
+  it('persists current thresholds onto an existing thread when metadata does not define overrides', async () => {
+    const harness = createHarness(storage, {
+      observationThreshold: 15000,
+      reflectionThreshold: 25000,
+    });
+    await harness.init();
+
+    const thread = await harness.createThread();
+    await harness.setState({ observationThreshold: 18000, reflectionThreshold: 28000 } as any);
+
+    await harness.switchThread({ threadId: thread.id });
+
+    expect((harness.getState() as any).observationThreshold).toBe(18000);
+    expect((harness.getState() as any).reflectionThreshold).toBe(28000);
+
+    const memory = await storage.getStore('memory');
+    const savedThread = await memory?.getThreadById({ threadId: thread.id });
+    expect(savedThread?.metadata?.observationThreshold).toBe(18000);
+    expect(savedThread?.metadata?.reflectionThreshold).toBe(28000);
+  });
+});


### PR DESCRIPTION
Fixes a bug where `/om` history-size changes would reset to default (30k/40k) after restarting mastracode.

Now thresholds persist across restarts in two places:
- Global settings for new threads
- Thread metadata for existing threads

When you change thresholds via `/om`, we save them to the current thread and update the global default. On startup, we seed thresholds from global defaults. When loading an existing thread that lacks saved thresholds, we backfill it with the current values.

Example behavior:
- Open thread A, set history-size to 50k
- Restart mastracode
- Thread A still uses 50k (restored from thread metadata)
- Threads B and C use 50k (inherited from global default)

Includes regression test for threshold persistence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Observational memory threshold settings now persist across application restarts.
  * Per-thread threshold override values are restored when switching between threads, maintaining customized configurations.

* **Tests**
  * Added comprehensive test coverage for observational memory threshold persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->