### PR TITLE
fix(mastracode): quote digit-leading provider names in gateway sync

### DIFF
--- a/.changeset/empty-dream-fix.md
+++ b/.changeset/empty-dream-fix.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed provider name quoting in gateway sync to properly quote digit-leading provider IDs (e.g. `302ai`), preventing repeated "invalid provider-types in global cache" warnings from GatewayRegistry.

--- a/mastracode/src/utils/gateway-sync.ts
+++ b/mastracode/src/utils/gateway-sync.ts
@@ -86,7 +86,7 @@ function generateTypesContent(models: Record<string, string[]>): string {
   const providerModelsEntries = Object.entries(models)
     .map(([provider, modelList]) => {
       const modelsList = modelList.map(m => `'${m}'`);
-      const needsQuotes = /[^a-zA-Z0-9_$]/.test(provider);
+      const needsQuotes = !/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(provider);
       const providerKey = needsQuotes ? `'${provider}'` : provider;
       const singleLine = `  readonly ${providerKey}: readonly [${modelsList.join(', ')}];`;
 


### PR DESCRIPTION
## Description

The `generateTypesContent` function in `mastracode/src/utils/gateway-sync.ts` used a regex that only checked for special characters in provider names, not whether the name starts with a digit. This meant providers like `302ai` were written unquoted to the global cache (`readonly 302ai: ...`), which is invalid TypeScript. The core package's `syncGlobalCacheToLocal()` would then detect the corruption, warn, and delete the file — but mastracode would recreate it on the next sync, causing repeated warnings.

This aligns the quoting logic with the fix already applied in `packages/core/src/llm/model/registry-generator.ts`.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider name quoting for digit-leading provider IDs (e.g., `302ai`) in gateway sync to eliminate repeated "invalid provider-types in global cache" warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->