### PR TITLE
fix(cli): respect --no-example flag when --default is passed

### DIFF
--- a/.changeset/flat-apples-smoke.md
+++ b/.changeset/flat-apples-smoke.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed `--no-example` flag being ignored when `--default` is also passed to `create-mastra`. Previously, running `create-mastra --default --no-example` would always scaffold the weather agent example. Now `--no-example` correctly suppresses example files even when using `--default`.

--- a/packages/cli/src/commands/actions/create-project.ts
+++ b/packages/cli/src/commands/actions/create-project.ts
@@ -32,7 +32,7 @@ export const createProject = async (projectNameArg: string | undefined, args: Cr
         await create({
           components: ['agents', 'tools', 'workflows'],
           llmProvider: 'openai',
-          addExample: true,
+          addExample: args.example === false ? false : true,
           timeout,
           projectName: projectNameArg,
           mcpServer: args.mcp,

--- a/packages/cli/src/commands/actions/init-project.ts
+++ b/packages/cli/src/commands/actions/init-project.ts
@@ -50,7 +50,7 @@ export const initProject = async (args: InitArgs) => {
           directory: 'src/',
           components: ['agents', 'tools', 'workflows'],
           llmProvider: 'openai',
-          addExample: true,
+          addExample: args.example === false ? false : true,
           mcpServer: args.mcp,
           versionTag,
         });


### PR DESCRIPTION
Fixes #14829

`--no-example` was being silently ignored whenever `--default` was also passed, because `addExample` was hardcoded to `true` in the default branch. Same bug existed in both `create` and `init`.

**Before:**
```bash
create-mastra my-app --default --no-example
# always scaffolds weather agent, tools, workflows
```

**After:**
```bash
create-mastra my-app --default --no-example
# scaffolds project without example files
```

The fix is the same in both `create-project.ts` and `init-project.ts` — `--no-example` now wins when explicitly passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `create-mastra` CLI to properly respect the `--no-example` flag when used with the `--default` flag. Example scaffolding is now correctly suppressed when both flags are combined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->