### PR TITLE
chore(docs): clarify `start()` vs `startAsync()` naming

### DIFF
--- a/docs/src/content/en/reference/client-js/workflows.mdx
+++ b/docs/src/content/en/reference/client-js/workflows.mdx
@@ -62,7 +62,7 @@ The `resourceId` parameter associates the workflow run with a specific resource 
 
 ### `startAsync()`
 
-Start a workflow run and wait for the full result. Despite the name, this method awaits completion and returns the workflow output:
+Start a workflow run and await its completion, returning the full result as the workflow output.
 
 ```typescript
 const run = await workflow.createRun()

--- a/docs/src/content/en/reference/client-js/workflows.mdx
+++ b/docs/src/content/en/reference/client-js/workflows.mdx
@@ -121,8 +121,6 @@ const result = await workflow.runById(run.runId)
 
 This is useful for long-running workflows where you want to start execution and check results later.
 
-> **Note:** The naming convention for `start()` and `startAsync()` in the client SDK differs from `@mastra/core`. In `@mastra/core`, `start()` waits for completion and `startAsync()` is fire-and-forget. In the client SDK, the behavior is reversed: `start()` is fire-and-forget and `startAsync()` waits for the result.
-
 ### `resumeAsync()`
 
 Resume a suspended workflow step and await the full result:

--- a/docs/src/content/en/reference/client-js/workflows.mdx
+++ b/docs/src/content/en/reference/client-js/workflows.mdx
@@ -62,7 +62,7 @@ The `resourceId` parameter associates the workflow run with a specific resource 
 
 ### `startAsync()`
 
-Start a workflow run and await the full result:
+Start a workflow run and wait for the full result. Despite the name, this method awaits completion and returns the workflow output:
 
 ```typescript
 const run = await workflow.createRun()
@@ -104,7 +104,7 @@ const result = await run.startAsync({
 
 ### `start()`
 
-Start a workflow run without waiting for completion:
+Start a workflow run without waiting for completion (fire-and-forget). Returns immediately with a success message. Use `runById()` on the workflow instance to check results later:
 
 ```typescript
 const run = await workflow.createRun()
@@ -120,6 +120,8 @@ const result = await workflow.runById(run.runId)
 ```
 
 This is useful for long-running workflows where you want to start execution and check results later.
+
+> **Note:** The naming convention for `start()` and `startAsync()` in the client SDK differs from `@mastra/core`. In `@mastra/core`, `start()` waits for completion and `startAsync()` is fire-and-forget. In the client SDK, the behavior is reversed: `start()` is fire-and-forget and `startAsync()` waits for the result.
 
 ### `resumeAsync()`
 


### PR DESCRIPTION
## Summary
Addresses the confusion reported in #14865 about `start()` and `startAsync()` method documentation for the client-js SDK.

After investigating the source code, the existing descriptions are actually correct for the client SDK — `startAsync()` waits for completion and `start()` is fire-and-forget. However, this naming is counterintuitive and reversed from `@mastra/core` behavior, which caused the confusion in the issue.

**Changes:**
- Added explicit clarification to `startAsync()` that it awaits completion despite the name
- Added explicit clarification to `start()` that it is fire-and-forget
- Added a note explaining that the naming convention differs between `@mastra/client-js` and `@mastra/core` (in core, `start()` waits and `startAsync()` is fire-and-forget)

## Why not swap the descriptions?
The issue suggested swapping the descriptions, but the docs are correct as-is for `@mastra/client-js`. The reporter was likely using `@mastra/core` directly (confirmed by their mention of `@mastra/core@1.17.0`), where the behavior is indeed reversed. Swapping the descriptions would make the client-js docs incorrect.

The `workflow.runById(run.runId)` reference is also valid — `runById` exists on the client SDK's `Workflow` class. It does not exist on `@mastra/core`'s `Workflow` class, which explains the reporter's `TypeError`.

## Issue
Fixes #14865

## Test plan
- Verified `start()` returns `Promise<{ message: string }>` in client-js source (`client-sdks/client-js/src/resources/run.ts`)
- Verified `startAsync()` returns `Promise<WorkflowRunResult>` in client-js source
- Verified `@mastra/core` has reversed behavior: `start()` awaits, `startAsync()` returns `{ runId }`
- Verified `runById()` exists on client-js `Workflow` class but not on core `Workflow` class
- Confirmed server endpoints match: `/start` is fire-and-forget, `/start-async` awaits result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that startAsync() waits for workflow completion and returns the full workflow result.
  * Clarified that start() is fire-and-forget, returning immediately with a success message.
  * Added guidance to use runById() to check workflow results later.
  * Noted naming/behavior differences from the core SDK for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->