### PR TITLE
fix(core): execute custom callbacks on provider-defined tools like applyPatch

### DIFF
--- a/.changeset/thin-rice-grab.md
+++ b/.changeset/thin-rice-grab.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed provider-defined tools with custom execute callbacks (e.g. openai.tools.applyPatch) being incorrectly skipped during execution. Previously, all provider-defined tools were assumed to be provider-executed, which meant user-supplied execute functions were never called. Now, provider tools with a custom execute are correctly identified as client-executed.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -67,6 +67,7 @@ import type { MastraAgentNetworkStream } from '../stream';
 import type { FullOutput, MastraModelOutput } from '../stream/base/output';
 import { createTool } from '../tools';
 import type { ToolToConvert } from '../tools/tool-builder/builder';
+import { isProviderTool } from '../tools/toolchecks';
 import type { CoreTool } from '../tools/types';
 import type { DynamicArgument } from '../types';
 import { makeCoreTool, createMastraProxy, ensureToolProperties, deepMerge } from '../utils';
@@ -3045,6 +3046,7 @@ export class Agent<
       this.logger.debug('Adding client tools', { agent: this.name, tools: Object.keys(clientTools || {}), runId });
       for (const [toolName, tool] of clientToolsForInput) {
         const { execute, ...toolRest } = tool;
+        const toolToConvert = isProviderTool(tool) ? tool : toolRest;
         const options: ToolOptions = {
           name: toolName,
           runId,
@@ -3063,7 +3065,7 @@ export class Agent<
           backgroundConfig: (tool as any).background,
         };
         const convertedToCoreTool = makeCoreTool(
-          toolRest,
+          toolToConvert,
           options,
           'client-tool',
           autoResumeSuspendedTools,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -104,13 +104,11 @@ describe('createLLMExecutionStep gateway provider tools', () => {
   });
 
   it('should infer providerExecuted for gateway tools and not merge streamed results onto toolCalls', async () => {
-    const executeSpy = vi.fn();
     const tools = {
       perplexitySearch: {
         type: 'provider' as const,
         id: 'gateway.perplexity_search',
         args: {},
-        execute: executeSpy,
       },
     };
 
@@ -245,7 +243,6 @@ describe('createLLMExecutionStep gateway provider tools', () => {
 
     expect(toolResult).toEqual(toolCallById['call-1']);
     expect(toolResult.result).toBeUndefined();
-    expect(executeSpy).not.toHaveBeenCalled();
   });
 
   it('merges model config headers with explicit modelSettings headers and lets modelSettings override duplicates', async () => {

--- a/packages/core/src/tools/provider-tool-utils.test.ts
+++ b/packages/core/src/tools/provider-tool-utils.test.ts
@@ -7,9 +7,23 @@ describe('inferProviderExecuted', () => {
     expect(inferProviderExecuted(false, { type: 'provider', id: 'openai.web_search' })).toBe(false);
   });
 
-  it('should infer true for provider-defined tools when providerExecuted is undefined', () => {
+  it('should infer true for provider tools without a custom execute', () => {
     expect(inferProviderExecuted(undefined, { type: 'provider', id: 'openai.web_search' })).toBe(true);
     expect(inferProviderExecuted(undefined, { type: 'provider-defined', id: 'openai.web_search' })).toBe(true);
+  });
+
+  it('should infer false for provider tools with a custom execute', () => {
+    const toolWithExecute = { type: 'provider-defined', id: 'openai.apply_patch', execute: async () => ({}) };
+    expect(inferProviderExecuted(undefined, toolWithExecute)).toBe(false);
+
+    const v6ToolWithExecute = { type: 'provider', id: 'openai.apply_patch', execute: async () => ({}) };
+    expect(inferProviderExecuted(undefined, v6ToolWithExecute)).toBe(false);
+  });
+
+  it('should respect explicit providerExecuted even when execute is present', () => {
+    const toolWithExecute = { type: 'provider-defined', id: 'openai.apply_patch', execute: async () => ({}) };
+    expect(inferProviderExecuted(true, toolWithExecute)).toBe(true);
+    expect(inferProviderExecuted(false, toolWithExecute)).toBe(false);
   });
 
   it('should return undefined for regular tools or missing tools when providerExecuted is undefined', () => {

--- a/packages/core/src/tools/provider-tool-utils.ts
+++ b/packages/core/src/tools/provider-tool-utils.ts
@@ -16,10 +16,14 @@ export function findProviderToolByName(tools: ToolSet | undefined, toolName: str
  *
  * When the raw stream from doStream doesn't include providerExecuted on a tool-call,
  * we infer it based on the tool definition:
- * - Provider tools (type: 'provider'/'provider-defined') → providerExecuted: true
+ * - Provider tools with a custom execute → providerExecuted: false (user handles execution)
+ * - Provider tools without execute → providerExecuted: true (provider handles execution)
  * - Regular function tools → leave as undefined
  */
 export function inferProviderExecuted(providerExecuted: boolean | undefined, tool: unknown): boolean | undefined {
   if (providerExecuted !== undefined) return providerExecuted;
-  return isProviderTool(tool) ? true : undefined;
+  if (!isProviderTool(tool)) return undefined;
+  const hasExecute =
+    typeof tool === 'object' && tool !== null && 'execute' in tool && typeof (tool as any).execute === 'function';
+  return !hasExecute;
 }


### PR DESCRIPTION
## Description

Provider-defined tools with user-supplied `execute` callbacks (e.g. `openai.tools.applyPatch`) were never invoked. `inferProviderExecuted` assumed all provider-defined tools were provider-executed, causing the agentic loop to skip client-side execution entirely. This fix checks for an `execute` function before inferring the flag and also stops stripping `execute` from client tools in `listClientTools`.

  ## Related Issue(s)

  Fixes #14816

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: Some tools provided by external services (like OpenAI) that included a user-provided "execute" function were being ignored. This PR makes sure those user-provided execute callbacks run when the model asks to use the tool.

Summary
- Bug fix: provider-defined tools with a custom execute callback (e.g., openai.tools.applyPatch) are no longer auto-classified as provider-executed; their client-side execute callbacks will be invoked.
- Root cause: inferProviderExecuted previously assumed provider tools were provider-executed when the raw flag was missing, causing client-side execute to be skipped.
- Key changes:
  - inferProviderExecuted(providerExecuted, tool) now:
    - returns undefined for non-provider tools (unchanged),
    - returns false for provider tools that include a callable execute (so client execution runs),
    - returns true for provider tools without an execute function,
    - and still respects an explicitly provided providerExecuted value.
  - Agent.listClientTools no longer strips execute from provider-defined tools when converting them to core tools (it passes the full tool object into makeCoreTool for provider tools).
  - Tests updated:
    - Added cases to provider-tool-utils.test.ts for provider tools that include execute and for explicit providerExecuted values.
    - Adjusted llm-execution-step.test.ts to remove an execute-spy assertion and instead validate providerExecuted inference via produced toolCalls.
  - Changeset added to release a patch for @mastra/core and release notes updated.
- Related: fixes issue #14816.
- Notes: CI showed some test failures reported by a reviewer; the author suspects a flaky OpenAI usage-tracking assertion and flagged that an OpenAI API key may be required to reproduce. One Coderabbit comment remains unaddressed.

Checklist
- Tests updated where applicable.
- Documentation/changeset added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->