### PR TITLE
fix(playground-ui): change Editor tab URL from /playground to /editor

### DIFF
--- a/.changeset/fair-pugs-pull.md
+++ b/.changeset/fair-pugs-pull.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Changed the Editor tab URL from /agents/:agentId/playground to /agents/:agentId/editor in Mastra Studio

--- a/packages/playground-ui/src/domains/agents/components/agent-page-tabs.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-page-tabs.tsx
@@ -71,7 +71,7 @@ export function AgentPageTabs({
       />
       {showPlayground && (
         <TabLink
-          href={`/agents/${agentId}/playground`}
+          href={`/agents/${agentId}/editor`}
           active={activeTab === 'versions'}
           icon={<GitBranch />}
           label="Editor"

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -245,7 +245,7 @@ const routes = [
           { path: 'chat/:threadId', element: <Agent /> },
           ...(isExperimentalFeatures
             ? [
-                { path: 'playground', element: <AgentPlayground /> },
+                { path: 'editor', element: <AgentPlayground /> },
                 { path: 'evaluate', element: <AgentEvaluate /> },
                 { path: 'review', element: <AgentReview /> },
               ]

--- a/packages/playground/src/domains/agents/agent-layout.tsx
+++ b/packages/playground/src/domains/agents/agent-layout.tsx
@@ -33,7 +33,7 @@ export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
   const defaultModel = agent?.modelId ?? '';
   const requestContextSchema = agent?.requestContextSchema;
 
-  const activeTab: AgentPageTab = location.pathname.includes('/playground')
+  const activeTab: AgentPageTab = location.pathname.includes('/editor')
     ? 'versions'
     : location.pathname.includes('/evaluate')
       ? 'evaluate'


### PR DESCRIPTION
The Editor tab in Mastra Studio was navigating to `/agents/:agentId/playground`. This changes it to `/agents/:agentId/editor` to match the tab's label.

Three spots updated:
- Tab href in `agent-page-tabs.tsx`
- Route path in `App.tsx`
- Active tab detection in `agent-layout.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Editor feature route path from `/agents/:agentId/playground` to `/agents/:agentId/editor` for improved consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->