### PR TITLE
fix(core): forward providerMetadata on tool-call events in generate-to-stream

### DIFF
--- a/.changeset/new-buckets-dress.md
+++ b/.changeset/new-buckets-dress.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed providerMetadata (e.g. Gemini's thoughtSignature) being stripped from tool-call events when using the non-streaming (generate) code path

--- a/packages/core/src/llm/model/aisdk/generate-to-stream.test.ts
+++ b/packages/core/src/llm/model/aisdk/generate-to-stream.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { createStreamFromGenerateResult } from './generate-to-stream';
+
+async function collectStream(stream: ReadableStream): Promise<unknown[]> {
+  const reader = stream.getReader();
+  const chunks: unknown[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return chunks;
+}
+
+describe('createStreamFromGenerateResult', () => {
+  it('should forward providerMetadata on tool-call stream events', async () => {
+    const providerMetadata = {
+      google: { thoughtSignature: 'sig_abc123' },
+    };
+
+    const result = {
+      warnings: [],
+      response: { id: 'resp_1', modelId: 'gemini-2.5-flash', timestamp: new Date() },
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'myTool',
+          input: '{"arg":"value"}',
+          providerMetadata,
+        },
+      ],
+      finishReason: 'tool-calls',
+      usage: { promptTokens: 10, completionTokens: 5 },
+    };
+
+    const chunks = await collectStream(createStreamFromGenerateResult(result));
+
+    const toolInputStart = chunks.find((c: any) => c.type === 'tool-input-start') as any;
+    expect(toolInputStart).toBeDefined();
+    expect(toolInputStart.providerMetadata).toEqual(providerMetadata);
+
+    const toolInputDelta = chunks.find((c: any) => c.type === 'tool-input-delta') as any;
+    expect(toolInputDelta).toBeDefined();
+    expect(toolInputDelta.providerMetadata).toEqual(providerMetadata);
+
+    const toolInputEnd = chunks.find((c: any) => c.type === 'tool-input-end') as any;
+    expect(toolInputEnd).toBeDefined();
+    expect(toolInputEnd.providerMetadata).toEqual(providerMetadata);
+
+    const toolCall = chunks.find((c: any) => c.type === 'tool-call') as any;
+    expect(toolCall).toBeDefined();
+    expect(toolCall.providerMetadata).toEqual(providerMetadata);
+  });
+
+  it('should handle tool-call without providerMetadata', async () => {
+    const result = {
+      warnings: [],
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call_2',
+          toolName: 'otherTool',
+          input: '{}',
+        },
+      ],
+      finishReason: 'tool-calls',
+      usage: { promptTokens: 5, completionTokens: 3 },
+    };
+
+    const chunks = await collectStream(createStreamFromGenerateResult(result));
+
+    const toolInputStart = chunks.find((c: any) => c.type === 'tool-input-start') as any;
+    expect(toolInputStart).toBeDefined();
+    expect(toolInputStart.providerMetadata).toBeUndefined();
+
+    const toolCall = chunks.find((c: any) => c.type === 'tool-call') as any;
+    expect(toolCall).toBeDefined();
+    expect(toolCall.providerMetadata).toBeUndefined();
+  });
+});

--- a/packages/core/src/llm/model/aisdk/generate-to-stream.ts
+++ b/packages/core/src/llm/model/aisdk/generate-to-stream.ts
@@ -39,6 +39,7 @@ export function createStreamFromGenerateResult(result: {
             input: unknown;
             providerExecuted?: boolean;
             dynamic?: boolean;
+            providerMetadata?: unknown;
           };
           toolCallMeta[toolCall.toolCallId] = { providerExecuted: toolCall.providerExecuted };
           controller.enqueue({
@@ -47,15 +48,18 @@ export function createStreamFromGenerateResult(result: {
             toolName: toolCall.toolName,
             providerExecuted: toolCall.providerExecuted,
             dynamic: toolCall.dynamic,
+            providerMetadata: toolCall.providerMetadata,
           });
           controller.enqueue({
             type: 'tool-input-delta',
             id: toolCall.toolCallId,
             delta: toolCall.input,
+            providerMetadata: toolCall.providerMetadata,
           });
           controller.enqueue({
             type: 'tool-input-end',
             id: toolCall.toolCallId,
+            providerMetadata: toolCall.providerMetadata,
           });
           controller.enqueue(toolCall);
         } else if (message.type === 'tool-result') {


### PR DESCRIPTION
Fixes https://github.com/mastra-ai/mastra/issues/14817

createStreamFromGenerateResult was stripping providerMetadata from tool-call events when converting a doGenerate result into a stream. This meant provider-specific metadata like Gemini thoughtSignature was lost during tool-call round-trips on the non-streaming path.

The type-narrowing cast for tool-call messages omitted providerMetadata, so it was never forwarded to the synthetic tool-input-start, tool-input-delta, and tool-input-end stream events. The streaming path (transform.ts) was already correct.

Added a test covering both the presence and absence of providerMetadata on tool-call stream events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider metadata being incorrectly removed from tool-call events in the non-streaming code path, ensuring metadata like Gemini's `thoughtSignature` is now properly preserved across all tool invocation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->