### PR TITLE
fix(mcp): handle builder-level validation errors in CallTool handler

### DIFF
--- a/.changeset/real-moose-dream.md
+++ b/.changeset/real-moose-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed MCP server returning confusing output schema errors when tool input fails Zod validation but passes JSON Schema validation. The server now correctly returns `isError: true` with the validation error message.

--- a/.changeset/short-mice-pull.md
+++ b/.changeset/short-mice-pull.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added `isValidationError` type guard for the `ValidationError` interface

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -3,4 +3,4 @@ export * from './types';
 export * from './ui-types';
 export { isProviderDefinedTool, isProviderTool, isVercelTool } from './toolchecks';
 export { ToolStream } from './stream';
-export { type ValidationError } from './validation';
+export { type ValidationError, isValidationError } from './validation';

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -49,6 +49,17 @@ export interface ValidationError<T = unknown> {
   message: string;
   validationErrors: FormattedValidationErrors<T>;
 }
+
+export function isValidationError(value: unknown): value is ValidationError {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'error' in value &&
+    value.error === true &&
+    'validationErrors' in value
+  );
+}
+
 /**
  * Extracts a string key from a path segment (handles both PropertyKey and PathSegment objects).
  */

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -2853,6 +2853,70 @@ describe('MCPServer - Tool Input Validation', () => {
     expect(invalidResult.message).toMatch(/Tool(?: input)? validation failed/i);
     expect(invalidResult.message).toContain('Message must be at least 3 characters');
   });
+
+  it('should return isError for builder-level validation failures on tools with output schemas', async () => {
+    // This test verifies the fix for a bug where input that passes the MCP server's
+    // JSON Schema validation but fails the builder's Zod validation would cause a
+    // confusing output schema error instead of a clear input validation error.
+    // We use .refine() because it cannot be expressed in JSON Schema, so the
+    // first-pass validation will pass but the builder's Zod validation will fail.
+    const toolWithOutputSchema = createTool({
+      id: 'toolWithOutputSchema',
+      description: 'Tool with output schema and strict input validation',
+      inputSchema: z.object({
+        value: z.string().refine(val => val.startsWith('ok:'), {
+          message: 'Value must start with "ok:"',
+        }),
+      }),
+      outputSchema: z.object({
+        result: z.string(),
+      }),
+      execute: async ({ value }) => ({
+        result: `Processed: ${value}`,
+      }),
+    });
+
+    const server = new MCPServer({
+      name: 'OutputSchemaValidationServer',
+      version: '1.0.0',
+      tools: { toolWithOutputSchema },
+    });
+
+    const serverInstance = server.getServer();
+    // @ts-expect-error - accessing internal for testing
+    const requestHandlers = serverInstance._requestHandlers;
+    const callToolHandler = requestHandlers.get('tools/call');
+    expect(callToolHandler).toBeDefined();
+
+    const mockExtra = {
+      signal: new AbortController().signal,
+      sessionId: 'test-session',
+      requestId: 'test-request',
+      sendNotification: vi.fn(),
+      sendRequest: vi.fn(),
+    };
+
+    // "bad" is a valid string (passes JSON Schema) but fails the .refine() check
+    const result = await callToolHandler(
+      {
+        jsonrpc: '2.0' as const,
+        id: 'test-validation-1',
+        method: 'tools/call' as const,
+        params: {
+          name: 'toolWithOutputSchema',
+          arguments: { value: 'bad' },
+        },
+      },
+      mockExtra,
+    );
+
+    // Should return isError: true with the validation message, NOT an output schema error
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/validation failed/i);
+    expect(result.content[0].text).toContain('Value must start with "ok:"');
+    // Should NOT contain output schema error
+    expect(result.content[0].text).not.toContain('Invalid structured content');
+  });
 });
 
 /**

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -12,7 +12,7 @@ import type {
 } from '@mastra/core/mcp';
 import { RequestContext } from '@mastra/core/request-context';
 import { isStandardSchemaWithJSON, standardSchemaToJSONSchema } from '@mastra/core/schema';
-import { createTool } from '@mastra/core/tools';
+import { createTool, isValidationError } from '@mastra/core/tools';
 import type { InternalCoreTool, MCPToolType, MastraToolInvocationOptions } from '@mastra/core/tools';
 import { makeCoreTool } from '@mastra/core/utils';
 import type { Workflow } from '@mastra/core/workflows';
@@ -515,8 +515,21 @@ export class MCPServer extends MCPServerBase {
 
         const result = await tool.execute(validation?.value ?? request.params.arguments ?? {}, mcpOptions);
 
-        this.logger.debug(`CallTool: Tool '${request.params.name}' executed successfully with result:`, result);
         const duration = Date.now() - startTime;
+
+        // Check if the tool builder returned a validation error (e.g. input failed Zod validation
+        // after passing the JSON Schema first-pass validation above)
+        if (isValidationError(result)) {
+          this.logger.warn(`CallTool: Tool '${request.params.name}' returned a validation error in ${duration}ms.`, {
+            error: result.message,
+          });
+          return {
+            content: [{ type: 'text', text: result.message }],
+            isError: true,
+          };
+        }
+
+        this.logger.debug(`CallTool: Tool '${request.params.name}' executed successfully with result:`, result);
         this.logger.info(`Tool '${request.params.name}' executed successfully in ${duration}ms.`);
 
         const response: CallToolResult = { isError: false, content: [] };


### PR DESCRIPTION
When a tool has both an output schema and Zod input constraints that can't be expressed in JSON Schema (like `.refine()`), input could pass the MCP server's first-pass JSON Schema validation but fail the builder's Zod validation. The builder returns a `ValidationError` object in this case, but the server was treating it as a successful result and trying to validate it against the output schema — producing a confusing `Invalid structured content` error instead of the actual input validation error.

Now the server checks for `ValidationError` results after `tool.execute` and returns them as `isError: true` with the original validation message. Added an `isValidationError` type guard to `@mastra/core` to keep the detection clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- MCP server now correctly identifies and reports tool input validation failures with clear, detailed error messages. Previously, validation errors occurring after initial schema checks would produce misleading output error messages.

## New Features  
- Added a new validation error detection utility available in core package exports for improved error classification and handling in tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->