### PR TITLE
fix(datadog): promote requestContextKeys from metadata to flat LLM Obs tags

### DIFF
--- a/.changeset/quiet-cougars-know.md
+++ b/.changeset/quiet-cougars-know.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': patch
+---
+
+Fixed Datadog request context keys so they are exported as flat LLM Observability tags instead of nested metadata.

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -1314,6 +1314,89 @@ describe('DatadogExporter', () => {
     });
   });
 
+  describe('requestContextKeys', () => {
+    it('promotes listed metadata keys to flat tags', async () => {
+      const exporter = new DatadogExporter({
+        mlApp: 'test',
+        apiKey: 'test-key',
+        requestContextKeys: ['tenantId', 'agentId'],
+      });
+
+      const span = createMockSpan({
+        type: SpanType.GENERIC,
+        metadata: { tenantId: 'tenant-123', agentId: 'agent-456', otherKey: 'stays-in-metadata' },
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      const annotateCall = mockAnnotate.mock.calls[0]?.[1];
+      // Promoted keys appear as flat tags
+      expect(annotateCall?.tags).toMatchObject({ tenantId: 'tenant-123', agentId: 'agent-456' });
+      // Promoted keys are NOT duplicated in metadata
+      expect(annotateCall?.metadata).not.toHaveProperty('tenantId');
+      expect(annotateCall?.metadata).not.toHaveProperty('agentId');
+      // Keys not listed remain in metadata
+      expect(annotateCall?.metadata).toMatchObject({ otherKey: 'stays-in-metadata' });
+    });
+
+    it('does not affect metadata when requestContextKeys is not set', async () => {
+      const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+
+      const span = createMockSpan({
+        type: SpanType.GENERIC,
+        metadata: { tenantId: 'tenant-123', someKey: 'some-value' },
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      const annotateCall = mockAnnotate.mock.calls[0]?.[1];
+      // All metadata stays in metadata when no requestContextKeys configured
+      expect(annotateCall?.metadata).toMatchObject({ tenantId: 'tenant-123', someKey: 'some-value' });
+    });
+
+    it('merges promoted context keys with existing span tags', async () => {
+      const exporter = new DatadogExporter({
+        mlApp: 'test',
+        apiKey: 'test-key',
+        requestContextKeys: ['tenantId'],
+      });
+
+      const span = createMockSpan({
+        type: SpanType.GENERIC,
+        metadata: { tenantId: 'tenant-abc' },
+        tags: ['production', 'instance_name:api-server'],
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      const annotateCall = mockAnnotate.mock.calls[0]?.[1];
+      expect(annotateCall?.tags).toMatchObject({
+        tenantId: 'tenant-abc',
+        production: true,
+        instance_name: 'api-server',
+      });
+    });
+
+    it('handles empty requestContextKeys array gracefully', async () => {
+      const exporter = new DatadogExporter({
+        mlApp: 'test',
+        apiKey: 'test-key',
+        requestContextKeys: [],
+      });
+
+      const span = createMockSpan({
+        type: SpanType.GENERIC,
+        metadata: { tenantId: 'tenant-123' },
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      const annotateCall = mockAnnotate.mock.calls[0]?.[1];
+      // All metadata stays in metadata when requestContextKeys is empty
+      expect(annotateCall?.metadata).toMatchObject({ tenantId: 'tenant-123' });
+    });
+  });
+
   describe('timer cancellation on new activity', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -1395,6 +1395,52 @@ describe('DatadogExporter', () => {
       // All metadata stays in metadata when requestContextKeys is empty
       expect(annotateCall?.metadata).toMatchObject({ tenantId: 'tenant-123' });
     });
+
+    it('promotes matching keys from span.attributes to flat tags', async () => {
+      const exporter = new DatadogExporter({
+        mlApp: 'test',
+        apiKey: 'test-key',
+        requestContextKeys: ['tenantId', 'agentId'],
+      });
+
+      const span = createMockSpan({
+        type: SpanType.GENERIC,
+        // Keys stored in span.attributes rather than span.metadata
+        attributes: { tenantId: 'tenant-from-attrs', agentId: 'agent-from-attrs', otherAttr: 'stays' },
+        metadata: { someKey: 'some-value' },
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      const annotateCall = mockAnnotate.mock.calls[0]?.[1];
+      // Keys from attributes are promoted to flat tags
+      expect(annotateCall?.tags).toMatchObject({ tenantId: 'tenant-from-attrs', agentId: 'agent-from-attrs' });
+      // Promoted attribute keys are NOT duplicated in metadata
+      expect(annotateCall?.metadata).not.toHaveProperty('tenantId');
+      expect(annotateCall?.metadata).not.toHaveProperty('agentId');
+      // Non-promoted attribute keys and metadata stay in metadata
+      expect(annotateCall?.metadata).toMatchObject({ otherAttr: 'stays', someKey: 'some-value' });
+    });
+
+    it('metadata wins over attributes when both have the same requestContextKey', async () => {
+      const exporter = new DatadogExporter({
+        mlApp: 'test',
+        apiKey: 'test-key',
+        requestContextKeys: ['tenantId'],
+      });
+
+      const span = createMockSpan({
+        type: SpanType.GENERIC,
+        attributes: { tenantId: 'tenant-from-attrs' },
+        metadata: { tenantId: 'tenant-from-metadata' },
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      const annotateCall = mockAnnotate.mock.calls[0]?.[1];
+      // metadata value wins
+      expect(annotateCall?.tags).toMatchObject({ tenantId: 'tenant-from-metadata' });
+    });
   });
 
   describe('timer cancellation on new activity', () => {

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -304,10 +304,10 @@ export class DatadogExporter extends BaseExporter {
     const knownFields = ['usage', 'model', 'provider', 'parameters'];
     const otherAttributes = omitKeys((span.attributes ?? {}) as Record<string, any>, knownFields);
 
-    // Separate requestContextKeys from span.metadata:
+    // Separate requestContextKeys from span.metadata AND span.attributes:
     // - Keys listed in this.config.requestContextKeys are promoted to flat LLM Obs tags,
     //   making them indexable and filterable in the Datadog UI (e.g. tenantId, agentId).
-    // - All remaining metadata keys stay nested in annotations.metadata as before.
+    // - All remaining keys stay nested in annotations.metadata as before.
     const contextKeySet = new Set(this.config.requestContextKeys ?? []);
     const flatContextTags: Record<string, any> = {};
     const remainingMetadata: Record<string, any> = {};
@@ -320,12 +320,26 @@ export class DatadogExporter extends BaseExporter {
       }
     }
 
+    // Also promote matching keys from span.attributes so requestContextKeys
+    // are consistently elevated regardless of where the caller stored them.
+    const remainingAttributes: Record<string, any> = {};
+    for (const [key, value] of Object.entries(otherAttributes)) {
+      if (contextKeySet.has(key)) {
+        // Only promote if not already set from span.metadata (metadata wins)
+        if (!(key in flatContextTags)) {
+          flatContextTags[key] = value;
+        }
+      } else {
+        remainingAttributes[key] = value;
+      }
+    }
+
     // Merge remaining span.metadata + span attributes into metadata
     // Error message goes into metadata (not tags) because tags get normalized/truncated
     // which mangles free-form error text (e.g. colons split into key/value, spaces become underscores)
     const combinedMetadata: Record<string, any> = {
       ...remainingMetadata,
-      ...otherAttributes,
+      ...remainingAttributes,
     };
     if (span.errorInfo) {
       combinedMetadata['error.message'] = span.errorInfo.message;

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -128,6 +128,24 @@ export interface DatadogExporterConfig extends BaseExporterConfig {
    * Defaults to false to avoid unexpected instrumentation.
    */
   integrationsEnabled?: boolean;
+
+  /**
+   * Keys from the request context (set via `requestContextKeys` in the Mastra
+   * Observability config) that should be promoted to flat Datadog LLM Observability
+   * tags instead of being nested inside `annotations.metadata`.
+   *
+   * Flat tags are indexable and filterable in the Datadog LLM Observability UI,
+   * which makes them suitable for multi-tenant filtering (e.g. tenantId, agentId).
+   *
+   * @example
+   * ```typescript
+   * new DatadogExporter({
+   *   mlApp: 'my-app',
+   *   requestContextKeys: ['tenantId', 'agentId'],
+   * })
+   * ```
+   */
+  requestContextKeys?: string[];
 }
 
 /**
@@ -286,11 +304,27 @@ export class DatadogExporter extends BaseExporter {
     const knownFields = ['usage', 'model', 'provider', 'parameters'];
     const otherAttributes = omitKeys((span.attributes ?? {}) as Record<string, any>, knownFields);
 
-    // Merge span.metadata + remaining attributes into metadata
+    // Separate requestContextKeys from span.metadata:
+    // - Keys listed in this.config.requestContextKeys are promoted to flat LLM Obs tags,
+    //   making them indexable and filterable in the Datadog UI (e.g. tenantId, agentId).
+    // - All remaining metadata keys stay nested in annotations.metadata as before.
+    const contextKeySet = new Set(this.config.requestContextKeys ?? []);
+    const flatContextTags: Record<string, any> = {};
+    const remainingMetadata: Record<string, any> = {};
+
+    for (const [key, value] of Object.entries(span.metadata ?? {})) {
+      if (contextKeySet.has(key)) {
+        flatContextTags[key] = value;
+      } else {
+        remainingMetadata[key] = value;
+      }
+    }
+
+    // Merge remaining span.metadata + span attributes into metadata
     // Error message goes into metadata (not tags) because tags get normalized/truncated
     // which mangles free-form error text (e.g. colons split into key/value, spaces become underscores)
     const combinedMetadata: Record<string, any> = {
-      ...span.metadata,
+      ...remainingMetadata,
       ...otherAttributes,
     };
     if (span.errorInfo) {
@@ -300,10 +334,14 @@ export class DatadogExporter extends BaseExporter {
       annotations.metadata = combinedMetadata;
     }
 
-    // Build tags from span.tags (user-provided string[] converted to object) and error info
-    // Datadog annotation tags accept Record<string, any>, so we use proper types
+    // Build tags from span.tags (user-provided string[] converted to object),
+    // promoted requestContextKeys values (flat, indexable in Datadog), and error info.
+    // Datadog annotation tags accept Record<string, any>, so we use proper types.
     // The native span error status is also set via ddSpan.setTag('error', true) in emitSpan()
-    const tags: Record<string, any> = {};
+    const tags: Record<string, any> = {
+      // Promote requestContextKeys values to flat, searchable LLM Observability tags
+      ...flatContextTags,
+    };
 
     // Convert span.tags (string[]) to object format
     // Tags in "key:value" format (e.g. "instance_name:career-scout-api") are split into { key: "value" }


### PR DESCRIPTION
## Problem

When using `requestContextKeys` in the Mastra Observability config (e.g. `tenantId`, `agentId`), the `DatadogExporter` was nesting these values under `annotations.metadata` when calling `llmobs.annotate()`. Datadog does not index nested metadata keys as searchable tags, making multi-tenant filtering impossible in the Datadog LLM Observability UI.

Fixes #14635

## What changed

**`observability/datadog/src/tracing.ts`**
- Added `requestContextKeys?: string[]` to `DatadogExporterConfig`
- In `buildAnnotations()`, keys listed in `requestContextKeys` are now extracted from `span.metadata` and merged into flat `annotations.tags` instead of nested `annotations.metadata`
- All other metadata keys continue to appear under `annotations.metadata` as before

**`observability/datadog/src/tracing.test.ts`**
- Added `describe('requestContextKeys')` block with 4 tests covering:
  - Promoted keys appear as flat tags and are removed from metadata
  - No change in behavior when `requestContextKeys` is not configured
  - Promoted keys merge correctly with existing `span.tags`
  - Empty `requestContextKeys` array is handled gracefully

## Usage

```typescript
new DatadogExporter({
  mlApp: 'my-app',
  apiKey: process.env.DD_API_KEY,
  requestContextKeys: ['tenantId', 'agentId'],
})
```

With this config, `tenantId` and `agentId` values from the request context appear as flat, filterable LLM Observability tags in Datadog rather than buried inside `metadata`.

## How to test

```bash
cd observability/datadog
pnpm test
```

All 116 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration to promote selected request context keys from span metadata/attributes into top-level annotation tags, merging with existing tags and keeping remaining metadata intact.

* **Tests**
  * Added tests verifying promotion, merging, preservation when the option is omitted or empty, and precedence rules between metadata and attributes.

* **Chores**
  * Prepared a patch release entry noting the request context keys now export as flat observability tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->