### PR TITLE
Fix scrolling on overview pages

### DIFF
--- a/.changeset/overview-pages-scroll-fix.md
+++ b/.changeset/overview-pages-scroll-fix.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed overflow scrolling on Primitives, Observability Overview, and Resources pages so content is scrollable when it exceeds the viewport.

--- a/packages/playground/src/pages/observability-overview/index.tsx
+++ b/packages/playground/src/pages/observability-overview/index.tsx
@@ -30,7 +30,7 @@ export default function ObservabilityOverview() {
         </MainHeader>
       </EntityListPageLayout.Top>
 
-      <div className="px-6 pt-6">
+      <div className="px-6 pt-6 overflow-y-auto">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-3xl">
           {sections.map(section => (
             <Link

--- a/packages/playground/src/pages/primitives/index.tsx
+++ b/packages/playground/src/pages/primitives/index.tsx
@@ -71,7 +71,7 @@ export default function Primitives() {
         </MainHeader>
       </EntityListPageLayout.Top>
 
-      <div className="px-6 pt-6">
+      <div className="px-6 pt-6 overflow-y-auto">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-5xl">
           {sections.map(section => (
             <Link

--- a/packages/playground/src/pages/resources/index.tsx
+++ b/packages/playground/src/pages/resources/index.tsx
@@ -52,7 +52,7 @@ export default function Resources() {
         </MainHeader>
       </EntityListPageLayout.Top>
 
-      <div className="px-6 pt-6">
+      <div className="px-6 pt-6 overflow-y-auto">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-3xl">
           {resources.map(resource => (
             <a


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

add overflow-y-auto to list on overview pages

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed scrolling behavior on Observability Overview, Primitives, and Resources pages when content exceeds viewport height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->