### PR TITLE
feat(mastracode): allow custom response on questions with options

### DIFF
--- a/.changeset/petite-ears-wish.md
+++ b/.changeset/petite-ears-wish.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added a "Custom response..." option to questions with predefined choices. When selected, it switches to a free-text input so you can type an answer not covered by the given options.

--- a/mastracode/src/tui/components/ask-question-dialog.ts
+++ b/mastracode/src/tui/components/ask-question-dialog.ts
@@ -5,7 +5,7 @@
  */
 
 import { Box, getEditorKeybindings, Input, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
-import type { Focusable, SelectItem } from '@mariozechner/pi-tui';
+import type { Focusable, SelectItem, Component } from '@mariozechner/pi-tui';
 import { theme, getSelectListTheme } from '../theme.js';
 
 export interface AskQuestionDialogOptions {
@@ -24,7 +24,7 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
   private onCancel: () => void;
 
   /** Children added by buildSelectMode/buildInputMode, tracked for removal on mode switch */
-  private modeChildren: import('@mariozechner/pi-tui').Component[] = [];
+  private modeChildren: Component[] = [];
 
   private _focused = false;
   get focused(): boolean {

--- a/mastracode/src/tui/components/ask-question-dialog.ts
+++ b/mastracode/src/tui/components/ask-question-dialog.ts
@@ -16,10 +16,15 @@ export interface AskQuestionDialogOptions {
 }
 
 export class AskQuestionDialogComponent extends Box implements Focusable {
+  private static readonly CUSTOM_RESPONSE_VALUE = '__custom_response__';
+
   private selectList?: SelectList;
   private input?: Input;
   private onSubmit: (answer: string) => void;
   private onCancel: () => void;
+
+  /** Children added by buildSelectMode/buildInputMode, tracked for removal on mode switch */
+  private modeChildren: import('@mariozechner/pi-tui').Component[] = [];
 
   private _focused = false;
   get focused(): boolean {
@@ -59,16 +64,33 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
       label: opt.description ? `  ${opt.label}  ${theme.fg('dim', opt.description)}` : `  ${opt.label}`,
     }));
 
+    // Append a "Custom response..." option so the user can type a free-text answer
+    items.push({
+      value: AskQuestionDialogComponent.CUSTOM_RESPONSE_VALUE,
+      label: `  ${theme.fg('dim', '✎ Custom response...')}`,
+    });
+
     this.selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
 
     this.selectList.onSelect = (item: SelectItem) => {
+      if (item.value === AskQuestionDialogComponent.CUSTOM_RESPONSE_VALUE) {
+        this.switchToCustomInput();
+        return;
+      }
       this.onSubmit(item.value);
     };
     this.selectList.onCancel = this.onCancel;
 
-    this.addChild(this.selectList);
-    this.addChild(new Spacer(1));
-    this.addChild(new Text(theme.fg('dim', '  ↑↓ to navigate · Enter to select · Esc to skip'), 0, 0));
+    this.modeChildren = [];
+    const selectChild = this.selectList;
+    this.addChild(selectChild);
+    this.modeChildren.push(selectChild);
+    const spacer = new Spacer(1);
+    this.addChild(spacer);
+    this.modeChildren.push(spacer);
+    const hint = new Text(theme.fg('dim', '  ↑↓ to navigate · Enter to select · Esc to skip'), 0, 0);
+    this.addChild(hint);
+    this.modeChildren.push(hint);
   }
 
   private buildInputMode(): void {
@@ -80,9 +102,26 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
       }
     };
 
-    this.addChild(this.input);
-    this.addChild(new Spacer(1));
-    this.addChild(new Text(theme.fg('dim', '  Enter to submit · Esc to skip'), 0, 0));
+    this.modeChildren = [];
+    const inputChild = this.input;
+    this.addChild(inputChild);
+    this.modeChildren.push(inputChild);
+    const spacer = new Spacer(1);
+    this.addChild(spacer);
+    this.modeChildren.push(spacer);
+    const hint = new Text(theme.fg('dim', '  Enter to submit · Esc to skip'), 0, 0);
+    this.addChild(hint);
+    this.modeChildren.push(hint);
+  }
+
+  private switchToCustomInput(): void {
+    // Remove select mode children
+    for (const child of this.modeChildren) {
+      this.removeChild(child);
+    }
+    this.selectList = undefined;
+    this.buildInputMode();
+    if (this.input) this.input.focused = this._focused;
   }
 
   handleInput(data: string): void {

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -378,20 +378,42 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     this.borderedBox.setInteractive(this.selectList, this.input, hintText);
   }
 
+  private static readonly CUSTOM_RESPONSE_VALUE = '__custom_response__';
+
   private buildSelectMode(opts: Array<{ label: string; description?: string }>): void {
     const items: SelectItem[] = opts.map(opt => ({
       value: opt.label,
       label: opt.description ? `  ${opt.label}  ${theme.fg('dim', opt.description)}` : `  ${opt.label}`,
     }));
 
+    // Append a "Custom response..." option so the user can type a free-text answer
+    items.push({
+      value: AskQuestionInlineComponent.CUSTOM_RESPONSE_VALUE,
+      label: `  ${theme.fg('dim', '✎ Custom response...')}`,
+    });
+
     this.selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
 
     this.selectList.onSelect = (item: SelectItem) => {
+      if (item.value === AskQuestionInlineComponent.CUSTOM_RESPONSE_VALUE) {
+        this.switchToCustomInput();
+        return;
+      }
       this.handleAnswer(item.value);
     };
     this.selectList.onCancel = () => {
       this.handleCancel();
     };
+  }
+
+  private switchToCustomInput(): void {
+    // Tear down the select list and switch to free-text input
+    this.selectList = undefined;
+    this.buildInputMode();
+
+    // Clear items so the answered state renders as free-text, not select
+    this.borderedBox.items = [];
+    this.borderedBox.setInteractive(undefined, this.input, 'Enter to submit · Esc to skip');
   }
 
   private buildInputMode(): void {


### PR DESCRIPTION
When a question has predefined options (e.g. from `ask_user`), there's now a "✎ Custom response..." entry appended to the select list. Selecting it switches to a free-text input so you can type something not covered by the given choices.

Works in both inline and dialog question components.

```
> Which approach?
  ○ Option A
  ○ Option B
  ○ ✎ Custom response...   ← new
```

Selecting it transitions to a text input where you can type freely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom free-text responses on questions with predefined choices—selecting "Custom response..." switches the UI from choice selection to a free-text input so users can enter answers not covered by options.

* **Documentation**
  * Added a changeset entry documenting this feature for the upcoming minor release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->