### PR TITLE
refactor(core): use serializeForSpan() for MODEL_GENERATION span input

### DIFF
--- a/.changeset/neat-turtles-arrive.md
+++ b/.changeset/neat-turtles-arrive.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Refactored MODEL_GENERATION span input to use serializeForSpan() for centralized, cleaner span serialization. Tagged system messages now include their tag metadata (e.g. 'memory') in trace output, making it easier to distinguish working memory and semantic recall instructions from base agent instructions in observability tools.
+Improved MODEL_GENERATION span input serialization. System messages now include their tag metadata (e.g. 'memory') in trace output, making it easier to distinguish working memory and semantic recall instructions from base agent instructions in observability tools.

--- a/.changeset/neat-turtles-arrive.md
+++ b/.changeset/neat-turtles-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Refactored MODEL_GENERATION span input to use serializeForSpan() for centralized, cleaner span serialization. Tagged system messages now include their tag metadata (e.g. 'memory') in trace output, making it easier to distinguish working memory and semantic recall instructions from base agent instructions in observability tools.

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -157,7 +157,7 @@ export class MastraLLMVNext extends MastraBase {
       name: `llm: '${firstModel.modelId}'`,
       type: SpanType.MODEL_GENERATION,
       input: {
-        messages: [...messageList.getAllSystemMessages(), ...messages],
+        messages: [...messageList.serializeForSpan().systemMessages, ...messages],
       },
       attributes: {
         model: firstModel.modelId,


### PR DESCRIPTION
## Description

Follow-up to #14800 per Eric's suggestion. Replaces `getAllSystemMessages()` with `serializeForSpan().systemMessages` for the MODEL_GENERATION span input construction. This uses the purpose-built span serialization method, which includes tag metadata on tagged system messages (e.g. `tag: "memory"` for working memory and semantic recall instructions).

  ## Related Issue(s)

  Follow-up to #14800

  ## Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [x] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated model-generation span input serialization through centralized handling to improve consistency and reliability of generation tracing.
  * Enhanced trace output to include metadata tags for system messages, making monitoring and logs clearer by distinguishing different instruction categories for easier debugging and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->