### PR TITLE
fix: prevent mastra build from hanging during bun dependency installation

### DIFF
--- a/.changeset/flat-llamas-cross.md
+++ b/.changeset/flat-llamas-cross.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'@mastra/deployer-cloud': patch
+---
+
+Fixed `mastra build` hanging sporadically during dependency installation when using bun. The child process stdin was left as an open pipe, causing bun to block when it attempted to read from stdin. Also fixed a potential crash (ERR_STREAM_WRITE_AFTER_END) when both stdout and stderr piped to a shared stream.

--- a/deployers/cloud/src/utils/execa.ts
+++ b/deployers/cloud/src/utils/execa.ts
@@ -36,6 +36,7 @@ export async function runWithExeca({
   try {
     const subprocess = execa(cmd, args, {
       cwd,
+      stdin: 'ignore',
       env: {
         ...process.env,
         ...env,
@@ -49,8 +50,10 @@ export async function runWithExeca({
     subprocess.stderr?.pipe(pinoStream, { end: false });
 
     const { stdout, stderr, exitCode } = await subprocess;
+    pinoStream.end();
     return { stdout, stderr, success: exitCode === 0 };
   } catch (error) {
+    pinoStream.end();
     logger.error('Process failed', { error });
     return { success: false, error: error instanceof Error ? error : new Error(String(error)) };
   }

--- a/deployers/cloud/src/utils/execa.ts
+++ b/deployers/cloud/src/utils/execa.ts
@@ -1,12 +1,12 @@
 import { createRequire } from 'node:module';
-import { Transform } from 'node:stream';
+import { Writable } from 'node:stream';
 import { execa } from 'execa';
 import { PROJECT_ENV_VARS, PROJECT_ROOT } from './constants.js';
 import { logger } from './logger.js';
 
 export const createPinoStream = () => {
-  return new Transform({
-    transform(chunk, encoding, callback) {
+  return new Writable({
+    write(chunk, _encoding, callback) {
       // Convert Buffer/string to string and trim whitespace
       const line = chunk.toString().trim();
 
@@ -15,8 +15,7 @@ export const createPinoStream = () => {
         logger.info(line);
       }
 
-      // Pass through the original data
-      callback(null, chunk);
+      callback();
     },
   });
 };
@@ -43,9 +42,11 @@ export async function runWithExeca({
       },
     });
 
-    // Pipe stdout and stderr through the Pino stream
-    subprocess.stdout?.pipe(pinoStream);
-    subprocess.stderr?.pipe(pinoStream);
+    // Pipe stdout and stderr through the logging stream.
+    // { end: false } prevents the first stream to close from ending pinoStream
+    // while the other may still be writing.
+    subprocess.stdout?.pipe(pinoStream, { end: false });
+    subprocess.stderr?.pipe(pinoStream, { end: false });
 
     const { stdout, stderr, exitCode } = await subprocess;
     return { stdout, stderr, success: exitCode === 0 };

--- a/packages/deployer/src/deploy/log.ts
+++ b/packages/deployer/src/deploy/log.ts
@@ -1,10 +1,10 @@
 import { spawn } from 'node:child_process';
-import { Transform } from 'node:stream';
+import { Writable } from 'node:stream';
 import type { IMastraLogger } from '@mastra/core/logger';
 
 export const createPinoStream = (logger: IMastraLogger) => {
-  return new Transform({
-    transform(chunk, _encoding, callback) {
+  return new Writable({
+    write(chunk, _encoding, callback) {
       // Convert Buffer/string to string and trim whitespace
       const line = chunk.toString().trim();
 
@@ -14,8 +14,7 @@ export const createPinoStream = (logger: IMastraLogger) => {
         logger.info(line);
       }
 
-      // Pass through the original data
-      callback(null, chunk);
+      callback();
     },
   });
 };
@@ -28,11 +27,15 @@ export function createChildProcessLogger({ logger, root }: { logger: IMastraLogg
         cwd: root,
         shell: true,
         env,
+        // No stdin for the child process — it doesn't need interactive input
+        stdio: ['ignore', 'pipe', 'pipe'],
       });
 
-      // Pipe stdout and stderr through the Pino stream
-      subprocess.stdout?.pipe(pinoStream);
-      subprocess.stderr?.pipe(pinoStream);
+      // Pipe stdout and stderr through the logging stream.
+      // { end: false } prevents the first stream to close from ending pinoStream
+      // while the other may still be writing.
+      subprocess.stdout?.pipe(pinoStream, { end: false });
+      subprocess.stderr?.pipe(pinoStream, { end: false });
 
       // Wait for the process to complete
       return new Promise((resolve, reject) => {

--- a/packages/deployer/src/validator/validate.ts
+++ b/packages/deployer/src/validator/validate.ts
@@ -31,7 +31,7 @@ function spawn(command: string, args: string[] = [], options: SpawnOptions = {})
   return new Promise((resolve, reject) => {
     let validationError: ValidationArgs | null = null;
     const childProcess = nodeSpawn(command, args, {
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['ignore', 'ignore', 'pipe'],
       ...options,
     });
 

--- a/packages/deployer/src/validator/validate.ts
+++ b/packages/deployer/src/validator/validate.ts
@@ -31,7 +31,7 @@ function spawn(command: string, args: string[] = [], options: SpawnOptions = {})
   return new Promise((resolve, reject) => {
     let validationError: ValidationArgs | null = null;
     const childProcess = nodeSpawn(command, args, {
-      // stdio: 'inherit',
+      stdio: ['ignore', 'pipe', 'pipe'],
       ...options,
     });
 


### PR DESCRIPTION
## Description

`mastra build` hangs ~30% of the time at "Resolving dependencies" when using bun as the package manager.

**Root cause:** `spawn()` in `createChildProcessLogger` used default `stdio`, which sets stdin to `'pipe'`. This creates an open pipe that is never written to or closed. When `bun install` attempts to read from stdin (e.g. for trusted dependency prompts), it blocks forever waiting for input that never arrives.

**Secondary bug:** Both `stdout` and `stderr` were piped to the same `Transform` stream with default `{ end: true }`. The first stream to close would end the shared stream, causing `ERR_STREAM_WRITE_AFTER_END` when the other stream tried to write.

## Related Issue(s)

Fixes #14871

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sporadic hangs during dependency installation in mastra build with bun.
  * Prevented runtime crashes from writes to streams after those streams have ended.
  * Improved process output handling to ensure subprocess output is captured and cleaned up reliably.

* **Chores**
  * Added release metadata for patch releases of deployer packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->