### PR TITLE
fix(tui): process queued messages on agent end and preserve on abort

### DIFF
--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -59,7 +59,7 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
         handleAgentEnd(ectx);
       }
 
-      while (state.pendingQueuedActions.length > 0) {
+      if (state.pendingQueuedActions.length > 0) {
         const action = state.pendingQueuedActions.shift();
 
         if (action === 'message') {
@@ -93,13 +93,6 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
           const msg = state.pendingFollowUpMessages.shift();
           if (msg) {
             ectx.fireMessage(msg.content, msg.images);
-          }
-        }
-
-        if (action === 'slash') {
-          const cmd = state.pendingSlashCommands.shift();
-          if (cmd) {
-            await ectx.handleSlashCommand(cmd);
           }
         }
       }

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -58,6 +58,25 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       } else {
         handleAgentEnd(ectx);
       }
+
+      while (state.pendingQueuedActions.length > 0) {
+        const action = state.pendingQueuedActions.shift();
+
+        if (action === 'message') {
+          const msg = state.pendingFollowUpMessages.shift();
+          if (msg) {
+            ectx.fireMessage(msg.content, msg.images);
+          }
+        }
+
+        if (action === 'slash') {
+          const cmd = state.pendingSlashCommands.shift();
+          if (cmd) {
+            await ectx.handleSlashCommand(cmd);
+          }
+        }
+      }
+
       break;
 
     case 'message_start':
@@ -66,6 +85,25 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
 
     case 'message_update':
       handleMessageUpdate(ectx, event.message);
+
+      if (state.pendingQueuedActions.length > 0 && state.harness.isRunning()) {
+        const action = state.pendingQueuedActions.shift();
+
+        if (action === 'message') {
+          const msg = state.pendingFollowUpMessages.shift();
+          if (msg) {
+            ectx.fireMessage(msg.content, msg.images);
+          }
+        }
+
+        if (action === 'slash') {
+          const cmd = state.pendingSlashCommands.shift();
+          if (cmd) {
+            await ectx.handleSlashCommand(cmd);
+          }
+        }
+      }
+
       break;
 
     case 'message_end':


### PR DESCRIPTION
## Description

Fixes issues with queued message handling in Mastra Code TUI where:

- Queued messages were only processed after the agent fully stopped
- Interrupting the agent with `Esc` caused queued messages to be dropped

This made it difficult to intervene when the agent was stuck in long-running tasks or loops.

## Changes

- Process queued actions (`message` and `slash`) immediately after `agent_end`
- Ensure queued messages are preserved and executed even when the agent is aborted (`Esc`)
- Allow optional mid-execution injection of queued messages during `message_update` to improve responsiveness

## Result

- Queued messages are no longer lost on interrupt
- Messages are executed promptly after agent completion or abort
- Improved UX when interacting with long-running or looping agents

## Related Issue(s)

Fixes #14792

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved event dispatching to automatically process one queued follow-up action (message or command) when an agent operation completes.
  * During message updates, the dispatcher now processes a single queued follow-up only while the interactive session is active, improving responsiveness and reducing duplicate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->