### PR TITLE
fix(core): use correct ModelMessage type for sub-agent context casts

### DIFF
--- a/.changeset/swift-mirrors-relax.md
+++ b/.changeset/swift-mirrors-relax.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed incorrect type cast for sub-agent context messages. The context option for new API methods (generate, stream, resumeGenerate, resumeStream) now correctly casts to ModelMessage[] instead of CoreMessage[].

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { TextPart, UIMessage } from '@internal/ai-sdk-v4';
+import type { ModelMessage } from '@internal/ai-sdk-v5';
 import { wrapSchemaWithNullTransform } from '@mastra/schema-compat';
 import type { StandardSchemaWithJSON } from '@mastra/schema-compat/schema';
 import type { JSONSchema7 } from 'json-schema';
@@ -3039,7 +3040,7 @@ export class Agent<
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
                       ...(effectiveMaxSteps && { maxSteps: effectiveMaxSteps }),
-                      context: filteredContextMessages as unknown as CoreMessage[],
+                      context: filteredContextMessages as unknown as ModelMessage[],
                       ...(resourceId && threadId && !subAgentHasOwnMemoryConfig
                         ? {
                             memory: {
@@ -3055,7 +3056,7 @@ export class Agent<
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
                       ...(effectiveMaxSteps && { maxSteps: effectiveMaxSteps }),
-                      context: filteredContextMessages as unknown as CoreMessage[],
+                      context: filteredContextMessages as unknown as ModelMessage[],
                       ...(resourceId && threadId && !subAgentHasOwnMemoryConfig
                         ? {
                             memory: {
@@ -3142,7 +3143,7 @@ export class Agent<
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
                       ...(effectiveMaxSteps && { maxSteps: effectiveMaxSteps }),
-                      context: filteredContextMessages as unknown as CoreMessage[],
+                      context: filteredContextMessages as unknown as ModelMessage[],
                       ...(resourceId && threadId && !subAgentHasOwnMemoryConfig
                         ? {
                             memory: {
@@ -3160,7 +3161,7 @@ export class Agent<
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
                       ...(effectiveMaxSteps && { maxSteps: effectiveMaxSteps }),
-                      context: filteredContextMessages as unknown as CoreMessage[],
+                      context: filteredContextMessages as unknown as ModelMessage[],
                       ...(resourceId && threadId && !subAgentHasOwnMemoryConfig
                         ? {
                             memory: {


### PR DESCRIPTION
Follows up on #13881. The sub-agent context casts were using `CoreMessage[]` for all call sites, but the new API methods (`generate`, `stream`, `resumeGenerate`, `resumeStream`) expect `ModelMessage[]`. The legacy API (`generateLegacy`) correctly expects `CoreMessage[]` and is left as-is.

Before:
```ts
context: filteredContextMessages as unknown as CoreMessage[]  // wrong for new API
```

After:
```ts
context: filteredContextMessages as unknown as ModelMessage[]  // new API (4 sites)
context: filteredContextMessages as unknown as CoreMessage[]   // legacy API (1 site, unchanged)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type handling for sub-agent context messages in agent API methods (generate, stream, resumeGenerate, resumeStream) for improved compatibility with v2 and v3 models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->