### PR TITLE
fix(core): include tagged system messages in MODEL_GENERATION span input

### DIFF
--- a/.changeset/small-brooms-tan.md
+++ b/.changeset/small-brooms-tan.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed MODEL_GENERATION observability span to include all system messages (tagged and untagged). Previously, working memory and semantic recall instructions were missing from trace inputs because only untagged system messages were captured.

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -157,7 +157,7 @@ export class MastraLLMVNext extends MastraBase {
       name: `llm: '${firstModel.modelId}'`,
       type: SpanType.MODEL_GENERATION,
       input: {
-        messages: [...messageList.getSystemMessages(), ...messages],
+        messages: [...messageList.getAllSystemMessages(), ...messages],
       },
       attributes: {
         model: firstModel.modelId,


### PR DESCRIPTION
## Description
The `MODEL_GENERATION` observability span in `MastraLLMVNext.stream()` used `messageList.getSystemMessages()` to construct its `input.messages`, which only returns untagged system messages. System messages added by memory processors (WorkingMemory, SemanticRecall) are tagged via `addSystem(instruction, 'memory')` and stored in `taggedSystemMessages`, making them invisible to `getSystemMessages()`. Changed to `getAllSystemMessages()` so the span input accurately reflects what the LLM actually receives.

  ## Related Issue(s)

  Fixes #14799

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model-generation observability tracing to ensure all system messages are included in trace inputs, including working memory and semantic recall system instructions that were previously omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->