### PR TITLE
feat(observability): Add recorded trace scoring and feedback APIs to observability

### DIFF
--- a/.changeset/cute-doors-jog.md
+++ b/.changeset/cute-doors-jog.md
@@ -1,0 +1,7 @@
+---
+'@mastra/observability': minor
+---
+
+Added recorded trace support to the Mastra observability runtime.
+
+Updated log and metric correlation to use top-level trace and span IDs, and aligned the test exporter and integration tests with the new correlation context shape.

--- a/.changeset/cute-doors-jog.md
+++ b/.changeset/cute-doors-jog.md
@@ -1,9 +1,8 @@
 ---
-'@mastra/core': minor
 '@mastra/observability': minor
 ---
 
-Added new observability APIs for working with persisted traces. You can now load a recorded trace with `mastra.observability.getRecordedTrace({ traceId })` and attach scores or feedback either through that recorded trace or with top-level `mastra.observability.addScore()` / `addFeedback()` calls.
+Added support for working with persisted traces through `@mastra/observability`. You can now load a recorded trace with `mastra.observability.getRecordedTrace({ traceId })` and attach scores or feedback either through that recorded trace/span or through top-level `mastra.observability.addScore()` and `addFeedback()` calls.
 
 Recorded trace and span annotation methods are now async, and Mastra will emit debug logs when a recorded score or feedback call cannot be delivered because no observability instance is available.
 

--- a/.changeset/cute-doors-jog.md
+++ b/.changeset/cute-doors-jog.md
@@ -1,7 +1,10 @@
 ---
+'@mastra/core': minor
 '@mastra/observability': minor
 ---
 
-Added recorded trace support to the Mastra observability runtime.
+Added new observability APIs for working with persisted traces. You can now load a recorded trace with `mastra.observability.getRecordedTrace({ traceId })` and attach scores or feedback either through that recorded trace or with top-level `mastra.observability.addScore()` / `addFeedback()` calls.
 
-Updated log and metric correlation to use top-level trace and span IDs, and aligned the test exporter and integration tests with the new correlation context shape.
+Recorded trace and span annotation methods are now async, and Mastra will emit debug logs when a recorded score or feedback call cannot be delivered because no observability instance is available.
+
+Log and metric correlation handling was also updated to match the current observability signal shape.

--- a/.changeset/green-birds-taste.md
+++ b/.changeset/green-birds-taste.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added new observability entrypoint APIs for persisted traces. You can now call `mastra.observability.getRecordedTrace({ traceId })` to load a recorded trace, and use optional top-level `mastra.observability.addScore()/addFeedback()` helpers to annotate a persisted trace by ID.

