### PR TITLE
fix(deployer): forward mcpOptions from server config to MastraServer

### DIFF
--- a/.changeset/short-deer-fix.md
+++ b/.changeset/short-deer-fix.md
@@ -1,0 +1,23 @@
+---
+'@mastra/deployer': patch
+'@mastra/core': patch
+---
+
+Fixed `mcpOptions` (including `serverless: true`) being silently ignored when using the Mastra deployer. The deployer now forwards `mcpOptions` from your server config to the underlying `MastraServer`, so MCP stateless mode works correctly in serverless environments like Cloudflare Workers, Vercel Edge, and AWS Lambda. ([#14810](https://github.com/mastra-ai/mastra/issues/14810))
+
+**What changed:**
+
+- Added `mcpOptions` to the `ServerConfig` type so it can be set in `new Mastra({ server: { ... } })`
+- The deployer now passes `server.mcpOptions` through to `MastraServer`
+
+**Example:**
+
+```typescript
+const mastra = new Mastra({
+  server: {
+    mcpOptions: {
+      serverless: true,
+    },
+  },
+});
+```

--- a/docs/src/content/en/docs/server/server-adapters.mdx
+++ b/docs/src/content/en/docs/server/server-adapters.mdx
@@ -396,7 +396,21 @@ The adapter registers routes for both HTTP and SSE (Server-Sent Events) transpor
 
 ### Serverless mode
 
-For serverless environments like Cloudflare Workers or Vercel Edge, enable stateless mode via `mcpOptions`:
+For serverless environments like Cloudflare Workers or Vercel Edge, enable stateless mode via `mcpOptions`.
+
+When using the Mastra deployer (the standard `mastra dev` / `mastra build` path), set `mcpOptions` in your server config:
+
+```typescript
+const mastra = new Mastra({
+  server: {
+    mcpOptions: {
+      serverless: true,
+    },
+  },
+})
+```
+
+When manually creating a server adapter, pass `mcpOptions` directly:
 
 ```typescript
 const server = new MastraServer({

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -599,6 +599,30 @@ export const mastra = new Mastra({
 })
 ```
 
+### server.mcpOptions
+
+**Type:** `object`\
+**Default:** `undefined`
+
+MCP transport options applied to all MCP HTTP and SSE routes. Use this to enable stateless mode for serverless environments (Cloudflare Workers, Vercel Edge, AWS Lambda, etc.) where persistent connections and in-memory session state are not available.
+
+| Property | Type | Default | Description |
+| - | - | - | - |
+| `serverless` | `boolean` | `false` | Run MCP in stateless mode without session management |
+| `sessionIdGenerator` | `() => string` | `undefined` | Custom session ID generator function |
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+
+export const mastra = new Mastra({
+  server: {
+    mcpOptions: {
+      serverless: true,
+    },
+  },
+})
+```
+
 ### server.build
 
 Build-time configuration for server features. These options control development tools like Swagger UI and request logging, which are enabled during local development but disabled in production by default.

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -224,6 +224,23 @@ export type ServerConfig = {
   bodySizeLimit?: number;
 
   /**
+   * MCP transport options applied to all MCP HTTP and SSE routes.
+   * Use this to enable stateless mode for serverless environments
+   * (Cloudflare Workers, Vercel Edge, AWS Lambda, etc.).
+   */
+  mcpOptions?: {
+    /**
+     * Run MCP in stateless mode without session management
+     * @default false
+     */
+    serverless?: boolean;
+    /**
+     * Custom session ID generator function
+     */
+    sessionIdGenerator?: () => string;
+  };
+
+  /**
    * Authentication configuration for the server.
    *
    * Handles WHO the user is (authentication only).

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -147,6 +147,7 @@ export async function createHonoServer(
     customRouteAuthConfig,
     customApiRoutes: processedRoutes,
     prefix: apiPrefix,
+    mcpOptions: server?.mcpOptions,
   });
 
   // Register context middleware FIRST - this sets mastra, requestContext, tools, taskStore in context


### PR DESCRIPTION
## Description

  The deployer was silently dropping `mcpOptions` when creating `MastraServer`, so
  `serverless: true` had no effect for anyone using `mastra dev` / `mastra build` or any
  deployer target (Vercel, Cloudflare, AWS Lambda, etc.). MCP would always fall back to
  session-based mode, which breaks in stateless environments where there is no shared memory
  between requests.

  **Changes:**
  - Added `mcpOptions` to the `ServerConfig` type in `@mastra/core` so users can set it in
  `new Mastra({ server: { ... } })`
  - Forwarded `server.mcpOptions` through the deployer to `MastraServer`
  - Updated configuration reference and server-adapters docs to document both the Mastra
  config path and the manual adapter path

  ## Related Issue(s)

  Fixes #14810

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where MCP serverless options were silently ignored by the deployer. MCP stateless/serverless configuration now properly propagates, enabling correct operation in Cloudflare Workers, Vercel Edge, and AWS Lambda environments.

* **Documentation**
  * Updated serverless mode guide with explicit configuration examples for setting up stateless MCP operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->