### PR TITLE
fix(core): normalize bare '*' pattern to '**/*' in list_files tool

### DIFF
--- a/.changeset/fix-list-files-bare-star-pattern.md
+++ b/.changeset/fix-list-files-bare-star-pattern.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Workspace list_files tool now correctly handles pattern "*" by treating it as "**/*", matching files at all depths instead of silently returning 0 files.

--- a/packages/core/src/workspace/tools/__tests__/tree-formatter.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tree-formatter.test.ts
@@ -592,6 +592,18 @@ src
       expect(result.fileCount).toBe(2);
     });
 
+    it('should treat bare "*" as "**/*" to match files at any depth (#14823)', async () => {
+      await fs.mkdir(path.join(tempDir, 'src'));
+      await fs.mkdir(path.join(tempDir, 'src', 'utils'));
+      await fs.writeFile(path.join(tempDir, 'index.ts'), '');
+      await fs.writeFile(path.join(tempDir, 'src', 'app.ts'), '');
+      await fs.writeFile(path.join(tempDir, 'src', 'utils', 'helpers.ts'), '');
+      const result = await formatAsTree(filesystem, '.', { pattern: '*' });
+      expect(result.tree).toContain('index.ts');
+      expect(result.tree).toContain('app.ts');
+      expect(result.tree).toContain('helpers.ts');
+      expect(result.fileCount).toBe(3);
+    });
     it('should support multiple patterns', async () => {
       await fs.writeFile(path.join(tempDir, 'index.ts'), '');
       await fs.writeFile(path.join(tempDir, 'App.tsx'), '');

--- a/packages/core/src/workspace/tools/tree-formatter.ts
+++ b/packages/core/src/workspace/tools/tree-formatter.ts
@@ -103,7 +103,11 @@ export async function formatAsTree(fs: WorkspaceFilesystem, path: string, option
   let globMatcher: GlobMatcher | undefined;
   if (pattern) {
     const patterns = Array.isArray(pattern) ? pattern : [pattern];
-    globMatcher = createGlobMatcher(patterns, { dot: showHidden });
+    // Normalize bare "*" to "**/*" so LLMs using "*" as "match everything"
+    // get the expected behavior — plain "*" doesn't cross "/" boundaries
+    // and silently excludes all files in subdirectories.
+    const normalizedPatterns = patterns.map(p => (p === '*' ? '**/*' : p));
+    globMatcher = createGlobMatcher(normalizedPatterns, { dot: showHidden });
   }
 
   const lines: string[] = ['.'];


### PR DESCRIPTION
## Summary
Fixes #14823

## Problem
When `list_files` is called with `pattern: "*"`, all files in 
subdirectories are silently excluded. Only top-level directories 
are returned, resulting in "N directories, 0 files".

Root cause: bare `*` doesn't cross `/` boundaries in glob matching,
so `subdir/file.txt` never matches `*`.

## Fix
Normalize bare `*` to `**/*` before compiling the glob matcher.
This matches LLM intent — `*` as "match everything".

## Changes
- `packages/core/src/workspace/tools/tree-formatter.ts` — 4-line fix
- `packages/core/src/workspace/tools/__tests__/tree-formatter.test.ts` — regression test

## Tests
- 1 new regression test added ✅
- 54/54 tests passing, 0 type errors ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `list_files` tool glob pattern matching. The bare `*` pattern now correctly matches files at any directory depth, including files in subdirectories, instead of failing to match nested files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->