### PR TITLE
fix(editor): preserve code defaults when no published version exists

### DIFF
--- a/.changeset/fix-agent-version-published-default.md
+++ b/.changeset/fix-agent-version-published-default.md
@@ -1,0 +1,5 @@
+---
+'@mastra/editor': patch
+---
+
+Code-defined agents no longer get overridden with draft version data when no version has been explicitly published. When requesting `published` status and no `activeVersionId` is set, the agent's code defaults are preserved instead of falling back to the latest draft.

--- a/packages/editor/src/apply-stored-overrides.test.ts
+++ b/packages/editor/src/apply-stored-overrides.test.ts
@@ -221,4 +221,19 @@ describe('applyStoredOverrides', () => {
     const instructions = await result.getInstructions();
     expect(instructions).toBe('Specific version instructions.');
   });
+
+  it('preserves code defaults when status is "published" but no version has been published', async () => {
+    // Setup creates a stored agent but does NOT set activeVersionId
+    const { editor, codeAgent } = await setup({
+      name: 'Stored Draft',
+      instructions: 'Stored draft instructions.',
+      model: { provider: 'openai', name: 'gpt-4o' },
+    });
+
+    // Request published status — but no activeVersionId exists, so code defaults should be used
+    const result = await editor.agent.applyStoredOverrides(codeAgent, { status: 'published' });
+    expect(result).toBe(codeAgent);
+    const instructions = await result.getInstructions();
+    expect(instructions).toBe('You are a code-defined agent.');
+  });
 });

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -221,6 +221,14 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
       return agent;
     }
 
+    // If requesting published status but no version has been published, don't override the code-defined agent
+    const requestedPublished = options && !('versionId' in options) && options.status === 'published';
+    if (requestedPublished && !storedConfig.activeVersionId) {
+      this.restoreCodeDefaults(agent);
+      this.clearResolvedVersionId(agent);
+      return agent;
+    }
+
     // Save the original code-defined values before first override,
     // then restore to a clean state before re-applying (so updated stored configs work correctly)
     this.saveCodeDefaults(agent);


### PR DESCRIPTION
When a code-defined agent has no published version (`activeVersionId` is unset), `applyStoredOverrides` was falling back to the latest draft via `resolveEntity`, causing the generate endpoint to return draft data instead of the code defaults.

Now, if `status: 'published'` is requested but no `activeVersionId` exists, code defaults are preserved:

Includes a test covering this scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed an issue where code-defined agents were incorrectly overridden by draft version data instead of preserving their code-defined defaults when no published version has been explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->