--- a/observability/mastra/src/context/logger.test.ts
+++ b/observability/mastra/src/context/logger.test.ts
@@ -29,9 +29,9 @@ describe('LoggerContextImpl', () => {
     captureEvents();
 
     const logger = new LoggerContextImpl({
+      traceId: 'trace-abc',
+      spanId: 'span-123',
       correlationContext: {
-        traceId: 'trace-abc',
-        spanId: 'span-123',
         tags: ['tag-a'],
       },
       metadata: { runId: 'run-1', environment: 'test' },
@@ -45,9 +45,9 @@ describe('LoggerContextImpl', () => {
     expect(log.level).toBe('info');
     expect(log.message).toBe('test message');
     expect(log.data).toEqual({ key: 'value' });
+    expect(log.traceId).toBe('trace-abc');
+    expect(log.spanId).toBe('span-123');
     expect(log.correlationContext).toEqual({
-      traceId: 'trace-abc',
-      spanId: 'span-123',
       tags: ['tag-a'],
     });
     expect(log.metadata).toEqual({ runId: 'run-1', environment: 'test' });
@@ -58,10 +58,8 @@ describe('LoggerContextImpl', () => {
     captureEvents();
 
     const logger = new LoggerContextImpl({
-      correlationContext: {
-        traceId: 'trace-1',
-        spanId: 'span-1',
-      },
+      traceId: 'trace-1',
+      spanId: 'span-1',
       observabilityBus: bus,
     });
 
@@ -135,10 +133,8 @@ describe('LoggerContextImpl', () => {
     });
 
     const logger = new LoggerContextImpl({
-      correlationContext: {
-        traceId: 'trace-1',
-        spanId: 'span-1',
-      },
+      traceId: 'trace-1',
+      spanId: 'span-1',
       observabilityBus: bus,
     });
 
@@ -153,10 +149,8 @@ describe('LoggerContextImpl', () => {
     captureEvents();
 
     const logger = new LoggerContextImpl({
-      correlationContext: {
-        traceId: 'trace-1',
-        spanId: 'span-1',
-      },
+      traceId: 'trace-1',
+      spanId: 'span-1',
       observabilityBus: bus,
       metadata: {
         entity_type: 'agent',

--- a/observability/mastra/src/context/logger.test.ts
+++ b/observability/mastra/src/context/logger.test.ts
@@ -191,4 +191,29 @@ describe('LoggerContextImpl', () => {
       tags: ['root-tag-1', 'root-tag-2'],
     });
   });
+
+  it('should fall back to deprecated traceId and spanId on correlationContext', () => {
+    bus = new ObservabilityBus();
+    captureEvents();
+
+    const logger = new LoggerContextImpl({
+      observabilityBus: bus,
+      correlationContext: {
+        traceId: 'legacy-trace',
+        spanId: 'legacy-span',
+        tags: ['tag-a'],
+      },
+    });
+
+    logger.info('legacy trace context');
+
+    const log = emittedEvents[0]!.log;
+    expect(log.traceId).toBe('legacy-trace');
+    expect(log.spanId).toBe('legacy-span');
+    expect(log.correlationContext).toEqual({
+      traceId: 'legacy-trace',
+      spanId: 'legacy-span',
+      tags: ['tag-a'],
+    });
+  });
 });

--- a/observability/mastra/src/context/logger.ts
+++ b/observability/mastra/src/context/logger.ts
@@ -46,11 +46,13 @@ export class LoggerContextImpl implements LoggerContext {
    * mutations after construction do not affect emitted logs.
    */
   constructor(config: LoggerContextConfig) {
+    const correlationContext = config.correlationContext ? { ...config.correlationContext } : undefined;
+
     this.config = {
       ...config,
-      traceId: config.traceId,
-      spanId: config.spanId,
-      correlationContext: config.correlationContext ? { ...config.correlationContext } : undefined,
+      traceId: config.traceId ?? correlationContext?.traceId,
+      spanId: config.spanId ?? correlationContext?.spanId,
+      correlationContext,
       metadata: config.metadata ? structuredClone(config.metadata) : undefined,
     };
   }

--- a/observability/mastra/src/context/logger.ts
+++ b/observability/mastra/src/context/logger.ts
@@ -10,6 +10,12 @@ import type { LogLevel, LoggerContext, ExportedLog, LogEvent, CorrelationContext
 import type { ObservabilityBus } from '../bus';
 
 export interface LoggerContextConfig {
+  /** Top-level trace identity for emitted log events */
+  traceId?: string;
+
+  /** Top-level span identity for emitted log events */
+  spanId?: string;
+
   /** Canonical correlation context for log correlation */
   correlationContext?: CorrelationContext;
 
@@ -42,6 +48,8 @@ export class LoggerContextImpl implements LoggerContext {
   constructor(config: LoggerContextConfig) {
     this.config = {
       ...config,
+      traceId: config.traceId,
+      spanId: config.spanId,
       correlationContext: config.correlationContext ? { ...config.correlationContext } : undefined,
       metadata: config.metadata ? structuredClone(config.metadata) : undefined,
     };
@@ -86,6 +94,8 @@ export class LoggerContextImpl implements LoggerContext {
       level,
       message,
       data,
+      traceId: this.config.traceId,
+      spanId: this.config.spanId,
       correlationContext: this.config.correlationContext,
       metadata: this.config.metadata,
     };

--- a/observability/mastra/src/context/metrics.test.ts
+++ b/observability/mastra/src/context/metrics.test.ts
@@ -135,9 +135,9 @@ describe('MetricsContextImpl', () => {
 
     const metrics = new MetricsContextImpl({
       cardinalityFilter,
+      traceId: 'trace-1',
+      spanId: 'span-1',
       correlationContext: {
-        traceId: 'trace-1',
-        spanId: 'span-1',
         entityType: EntityType.AGENT,
         entityName: 'test-agent',
         environment: 'test',
@@ -148,12 +148,12 @@ describe('MetricsContextImpl', () => {
     metrics.emit('calls', 1, { agent: 'test-agent' });
 
     expect(emittedEvents[0]!.metric.correlationContext).toEqual({
-      traceId: 'trace-1',
-      spanId: 'span-1',
       entityType: EntityType.AGENT,
       entityName: 'test-agent',
       environment: 'test',
     });
+    expect(emittedEvents[0]!.metric.traceId).toBe('trace-1');
+    expect(emittedEvents[0]!.metric.spanId).toBe('span-1');
   });
 
   it('should include metadata when provided', () => {

--- a/observability/mastra/src/context/metrics.test.ts
+++ b/observability/mastra/src/context/metrics.test.ts
@@ -246,4 +246,32 @@ describe('MetricsContextImpl', () => {
       entityType: EntityType.AGENT,
     });
   });
+
+  it('should prefer top-level traceId and spanId over deprecated correlationContext values', () => {
+    setupBus();
+    const cardinalityFilter = new CardinalityFilter();
+
+    const metrics = new MetricsContextImpl({
+      cardinalityFilter,
+      observabilityBus: bus,
+      traceId: 'top-level-trace',
+      spanId: 'top-level-span',
+      correlationContext: {
+        traceId: 'legacy-trace',
+        spanId: 'legacy-span',
+        entityType: EntityType.AGENT,
+      },
+    });
+
+    metrics.emit('calls', 1);
+
+    const metric = emittedEvents[0]!.metric;
+    expect(metric.traceId).toBe('top-level-trace');
+    expect(metric.spanId).toBe('top-level-span');
+    expect(metric.correlationContext).toEqual({
+      traceId: 'legacy-trace',
+      spanId: 'legacy-span',
+      entityType: EntityType.AGENT,
+    });
+  });
 });

--- a/observability/mastra/src/context/metrics.test.ts
+++ b/observability/mastra/src/context/metrics.test.ts
@@ -220,4 +220,30 @@ describe('MetricsContextImpl', () => {
     expect(onMetricEvent).toHaveBeenCalledTimes(1);
     expect(onMetricEvent.mock.calls[0]![0].metric.name).toBe('test_metric');
   });
+
+  it('should fall back to deprecated traceId and spanId on correlationContext', () => {
+    setupBus();
+    const cardinalityFilter = new CardinalityFilter();
+
+    const metrics = new MetricsContextImpl({
+      cardinalityFilter,
+      observabilityBus: bus,
+      correlationContext: {
+        traceId: 'legacy-trace',
+        spanId: 'legacy-span',
+        entityType: EntityType.AGENT,
+      },
+    });
+
+    metrics.emit('calls', 1);
+
+    const metric = emittedEvents[0]!.metric;
+    expect(metric.traceId).toBe('legacy-trace');
+    expect(metric.spanId).toBe('legacy-span');
+    expect(metric.correlationContext).toEqual({
+      traceId: 'legacy-trace',
+      spanId: 'legacy-span',
+      entityType: EntityType.AGENT,
+    });
+  });
 });

--- a/observability/mastra/src/context/metrics.ts
+++ b/observability/mastra/src/context/metrics.ts
@@ -59,9 +59,9 @@ export class MetricsContextImpl implements MetricsContext {
    * copied so mutations after construction do not affect emitted metrics.
    */
   constructor(config: MetricsContextConfig) {
-    this.traceId = config.traceId;
-    this.spanId = config.spanId;
     this.correlationContext = config.correlationContext ? { ...config.correlationContext } : undefined;
+    this.traceId = config.traceId ?? this.correlationContext?.traceId;
+    this.spanId = config.spanId ?? this.correlationContext?.spanId;
     this.metadata = config.metadata ? structuredClone(config.metadata) : undefined;
     this.cardinalityFilter = config.cardinalityFilter;
     this.observabilityBus = config.observabilityBus;

--- a/observability/mastra/src/context/metrics.ts
+++ b/observability/mastra/src/context/metrics.ts
@@ -23,6 +23,12 @@ import type { CardinalityFilter } from '../metrics/cardinality';
 
 /** Configuration for creating a MetricsContextImpl. */
 export interface MetricsContextConfig {
+  /** Top-level trace identity for emitted metric events */
+  traceId?: string;
+
+  /** Top-level span identity for emitted metric events */
+  spanId?: string;
+
   /** Canonical correlation context derived from the current span */
   correlationContext?: CorrelationContext;
 
@@ -41,6 +47,8 @@ export interface MetricsContextConfig {
  * ObservabilityBus.emit() after validation and cardinality filtering.
  */
 export class MetricsContextImpl implements MetricsContext {
+  private traceId?: string;
+  private spanId?: string;
   private correlationContext?: CorrelationContext;
   private metadata?: Record<string, unknown>;
   private cardinalityFilter: CardinalityFilter;
@@ -51,6 +59,8 @@ export class MetricsContextImpl implements MetricsContext {
    * copied so mutations after construction do not affect emitted metrics.
    */
   constructor(config: MetricsContextConfig) {
+    this.traceId = config.traceId;
+    this.spanId = config.spanId;
     this.correlationContext = config.correlationContext ? { ...config.correlationContext } : undefined;
     this.metadata = config.metadata ? structuredClone(config.metadata) : undefined;
     this.cardinalityFilter = config.cardinalityFilter;
@@ -68,6 +78,8 @@ export class MetricsContextImpl implements MetricsContext {
 
     const exportedMetric: ExportedMetric = {
       timestamp: new Date(),
+      traceId: this.traceId,
+      spanId: this.spanId,
       name,
       value,
       labels: filteredLabels,

--- a/observability/mastra/src/default.ts
+++ b/observability/mastra/src/default.ts
@@ -6,10 +6,12 @@ import type { IMastraLogger } from '@mastra/core/logger';
 import type {
   ConfigSelector,
   ConfigSelectorOptions,
+  FeedbackInput,
   FeedbackEvent,
   ObservabilityEntrypoint,
   ObservabilityInstance,
   RecordedTrace,
+  ScoreInput,
   ScoreEvent,
 } from '@mastra/core/observability';
 import type { ObservabilityStorage } from '@mastra/core/storage';
@@ -18,7 +20,11 @@ import { SamplingStrategyType, observabilityRegistryConfigSchema, observabilityC
 import type { ObservabilityInstanceConfig, ObservabilityRegistryConfig } from './config';
 import { CloudExporter, DefaultExporter } from './exporters';
 import { BaseObservabilityInstance, DefaultObservabilityInstance } from './instances';
-import { hydrateRecordedTrace } from './recorded';
+import {
+  buildRecordedFeedbackEventFromTrace,
+  buildRecordedScoreEventFromTrace,
+  hydrateRecordedTrace,
+} from './recorded';
 import { ObservabilityRegistry } from './registry';
 import { SensitiveDataFilter } from './span_processors';
 
@@ -189,7 +195,57 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
     return hydrateRecordedTrace({
       trace,
       emitRecordedEvent: event => this.#emitRecordedEvent(event),
+      canEmitRecordedEvent: () => !!this.#getRecordedTraceInstance(),
+      debugRecordedAnnotationUnavailable: ({ kind, traceId, spanId }) => {
+        this.logger?.debug(
+          kind === 'score'
+            ? 'addScore() is unavailable; rehydrate the trace before calling addScore()'
+            : 'addFeedback() is unavailable; rehydrate the trace before calling addFeedback()',
+          {
+            traceId,
+            spanId,
+          },
+        );
+      },
     });
+  }
+
+  async addScore(args: { traceId: string; spanId?: string; score: ScoreInput }): Promise<void> {
+    const trace = await this.#getStoredTrace(args.traceId);
+    if (!trace) {
+      return;
+    }
+
+    const event = buildRecordedScoreEventFromTrace({
+      trace,
+      spanId: args.spanId,
+      score: args.score,
+    });
+
+    if (!event) {
+      return;
+    }
+
+    await this.#emitRecordedEvent(event);
+  }
+
+  async addFeedback(args: { traceId: string; spanId?: string; feedback: FeedbackInput }): Promise<void> {
+    const trace = await this.#getStoredTrace(args.traceId);
+    if (!trace) {
+      return;
+    }
+
+    const event = buildRecordedFeedbackEventFromTrace({
+      trace,
+      spanId: args.spanId,
+      feedback: args.feedback,
+    });
+
+    if (!event) {
+      return;
+    }
+
+    await this.#emitRecordedEvent(event);
   }
 
   /** Register a named observability instance, optionally marking it as default. */
@@ -246,6 +302,15 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
     return (await storage.getStore('observability')) ?? null;
   }
 
+  async #getStoredTrace(traceId: string) {
+    const observabilityStorage = await this.#getObservabilityStorage();
+    if (!observabilityStorage) {
+      return null;
+    }
+
+    return observabilityStorage.getTrace({ traceId });
+  }
+
   #getRecordedTraceInstance(): ObservabilityInstance | undefined {
     return this.getDefaultInstance() ?? Array.from(this.listInstances().values())[0];
   }
@@ -253,6 +318,12 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
   async #emitRecordedEvent(event: ScoreEvent | FeedbackEvent): Promise<void> {
     const instance = this.#getRecordedTraceInstance();
     if (!instance) {
+      this.logger?.debug(
+        event.type === 'score'
+          ? 'Score event was dropped because no observability instance is registered'
+          : 'Feedback event was dropped because no observability instance is registered',
+        { eventType: event.type },
+      );
       return;
     }
 

--- a/observability/mastra/src/default.ts
+++ b/observability/mastra/src/default.ts
@@ -6,13 +6,19 @@ import type { IMastraLogger } from '@mastra/core/logger';
 import type {
   ConfigSelector,
   ConfigSelectorOptions,
+  FeedbackEvent,
   ObservabilityEntrypoint,
   ObservabilityInstance,
+  RecordedTrace,
+  ScoreEvent,
 } from '@mastra/core/observability';
+import type { ObservabilityStorage } from '@mastra/core/storage';
+import { routeToHandler } from './bus/route-event';
 import { SamplingStrategyType, observabilityRegistryConfigSchema, observabilityConfigValueSchema } from './config';
 import type { ObservabilityInstanceConfig, ObservabilityRegistryConfig } from './config';
 import { CloudExporter, DefaultExporter } from './exporters';
 import { BaseObservabilityInstance, DefaultObservabilityInstance } from './instances';
+import { hydrateRecordedTrace } from './recorded';
 import { ObservabilityRegistry } from './registry';
 import { SensitiveDataFilter } from './span_processors';
 
@@ -31,6 +37,7 @@ function isInstance(
  */
 export class Observability extends MastraBase implements ObservabilityEntrypoint {
   #registry = new ObservabilityRegistry();
+  #mastra?: Mastra;
 
   constructor(config: ObservabilityRegistryConfig) {
     super({
@@ -134,6 +141,7 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
   setMastraContext(options: { mastra: Mastra }): void {
     const instances = this.listInstances();
     const { mastra } = options;
+    this.#mastra = mastra;
 
     instances.forEach(instance => {
       const config = instance.getConfig();
@@ -165,6 +173,23 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
   /** Get the observability instance chosen by the config selector for the given options. */
   getSelectedInstance(options: ConfigSelectorOptions): ObservabilityInstance | undefined {
     return this.#registry.getSelected(options);
+  }
+
+  async getRecordedTrace(args: { traceId: string }): Promise<RecordedTrace | null> {
+    const observabilityStorage = await this.#getObservabilityStorage();
+    if (!observabilityStorage) {
+      return null;
+    }
+
+    const trace = await observabilityStorage.getTrace({ traceId: args.traceId });
+    if (!trace) {
+      return null;
+    }
+
+    return hydrateRecordedTrace({
+      trace,
+      emitRecordedEvent: event => this.#emitRecordedEvent(event),
+    });
   }
 
   /** Register a named observability instance, optionally marking it as default. */
@@ -210,5 +235,40 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
   /** Shut down all registered instances, flushing any pending data. */
   async shutdown(): Promise<void> {
     await this.#registry.shutdown();
+  }
+
+  async #getObservabilityStorage(): Promise<ObservabilityStorage | null> {
+    const storage = this.#mastra?.getStorage();
+    if (!storage) {
+      return null;
+    }
+
+    return (await storage.getStore('observability')) ?? null;
+  }
+
+  #getRecordedTraceInstance(): ObservabilityInstance | undefined {
+    return this.getDefaultInstance() ?? Array.from(this.listInstances().values())[0];
+  }
+
+  async #emitRecordedEvent(event: ScoreEvent | FeedbackEvent): Promise<void> {
+    const instance = this.#getRecordedTraceInstance();
+    if (!instance) {
+      return;
+    }
+
+    if (instance instanceof BaseObservabilityInstance) {
+      instance.__emitRecordedEvent(event);
+      return;
+    }
+
+    const bridge = instance.getBridge();
+    const handlerResults = [
+      ...instance.getExporters().map(exporter => routeToHandler(exporter, event, this.logger)),
+      ...(bridge ? [routeToHandler(bridge, event, this.logger)] : []),
+    ].filter((result): result is Promise<void> => !!result && typeof result.then === 'function');
+
+    if (handlerResults.length > 0) {
+      await Promise.allSettled(handlerResults);
+    }
   }
 }

--- a/observability/mastra/src/exporters/default.test.ts
+++ b/observability/mastra/src/exporters/default.test.ts
@@ -948,6 +948,8 @@ describe('DefaultExporter', () => {
           type: 'metric',
           metric: {
             timestamp: new Date('2026-01-01T00:00:00Z'),
+            traceId: 'trace-1',
+            spanId: 'span-1',
             name: 'mastra_agent_duration_ms',
             value: 1,
             labels: {
@@ -959,8 +961,6 @@ describe('DefaultExporter', () => {
               other_label: 'kept',
             },
             correlationContext: {
-              traceId: 'trace-1',
-              spanId: 'span-1',
               environment: 'production',
               entityType: EntityType.AGENT,
               entityName: 'my-agent',
@@ -1131,7 +1131,7 @@ describe('DefaultExporter', () => {
           feedbacks: [
             expect.objectContaining({
               traceId: 'trace-1',
-              source: 'user',
+              feedbackSource: 'user',
               feedbackType: 'thumbs',
               value: 1,
             }),
@@ -1150,10 +1150,10 @@ describe('DefaultExporter', () => {
           type: 'log',
           log: {
             timestamp: new Date('2026-01-01T00:00:00Z'),
+            traceId: 'trace-1',
             level: 'info',
             message: 'Agent started',
             correlationContext: {
-              traceId: 'trace-1',
               entityType: EntityType.AGENT,
               entityName: 'my-agent',
               environment: 'production',

--- a/observability/mastra/src/exporters/test.test.ts
+++ b/observability/mastra/src/exporters/test.test.ts
@@ -517,11 +517,9 @@ function createMockLogEvent(overrides: Partial<ExportedLog> = {}): LogEvent {
     type: 'log',
     log: {
       timestamp: new Date(),
+      traceId: 'trace-123',
       level: 'info',
       message: 'test log message',
-      correlationContext: {
-        traceId: 'trace-123',
-      },
       ...overrides,
     },
   };
@@ -601,9 +599,9 @@ describe('TestExporter - Log Events', () => {
   });
 
   it('should filter logs by traceId', async () => {
-    await exporter.onLogEvent(createMockLogEvent({ correlationContext: { traceId: 'trace-A' }, message: 'log A' }));
-    await exporter.onLogEvent(createMockLogEvent({ correlationContext: { traceId: 'trace-B' }, message: 'log B' }));
-    await exporter.onLogEvent(createMockLogEvent({ correlationContext: { traceId: 'trace-A' }, message: 'log A2' }));
+    await exporter.onLogEvent(createMockLogEvent({ traceId: 'trace-A', message: 'log A' }));
+    await exporter.onLogEvent(createMockLogEvent({ traceId: 'trace-B', message: 'log B' }));
+    await exporter.onLogEvent(createMockLogEvent({ traceId: 'trace-A', message: 'log A2' }));
 
     const logsA = exporter.getLogsByTraceId('trace-A');
     expect(logsA).toHaveLength(2);
@@ -798,7 +796,7 @@ describe('TestExporter - Cross-Signal Integration', () => {
 
     await exporter.exportTracingEvent(createEvent(TracingEventType.SPAN_STARTED, span));
     await exporter.exportTracingEvent(createEvent(TracingEventType.SPAN_ENDED, { ...span, endTime: new Date() }));
-    await exporter.onLogEvent(createMockLogEvent({ correlationContext: { traceId }, message: 'correlated log' }));
+    await exporter.onLogEvent(createMockLogEvent({ traceId, message: 'correlated log' }));
     await exporter.onScoreEvent(createMockScoreEvent({ traceId, scorerId: 'accuracy' }));
     await exporter.onFeedbackEvent(createMockFeedbackEvent({ traceId }));
 
@@ -816,7 +814,7 @@ describe('TestExporter - Cross-Signal Integration', () => {
   it('should include trace IDs from all signal types in getTraceIds', async () => {
     const span = createMockSpan({ traceId: 'trace-from-span' });
     await exporter.exportTracingEvent(createEvent(TracingEventType.SPAN_STARTED, span));
-    await exporter.onLogEvent(createMockLogEvent({ correlationContext: { traceId: 'trace-from-log' } }));
+    await exporter.onLogEvent(createMockLogEvent({ traceId: 'trace-from-log' }));
     await exporter.onScoreEvent(createMockScoreEvent({ traceId: 'trace-from-score' }));
     await exporter.onFeedbackEvent(createMockFeedbackEvent({ traceId: 'trace-from-feedback' }));
 

--- a/observability/mastra/src/exporters/test.ts
+++ b/observability/mastra/src/exporters/test.ts
@@ -385,7 +385,7 @@ export class TestExporter extends BaseExporter {
 
     if (this.#config.storeLogs) {
       const log = event.log;
-      const traceId = log.correlationContext?.traceId;
+      const traceId = log.traceId;
       const logMessage = `[TestExporter] log.${log.level}: "${log.message}"${traceId ? ` (trace: ${traceId.slice(-8)})` : ''}`;
       this.#debugLogs.push(logMessage);
     }
@@ -534,7 +534,7 @@ export class TestExporter extends BaseExporter {
   } {
     const events = this.#tracingEvents.filter(e => e.exportedSpan.traceId === traceId);
     const spans = this.#getUniqueSpansFromEvents(events);
-    const logs = this.#logEvents.filter(e => e.log.correlationContext?.traceId === traceId).map(e => e.log);
+    const logs = this.#logEvents.filter(e => e.log.traceId === traceId).map(e => e.log);
     const scores = this.#scoreEvents.filter(e => e.score.traceId === traceId).map(e => e.score);
     const feedback = this.#feedbackEvents.filter(e => e.feedback.traceId === traceId).map(e => e.feedback);
     return { events, spans, logs, scores, feedback };
@@ -619,7 +619,7 @@ export class TestExporter extends BaseExporter {
       traceIds.add(event.exportedSpan.traceId);
     }
     for (const event of this.#logEvents) {
-      if (event.log.correlationContext?.traceId) traceIds.add(event.log.correlationContext.traceId);
+      if (event.log.traceId) traceIds.add(event.log.traceId);
     }
     for (const event of this.#scoreEvents) {
       traceIds.add(event.score.traceId);
@@ -659,7 +659,7 @@ export class TestExporter extends BaseExporter {
    * Get logs for a specific trace
    */
   getLogsByTraceId(traceId: string): ExportedLog[] {
-    return this.#logEvents.filter(e => e.log.correlationContext?.traceId === traceId).map(e => e.log);
+    return this.#logEvents.filter(e => e.log.traceId === traceId).map(e => e.log);
   }
 
   // ============================================================================

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -339,6 +339,8 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     const metadata: Record<string, unknown> | undefined = span?.metadata ? structuredClone(span.metadata) : undefined;
 
     return new LoggerContextImpl({
+      traceId: span?.traceId,
+      spanId: span?.id,
       correlationContext,
       metadata,
       observabilityBus: this.observabilityBus,
@@ -355,6 +357,8 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     const metadata: Record<string, unknown> | undefined = span?.metadata ? structuredClone(span.metadata) : undefined;
 
     return new MetricsContextImpl({
+      traceId: span?.traceId,
+      spanId: span?.id,
       correlationContext,
       metadata,
       cardinalityFilter: this.cardinalityFilter,
@@ -369,6 +373,14 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    */
   protected emitObservabilityEvent(event: ObservabilityEvent): void {
     this.observabilityBus.emit(event);
+  }
+
+  /**
+   * Internal hook used by RecordedTrace/RecordedSpan hydration to route
+   * non-tracing annotation events back through the normal exporter pipeline.
+   */
+  __emitRecordedEvent(event: ObservabilityEvent): void {
+    this.emitObservabilityEvent(event);
   }
 
   // ============================================================================

--- a/observability/mastra/src/integration-tests.test.ts
+++ b/observability/mastra/src/integration-tests.test.ts
@@ -725,8 +725,8 @@ describe('Tracing Integration Tests', () => {
     const stepLog = testExporter.getLogsByLevel('info').find(l => l.message === 'workflow-step: processing');
     expect(stepLog, 'loggerVNext.info() in workflow step should be captured by the exporter').toBeDefined();
     expect(stepLog!.data).toEqual({ value: 'tacos' });
-    expect(stepLog!.correlationContext?.traceId).toBe(result.traceId);
-    expect(stepLog!.correlationContext?.spanId).toBeDefined();
+    expect(stepLog!.traceId).toBe(result.traceId);
+    expect(stepLog!.spanId).toBeDefined();
 
     // Verify auto-extracted workflow metrics
     const workflowDuration = testExporter.getMetricsByName('mastra_workflow_duration_ms');
@@ -1255,8 +1255,8 @@ describe('Tracing Integration Tests', () => {
       const toolLog = infoLogs.find(l => l.message === 'metadata-tool: processing');
       expect(toolLog, 'loggerVNext.info() in tool should be captured by the exporter').toBeDefined();
       expect(toolLog!.data).toEqual({ inputValue: 'some data' });
-      expect(toolLog!.correlationContext?.traceId).toBe(result.traceId);
-      expect(toolLog!.correlationContext?.spanId).toBeDefined();
+      expect(toolLog!.traceId).toBe(result.traceId);
+      expect(toolLog!.spanId).toBeDefined();
 
       // Verify custom metrics delivered to the exporter
       const counterMetrics = testExporter.getMetricsByName('metadata_tool_calls');
@@ -1385,10 +1385,10 @@ describe('Tracing Integration Tests', () => {
       const finishLog = allLogs.find(l => l.message === 'child-span-tool: finished');
       expect(startLog, 'loggerVNext in tool should deliver logs to the exporter').toBeDefined();
       expect(finishLog).toBeDefined();
-      expect(startLog!.correlationContext?.traceId).toBe(result.traceId);
-      expect(finishLog!.correlationContext?.traceId).toBe(result.traceId);
+      expect(startLog!.traceId).toBe(result.traceId);
+      expect(finishLog!.traceId).toBe(result.traceId);
       // Both logs share the same span (the tool call span)
-      expect(startLog!.correlationContext?.spanId).toBe(finishLog!.correlationContext?.spanId);
+      expect(startLog!.spanId).toBe(finishLog!.spanId);
     });
   });
 

--- a/observability/mastra/src/recorded.test.ts
+++ b/observability/mastra/src/recorded.test.ts
@@ -5,6 +5,7 @@ import { MockStore } from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
 import { Observability } from './default';
 import { DefaultExporter } from './exporters/default';
+import { hydrateRecordedTrace } from './recorded';
 
 describe('RecordedTrace', () => {
   it('hydrates persisted traces and routes recorded annotations through exporters', async () => {
@@ -173,5 +174,250 @@ describe('RecordedTrace', () => {
         }),
       }),
     );
+  });
+
+  it('adds annotations through top-level observability APIs using persisted trace data', async () => {
+    const storage = new MockStore();
+    const onScoreEvent = vi.fn().mockResolvedValue(undefined);
+    const onFeedbackEvent = vi.fn().mockResolvedValue(undefined);
+
+    const mirrorExporter: ObservabilityExporter = {
+      name: 'mirror-exporter',
+      exportTracingEvent: vi.fn().mockResolvedValue(undefined),
+      onScoreEvent,
+      onFeedbackEvent,
+      flush: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mastra = new Mastra({
+      logger: false,
+      storage,
+      observability: new Observability({
+        configs: {
+          default: {
+            serviceName: 'test-service',
+            exporters: [new DefaultExporter(), mirrorExporter],
+          },
+        },
+      }),
+    });
+
+    const observabilityStore = await storage.getStore('observability');
+    expect(observabilityStore).toBeTruthy();
+
+    await observabilityStore!.batchCreateSpans({
+      records: [
+        {
+          traceId: 'trace-2',
+          spanId: 'root-span',
+          parentSpanId: null,
+          name: 'workflow-root',
+          spanType: SpanType.WORKFLOW_RUN,
+          entityType: EntityType.WORKFLOW_RUN,
+          entityId: 'workflow-2',
+          entityName: 'workflow-root',
+          userId: 'trace-user',
+          environment: 'production',
+          source: 'cloud',
+          serviceName: 'test-service',
+          experimentId: 'exp-2',
+          metadata: { inherited: true },
+          tags: ['prod', 'review'],
+          isEvent: false,
+          startedAt: new Date('2026-01-01T00:00:00Z'),
+          endedAt: new Date('2026-01-01T00:00:01Z'),
+        },
+        {
+          traceId: 'trace-2',
+          spanId: 'child-span',
+          parentSpanId: 'root-span',
+          name: 'tool-call',
+          spanType: SpanType.TOOL_CALL,
+          entityType: EntityType.TOOL,
+          entityId: 'tool-2',
+          entityName: 'tool-call',
+          userId: 'trace-user',
+          environment: 'production',
+          source: 'cloud',
+          serviceName: 'test-service',
+          experimentId: 'exp-2',
+          metadata: { inherited: true, tool: 'search' },
+          isEvent: false,
+          startedAt: new Date('2026-01-01T00:00:00.250Z'),
+          endedAt: new Date('2026-01-01T00:00:00.750Z'),
+        },
+      ],
+    });
+
+    await mastra.observability.addScore({
+      traceId: 'trace-2',
+      spanId: 'child-span',
+      score: {
+        scorerId: 'durable-review',
+        scoreSource: 'manual',
+        score: 0.9,
+        reason: 'Strong answer',
+        metadata: { reviewer: 'qa' },
+      },
+    });
+
+    await mastra.observability.addFeedback({
+      traceId: 'trace-2',
+      feedback: {
+        feedbackSource: 'user',
+        feedbackType: 'thumbs',
+        value: 1,
+        feedbackUserId: 'user-456',
+        comment: 'Helpful',
+        metadata: { channel: 'workflow' },
+      },
+    });
+
+    await mastra.observability.getDefaultInstance()?.flush();
+
+    const scores = await observabilityStore!.listScores({
+      filters: { traceId: 'trace-2' },
+      pagination: { page: 0, perPage: 10 },
+      orderBy: { field: 'timestamp', direction: 'ASC' },
+    });
+    const feedback = await observabilityStore!.listFeedback({
+      filters: { traceId: 'trace-2' },
+      pagination: { page: 0, perPage: 10 },
+      orderBy: { field: 'timestamp', direction: 'ASC' },
+    });
+
+    expect(scores.scores[0]).toMatchObject({
+      traceId: 'trace-2',
+      spanId: 'child-span',
+      scorerId: 'durable-review',
+      scoreSource: 'manual',
+      entityName: 'tool-call',
+      parentEntityName: 'workflow-root',
+      rootEntityName: 'workflow-root',
+      executionSource: 'cloud',
+      experimentId: 'exp-2',
+    });
+
+    expect(feedback.feedback[0]).toMatchObject({
+      traceId: 'trace-2',
+      spanId: null,
+      feedbackSource: 'user',
+      feedbackType: 'thumbs',
+      value: 1,
+      feedbackUserId: 'user-456',
+      entityName: 'workflow-root',
+      rootEntityName: 'workflow-root',
+      executionSource: 'cloud',
+      experimentId: 'exp-2',
+    });
+
+    expect(onScoreEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        score: expect.objectContaining({
+          traceId: 'trace-2',
+          spanId: 'child-span',
+          scoreSource: 'manual',
+        }),
+      }),
+    );
+
+    expect(onFeedbackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedback: expect.objectContaining({
+          traceId: 'trace-2',
+          feedbackSource: 'user',
+          feedbackUserId: 'user-456',
+        }),
+      }),
+    );
+  });
+
+  it('debug-logs and skips annotation when the recorded emit path is no longer wired', async () => {
+    const emitRecordedEvent = vi.fn().mockResolvedValue(undefined);
+    const debugRecordedAnnotationUnavailable = vi.fn();
+
+    const trace = hydrateRecordedTrace({
+      trace: {
+        traceId: 'trace-dead',
+        spans: [
+          {
+            traceId: 'trace-dead',
+            spanId: 'root-span',
+            parentSpanId: null,
+            name: 'workflow-root',
+            spanType: SpanType.WORKFLOW_RUN,
+            entityType: EntityType.WORKFLOW_RUN,
+            entityId: 'workflow-dead',
+            entityName: 'workflow-root',
+            isEvent: false,
+            startedAt: new Date('2026-01-01T00:00:00Z'),
+            endedAt: new Date('2026-01-01T00:00:01Z'),
+          },
+        ],
+      },
+      emitRecordedEvent,
+      canEmitRecordedEvent: () => false,
+      debugRecordedAnnotationUnavailable,
+    });
+
+    expect(trace).not.toBeNull();
+
+    await trace!.addScore({
+      scorerId: 'manual-review',
+      score: 0.5,
+    });
+
+    expect(emitRecordedEvent).not.toHaveBeenCalled();
+    expect(debugRecordedAnnotationUnavailable).toHaveBeenCalledWith({
+      kind: 'score',
+      traceId: 'trace-dead',
+    });
+  });
+
+  it('debug-logs when a top-level recorded annotation is dropped because no observability instance is registered', async () => {
+    const storage = new MockStore();
+    const debug = vi.fn();
+
+    const mastra = new Mastra({
+      logger: false,
+      storage,
+      observability: new Observability({}),
+    });
+
+    mastra.observability.setLogger({ logger: { debug } as any });
+
+    const observabilityStore = await storage.getStore('observability');
+    expect(observabilityStore).toBeTruthy();
+
+    await observabilityStore!.batchCreateSpans({
+      records: [
+        {
+          traceId: 'trace-no-instance',
+          spanId: 'root-span',
+          parentSpanId: null,
+          name: 'workflow-root',
+          spanType: SpanType.WORKFLOW_RUN,
+          entityType: EntityType.WORKFLOW_RUN,
+          entityId: 'workflow-no-instance',
+          entityName: 'workflow-root',
+          isEvent: false,
+          startedAt: new Date('2026-01-01T00:00:00Z'),
+          endedAt: new Date('2026-01-01T00:00:01Z'),
+        },
+      ],
+    });
+
+    await mastra.observability.addScore({
+      traceId: 'trace-no-instance',
+      score: {
+        scorerId: 'manual-review',
+        score: 0.5,
+      },
+    });
+
+    expect(debug).toHaveBeenCalledWith('Score event was dropped because no observability instance is registered', {
+      eventType: 'score',
+    });
   });
 });

--- a/observability/mastra/src/recorded.test.ts
+++ b/observability/mastra/src/recorded.test.ts
@@ -1,0 +1,177 @@
+import { Mastra } from '@mastra/core';
+import type { ObservabilityExporter } from '@mastra/core/observability';
+import { EntityType, SpanType } from '@mastra/core/observability';
+import { MockStore } from '@mastra/core/storage';
+import { describe, expect, it, vi } from 'vitest';
+import { Observability } from './default';
+import { DefaultExporter } from './exporters/default';
+
+describe('RecordedTrace', () => {
+  it('hydrates persisted traces and routes recorded annotations through exporters', async () => {
+    const storage = new MockStore();
+    const onScoreEvent = vi.fn().mockResolvedValue(undefined);
+    const onFeedbackEvent = vi.fn().mockResolvedValue(undefined);
+
+    const mirrorExporter: ObservabilityExporter = {
+      name: 'mirror-exporter',
+      exportTracingEvent: vi.fn().mockResolvedValue(undefined),
+      onScoreEvent,
+      onFeedbackEvent,
+      flush: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mastra = new Mastra({
+      logger: false,
+      storage,
+      observability: new Observability({
+        configs: {
+          default: {
+            serviceName: 'test-service',
+            exporters: [new DefaultExporter(), mirrorExporter],
+          },
+        },
+      }),
+    });
+
+    const observabilityStore = await storage.getStore('observability');
+    expect(observabilityStore).toBeTruthy();
+
+    await observabilityStore!.batchCreateSpans({
+      records: [
+        {
+          traceId: 'trace-1',
+          spanId: 'root-span',
+          parentSpanId: null,
+          name: 'workflow-root',
+          spanType: SpanType.WORKFLOW_RUN,
+          entityType: EntityType.WORKFLOW_RUN,
+          entityId: 'workflow-1',
+          entityName: 'workflow-root',
+          userId: 'trace-user',
+          environment: 'production',
+          source: 'cloud',
+          serviceName: 'test-service',
+          experimentId: 'exp-1',
+          metadata: { inherited: true },
+          tags: ['prod', 'review'],
+          isEvent: false,
+          startedAt: new Date('2026-01-01T00:00:00Z'),
+          endedAt: new Date('2026-01-01T00:00:01Z'),
+        },
+        {
+          traceId: 'trace-1',
+          spanId: 'child-span',
+          parentSpanId: 'root-span',
+          name: 'tool-call',
+          spanType: SpanType.TOOL_CALL,
+          entityType: EntityType.TOOL,
+          entityId: 'tool-1',
+          entityName: 'tool-call',
+          userId: 'trace-user',
+          environment: 'production',
+          source: 'cloud',
+          serviceName: 'test-service',
+          experimentId: 'exp-1',
+          metadata: { inherited: true, tool: 'weather' },
+          isEvent: false,
+          startedAt: new Date('2026-01-01T00:00:00.250Z'),
+          endedAt: new Date('2026-01-01T00:00:00.750Z'),
+        },
+      ],
+    });
+
+    const trace = await mastra.observability.getRecordedTrace({ traceId: 'trace-1' });
+
+    expect(trace).not.toBeNull();
+    expect(trace!.traceId).toBe('trace-1');
+    expect(trace!.rootSpan.id).toBe('root-span');
+    expect(trace!.rootSpan.children).toHaveLength(1);
+
+    const childSpan = trace!.getSpan('child-span');
+    expect(childSpan).not.toBeNull();
+    expect(childSpan!.parent?.id).toBe('root-span');
+
+    await childSpan!.addScore({
+      scorerId: 'manual-review',
+      source: 'manual',
+      score: 0.75,
+      reason: 'Helpful tool use',
+      metadata: { reviewer: 'qa' },
+    });
+
+    await trace!.addFeedback({
+      source: 'user',
+      feedbackType: 'thumbs',
+      value: 1,
+      feedbackUserId: 'user-123',
+      comment: 'Great answer',
+      metadata: { channel: 'chat' },
+    });
+
+    await mastra.observability.getDefaultInstance()?.flush();
+
+    const scores = await observabilityStore!.listScores({
+      filters: { traceId: 'trace-1' },
+      pagination: { page: 0, perPage: 10 },
+      orderBy: { field: 'timestamp', direction: 'ASC' },
+    });
+    const feedback = await observabilityStore!.listFeedback({
+      filters: { traceId: 'trace-1' },
+      pagination: { page: 0, perPage: 10 },
+      orderBy: { field: 'timestamp', direction: 'ASC' },
+    });
+
+    expect(scores.scores[0]).toMatchObject({
+      traceId: 'trace-1',
+      spanId: 'child-span',
+      scorerId: 'manual-review',
+      scoreSource: 'manual',
+      entityName: 'tool-call',
+      parentEntityName: 'workflow-root',
+      rootEntityName: 'workflow-root',
+      executionSource: 'cloud',
+      experimentId: 'exp-1',
+    });
+
+    expect(feedback.feedback[0]).toMatchObject({
+      traceId: 'trace-1',
+      spanId: null,
+      feedbackSource: 'user',
+      feedbackType: 'thumbs',
+      value: 1,
+      feedbackUserId: 'user-123',
+      entityName: 'workflow-root',
+      rootEntityName: 'workflow-root',
+      executionSource: 'cloud',
+      experimentId: 'exp-1',
+    });
+
+    expect(onScoreEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        score: expect.objectContaining({
+          traceId: 'trace-1',
+          spanId: 'child-span',
+          correlationContext: expect.objectContaining({
+            parentEntityName: 'workflow-root',
+            rootEntityName: 'workflow-root',
+            experimentId: 'exp-1',
+          }),
+        }),
+      }),
+    );
+
+    expect(onFeedbackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedback: expect.objectContaining({
+          traceId: 'trace-1',
+          correlationContext: expect.objectContaining({
+            entityName: 'workflow-root',
+            rootEntityName: 'workflow-root',
+            experimentId: 'exp-1',
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/observability/mastra/src/recorded.ts
+++ b/observability/mastra/src/recorded.ts
@@ -1,0 +1,308 @@
+import type {
+  AnyRecordedSpan,
+  CorrelationContext,
+  FeedbackEvent,
+  FeedbackInput,
+  RecordedSpan,
+  RecordedTrace,
+  ScoreEvent,
+  ScoreInput,
+  SpanType,
+  SpanTypeMap,
+} from '@mastra/core/observability';
+import type { GetTraceResponse, SpanRecord } from '@mastra/core/storage';
+
+type RecordedAnnotationEvent = ScoreEvent | FeedbackEvent;
+type EmitRecordedEvent = (event: RecordedAnnotationEvent) => void | Promise<void>;
+type RecordedErrorInfo = AnyRecordedSpan['errorInfo'];
+
+function nullToUndefined<T>(value: T | null | undefined): T | undefined {
+  return value ?? undefined;
+}
+
+function mergeMetadata(
+  base: Record<string, any> | null | undefined,
+  extra: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!base && !extra) return undefined;
+  return {
+    ...(base ?? {}),
+    ...(extra ?? {}),
+  };
+}
+
+function normalizeErrorInfo(error: SpanRecord['error']): RecordedErrorInfo {
+  if (!error || typeof error !== 'object' || !('message' in error) || typeof error.message !== 'string') {
+    return undefined;
+  }
+
+  return {
+    message: error.message,
+    id: 'id' in error && typeof error.id === 'string' ? error.id : undefined,
+    domain: 'domain' in error && typeof error.domain === 'string' ? error.domain : undefined,
+    category: 'category' in error && typeof error.category === 'string' ? error.category : undefined,
+    details:
+      'details' in error && error.details && typeof error.details === 'object'
+        ? (error.details as Record<string, any>)
+        : undefined,
+  };
+}
+
+function buildCorrelationContext(span: SpanRecord, rootSpan: SpanRecord, parent?: AnyRecordedSpan): CorrelationContext {
+  return {
+    tags: rootSpan.tags ?? undefined,
+    entityType: nullToUndefined(span.entityType),
+    entityId: nullToUndefined(span.entityId),
+    entityName: nullToUndefined(span.entityName),
+    parentEntityType: parent?.entityType,
+    parentEntityId: parent?.entityId,
+    parentEntityName: parent?.entityName,
+    rootEntityType: nullToUndefined(rootSpan.entityType),
+    rootEntityId: nullToUndefined(rootSpan.entityId),
+    rootEntityName: nullToUndefined(rootSpan.entityName),
+    userId: nullToUndefined(span.userId),
+    organizationId: nullToUndefined(span.organizationId),
+    resourceId: nullToUndefined(span.resourceId),
+    runId: nullToUndefined(span.runId),
+    sessionId: nullToUndefined(span.sessionId),
+    threadId: nullToUndefined(span.threadId),
+    requestId: nullToUndefined(span.requestId),
+    environment: nullToUndefined(span.environment),
+    source: nullToUndefined(span.source),
+    serviceName: nullToUndefined(span.serviceName),
+    experimentId: nullToUndefined(span.experimentId),
+  };
+}
+
+function buildScoreEvent(args: {
+  span: SpanRecord;
+  rootSpan: SpanRecord;
+  parent?: AnyRecordedSpan;
+  score: ScoreInput;
+  spanId?: string;
+}): ScoreEvent {
+  const { span, rootSpan, parent, score, spanId } = args;
+
+  return {
+    type: 'score',
+    score: {
+      timestamp: new Date(),
+      traceId: span.traceId,
+      spanId,
+      scorerId: score.scorerId,
+      scorerVersion: score.scorerVersion,
+      source: score.source,
+      score: score.score,
+      reason: score.reason,
+      experimentId: score.experimentId,
+      scoreTraceId: score.scoreTraceId,
+      correlationContext: buildCorrelationContext(span, rootSpan, parent),
+      metadata: mergeMetadata(span.metadata, score.metadata),
+    },
+  };
+}
+
+function buildFeedbackEvent(args: {
+  span: SpanRecord;
+  rootSpan: SpanRecord;
+  parent?: AnyRecordedSpan;
+  feedback: FeedbackInput;
+  spanId?: string;
+}): FeedbackEvent {
+  const { span, rootSpan, parent, feedback, spanId } = args;
+
+  return {
+    type: 'feedback',
+    feedback: {
+      timestamp: new Date(),
+      traceId: span.traceId,
+      spanId,
+      source: feedback.source,
+      feedbackType: feedback.feedbackType,
+      value: feedback.value,
+      feedbackUserId: feedback.feedbackUserId,
+      comment: feedback.comment,
+      sourceId: feedback.sourceId,
+      experimentId: feedback.experimentId,
+      correlationContext: buildCorrelationContext(span, rootSpan, parent),
+      metadata: mergeMetadata(span.metadata, feedback.metadata),
+    },
+  };
+}
+
+class RecordedSpanImpl<TType extends SpanType = SpanType> implements RecordedSpan<TType> {
+  public readonly id: string;
+  public readonly traceId: string;
+  public readonly name: string;
+  public readonly type: TType;
+  public readonly entityType?: RecordedSpan<TType>['entityType'];
+  public readonly entityId?: string;
+  public readonly entityName?: string;
+  public readonly startTime: Date;
+  public readonly endTime?: Date;
+  public readonly attributes?: SpanTypeMap[TType];
+  public readonly metadata?: Record<string, any>;
+  public readonly tags?: string[];
+  public readonly input?: any;
+  public readonly output?: any;
+  public readonly errorInfo?: {
+    message: string;
+    id?: string;
+    domain?: string;
+    category?: string;
+    details?: Record<string, any>;
+  };
+  public readonly requestContext?: Record<string, any>;
+  public readonly isEvent: boolean;
+  public readonly isRootSpan: boolean;
+  public readonly parentSpanId?: string;
+  public parent?: RecordedSpanImpl;
+  public readonly children: RecordedSpanImpl[] = [];
+
+  readonly #raw: SpanRecord;
+  readonly #rootSpan: SpanRecord;
+  readonly #emitRecordedEvent: EmitRecordedEvent;
+
+  constructor(args: { raw: SpanRecord; rootSpan: SpanRecord; emitRecordedEvent: EmitRecordedEvent }) {
+    const { raw, rootSpan, emitRecordedEvent } = args;
+
+    this.#raw = raw;
+    this.#rootSpan = rootSpan;
+    this.#emitRecordedEvent = emitRecordedEvent;
+
+    this.id = raw.spanId;
+    this.traceId = raw.traceId;
+    this.name = raw.name;
+    this.type = raw.spanType as TType;
+    this.entityType = raw.entityType ?? undefined;
+    this.entityId = raw.entityId ?? undefined;
+    this.entityName = raw.entityName ?? undefined;
+    this.startTime = raw.startedAt;
+    this.endTime = raw.endedAt ?? undefined;
+    this.attributes = (raw.attributes ?? undefined) as SpanTypeMap[TType] | undefined;
+    this.metadata = raw.metadata ?? undefined;
+    this.tags = raw.tags ?? undefined;
+    this.input = raw.input ?? undefined;
+    this.output = raw.output ?? undefined;
+    this.errorInfo = normalizeErrorInfo(raw.error);
+    this.requestContext = raw.requestContext ?? undefined;
+    this.isEvent = raw.isEvent;
+    this.isRootSpan = !raw.parentSpanId;
+    this.parentSpanId = raw.parentSpanId ?? undefined;
+  }
+
+  async addScore(score: ScoreInput): Promise<void> {
+    await this.#emitRecordedEvent(
+      buildScoreEvent({
+        span: this.#raw,
+        rootSpan: this.#rootSpan,
+        parent: this.parent,
+        score,
+        spanId: this.id,
+      }),
+    );
+  }
+
+  async addFeedback(feedback: FeedbackInput): Promise<void> {
+    await this.#emitRecordedEvent(
+      buildFeedbackEvent({
+        span: this.#raw,
+        rootSpan: this.#rootSpan,
+        parent: this.parent,
+        feedback,
+        spanId: this.id,
+      }),
+    );
+  }
+}
+
+class RecordedTraceImpl implements RecordedTrace {
+  public readonly traceId: string;
+  public readonly rootSpan: AnyRecordedSpan;
+  public readonly spans: ReadonlyArray<AnyRecordedSpan>;
+
+  readonly #rootRecord: SpanRecord;
+  readonly #emitRecordedEvent: EmitRecordedEvent;
+  readonly #spanMap: Map<string, AnyRecordedSpan>;
+
+  constructor(args: {
+    traceId: string;
+    rootSpan: AnyRecordedSpan;
+    rootRecord: SpanRecord;
+    spans: AnyRecordedSpan[];
+    emitRecordedEvent: EmitRecordedEvent;
+  }) {
+    this.traceId = args.traceId;
+    this.rootSpan = args.rootSpan;
+    this.#rootRecord = args.rootRecord;
+    this.spans = args.spans;
+    this.#emitRecordedEvent = args.emitRecordedEvent;
+    this.#spanMap = new Map(args.spans.map(span => [span.id, span]));
+  }
+
+  getSpan(spanId: string): AnyRecordedSpan | null {
+    return this.#spanMap.get(spanId) ?? null;
+  }
+
+  async addScore(score: ScoreInput): Promise<void> {
+    await this.#emitRecordedEvent(
+      buildScoreEvent({
+        span: this.#rootRecord,
+        rootSpan: this.#rootRecord,
+        score,
+      }),
+    );
+  }
+
+  async addFeedback(feedback: FeedbackInput): Promise<void> {
+    await this.#emitRecordedEvent(
+      buildFeedbackEvent({
+        span: this.#rootRecord,
+        rootSpan: this.#rootRecord,
+        feedback,
+      }),
+    );
+  }
+}
+
+function findRootSpan(spans: SpanRecord[]): SpanRecord | undefined {
+  const spanIds = new Set(spans.map(span => span.spanId));
+  return spans.find(span => !span.parentSpanId || !spanIds.has(span.parentSpanId)) ?? spans[0];
+}
+
+export function hydrateRecordedTrace(args: {
+  trace: GetTraceResponse;
+  emitRecordedEvent: EmitRecordedEvent;
+}): RecordedTrace | null {
+  const { trace, emitRecordedEvent } = args;
+  const rootSpan = findRootSpan(trace.spans);
+
+  if (!rootSpan) {
+    return null;
+  }
+
+  const recordedSpans = trace.spans.map(raw => new RecordedSpanImpl({ raw, rootSpan, emitRecordedEvent }));
+  const spanMap = new Map(recordedSpans.map(span => [span.id, span]));
+
+  for (const span of recordedSpans) {
+    if (!span.parentSpanId) continue;
+    const parent = spanMap.get(span.parentSpanId);
+    if (!parent) continue;
+
+    span.parent = parent;
+    parent.children.push(span);
+  }
+
+  const hydratedRootSpan = spanMap.get(rootSpan.spanId);
+  if (!hydratedRootSpan) {
+    return null;
+  }
+
+  return new RecordedTraceImpl({
+    traceId: trace.traceId,
+    rootSpan: hydratedRootSpan,
+    rootRecord: rootSpan,
+    spans: recordedSpans,
+    emitRecordedEvent,
+  });
+}

--- a/observability/mastra/src/recorded.ts
+++ b/observability/mastra/src/recorded.ts
@@ -14,7 +14,14 @@ import type { GetTraceResponse, SpanRecord } from '@mastra/core/storage';
 
 type RecordedAnnotationEvent = ScoreEvent | FeedbackEvent;
 type EmitRecordedEvent = (event: RecordedAnnotationEvent) => void | Promise<void>;
+type CanEmitRecordedEvent = () => boolean;
+type DebugRecordedAnnotationUnavailable = (args: {
+  kind: 'score' | 'feedback';
+  traceId: string;
+  spanId?: string;
+}) => void;
 type RecordedErrorInfo = AnyRecordedSpan['errorInfo'];
+type CorrelationParent = Pick<SpanRecord, 'entityType' | 'entityId' | 'entityName'> | AnyRecordedSpan | undefined;
 
 function nullToUndefined<T>(value: T | null | undefined): T | undefined {
   return value ?? undefined;
@@ -48,15 +55,19 @@ function normalizeErrorInfo(error: SpanRecord['error']): RecordedErrorInfo {
   };
 }
 
-function buildCorrelationContext(span: SpanRecord, rootSpan: SpanRecord, parent?: AnyRecordedSpan): CorrelationContext {
+function buildCorrelationContext(
+  span: SpanRecord,
+  rootSpan: SpanRecord,
+  parent?: CorrelationParent,
+): CorrelationContext {
   return {
     tags: rootSpan.tags ?? undefined,
     entityType: nullToUndefined(span.entityType),
     entityId: nullToUndefined(span.entityId),
     entityName: nullToUndefined(span.entityName),
-    parentEntityType: parent?.entityType,
-    parentEntityId: parent?.entityId,
-    parentEntityName: parent?.entityName,
+    parentEntityType: parent?.entityType ?? undefined,
+    parentEntityId: parent?.entityId ?? undefined,
+    parentEntityName: parent?.entityName ?? undefined,
     rootEntityType: nullToUndefined(rootSpan.entityType),
     rootEntityId: nullToUndefined(rootSpan.entityId),
     rootEntityName: nullToUndefined(rootSpan.entityName),
@@ -74,10 +85,10 @@ function buildCorrelationContext(span: SpanRecord, rootSpan: SpanRecord, parent?
   };
 }
 
-function buildScoreEvent(args: {
+export function buildRecordedScoreEvent(args: {
   span: SpanRecord;
   rootSpan: SpanRecord;
-  parent?: AnyRecordedSpan;
+  parent?: CorrelationParent;
   score: ScoreInput;
   spanId?: string;
 }): ScoreEvent {
@@ -92,6 +103,7 @@ function buildScoreEvent(args: {
       scorerId: score.scorerId,
       scorerVersion: score.scorerVersion,
       source: score.source,
+      scoreSource: score.scoreSource,
       score: score.score,
       reason: score.reason,
       experimentId: score.experimentId,
@@ -102,10 +114,10 @@ function buildScoreEvent(args: {
   };
 }
 
-function buildFeedbackEvent(args: {
+export function buildRecordedFeedbackEvent(args: {
   span: SpanRecord;
   rootSpan: SpanRecord;
-  parent?: AnyRecordedSpan;
+  parent?: CorrelationParent;
   feedback: FeedbackInput;
   spanId?: string;
 }): FeedbackEvent {
@@ -118,8 +130,10 @@ function buildFeedbackEvent(args: {
       traceId: span.traceId,
       spanId,
       source: feedback.source,
+      feedbackSource: feedback.feedbackSource,
       feedbackType: feedback.feedbackType,
       value: feedback.value,
+      userId: feedback.userId,
       feedbackUserId: feedback.feedbackUserId,
       comment: feedback.comment,
       sourceId: feedback.sourceId,
@@ -128,6 +142,55 @@ function buildFeedbackEvent(args: {
       metadata: mergeMetadata(span.metadata, feedback.metadata),
     },
   };
+}
+
+function findSpanById(spans: SpanRecord[], spanId: string | undefined): SpanRecord | undefined {
+  if (!spanId) return undefined;
+  return spans.find(span => span.spanId === spanId);
+}
+
+export function buildRecordedScoreEventFromTrace(args: {
+  trace: GetTraceResponse;
+  score: ScoreInput;
+  spanId?: string;
+}): ScoreEvent | null {
+  const rootSpan = findRootSpan(args.trace.spans);
+  if (!rootSpan) return null;
+
+  const span = args.spanId ? findSpanById(args.trace.spans, args.spanId) : rootSpan;
+  if (!span) return null;
+
+  const parent = span.parentSpanId ? findSpanById(args.trace.spans, span.parentSpanId) : undefined;
+
+  return buildRecordedScoreEvent({
+    span,
+    rootSpan,
+    parent,
+    score: args.score,
+    spanId: args.spanId,
+  });
+}
+
+export function buildRecordedFeedbackEventFromTrace(args: {
+  trace: GetTraceResponse;
+  feedback: FeedbackInput;
+  spanId?: string;
+}): FeedbackEvent | null {
+  const rootSpan = findRootSpan(args.trace.spans);
+  if (!rootSpan) return null;
+
+  const span = args.spanId ? findSpanById(args.trace.spans, args.spanId) : rootSpan;
+  if (!span) return null;
+
+  const parent = span.parentSpanId ? findSpanById(args.trace.spans, span.parentSpanId) : undefined;
+
+  return buildRecordedFeedbackEvent({
+    span,
+    rootSpan,
+    parent,
+    feedback: args.feedback,
+    spanId: args.spanId,
+  });
 }
 
 class RecordedSpanImpl<TType extends SpanType = SpanType> implements RecordedSpan<TType> {
@@ -162,13 +225,23 @@ class RecordedSpanImpl<TType extends SpanType = SpanType> implements RecordedSpa
   readonly #raw: SpanRecord;
   readonly #rootSpan: SpanRecord;
   readonly #emitRecordedEvent: EmitRecordedEvent;
+  readonly #canEmitRecordedEvent: CanEmitRecordedEvent;
+  readonly #debugRecordedAnnotationUnavailable: DebugRecordedAnnotationUnavailable;
 
-  constructor(args: { raw: SpanRecord; rootSpan: SpanRecord; emitRecordedEvent: EmitRecordedEvent }) {
-    const { raw, rootSpan, emitRecordedEvent } = args;
+  constructor(args: {
+    raw: SpanRecord;
+    rootSpan: SpanRecord;
+    emitRecordedEvent: EmitRecordedEvent;
+    canEmitRecordedEvent: CanEmitRecordedEvent;
+    debugRecordedAnnotationUnavailable: DebugRecordedAnnotationUnavailable;
+  }) {
+    const { raw, rootSpan, emitRecordedEvent, canEmitRecordedEvent, debugRecordedAnnotationUnavailable } = args;
 
     this.#raw = raw;
     this.#rootSpan = rootSpan;
     this.#emitRecordedEvent = emitRecordedEvent;
+    this.#canEmitRecordedEvent = canEmitRecordedEvent;
+    this.#debugRecordedAnnotationUnavailable = debugRecordedAnnotationUnavailable;
 
     this.id = raw.spanId;
     this.traceId = raw.traceId;
@@ -192,8 +265,13 @@ class RecordedSpanImpl<TType extends SpanType = SpanType> implements RecordedSpa
   }
 
   async addScore(score: ScoreInput): Promise<void> {
+    if (!this.#canEmitRecordedEvent()) {
+      this.#debugRecordedAnnotationUnavailable({ kind: 'score', traceId: this.traceId, spanId: this.id });
+      return;
+    }
+
     await this.#emitRecordedEvent(
-      buildScoreEvent({
+      buildRecordedScoreEvent({
         span: this.#raw,
         rootSpan: this.#rootSpan,
         parent: this.parent,
@@ -204,8 +282,13 @@ class RecordedSpanImpl<TType extends SpanType = SpanType> implements RecordedSpa
   }
 
   async addFeedback(feedback: FeedbackInput): Promise<void> {
+    if (!this.#canEmitRecordedEvent()) {
+      this.#debugRecordedAnnotationUnavailable({ kind: 'feedback', traceId: this.traceId, spanId: this.id });
+      return;
+    }
+
     await this.#emitRecordedEvent(
-      buildFeedbackEvent({
+      buildRecordedFeedbackEvent({
         span: this.#raw,
         rootSpan: this.#rootSpan,
         parent: this.parent,
@@ -224,6 +307,8 @@ class RecordedTraceImpl implements RecordedTrace {
   readonly #rootRecord: SpanRecord;
   readonly #emitRecordedEvent: EmitRecordedEvent;
   readonly #spanMap: Map<string, AnyRecordedSpan>;
+  readonly #canEmitRecordedEvent: CanEmitRecordedEvent;
+  readonly #debugRecordedAnnotationUnavailable: DebugRecordedAnnotationUnavailable;
 
   constructor(args: {
     traceId: string;
@@ -231,6 +316,8 @@ class RecordedTraceImpl implements RecordedTrace {
     rootRecord: SpanRecord;
     spans: AnyRecordedSpan[];
     emitRecordedEvent: EmitRecordedEvent;
+    canEmitRecordedEvent: CanEmitRecordedEvent;
+    debugRecordedAnnotationUnavailable: DebugRecordedAnnotationUnavailable;
   }) {
     this.traceId = args.traceId;
     this.rootSpan = args.rootSpan;
@@ -238,6 +325,8 @@ class RecordedTraceImpl implements RecordedTrace {
     this.spans = args.spans;
     this.#emitRecordedEvent = args.emitRecordedEvent;
     this.#spanMap = new Map(args.spans.map(span => [span.id, span]));
+    this.#canEmitRecordedEvent = args.canEmitRecordedEvent;
+    this.#debugRecordedAnnotationUnavailable = args.debugRecordedAnnotationUnavailable;
   }
 
   getSpan(spanId: string): AnyRecordedSpan | null {
@@ -245,8 +334,13 @@ class RecordedTraceImpl implements RecordedTrace {
   }
 
   async addScore(score: ScoreInput): Promise<void> {
+    if (!this.#canEmitRecordedEvent()) {
+      this.#debugRecordedAnnotationUnavailable({ kind: 'score', traceId: this.traceId });
+      return;
+    }
+
     await this.#emitRecordedEvent(
-      buildScoreEvent({
+      buildRecordedScoreEvent({
         span: this.#rootRecord,
         rootSpan: this.#rootRecord,
         score,
@@ -255,8 +349,13 @@ class RecordedTraceImpl implements RecordedTrace {
   }
 
   async addFeedback(feedback: FeedbackInput): Promise<void> {
+    if (!this.#canEmitRecordedEvent()) {
+      this.#debugRecordedAnnotationUnavailable({ kind: 'feedback', traceId: this.traceId });
+      return;
+    }
+
     await this.#emitRecordedEvent(
-      buildFeedbackEvent({
+      buildRecordedFeedbackEvent({
         span: this.#rootRecord,
         rootSpan: this.#rootRecord,
         feedback,
@@ -273,15 +372,31 @@ function findRootSpan(spans: SpanRecord[]): SpanRecord | undefined {
 export function hydrateRecordedTrace(args: {
   trace: GetTraceResponse;
   emitRecordedEvent: EmitRecordedEvent;
+  canEmitRecordedEvent?: CanEmitRecordedEvent;
+  debugRecordedAnnotationUnavailable?: DebugRecordedAnnotationUnavailable;
 }): RecordedTrace | null {
-  const { trace, emitRecordedEvent } = args;
+  const {
+    trace,
+    emitRecordedEvent,
+    canEmitRecordedEvent = () => true,
+    debugRecordedAnnotationUnavailable = () => {},
+  } = args;
   const rootSpan = findRootSpan(trace.spans);
 
   if (!rootSpan) {
     return null;
   }
 
-  const recordedSpans = trace.spans.map(raw => new RecordedSpanImpl({ raw, rootSpan, emitRecordedEvent }));
+  const recordedSpans = trace.spans.map(
+    raw =>
+      new RecordedSpanImpl({
+        raw,
+        rootSpan,
+        emitRecordedEvent,
+        canEmitRecordedEvent,
+        debugRecordedAnnotationUnavailable,
+      }),
+  );
   const spanMap = new Map(recordedSpans.map(span => [span.id, span]));
 
   for (const span of recordedSpans) {
@@ -304,5 +419,7 @@ export function hydrateRecordedTrace(args: {
     rootRecord: rootSpan,
     spans: recordedSpans,
     emitRecordedEvent,
+    canEmitRecordedEvent,
+    debugRecordedAnnotationUnavailable,
   });
 }

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -283,6 +283,8 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     const rootTags = rootSpan.tags?.length ? [...rootSpan.tags] : undefined;
 
     this.correlationContext = {
+      traceId: this.traceId,
+      spanId: this.id,
       tags: rootTags,
       entityType: this.entityType,
       entityId: this.entityId,

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -283,8 +283,6 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     const rootTags = rootSpan.tags?.length ? [...rootSpan.tags] : undefined;
 
     this.correlationContext = {
-      traceId: this.traceId,
-      spanId: this.id,
       tags: rootTags,
       entityType: this.entityType,
       entityId: this.entityId,

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -1437,11 +1437,11 @@ describe('Tracing', () => {
 
       expect(testExporter.logEvents).toHaveLength(1);
       expect(testExporter.logEvents[0]!.log).toMatchObject({
+        traceId: childSpan.traceId,
+        spanId: childSpan.id,
         message: 'tool running',
         data: { attempt: 1 },
         correlationContext: {
-          traceId: childSpan.traceId,
-          spanId: childSpan.id,
           entityName: childSpan.entityName,
           tags: ['batch-processing', 'priority-high'],
         },
@@ -1477,12 +1477,12 @@ describe('Tracing', () => {
 
       expect(testExporter.metricEvents).toHaveLength(1);
       expect(testExporter.metricEvents[0]!.metric).toMatchObject({
+        traceId: modelSpan.traceId,
+        spanId: modelSpan.id,
         name: 'user_metric',
         value: 1,
         labels: { status: 'ok' },
         correlationContext: {
-          traceId: modelSpan.traceId,
-          spanId: modelSpan.id,
           entityName: modelSpan.entityName,
         },
       });

--- a/packages/core/src/observability/no-op.ts
+++ b/packages/core/src/observability/no-op.ts
@@ -4,6 +4,7 @@ import type {
   ConfigSelector,
   ConfigSelectorOptions,
   Counter,
+  FeedbackInput,
   Gauge,
   Histogram,
   LoggerContext,
@@ -11,6 +12,7 @@ import type {
   ObservabilityEntrypoint,
   ObservabilityInstance,
   RecordedTrace,
+  ScoreInput,
   TracingContext,
 } from './types';
 
@@ -98,6 +100,14 @@ export class NoOpObservability implements ObservabilityEntrypoint {
 
   async getRecordedTrace(_args: { traceId: string }): Promise<RecordedTrace | null> {
     return null;
+  }
+
+  async addScore(_args: { traceId: string; spanId?: string; score: ScoreInput }): Promise<void> {
+    return;
+  }
+
+  async addFeedback(_args: { traceId: string; spanId?: string; feedback: FeedbackInput }): Promise<void> {
+    return;
   }
 
   registerInstance(_name: string, _instance: ObservabilityInstance, _isDefault = false): void {

--- a/packages/core/src/observability/types/core.ts
+++ b/packages/core/src/observability/types/core.ts
@@ -9,10 +9,10 @@
 import type { IMastraLogger } from '../../logger';
 import type { Mastra } from '../../mastra';
 import type { RequestContext } from '../../request-context';
-import type { FeedbackEvent } from './feedback';
+import type { FeedbackEvent, FeedbackInput } from './feedback';
 import type { LoggerContext, LogEvent } from './logging';
 import type { MetricsContext, MetricEvent } from './metrics';
-import type { ScoreEvent } from './scores';
+import type { ScoreEvent, ScoreInput } from './scores';
 import type {
   AnySpan,
   RecordedTrace,
@@ -250,6 +250,18 @@ export interface ObservabilityEntrypoint {
    * Returns null when storage is unavailable or the trace does not exist.
    */
   getRecordedTrace?(args: { traceId: string }): Promise<RecordedTrace | null>;
+
+  /**
+   * Add a score to a persisted trace or span without hydrating a RecordedTrace.
+   * Useful for durable executions that persist only identifiers across serialization boundaries.
+   */
+  addScore?(args: { traceId: string; spanId?: string; score: ScoreInput }): Promise<void>;
+
+  /**
+   * Add feedback to a persisted trace or span without hydrating a RecordedTrace.
+   * Useful for durable executions that persist only identifiers across serialization boundaries.
+   */
+  addFeedback?(args: { traceId: string; spanId?: string; feedback: FeedbackInput }): Promise<void>;
 
   // Registry management methods
   registerInstance(name: string, instance: ObservabilityInstance, isDefault?: boolean): void;

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -647,6 +647,10 @@ export type AnyExportedSpan = ExportedSpan<keyof SpanTypeMap>;
  * - Spans loaded from storage for evaluation
  * - Spans from completed traces being annotated
  * - Post-hoc quality scoring and user feedback
+ *
+ * RecordedSpan objects are hydrated runtime wrappers and should not be treated as
+ * durable serialized state. Persist `traceId` / `spanId` and rehydrate, or use
+ * top-level observability annotation APIs after resume.
  */
 export interface RecordedSpan<TType extends SpanType> extends SpanData<TType> {
   /** Parent span reference (undefined for root spans) */
@@ -679,6 +683,9 @@ export type AnyRecordedSpan = RecordedSpan<keyof SpanTypeMap>;
  * All references point to the same span objects - no memory duplication.
  *
  * Obtained via mastra.observability.getRecordedTrace({ traceId }) for post-execution annotation.
+ * RecordedTrace objects are hydrated runtime wrappers and should not be stored
+ * across durable workflow serialization boundaries. Persist identifiers instead
+ * and rehydrate, or use top-level observability annotation APIs after resume.
  */
 export interface RecordedTrace {
   /** The trace identifier */


### PR DESCRIPTION
## Description

This PR adds support for working with persisted traces through Mastra observability.

You can now load a recorded trace with mastra.observability.getRecordedTrace({ traceId }) and attach scores or feedback either through the returned recorded trace/span objects or through top-level mastra.observability.addScore() and addFeedback() calls. This makes post-execution scoring and feedback flows work more cleanly for persisted traces, including durable workflow scenarios where trace IDs can be rehydrated
later.

This PR also updates recorded trace/span annotation methods to be async, improves compatibility around the current correlation shape used by logs and metrics, and adds debug logging when recorded score or feedback calls cannot be delivered because no observability instance is available.

## Related Issue(s)


## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Code refactoring
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persisted trace support with APIs to load recorded traces and attach scores/feedback after execution; recorded annotation methods are async.

* **Improvements**
  * Logs and metrics now include traceId/spanId as top-level fields for consistent correlation.
  * Recorded annotations route through standard observability export pipeline when available.

* **Documentation**
  * Clarified that recorded trace/span objects are runtime wrappers and should not be serialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->