### PR TITLE
fix: strip pnpm trust policy in verdaccio e2e setup

### DIFF
--- a/e2e-tests/_local-registry-setup/prepare.js
+++ b/e2e-tests/_local-registry-setup/prepare.js
@@ -96,6 +96,32 @@ function cleanup(monorepoDir, resetChanges = false) {
   }
 }
 
+function stripWorkspaceTrustPolicy(monorepoDir) {
+  const workspacePath = join(monorepoDir, 'pnpm-workspace.yaml');
+  const trustPolicySettings = [
+    'blockExoticSubdeps',
+    'trustPolicy',
+    'trustPolicyIgnoreAfter',
+  ];
+
+  try {
+    const content = readFileSync(workspacePath, 'utf8');
+    const nextContent = content
+      .split('\n')
+      .filter(line => !trustPolicySettings.some(setting => line.startsWith(`${setting}:`)))
+      .join('\n');
+
+    if (nextContent !== content) {
+      console.log('Removing pnpm trust-policy settings for local registry tests');
+      writeFileSync(workspacePath, nextContent);
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
 /**
  *
  * @param {string} monorepoDir
@@ -128,6 +154,8 @@ export async function prepareMonorepo(monorepoDir, glob, tag) {
       });
       shelvedChanges = true;
     }
+
+    stripWorkspaceTrustPolicy(monorepoDir);
 
     console.log('Updating workspace dependencies to use * instead of ^');
     await (async function updateWorkspaceDependencies() {

--- a/e2e-tests/_local-registry-setup/prepare.js
+++ b/e2e-tests/_local-registry-setup/prepare.js
@@ -98,11 +98,7 @@ function cleanup(monorepoDir, resetChanges = false) {
 
 function stripWorkspaceTrustPolicy(monorepoDir) {
   const workspacePath = join(monorepoDir, 'pnpm-workspace.yaml');
-  const trustPolicySettings = [
-    'blockExoticSubdeps',
-    'trustPolicy',
-    'trustPolicyIgnoreAfter',
-  ];
+  const trustPolicySettings = ['blockExoticSubdeps', 'trustPolicy', 'trustPolicyIgnoreAfter'];
 
   try {
     const content = readFileSync(workspacePath, 'utf8');

--- a/e2e-tests/create-mastra/create-mastra.test.ts
+++ b/e2e-tests/create-mastra/create-mastra.test.ts
@@ -21,11 +21,17 @@ describe('create mastra', () => {
 
       fixturePath = await mkdtemp(join(tmpdir(), 'mastra-create-test-'));
       projectPath = join(fixturePath, 'project');
-      process.env.npm_config_registry = registry;
-      execSync(`pnpm dlx create-mastra@${tag} -c agents,tools,workflows,scorers -l openai -e project`, {
-        cwd: fixturePath,
-        stdio: ['inherit', 'inherit', 'inherit'],
-      });
+      execSync(
+        `pnpm --config.trust-policy=off --config.block-exotic-subdeps=false dlx create-mastra@${tag} -c agents,tools,workflows,scorers -l openai -e project`,
+        {
+          cwd: fixturePath,
+          stdio: ['inherit', 'inherit', 'inherit'],
+          env: {
+            ...process.env,
+            npm_config_registry: registry,
+          },
+        },
+      );
     },
     10 * 60 * 1000,
   );

--- a/packages/playground-ui/src/domains/agents/hooks/use-agent-trace-scores.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-agent-trace-scores.ts
@@ -24,7 +24,6 @@ export function useAgentTraceScores({ agentId, scorerId, enabled }: UseAgentTrac
       let page = 0;
       const scores: ScoreRecord[] = [];
 
-      // eslint-disable-next-line no-constant-condition
       while (true) {
         const res = await client.listScores({
           filters: {


### PR DESCRIPTION
## Summary
- strip pnpm trust-policy settings from the temporary monorepo copy used by Verdaccio E2E setup
- run the cleanup before snapshot versioning and package publishing so fixture installs use the pre-policy behavior
- keep the change centralized in the shared local registry preparation path used by the Verdaccio suites

## Test plan
- pnpm --filter ./e2e-tests/workspace-compat test *(assertions pass; suite still hits an existing afterAll hook timeout during teardown)*
- cd e2e-tests/workspace-tools && pnpm install --ignore-workspace && pnpm test *(setup reaches the new trust-policy stripping path; suite still fails on the existing optional dependency gating assertion for @ast-grep/napi)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test setup now strips workspace trust policy entries before runs and ignores missing workspace manifests while surfacing other I/O errors.
* **Tests**
  * Test tooling supplies the registry via an explicit environment object and passes CLI flags to disable trust policy and exotic subdependency blocking.
* **Style**
  * Removed a linter suppression comment in a pagination hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->