### PR TITLE
fix(core): improve list_files pattern description to prevent LLM misuse of "*"

### DIFF
--- a/.changeset/few-cobras-lick.md
+++ b/.changeset/few-cobras-lick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved the `pattern` field description in the `list_files` workspace tool to prevent AI models from passing `"*"` when they intend to match all files. The description now clarifies that omitting `pattern` lists all files, that `*` only matches within a single directory level (standard glob), and that glob patterns only filter files while directories are always shown.

--- a/packages/core/src/workspace/tools/list-files.ts
+++ b/packages/core/src/workspace/tools/list-files.ts
@@ -18,7 +18,9 @@ Examples:
 - Exclude node_modules: { path: ".", exclude: "node_modules" }
 - Find TypeScript files: { path: "src", pattern: "**/*.ts" }
 - Find config files: { path: ".", pattern: "*.config.{js,ts}" }
-- Multiple patterns: { path: ".", pattern: ["**/*.ts", "**/*.tsx"] }`,
+- Multiple patterns: { path: ".", pattern: ["**/*.ts", "**/*.tsx"] }
+
+To list ALL files, omit the pattern parameter — do NOT pass pattern: "*".`,
   inputSchema: z.object({
     path: z.string().default('.').describe('Directory path to list'),
     maxDepth: z
@@ -42,7 +44,7 @@ Examples:
       .union([z.string(), z.array(z.string())])
       .optional()
       .describe(
-        'Glob pattern(s) to filter files. Examples: "**/*.ts", "src/**/*.test.ts", "*.config.{js,ts}". Directories always pass through.',
+        'Glob pattern(s) to filter files. Omit this parameter to list all files (do NOT pass "*"). Use "**/*.ext" to match files recursively across directories. "*" only matches within a single directory level (standard glob). Glob patterns only filter files — directories are always shown to preserve tree structure. Examples: "**/*.ts", "src/**/*.test.ts", "*.config.{js,ts}".',
       ),
     respectGitignore: z
       .boolean()


### PR DESCRIPTION
## Summary

Alternative fix for #14823 (see #14830 for the other approach).

## Problem

LLMs pass `pattern: "*"` to `list_files` expecting it to match all files, but `*` is a standard glob that only matches within a single directory level — it doesn't cross `/` boundaries. This causes `subdir/file.txt` to be silently excluded, resulting in "N directories, 0 files".

## Why not rewrite `*` → `**/*`?

PR #14830 silently normalizes bare `*` to `**/*` before compiling the glob matcher. This changes standard glob semantics and **breaks the valid use case** of matching only top-level files with `*`. The glob engine is working correctly — the issue is that the tool description doesn't guide LLMs well enough.

## Fix

Improve the tool description and the `pattern` field's `.describe()` to steer LLMs:
- Explicitly state to **omit `pattern`** to list all files (do NOT pass `"*"`)
- Clarify that `*` only matches within a single directory level (standard glob)
- Recommend `**/*.ext` for recursive matching
- Reword "Directories always pass through" to the clearer "Glob patterns only filter files — directories are always shown to preserve tree structure"

## Changes
- `packages/core/src/workspace/tools/list-files.ts` — description updates only, no behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified file-listing tool docs: omitting the pattern lists all files; "*" matches only within a single directory level; glob patterns filter files while directories are always included to preserve tree structure; added examples and clearer wording, including guidance for recursive patterns (e.g., "**/*.ext").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->