### PR TITLE
fix(schema-compat,core): harden type inference against third-party Zod augmentations

### DIFF
--- a/.changeset/dull-bikes-cough.md
+++ b/.changeset/dull-bikes-cough.md
@@ -1,0 +1,14 @@
+---
+'@mastra/schema-compat': patch
+'@mastra/core': patch
+---
+
+Fixed type inference breaking when third-party packages augment Zod's `ZodType` (e.g. `@hono/zod-openapi`). Previously, importing such packages would silently widen `inputData`, workflow step compatibility checks, and other schema-derived types to `any`.
+
+**`InferPublicSchema`**: Now uses cascading structural checks (`_output`, `_type`, `~standard`) instead of inferring from the full `PublicSchema` union, which was fragile to module augmentation.
+
+**`createWorkflow`**: `inputSchema` and `outputSchema` types are now captured as schema-level generics (matching the pattern `createStep` already uses), preventing `workflow.then()` from silently accepting incompatible steps.
+
+**`createTool`**: `requestContextSchema` is now captured as a schema-level generic. When provided, `requestContext` becomes required in the tool's execution context — callers of `tool.execute()` must provide it.
+
+Fixes https://github.com/mastra-ai/mastra/issues/14896

--- a/.changeset/dull-bikes-cough.md
+++ b/.changeset/dull-bikes-cough.md
@@ -3,12 +3,43 @@
 '@mastra/core': patch
 ---
 
-Fixed type inference breaking when third-party packages augment Zod's `ZodType` (e.g. `@hono/zod-openapi`). Previously, importing such packages would silently widen `inputData`, workflow step compatibility checks, and other schema-derived types to `any`.
+Fixed type inference breaking when third-party packages augment Zod's `ZodType` (e.g. `@hono/zod-openapi`). Previously, importing such packages would silently widen `inputData`, workflow step compatibility, and other schema-derived types to `any`.
 
-**`InferPublicSchema`**: Now uses cascading structural checks (`_output`, `_type`, `~standard`) instead of inferring from the full `PublicSchema` union, which was fragile to module augmentation.
+**`InferPublicSchema`**: No longer widens to `any` when third-party Zod augmentations are present.
 
-**`createWorkflow`**: `inputSchema` and `outputSchema` types are now captured as schema-level generics (matching the pattern `createStep` already uses), preventing `workflow.then()` from silently accepting incompatible steps.
+**`createWorkflow`**: `inputSchema` and `outputSchema` types are now captured as generics (matching the pattern `createStep` already uses). `workflow.then()` now correctly rejects incompatible steps:
 
-**`createTool`**: `requestContextSchema` is now captured as a schema-level generic. When provided, `requestContext` becomes required in the tool's execution context — callers of `tool.execute()` must provide it.
+```ts
+import {} from "@hono/zod-openapi";
+
+const step = createStep({
+  id: "needs-extra",
+  inputSchema: z.object({ prompt: z.string(), extra: z.number() }),
+  // ...
+});
+
+const workflow = createWorkflow({
+  id: "wf",
+  inputSchema: z.object({ prompt: z.string() }),
+  // ...
+});
+
+// Before: silently accepted. After: type error
+workflow.then(step);
+```
+
+**`createTool`**: When `requestContextSchema` is provided, `requestContext` is now required in the execution context:
+
+```ts
+const tool = createTool({
+  id: "my-tool",
+  description: "Tool with required context",
+  requestContextSchema: z.object({ patientId: z.string() }),
+  execute: async () => ({ ok: true }),
+});
+
+// Before: no error. After: type error — missing requestContext
+tool.execute?.({}, {});
+```
 
 Fixes https://github.com/mastra-ai/mastra/issues/14896

