### PR TITLE
fix(client-js): move @mastra/core to peerDependencies

### DIFF
--- a/.changeset/fix-client-js-core-peer-dep.md
+++ b/.changeset/fix-client-js-core-peer-dep.md
@@ -2,4 +2,4 @@
 '@mastra/client-js': patch
 ---
 
-Fixed RequestContext type mismatch when using @mastra/client-js alongside @mastra/core. Moved @mastra/core from a bundled dependency to a peer dependency, matching the pattern used by all other @mastra packages. This prevents duplicate installations that caused TypeScript error `ts(2769): Types have separate declarations of a private property 'registry'`.
+Fixed RequestContext type incompatibility when using @mastra/client-js alongside @mastra/core. Previously, @mastra/client-js could install its own separate copy of @mastra/core, causing TypeScript to reject valid RequestContext usage. Now @mastra/client-js shares the same @mastra/core instance as the rest of your project, matching the pattern used by all other @mastra packages.

--- a/.changeset/fix-client-js-core-peer-dep.md
+++ b/.changeset/fix-client-js-core-peer-dep.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fixed RequestContext type mismatch when using @mastra/client-js alongside @mastra/core. Moved @mastra/core from a bundled dependency to a peer dependency, matching the pattern used by all other @mastra packages. This prevents duplicate installations that caused TypeScript error `ts(2769): Types have separate declarations of a private property 'registry'`.

--- a/client-sdks/client-js/package.json
+++ b/client-sdks/client-js/package.json
@@ -44,11 +44,11 @@
   "dependencies": {
     "@ai-sdk/ui-utils": "^1.2.11",
     "@lukeed/uuid": "^2.0.1",
-    "@mastra/core": "workspace:*",
     "@mastra/schema-compat": "workspace:*",
     "json-schema": "^0.4.0"
   },
   "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {
@@ -56,6 +56,7 @@
     "@internal/ai-sdk-v5": "workspace:*",
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
     "@types/json-schema": "^7.0.15",
     "@types/node": "22.19.15",
     "@vitest/coverage-v8": "catalog:",

--- a/e2e-tests/pkg-outputs/bundle.test.ts
+++ b/e2e-tests/pkg-outputs/bundle.test.ts
@@ -85,7 +85,6 @@ describe.for(
   it.skipIf(
     pkgJson.name === 'mastra' ||
       pkgJson.name === 'create-mastra' ||
-      pkgJson.name === '@mastra/client-js' ||
       pkgJson.name === '@mastra/opencode' ||
       pkgJson.name === 'mastracode' ||
       !pkgJson.name.startsWith('@mastra/'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,9 +542,6 @@ importers:
       '@lukeed/uuid':
         specifier: ^2.0.1
         version: 2.0.1
-      '@mastra/core':
-        specifier: workspace:*
-        version: link:../../packages/core
       '@mastra/schema-compat':
         specifier: workspace:*
         version: link:../../packages/schema-compat
@@ -564,6 +561,9 @@ importers:
       '@internal/types-builder':
         specifier: workspace:*
         version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15


### PR DESCRIPTION
## Summary

`@mastra/client-js` listed `@mastra/core` as a bundled dependency instead of a peer dependency. This caused package managers to install two separate copies of `@mastra/core` — one nested inside `client-js` and one hoisted for the rest of the app. Because `RequestContext` uses a private property (`registry`), TypeScript treated the two copies as incompatible types, producing `ts(2769)`.

Every other `@mastra/*` package (`memory`, `mcp`, `rag`, `server`) already declares `@mastra/core` as a peer dependency. This PR aligns `client-js` with that pattern.

  ## Context

  - `@mastra/core` was originally moved to `peerDependencies` across all packages by Ward
  Peeters in May 2025 (`83da932`).
  - It was reverted to a regular dependency in `client-js` only, as a quick fix for Vercel
  example builds in June 2025 (`b2810ab`, PR #4774).
  - That workaround was never cleaned up, and later refactors continued building on it.

## Issue

  Fixes #14855 

## Test plan

  - [x] `client-js` build passes (`pnpm build:lib`)
  - [x] All 343 `client-js` unit tests pass (`pnpm test:unit`)
  - [x] `e2e-tests/pkg-outputs/bundle.test.ts` now validates `client-js` follows the peer
  dependency rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RequestContext type mismatch when using `@mastra/client-js` with `@mastra/core` together
  * Resolved TypeScript errors caused by duplicate dependency installations by updating dependency structure

* **Tests**
  * Enhanced validation for `@mastra/client-js` package compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->