### PR TITLE
fix(server-adapters): add error handling for datastream-response stream processing

### DIFF
--- a/.changeset/tired-moons-kneel.md
+++ b/.changeset/tired-moons-kneel.md
@@ -1,0 +1,7 @@
+---
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/koa': patch
+---
+
+Added error handling for datastream-response stream processing. The read loop now catches reader.read() rejections and logs them with context instead of silently terminating the response. Also added a listener on the response stream for socket-level write errors (backpressure, connection resets), which cancels the reader gracefully.

--- a/server-adapters/express/src/__tests__/datastream-error-handling.test.ts
+++ b/server-adapters/express/src/__tests__/datastream-error-handling.test.ts
@@ -1,4 +1,4 @@
-import type { Server } from 'node:http';
+import type { Server, ServerResponse } from 'node:http';
 import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
 import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
 import type { ServerRoute } from '@mastra/server/server-adapter';
@@ -117,7 +117,7 @@ describe('datastream-response error handling', () => {
     expect(genericHandlerErrorCall).toBeUndefined();
   });
 
-  it('should listen for res error events during datastream-response piping', async () => {
+  it('should log errors when res emits an error during datastream-response piping', async () => {
     const app = express();
     app.use(express.json());
 
@@ -134,15 +134,17 @@ describe('datastream-response error handling', () => {
       debug: vi.fn(),
     } as any);
 
-    // Create a stream that sends data slowly so we can trigger a write error
+    // Capture the raw response so we can destroy it mid-stream
+    let capturedRes: ServerResponse | null = null;
+
+    // Create a stream that sends data slowly so we have time to destroy the response
     const createSlowStream = () => {
       let chunkCount = 0;
       return new ReadableStream({
         async pull(controller) {
           chunkCount++;
-          if (chunkCount <= 10) {
+          if (chunkCount <= 20) {
             controller.enqueue(new TextEncoder().encode(`chunk-${chunkCount}\n`));
-            // Small delay between chunks
             await new Promise(resolve => setTimeout(resolve, 50));
           } else {
             controller.close();
@@ -165,6 +167,11 @@ describe('datastream-response error handling', () => {
       },
     };
 
+    // Middleware to capture the response object before the route handler
+    app.use((req, res, next) => {
+      capturedRes = res;
+      next();
+    });
     app.use(adapter.createContextMiddleware());
     await adapter.registerRoute(app, testRoute, { prefix: '' });
 
@@ -174,25 +181,27 @@ describe('datastream-response error handling', () => {
     const address = server.address();
     const port = typeof address === 'object' && address ? address.port : 0;
 
-    // Use AbortController to abort the request mid-stream, simulating a client disconnect
-    const controller = new AbortController();
-
-    const response = await fetch(`http://localhost:${port}/test/datastream-write-error`, {
+    // Start the request (don't await the full response)
+    const fetchPromise = fetch(`http://localhost:${port}/test/datastream-write-error`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({}),
-      signal: controller.signal,
-    });
+    }).catch(() => {});
 
-    // Read one chunk then abort
-    const reader = response.body!.getReader();
-    await reader.read(); // Read first chunk
-    controller.abort();
+    // Wait for the response to start streaming
+    await new Promise(resolve => setTimeout(resolve, 150));
 
-    // Wait for the server-side stream processing to notice the disconnect
-    await new Promise(resolve => setTimeout(resolve, 500));
+    // Emit an error on the response to simulate a socket-level write failure
+    capturedRes!.emit('error', new Error('simulated connection reset'));
 
-    // The server should not have crashed — this test passing without unhandled rejection is the assertion
-    expect(true).toBe(true);
+    // Wait for error handling to complete
+    await new Promise(resolve => setTimeout(resolve, 300));
+    await fetchPromise;
+
+    // Verify the error was logged through the response error handler
+    const writePathErrorCall = loggerErrorSpy.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0] === 'Error writing datastream response',
+    );
+    expect(writePathErrorCall).toBeDefined();
   });
 });

--- a/server-adapters/express/src/__tests__/datastream-error-handling.test.ts
+++ b/server-adapters/express/src/__tests__/datastream-error-handling.test.ts
@@ -1,0 +1,198 @@
+import type { Server } from 'node:http';
+import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
+import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
+import type { ServerRoute } from '@mastra/server/server-adapter';
+import express from 'express';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MastraServer } from '../index';
+
+describe('datastream-response error handling', () => {
+  let context: AdapterTestContext;
+  let server: Server | null = null;
+
+  beforeEach(async () => {
+    context = await createDefaultTestContext();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server!.close(err => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      server = null;
+    }
+  });
+
+  it('should catch and log errors when reader.read() rejects during datastream-response piping', async () => {
+    const app = express();
+    app.use(express.json());
+
+    const adapter = new MastraServer({
+      app,
+      mastra: context.mastra,
+    });
+
+    // Spy on the logger's error method
+    const loggerErrorSpy = vi.fn();
+    vi.spyOn(context.mastra, 'getLogger').mockReturnValue({
+      error: loggerErrorSpy,
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as any);
+
+    // Create a ReadableStream that errors mid-stream
+    const createErroringStream = () => {
+      let chunkCount = 0;
+      return new ReadableStream({
+        pull(controller) {
+          chunkCount++;
+          if (chunkCount <= 2) {
+            controller.enqueue(new TextEncoder().encode(`chunk-${chunkCount}\n`));
+          } else {
+            controller.error(new Error('upstream TransformStream flush error'));
+          }
+        },
+      });
+    };
+
+    const testRoute: ServerRoute<any, any, any> = {
+      method: 'POST',
+      path: '/test/datastream',
+      responseType: 'datastream-response',
+      handler: async () => {
+        return new Response(createErroringStream(), {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Transfer-Encoding': 'chunked',
+          },
+        });
+      },
+    };
+
+    app.use(adapter.createContextMiddleware());
+    await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+    server = await new Promise(resolve => {
+      const s = app.listen(0, () => resolve(s));
+    });
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+
+    const response = await fetch(`http://localhost:${port}/test/datastream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    // Consume the stream to trigger the error
+    try {
+      const reader = response.body!.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    } catch {
+      // Client may see an error too — that's fine
+    }
+
+    // Wait a tick for async error handling to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // The error should be caught and logged within the datastream-response handler itself,
+    // NOT propagate up to the generic "Error calling handler" catch in registerRoute.
+    const datastreamErrorCall = loggerErrorSpy.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('datastream'),
+    );
+    expect(datastreamErrorCall).toBeDefined();
+
+    // It should NOT have been logged as a generic handler error
+    const genericHandlerErrorCall = loggerErrorSpy.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0] === 'Error calling handler',
+    );
+    expect(genericHandlerErrorCall).toBeUndefined();
+  });
+
+  it('should listen for res error events during datastream-response piping', async () => {
+    const app = express();
+    app.use(express.json());
+
+    const adapter = new MastraServer({
+      app,
+      mastra: context.mastra,
+    });
+
+    const loggerErrorSpy = vi.fn();
+    vi.spyOn(context.mastra, 'getLogger').mockReturnValue({
+      error: loggerErrorSpy,
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as any);
+
+    // Create a stream that sends data slowly so we can trigger a write error
+    const createSlowStream = () => {
+      let chunkCount = 0;
+      return new ReadableStream({
+        async pull(controller) {
+          chunkCount++;
+          if (chunkCount <= 10) {
+            controller.enqueue(new TextEncoder().encode(`chunk-${chunkCount}\n`));
+            // Small delay between chunks
+            await new Promise(resolve => setTimeout(resolve, 50));
+          } else {
+            controller.close();
+          }
+        },
+      });
+    };
+
+    const testRoute: ServerRoute<any, any, any> = {
+      method: 'POST',
+      path: '/test/datastream-write-error',
+      responseType: 'datastream-response',
+      handler: async () => {
+        return new Response(createSlowStream(), {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+          },
+        });
+      },
+    };
+
+    app.use(adapter.createContextMiddleware());
+    await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+    server = await new Promise(resolve => {
+      const s = app.listen(0, () => resolve(s));
+    });
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+
+    // Use AbortController to abort the request mid-stream, simulating a client disconnect
+    const controller = new AbortController();
+
+    const response = await fetch(`http://localhost:${port}/test/datastream-write-error`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+      signal: controller.signal,
+    });
+
+    // Read one chunk then abort
+    const reader = response.body!.getReader();
+    await reader.read(); // Read first chunk
+    controller.abort();
+
+    // Wait for the server-side stream processing to notice the disconnect
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // The server should not have crashed — this test passing without unhandled rejection is the assertion
+    expect(true).toBe(true);
+  });
+});

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -292,12 +292,13 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
       if (fetchResponse.body) {
         const reader = fetchResponse.body.getReader();
 
-        response.on('error', err => {
+        const onResError = (err: unknown) => {
           this.mastra.getLogger()?.error('Error writing datastream response', {
             error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
           });
           void reader.cancel('response write error');
-        });
+        };
+        response.once('error', onResError);
 
         try {
           while (true) {
@@ -310,6 +311,7 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
             error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
           });
         } finally {
+          response.off('error', onResError);
           response.end();
         }
       } else {

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -291,12 +291,24 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
       response.status(fetchResponse.status);
       if (fetchResponse.body) {
         const reader = fetchResponse.body.getReader();
+
+        response.on('error', err => {
+          this.mastra.getLogger()?.error('Error writing datastream response', {
+            error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+          });
+          void reader.cancel('response write error');
+        });
+
         try {
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
             response.write(value);
           }
+        } catch (error) {
+          this.mastra.getLogger()?.error('Error in datastream processing', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
         } finally {
           response.end();
         }

--- a/server-adapters/fastify/src/__tests__/datastream-error-handling.test.ts
+++ b/server-adapters/fastify/src/__tests__/datastream-error-handling.test.ts
@@ -1,3 +1,4 @@
+import type { ServerResponse } from 'node:http';
 import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
 import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
 import type { ServerRoute } from '@mastra/server/server-adapter';
@@ -107,7 +108,7 @@ describe('datastream-response error handling', () => {
     expect(genericHandlerErrorCall).toBeUndefined();
   });
 
-  it('should listen for reply.raw error events during datastream-response piping', { timeout: 15000 }, async () => {
+  it('should log errors when reply.raw emits an error during datastream-response piping', async () => {
     app = Fastify({ forceCloseConnections: true });
 
     const adapter = new MastraServer({
@@ -123,15 +124,17 @@ describe('datastream-response error handling', () => {
       debug: vi.fn(),
     } as any);
 
-    // Create a stream that sends data slowly so we can trigger a write error
+    // Capture the raw response so we can destroy it mid-stream
+    let capturedRes: ServerResponse | null = null;
+
+    // Create a stream that sends data slowly so we have time to destroy the response
     const createSlowStream = () => {
       let chunkCount = 0;
       return new ReadableStream({
         async pull(controller) {
           chunkCount++;
-          if (chunkCount <= 10) {
+          if (chunkCount <= 20) {
             controller.enqueue(new TextEncoder().encode(`chunk-${chunkCount}\n`));
-            // Small delay between chunks
             await new Promise(resolve => setTimeout(resolve, 50));
           } else {
             controller.close();
@@ -154,30 +157,36 @@ describe('datastream-response error handling', () => {
       },
     };
 
+    // Hook to capture the raw response object before the route handler
+    app.addHook('onRequest', async (request, reply) => {
+      capturedRes = reply.raw;
+    });
     app.addHook('preHandler', adapter.createContextMiddleware());
     await adapter.registerRoute(app, testRoute, { prefix: '' });
 
     const address = await app.listen({ port: 0 });
 
-    // Use AbortController to abort the request mid-stream, simulating a client disconnect
-    const controller = new AbortController();
-
-    const response = await fetch(`${address}/test/datastream-write-error`, {
+    // Start the request (don't await the full response)
+    const fetchPromise = fetch(`${address}/test/datastream-write-error`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({}),
-      signal: controller.signal,
-    });
+    }).catch(() => {});
 
-    // Read one chunk then abort
-    const reader = response.body!.getReader();
-    await reader.read(); // Read first chunk
-    controller.abort();
+    // Wait for the response to start streaming
+    await new Promise(resolve => setTimeout(resolve, 150));
 
-    // Wait for the server-side stream processing to notice the disconnect
-    await new Promise(resolve => setTimeout(resolve, 500));
+    // Emit an error on the response to simulate a socket-level write failure
+    capturedRes!.emit('error', new Error('simulated connection reset'));
 
-    // The server should not have crashed — this test passing without unhandled rejection is the assertion
-    expect(true).toBe(true);
+    // Wait for error handling to complete
+    await new Promise(resolve => setTimeout(resolve, 300));
+    await fetchPromise;
+
+    // Verify the error was logged through the response error handler
+    const writePathErrorCall = loggerErrorSpy.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0] === 'Error writing datastream response',
+    );
+    expect(writePathErrorCall).toBeDefined();
   });
 });

--- a/server-adapters/fastify/src/__tests__/datastream-error-handling.test.ts
+++ b/server-adapters/fastify/src/__tests__/datastream-error-handling.test.ts
@@ -1,0 +1,183 @@
+import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
+import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
+import type { ServerRoute } from '@mastra/server/server-adapter';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MastraServer } from '../index';
+
+describe('datastream-response error handling', () => {
+  let context: AdapterTestContext;
+  let app: FastifyInstance | null = null;
+
+  beforeEach(async () => {
+    context = await createDefaultTestContext();
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+      app = null;
+    }
+  });
+
+  it('should catch and log errors when reader.read() rejects during datastream-response piping', async () => {
+    app = Fastify();
+
+    const adapter = new MastraServer({
+      app,
+      mastra: context.mastra,
+    });
+
+    // Spy on the logger's error method
+    const loggerErrorSpy = vi.fn();
+    vi.spyOn(context.mastra, 'getLogger').mockReturnValue({
+      error: loggerErrorSpy,
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as any);
+
+    // Create a ReadableStream that errors mid-stream
+    const createErroringStream = () => {
+      let chunkCount = 0;
+      return new ReadableStream({
+        pull(controller) {
+          chunkCount++;
+          if (chunkCount <= 2) {
+            controller.enqueue(new TextEncoder().encode(`chunk-${chunkCount}\n`));
+          } else {
+            controller.error(new Error('upstream TransformStream flush error'));
+          }
+        },
+      });
+    };
+
+    const testRoute: ServerRoute<any, any, any> = {
+      method: 'POST',
+      path: '/test/datastream',
+      responseType: 'datastream-response',
+      handler: async () => {
+        return new Response(createErroringStream(), {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Transfer-Encoding': 'chunked',
+          },
+        });
+      },
+    };
+
+    app.addHook('preHandler', adapter.createContextMiddleware());
+    await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+    const address = await app.listen({ port: 0 });
+
+    const response = await fetch(`${address}/test/datastream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    // Consume the stream to trigger the error
+    try {
+      const reader = response.body!.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    } catch {
+      // Client may see an error too — that's fine
+    }
+
+    // Wait a tick for async error handling to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // The error should be caught and logged within the datastream-response handler itself,
+    // NOT propagate up to the generic "Error calling handler" catch in registerRoute.
+    const datastreamErrorCall = loggerErrorSpy.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('datastream'),
+    );
+    expect(datastreamErrorCall).toBeDefined();
+
+    // It should NOT have been logged as a generic handler error
+    const genericHandlerErrorCall = loggerErrorSpy.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0] === 'Error calling handler',
+    );
+    expect(genericHandlerErrorCall).toBeUndefined();
+  });
+
+  it('should listen for reply.raw error events during datastream-response piping', { timeout: 15000 }, async () => {
+    app = Fastify({ forceCloseConnections: true });
+
+    const adapter = new MastraServer({
+      app,
+      mastra: context.mastra,
+    });
+
+    const loggerErrorSpy = vi.fn();
+    vi.spyOn(context.mastra, 'getLogger').mockReturnValue({
+      error: loggerErrorSpy,
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as any);
+
+    // Create a stream that sends data slowly so we can trigger a write error
+    const createSlowStream = () => {
+      let chunkCount = 0;
+      return new ReadableStream({
+        async pull(controller) {
+          chunkCount++;
+          if (chunkCount <= 10) {
+            controller.enqueue(new TextEncoder().encode(`chunk-${chunkCount}\n`));
+            // Small delay between chunks
+            await new Promise(resolve => setTimeout(resolve, 50));
+          } else {
+            controller.close();
+          }
+        },
+      });
+    };
+
+    const testRoute: ServerRoute<any, any, any> = {
+      method: 'POST',
+      path: '/test/datastream-write-error',
+      responseType: 'datastream-response',
+      handler: async () => {
+        return new Response(createSlowStream(), {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+          },
+        });
+      },
+    };
+
+    app.addHook('preHandler', adapter.createContextMiddleware());
+    await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+    const address = await app.listen({ port: 0 });
+
+    // Use AbortController to abort the request mid-stream, simulating a client disconnect
+    const controller = new AbortController();
+
+    const response = await fetch(`${address}/test/datastream-write-error`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+      signal: controller.signal,
+    });
+
+    // Read one chunk then abort
+    const reader = response.body!.getReader();
+    await reader.read(); // Read first chunk
+    controller.abort();
+
+    // Wait for the server-side stream processing to notice the disconnect
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // The server should not have crashed — this test passing without unhandled rejection is the assertion
+    expect(true).toBe(true);
+  });
+});

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -320,12 +320,24 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
       reply.status(fetchResponse.status);
       if (fetchResponse.body) {
         const reader = fetchResponse.body.getReader();
+
+        reply.raw.on('error', err => {
+          this.mastra.getLogger()?.error('Error writing datastream response', {
+            error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+          });
+          void reader.cancel('response write error');
+        });
+
         try {
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
             reply.raw.write(value);
           }
+        } catch (error) {
+          this.mastra.getLogger()?.error('Error in datastream processing', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
         } finally {
           reply.raw.end();
         }

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -321,12 +321,13 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
       if (fetchResponse.body) {
         const reader = fetchResponse.body.getReader();
 
-        reply.raw.on('error', err => {
+        const onResError = (err: unknown) => {
           this.mastra.getLogger()?.error('Error writing datastream response', {
             error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
           });
           void reader.cancel('response write error');
-        });
+        };
+        reply.raw.once('error', onResError);
 
         try {
           while (true) {
@@ -339,6 +340,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
             error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
           });
         } finally {
+          reply.raw.off('error', onResError);
           reply.raw.end();
         }
       } else {

--- a/server-adapters/koa/src/__tests__/datastream-error-handling.test.ts
+++ b/server-adapters/koa/src/__tests__/datastream-error-handling.test.ts
@@ -1,0 +1,200 @@
+import type { Server } from 'node:http';
+import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
+import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
+import type { ServerRoute } from '@mastra/server/server-adapter';
+import Koa from 'koa';
+import bodyParser from 'koa-bodyparser';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MastraServer } from '../index';
+
+describe('datastream-response error handling', () => {
+  let context: AdapterTestContext;
+  let server: Server | null = null;
+
+  beforeEach(async () => {
+    context = await createDefaultTestContext();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server!.close(err => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      server = null;
+    }
+  });
+
+  it('should catch and log errors when reader.read() rejects during datastream-response piping', async () => {
+    const app = new Koa();
+    app.use(bodyParser());
+
+    const adapter = new MastraServer({
+      app,
+      mastra: context.mastra,
+    });
+
+    // Spy on the logger's error method
+    const loggerErrorSpy = vi.fn();
+    vi.spyOn(context.mastra, 'getLogger').mockReturnValue({
+      error: loggerErrorSpy,
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as any);
+
+    // Create a ReadableStream that errors mid-stream
+    const createErroringStream = () => {
+      let chunkCount = 0;
+      return new ReadableStream({
+        pull(controller) {
+          chunkCount++;
+          if (chunkCount <= 2) {
+            controller.enqueue(new TextEncoder().encode(`chunk-${chunkCount}\n`));
+          } else {
+            controller.error(new Error('upstream TransformStream flush error'));
+          }
+        },
+      });
+    };
+
+    const testRoute: ServerRoute<any, any, any> = {
+      method: 'POST',
+      path: '/test/datastream',
+      responseType: 'datastream-response',
+      handler: async () => {
+        return new Response(createErroringStream(), {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Transfer-Encoding': 'chunked',
+          },
+        });
+      },
+    };
+
+    app.use(adapter.createContextMiddleware());
+    await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+    server = await new Promise(resolve => {
+      const s = app.listen(0, () => resolve(s));
+    });
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+
+    const response = await fetch(`http://localhost:${port}/test/datastream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    // Consume the stream to trigger the error
+    try {
+      const reader = response.body!.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    } catch {
+      // Client may see an error too — that's fine
+    }
+
+    // Wait a tick for async error handling to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // The error should be caught and logged within the datastream-response handler itself,
+    // NOT propagate up to the generic "Error calling handler" catch in registerRoute.
+    // Currently, it propagates because there's no catch block — only a finally.
+    const datastreamErrorCall = loggerErrorSpy.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('datastream'),
+    );
+    expect(datastreamErrorCall).toBeDefined();
+
+    // It should NOT have been logged as a generic handler error
+    const genericHandlerErrorCall = loggerErrorSpy.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0] === 'Error calling handler',
+    );
+    expect(genericHandlerErrorCall).toBeUndefined();
+  });
+
+  it('should listen for ctx.res error events during datastream-response piping', async () => {
+    const app = new Koa();
+    app.use(bodyParser());
+
+    const adapter = new MastraServer({
+      app,
+      mastra: context.mastra,
+    });
+
+    const loggerErrorSpy = vi.fn();
+    vi.spyOn(context.mastra, 'getLogger').mockReturnValue({
+      error: loggerErrorSpy,
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as any);
+
+    // Create a stream that sends data slowly so we can trigger a write error
+    const createSlowStream = () => {
+      let chunkCount = 0;
+      return new ReadableStream({
+        async pull(controller) {
+          chunkCount++;
+          if (chunkCount <= 10) {
+            controller.enqueue(new TextEncoder().encode(`chunk-${chunkCount}\n`));
+            // Small delay between chunks
+            await new Promise(resolve => setTimeout(resolve, 50));
+          } else {
+            controller.close();
+          }
+        },
+      });
+    };
+
+    const testRoute: ServerRoute<any, any, any> = {
+      method: 'POST',
+      path: '/test/datastream-write-error',
+      responseType: 'datastream-response',
+      handler: async () => {
+        return new Response(createSlowStream(), {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+          },
+        });
+      },
+    };
+
+    app.use(adapter.createContextMiddleware());
+    await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+    server = await new Promise(resolve => {
+      const s = app.listen(0, () => resolve(s));
+    });
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+
+    // Use AbortController to abort the request mid-stream, simulating a client disconnect
+    const controller = new AbortController();
+
+    const response = await fetch(`http://localhost:${port}/test/datastream-write-error`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+      signal: controller.signal,
+    });
+
+    // Read one chunk then abort
+    const reader = response.body!.getReader();
+    await reader.read(); // Read first chunk
+    controller.abort();
+
+    // Wait for the server-side stream processing to notice the disconnect
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // The server should not have crashed — this test passing without unhandled rejection is the assertion
+    expect(true).toBe(true);
+  });
+});

--- a/server-adapters/koa/src/__tests__/datastream-error-handling.test.ts
+++ b/server-adapters/koa/src/__tests__/datastream-error-handling.test.ts
@@ -1,4 +1,4 @@
-import type { Server } from 'node:http';
+import type { Server, ServerResponse } from 'node:http';
 import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
 import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
 import type { ServerRoute } from '@mastra/server/server-adapter';
@@ -106,7 +106,6 @@ describe('datastream-response error handling', () => {
 
     // The error should be caught and logged within the datastream-response handler itself,
     // NOT propagate up to the generic "Error calling handler" catch in registerRoute.
-    // Currently, it propagates because there's no catch block — only a finally.
     const datastreamErrorCall = loggerErrorSpy.mock.calls.find(
       (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('datastream'),
     );
@@ -119,7 +118,7 @@ describe('datastream-response error handling', () => {
     expect(genericHandlerErrorCall).toBeUndefined();
   });
 
-  it('should listen for ctx.res error events during datastream-response piping', async () => {
+  it('should log errors when ctx.res emits an error during datastream-response piping', async () => {
     const app = new Koa();
     app.use(bodyParser());
 
@@ -136,15 +135,17 @@ describe('datastream-response error handling', () => {
       debug: vi.fn(),
     } as any);
 
-    // Create a stream that sends data slowly so we can trigger a write error
+    // Capture the raw response so we can destroy it mid-stream
+    let capturedRes: ServerResponse | null = null;
+
+    // Create a stream that sends data slowly so we have time to destroy the response
     const createSlowStream = () => {
       let chunkCount = 0;
       return new ReadableStream({
         async pull(controller) {
           chunkCount++;
-          if (chunkCount <= 10) {
+          if (chunkCount <= 20) {
             controller.enqueue(new TextEncoder().encode(`chunk-${chunkCount}\n`));
-            // Small delay between chunks
             await new Promise(resolve => setTimeout(resolve, 50));
           } else {
             controller.close();
@@ -167,6 +168,11 @@ describe('datastream-response error handling', () => {
       },
     };
 
+    // Middleware to capture the response object before the route handler
+    app.use(async (ctx, next) => {
+      capturedRes = ctx.res;
+      await next();
+    });
     app.use(adapter.createContextMiddleware());
     await adapter.registerRoute(app, testRoute, { prefix: '' });
 
@@ -176,25 +182,27 @@ describe('datastream-response error handling', () => {
     const address = server.address();
     const port = typeof address === 'object' && address ? address.port : 0;
 
-    // Use AbortController to abort the request mid-stream, simulating a client disconnect
-    const controller = new AbortController();
-
-    const response = await fetch(`http://localhost:${port}/test/datastream-write-error`, {
+    // Start the request (don't await the full response)
+    const fetchPromise = fetch(`http://localhost:${port}/test/datastream-write-error`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({}),
-      signal: controller.signal,
-    });
+    }).catch(() => {});
 
-    // Read one chunk then abort
-    const reader = response.body!.getReader();
-    await reader.read(); // Read first chunk
-    controller.abort();
+    // Wait for the response to start streaming
+    await new Promise(resolve => setTimeout(resolve, 150));
 
-    // Wait for the server-side stream processing to notice the disconnect
-    await new Promise(resolve => setTimeout(resolve, 500));
+    // Emit an error on the response to simulate a socket-level write failure
+    capturedRes!.emit('error', new Error('simulated connection reset'));
 
-    // The server should not have crashed — this test passing without unhandled rejection is the assertion
-    expect(true).toBe(true);
+    // Wait for error handling to complete
+    await new Promise(resolve => setTimeout(resolve, 300));
+    await fetchPromise;
+
+    // Verify the error was logged through the response error handler
+    const writePathErrorCall = loggerErrorSpy.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0] === 'Error writing datastream response',
+    );
+    expect(writePathErrorCall).toBeDefined();
   });
 });

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -422,12 +422,13 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       if (fetchResponse.body) {
         const reader = fetchResponse.body.getReader();
 
-        ctx.res.on('error', err => {
+        const onResError = (err: unknown) => {
           this.mastra.getLogger()?.error('Error writing datastream response', {
             error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
           });
           void reader.cancel('response write error');
-        });
+        };
+        ctx.res.once('error', onResError);
 
         try {
           while (true) {
@@ -440,6 +441,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
             error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
           });
         } finally {
+          ctx.res.off('error', onResError);
           ctx.res.end();
         }
       } else {

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -421,12 +421,24 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
 
       if (fetchResponse.body) {
         const reader = fetchResponse.body.getReader();
+
+        ctx.res.on('error', err => {
+          this.mastra.getLogger()?.error('Error writing datastream response', {
+            error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+          });
+          void reader.cancel('response write error');
+        });
+
         try {
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
             ctx.res.write(value);
           }
+        } catch (error) {
+          this.mastra.getLogger()?.error('Error in datastream processing', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
         } finally {
           ctx.res.end();
         }


### PR DESCRIPTION
## Description

Adds error handling to the `datastream-response` stream read loop in all three Node.js server adapters (Express, Fastify, Koa). Previously, if `reader.read()` rejected (e.g., an upstream TransformStream errored during transform or flush), the error propagated silently — `finally` called `res.end()`, abruptly terminating the chunked response with no error logged. This adds a `catch` block that logs errors with datastream-specific context and a `res.on('error')` listener for socket-level write failures (backpressure, connection resets), which cancels the reader gracefully.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Datastream responses now detect and log stream/read/write and socket-level write errors, gracefully cancelling in-progress streams instead of failing silently across Express, Fastify, and Koa adapters.

* **Tests**
  * Added end-to-end tests validating datastream error logging and handling for all server adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->