### PR TITLE
fix(core): pass accumulated steps to processInputStep in workflow processor path

### DIFF
--- a/.changeset/spotty-bats-laugh.md
+++ b/.changeset/spotty-bats-laugh.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed processInputStep always receiving an empty steps array. Processors can now inspect previous step results (tool calls, LLM responses) when running inside the agentic loop.

--- a/packages/core/src/agent/agent-processor.test.ts
+++ b/packages/core/src/agent/agent-processor.test.ts
@@ -7,6 +7,7 @@ import type { Processor, ProcessOutputStepArgs } from '../processors/index';
 import { isProcessorWorkflow } from '../processors/index';
 import { ProcessorStepInputSchema, ProcessorStepOutputSchema } from '../processors/step-schema';
 import { RequestContext } from '../request-context';
+import { createTool } from '../tools/tool';
 import { createStep, createWorkflow, isProcessor } from '../workflows';
 import type { MastraDBMessage } from './types';
 import { Agent } from './index';
@@ -3272,6 +3273,116 @@ describe('Workflow as Processor', () => {
       const found = await agent.resolveProcessorById('findable-processor');
       expect(found).toBeDefined();
       expect(found).toHaveProperty('id', 'findable-processor');
+    });
+  });
+
+  describe('processInputStep steps accumulation', () => {
+    it('should pass accumulated steps to processInputStep across agentic loop iterations', async () => {
+      const stepLog: { stepNumber: number; stepsLength: number }[] = [];
+
+      const greetTool = createTool({
+        id: 'greet',
+        description: 'Greets a person by name',
+        inputSchema: z.object({ name: z.string() }),
+        outputSchema: z.object({ greeting: z.string() }),
+        execute: async ({ name }) => ({ greeting: `Hello, ${name}!` }),
+      });
+
+      let callCount = 0;
+      const multiStepModel = new MockLanguageModelV2({
+        doGenerate: async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              content: [
+                {
+                  type: 'tool-call' as const,
+                  id: 'tc-1',
+                  toolCallId: 'call-1',
+                  toolName: 'greet',
+                  args: JSON.stringify({ name: 'World' }),
+                },
+              ],
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              rawCall: { rawPrompt: [], rawSettings: {} },
+              warnings: [],
+            };
+          }
+          return {
+            content: [{ type: 'text' as const, text: 'Done!' }],
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        },
+        doStream: async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                { type: 'response-metadata', id: 'resp-1', modelId: 'mock', timestamp: new Date(0) },
+                {
+                  type: 'tool-call',
+                  id: 'tc-1',
+                  toolCallId: 'call-1',
+                  toolName: 'greet',
+                  args: JSON.stringify({ name: 'World' }),
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                },
+              ]),
+              rawCall: { rawPrompt: [], rawSettings: {} },
+              warnings: [],
+            };
+          }
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'resp-2', modelId: 'mock', timestamp: new Date(0) },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'Done!' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 20, outputTokens: 5, totalTokens: 25 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        },
+      });
+
+      const trackingProcessor: Processor = {
+        id: 'step-tracker',
+        processInputStep: async ({ stepNumber, steps }) => {
+          stepLog.push({ stepNumber, stepsLength: steps.length });
+          return {};
+        },
+      };
+
+      const agent = new Agent({
+        id: 'steps-accumulation-test-agent',
+        name: 'Steps Accumulation Test Agent',
+        instructions: 'Use the greet tool when asked.',
+        model: multiStepModel,
+        tools: { greet: greetTool },
+        inputProcessors: [trackingProcessor],
+      });
+
+      const result = await agent.generate('Greet World');
+
+      expect(result.text).toBe('Done!');
+      expect(stepLog.length).toBeGreaterThanOrEqual(2);
+      expect(stepLog[0]).toEqual({ stepNumber: 0, stepsLength: 0 });
+      expect(stepLog[1]).toEqual({ stepNumber: 1, stepsLength: 1 });
     });
   });
 });

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -906,6 +906,7 @@ export class ProcessorRunner {
             messages: processableMessages,
             messageList,
             stepNumber,
+            steps,
             systemMessages: currentSystemMessages,
             rotateResponseMessageId: args.rotateResponseMessageId
               ? () => {


### PR DESCRIPTION
## Description

  <!-- Provide a brief description of the changes in this PR -->

`processInputStep` always receives an empty `steps` array (`[]`) regardless of the current step number in the agentic loop. This prevents processors from inspecting previous step results (tool calls, LLM responses) during multi-step agent execution.

  ## Related Issue(s)

  <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

  Fixes #14813

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `processInputStep` to include the accumulated steps array, enabling processors to inspect prior step results—such as tool calls and LLM responses—during agentic loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->