### PR TITLE
fix(auth): remove EE license gating from OSS auth features

### DIFF
--- a/.changeset/sharp-drinks-roll.md
+++ b/.changeset/sharp-drinks-roll.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed buildCapabilities() incorrectly gating SSO, credentials, session, and user features behind an EE license. These are OSS features that should work without a license in production. Only RBAC and ACL remain gated behind the EE license, matching the documented intent.

--- a/packages/core/src/auth/ee/capabilities.test.ts
+++ b/packages/core/src/auth/ee/capabilities.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { buildCapabilities } from './capabilities';
+import type { AuthenticatedCapabilities } from './capabilities';
+import { clearLicenseCache } from './license';
+
+/**
+ * Minimal mock auth provider that implements SSO, credentials, user, and session interfaces.
+ * Simulates a custom Auth0-style provider with SSO login.
+ */
+function createMockAuthProvider(overrides?: {
+  isMastraCloudAuth?: boolean;
+  isSimpleAuth?: boolean;
+  getCurrentUser?: (req: Request) => Promise<{ id: string; email?: string; name?: string; avatarUrl?: string } | null>;
+}) {
+  return {
+    // ISSOProvider
+    getLoginUrl: (redirectUri: string, _state: string) =>
+      `https://auth0.example.com/authorize?redirect_uri=${redirectUri}`,
+    handleCallback: async (_code: string, _state: string) => ({
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      tokens: { accessToken: 'token-123' },
+    }),
+    getLoginButtonConfig: () => ({ provider: 'auth0', text: 'Sign in with Auth0' }),
+
+    // ICredentialsProvider
+    signIn: async (_email: string, _password: string) => ({
+      user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+      tokens: { accessToken: 'token-123' },
+    }),
+
+    // IUserProvider
+    getCurrentUser:
+      overrides?.getCurrentUser ??
+      (async (_req: Request) => ({ id: 'user-1', email: 'test@example.com', name: 'Test User' })),
+    getUser: async (_userId: string) => ({ id: 'user-1', email: 'test@example.com', name: 'Test User' }),
+
+    // ISessionProvider
+    createSession: async (_user: unknown) => ({
+      id: 'session-1',
+      userId: 'user-1',
+      expiresAt: new Date(Date.now() + 86400000),
+    }),
+    getSession: async (_req: Request) => ({
+      id: 'session-1',
+      userId: 'user-1',
+      expiresAt: new Date(Date.now() + 86400000),
+    }),
+    deleteSession: async (_sessionId: string) => {},
+    getSessionCookie: () => 'mastra-session=abc',
+
+    // Cloud/Simple markers
+    ...(overrides?.isMastraCloudAuth !== undefined && { isMastraCloudAuth: overrides.isMastraCloudAuth }),
+    ...(overrides?.isSimpleAuth !== undefined && { isSimpleAuth: overrides.isSimpleAuth }),
+  } as any;
+}
+
+/** Mock RBAC provider */
+function createMockRBACProvider() {
+  return {
+    getRoles: async () => ['admin'],
+    hasRole: async () => true,
+    getPermissions: async () => ['*'],
+    hasPermission: async () => true,
+    hasAllPermissions: async () => true,
+    hasAnyPermission: async () => true,
+  };
+}
+
+/** Mock ACL provider */
+function createMockACLProvider() {
+  return {
+    canAccess: async () => true,
+    listAccessible: async () => ['resource-1'],
+    filterAccessible: async <T extends { id: string }>(_user: unknown, resources: T[]) => resources,
+  };
+}
+
+function createMockRequest(): Request {
+  return new Request('http://localhost:3000/api/auth/capabilities');
+}
+
+describe('buildCapabilities', () => {
+  let originalNodeEnv: string | undefined;
+  let originalMastraDev: string | undefined;
+  let originalLicense: string | undefined;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env['NODE_ENV'];
+    originalMastraDev = process.env['MASTRA_DEV'];
+    originalLicense = process.env['MASTRA_EE_LICENSE'];
+    clearLicenseCache();
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv !== undefined) process.env['NODE_ENV'] = originalNodeEnv;
+    else delete process.env['NODE_ENV'];
+    if (originalMastraDev !== undefined) process.env['MASTRA_DEV'] = originalMastraDev;
+    else delete process.env['MASTRA_DEV'];
+    if (originalLicense !== undefined) process.env['MASTRA_EE_LICENSE'] = originalLicense;
+    else delete process.env['MASTRA_EE_LICENSE'];
+  });
+
+  it('should return disabled when no auth provider is configured', async () => {
+    const result = await buildCapabilities(null, createMockRequest());
+    expect(result).toEqual({ enabled: false, login: null });
+  });
+
+  describe('production without EE license (OSS features)', () => {
+    beforeEach(() => {
+      process.env['NODE_ENV'] = 'production';
+      delete process.env['MASTRA_DEV'];
+      delete process.env['MASTRA_EE_LICENSE'];
+      clearLicenseCache();
+    });
+
+    it('should enable SSO login without a license', async () => {
+      const auth = createMockAuthProvider();
+      const result = await buildCapabilities(auth, createMockRequest());
+
+      expect(result.enabled).toBe(true);
+      expect(result.login).not.toBeNull();
+      expect(result.login!.type).toBe('both');
+      expect(result.login!.sso).toBeDefined();
+      expect(result.login!.sso!.provider).toBe('auth0');
+    });
+
+    it('should enable credentials login without a license', async () => {
+      // Provider with only credentials (no SSO)
+      const auth = {
+        signIn: async () => ({
+          user: { id: 'user-1' },
+          tokens: { accessToken: 'token-123' },
+        }),
+        getCurrentUser: async () => ({ id: 'user-1', email: 'test@example.com', name: 'Test' }),
+        getUser: async () => ({ id: 'user-1' }),
+        createSession: async () => ({ id: 's-1', userId: 'user-1', expiresAt: new Date() }),
+        getSession: async () => ({ id: 's-1', userId: 'user-1', expiresAt: new Date() }),
+        deleteSession: async () => {},
+        getSessionCookie: () => 'session=abc',
+      } as any;
+
+      const result = await buildCapabilities(auth, createMockRequest());
+
+      expect(result.enabled).toBe(true);
+      expect(result.login).not.toBeNull();
+      expect(result.login!.type).toBe('credentials');
+    });
+
+    it('should resolve the current user without a license', async () => {
+      const auth = createMockAuthProvider();
+      const result = (await buildCapabilities(auth, createMockRequest())) as AuthenticatedCapabilities;
+
+      expect(result.user).toBeDefined();
+      expect(result.user.id).toBe('user-1');
+      expect(result.user.email).toBe('test@example.com');
+    });
+
+    it('should report user/session/sso capabilities as true without a license', async () => {
+      const auth = createMockAuthProvider();
+      const result = (await buildCapabilities(auth, createMockRequest())) as AuthenticatedCapabilities;
+
+      expect(result.capabilities.user).toBe(true);
+      expect(result.capabilities.session).toBe(true);
+      expect(result.capabilities.sso).toBe(true);
+    });
+
+    it('should gate RBAC behind a license', async () => {
+      const auth = createMockAuthProvider();
+      const rbac = createMockRBACProvider();
+      const result = (await buildCapabilities(auth, createMockRequest(), { rbac })) as AuthenticatedCapabilities;
+
+      expect(result.capabilities.rbac).toBe(false);
+      expect(result.access).toBeNull();
+    });
+
+    it('should gate ACL behind a license', async () => {
+      const auth = {
+        ...createMockAuthProvider(),
+        canAccess: createMockACLProvider().canAccess,
+        listAccessible: createMockACLProvider().listAccessible,
+        filterAccessible: createMockACLProvider().filterAccessible,
+      } as any;
+
+      const result = (await buildCapabilities(auth, createMockRequest())) as AuthenticatedCapabilities;
+
+      expect(result.capabilities.acl).toBe(false);
+    });
+
+    it('should return public response when user is not authenticated', async () => {
+      const auth = createMockAuthProvider({
+        getCurrentUser: async () => null,
+      });
+
+      const result = await buildCapabilities(auth, createMockRequest());
+
+      expect(result.enabled).toBe(true);
+      expect(result.login).not.toBeNull();
+      // Should be a public response (no user property)
+      expect('capabilities' in result).toBe(false);
+    });
+  });
+
+  describe('production with EE license', () => {
+    beforeEach(() => {
+      process.env['NODE_ENV'] = 'production';
+      delete process.env['MASTRA_DEV'];
+      process.env['MASTRA_EE_LICENSE'] = 'a'.repeat(32);
+      clearLicenseCache();
+    });
+
+    it('should enable all features including RBAC and ACL', async () => {
+      const auth = {
+        ...createMockAuthProvider(),
+        canAccess: createMockACLProvider().canAccess,
+        listAccessible: createMockACLProvider().listAccessible,
+        filterAccessible: createMockACLProvider().filterAccessible,
+      } as any;
+      const rbac = createMockRBACProvider();
+
+      const result = (await buildCapabilities(auth, createMockRequest(), { rbac })) as AuthenticatedCapabilities;
+
+      expect(result.capabilities.user).toBe(true);
+      expect(result.capabilities.session).toBe(true);
+      expect(result.capabilities.sso).toBe(true);
+      expect(result.capabilities.rbac).toBe(true);
+      expect(result.capabilities.acl).toBe(true);
+      expect(result.access).not.toBeNull();
+      expect(result.access!.roles).toEqual(['admin']);
+    });
+  });
+
+  describe('development environment', () => {
+    beforeEach(() => {
+      process.env['NODE_ENV'] = 'development';
+      delete process.env['MASTRA_DEV'];
+      delete process.env['MASTRA_EE_LICENSE'];
+      clearLicenseCache();
+    });
+
+    it('should enable all features without a license in dev', async () => {
+      const auth = createMockAuthProvider();
+      const rbac = createMockRBACProvider();
+
+      const result = (await buildCapabilities(auth, createMockRequest(), { rbac })) as AuthenticatedCapabilities;
+
+      expect(result.capabilities.user).toBe(true);
+      expect(result.capabilities.session).toBe(true);
+      expect(result.capabilities.sso).toBe(true);
+      expect(result.capabilities.rbac).toBe(true);
+    });
+  });
+
+  describe('SSO login URL', () => {
+    beforeEach(() => {
+      process.env['NODE_ENV'] = 'production';
+      delete process.env['MASTRA_DEV'];
+      delete process.env['MASTRA_EE_LICENSE'];
+      clearLicenseCache();
+    });
+
+    it('should use default /api prefix for SSO login URL', async () => {
+      const auth = createMockAuthProvider({ getCurrentUser: async () => null });
+      const result = await buildCapabilities(auth, createMockRequest());
+
+      expect(result.login!.sso!.url).toBe('/api/auth/sso/login');
+    });
+
+    it('should use custom apiPrefix for SSO login URL', async () => {
+      const auth = createMockAuthProvider({ getCurrentUser: async () => null });
+      const result = await buildCapabilities(auth, createMockRequest(), { apiPrefix: '/mastra' });
+
+      expect(result.login!.sso!.url).toBe('/mastra/auth/sso/login');
+    });
+  });
+});

