### PR TITLE
fix: default agent version resolution to published instead of draft

### DIFF
--- a/.changeset/chubby-cameras-poke.md
+++ b/.changeset/chubby-cameras-poke.md
@@ -1,0 +1,6 @@
+---
+'@mastra/client-js': patch
+'@mastra/react': patch
+---
+
+Added requestContext support to tool approval and decline methods, ensuring agent version context is preserved when resuming after tool approval.

--- a/.changeset/empty-rabbits-count.md
+++ b/.changeset/empty-rabbits-count.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added resolvedVersionId to agent run trace span attributes for tracking which agent version was used during execution.

--- a/.changeset/famous-candies-cheat.md
+++ b/.changeset/famous-candies-cheat.md
@@ -1,0 +1,6 @@
+---
+'@mastra/editor': patch
+'@mastra/server': patch
+---
+
+Changed default agent version resolution from draft to published. Execution endpoints now use the latest published agent version by default instead of the draft version.

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -1540,7 +1540,10 @@ export class Agent extends BaseResource {
     return streamResponse;
   }
 
-  async approveNetworkToolCall(params: { runId: string }): Promise<
+  async approveNetworkToolCall(params: {
+    runId: string;
+    requestContext?: RequestContext | Record<string, any>;
+  }): Promise<
     Response & {
       processDataStream: ({
         onChunk,
@@ -1549,9 +1552,10 @@ export class Agent extends BaseResource {
       }) => Promise<void>;
     }
   > {
+    const { requestContext, ...rest } = params;
     const response: Response = await this.request(`/agents/${this.agentId}/approve-network-tool-call`, {
       method: 'POST',
-      body: params,
+      body: { ...rest, requestContext: parseClientRequestContext(requestContext) },
       stream: true,
     });
 
@@ -1585,7 +1589,10 @@ export class Agent extends BaseResource {
     return streamResponse;
   }
 
-  async declineNetworkToolCall(params: { runId: string }): Promise<
+  async declineNetworkToolCall(params: {
+    runId: string;
+    requestContext?: RequestContext | Record<string, any>;
+  }): Promise<
     Response & {
       processDataStream: ({
         onChunk,
@@ -1594,9 +1601,10 @@ export class Agent extends BaseResource {
       }) => Promise<void>;
     }
   > {
+    const { requestContext, ...rest } = params;
     const response: Response = await this.request(`/agents/${this.agentId}/decline-network-tool-call`, {
       method: 'POST',
-      body: params,
+      body: { ...rest, requestContext: parseClientRequestContext(requestContext) },
       stream: true,
     });
 
@@ -1744,7 +1752,11 @@ export class Agent extends BaseResource {
     return streamResponse;
   }
 
-  async approveToolCall(params: { runId: string; toolCallId: string }): Promise<
+  async approveToolCall(params: {
+    runId: string;
+    toolCallId: string;
+    requestContext?: RequestContext | Record<string, any>;
+  }): Promise<
     Response & {
       processDataStream: ({
         onChunk,
@@ -1753,6 +1765,9 @@ export class Agent extends BaseResource {
       }) => Promise<void>;
     }
   > {
+    const { requestContext, ...rest } = params;
+    const processedParams = { ...rest, requestContext: parseClientRequestContext(requestContext) };
+
     // Create a manually controlled readable stream
     let readableController: ReadableStreamDefaultController<Uint8Array>;
     const readable = new ReadableStream<Uint8Array>({
@@ -1762,7 +1777,7 @@ export class Agent extends BaseResource {
     });
 
     // Start processing the response in the background
-    const response = await this.processStreamResponse(params, readableController!, 'approve-tool-call');
+    const response = await this.processStreamResponse(processedParams, readableController!, 'approve-tool-call');
 
     // Create a new response with the readable stream
     const streamResponse = new Response(readable, {
@@ -1792,7 +1807,11 @@ export class Agent extends BaseResource {
     return streamResponse;
   }
 
-  async declineToolCall(params: { runId: string; toolCallId: string }): Promise<
+  async declineToolCall(params: {
+    runId: string;
+    toolCallId: string;
+    requestContext?: RequestContext | Record<string, any>;
+  }): Promise<
     Response & {
       processDataStream: ({
         onChunk,
@@ -1801,6 +1820,9 @@ export class Agent extends BaseResource {
       }) => Promise<void>;
     }
   > {
+    const { requestContext, ...rest } = params;
+    const processedParams = { ...rest, requestContext: parseClientRequestContext(requestContext) };
+
     // Create a manually controlled readable stream
     let readableController: ReadableStreamDefaultController<Uint8Array>;
     const readable = new ReadableStream<Uint8Array>({
@@ -1810,7 +1832,7 @@ export class Agent extends BaseResource {
     });
 
     // Start processing the response in the background
-    const response = await this.processStreamResponse(params, readableController!, 'decline-tool-call');
+    const response = await this.processStreamResponse(processedParams, readableController!, 'decline-tool-call');
 
     // Create a new response with the readable stream
     const streamResponse = new Response(readable, {
@@ -1844,10 +1866,15 @@ export class Agent extends BaseResource {
    * Approves a pending tool call and returns the complete response (non-streaming).
    * Used when `requireToolApproval` is enabled with generate() to allow the agent to proceed.
    */
-  async approveToolCallGenerate(params: { runId: string; toolCallId: string }): Promise<any> {
+  async approveToolCallGenerate(params: {
+    runId: string;
+    toolCallId: string;
+    requestContext?: RequestContext | Record<string, any>;
+  }): Promise<any> {
+    const { requestContext, ...rest } = params;
     return this.request(`/agents/${this.agentId}/approve-tool-call-generate`, {
       method: 'POST',
-      body: params,
+      body: { ...rest, requestContext: parseClientRequestContext(requestContext) },
     });
   }
 
@@ -1855,10 +1882,15 @@ export class Agent extends BaseResource {
    * Declines a pending tool call and returns the complete response (non-streaming).
    * Used when `requireToolApproval` is enabled with generate() to prevent tool execution.
    */
-  async declineToolCallGenerate(params: { runId: string; toolCallId: string }): Promise<any> {
+  async declineToolCallGenerate(params: {
+    runId: string;
+    toolCallId: string;
+    requestContext?: RequestContext | Record<string, any>;
+  }): Promise<any> {
+    const { requestContext, ...rest } = params;
     return this.request(`/agents/${this.agentId}/decline-tool-call-generate`, {
       method: 'POST',
-      body: params,
+      body: { ...rest, requestContext: parseClientRequestContext(requestContext) },
     });
   }
 

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -65,6 +65,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
   const _onChunk = useRef<((chunk: ChunkType) => Promise<void>) | undefined>(undefined);
   const _networkRunId = useRef<string | undefined>(undefined);
   const _onNetworkChunk = useRef<((chunk: NetworkChunkType) => Promise<void>) | undefined>(undefined);
+  const _requestContext = useRef<RequestContext | undefined>(undefined);
   const [messages, setMessages] = useState<MastraUIMessage[]>([]);
   const [toolCallApprovals, setToolCallApprovals] = useState<{
     [toolCallId: string]: { status: 'approved' | 'declined' };
@@ -104,6 +105,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
       maxSteps,
       requireToolApproval,
     } = modelSettings || {};
+    _requestContext.current = requestContext;
     setIsRunning(true);
 
     // Create a new client instance with the abort signal
@@ -205,6 +207,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
       requireToolApproval,
     } = modelSettings || {};
 
+    _requestContext.current = requestContext;
     setIsRunning(true);
 
     // Create a new client instance with the abort signal
@@ -266,6 +269,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
     const { frequencyPenalty, presencePenalty, maxRetries, maxTokens, temperature, topK, topP, maxSteps } =
       modelSettings || {};
 
+    _requestContext.current = requestContext;
     setIsRunning(true);
 
     // Create a new client instance with the abort signal
@@ -317,6 +321,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
     _onChunk.current = undefined;
     _networkRunId.current = undefined;
     _onNetworkChunk.current = undefined;
+    _requestContext.current = undefined;
   };
 
   const approveToolCall = async (toolCallId: string) => {
@@ -330,7 +335,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
     setToolCallApprovals(prev => ({ ...prev, [toolCallId]: { status: 'approved' } }));
 
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.approveToolCall({ runId: currentRunId, toolCallId });
+    const response = await agent.approveToolCall({ runId: currentRunId, toolCallId, requestContext: _requestContext.current });
 
     await response.processDataStream({
       onChunk: async (chunk: ChunkType) => {
@@ -354,7 +359,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
     setIsRunning(true);
     setToolCallApprovals(prev => ({ ...prev, [toolCallId]: { status: 'declined' } }));
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.declineToolCall({ runId: currentRunId, toolCallId });
+    const response = await agent.declineToolCall({ runId: currentRunId, toolCallId, requestContext: _requestContext.current });
 
     await response.processDataStream({
       onChunk: async (chunk: ChunkType) => {
@@ -380,7 +385,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
     setToolCallApprovals(prev => ({ ...prev, [toolCallId]: { status: 'approved' } }));
 
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.approveToolCallGenerate({ runId: currentRunId, toolCallId });
+    const response = await agent.approveToolCallGenerate({ runId: currentRunId, toolCallId, requestContext: _requestContext.current });
 
     if (response && 'uiMessages' in response.response && response.response.uiMessages) {
       const mastraUIMessages: MastraUIMessage[] = (response.response.uiMessages || []).map((message: any) => ({
@@ -408,7 +413,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
     setToolCallApprovals(prev => ({ ...prev, [toolCallId]: { status: 'declined' } }));
 
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.declineToolCallGenerate({ runId: currentRunId, toolCallId });
+    const response = await agent.declineToolCallGenerate({ runId: currentRunId, toolCallId, requestContext: _requestContext.current });
 
     if (response && 'uiMessages' in response.response && response.response.uiMessages) {
       const mastraUIMessages: MastraUIMessage[] = (response.response.uiMessages || []).map((message: any) => ({
@@ -440,7 +445,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
     }));
 
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.approveNetworkToolCall({ runId: networkRunId });
+    const response = await agent.approveNetworkToolCall({ runId: networkRunId, requestContext: _requestContext.current });
 
     const transformer = new AISdkNetworkTransformer();
 
@@ -470,7 +475,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
     }));
 
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.declineNetworkToolCall({ runId: networkRunId });
+    const response = await agent.declineNetworkToolCall({ runId: networkRunId, requestContext: _requestContext.current });
 
     const transformer = new AISdkNetworkTransformer();
 

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -18,6 +18,8 @@ export interface MastraChatProps {
   agentId: string;
   resourceId?: string;
   initialMessages?: MastraUIMessage[];
+  /** Persistent request context used for tool approval/decline calls (e.g. agentVersionId). */
+  requestContext?: RequestContext;
 }
 
 interface SharedArgs {
@@ -60,12 +62,12 @@ const extractRunIdFromMessages = (messages: ExtendedMastraUIMessage[]): string |
   return undefined;
 };
 
-export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProps) => {
+export const useChat = ({ agentId, resourceId, initialMessages, requestContext: propsRequestContext }: MastraChatProps) => {
   const _currentRunId = useRef<string | undefined>(undefined);
   const _onChunk = useRef<((chunk: ChunkType) => Promise<void>) | undefined>(undefined);
   const _networkRunId = useRef<string | undefined>(undefined);
   const _onNetworkChunk = useRef<((chunk: NetworkChunkType) => Promise<void>) | undefined>(undefined);
-  const _requestContext = useRef<RequestContext | undefined>(undefined);
+  const _requestContext = useRef<RequestContext | undefined>(propsRequestContext);
   const [messages, setMessages] = useState<MastraUIMessage[]>([]);
   const [toolCallApprovals, setToolCallApprovals] = useState<{
     [toolCallId: string]: { status: 'approved' | 'declined' };
@@ -81,7 +83,10 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
     const formattedMessages = resolveInitialMessages(initialMessages || []);
     setMessages(formattedMessages);
     _currentRunId.current = extractRunIdFromMessages(formattedMessages);
-  }, [initialMessages]);
+    if (propsRequestContext) {
+      _requestContext.current = propsRequestContext;
+    }
+  }, [initialMessages, propsRequestContext]);
 
   const generate = async ({
     coreUserMessages,

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -88,8 +88,11 @@ export const useChat = ({
     const formattedMessages = resolveInitialMessages(initialMessages || []);
     setMessages(formattedMessages);
     _currentRunId.current = extractRunIdFromMessages(formattedMessages);
+  }, [initialMessages]);
+
+  useEffect(() => {
     _requestContext.current = propsRequestContext;
-  }, [initialMessages, propsRequestContext]);
+  }, [propsRequestContext]);
 
   const generate = async ({
     coreUserMessages,

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -62,7 +62,12 @@ const extractRunIdFromMessages = (messages: ExtendedMastraUIMessage[]): string |
   return undefined;
 };
 
-export const useChat = ({ agentId, resourceId, initialMessages, requestContext: propsRequestContext }: MastraChatProps) => {
+export const useChat = ({
+  agentId,
+  resourceId,
+  initialMessages,
+  requestContext: propsRequestContext,
+}: MastraChatProps) => {
   const _currentRunId = useRef<string | undefined>(undefined);
   const _onChunk = useRef<((chunk: ChunkType) => Promise<void>) | undefined>(undefined);
   const _networkRunId = useRef<string | undefined>(undefined);
@@ -340,7 +345,11 @@ export const useChat = ({ agentId, resourceId, initialMessages, requestContext: 
     setToolCallApprovals(prev => ({ ...prev, [toolCallId]: { status: 'approved' } }));
 
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.approveToolCall({ runId: currentRunId, toolCallId, requestContext: _requestContext.current });
+    const response = await agent.approveToolCall({
+      runId: currentRunId,
+      toolCallId,
+      requestContext: _requestContext.current,
+    });
 
     await response.processDataStream({
       onChunk: async (chunk: ChunkType) => {
@@ -364,7 +373,11 @@ export const useChat = ({ agentId, resourceId, initialMessages, requestContext: 
     setIsRunning(true);
     setToolCallApprovals(prev => ({ ...prev, [toolCallId]: { status: 'declined' } }));
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.declineToolCall({ runId: currentRunId, toolCallId, requestContext: _requestContext.current });
+    const response = await agent.declineToolCall({
+      runId: currentRunId,
+      toolCallId,
+      requestContext: _requestContext.current,
+    });
 
     await response.processDataStream({
       onChunk: async (chunk: ChunkType) => {
@@ -390,7 +403,11 @@ export const useChat = ({ agentId, resourceId, initialMessages, requestContext: 
     setToolCallApprovals(prev => ({ ...prev, [toolCallId]: { status: 'approved' } }));
 
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.approveToolCallGenerate({ runId: currentRunId, toolCallId, requestContext: _requestContext.current });
+    const response = await agent.approveToolCallGenerate({
+      runId: currentRunId,
+      toolCallId,
+      requestContext: _requestContext.current,
+    });
 
     if (response && 'uiMessages' in response.response && response.response.uiMessages) {
       const mastraUIMessages: MastraUIMessage[] = (response.response.uiMessages || []).map((message: any) => ({
@@ -418,7 +435,11 @@ export const useChat = ({ agentId, resourceId, initialMessages, requestContext: 
     setToolCallApprovals(prev => ({ ...prev, [toolCallId]: { status: 'declined' } }));
 
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.declineToolCallGenerate({ runId: currentRunId, toolCallId, requestContext: _requestContext.current });
+    const response = await agent.declineToolCallGenerate({
+      runId: currentRunId,
+      toolCallId,
+      requestContext: _requestContext.current,
+    });
 
     if (response && 'uiMessages' in response.response && response.response.uiMessages) {
       const mastraUIMessages: MastraUIMessage[] = (response.response.uiMessages || []).map((message: any) => ({
@@ -450,7 +471,10 @@ export const useChat = ({ agentId, resourceId, initialMessages, requestContext: 
     }));
 
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.approveNetworkToolCall({ runId: networkRunId, requestContext: _requestContext.current });
+    const response = await agent.approveNetworkToolCall({
+      runId: networkRunId,
+      requestContext: _requestContext.current,
+    });
 
     const transformer = new AISdkNetworkTransformer();
 
@@ -480,7 +504,10 @@ export const useChat = ({ agentId, resourceId, initialMessages, requestContext: 
     }));
 
     const agent = baseClient.getAgent(agentId);
-    const response = await agent.declineNetworkToolCall({ runId: networkRunId, requestContext: _requestContext.current });
+    const response = await agent.declineNetworkToolCall({
+      runId: networkRunId,
+      requestContext: _requestContext.current,
+    });
 
     const transformer = new AISdkNetworkTransformer();
 

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -88,9 +88,7 @@ export const useChat = ({
     const formattedMessages = resolveInitialMessages(initialMessages || []);
     setMessages(formattedMessages);
     _currentRunId.current = extractRunIdFromMessages(formattedMessages);
-    if (propsRequestContext) {
-      _requestContext.current = propsRequestContext;
-    }
+    _requestContext.current = propsRequestContext;
   }, [initialMessages, propsRequestContext]);
 
   const generate = async ({
@@ -115,7 +113,8 @@ export const useChat = ({
       maxSteps,
       requireToolApproval,
     } = modelSettings || {};
-    _requestContext.current = requestContext;
+    const resolvedRequestContext = requestContext ?? propsRequestContext;
+    _requestContext.current = resolvedRequestContext;
     setIsRunning(true);
 
     // Create a new client instance with the abort signal
@@ -143,7 +142,7 @@ export const useChat = ({
         topP,
       },
       instructions,
-      requestContext,
+      requestContext: resolvedRequestContext,
       ...(threadId ? { memory: { thread: threadId, resource: resourceId || agentId } } : {}),
       providerOptions: providerOptions as any,
       tracingOptions,
@@ -217,7 +216,8 @@ export const useChat = ({
       requireToolApproval,
     } = modelSettings || {};
 
-    _requestContext.current = requestContext;
+    const resolvedRequestContext = requestContext ?? propsRequestContext;
+    _requestContext.current = resolvedRequestContext;
     setIsRunning(true);
 
     // Create a new client instance with the abort signal
@@ -244,7 +244,7 @@ export const useChat = ({
         topP,
       },
       instructions,
-      requestContext,
+      requestContext: resolvedRequestContext,
       ...(threadId ? { memory: { thread: threadId, resource: resourceId || agentId } } : {}),
       providerOptions: providerOptions as any,
       requireToolApproval,
@@ -279,7 +279,8 @@ export const useChat = ({
     const { frequencyPenalty, presencePenalty, maxRetries, maxTokens, temperature, topK, topP, maxSteps } =
       modelSettings || {};
 
-    _requestContext.current = requestContext;
+    const resolvedRequestContext = requestContext ?? propsRequestContext;
+    _requestContext.current = resolvedRequestContext;
     setIsRunning(true);
 
     // Create a new client instance with the abort signal
@@ -305,7 +306,7 @@ export const useChat = ({
         topP,
       },
       runId,
-      requestContext,
+      requestContext: resolvedRequestContext,
       ...(threadId ? { memory: { thread: threadId, resource: resourceId || agentId } } : {}),
       tracingOptions,
     });

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -166,6 +166,8 @@ export interface AgentLegacyCapabilities {
   convertInstructionsToString(instructions: AgentInstructions): string;
   /** Options for tracing policy */
   tracingPolicy?: any;
+  /** Resolved version ID from stored config */
+  resolvedVersionId?: string;
   /** Agent network append flag */
   _agentNetworkAppend?: boolean;
   /** List resolved output processors */
@@ -264,6 +266,7 @@ export class AgentLegacyHandler {
               ...(toolsets ? Object.keys(toolsets) : []),
               ...(clientTools ? Object.keys(clientTools) : []),
             ],
+            ...(this.capabilities.resolvedVersionId ? { resolvedVersionId: this.capabilities.resolvedVersionId } : {}),
           },
           metadata: {
             runId,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1160,6 +1160,7 @@ export class Agent<
         saveStepMessages: this.saveStepMessages.bind(this),
         convertInstructionsToString: this.#convertInstructionsToString.bind(this),
         tracingPolicy: this.#options?.tracingPolicy,
+        resolvedVersionId: this.toRawConfig()?.resolvedVersionId as string | undefined,
         _agentNetworkAppend: this._agentNetworkAppend,
         listResolvedOutputProcessors: this.listResolvedOutputProcessors.bind(this),
         __runOutputProcessors: this.__runOutputProcessors.bind(this),
@@ -4202,6 +4203,9 @@ export class Agent<
       attributes: {
         conversationId: threadFromArgs?.id,
         instructions: this.#convertInstructionsToString(instructions),
+        ...(this.toRawConfig()?.resolvedVersionId
+          ? { resolvedVersionId: this.toRawConfig()!.resolvedVersionId as string }
+          : {}),
       },
       metadata: {
         runId,

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -83,6 +83,8 @@ export interface AgentRunAttributes extends AIBaseAttributes {
   availableTools?: string[];
   /** Maximum steps allowed */
   maxSteps?: number;
+  /** The resolved agent version ID used for this execution */
+  resolvedVersionId?: string;
   /** Tripwire abort details when a processor triggered a tripwire */
   tripwireAbort?: {
     /** Abort reason */

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -183,6 +183,13 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
    * they may contain SDK instances or dynamic functions that cannot be safely serialized.
    * Returns the (possibly mutated) agent.
    */
+  private clearResolvedVersionId(agent: Agent): void {
+    const raw = agent.toRawConfig();
+    if (!raw || !('resolvedVersionId' in raw)) return;
+    const { resolvedVersionId: _removed, ...rest } = raw;
+    agent.__setRawConfig(rest);
+  }
+
   async applyStoredOverrides(
     agent: Agent,
     options?: { status?: 'draft' | 'published' } | { versionId: string },
@@ -199,12 +206,14 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
     } catch {
       // Editor not registered, storage not available, or agent not found — restore and return unchanged
       this.restoreCodeDefaults(agent);
+      this.clearResolvedVersionId(agent);
       return agent;
     }
 
     if (!storedConfig) {
       // No stored config — restore code defaults if previously overridden
       this.restoreCodeDefaults(agent);
+      this.clearResolvedVersionId(agent);
       return agent;
     }
 
@@ -293,6 +302,8 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
     if (storedConfig.resolvedVersionId) {
       const existing = agent.toRawConfig() ?? {};
       agent.__setRawConfig({ ...existing, resolvedVersionId: storedConfig.resolvedVersionId });
+    } else {
+      this.clearResolvedVersionId(agent);
     }
 
     return agent;

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -194,7 +194,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
       const resolvedOptions: { versionId: string } | { status: 'draft' | 'published' | 'archived' } =
         options && 'versionId' in options
           ? { versionId: options.versionId }
-          : { status: (options as { status?: 'draft' | 'published' } | undefined)?.status ?? 'published' };
+          : { status: (options as { status?: 'draft' | 'published' } | undefined)?.status ?? 'draft' };
       storedConfig = await adapter.getByIdResolved(agent.id, resolvedOptions);
     } catch {
       // Editor not registered, storage not available, or agent not found — restore and return unchanged

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -191,7 +191,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
       const resolvedOptions: { versionId: string } | { status: 'draft' | 'published' | 'archived' } =
         options && 'versionId' in options
           ? { versionId: options.versionId }
-          : { status: (options as { status?: 'draft' | 'published' } | undefined)?.status ?? 'draft' };
+          : { status: (options as { status?: 'draft' | 'published' } | undefined)?.status ?? 'published' };
       storedConfig = await adapter.getByIdResolved(agent.id, resolvedOptions);
     } catch {
       // Editor not registered, storage not available, or agent not found — restore and return unchanged
@@ -284,6 +284,12 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
         );
         agent.__setTools({ ...codeTools, ...registryTools, ...mcpTools, ...integrationTools });
       }
+    }
+
+    // Persist the resolved version ID so it can be read by span attributes / handlers
+    if (storedConfig.resolvedVersionId) {
+      const existing = agent.toRawConfig() ?? {};
+      agent.__setRawConfig({ ...existing, resolvedVersionId: storedConfig.resolvedVersionId });
     }
 
     return agent;

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -92,6 +92,9 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
             : await store.getVersionByNumber(id, options.versionNumber!);
 
           if (!version) return null;
+          if (version.agentId !== id) {
+            throw new Error(`Version "${version.id}" does not belong to agent "${id}"`);
+          }
 
           const {
             id: versionId,

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -203,7 +203,11 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
           ? { versionId: options.versionId }
           : { status: (options as { status?: 'draft' | 'published' } | undefined)?.status ?? 'draft' };
       storedConfig = await adapter.getByIdResolved(agent.id, resolvedOptions);
-    } catch {
+    } catch (error) {
+      // If a specific versionId was requested, don't fail open — propagate the error
+      if (options && 'versionId' in options) {
+        throw error;
+      }
       // Editor not registered, storage not available, or agent not found — restore and return unchanged
       this.restoreCodeDefaults(agent);
       this.clearResolvedVersionId(agent);

--- a/packages/playground-ui/src/domains/agents/components/agent-chat.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-chat.tsx
@@ -16,6 +16,7 @@ export const AgentChat = ({
   memory,
   refreshThreadList,
   modelVersion,
+  agentVersionId,
   modelList,
   messageId,
   isNewThread,
@@ -65,6 +66,7 @@ export const AgentChat = ({
       agentId={agentId}
       agentName={agentName}
       modelVersion={modelVersion}
+      agentVersionId={agentVersionId}
       threadId={threadId}
       initialMessages={v5Messages}
       initialLegacyMessages={v4Messages}

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
@@ -14,7 +14,13 @@ interface AgentPlaygroundTestChatProps {
   hasMemory: boolean;
 }
 
-export function AgentPlaygroundTestChat({ agentId, agentName, modelVersion, agentVersionId, hasMemory }: AgentPlaygroundTestChatProps) {
+export function AgentPlaygroundTestChat({
+  agentId,
+  agentName,
+  modelVersion,
+  agentVersionId,
+  hasMemory,
+}: AgentPlaygroundTestChatProps) {
   // Generate a stable ephemeral thread ID for test chat sessions
   const testThreadId = useMemo(() => uuid(), [agentId]);
   const mergedRequestContext = useMergedRequestContext();

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
@@ -10,10 +10,11 @@ interface AgentPlaygroundTestChatProps {
   agentId: string;
   agentName?: string;
   modelVersion?: string;
+  agentVersionId?: string;
   hasMemory: boolean;
 }
 
-export function AgentPlaygroundTestChat({ agentId, agentName, modelVersion, hasMemory }: AgentPlaygroundTestChatProps) {
+export function AgentPlaygroundTestChat({ agentId, agentName, modelVersion, agentVersionId, hasMemory }: AgentPlaygroundTestChatProps) {
   // Generate a stable ephemeral thread ID for test chat sessions
   const testThreadId = useMemo(() => uuid(), [agentId]);
   const mergedRequestContext = useMergedRequestContext();
@@ -34,6 +35,7 @@ export function AgentPlaygroundTestChat({ agentId, agentName, modelVersion, hasM
               agentId={agentId}
               agentName={agentName}
               modelVersion={modelVersion}
+              agentVersionId={agentVersionId}
               threadId={testThreadId}
               memory={hasMemory}
               refreshThreadList={async () => {}}

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-view.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-view.tsx
@@ -10,6 +10,7 @@ interface AgentPlaygroundViewProps {
   agentId: string;
   agentName?: string;
   modelVersion?: string;
+  agentVersionId?: string;
   hasMemory: boolean;
   activeVersionId?: string;
   selectedVersionId?: string;
@@ -92,6 +93,7 @@ export function AgentPlaygroundView({
   agentId,
   agentName,
   modelVersion,
+  agentVersionId,
   hasMemory,
   activeVersionId,
   selectedVersionId,
@@ -141,6 +143,7 @@ export function AgentPlaygroundView({
                 agentId={agentId}
                 agentName={agentName}
                 modelVersion={modelVersion}
+                agentVersionId={agentVersionId}
                 hasMemory={hasMemory}
               />
             </div>

--- a/packages/playground-ui/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground-ui/src/services/mastra-runtime-provider.tsx
@@ -377,6 +377,7 @@ export function MastraRuntimeProvider({
   settings,
   requestContext,
   modelVersion,
+  agentVersionId,
 }: Readonly<{
   children: ReactNode;
 }> &
@@ -688,6 +689,9 @@ export function MastraRuntimeProvider({
     Object.entries(requestContext ?? {}).forEach(([key, value]) => {
       requestContextInstance.set(key, value);
     });
+    if (agentVersionId) {
+      requestContextInstance.set('agentVersionId', agentVersionId);
+    }
 
     try {
       if (isSupportedModel) {

--- a/packages/playground-ui/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground-ui/src/services/mastra-runtime-provider.tsx
@@ -390,6 +390,13 @@ export function MastraRuntimeProvider({
     setLegacyMessages(initializeMessageState(initialLegacyMessages || []));
   }, [initialLegacyMessages]);
 
+  const chatRequestContext = useMemo(() => {
+    if (!agentVersionId) return undefined;
+    const ctx = new RequestContext();
+    ctx.set('agentVersionId', agentVersionId);
+    return ctx;
+  }, [agentVersionId]);
+
   const {
     messages,
     sendMessage,
@@ -407,6 +414,7 @@ export function MastraRuntimeProvider({
   } = useChat({
     agentId,
     initialMessages,
+    requestContext: chatRequestContext,
   });
 
   const { refetch: refreshWorkingMemory } = useWorkingMemory();

--- a/packages/playground-ui/src/types.ts
+++ b/packages/playground-ui/src/types.ts
@@ -56,6 +56,7 @@ export interface ChatProps {
   agentId: string;
   agentName?: string;
   modelVersion?: string;
+  agentVersionId?: string;
   threadId: string;
   initialMessages?: MastraUIMessage[];
   initialLegacyMessages?: UIMessageWithMetadata[];

--- a/packages/playground/src/pages/agents/agent-playground/index.tsx
+++ b/packages/playground/src/pages/agents/agent-playground/index.tsx
@@ -112,6 +112,7 @@ function AgentPlayground() {
         agentId={agentId!}
         agentName={codeAgent?.name}
         modelVersion={codeAgent?.modelVersion}
+        agentVersionId={selectedVersionId ?? latestVersion?.id}
         hasMemory={hasMemory}
         activeVersionId={activeVersionId}
         selectedVersionId={selectedVersionId ?? undefined}

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -616,7 +616,7 @@ export async function getAgentFromSystem({
   if (!agent) {
     logger.debug(`Agent ${agentId} not found in code-defined agents, looking in stored agents`);
     try {
-      agent = (await mastra.getEditor()?.agent.getById(agentId)) ?? null;
+      agent = (await mastra.getEditor()?.agent.getById(agentId, versionOptions)) ?? null;
     } catch (error) {
       logger.debug('Error getting stored agent', error);
     }

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -605,7 +605,7 @@ export async function getAgentFromSystem({
     try {
       const editorAgent = mastra.getEditor()?.agent;
       if (editorAgent) {
-        agent = await editorAgent.applyStoredOverrides(agent, versionOptions);
+        agent = await editorAgent.applyStoredOverrides(agent, versionOptions ?? { status: 'published' });
       }
     } catch (error) {
       logger.debug('Error applying stored overrides to code agent', error);

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -550,6 +550,14 @@ async function formatAgentList({
   };
 }
 
+export function extractVersionOptions(requestContext?: RequestContext): { versionId: string } | undefined {
+  const agentVersionId = requestContext?.get('agentVersionId');
+  if (typeof agentVersionId === 'string' && agentVersionId) {
+    return { versionId: agentVersionId };
+  }
+  return undefined;
+}
+
 export async function getAgentFromSystem({
   mastra,
   agentId,
@@ -881,7 +889,7 @@ export const GET_AGENT_BY_ID_ROUTE = createRoute({
   responseSchema: serializedAgentSchema,
   summary: 'Get agent by ID',
   description:
-    'Returns details for a specific agent including configuration, tools, and memory settings. Use query params to control which stored config version is used for overrides: ?status=draft (latest, default), ?status=published (active version), or ?versionId=<id> (specific version). Use either status or versionId, not both.',
+    'Returns details for a specific agent including configuration, tools, and memory settings. Use query params to control which stored config version is used for overrides: ?status=published (active version, default), ?status=draft (latest draft), or ?versionId=<id> (specific version). Use either status or versionId, not both.',
   tags: ['Agents'],
   requiresAuth: true,
   requiresPermission: 'agents:read',
@@ -929,7 +937,11 @@ export const CLONE_AGENT_ROUTE = createRoute({
         return handleError(new Error('Editor is not configured on the Mastra instance'), 'Error cloning agent');
       }
 
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(requestContext),
+      });
 
       const cloneId = toSlug(newId || `${agentId}-clone`);
 
@@ -962,7 +974,11 @@ export const GENERATE_AGENT_ROUTE = createRoute({
   requiresPermission: 'agents:execute',
   handler: async ({ agentId, mastra, abortSignal, requestContext: serverRequestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(serverRequestContext),
+      });
 
       // UI Frameworks may send "client tools" in the body,
       // but it interferes with llm providers tool handling, so we remove them
@@ -1042,7 +1058,11 @@ export const GENERATE_LEGACY_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(requestContext),
+      });
 
       // UI Frameworks may send "client tools" in the body,
       // but it interferes with llm providers tool handling, so we remove them
@@ -1098,7 +1118,11 @@ export const STREAM_GENERATE_LEGACY_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(requestContext),
+      });
 
       // UI Frameworks may send "client tools" in the body,
       // but it interferes with llm providers tool handling, so we remove them
@@ -1235,7 +1259,11 @@ export const STREAM_GENERATE_ROUTE = createRoute({
   requiresPermission: 'agents:execute',
   handler: async ({ mastra, agentId, abortSignal, requestContext: serverRequestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(serverRequestContext),
+      });
 
       // UI Frameworks may send "client tools" in the body,
       // but it interferes with llm providers tool handling, so we remove them
@@ -1327,9 +1355,13 @@ export const APPROVE_TOOL_CALL_ROUTE = createRoute({
   description: 'Approves a pending tool call and continues agent execution',
   tags: ['Agents', 'Tools'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, abortSignal, ...params }) => {
+  handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(requestContext),
+      });
 
       if (!params.runId) {
         throw new HTTPException(400, { message: 'Run id is required' });
@@ -1367,9 +1399,13 @@ export const DECLINE_TOOL_CALL_ROUTE = createRoute({
   description: 'Declines a pending tool call and continues agent execution without executing the tool',
   tags: ['Agents', 'Tools'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, abortSignal, ...params }) => {
+  handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(requestContext),
+      });
 
       if (!params.runId) {
         throw new HTTPException(400, { message: 'Run id is required' });
@@ -1406,9 +1442,13 @@ export const APPROVE_TOOL_CALL_GENERATE_ROUTE = createRoute({
   description: 'Approves a pending tool call and returns the complete response',
   tags: ['Agents', 'Tools'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, abortSignal, ...params }) => {
+  handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(requestContext),
+      });
 
       if (!params.runId) {
         throw new HTTPException(400, { message: 'Run id is required' });
@@ -1445,9 +1485,13 @@ export const DECLINE_TOOL_CALL_GENERATE_ROUTE = createRoute({
   description: 'Declines a pending tool call and returns the complete response',
   tags: ['Agents', 'Tools'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, abortSignal, ...params }) => {
+  handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(requestContext),
+      });
 
       if (!params.runId) {
         throw new HTTPException(400, { message: 'Run id is required' });
@@ -1485,9 +1529,13 @@ export const STREAM_NETWORK_ROUTE = createRoute({
   description: 'Executes an agent network with multiple agents and streams the response',
   tags: ['Agents'],
   requiresAuth: true,
-  handler: async ({ mastra, messages, agentId, ...params }) => {
+  handler: async ({ mastra, messages, agentId, requestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(requestContext),
+      });
 
       // UI Frameworks may send "client tools" in the body,
       // but it interferes with llm providers tool handling, so we remove them
@@ -1518,9 +1566,13 @@ export const APPROVE_NETWORK_TOOL_CALL_ROUTE = createRoute({
   description: 'Approves a pending network tool call and continues network agent execution',
   tags: ['Agents', 'Tools'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, ...params }) => {
+  handler: async ({ mastra, agentId, requestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(requestContext),
+      });
 
       if (!params.runId) {
         throw new HTTPException(400, { message: 'Run id is required' });
@@ -1553,9 +1605,13 @@ export const DECLINE_NETWORK_TOOL_CALL_ROUTE = createRoute({
   description: 'Declines a pending network tool call and continues network agent execution without executing the tool',
   tags: ['Agents', 'Tools'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, ...params }) => {
+  handler: async ({ mastra, agentId, requestContext, ...params }) => {
     try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
+      const agent = await getAgentFromSystem({
+        mastra,
+        agentId,
+        versionOptions: extractVersionOptions(requestContext),
+      });
 
       if (!params.runId) {
         throw new HTTPException(400, { message: 'Run id is required' });


### PR DESCRIPTION
Agents were resolving to the draft version by default across all execution endpoints. Now they default to the latest published version, which is what users expect in the playground chat tab and versioned endpoints.

The editor tab still uses the draft/selected version — it passes `agentVersionId` via `requestContext` so the server knows which version to resolve.

Also wires `requestContext` through the client-js tool approval/decline methods (`approveToolCall`, `declineToolCall`, etc.) so the version context isn't lost when resuming after a tool approval pause.

Adds `resolvedVersionId` to agent run trace span attributes so you can see which version was actually used during execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool approval/decline flows now carry per-request context so agent version info is preserved when resuming.
  * Agent execution traces include a resolvedVersionId for clearer version traceability.
  * UI, chat, playground, and runtime accept an optional agentVersionId to target specific agent versions.

* **Documentation**
  * Agent retrieval docs updated: published versions are described as the default "active" selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->