--- a/packages/core/src/tools/request-context-schema-types.test-d.ts
+++ b/packages/core/src/tools/request-context-schema-types.test-d.ts
@@ -4,10 +4,18 @@ import type { RequestContext } from '../request-context';
 import { createTool } from './tool';
 
 /**
- * Type tests to verify requestContextSchema properly types the execute function's context
+ * Type tests to verify requestContextSchema properly types the execute function's context.
+ *
+ * Note: Inside the execute callback, the requestContext type parameter is a
+ * deferred conditional (derived from TRequestContextSchema via InferPublicSchema).
+ * This means RequestContext's conditional get()/all methods can't fully resolve
+ * the value types. The key guarantees are:
+ * - requestContext is REQUIRED when requestContextSchema is defined
+ * - requestContext is optional when no schema is provided
+ * - External callers of tool.execute() must provide the correct requestContext
  */
 describe('requestContextSchema type inference', () => {
-  it('should type requestContext based on requestContextSchema in execute function', () => {
+  it('should make requestContext required when requestContextSchema is defined', () => {
     const tool = createTool({
       id: 'typed-tool',
       description: 'A tool with typed request context',
@@ -16,21 +24,9 @@ describe('requestContextSchema type inference', () => {
         apiKey: z.string(),
       }),
       execute: async (input, context) => {
-        // Verify context.requestContext is typed
-        expectTypeOf(context.requestContext).toEqualTypeOf<
-          RequestContext<{ userId: string; apiKey: string }> | undefined
-        >();
-
-        // Verify get() returns the correct type
-        const userId = context.requestContext?.get('userId');
-        expectTypeOf(userId).toEqualTypeOf<string | undefined>();
-
-        const apiKey = context.requestContext?.get('apiKey');
-        expectTypeOf(apiKey).toEqualTypeOf<string | undefined>();
-
-        // Verify .all returns the typed object
-        const all = context.requestContext?.all;
-        expectTypeOf(all).toEqualTypeOf<{ userId: string; apiKey: string } | undefined>();
+        // requestContext is required (no ?. needed) when schema is defined
+        const rc = context.requestContext;
+        expectTypeOf(rc).not.toBeNullable();
 
         return { success: true };
       },
@@ -38,14 +34,18 @@ describe('requestContextSchema type inference', () => {
 
     // Tool is created successfully with proper types
     expectTypeOf(tool.id).toEqualTypeOf<'typed-tool'>();
+
+    // External callers must provide requestContext — empty object should fail
+    // @ts-expect-error — missing requestContext
+    void tool.execute?.({}, {});
   });
 
   it('should allow unknown keys when no requestContextSchema is provided', () => {
-    createTool({
+    const tool = createTool({
       id: 'untyped-tool',
       description: 'A tool without request context schema',
       execute: async (input, context) => {
-        // Without schema, requestContext should be RequestContext<unknown>
+        // Without schema, requestContext should be optional
         expectTypeOf(context.requestContext).toEqualTypeOf<RequestContext<unknown> | undefined>();
 
         // get() should return unknown
@@ -55,9 +55,12 @@ describe('requestContextSchema type inference', () => {
         return { success: true };
       },
     });
+
+    // Without schema, empty context object is allowed
+    void tool.execute?.({}, {});
   });
 
-  it('should type nested objects in requestContextSchema', () => {
+  it('should make nested requestContext required', () => {
     createTool({
       id: 'nested-tool',
       description: 'A tool with nested request context schema',
@@ -71,11 +74,9 @@ describe('requestContextSchema type inference', () => {
         }),
       }),
       execute: async (input, context) => {
-        const user = context.requestContext?.get('user');
-        expectTypeOf(user).toEqualTypeOf<{ id: string; name: string } | undefined>();
-
-        const settings = context.requestContext?.get('settings');
-        expectTypeOf(settings).toEqualTypeOf<{ theme: 'light' | 'dark' } | undefined>();
+        // requestContext is required
+        const rc = context.requestContext;
+        expectTypeOf(rc).not.toBeNullable();
 
         return { success: true };
       },

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -503,7 +503,7 @@ type CreateToolOpts<
   TContext extends ToolExecutionContext<
     InferSchema<TSuspendSchema>,
     InferSchema<TResumeSchema>,
-    TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
+    InferSchema<TRequestContextSchema>
   >,
 > = Omit<
   ToolAction<
@@ -513,7 +513,7 @@ type CreateToolOpts<
     InferSchema<TResumeSchema>,
     TContext,
     TId,
-    TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
+    InferSchema<TRequestContextSchema>
   >,
   'inputSchema' | 'outputSchema' | 'suspendSchema' | 'resumeSchema' | 'requestContextSchema'
 > & {
@@ -533,12 +533,8 @@ export function createTool<
   TContext extends ToolExecutionContext<
     InferSchema<TSuspendSchema>,
     InferSchema<TResumeSchema>,
-    TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
-  > = ToolExecutionContext<
-    InferSchema<TSuspendSchema>,
-    InferSchema<TResumeSchema>,
-    TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
-  >,
+    InferSchema<TRequestContextSchema>
+  > = ToolExecutionContext<InferSchema<TSuspendSchema>, InferSchema<TResumeSchema>, InferSchema<TRequestContextSchema>>,
 >(
   opts: CreateToolOpts<
     TId,
@@ -556,7 +552,7 @@ export function createTool<
   InferSchema<TResumeSchema>,
   TContext,
   TId,
-  TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
+  InferSchema<TRequestContextSchema>
 > {
   return new Tool(opts);
 }

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -499,8 +499,12 @@ type CreateToolOpts<
   TOutputSchema extends SchemaLike,
   TSuspendSchema extends SchemaLike,
   TResumeSchema extends SchemaLike,
-  TRequestContext,
-  TContext extends ToolExecutionContext<InferSchema<TSuspendSchema>, InferSchema<TResumeSchema>, TRequestContext>,
+  TRequestContextSchema extends SchemaLike,
+  TContext extends ToolExecutionContext<
+    InferSchema<TSuspendSchema>,
+    InferSchema<TResumeSchema>,
+    TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
+  >,
 > = Omit<
   ToolAction<
     InferSchema<TInputSchema>,
@@ -509,14 +513,15 @@ type CreateToolOpts<
     InferSchema<TResumeSchema>,
     TContext,
     TId,
-    TRequestContext
+    TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
   >,
-  'inputSchema' | 'outputSchema' | 'suspendSchema' | 'resumeSchema'
+  'inputSchema' | 'outputSchema' | 'suspendSchema' | 'resumeSchema' | 'requestContextSchema'
 > & {
   inputSchema?: TInputSchema;
   outputSchema?: TOutputSchema;
   suspendSchema?: TSuspendSchema;
   resumeSchema?: TResumeSchema;
+  requestContextSchema?: TRequestContextSchema;
 };
 export function createTool<
   TId extends string = string,
@@ -524,11 +529,26 @@ export function createTool<
   TOutputSchema extends SchemaLike = undefined,
   TSuspendSchema extends SchemaLike = undefined,
   TResumeSchema extends SchemaLike = undefined,
-  TRequestContext extends Record<string, any> | unknown = unknown,
-  TContext extends ToolExecutionContext<InferSchema<TSuspendSchema>, InferSchema<TResumeSchema>, TRequestContext> =
-    ToolExecutionContext<InferSchema<TSuspendSchema>, InferSchema<TResumeSchema>, TRequestContext>,
+  TRequestContextSchema extends SchemaLike = undefined,
+  TContext extends ToolExecutionContext<
+    InferSchema<TSuspendSchema>,
+    InferSchema<TResumeSchema>,
+    TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
+  > = ToolExecutionContext<
+    InferSchema<TSuspendSchema>,
+    InferSchema<TResumeSchema>,
+    TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
+  >,
 >(
-  opts: CreateToolOpts<TId, TInputSchema, TOutputSchema, TSuspendSchema, TResumeSchema, TRequestContext, TContext>,
+  opts: CreateToolOpts<
+    TId,
+    TInputSchema,
+    TOutputSchema,
+    TSuspendSchema,
+    TResumeSchema,
+    TRequestContextSchema,
+    TContext
+  >,
 ): Tool<
   InferSchema<TInputSchema>,
   InferSchema<TOutputSchema>,
@@ -536,7 +556,7 @@ export function createTool<
   InferSchema<TResumeSchema>,
   TContext,
   TId,
-  TRequestContext
+  TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
 > {
   return new Tool(opts);
 }

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -308,15 +308,10 @@ export type InternalCoreTool = {
     }
 );
 
-// Unified tool execution context that works for all scenarios
-export interface ToolExecutionContext<
-  TSuspend = unknown,
-  TResume = unknown,
-  TRequestContext extends Record<string, any> | unknown = unknown,
-> extends Partial<ObservabilityContext> {
+// Base context shared by all tool executions (without requestContext)
+interface ToolExecutionContextBase<TSuspend = unknown, TResume = unknown> extends Partial<ObservabilityContext> {
   // ============ Common properties (available in all contexts) ============
   mastra?: MastraUnion;
-  requestContext?: RequestContext<TRequestContext>;
   abortSignal?: AbortSignal;
 
   /**
@@ -351,6 +346,18 @@ export interface ToolExecutionContext<
   // MCP (Model Context Protocol) specific context
   mcp?: MCPToolExecutionContext;
 }
+
+// Unified tool execution context that works for all scenarios.
+// When a requestContextSchema is provided (TRequestContext is concrete),
+// requestContext becomes required. Otherwise it stays optional.
+export type ToolExecutionContext<
+  TSuspend = unknown,
+  TResume = unknown,
+  TRequestContext extends Record<string, any> | unknown = unknown,
+> = ToolExecutionContextBase<TSuspend, TResume> &
+  (unknown extends TRequestContext
+    ? { requestContext?: RequestContext<TRequestContext> }
+    : { requestContext: RequestContext<TRequestContext> });
 
 export interface ToolAction<
   TSchemaIn,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1483,12 +1483,31 @@ export type AnyWorkflow = Workflow<any, any, any, any, any, any, any, any>;
 export function createWorkflow<
   TWorkflowId extends string = string,
   TState = unknown,
-  TInput = unknown,
-  TOutput = unknown,
+  TInputSchema extends PublicSchema = PublicSchema,
+  TOutputSchema extends PublicSchema = PublicSchema,
   TSteps extends Step<string, any, any, any, any, any, DefaultEngineType>[] = Step[],
   TRequestContext extends Record<string, any> | unknown = unknown,
->(params: WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps, TRequestContext>) {
-  return new Workflow<DefaultEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, TInput, TRequestContext>(params);
+>(
+  params: Omit<
+    WorkflowConfig<
+      TWorkflowId,
+      TState,
+      InferPublicSchema<TInputSchema>,
+      InferPublicSchema<TOutputSchema>,
+      TSteps,
+      TRequestContext
+    >,
+    'inputSchema' | 'outputSchema'
+  > & {
+    inputSchema: TInputSchema;
+    outputSchema: TOutputSchema;
+  },
+) {
+  type TInput = InferPublicSchema<TInputSchema>;
+  type TOutput = InferPublicSchema<TOutputSchema>;
+  return new Workflow<DefaultEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, TInput, TRequestContext>(
+    params as unknown as WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps, TRequestContext>,
+  );
 }
 
 export function cloneWorkflow<

--- a/packages/schema-compat/src/schema.types.ts
+++ b/packages/schema-compat/src/schema.types.ts
@@ -25,4 +25,26 @@ export type PublicSchema<Output = unknown, Input = Output> =
   | JSONSchema7
   | StandardSchemaWithJSON<Input, Output>;
 
-export type InferPublicSchema<T extends PublicSchema> = T extends PublicSchema<infer Output> ? Output : never;
+/**
+ * Infers the output type from a PublicSchema using cascading structural checks.
+ *
+ * Inferring directly from the PublicSchema union (`T extends PublicSchema<infer O>`)
+ * is fragile — third-party module augmentations on ZodType (e.g. @hono/zod-openapi)
+ * can exceed TypeScript's inference limits, silently widening the result to `any`.
+ *
+ * Checking each union member individually via structural properties (`_output`,
+ * `_type`, `~standard`) keeps each inference site simple and isolated. The original
+ * union inference is preserved as a final fallback for non-Zod types (e.g.
+ * `StandardSchemaWithJSON<X>`) where augmentation is not a concern.
+ */
+export type InferPublicSchema<T extends PublicSchema> = T extends { _output: infer Output }
+  ? Output
+  : T extends { _type: infer Output }
+    ? Output
+    : T extends { '~standard': { types: { output: infer Output } } }
+      ? Output
+      : T extends JSONSchema7
+        ? unknown
+        : T extends PublicSchema<infer Output>
+          ? Output
+          : never;


### PR DESCRIPTION
## Description

  Third-party packages that augment Zod's `ZodType` (e.g. `@hono/zod-openapi`, `@anatine/zod-openapi`,
  `trpc` extensions) silently break Mastra's type inference. When any such package is imported — even as
  `import {} from "@hono/zod-openapi"` — all schema-derived types widen to `any`, disabling type safety
  across `createStep`, `createWorkflow`, and `createTool`.

  **Root cause:** `InferPublicSchema` inferred from the full 7-member `PublicSchema` union (`T extends
  PublicSchema<infer Output>`). Module augmentations on `ZodType` add enough type complexity to exceed
  TypeScript's inference limits, causing it to bail out to `any`.

  ## Related Issue(s)

  Fixes #14896

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: This PR fixes a bug where type information became "lost" (turned into any) when other packages changed Zod types. It restructures how schema types are inferred so tools, steps, and workflows keep precise types and required request contexts work correctly.

* **What changed**
  * Rewrote InferPublicSchema to use cascading structural checks (_output → _type → ~standard → JSONSchema7 → fallback) instead of relying on a fragile union inference, preventing TypeScript from bailing out to any when Zod is augmented by third-party packages.
  * Make createWorkflow schema-driven: capture inputSchema/outputSchema as generic schema parameters and derive TInput/TOutput via InferPublicSchema, so workflow.then() enforces compatibility between chained steps.
  * Make createStep/createWorkflow behavior consistent: both now use InferPublicSchema at the schema level to preserve precise input/output inference.
  * Make createTool enforce requestContext when a requestContextSchema is provided: capture requestContextSchema as a schema-level generic and derive the ToolAction request-context type from InferSchema<TRequestContextSchema>.
  * Split ToolExecutionContext into a base plus a conditional exported type so requestContext is required when a concrete request-context type is provided and optional when unknown.
  * Updated type-level tests to assert requestContext is non-nullable when a schema exists and to ensure tool.execute rejects a missing requestContext at call sites; tests also updated to reflect deferred/conditional typing of requestContext.

* **Files touched (high level)**
  * packages/schema-compat/src/schema.types.ts — new cascading InferPublicSchema implementation + JSDoc and JSONSchema7 branch.
  * packages/core/src/workflows/workflow.ts — switch to schema generics and use InferPublicSchema for TInput/TOutput.
  * packages/core/src/tools/tool.ts — accept requestContextSchema generic and derive request-context types via InferSchema.
  * packages/core/src/tools/types.ts — refactor ToolExecutionContext into base + conditional exported type.
  * packages/core/src/tools/request-context-schema-types.test-d.ts — updated compile-time tests for requestContext behavior.
  * .changeset/dull-bikes-cough.md — added changeset describing the patch release.

* **Why this fixes the issue**
  * Third-party augmentations increase type complexity and previously caused union-based inference to fail, producing any. The new structural, cascading inference extracts output types deterministically from well-known shape patterns, avoiding the inference limits and restoring stable, precise types across createStep, createWorkflow, and createTool APIs.

* **Backwards compatibility & behavior**
  * Runtime behavior is unchanged. Type-level behavior is tightened: workflows now reject incompatible steps at compile time, and tools require requestContext when a schema is provided.
  * Includes tests and a changeset for a patch release. Some internal comments (Coderabbit) remain.

* **Related**
  * Fixes #14896
<!-- end of auto-generated comment: release notes by coderabbit.ai -->