### PR TITLE
updated `playground-ui` to send both new and legacy `feedbackSource` fields

### DIFF
--- a/.changeset/metal-radios-enjoy.md
+++ b/.changeset/metal-radios-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+updated `playground-ui` to send both new and legacy `feedbackSource` fields

--- a/packages/playground-ui/src/domains/agents/context/review-queue-context.tsx
+++ b/packages/playground-ui/src/domains/agents/context/review-queue-context.tsx
@@ -179,6 +179,7 @@ export function ReviewQueueProvider({ children }: { children: ReactNode }) {
             feedback: {
               traceId: item.traceId,
               source: 'studio',
+              feedbackSource: 'studio',
               feedbackType: 'rating',
               value: rating === 'positive' ? 1 : -1,
               experimentId: item.experimentId ?? undefined,
@@ -204,6 +205,7 @@ export function ReviewQueueProvider({ children }: { children: ReactNode }) {
             feedback: {
               traceId: item.traceId,
               source: 'studio',
+              feedbackSource: 'studio',
               feedbackType: 'comment',
               value: comment,
               comment,

--- a/packages/playground-ui/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground-ui/src/domains/review/components/dataset-review.tsx
@@ -149,6 +149,7 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
             feedback: {
               traceId: item.traceId,
               source: 'studio',
+              feedbackSource: 'studio',
               feedbackType: 'rating',
               value: rating === 'positive' ? 1 : -1,
               experimentId: item.experimentId ?? undefined,
@@ -171,6 +172,7 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
             feedback: {
               traceId: item.traceId,
               source: 'studio',
+              feedbackSource: 'studio',
               feedbackType: 'comment',
               value: comment,
               comment,


### PR DESCRIPTION
## Description

updated `playground-ui` to send both new and legacy `feedbackSource` fields

## Related Issue(s)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the feedback submission system to properly include source tracking information for all feedback types. Both rating and comment actions now include source attribution details, improving feedback tracking and reporting accuracy across the review interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->