--- a/packages/core/src/auth/ee/capabilities.test.ts
+++ b/packages/core/src/auth/ee/capabilities.test.ts
@@ -146,6 +146,33 @@ describe('buildCapabilities', () => {
       expect(result.login!.type).toBe('credentials');
     });
 
+    it('should enable SSO-only login without a license', async () => {
+      // Provider with only SSO (no credentials) — matches the reported scenario
+      const auth = {
+        getLoginUrl: (redirectUri: string, _state: string) =>
+          `https://auth0.example.com/authorize?redirect_uri=${redirectUri}`,
+        handleCallback: async (_code: string, _state: string) => ({
+          user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+          tokens: { accessToken: 'token-123' },
+        }),
+        getLoginButtonConfig: () => ({ provider: 'auth0', text: 'Sign in with Auth0' }),
+        getCurrentUser: async () => ({ id: 'user-1', email: 'test@example.com', name: 'Test User' }),
+        getUser: async () => ({ id: 'user-1', email: 'test@example.com', name: 'Test User' }),
+        createSession: async () => ({ id: 's-1', userId: 'user-1', expiresAt: new Date() }),
+        getSession: async () => ({ id: 's-1', userId: 'user-1', expiresAt: new Date() }),
+        deleteSession: async () => {},
+        getSessionCookie: () => 'session=abc',
+      } as any;
+
+      const result = await buildCapabilities(auth, createMockRequest());
+
+      expect(result.enabled).toBe(true);
+      expect(result.login).not.toBeNull();
+      expect(result.login!.type).toBe('sso');
+      expect(result.login!.sso).toBeDefined();
+      expect(result.login!.sso!.provider).toBe('auth0');
+    });
+
     it('should resolve the current user without a license', async () => {
       const auth = createMockAuthProvider();
       const result = (await buildCapabilities(auth, createMockRequest())) as AuthenticatedCapabilities;

--- a/packages/core/src/auth/ee/capabilities.ts
+++ b/packages/core/src/auth/ee/capabilities.ts
@@ -51,18 +51,20 @@ export interface AuthenticatedUser {
 }
 
 /**
- * Capability flags indicating which EE features are available.
+ * Capability flags indicating which features are available.
+ * SSO, session, and user are OSS features (no license required).
+ * RBAC and ACL are EE features (require license in production).
  */
 export interface CapabilityFlags {
-  /** IUserProvider is implemented and licensed */
+  /** IUserProvider is implemented */
   user: boolean;
-  /** ISessionProvider is implemented and licensed */
+  /** ISessionProvider is implemented */
   session: boolean;
-  /** ISSOProvider is implemented and licensed */
+  /** ISSOProvider is implemented */
   sso: boolean;
-  /** IRBACProvider is implemented and licensed */
+  /** IRBACProvider is implemented and licensed (EE) */
   rbac: boolean;
-  /** IACLProvider is implemented and licensed */
+  /** IACLProvider is implemented and licensed (EE) */
   acl: boolean;
 }
 
@@ -184,8 +186,9 @@ export async function buildCapabilities(
   // Build login configuration (always public)
   let login: PublicAuthCapabilities['login'] = null;
 
-  const hasSSO = implementsInterface<ISSOProvider>(auth, 'getLoginUrl') && isLicensedOrCloud;
-  const hasCredentials = implementsInterface<ICredentialsProvider>(auth, 'signIn') && isLicensedOrCloud;
+  // SSO and credentials are OSS features — no license required
+  const hasSSO = implementsInterface<ISSOProvider>(auth, 'getLoginUrl');
+  const hasCredentials = implementsInterface<ICredentialsProvider>(auth, 'signIn');
 
   // Build SSO login URL using the configured prefix (default: /api)
   const raw = (options?.apiPrefix || '/api').trim();
@@ -229,9 +232,9 @@ export async function buildCapabilities(
     };
   }
 
-  // Try to get current user (requires session)
+  // Try to get current user (requires session) — user retrieval is an OSS feature
   let user: EEUser | null = null;
-  if (implementsInterface<IUserProvider>(auth, 'getCurrentUser') && isLicensedOrCloud) {
+  if (implementsInterface<IUserProvider>(auth, 'getCurrentUser')) {
     try {
       user = await auth.getCurrentUser(request);
     } catch {
@@ -250,10 +253,11 @@ export async function buildCapabilities(
   const hasRBAC = !!rbacProvider && isLicensedOrCloud;
 
   // Build capability flags
+  // SSO, session, and user are OSS — only RBAC and ACL require a license
   const capabilities: CapabilityFlags = {
-    user: implementsInterface<IUserProvider>(auth, 'getCurrentUser') && isLicensedOrCloud,
-    session: implementsInterface<ISessionProvider>(auth, 'createSession') && isLicensedOrCloud,
-    sso: implementsInterface<ISSOProvider>(auth, 'getLoginUrl') && isLicensedOrCloud,
+    user: implementsInterface<IUserProvider>(auth, 'getCurrentUser'),
+    session: implementsInterface<ISessionProvider>(auth, 'createSession'),
+    sso: implementsInterface<ISSOProvider>(auth, 'getLoginUrl'),
     rbac: hasRBAC,
     acl: implementsInterface<IACLProvider>(auth, 'canAccess') && isLicensedOrCloud,
   };


### PR DESCRIPTION
## Description

  `buildCapabilities()` in `@mastra/core/auth/ee/capabilities.ts` incorrectly gates SSO, credentials, session, and
  user features behind `isLicensedOrCloud`. These are OSS features that should work without an EE license in
  production. Only RBAC and ACL are EE features requiring a license.

  This caused custom auth providers (Auth0, WorkOS, etc.) to show "Authentication Required, but no login method is
  configured" in production deployments without an EE license, even though no RBAC was configured.

  **Changes:**
  - Removed `&& isLicensedOrCloud` from SSO, credentials, user retrieval, and session capability checks
  - Kept `isLicensedOrCloud` gating for RBAC and ACL (correct EE behavior)
  - Updated `CapabilityFlags` interface comments to reflect OSS vs EE distinction
  - Added `capabilities.test.ts` with 12 tests covering production-without-license, production-with-license, and
  dev-environment scenarios

  ## Related Issue(s)

  Fixes #14619

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSO, credentials, session, and user authentication no longer require an EE license and are available in the open-source build; RBAC and ACL remain EE-licensed.

* **Tests**
  * Added end-to-end tests covering capability detection, license gating, authentication flows, and login URL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->