### PR TITLE
fix: forward mcpOptions from server config to MastraServer

### DIFF
--- a/.changeset/odd-spiders-care.md
+++ b/.changeset/odd-spiders-care.md
@@ -3,4 +3,4 @@
 '@mastra/core': patch
 ---
 
-Fix `mcpOptions` being ignored when creating `MastraServer` through the deployer path. The deployer now forwards `server.mcpOptions` so `serverless` mode and custom `sessionIdGenerator` are applied correctly.
+Fixed an issue where MCP server options in Mastra server config were not applied when using the deployer, so serverless mode and custom session IDs now work as expected.

--- a/.changeset/odd-spiders-care.md
+++ b/.changeset/odd-spiders-care.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'@mastra/core': patch
+---
+
+Fix `mcpOptions` being ignored when creating `MastraServer` through the deployer path. The deployer now forwards `server.mcpOptions` so `serverless` mode and custom `sessionIdGenerator` are applied correctly.

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -224,6 +224,17 @@ export type ServerConfig = {
   bodySizeLimit?: number;
 
   /**
+   * MCP transport options applied to all MCP HTTP and SSE routes.
+   * Use this to enable serverless mode for stateless environments.
+   */
+  mcpOptions?: {
+    /** When true, runs in stateless mode without session management. */
+    serverless?: boolean;
+    /** Custom session ID generator function. */
+    sessionIdGenerator?: () => string;
+  };
+
+  /**
    * Authentication configuration for the server.
    *
    * Handles WHO the user is (authentication only).

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -147,6 +147,7 @@ export async function createHonoServer(
     customRouteAuthConfig,
     customApiRoutes: processedRoutes,
     prefix: apiPrefix,
+    mcpOptions: server?.mcpOptions,
   });
 
   // Register context middleware FIRST - this sets mastra, requestContext, tools, taskStore in context

--- a/packages/deployer/src/server/server-app-access.test.ts
+++ b/packages/deployer/src/server/server-app-access.test.ts
@@ -37,6 +37,27 @@ describe('Server App Access via createHonoServer', () => {
     expect(typeof adapter?.getApp).toBe('function');
   });
 
+  it('should forward server.mcpOptions to the server adapter', async () => {
+    const sessionIdGenerator = () => 'session-id';
+    const mastra = new Mastra({
+      logger: false,
+      server: {
+        mcpOptions: {
+          serverless: true,
+          sessionIdGenerator,
+        },
+      },
+    });
+
+    await createHonoServer(mastra, { tools: {} });
+
+    const adapter = mastra.getMastraServer() as any;
+
+    expect(adapter).toBeDefined();
+    expect(adapter.mcpOptions?.serverless).toBe(true);
+    expect(adapter.mcpOptions?.sessionIdGenerator).toBe(sessionIdGenerator);
+  });
+
   it('should allow calling routes directly via app.fetch() - the primary use case', async () => {
     const mastra = new Mastra({
       logger: false,


### PR DESCRIPTION
## Description

`MastraServer` constructor in the deployer wasn't receiving `mcpOptions` from the server config, so `serverless: true` had no effect. The MCP HTTP transport's `sendResponse()` always got `undefined` options and fell back to session-based mode.

Added `mcpOptions` to the `ServerConfig` type in core, and forwarded it in the deployer's `createHonoServer()`.

## Related Issue(s)

Fixes #14810

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server settings can now include MCP options, enabling serverless mode and custom session ID generation.

* **Bug Fixes**
  * MCP options are now correctly applied when a server is created via the deployer.

* **Tests**
  * Added test coverage to verify MCP options are forwarded and honored by the server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->