### PR TITLE
feat: improve recall raw message navigation

### DIFF
--- a/.changeset/fair-rivers-smile.md
+++ b/.changeset/fair-rivers-smile.md
@@ -1,0 +1,7 @@
+---
+'@mastra/memory': minor
+---
+
+Added more forgiving raw message browsing in the recall tool for agent follow-up calls.
+
+When an agent requests a `partIndex` greater than the highest visible part in a message, recall now returns the first visible part from the next visible message instead of failing. This makes it easier for agents using `recall` to keep browsing raw messages even when they guess the wrong part index.

--- a/packages/memory/src/tools/om-tools.test.ts
+++ b/packages/memory/src/tools/om-tools.test.ts
@@ -143,7 +143,51 @@ describe('om-tools', () => {
       expect(result.messages).toContain('Message 5');
     });
 
-    it('should reject cursors from a different thread', async () => {
+    it('should browse the cursor thread in resource scope when the cursor belongs to another thread', async () => {
+      await memory.saveThread({
+        thread: {
+          id: 'other-thread',
+          resourceId,
+          title: 'Other thread',
+          createdAt: new Date('2024-01-01T11:00:00Z'),
+          updatedAt: new Date('2024-01-01T11:00:00Z'),
+        },
+      });
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'other-1',
+            threadId: 'other-thread',
+            resourceId,
+            role: 'user',
+            content: { format: 2, parts: [{ type: 'text', text: 'Wrong thread' }] },
+            createdAt: new Date('2024-01-01T11:00:00Z'),
+          },
+          {
+            id: 'other-2',
+            threadId: 'other-thread',
+            resourceId,
+            role: 'assistant',
+            content: { format: 2, parts: [{ type: 'text', text: 'Follow-up in other thread' }] },
+            createdAt: new Date('2024-01-01T11:01:00Z'),
+          },
+        ],
+      });
+
+      const result = await recallMessages({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'other-1',
+      });
+
+      expect(result.count).toBe(1);
+      expect(result.messages).toContain('Follow-up in other thread');
+      expect(result.messages).not.toContain('Cursor does not belong to the active thread');
+    });
+
+    it('should return a helpful message for cross-thread cursors in strict thread scope', async () => {
       await memory.saveThread({
         thread: {
           id: 'other-thread',
@@ -172,11 +216,13 @@ describe('om-tools', () => {
         threadId,
         resourceId,
         cursor: 'other-1',
+        threadScope: threadId,
       });
 
       expect(result.count).toBe(0);
       expect(result.messages).toContain('Cursor does not belong to the active thread');
-      expect(result.messages).toContain('other-thread');
+      expect(result.messages).toContain('Pass threadId="other-thread"');
+      expect(result.messages).toContain('omit threadId and use this cursor directly in resource scope');
     });
 
     it('should return a hint when cursor is a colon-delimited range', async () => {
@@ -453,6 +499,35 @@ describe('om-tools', () => {
       expect(result.messages).toContain('partIndex=1');
     });
 
+    it('should keep next-message continuation hints compatible with part overflow fallback', async () => {
+      const highDetail = await recallMessages({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-1',
+        page: 1,
+        limit: 10,
+        detail: 'high',
+      });
+
+      expect(highDetail.messages).toContain('next message: partIndex=0 on cursor="msg-3"');
+
+      const continued = await recallPart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-2',
+        partIndex: 1,
+      });
+
+      expect(continued.messageId).toBe('msg-3');
+      expect(continued.partIndex).toBe(0);
+      expect(continued.text).toContain(
+        'Part index 1 not found in message msg-2; showing partIndex 0 from next message msg-3.',
+      );
+      expect(continued.text).toContain('Message 3');
+    });
+
     // ── Pagination flags ────────────────────────────────────────────
 
     it('should report hasNextPage when more messages exist forward', async () => {
@@ -659,16 +734,19 @@ describe('om-tools', () => {
       ).rejects.toThrow('Could not resolve cursor message');
     });
 
-    it('should reject cursor from a different thread in thread scope', async () => {
-      await expect(
-        recallMessages({
-          memory: memory as any,
-          threadId,
-          resourceId,
-          cursor: 'owner-msg-1',
-          threadScope: 'different-thread',
-        }),
-      ).rejects.toThrow('Could not resolve cursor message');
+    it('should return a helpful message for cross-thread cursors in strict thread scope', async () => {
+      const result = await recallMessages({
+        memory: memory as any,
+        threadId: 'different-thread',
+        resourceId,
+        cursor: 'owner-msg-1',
+        threadScope: 'different-thread',
+      });
+
+      expect(result.count).toBe(0);
+      expect(result.messages).toContain('Cursor does not belong to the active thread');
+      expect(result.messages).toContain('different-thread');
+      expect(result.messages).toContain(threadId);
     });
 
     it('should allow cursor from same resource in resource scope', async () => {
@@ -692,6 +770,44 @@ describe('om-tools', () => {
           partIndex: 0,
         }),
       ).rejects.toThrow('Could not resolve cursor message');
+    });
+
+    it('should allow recallPart to resolve a cursor from another thread in the same resource', async () => {
+      await memory.saveThread({
+        thread: {
+          id: 'same-resource-other-thread',
+          resourceId,
+          title: 'Same resource other thread',
+          createdAt: new Date('2024-01-01T10:00:00Z'),
+          updatedAt: new Date('2024-01-01T10:00:00Z'),
+        },
+      });
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'same-resource-other-msg-1',
+            threadId: 'same-resource-other-thread',
+            resourceId,
+            role: 'assistant',
+            content: { format: 2, parts: [{ type: 'text', text: 'Same resource other thread message' }] },
+            createdAt: new Date('2024-01-01T10:05:00Z'),
+          },
+        ],
+      });
+
+      const result = await recallPart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        threadScope: threadId,
+        cursor: 'same-resource-other-msg-1',
+        partIndex: 0,
+      });
+
+      expect(result.messageId).toBe('same-resource-other-msg-1');
+      expect(result.partIndex).toBe(0);
+      expect(result.text).toContain('Same resource other thread message');
     });
 
     it('should reject recallThreadFromStart for a thread from another resource', async () => {
@@ -790,7 +906,110 @@ describe('om-tools', () => {
       expect(result.text).toContain('export function main()');
     });
 
-    it('should throw for invalid part index', async () => {
+    it('should fall forward to the first part of the next visible message when partIndex overflows', async () => {
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-single',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: 'Only part here' }],
+            },
+            createdAt: new Date('2024-01-01T10:02:00Z'),
+          },
+          {
+            id: 'msg-next-visible',
+            threadId,
+            resourceId,
+            role: 'user',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: 'This is the next visible message' }],
+            },
+            createdAt: new Date('2024-01-01T10:03:00Z'),
+          },
+        ],
+      });
+
+      const result = await recallPart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-single',
+        partIndex: 1,
+      });
+
+      expect(result.messageId).toBe('msg-next-visible');
+      expect(result.partIndex).toBe(0);
+      expect(result.role).toBe('user');
+      expect(result.type).toBe('text');
+      expect(result.text).toContain(
+        'Part index 1 not found in message msg-single; showing partIndex 0 from next message msg-next-visible.',
+      );
+      expect(result.text).toContain('This is the next visible message');
+    });
+
+    it('should skip data-only messages when falling forward to the next visible message', async () => {
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-overflow-source',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: 'Source message' }],
+            },
+            createdAt: new Date('2024-01-01T10:02:00Z'),
+          },
+          {
+            id: 'msg-hidden-middle',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [
+                {
+                  type: 'data-om-buffering-start',
+                  data: { cycleId: 'test-cycle', operationType: 'observation' },
+                },
+              ],
+            },
+            createdAt: new Date('2024-01-01T10:03:00Z'),
+          },
+          {
+            id: 'msg-visible-after-hidden',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: 'Visible after hidden' }],
+            },
+            createdAt: new Date('2024-01-01T10:04:00Z'),
+          },
+        ],
+      });
+
+      const result = await recallPart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-overflow-source',
+        partIndex: 1,
+      });
+
+      expect(result.messageId).toBe('msg-visible-after-hidden');
+      expect(result.text).toContain('Visible after hidden');
+      expect(result.text).not.toContain('msg-hidden-middle');
+    });
+
+    it('should throw for invalid part index when there is no next visible message', async () => {
       await expect(
         recallPart({
           memory: memory as any,
@@ -1715,12 +1934,105 @@ describe('om-tools', () => {
       ).rejects.toThrow('Either cursor or threadId is required for mode="messages"');
     });
 
-    it('should require an active thread when browsing by cursor only', async () => {
+    it('should allow cursor-only browsing in resource scope by resolving the cursor thread', async () => {
       const tool = recallTool(undefined, { retrievalScope: 'resource' });
+      const recallMock = vi.fn().mockResolvedValue({ messages: [] });
 
-      await expect(
-        tool.execute?.({ mode: 'messages', cursor: 'msg-1' }, { memory: {}, agent: { resourceId: 'res-a' } } as any),
-      ).rejects.toThrow('Current thread is required when browsing by cursor');
+      const memory = {
+        getMemoryStore: async () => ({
+          listMessagesById: async () => ({
+            messages: [
+              {
+                id: 'msg-1',
+                threadId: 'thread-from-cursor',
+                resourceId: 'res-a',
+                role: 'user',
+                content: { format: 2, parts: [{ type: 'text', text: 'Message 1' }] },
+                createdAt: new Date('2024-01-01T10:00:00Z'),
+              },
+            ],
+          }),
+        }),
+        recall: recallMock,
+      };
+
+      const result = await tool.execute?.({ mode: 'messages', cursor: 'msg-1' }, {
+        memory,
+        agent: { resourceId: 'res-a' },
+      } as any);
+
+      expect((result as any)?.cursor).toBe('msg-1');
+      expect(recallMock).toHaveBeenCalled();
+    });
+
+    it('should resolve a visible cursor from resource recall when direct lookup misses', async () => {
+      const tool = recallTool(undefined, { retrievalScope: 'resource' });
+      const listThreadsMock = vi.fn().mockResolvedValue({
+        threads: [
+          {
+            id: 'thread-from-recall',
+            resourceId: 'res-a',
+            title: 'Recovered thread',
+            createdAt: new Date('2024-01-01T09:00:00Z'),
+            updatedAt: new Date('2024-01-01T10:00:00Z'),
+          },
+        ],
+        total: 1,
+        hasMore: false,
+        page: 0,
+      });
+      const recoveredMessage = {
+        id: 'visible-msg',
+        threadId: 'thread-from-recall',
+        resourceId: 'res-a',
+        role: 'assistant',
+        content: { format: 2, parts: [{ type: 'text', text: 'Recovered message' }] },
+        createdAt: new Date('2024-01-01T10:00:00Z'),
+      };
+      const recallMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          messages: [recoveredMessage],
+        })
+        .mockResolvedValueOnce({
+          messages: [recoveredMessage],
+        })
+        .mockResolvedValueOnce({
+          messages: [],
+        });
+      const memory = {
+        getMemoryStore: async () => ({
+          listMessagesById: async () => ({ messages: [] }),
+        }),
+        listThreads: listThreadsMock,
+        recall: recallMock,
+      };
+
+      const result = await tool.execute?.({ mode: 'messages', cursor: 'visible-msg' }, {
+        memory,
+        agent: { resourceId: 'res-a' },
+      } as any);
+
+      expect((result as any)?.cursor).toBe('visible-msg');
+      expect(listThreadsMock).toHaveBeenCalledWith({
+        page: 0,
+        perPage: 100,
+        orderBy: { field: 'updatedAt', direction: 'DESC' },
+        filter: { resourceId: 'res-a' },
+      });
+      expect(recallMock).toHaveBeenNthCalledWith(1, {
+        threadId: 'thread-from-recall',
+        resourceId: 'res-a',
+        page: 0,
+        perPage: false,
+      });
+      expect(recallMock).toHaveBeenNthCalledWith(2, {
+        threadId: 'thread-from-recall',
+        resourceId: 'res-a',
+        page: 0,
+        perPage: false,
+      });
+      expect(recallMock).toHaveBeenNthCalledWith(3, expect.objectContaining({ threadId: 'thread-from-recall' }));
     });
 
     it('should reject threadId values outside the active resource', async () => {

--- a/packages/memory/src/tools/om-tools.ts
+++ b/packages/memory/src/tools/om-tools.ts
@@ -106,7 +106,7 @@ function parseRangeFormat(cursor: string): { startId: string; endId: string } | 
 async function resolveCursorMessage(
   memory: RecallMemory,
   cursor: string,
-  access?: { resourceId?: string; threadScope?: string },
+  access?: { resourceId?: string; threadScope?: string; enforceThreadScope?: boolean },
 ): Promise<MastraDBMessage | { hint: string; startId: string; endId: string }> {
   const normalized = cursor.trim();
 
@@ -124,7 +124,11 @@ async function resolveCursorMessage(
 
   const memoryStore = await memory.getMemoryStore();
   const result = await memoryStore.listMessagesById({ messageIds: [normalized] });
-  const message = result.messages.find(message => message.id === normalized);
+  let message = result.messages.find(message => message.id === normalized) ?? null;
+
+  if (!message) {
+    message = await resolveCursorMessageByRecall(memory, normalized, access);
+  }
 
   if (!message) {
     throw new Error(`Could not resolve cursor message: ${cursor}`);
@@ -135,12 +139,55 @@ async function resolveCursorMessage(
     throw new Error(`Could not resolve cursor message: ${cursor}`);
   }
 
-  // In thread scope, verify the cursor belongs to the current thread
-  if (access?.threadScope && message.threadId !== access.threadScope) {
+  // In strict thread scope, verify the cursor belongs to the current thread
+  if (access?.enforceThreadScope && access.threadScope && message.threadId !== access.threadScope) {
     throw new Error(`Could not resolve cursor message: ${cursor}`);
   }
 
   return message;
+}
+
+async function resolveCursorMessageByRecall(
+  memory: RecallMemory,
+  cursor: string,
+  access?: { resourceId?: string; threadScope?: string; enforceThreadScope?: boolean },
+): Promise<MastraDBMessage | null> {
+  if (access?.enforceThreadScope && access.threadScope) {
+    const result = await memory.recall({
+      threadId: access.threadScope,
+      resourceId: access.resourceId,
+      page: 0,
+      perPage: false,
+    });
+
+    return result.messages.find(message => message.id === cursor) ?? null;
+  }
+
+  if (!access?.resourceId) {
+    return null;
+  }
+
+  const threads = await memory.listThreads({
+    page: 0,
+    perPage: 100,
+    orderBy: { field: 'updatedAt', direction: 'DESC' },
+    filter: { resourceId: access.resourceId },
+  });
+
+  for (const thread of threads.threads) {
+    const result = await memory.recall({
+      threadId: thread.id,
+      resourceId: access.resourceId,
+      page: 0,
+      perPage: false,
+    });
+    const message = result.messages.find(message => message.id === cursor);
+    if (message) {
+      return message;
+    }
+  }
+
+  return null;
 }
 
 // ── Thread listing ──────────────────────────────────────────────────
@@ -494,6 +541,34 @@ function buildRenderedText(parts: FormattedPart[], timestamps: Map<string, Date>
   return lines.join('\n');
 }
 
+async function getNextVisibleMessage({
+  memory,
+  threadId,
+  resourceId,
+  after,
+}: {
+  memory: RecallMemory;
+  threadId: string;
+  resourceId?: string;
+  after: Date;
+}): Promise<MastraDBMessage | null> {
+  const result = await memory.recall({
+    threadId,
+    resourceId,
+    page: 0,
+    perPage: 50,
+    orderBy: { field: 'createdAt', direction: 'ASC' },
+    filter: {
+      dateRange: {
+        start: after,
+        startExclusive: true,
+      },
+    },
+  });
+
+  return result.messages.find(hasVisibleParts) ?? null;
+}
+
 const MAX_EXPAND_USER_TEXT_TOKENS = 200;
 const MAX_EXPAND_OTHER_TOKENS = 50;
 
@@ -606,7 +681,11 @@ export async function recallPart({
     throw new Error('Thread ID is required for recall');
   }
 
-  const resolved = await resolveCursorMessage(memory, cursor, { resourceId, threadScope });
+  const resolved = await resolveCursorMessage(memory, cursor, {
+    resourceId,
+    threadScope,
+    enforceThreadScope: false,
+  });
 
   if ('hint' in resolved) {
     throw new Error(resolved.hint);
@@ -623,9 +702,40 @@ export async function recallPart({
   const target = allParts.find(p => p.partIndex === partIndex);
 
   if (!target) {
-    throw new Error(
-      `Part index ${partIndex} not found in message ${cursor}. Available indices: ${allParts.map(p => p.partIndex).join(', ')}`,
-    );
+    const availableIndices = allParts.map(p => p.partIndex).join(', ');
+    const highestVisiblePartIndex = Math.max(...allParts.map(p => p.partIndex));
+
+    if (partIndex > highestVisiblePartIndex) {
+      const nextMessage = await getNextVisibleMessage({
+        memory,
+        threadId,
+        resourceId,
+        after: resolved.createdAt,
+      });
+
+      if (nextMessage) {
+        const nextParts = formatMessageParts(nextMessage, 'high');
+        const firstNextPart = nextParts[0];
+
+        if (firstNextPart) {
+          const fallbackNote = `Part index ${partIndex} not found in message ${cursor}; showing partIndex ${firstNextPart.partIndex} from next message ${firstNextPart.messageId}.\n\n`;
+          const fallbackText = `${fallbackNote}${firstNextPart.text}`;
+          const truncatedText = truncateStringByTokens(fallbackText, maxTokens);
+          const wasTruncated = truncatedText !== fallbackText;
+
+          return {
+            text: truncatedText,
+            messageId: firstNextPart.messageId,
+            partIndex: firstNextPart.partIndex,
+            role: firstNextPart.role,
+            type: firstNextPart.type,
+            truncated: wasTruncated,
+          };
+        }
+      }
+    }
+
+    throw new Error(`Part index ${partIndex} not found in message ${cursor}. Available indices: ${availableIndices}`);
   }
 
   const truncatedText = truncateStringByTokens(target.text, maxTokens);
@@ -695,7 +805,11 @@ export async function recallMessages({
   const normalizedPage = Math.max(Math.min(rawPage, MAX_PAGE), -MAX_PAGE);
   const normalizedLimit = Math.min(limit, MAX_LIMIT);
 
-  const resolved = await resolveCursorMessage(memory, cursor, { resourceId, threadScope });
+  const resolved = await resolveCursorMessage(memory, cursor, {
+    resourceId,
+    threadScope,
+    enforceThreadScope: false,
+  });
 
   if ('hint' in resolved) {
     return {
@@ -713,10 +827,11 @@ export async function recallMessages({
   }
 
   const anchor = resolved;
+  const crossThreadId = anchor.threadId && anchor.threadId !== threadId ? anchor.threadId : undefined;
 
-  if (anchor.threadId && anchor.threadId !== threadId) {
+  if (crossThreadId && threadScope) {
     return {
-      messages: `Cursor does not belong to the active thread. Expected thread "${threadId}" but cursor "${cursor}" belongs to "${anchor.threadId}".`,
+      messages: `Cursor does not belong to the active thread. Expected thread "${threadId}" but cursor "${cursor}" belongs to "${anchor.threadId}". Pass threadId="${anchor.threadId}" to browse that thread, or omit threadId and use this cursor directly in resource scope.`,
       count: 0,
       cursor,
       page: normalizedPage,
@@ -729,7 +844,10 @@ export async function recallMessages({
     };
   }
 
-  const resolvedThreadId = threadId;
+  const resolvedThreadId = crossThreadId ?? threadId;
+  if (!resolvedThreadId) {
+    throw new Error('Thread ID is required for recall');
+  }
 
   const isForward = normalizedPage > 0;
   const pageIndex = Math.max(Math.abs(normalizedPage), 1) - 1;
@@ -1139,7 +1257,27 @@ export const recallTool = (
       }
 
       if (hasCursor && !hasExplicitThreadId && !currentThreadId) {
-        throw new Error('Current thread is required when browsing by cursor');
+        if (!isResourceScope) {
+          throw new Error('Current thread is required when browsing by cursor');
+        }
+
+        const resolved = await resolveCursorMessage(memory, cursor!, { resourceId });
+        if ('hint' in resolved) {
+          return {
+            messages: resolved.hint,
+            count: 0,
+            cursor: cursor!,
+            page: page ?? 1,
+            limit: Math.min(limit ?? 20, 20),
+            detail: detail ?? 'low',
+            hasNextPage: false,
+            hasPrevPage: false,
+            truncated: false,
+            tokenOffset: 0,
+          };
+        }
+
+        targetThreadId = resolved.threadId;
       }
 
       if (!targetThreadId) {


### PR DESCRIPTION
This makes the recall tool a bit more forgiving when agents browse raw messages.

Before:
```ts
await recall({ detail: 'high', cursor, partIndex: 99 })
// Error: Part index 99 not found...
```

After:
```ts
await recall({ detail: 'high', cursor, partIndex: 99 })
// returns partIndex 0 from the next visible message
```

It also improves resource-scope cursor browsing when direct message lookup misses, so cursor-only recall is more likely to recover the intended message instead of failing early.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced message recall to gracefully handle invalid part indices by falling back to the next visible message, enabling uninterrupted browsing.
  * Added support for cross-thread message cursors in resource scope, allowing seamless browsing across thread boundaries.

* **Bug Fixes**
  * Improved error messaging in strict thread scope mode with actionable guidance for cursor usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->