### PR TITLE
fix(workspaces): resolve . as root path in GCS and S3 filesystem providers

### DIFF
--- a/.changeset/fix-dot-path-root-resolution.md
+++ b/.changeset/fix-dot-path-root-resolution.md
@@ -1,0 +1,10 @@
+---
+'@mastra/gcs': patch
+'@mastra/s3': patch
+---
+
+Fix `toKey()` to resolve `"."` and `"./"` as the root path
+
+Both `GCSFilesystem` and `S3Filesystem` produced invalid object keys when called with `path: "."` (e.g. `prefix/.` instead of `prefix/`). Since the built-in `mastra_workspace_list_files` tool and Mastra Studio both default to `path: "."`, workspace directory listings returned empty results when backed by GCS or S3.
+
+`toKey()` now normalises `"."` and `"./"` to empty string before prepending the prefix, matching the existing behaviour of `"/"`. Dotfiles like `.env` or `.gitignore` are unaffected.

--- a/workspaces/gcs/src/filesystem/index.test.ts
+++ b/workspaces/gcs/src/filesystem/index.test.ts
@@ -793,6 +793,46 @@ describe('GCSFilesystem SDK Operations', () => {
       const result = await fs.isDirectory('/');
       expect(result).toBe(true);
     });
+
+    it('exists(".") resolves to root and returns true', async () => {
+      const result = await fs.exists('.');
+      expect(result).toBe(true);
+      expect(mockBucket.file).not.toHaveBeenCalled();
+    });
+
+    it('stat(".") returns directory stat', async () => {
+      const stat = await fs.stat('.');
+      expect(stat.type).toBe('directory');
+    });
+
+    it('isDirectory(".") returns true', async () => {
+      const result = await fs.isDirectory('.');
+      expect(result).toBe(true);
+    });
+
+    it('isFile(".") returns false', async () => {
+      const result = await fs.isFile('.');
+      expect(result).toBe(false);
+    });
+
+    it('readdir(".") lists entries the same as readdir("/")', async () => {
+      const files = [
+        { name: 'file1.txt', metadata: { size: 100 } },
+        { name: 'subdir/nested.txt', metadata: { size: 50 } },
+      ];
+      mockBucket.getFiles.mockResolvedValueOnce([files]).mockResolvedValueOnce([files]);
+
+      const dotEntries = await fs.readdir('.');
+      const slashEntries = await fs.readdir('/');
+
+      expect(dotEntries).toEqual(slashEntries);
+    });
+
+    it('exists("./") resolves to root and returns true', async () => {
+      const result = await fs.exists('./');
+      expect(result).toBe(true);
+      expect(mockBucket.file).not.toHaveBeenCalled();
+    });
   });
 
   describe('exists()', () => {

--- a/workspaces/gcs/src/filesystem/index.ts
+++ b/workspaces/gcs/src/filesystem/index.ts
@@ -347,8 +347,8 @@ export class GCSFilesystem extends MastraFilesystem {
   }
 
   private toKey(path: string): string {
-    // Remove leading slash and add prefix
-    const cleanPath = path.replace(/^\/+/, '');
+    // Remove leading slashes, then resolve "." and "./" to empty string (root)
+    const cleanPath = path.replace(/^\/+/, '').replace(/^\.(?:\/|$)/, '');
     return this.prefix + cleanPath;
   }
 

--- a/workspaces/s3/src/filesystem/index.test.ts
+++ b/workspaces/s3/src/filesystem/index.test.ts
@@ -582,6 +582,40 @@ describe('S3Filesystem', () => {
       const key2 = (fs as any).toKey('///multi-slash.txt');
       expect(key2).toBe('multi-slash.txt');
     });
+
+    it('toKey resolves "." to empty string (root)', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+      });
+
+      expect((fs as any).toKey('.')).toBe('');
+      expect((fs as any).toKey('./')).toBe('');
+      expect((fs as any).toKey('./subdir')).toBe('subdir');
+    });
+
+    it('toKey resolves "." with prefix to prefix root', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        prefix: 'workspace',
+      });
+
+      expect((fs as any).toKey('.')).toBe('workspace/');
+      expect((fs as any).toKey('./')).toBe('workspace/');
+      expect((fs as any).toKey('./file.txt')).toBe('workspace/file.txt');
+    });
+
+    it('toKey does not alter dotfiles', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+      });
+
+      expect((fs as any).toKey('.hidden')).toBe('.hidden');
+      expect((fs as any).toKey('.env')).toBe('.env');
+      expect((fs as any).toKey('/.gitignore')).toBe('.gitignore');
+    });
   });
 
   describe('Prefix Handling', () => {
@@ -1075,6 +1109,35 @@ describe('S3Filesystem SDK Operations', () => {
     it('isDirectory("/") returns true', async () => {
       const result = await fs.isDirectory('/');
       expect(result).toBe(true);
+    });
+
+    it('exists(".") resolves to root and returns true', async () => {
+      mockSend.mockClear();
+      const result = await fs.exists('.');
+      expect(result).toBe(true);
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('stat(".") returns directory stat', async () => {
+      const stat = await fs.stat('.');
+      expect(stat.type).toBe('directory');
+    });
+
+    it('isDirectory(".") returns true', async () => {
+      const result = await fs.isDirectory('.');
+      expect(result).toBe(true);
+    });
+
+    it('isFile(".") returns false', async () => {
+      const result = await fs.isFile('.');
+      expect(result).toBe(false);
+    });
+
+    it('exists("./") resolves to root and returns true', async () => {
+      mockSend.mockClear();
+      const result = await fs.exists('./');
+      expect(result).toBe(true);
+      expect(mockSend).not.toHaveBeenCalled();
     });
   });
 

--- a/workspaces/s3/src/filesystem/index.ts
+++ b/workspaces/s3/src/filesystem/index.ts
@@ -476,8 +476,8 @@ export class S3Filesystem extends MastraFilesystem {
   }
 
   private toKey(path: string): string {
-    // Remove leading slash and add prefix
-    const cleanPath = path.replace(/^\/+/, '');
+    // Remove leading slashes, then resolve "." and "./" to empty string (root)
+    const cleanPath = path.replace(/^\/+/, '').replace(/^\.(?:\/|$)/, '');
     return this.prefix + cleanPath;
   }
 


### PR DESCRIPTION
## Description

  <!-- Provide a brief description of the changes in this PR -->

`GCSFilesystem.toKey(".")` and `S3Filesystem.toKey(".")` produce invalid object keys (e.g. `prefix/.`) instead of resolving `"."` to the prefix root. This causes `exists(".")`, `readdir(".")`, and all other filesystem methods to fail when called with `"."` as the path. Both the built-in `mastra_workspace_list_files` tool and Mastra Studio workspace
browser use `path: "."` as the default root path, so all workspace directory listings return empty results when backed by GCS or S3.

The fix adds a second `.replace()` in `toKey()` to normalise `"."` and `"./"` to empty string before prepending the prefix, matching the existing behaviour of `"/"`. Dotfiles like `.env` or `.gitignore` are unaffected.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

Fixes #14822

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path resolution for dot-paths (`"."` and `"./"`) in GCS and S3 cloud storage operations to correctly map to the root directory, preventing invalid object key generation.
  * Ensured dotfiles like `.env` and `.gitignore` continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->