### PR TITLE
fix(gcs): normalize '.' path to root in toKey()

### DIFF
--- a/workspaces/gcs/src/filesystem/index.test.ts
+++ b/workspaces/gcs/src/filesystem/index.test.ts
@@ -793,6 +793,31 @@ describe('GCSFilesystem SDK Operations', () => {
       const result = await fs.isDirectory('/');
       expect(result).toBe(true);
     });
+
+    it('exists(".") is treated the same as "/" (root)', async () => {
+      // "." should resolve to root — toKey(".") must not produce "." as a GCS key
+      const result = await fs.exists('.');
+      expect(result).toBe(true);
+      expect(mockBucket.file).not.toHaveBeenCalled();
+    });
+
+    it('readdir(".") lists root directory', async () => {
+      mockBucket.getFiles.mockResolvedValueOnce([
+        [{ name: 'file.txt', metadata: { size: 42 } }],
+      ]);
+
+      const entries = await fs.readdir('.');
+      expect(entries).toEqual([{ name: 'file.txt', type: 'file', size: 42 }]);
+    });
+
+    it('readdir("./subdir") works like readdir("/subdir")', async () => {
+      mockBucket.getFiles.mockResolvedValueOnce([
+        [{ name: 'subdir/a.txt', metadata: { size: 10 } }],
+      ]);
+
+      const entries = await fs.readdir('./subdir');
+      expect(entries).toEqual([{ name: 'a.txt', type: 'file', size: 10 }]);
+    });
   });
 
   describe('exists()', () => {

--- a/workspaces/gcs/src/filesystem/index.ts
+++ b/workspaces/gcs/src/filesystem/index.ts
@@ -347,8 +347,8 @@ export class GCSFilesystem extends MastraFilesystem {
   }
 
   private toKey(path: string): string {
-    // Remove leading slash and add prefix
-    const cleanPath = path.replace(/^\/+/, '');
+    // Remove leading slashes, then normalize "." and "./" to root
+    const cleanPath = path.replace(/^\/+/, '').replace(/^\.(?:\/|$)/, '');
     return this.prefix + cleanPath;
   }
 


### PR DESCRIPTION
## Problem

`GCSFilesystem.toKey('.')` produced `prefix/.` — a GCS key that matches neither a file nor any object prefix. Both the built-in `mastra_workspace_list_files` tool and Mastra Studio pass `path: "."` as the default root path, so workspace directory listings returned empty results (or `Path "." not found` errors in Studio) for any GCS-backed filesystem.

Listing with `path='/'` worked correctly because `toKey('/')` strips leading slashes and returns `prefix/`, which is a valid GCS prefix.

Closes #14822

## What changed

**`workspaces/gcs/src/filesystem/index.ts`**
- `toKey()`: after stripping leading slashes, also strip a leading `.` or `./` so that `"."` and `"./"` resolve to the bucket root (identical behaviour to `"/"`).



**`workspaces/gcs/src/filesystem/index.test.ts`**
- Added three unit tests inside the existing `root path handling` block:
  - `exists('.')` returns `true` (treated as root)
  - `readdir('.')` lists root-level files
  - `readdir('./subdir')` works the same as `readdir('/subdir')`

## How to test


[1m[46m RUN [49m[22m [36mv4.1.2 [39m[90m/Users/sputnik/.openclaw/agents/serhii/workspace[39m

All 68 tests pass (65 existing + 3 new).