### PR TITLE
feat: integrate Mastra Gateway with mastracode

### DIFF
--- a/.changeset/moody-camels-wear.md
+++ b/.changeset/moody-camels-wear.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Added /memory-gateway command to configure the Mastra Gateway for model routing through server.mastra.ai. When a gateway API key is set, all models route through the gateway with full support for Claude Max OAuth and OpenAI Codex OAuth (including middleware like instructions and reasoning effort). Gateway-backed providers now appear in onboarding packs and show as authenticated in the model picker.

--- a/.changeset/new-islands-itch.md
+++ b/.changeset/new-islands-itch.md
@@ -1,5 +1,10 @@
 ---
-'@mastra/core': patch
+'@mastra/core': minor
 ---
 
-Added runtime configuration support to MastraGateway (apiKey, baseUrl, customFetch). When a custom fetch function is provided, the gateway uses X-Mastra-Authorization for gateway auth, allowing OAuth tokens to be passed via the standard Authorization header.
+Added Memory Gateway support
+
+- `GATEWAY_AUTH_HEADER` — exported constant for the custom gateway authentication header (`X-Memory-Gateway-Authorization`)
+- `MastraGatewayConfig` — new type for configuring gateway instances with `apiKey`, `baseUrl`, and `customFetch`
+
+When a custom fetch function is provided, the gateway uses `X-Memory-Gateway-Authorization` for gateway auth, allowing OAuth tokens to be passed via the standard `Authorization` header.

--- a/.changeset/new-islands-itch.md
+++ b/.changeset/new-islands-itch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added runtime configuration support to MastraGateway (apiKey, baseUrl, customFetch). When a custom fetch function is provided, the gateway uses X-Mastra-Authorization for gateway auth, allowing OAuth tokens to be passed via the standard Authorization header.

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -96,6 +96,7 @@ vi.mock('@mastra/core/llm', () => ({
     this.baseUrl = config?.baseUrl;
     this.customFetch = config?.customFetch;
   }),
+  GATEWAY_AUTH_HEADER: 'X-Memory-Gateway-Authorization',
 }));
 
 const mockLoadSettings = vi.hoisted(() =>
@@ -369,7 +370,7 @@ describe('resolveModel', () => {
         }),
       );
       const opts = vi.mocked(createAnthropic).mock.calls[0]?.[0] as Record<string, unknown> | undefined;
-      expect((opts?.headers as Record<string, string>)?.['X-Mastra-Authorization']).toBe(
+      expect((opts?.headers as Record<string, string>)?.['X-Memory-Gateway-Authorization']).toBe(
         'Bearer msk_gateway_key_123',
       );
       // Should wrap with middleware
@@ -402,7 +403,7 @@ describe('resolveModel', () => {
         }),
       );
       const opts = vi.mocked(createOpenAI).mock.calls[0]?.[0] as Record<string, unknown> | undefined;
-      expect((opts?.headers as Record<string, string>)?.['X-Mastra-Authorization']).toBe(
+      expect((opts?.headers as Record<string, string>)?.['X-Memory-Gateway-Authorization']).toBe(
         'Bearer msk_gateway_key_123',
       );
       expect(buildOpenAICodexOAuthFetch).toHaveBeenCalledWith({

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -38,6 +38,15 @@ const mockCodexOAuthFetch = vi.hoisted(() => vi.fn());
 vi.mock('../../providers/openai-codex.js', () => ({
   openaiCodexProvider: vi.fn(() => ({ __provider: 'openai-codex' })),
   buildOpenAICodexOAuthFetch: vi.fn(() => mockCodexOAuthFetch),
+  createCodexMiddleware: vi.fn((effort?: string) => ({ __middleware: 'codex', effort })),
+  getEffectiveThinkingLevel: vi.fn((_modelId: string, level: string) => level),
+  THINKING_LEVEL_TO_REASONING_EFFORT: {
+    off: undefined,
+    low: 'low',
+    medium: 'medium',
+    high: 'high',
+    xhigh: 'xhigh',
+  },
 }));
 
 // Mock @ai-sdk/anthropic
@@ -115,6 +124,7 @@ vi.mock('../../onboarding/settings.js', () => ({
 }));
 
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
 import { MastraGateway, ModelRouterLanguageModel } from '@mastra/core/llm';
 import { wrapLanguageModel } from 'ai';
 import { opencodeClaudeMaxProvider, buildAnthropicOAuthFetch } from '../../providers/claude-max.js';
@@ -373,7 +383,7 @@ describe('resolveModel', () => {
       expect(opencodeClaudeMaxProvider).not.toHaveBeenCalled();
     });
 
-    it('routes openai OAuth model through gateway with customFetch and rewriteUrl: false', () => {
+    it('routes openai OAuth model directly with Codex middleware (bypasses ModelRouterLanguageModel)', () => {
       mockAuthStorageInstance.get.mockReturnValue({
         type: 'oauth',
         access: 'openai-oauth-access-token',
@@ -383,17 +393,30 @@ describe('resolveModel', () => {
 
       const result = resolveModel('openai/gpt-4o') as Record<string, unknown>;
 
-      expect(result.__provider).toBe('model-router');
-      expect(result.modelId).toBe('mastra/openai/gpt-4o');
+      // Should use createOpenAI directly, NOT go through ModelRouterLanguageModel
+      expect(createOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'oauth-gateway-placeholder',
+          baseURL: 'https://server.mastra.ai/v1',
+          fetch: mockCodexOAuthFetch,
+        }),
+      );
+      const opts = vi.mocked(createOpenAI).mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+      expect((opts?.headers as Record<string, string>)?.['X-Mastra-Authorization']).toBe(
+        'Bearer msk_gateway_key_123',
+      );
       expect(buildOpenAICodexOAuthFetch).toHaveBeenCalledWith({
         authStorage: expect.anything(),
         rewriteUrl: false,
       });
-      expect(MastraGateway).toHaveBeenCalledWith({
-        apiKey: 'msk_gateway_key_123',
-        customFetch: mockCodexOAuthFetch,
-      });
-      // Should NOT call the direct provider
+      // Should wrap with middleware
+      expect(wrapLanguageModel).toHaveBeenCalled();
+      expect(result.__wrapped).toBe(true);
+      expect(result.__provider).toBe('openai-direct');
+      expect(result.modelId).toBe('gpt-4o');
+      // Should NOT use ModelRouterLanguageModel or MastraGateway
+      expect(MastraGateway).not.toHaveBeenCalled();
+      expect(ModelRouterLanguageModel).not.toHaveBeenCalled();
       expect(openaiCodexProvider).not.toHaveBeenCalled();
     });
 
@@ -475,15 +498,29 @@ describe('resolveModel', () => {
       );
     });
 
-    it('skips gateway when no API key is stored', () => {
+    it('skips gateway when no API key is stored and no env var', () => {
       mockAuthStorageInstance.getStoredApiKey.mockReturnValue(undefined);
       mockAuthStorageInstance.get.mockReturnValue(undefined);
+      delete process.env['MASTRA_GATEWAY_API_KEY'];
 
       resolveModel('anthropic/claude-sonnet-4');
 
       expect(MastraGateway).not.toHaveBeenCalled();
       // Falls through to normal flow
       expect(opencodeClaudeMaxProvider).toHaveBeenCalled();
+    });
+
+    it('activates gateway via MASTRA_GATEWAY_API_KEY env var when AuthStorage is empty', () => {
+      mockAuthStorageInstance.getStoredApiKey.mockReturnValue(undefined);
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+      process.env['MASTRA_GATEWAY_API_KEY'] = 'msk_env_key';
+
+      const result = resolveModel('anthropic/claude-sonnet-4') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.modelId).toBe('mastra/anthropic/claude-sonnet-4');
+      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_env_key' });
+      delete process.env['MASTRA_GATEWAY_API_KEY'];
     });
   });
 });

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -9,6 +9,7 @@ vi.hoisted(() => vi.resetModules());
 const mockAuthStorageInstance = vi.hoisted(() => ({
   reload: vi.fn(),
   get: vi.fn(),
+  getStoredApiKey: vi.fn().mockReturnValue(undefined),
   isLoggedIn: vi.fn().mockReturnValue(false),
 }));
 
@@ -17,20 +18,26 @@ vi.mock('../../auth/storage.js', () => {
     AuthStorage: class MockAuthStorage {
       reload = mockAuthStorageInstance.reload;
       get = mockAuthStorageInstance.get;
+      getStoredApiKey = mockAuthStorageInstance.getStoredApiKey;
       isLoggedIn = mockAuthStorageInstance.isLoggedIn;
     },
   };
 });
 
 // Mock claude-max provider
+const mockAnthropicOAuthFetch = vi.hoisted(() => vi.fn());
 vi.mock('../../providers/claude-max.js', () => ({
   opencodeClaudeMaxProvider: vi.fn(() => ({ __provider: 'claude-max-oauth' })),
+  claudeCodeMiddleware: { specificationVersion: 'v3', transformParams: vi.fn() },
   promptCacheMiddleware: { specificationVersion: 'v3', transformParams: vi.fn() },
+  buildAnthropicOAuthFetch: vi.fn(() => mockAnthropicOAuthFetch),
 }));
 
 // Mock openai-codex provider
+const mockCodexOAuthFetch = vi.hoisted(() => vi.fn());
 vi.mock('../../providers/openai-codex.js', () => ({
   openaiCodexProvider: vi.fn(() => ({ __provider: 'openai-codex' })),
+  buildOpenAICodexOAuthFetch: vi.fn(() => mockCodexOAuthFetch),
 }));
 
 // Mock @ai-sdk/anthropic
@@ -59,23 +66,40 @@ vi.mock('ai', () => ({
   })),
 }));
 
-// Mock ModelRouterLanguageModel
+// Mock ModelRouterLanguageModel and MastraGateway
 vi.mock('@mastra/core/llm', () => ({
   ModelRouterLanguageModel: vi.fn(function (
     this: Record<string, unknown>,
     config: string | { id: string; url?: string; apiKey?: string; headers?: Record<string, string> },
+    customGateways?: unknown[],
   ) {
     this.__provider = 'model-router';
     this.modelId = typeof config === 'string' ? config : config.id;
     this.url = typeof config === 'string' ? undefined : config.url;
     this.apiKey = typeof config === 'string' ? undefined : config.apiKey;
     this.headers = typeof config === 'string' ? undefined : config.headers;
+    this.customGateways = customGateways;
+  }),
+  MastraGateway: vi.fn(function (
+    this: Record<string, unknown>,
+    config?: { apiKey?: string; baseUrl?: string; customFetch?: unknown },
+  ) {
+    this.__gateway = 'mastra';
+    this.apiKey = config?.apiKey;
+    this.baseUrl = config?.baseUrl;
+    this.customFetch = config?.customFetch;
   }),
 }));
 
 const mockLoadSettings = vi.hoisted(() =>
-  vi.fn<() => { customProviders: Array<{ name: string; url: string; apiKey?: string }> }>(() => ({
+  vi.fn<
+    () => {
+      customProviders: Array<{ name: string; url: string; apiKey?: string }>;
+      memoryGateway: { baseUrl?: string };
+    }
+  >(() => ({
     customProviders: [],
+    memoryGateway: {},
   })),
 );
 
@@ -86,10 +110,15 @@ vi.mock('../../onboarding/settings.js', () => ({
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-|-$/g, ''),
+  MEMORY_GATEWAY_PROVIDER: 'mastra-gateway',
+  MEMORY_GATEWAY_DEFAULT_URL: 'https://server.mastra.ai',
 }));
 
-import { opencodeClaudeMaxProvider } from '../../providers/claude-max.js';
-import { openaiCodexProvider } from '../../providers/openai-codex.js';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { MastraGateway, ModelRouterLanguageModel } from '@mastra/core/llm';
+import { wrapLanguageModel } from 'ai';
+import { opencodeClaudeMaxProvider, buildAnthropicOAuthFetch } from '../../providers/claude-max.js';
+import { openaiCodexProvider, buildOpenAICodexOAuthFetch } from '../../providers/openai-codex.js';
 import { resolveModel, getAnthropicApiKey, getOpenAIApiKey } from '../model.js';
 
 function makeRequestContext({ threadId, resourceId }: { threadId?: string; resourceId?: string } = {}) {
@@ -106,7 +135,8 @@ describe('resolveModel', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoadSettings.mockReturnValue({ customProviders: [] });
+    mockLoadSettings.mockReturnValue({ customProviders: [], memoryGateway: {} });
+    mockAuthStorageInstance.getStoredApiKey.mockReturnValue(undefined);
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.MOONSHOT_AI_API_KEY;
   });
@@ -274,6 +304,7 @@ describe('resolveModel', () => {
             apiKey: 'acme-secret',
           },
         ],
+        memoryGateway: {},
       });
 
       const result = resolveModel('acme/reasoner-v1', {
@@ -288,6 +319,171 @@ describe('resolveModel', () => {
         'x-thread-id': 'thread-123',
         'x-resource-id': 'resource-456',
       });
+    });
+  });
+
+  describe('memory gateway enabled (gateway API key stored)', () => {
+    beforeEach(() => {
+      mockAuthStorageInstance.getStoredApiKey.mockReturnValue('msk_gateway_key_123');
+    });
+
+    it('routes anthropic model through gateway with mastra/ prefix', () => {
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+      const result = resolveModel('anthropic/claude-sonnet-4') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.modelId).toBe('mastra/anthropic/claude-sonnet-4');
+      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123' });
+      expect(ModelRouterLanguageModel).toHaveBeenCalledWith(
+        { id: 'mastra/anthropic/claude-sonnet-4', headers: undefined },
+        [expect.objectContaining({ __gateway: 'mastra', apiKey: 'msk_gateway_key_123' })],
+      );
+    });
+
+    it('routes anthropic OAuth model directly with middleware (bypasses ModelRouterLanguageModel)', () => {
+      mockAuthStorageInstance.get.mockReturnValue({
+        type: 'oauth',
+        access: 'oauth-access-token',
+        refresh: 'oauth-refresh-token',
+        expires: Date.now() + 60_000,
+      });
+
+      const result = resolveModel('anthropic/claude-sonnet-4') as Record<string, unknown>;
+
+      // Should use createAnthropic directly, NOT go through ModelRouterLanguageModel
+      expect(createAnthropic).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'oauth-gateway-placeholder',
+          baseURL: 'https://server.mastra.ai/v1',
+          fetch: mockAnthropicOAuthFetch,
+        }),
+      );
+      const opts = vi.mocked(createAnthropic).mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+      expect((opts?.headers as Record<string, string>)?.['X-Mastra-Authorization']).toBe(
+        'Bearer msk_gateway_key_123',
+      );
+      // Should wrap with middleware
+      expect(wrapLanguageModel).toHaveBeenCalled();
+      expect(result.__wrapped).toBe(true);
+      expect(result.__provider).toBe('anthropic-direct');
+      expect(result.modelId).toBe('claude-sonnet-4');
+      // Should NOT use ModelRouterLanguageModel or MastraGateway
+      expect(MastraGateway).not.toHaveBeenCalled();
+      expect(ModelRouterLanguageModel).not.toHaveBeenCalled();
+      expect(opencodeClaudeMaxProvider).not.toHaveBeenCalled();
+    });
+
+    it('routes openai OAuth model through gateway with customFetch and rewriteUrl: false', () => {
+      mockAuthStorageInstance.get.mockReturnValue({
+        type: 'oauth',
+        access: 'openai-oauth-access-token',
+        refresh: 'openai-oauth-refresh-token',
+        expires: Date.now() + 60_000,
+      });
+
+      const result = resolveModel('openai/gpt-4o') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.modelId).toBe('mastra/openai/gpt-4o');
+      expect(buildOpenAICodexOAuthFetch).toHaveBeenCalledWith({
+        authStorage: expect.anything(),
+        rewriteUrl: false,
+      });
+      expect(MastraGateway).toHaveBeenCalledWith({
+        apiKey: 'msk_gateway_key_123',
+        customFetch: mockCodexOAuthFetch,
+      });
+      // Should NOT call the direct provider
+      expect(openaiCodexProvider).not.toHaveBeenCalled();
+    });
+
+    it('routes anthropic API key model through gateway without customFetch', () => {
+      mockAuthStorageInstance.get.mockReturnValue({ type: 'api_key', key: 'sk-stored-key' });
+
+      const result = resolveModel('anthropic/claude-sonnet-4') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.modelId).toBe('mastra/anthropic/claude-sonnet-4');
+      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123' });
+      expect(buildAnthropicOAuthFetch).not.toHaveBeenCalled();
+    });
+
+    it('routes unknown provider through gateway', () => {
+      const result = resolveModel('google/gemini-2.0-flash') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.modelId).toBe('mastra/google/gemini-2.0-flash');
+      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123' });
+    });
+
+    it('custom provider bypasses gateway', () => {
+      mockLoadSettings.mockReturnValue({
+        customProviders: [
+          { name: 'Acme', url: 'https://llm.acme.dev/v1', apiKey: 'acme-secret' },
+        ],
+        memoryGateway: {},
+      });
+
+      const result = resolveModel('acme/reasoner-v1') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('model-router');
+      expect(result.modelId).toBe('acme/reasoner-v1');
+      expect(result.url).toBe('https://llm.acme.dev/v1');
+      expect(MastraGateway).not.toHaveBeenCalled();
+    });
+
+    it('passes baseUrl when explicitly set in settings', () => {
+      mockLoadSettings.mockReturnValue({
+        customProviders: [],
+        memoryGateway: { baseUrl: 'https://custom-gateway.example.com' },
+      });
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+
+      resolveModel('anthropic/claude-sonnet-4');
+
+      expect(MastraGateway).toHaveBeenCalledWith({
+        apiKey: 'msk_gateway_key_123',
+        baseUrl: 'https://custom-gateway.example.com',
+      });
+    });
+
+    it('does not pass baseUrl when not set in settings', () => {
+      mockLoadSettings.mockReturnValue({
+        customProviders: [],
+        memoryGateway: {},
+      });
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+
+      resolveModel('anthropic/claude-sonnet-4');
+
+      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123' });
+    });
+
+    it('passes harness headers to ModelRouterLanguageModel', () => {
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+
+      resolveModel('anthropic/claude-sonnet-4', {
+        requestContext: makeRequestContext({ threadId: 'thread-123', resourceId: 'resource-456' }),
+      });
+
+      expect(ModelRouterLanguageModel).toHaveBeenCalledWith(
+        {
+          id: 'mastra/anthropic/claude-sonnet-4',
+          headers: { 'x-thread-id': 'thread-123', 'x-resource-id': 'resource-456' },
+        },
+        expect.any(Array),
+      );
+    });
+
+    it('skips gateway when no API key is stored', () => {
+      mockAuthStorageInstance.getStoredApiKey.mockReturnValue(undefined);
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+
+      resolveModel('anthropic/claude-sonnet-4');
+
+      expect(MastraGateway).not.toHaveBeenCalled();
+      // Falls through to normal flow
+      expect(opencodeClaudeMaxProvider).toHaveBeenCalled();
     });
   });
 });

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -344,7 +344,7 @@ describe('resolveModel', () => {
 
       expect(result.__provider).toBe('model-router');
       expect(result.modelId).toBe('mastra/anthropic/claude-sonnet-4');
-      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123' });
+      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123', baseUrl: 'https://server.mastra.ai' });
       expect(ModelRouterLanguageModel).toHaveBeenCalledWith(
         { id: 'mastra/anthropic/claude-sonnet-4', headers: undefined },
         [expect.objectContaining({ __gateway: 'mastra', apiKey: 'msk_gateway_key_123' })],
@@ -428,7 +428,7 @@ describe('resolveModel', () => {
 
       expect(result.__provider).toBe('model-router');
       expect(result.modelId).toBe('mastra/anthropic/claude-sonnet-4');
-      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123' });
+      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123', baseUrl: 'https://server.mastra.ai' });
       expect(buildAnthropicOAuthFetch).not.toHaveBeenCalled();
     });
 
@@ -437,7 +437,7 @@ describe('resolveModel', () => {
 
       expect(result.__provider).toBe('model-router');
       expect(result.modelId).toBe('mastra/google/gemini-2.0-flash');
-      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123' });
+      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123', baseUrl: 'https://server.mastra.ai' });
     });
 
     it('custom provider bypasses gateway', () => {
@@ -471,7 +471,7 @@ describe('resolveModel', () => {
       });
     });
 
-    it('does not pass baseUrl when not set in settings', () => {
+    it('uses default baseUrl when not set in settings', () => {
       mockLoadSettings.mockReturnValue({
         customProviders: [],
         memoryGateway: {},
@@ -480,7 +480,7 @@ describe('resolveModel', () => {
 
       resolveModel('anthropic/claude-sonnet-4');
 
-      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123' });
+      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_gateway_key_123', baseUrl: 'https://server.mastra.ai' });
     });
 
     it('passes harness headers to ModelRouterLanguageModel', () => {
@@ -520,7 +520,7 @@ describe('resolveModel', () => {
 
       expect(result.__provider).toBe('model-router');
       expect(result.modelId).toBe('mastra/anthropic/claude-sonnet-4');
-      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_env_key' });
+      expect(MastraGateway).toHaveBeenCalledWith({ apiKey: 'msk_env_key', baseUrl: 'https://server.mastra.ai' });
       delete process.env['MASTRA_GATEWAY_API_KEY'];
     });
   });

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -1,5 +1,3 @@
-import { RequestContext } from '@mastra/core/request-context';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Clear the module registry so vi.mock factories take effect even when
 // a previous test file (running under isolate:false) already cached the real modules.
@@ -126,7 +124,9 @@ vi.mock('../../onboarding/settings.js', () => ({
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import { MastraGateway, ModelRouterLanguageModel } from '@mastra/core/llm';
+import { RequestContext } from '@mastra/core/request-context';
 import { wrapLanguageModel } from 'ai';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { opencodeClaudeMaxProvider, buildAnthropicOAuthFetch } from '../../providers/claude-max.js';
 import { openaiCodexProvider, buildOpenAICodexOAuthFetch } from '../../providers/openai-codex.js';
 import { resolveModel, getAnthropicApiKey, getOpenAIApiKey } from '../model.js';

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -2,13 +2,18 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import type { LanguageModelV1 } from '@ai-sdk/provider';
 import type { HarnessRequestContext } from '@mastra/core/harness';
-import { ModelRouterLanguageModel } from '@mastra/core/llm';
+import { MastraGateway, ModelRouterLanguageModel } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';
 import { wrapLanguageModel } from 'ai';
 import { AuthStorage } from '../auth/storage.js';
-import { getCustomProviderId, loadSettings } from '../onboarding/settings.js';
-import { opencodeClaudeMaxProvider, promptCacheMiddleware } from '../providers/claude-max.js';
-import { openaiCodexProvider } from '../providers/openai-codex.js';
+import { getCustomProviderId, loadSettings, MEMORY_GATEWAY_PROVIDER } from '../onboarding/settings.js';
+import {
+  buildAnthropicOAuthFetch,
+  claudeCodeMiddleware,
+  opencodeClaudeMaxProvider,
+  promptCacheMiddleware,
+} from '../providers/claude-max.js';
+import { buildOpenAICodexOAuthFetch, openaiCodexProvider } from '../providers/openai-codex.js';
 import type { ThinkingLevel } from '../providers/openai-codex.js';
 
 const authStorage = new AuthStorage();
@@ -141,6 +146,51 @@ export function resolveModel(
       apiKey: customProvider.apiKey,
       headers,
     });
+  }
+
+  // --- Memory Gateway path ---
+  const mgApiKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER);
+  if (mgApiKey) {
+    const baseUrl = settings.memoryGateway?.baseUrl;
+    const gatewayBaseURL = `${baseUrl ?? process.env['MASTRA_GATEWAY_URL'] ?? 'https://server.mastra.ai'}/v1`;
+    const anthropicCred = authStorage.get('anthropic');
+    const openaiCred = authStorage.get('openai-codex');
+
+    // Anthropic OAuth: build model directly with middleware (bypasses ModelRouterLanguageModel)
+    // Required because claudeCodeMiddleware must inject the Claude Code identity system message
+    if (modelId.startsWith('anthropic/') && anthropicCred?.type === 'oauth') {
+      const bareModelId = modelId.substring('anthropic/'.length);
+      const anthropic = createAnthropic({
+        apiKey: 'oauth-gateway-placeholder',
+        baseURL: gatewayBaseURL,
+        headers: {
+          'X-Mastra-Authorization': `Bearer ${mgApiKey}`,
+          ...headers,
+        },
+        fetch: buildAnthropicOAuthFetch({ authStorage }) as any,
+      });
+      return wrapLanguageModel({
+        model: anthropic(bareModelId),
+        middleware: [claudeCodeMiddleware, promptCacheMiddleware],
+      });
+    }
+
+    // All other models: route through MastraGateway + ModelRouterLanguageModel
+    let customFetch: typeof globalThis.fetch | undefined;
+    if (modelId.startsWith('openai/') && openaiCred?.type === 'oauth') {
+      customFetch = buildOpenAICodexOAuthFetch({ authStorage, rewriteUrl: false });
+    }
+
+    const gateway = new MastraGateway({
+      apiKey: mgApiKey,
+      ...(baseUrl ? { baseUrl } : {}),
+      ...(customFetch ? { customFetch } : {}),
+    });
+
+    return new ModelRouterLanguageModel(
+      { id: `mastra/${modelId}` as `${string}/${string}`, headers },
+      [gateway],
+    );
   }
 
   const isAnthropicModel = modelId.startsWith('anthropic/');

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -2,7 +2,7 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import type { LanguageModelV1 } from '@ai-sdk/provider';
 import type { HarnessRequestContext } from '@mastra/core/harness';
-import { MastraGateway, ModelRouterLanguageModel } from '@mastra/core/llm';
+import { GATEWAY_AUTH_HEADER, MastraGateway, ModelRouterLanguageModel } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';
 import { wrapLanguageModel } from 'ai';
 import { AuthStorage } from '../auth/storage.js';
@@ -170,7 +170,7 @@ export function resolveModel(
         apiKey: 'oauth-gateway-placeholder',
         baseURL: gatewayBaseURL,
         headers: {
-          'X-Mastra-Authorization': `Bearer ${mgApiKey}`,
+          [GATEWAY_AUTH_HEADER]: `Bearer ${mgApiKey}`,
           ...headers,
         },
         fetch: buildAnthropicOAuthFetch({ authStorage }) as any,
@@ -195,7 +195,7 @@ export function resolveModel(
         apiKey: 'oauth-gateway-placeholder',
         baseURL: gatewayBaseURL,
         headers: {
-          'X-Mastra-Authorization': `Bearer ${mgApiKey}`,
+          [GATEWAY_AUTH_HEADER]: `Bearer ${mgApiKey}`,
           ...headers,
         },
         fetch: buildOpenAICodexOAuthFetch({ authStorage, rewriteUrl: false }) as any,

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -157,8 +157,10 @@ export function resolveModel(
   // --- Memory Gateway path ---
   const mgApiKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
   if (mgApiKey) {
-    const baseUrl = settings.memoryGateway?.baseUrl;
-    const gatewayBaseURL = `${baseUrl ?? process.env['MASTRA_GATEWAY_URL'] ?? 'https://server.mastra.ai'}/v1`;
+    // Normalize gateway base URL: strip trailing slashes and "/v1", then append "/v1"
+    const rawBase = settings.memoryGateway?.baseUrl ?? process.env['MASTRA_GATEWAY_URL'] ?? 'https://server.mastra.ai';
+    const gatewayBaseURL = rawBase.replace(/\/+$/, '').replace(/\/v1$/, '') + '/v1';
+
     const anthropicCred = authStorage.get('anthropic');
     const openaiCred = authStorage.get('openai-codex');
 
@@ -209,7 +211,7 @@ export function resolveModel(
     // All other models: route through MastraGateway + ModelRouterLanguageModel
     const gateway = new MastraGateway({
       apiKey: mgApiKey,
-      ...(baseUrl ? { baseUrl } : {}),
+      baseUrl: gatewayBaseURL.replace(/\/v1$/, ''),
     });
 
     return new ModelRouterLanguageModel(

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -13,7 +13,13 @@ import {
   opencodeClaudeMaxProvider,
   promptCacheMiddleware,
 } from '../providers/claude-max.js';
-import { buildOpenAICodexOAuthFetch, openaiCodexProvider } from '../providers/openai-codex.js';
+import {
+  buildOpenAICodexOAuthFetch,
+  createCodexMiddleware,
+  getEffectiveThinkingLevel,
+  openaiCodexProvider,
+  THINKING_LEVEL_TO_REASONING_EFFORT,
+} from '../providers/openai-codex.js';
 import type { ThinkingLevel } from '../providers/openai-codex.js';
 
 const authStorage = new AuthStorage();
@@ -149,7 +155,7 @@ export function resolveModel(
   }
 
   // --- Memory Gateway path ---
-  const mgApiKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER);
+  const mgApiKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
   if (mgApiKey) {
     const baseUrl = settings.memoryGateway?.baseUrl;
     const gatewayBaseURL = `${baseUrl ?? process.env['MASTRA_GATEWAY_URL'] ?? 'https://server.mastra.ai'}/v1`;
@@ -175,16 +181,35 @@ export function resolveModel(
       });
     }
 
-    // All other models: route through MastraGateway + ModelRouterLanguageModel
-    let customFetch: typeof globalThis.fetch | undefined;
+    // OpenAI Codex OAuth: build model directly with middleware (bypasses ModelRouterLanguageModel)
+    // Required because createCodexMiddleware injects instructions, store:false, and reasoningEffort
     if (modelId.startsWith('openai/') && openaiCred?.type === 'oauth') {
-      customFetch = buildOpenAICodexOAuthFetch({ authStorage, rewriteUrl: false });
+      const resolvedModelId = options?.remapForCodexOAuth ? remapOpenAIModelForCodexOAuth(modelId) : modelId;
+      const resolvedBareModelId = resolvedModelId.substring('openai/'.length);
+      const requestedLevel: ThinkingLevel = options?.thinkingLevel ?? 'medium';
+      const effectiveLevel = getEffectiveThinkingLevel(resolvedBareModelId, requestedLevel);
+      const reasoningEffort = THINKING_LEVEL_TO_REASONING_EFFORT[effectiveLevel];
+      const middleware = createCodexMiddleware(reasoningEffort);
+
+      const openai = createOpenAI({
+        apiKey: 'oauth-gateway-placeholder',
+        baseURL: gatewayBaseURL,
+        headers: {
+          'X-Mastra-Authorization': `Bearer ${mgApiKey}`,
+          ...headers,
+        },
+        fetch: buildOpenAICodexOAuthFetch({ authStorage, rewriteUrl: false }) as any,
+      });
+      return wrapLanguageModel({
+        model: openai.responses(resolvedBareModelId),
+        middleware: [middleware],
+      });
     }
 
+    // All other models: route through MastraGateway + ModelRouterLanguageModel
     const gateway = new MastraGateway({
       apiKey: mgApiKey,
       ...(baseUrl ? { baseUrl } : {}),
-      ...(customFetch ? { customFetch } : {}),
     });
 
     return new ModelRouterLanguageModel(

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -139,6 +139,11 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   const storage = storageResult.storage;
   const storageWarning = storageResult.warning;
 
+  // When a gateway API key is present (mgApiKey), local observational memory is disabled because
+  // the gateway server manages memory remotely. This means getDynamicMemory returns undefined and
+  // Harness.resolveMemory() will throw "Memory is not configured" if called. This decision is made
+  // once at startup — changing the gateway key mid-session (via /memory-gateway) requires a restart
+  // for memory mode to switch.
   const mgApiKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
   const memory = mgApiKey ? undefined : getDynamicMemory(storage);
 

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -319,7 +319,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     heartbeatHandlers: config?.heartbeatHandlers ?? defaultHeartbeatHandlers,
     modelAuthChecker: provider => {
       // Gateway covers all providers
-      if (mgApiKey) return true;
+      const gatewayKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
+      if (gatewayKey) return true;
       const oauthId = PROVIDER_TO_OAUTH_ID[provider];
       if (oauthId && authStorage.isLoggedIn(oauthId)) {
         return true;

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -139,7 +139,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   const storage = storageResult.storage;
   const storageWarning = storageResult.warning;
 
-  const mgApiKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER);
+  const mgApiKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
   const memory = mgApiKey ? undefined : getDynamicMemory(storage);
 
   // MCP
@@ -220,6 +220,11 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     google: process.env.GOOGLE_GENERATIVE_AI_API_KEY ? 'apikey' : false,
     deepseek: process.env.DEEPSEEK_API_KEY ? 'apikey' : false,
   };
+  // Gateway covers all providers — ensure Anthropic/OpenAI packs are visible
+  if (mgApiKey) {
+    if (!startupAccess.anthropic) startupAccess.anthropic = 'apikey';
+    if (!startupAccess.openai) startupAccess.openai = 'apikey';
+  }
   // Check all providers in the registry for API keys
   try {
     const registry = PROVIDER_REGISTRY as Record<string, ProviderConfig>;
@@ -313,6 +318,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     modes,
     heartbeatHandlers: config?.heartbeatHandlers ?? defaultHeartbeatHandlers,
     modelAuthChecker: provider => {
+      // Gateway covers all providers
+      if (mgApiKey) return true;
       const oauthId = PROVIDER_TO_OAUTH_ID[provider];
       if (oauthId && authStorage.isLoggedIn(oauthId)) {
         return true;

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -29,6 +29,7 @@ import { getAvailableModePacks, getAvailableOmPacks } from './onboarding/packs.j
 import {
   getCustomProviderId,
   loadSettings,
+  MEMORY_GATEWAY_PROVIDER,
   resolveModelDefaults,
   resolveOmModel,
   saveSettings,
@@ -113,6 +114,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       const envVars = cfg?.apiKeyEnvVar;
       providerEnvVars[provider] = Array.isArray(envVars) ? envVars[0] : envVars;
     }
+    // Include the memory gateway key so it's loaded from AuthStorage into process.env
+    providerEnvVars[MEMORY_GATEWAY_PROVIDER] = 'MASTRA_GATEWAY_API_KEY';
     authStorage.loadStoredApiKeysIntoEnv(providerEnvVars);
   } catch {
     // Non-fatal — provider registry may not be available
@@ -136,7 +139,8 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   const storage = storageResult.storage;
   const storageWarning = storageResult.warning;
 
-  const memory = getDynamicMemory(storage);
+  const mgApiKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER);
+  const memory = mgApiKey ? undefined : getDynamicMemory(storage);
 
   // MCP
   const mcpManager = config?.disableMcp ? undefined : createMcpManager(project.rootPath, config?.mcpServers);

--- a/mastracode/src/onboarding/settings.ts
+++ b/mastracode/src/onboarding/settings.ts
@@ -56,6 +56,12 @@ export interface StorageSettings {
   pg: PgStorageSettings;
 }
 
+/** Memory gateway provider key used in AuthStorage. */
+export const MEMORY_GATEWAY_PROVIDER = 'mastra-gateway';
+
+/** Default gateway URL. */
+export const MEMORY_GATEWAY_DEFAULT_URL = 'https://server.mastra.ai';
+
 /** Valid persisted thinking level values. */
 export type ThinkingLevelSetting = 'off' | 'low' | 'medium' | 'high' | 'xhigh';
 
@@ -113,6 +119,8 @@ export interface GlobalSettings {
   modelUseCounts: Record<string, number>;
   // Version the user dismissed the update prompt for (skip until they manually update past this)
   updateDismissedVersion: string | null;
+  // Memory gateway configuration
+  memoryGateway: { baseUrl?: string };
   // LSP configuration forwarded to the workspace
   lsp?: LSPConfig;
 }
@@ -150,6 +158,7 @@ const DEFAULTS: GlobalSettings = {
   customProviders: [],
   modelUseCounts: {},
   updateDismissedVersion: null,
+  memoryGateway: {},
   lsp: {},
 };
 
@@ -277,6 +286,7 @@ function migrateFromAuth(settingsPath: string): boolean {
         customProviders: parseCustomProviders(raw.customProviders),
         modelUseCounts: raw.modelUseCounts && typeof raw.modelUseCounts === 'object' ? raw.modelUseCounts : {},
         updateDismissedVersion: typeof raw.updateDismissedVersion === 'string' ? raw.updateDismissedVersion : null,
+        memoryGateway: raw.memoryGateway && typeof raw.memoryGateway === 'object' ? raw.memoryGateway : {},
         lsp: raw.lsp && typeof raw.lsp === 'object' ? (raw.lsp as LSPConfig) : undefined,
       };
     } catch {
@@ -393,6 +403,7 @@ export function loadSettings(filePath: string = getSettingsPath()): GlobalSettin
       customProviders: parseCustomProviders(raw.customProviders),
       modelUseCounts: raw.modelUseCounts && typeof raw.modelUseCounts === 'object' ? raw.modelUseCounts : {},
       updateDismissedVersion: typeof raw.updateDismissedVersion === 'string' ? raw.updateDismissedVersion : null,
+      memoryGateway: raw.memoryGateway && typeof raw.memoryGateway === 'object' ? raw.memoryGateway : {},
       lsp: raw.lsp && typeof raw.lsp === 'object' ? (raw.lsp as LSPConfig) : undefined,
     };
 

--- a/mastracode/src/providers/claude-max.ts
+++ b/mastracode/src/providers/claude-max.ts
@@ -38,7 +38,7 @@ export function setAuthStorage(storage: AuthStorage | undefined): void {
  * Middleware that injects the Claude Code identity system message
  * Required for Claude Max OAuth authentication
  */
-const claudeCodeMiddleware: LanguageModelMiddleware = {
+export const claudeCodeMiddleware: LanguageModelMiddleware = {
   specificationVersion: 'v3',
   transformParams: async ({ params }) => {
     // Prepend the Claude Code identity as the first system message
@@ -131,6 +131,56 @@ export const promptCacheMiddleware: LanguageModelMiddleware = {
 };
 
 /**
+ * Build a fetch function that handles Anthropic OAuth.
+ * Preserves non-auth headers from init (critical for X-Mastra-Authorization to survive
+ * when used with the gateway). Strips `authorization` and `x-api-key`.
+ */
+export function buildAnthropicOAuthFetch(opts: { authStorage?: AuthStorage } = {}): typeof fetch {
+  return (async (url: string | URL | Request, init?: Parameters<typeof fetch>[1]) => {
+    const storage = opts.authStorage ?? getAuthStorage();
+    storage.reload();
+
+    const storedCred = storage.get('anthropic');
+    if (storedCred?.type === 'api_key') {
+      throw new Error(
+        'Anthropic API key credential is configured, but OAuth is required.',
+      );
+    }
+
+    const accessToken = await storage.getApiKey('anthropic');
+    if (!accessToken) {
+      throw new Error('Not logged in to Anthropic. Run /login first.');
+    }
+
+    // Preserve existing headers, strip auth-related ones
+    const headers = new Headers();
+    if (init?.headers) {
+      const source =
+        init.headers instanceof Headers
+          ? init.headers
+          : Array.isArray(init.headers)
+            ? new Headers(init.headers as Array<[string, string]>)
+            : new Headers(init.headers as Record<string, string>);
+      source.forEach((value, key) => {
+        const lower = key.toLowerCase();
+        if (lower !== 'authorization' && lower !== 'x-api-key') {
+          headers.set(key, value);
+        }
+      });
+    }
+
+    headers.set('Authorization', `Bearer ${accessToken}`);
+    headers.set(
+      'anthropic-beta',
+      'oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14',
+    );
+    headers.set('anthropic-version', '2023-06-01');
+
+    return fetch(url, { ...init, headers });
+  }) as typeof fetch;
+}
+
+/**
  * Creates an Anthropic model using Claude Max OAuth authentication
  * Uses OAuth tokens from AuthStorage (auto-refreshes when needed)
  */
@@ -146,44 +196,9 @@ export function opencodeClaudeMaxProvider(modelId: string = 'claude-sonnet-4-202
     });
   }
 
-  // Custom fetch that handles OAuth
-  const oauthFetch = async (url: string | URL | Request, init?: Parameters<typeof fetch>[1]) => {
-    const authStorage = getAuthStorage();
-
-    // Reload from disk to handle multi-instance refresh
-    authStorage.reload();
-
-    const storedCred = authStorage.get('anthropic');
-    if (storedCred?.type === 'api_key') {
-      throw new Error(
-        'Anthropic API key credential is configured, but Claude Max OAuth provider requires OAuth credentials.',
-      );
-    }
-
-    // Get access token (auto-refreshes if expired)
-    const accessToken = await authStorage.getApiKey('anthropic');
-
-    if (!accessToken) {
-      throw new Error('Not logged in to Anthropic. Run /login first.');
-    }
-
-    // Make request with OAuth headers
-    return fetch(url, {
-      ...init,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'anthropic-beta':
-          'oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14',
-        'anthropic-version': '2023-06-01',
-      },
-    });
-  };
-
   const anthropic = createAnthropic({
-    // Provide a dummy API key - the actual auth is handled via OAuth in oauthFetch
-    // This prevents the SDK from throwing "API key is missing" at model creation time
     apiKey: 'oauth-placeholder',
-    fetch: oauthFetch as any,
+    fetch: buildAnthropicOAuthFetch() as any,
   });
 
   // Wrap with middleware to inject Claude Code identity and enable prompt caching

--- a/mastracode/src/providers/claude-max.ts
+++ b/mastracode/src/providers/claude-max.ts
@@ -132,7 +132,7 @@ export const promptCacheMiddleware: LanguageModelMiddleware = {
 
 /**
  * Build a fetch function that handles Anthropic OAuth.
- * Preserves non-auth headers from init (critical for X-Mastra-Authorization to survive
+ * Preserves non-auth headers from init (critical for gateway auth header to survive
  * when used with the gateway). Strips `authorization` and `x-api-key`.
  */
 export function buildAnthropicOAuthFetch(opts: { authStorage?: AuthStorage } = {}): typeof fetch {

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -100,66 +100,37 @@ function createCodexMiddleware(reasoningEffort?: string): LanguageModelMiddlewar
 }
 
 /**
- * Creates an OpenAI model using ChatGPT OAuth authentication
- * Uses OAuth tokens from AuthStorage (auto-refreshes when needed)
- *
- * IMPORTANT: This uses the Codex API endpoint, not the standard OpenAI API.
- * URLs are rewritten from /v1/responses or /chat/completions to the Codex endpoint.
+ * Build a fetch function that handles OpenAI Codex OAuth.
+ * Preserves non-authorization headers from init.
+ * When rewriteUrl is true (default), rewrites /v1/responses and /chat/completions
+ * to the Codex API endpoint. Set rewriteUrl: false for gateway usage where the
+ * SDK already targets the correct URL.
  */
-export function openaiCodexProvider(
-  modelId: string = 'codex-mini-latest',
-  options?: { thinkingLevel?: ThinkingLevel },
-): MastraModelConfig {
-  // Map thinkingLevel to OpenAI reasoningEffort, defaulting to 'medium'.
-  // When level is 'off', reasoningEffort is undefined and the parameter is omitted.
-  // GPT-5.* models are floored to at least "low" on Codex.
-  const requestedLevel: ThinkingLevel = options?.thinkingLevel ?? 'medium';
-  const effectiveLevel = getEffectiveThinkingLevel(modelId, requestedLevel);
-  const reasoningEffort = THINKING_LEVEL_TO_REASONING_EFFORT[effectiveLevel];
-  const middleware = createCodexMiddleware(reasoningEffort);
+export function buildOpenAICodexOAuthFetch(
+  opts: { authStorage?: AuthStorage; rewriteUrl?: boolean } = {},
+): typeof fetch {
+  return (async (url: string | URL | Request, init?: Parameters<typeof fetch>[1]) => {
+    const storage = opts.authStorage ?? getAuthStorage();
+    storage.reload();
 
-  // Test environment: use API key
-  if (process.env.NODE_ENV === 'test' || process.env.VITEST) {
-    const openai = createOpenAI({
-      apiKey: 'test-api-key',
-    });
-    return wrapLanguageModel({
-      model: openai.responses(modelId),
-      middleware: [middleware],
-    });
-  }
-
-  // Custom fetch that handles OAuth and URL rewriting
-  const oauthFetch = async (url: string | URL | Request, init?: Parameters<typeof fetch>[1]) => {
-    const authStorage = getAuthStorage();
-
-    // Reload from disk to handle multi-instance refresh
-    authStorage.reload();
-
-    // Get credentials (includes accountId)
-    const cred = authStorage.get('openai-codex');
-
+    const cred = storage.get('openai-codex');
     if (!cred || cred.type !== 'oauth') {
       throw new Error('Not logged in to OpenAI Codex. Run /login first.');
     }
 
-    // Check if token needs refresh
     let accessToken = cred.access;
     if (Date.now() >= cred.expires) {
-      // Token expired, need to refresh via getApiKey which handles refresh
-      const refreshedToken = await authStorage.getApiKey('openai-codex');
+      const refreshedToken = await storage.getApiKey('openai-codex');
       if (!refreshedToken) {
         throw new Error('Failed to refresh OpenAI Codex token. Please /login again.');
       }
       accessToken = refreshedToken;
-      // Reload to get updated accountId
-      authStorage.reload();
+      storage.reload();
     }
 
-    // Get accountId from credentials
     const accountId = (cred as any).accountId as string | undefined;
 
-    // Build headers - remove any existing authorization header first
+    // Preserve non-authorization headers
     const headers = new Headers();
     if (init?.headers) {
       if (init.headers instanceof Headers) {
@@ -183,30 +154,52 @@ export function openaiCodexProvider(
       }
     }
 
-    // Set authorization header with access token
     headers.set('Authorization', `Bearer ${accessToken}`);
-
-    // Set ChatGPT-Account-Id header for organization subscriptions
     if (accountId) {
       headers.set('ChatGPT-Account-Id', accountId);
     }
 
-    // Rewrite URL to Codex endpoint if it's a chat/responses request
+    // URL rewriting — only when rewriteUrl !== false
     const parsed = url instanceof URL ? url : new URL(typeof url === 'string' ? url : (url as Request).url);
-
-    const shouldRewrite = parsed.pathname.includes('/v1/responses') || parsed.pathname.includes('/chat/completions');
+    const shouldRewrite =
+      opts.rewriteUrl !== false &&
+      (parsed.pathname.includes('/v1/responses') || parsed.pathname.includes('/chat/completions'));
     const finalUrl = shouldRewrite ? new URL(CODEX_API_ENDPOINT) : parsed;
 
-    return fetch(finalUrl, {
-      ...init,
-      headers,
+    return fetch(finalUrl, { ...init, headers });
+  }) as typeof fetch;
+}
+
+/**
+ * Creates an OpenAI model using ChatGPT OAuth authentication
+ * Uses OAuth tokens from AuthStorage (auto-refreshes when needed)
+ *
+ * IMPORTANT: This uses the Codex API endpoint, not the standard OpenAI API.
+ * URLs are rewritten from /v1/responses or /chat/completions to the Codex endpoint.
+ */
+export function openaiCodexProvider(
+  modelId: string = 'codex-mini-latest',
+  options?: { thinkingLevel?: ThinkingLevel },
+): MastraModelConfig {
+  const requestedLevel: ThinkingLevel = options?.thinkingLevel ?? 'medium';
+  const effectiveLevel = getEffectiveThinkingLevel(modelId, requestedLevel);
+  const reasoningEffort = THINKING_LEVEL_TO_REASONING_EFFORT[effectiveLevel];
+  const middleware = createCodexMiddleware(reasoningEffort);
+
+  // Test environment: use API key
+  if (process.env.NODE_ENV === 'test' || process.env.VITEST) {
+    const openai = createOpenAI({
+      apiKey: 'test-api-key',
     });
-  };
+    return wrapLanguageModel({
+      model: openai.responses(modelId),
+      middleware: [middleware],
+    });
+  }
 
   const openai = createOpenAI({
-    // Use a dummy API key since we're using OAuth
     apiKey: 'oauth-dummy-key',
-    fetch: oauthFetch as any,
+    fetch: buildOpenAICodexOAuthFetch() as any,
   });
 
   // Use the responses API for Codex models

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -58,7 +58,7 @@ export function getEffectiveThinkingLevel(modelId: string, level: ThinkingLevel)
 
 // Map thinkingLevel state values to OpenAI reasoningEffort values.
 // undefined means omit the parameter (no reasoning).
-const THINKING_LEVEL_TO_REASONING_EFFORT: Record<ThinkingLevel, string | undefined> = {
+export const THINKING_LEVEL_TO_REASONING_EFFORT: Record<ThinkingLevel, string | undefined> = {
   off: undefined,
   low: 'low',
   medium: 'medium',
@@ -69,7 +69,7 @@ const THINKING_LEVEL_TO_REASONING_EFFORT: Record<ThinkingLevel, string | undefin
 /**
  * Create Codex middleware with the given reasoning effort level.
  */
-function createCodexMiddleware(reasoningEffort?: string): LanguageModelMiddleware {
+export function createCodexMiddleware(reasoningEffort?: string): LanguageModelMiddleware {
   return {
     specificationVersion: 'v3',
     transformParams: async ({ params }) => {

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -32,6 +32,7 @@ import {
   handleSetupCommand,
   handleThemeCommand,
   handleUpdateCommand,
+  handleMemoryGatewayCommand,
 } from './commands/index.js';
 import type { SlashCommandContext } from './commands/types.js';
 import { SlashCommandComponent } from './components/slash-command.js';
@@ -157,6 +158,9 @@ export async function dispatchSlashCommand(
       return true;
     case 'update':
       await handleUpdateCommand(buildCtx());
+      return true;
+    case 'memory-gateway':
+      await handleMemoryGatewayCommand(buildCtx());
       return true;
     default: {
       const customCommand = state.customSlashCommands.find(cmd => cmd.name === command);

--- a/mastracode/src/tui/commands/index.ts
+++ b/mastracode/src/tui/commands/index.ts
@@ -29,3 +29,4 @@ export { handleReportIssueCommand } from './report-issue.js';
 export { handleSetupCommand } from './setup.js';
 export { handleThemeCommand } from './theme.js';
 export { handleUpdateCommand } from './update.js';
+export { handleMemoryGatewayCommand } from './memory-gateway.js';

--- a/mastracode/src/tui/commands/memory-gateway.ts
+++ b/mastracode/src/tui/commands/memory-gateway.ts
@@ -51,36 +51,39 @@ export async function handleMemoryGatewayCommand(ctx: SlashCommandContext): Prom
     return;
   }
 
-  // Show current state
-  const currentKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER);
+  // Resolve effective state from storage + env
+  const currentKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
   const settings = loadSettings();
-  const currentUrl = settings.memoryGateway?.baseUrl ?? MEMORY_GATEWAY_DEFAULT_URL;
+  const effectiveUrl =
+    settings.memoryGateway?.baseUrl ?? process.env['MASTRA_GATEWAY_URL'] ?? MEMORY_GATEWAY_DEFAULT_URL;
 
   if (currentKey) {
     const masked = currentKey.length > 6 ? `****${currentKey.slice(-4)}` : '****';
-    ctx.showInfo(`Current API key: ${masked} | URL: ${currentUrl}`);
+    ctx.showInfo(`Current API key: ${masked} | URL: ${effectiveUrl}`);
   } else {
-    ctx.showInfo(`No API key set | URL: ${currentUrl}`);
+    ctx.showInfo(`No API key set | URL: ${effectiveUrl}`);
   }
 
   // Ask for API key
-  const keyAnswer = await askText(ctx, `API key (or 'clear' to remove, ESC to cancel):`);
-  if (keyAnswer === null) return; // ESC
-
-  if (keyAnswer.toLowerCase() === 'clear') {
+  const keyAnswer = await askText(ctx, currentKey
+    ? `API key (ENTER to keep current, 'clear' to remove, ESC to cancel):`
+    : `API key (or 'clear' to remove, ESC to cancel):`);
+  if (keyAnswer === null) {
+    // ESC with no key — abort; ESC with existing key — proceed to URL prompt
+    if (!currentKey) return;
+  } else if (keyAnswer.toLowerCase() === 'clear') {
     authStorage.remove(`apikey:${MEMORY_GATEWAY_PROVIDER}`);
     delete process.env['MASTRA_GATEWAY_API_KEY'];
     settings.memoryGateway = {};
     saveSettings(settings);
     ctx.showInfo('Memory gateway cleared. Note: memory mode changes take effect on next restart.');
     return;
+  } else if (keyAnswer.length > 0) {
+    authStorage.setStoredApiKey(MEMORY_GATEWAY_PROVIDER, keyAnswer, 'MASTRA_GATEWAY_API_KEY');
   }
 
-  // Store the key
-  authStorage.setStoredApiKey(MEMORY_GATEWAY_PROVIDER, keyAnswer, 'MASTRA_GATEWAY_API_KEY');
-
-  // Ask for URL
-  const urlAnswer = await askText(ctx, `Gateway URL (ESC for default):`, currentUrl);
+  // Always prompt for URL so users can change it independently
+  const urlAnswer = await askText(ctx, `Gateway URL (ESC for default):`, effectiveUrl);
   if (urlAnswer && urlAnswer !== MEMORY_GATEWAY_DEFAULT_URL) {
     settings.memoryGateway = { baseUrl: urlAnswer };
   } else {

--- a/mastracode/src/tui/commands/memory-gateway.ts
+++ b/mastracode/src/tui/commands/memory-gateway.ts
@@ -1,0 +1,90 @@
+import { Spacer } from '@mariozechner/pi-tui';
+import {
+  loadSettings,
+  saveSettings,
+  MEMORY_GATEWAY_PROVIDER,
+  MEMORY_GATEWAY_DEFAULT_URL,
+} from '../../onboarding/settings.js';
+import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
+import type { SlashCommandContext } from './types.js';
+
+function askText(
+  ctx: SlashCommandContext,
+  question: string,
+  defaultValue?: string,
+): Promise<string | null> {
+  return new Promise(resolve => {
+    const component = new AskQuestionInlineComponent(
+      {
+        question,
+        allowEmptyInput: false,
+        onSubmit: answer => {
+          ctx.state.activeInlineQuestion = undefined;
+          const trimmed = answer.trim();
+          resolve(trimmed.length > 0 ? trimmed : null);
+        },
+        onCancel: () => {
+          ctx.state.activeInlineQuestion = undefined;
+          resolve(null);
+        },
+      },
+      ctx.state.ui,
+    );
+
+    if (defaultValue) {
+      (component as any).input?.setValue?.(defaultValue);
+    }
+
+    ctx.state.activeInlineQuestion = component;
+    ctx.state.chatContainer.addChild(new Spacer(1));
+    ctx.state.chatContainer.addChild(component);
+    ctx.state.chatContainer.addChild(new Spacer(1));
+    ctx.state.ui.requestRender();
+    ctx.state.chatContainer.invalidate();
+  });
+}
+
+export async function handleMemoryGatewayCommand(ctx: SlashCommandContext): Promise<void> {
+  const authStorage = ctx.authStorage;
+  if (!authStorage) {
+    ctx.showError('Auth storage not available');
+    return;
+  }
+
+  // Show current state
+  const currentKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER);
+  const settings = loadSettings();
+  const currentUrl = settings.memoryGateway?.baseUrl ?? MEMORY_GATEWAY_DEFAULT_URL;
+
+  if (currentKey) {
+    const masked = currentKey.length > 6 ? `****${currentKey.slice(-4)}` : '****';
+    ctx.showInfo(`Current API key: ${masked} | URL: ${currentUrl}`);
+  } else {
+    ctx.showInfo(`No API key set | URL: ${currentUrl}`);
+  }
+
+  // Ask for API key
+  const keyAnswer = await askText(ctx, `API key (or 'clear' to remove, ESC to cancel):`);
+  if (keyAnswer === null) return; // ESC
+
+  if (keyAnswer.toLowerCase() === 'clear') {
+    authStorage.remove(`apikey:${MEMORY_GATEWAY_PROVIDER}`);
+    delete process.env['MASTRA_GATEWAY_API_KEY'];
+    ctx.showInfo('Memory gateway API key cleared');
+    return;
+  }
+
+  // Store the key
+  authStorage.setStoredApiKey(MEMORY_GATEWAY_PROVIDER, keyAnswer, 'MASTRA_GATEWAY_API_KEY');
+
+  // Ask for URL
+  const urlAnswer = await askText(ctx, `Gateway URL (ESC for default):`, currentUrl);
+  if (urlAnswer && urlAnswer !== MEMORY_GATEWAY_DEFAULT_URL) {
+    settings.memoryGateway = { baseUrl: urlAnswer };
+  } else {
+    settings.memoryGateway = {};
+  }
+  saveSettings(settings);
+
+  ctx.showInfo('Memory gateway configured');
+}

--- a/mastracode/src/tui/commands/memory-gateway.ts
+++ b/mastracode/src/tui/commands/memory-gateway.ts
@@ -70,7 +70,9 @@ export async function handleMemoryGatewayCommand(ctx: SlashCommandContext): Prom
   if (keyAnswer.toLowerCase() === 'clear') {
     authStorage.remove(`apikey:${MEMORY_GATEWAY_PROVIDER}`);
     delete process.env['MASTRA_GATEWAY_API_KEY'];
-    ctx.showInfo('Memory gateway API key cleared');
+    settings.memoryGateway = {};
+    saveSettings(settings);
+    ctx.showInfo('Memory gateway cleared. Note: memory mode changes take effect on next restart.');
     return;
   }
 
@@ -86,5 +88,5 @@ export async function handleMemoryGatewayCommand(ctx: SlashCommandContext): Prom
   }
   saveSettings(settings);
 
-  ctx.showInfo('Memory gateway configured');
+  ctx.showInfo('Memory gateway configured. Note: memory mode changes take effect on next restart.');
 }

--- a/mastracode/src/tui/components/help-overlay.ts
+++ b/mastracode/src/tui/components/help-overlay.ts
@@ -46,6 +46,7 @@ function getCommands(modes: number): HelpEntry[] {
     { key: '/setup', description: 'Run the setup wizard' },
     { key: '/theme', description: 'Switch color theme (auto/dark/light)' },
     { key: '/update', description: 'Check for and install updates' },
+    { key: '/memory-gateway', description: 'Configure Mastra memory gateway' },
   ];
 
   if (modes > 1) {

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -489,6 +489,12 @@ export class MastraTUI {
       google: hasEnv('google') ? ('apikey' as const) : false,
       deepseek: hasEnv('deepseek') ? ('apikey' as const) : false,
     };
+    // Gateway covers all providers
+    const mgKey = this.state.authStorage?.getStoredApiKey('mastra-gateway') ?? process.env['MASTRA_GATEWAY_API_KEY'];
+    if (mgKey) {
+      if (!access.anthropic) access.anthropic = 'apikey';
+      if (!access.openai) access.openai = 'apikey';
+    }
     // Include all other providers that have API keys configured
     const seen = new Set(Object.keys(access));
     for (const m of models) {

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -19,7 +19,11 @@ import {
   saveSettings,
 } from '../onboarding/index.js';
 import type { OnboardingResult, ProviderAccess, ProviderAccessLevel } from '../onboarding/index.js';
-import { resolveThreadActiveModelPackId, THREAD_ACTIVE_MODEL_PACK_ID_KEY } from '../onboarding/settings.js';
+import {
+  resolveThreadActiveModelPackId,
+  THREAD_ACTIVE_MODEL_PACK_ID_KEY,
+  MEMORY_GATEWAY_PROVIDER,
+} from '../onboarding/settings.js';
 import {
   detectPackageManager,
   fetchLatestVersion,
@@ -490,7 +494,7 @@ export class MastraTUI {
       deepseek: hasEnv('deepseek') ? ('apikey' as const) : false,
     };
     // Gateway covers all providers
-    const mgKey = this.state.authStorage?.getStoredApiKey('mastra-gateway') ?? process.env['MASTRA_GATEWAY_API_KEY'];
+    const mgKey = this.state.authStorage?.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
     if (mgKey) {
       if (!access.anthropic) access.anthropic = 'apikey';
       if (!access.openai) access.openai = 'apikey';

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -291,6 +291,7 @@ export function setupAutocomplete(state: TUIState): void {
     { name: 'setup', description: 'Re-run the setup wizard' },
     { name: 'theme', description: 'Switch color theme (auto/dark/light)' },
     { name: 'update', description: 'Check for and install updates' },
+    { name: 'memory-gateway', description: 'Configure Mastra memory gateway' },
     { name: 'exit', description: 'Exit the TUI' },
     { name: 'help', description: 'Show available commands' },
   ];

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -155,5 +155,6 @@ export {
   MastraGateway,
 } from './model/gateways';
 export type { AzureOpenAIGatewayConfig, MastraGatewayConfig } from './model/gateways';
+export { GATEWAY_AUTH_HEADER } from './model/gateways/constants';
 
 export { ModelRouterEmbeddingModel, type EmbeddingModelId, EMBEDDING_MODELS, type EmbeddingModelInfo } from './model';

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -154,6 +154,6 @@ export {
   AzureOpenAIGateway,
   MastraGateway,
 } from './model/gateways';
-export type { AzureOpenAIGatewayConfig } from './model/gateways';
+export type { AzureOpenAIGatewayConfig, MastraGatewayConfig } from './model/gateways';
 
 export { ModelRouterEmbeddingModel, type EmbeddingModelId, EMBEDDING_MODELS, type EmbeddingModelInfo } from './model';

--- a/packages/core/src/llm/model/gateways/constants.ts
+++ b/packages/core/src/llm/model/gateways/constants.ts
@@ -21,3 +21,6 @@ export const PROVIDERS_WITH_INSTALLED_PACKAGES = [
 
 // anything here doesn't show up in model router. for now that's just copilot which requires a special oauth flow
 export const EXCLUDED_PROVIDERS = ['github-copilot'];
+
+// Header used to pass gateway API key when Authorization is occupied by an OAuth token
+export const GATEWAY_AUTH_HEADER = 'X-Memory-Gateway-Authorization';

--- a/packages/core/src/llm/model/gateways/index.ts
+++ b/packages/core/src/llm/model/gateways/index.ts
@@ -3,7 +3,7 @@ import type { MastraModelGateway } from './base.js';
 export { MastraModelGateway, type ProviderConfig, type GatewayLanguageModel } from './base.js';
 export { AzureOpenAIGateway, type AzureOpenAIGatewayConfig } from './azure.js';
 export { ModelsDevGateway } from './models-dev.js';
-export { MastraGateway } from './mastra.js';
+export { MastraGateway, type MastraGatewayConfig } from './mastra.js';
 export { NetlifyGateway } from './netlify.js';
 
 /**

--- a/packages/core/src/llm/model/gateways/mastra.test.ts
+++ b/packages/core/src/llm/model/gateways/mastra.test.ts
@@ -104,11 +104,11 @@ describe('MastraGateway', () => {
           baseURL: 'https://server.mastra.ai/v1',
         }),
       );
-      // No X-Mastra-Authorization header
+      // No gateway auth header
       const call = createOpenRouterMock.mock.calls[0]?.[0];
       expect(call).toBeDefined();
       const callHeaders = call!.headers as Record<string, string>;
-      expect(callHeaders['X-Mastra-Authorization']).toBeUndefined();
+      expect(callHeaders['X-Memory-Gateway-Authorization']).toBeUndefined();
       // No fetch option
       expect(call).not.toHaveProperty('fetch');
     });
@@ -128,7 +128,7 @@ describe('MastraGateway', () => {
       const call = createAnthropicMock.mock.calls[0]?.[0];
       expect(call).toBeDefined();
       const callHeaders = (call as any)!.headers as Record<string, string>;
-      expect(callHeaders['X-Mastra-Authorization']).toBe('Bearer gw-key');
+      expect(callHeaders['X-Memory-Gateway-Authorization']).toBe('Bearer gw-key');
       // Should call with bare modelId, not providerId/modelId
       expect(anthropicModelMock).toHaveBeenCalledWith('claude-sonnet-4');
       // Should NOT use createOpenRouter
@@ -149,7 +149,7 @@ describe('MastraGateway', () => {
       const call = createOpenRouterMock.mock.calls[0]?.[0];
       expect(call).toBeDefined();
       const callHeaders = call!.headers as Record<string, string>;
-      expect(callHeaders['X-Mastra-Authorization']).toBe('Bearer gw-key');
+      expect(callHeaders['X-Memory-Gateway-Authorization']).toBe('Bearer gw-key');
       expect(chatMock).toHaveBeenCalledWith('openai/gpt-4o');
       // Should NOT use createAnthropic
       expect(createAnthropicMock).not.toHaveBeenCalled();

--- a/packages/core/src/llm/model/gateways/mastra.test.ts
+++ b/packages/core/src/llm/model/gateways/mastra.test.ts
@@ -1,0 +1,198 @@
+import { createAnthropic } from '@ai-sdk/anthropic-v5';
+import { createOpenRouter } from '@openrouter/ai-sdk-provider-v5';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { MastraGateway } from './mastra';
+
+vi.mock('@ai-sdk/anthropic-v5', () => {
+  const anthropicModelMock = vi.fn().mockReturnValue({ modelId: 'mock-anthropic-model' });
+  const createAnthropicMock = vi.fn().mockReturnValue(anthropicModelMock);
+  return { createAnthropic: createAnthropicMock };
+});
+
+vi.mock('@openrouter/ai-sdk-provider-v5', () => {
+  const chatMock = vi.fn().mockReturnValue({ modelId: 'mock-model' });
+  const createOpenRouterMock = vi.fn().mockReturnValue({ chat: chatMock });
+  return { createOpenRouter: createOpenRouterMock };
+});
+
+const createAnthropicMock = vi.mocked(createAnthropic);
+const anthropicModelMock = vi.mocked(createAnthropicMock() as unknown as ReturnType<typeof vi.fn>);
+const createOpenRouterMock = vi.mocked(createOpenRouter);
+const chatMock = vi.mocked(createOpenRouterMock().chat);
+
+describe('MastraGateway', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('constructor', () => {
+    it('works with no arguments', () => {
+      const gw = new MastraGateway();
+      expect(gw.id).toBe('mastra');
+      expect(gw.name).toBe('Mastra Gateway');
+    });
+
+    it('accepts config object', () => {
+      const gw = new MastraGateway({ apiKey: 'test-key', baseUrl: 'https://custom.example.com' });
+      expect(gw.id).toBe('mastra');
+    });
+  });
+
+  describe('getApiKey', () => {
+    it('returns config apiKey over env var', async () => {
+      process.env['MASTRA_GATEWAY_API_KEY'] = 'env-key';
+      const gw = new MastraGateway({ apiKey: 'config-key' });
+      expect(await gw.getApiKey()).toBe('config-key');
+    });
+
+    it('falls back to env var when no config apiKey', async () => {
+      process.env['MASTRA_GATEWAY_API_KEY'] = 'env-key';
+      const gw = new MastraGateway();
+      expect(await gw.getApiKey()).toBe('env-key');
+    });
+
+    it('throws when neither config nor env var is set', async () => {
+      delete process.env['MASTRA_GATEWAY_API_KEY'];
+      const gw = new MastraGateway();
+      await expect(gw.getApiKey()).rejects.toThrow('Missing MASTRA_GATEWAY_API_KEY');
+    });
+  });
+
+  describe('buildUrl', () => {
+    it('uses config baseUrl', async () => {
+      const gw = new MastraGateway({ baseUrl: 'https://custom.example.com' });
+      expect(await gw.buildUrl('test')).toBe('https://custom.example.com/v1');
+    });
+
+    it('uses env var when no config baseUrl', async () => {
+      process.env['MASTRA_GATEWAY_URL'] = 'https://env.example.com';
+      const gw = new MastraGateway();
+      expect(await gw.buildUrl('test')).toBe('https://env.example.com/v1');
+    });
+
+    it('uses default when neither config nor env var', async () => {
+      delete process.env['MASTRA_GATEWAY_URL'];
+      const gw = new MastraGateway();
+      expect(await gw.buildUrl('test')).toBe('https://server.mastra.ai/v1');
+    });
+
+    it('config baseUrl takes precedence over env var', async () => {
+      process.env['MASTRA_GATEWAY_URL'] = 'https://env.example.com';
+      const gw = new MastraGateway({ baseUrl: 'https://config.example.com' });
+      expect(await gw.buildUrl('test')).toBe('https://config.example.com/v1');
+    });
+  });
+
+  describe('resolveLanguageModel', () => {
+    const args = { modelId: 'claude-sonnet-4', providerId: 'anthropic', apiKey: 'gw-key' };
+
+    it('without customFetch — passes apiKey directly', () => {
+      const gw = new MastraGateway();
+      gw.resolveLanguageModel(args);
+
+      expect(createOpenRouterMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'gw-key',
+          baseURL: 'https://server.mastra.ai/v1',
+        }),
+      );
+      // No X-Mastra-Authorization header
+      const call = createOpenRouterMock.mock.calls[0]?.[0];
+      expect(call).toBeDefined();
+      const callHeaders = call!.headers as Record<string, string>;
+      expect(callHeaders['X-Mastra-Authorization']).toBeUndefined();
+      // No fetch option
+      expect(call).not.toHaveProperty('fetch');
+    });
+
+    it('with customFetch + anthropic — uses createAnthropic and sends /messages', () => {
+      const myFetch = vi.fn();
+      const gw = new MastraGateway({ customFetch: myFetch as unknown as typeof fetch });
+      gw.resolveLanguageModel(args); // args has providerId: 'anthropic'
+
+      expect(createAnthropicMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'oauth-gateway-placeholder',
+          baseURL: 'https://server.mastra.ai/v1',
+          fetch: myFetch,
+        }),
+      );
+      const call = createAnthropicMock.mock.calls[0]?.[0];
+      expect(call).toBeDefined();
+      const callHeaders = (call as any)!.headers as Record<string, string>;
+      expect(callHeaders['X-Mastra-Authorization']).toBe('Bearer gw-key');
+      // Should call with bare modelId, not providerId/modelId
+      expect(anthropicModelMock).toHaveBeenCalledWith('claude-sonnet-4');
+      // Should NOT use createOpenRouter
+      expect(createOpenRouterMock).not.toHaveBeenCalled();
+    });
+
+    it('with customFetch + non-anthropic — uses createOpenRouter', () => {
+      const myFetch = vi.fn();
+      const gw = new MastraGateway({ customFetch: myFetch as unknown as typeof fetch });
+      gw.resolveLanguageModel({ modelId: 'gpt-4o', providerId: 'openai', apiKey: 'gw-key' });
+
+      expect(createOpenRouterMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'oauth-gateway-placeholder',
+          fetch: myFetch,
+        }),
+      );
+      const call = createOpenRouterMock.mock.calls[0]?.[0];
+      expect(call).toBeDefined();
+      const callHeaders = call!.headers as Record<string, string>;
+      expect(callHeaders['X-Mastra-Authorization']).toBe('Bearer gw-key');
+      expect(chatMock).toHaveBeenCalledWith('openai/gpt-4o');
+      // Should NOT use createAnthropic
+      expect(createAnthropicMock).not.toHaveBeenCalled();
+    });
+
+    it('passes headers through', () => {
+      const gw = new MastraGateway();
+      gw.resolveLanguageModel({ ...args, headers: { 'x-thread-id': 'abc' } });
+
+      const call = createOpenRouterMock.mock.calls[0]?.[0];
+      expect(call).toBeDefined();
+      const callHeaders = call!.headers as Record<string, string>;
+      expect(callHeaders['x-thread-id']).toBe('abc');
+      expect(callHeaders['User-Agent']).toBeDefined();
+    });
+
+    it('calls .chat() with providerId/modelId', () => {
+      const gw = new MastraGateway();
+      gw.resolveLanguageModel(args);
+
+      expect(chatMock).toHaveBeenCalledWith('anthropic/claude-sonnet-4');
+    });
+
+    it('uses config baseUrl for baseURL', () => {
+      const gw = new MastraGateway({ baseUrl: 'https://custom.gw.com' });
+      gw.resolveLanguageModel(args);
+
+      expect(createOpenRouterMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://custom.gw.com/v1',
+        }),
+      );
+    });
+  });
+
+  describe('fetchProviders', () => {
+    it('returns mastra provider with openrouter models', async () => {
+      const gw = new MastraGateway();
+      const providers = await gw.fetchProviders();
+
+      expect(providers['mastra']).toBeDefined();
+      expect(providers['mastra'].gateway).toBe('mastra');
+      expect(providers['mastra'].apiKeyEnvVar).toBe('MASTRA_GATEWAY_API_KEY');
+    });
+  });
+});

--- a/packages/core/src/llm/model/gateways/mastra.ts
+++ b/packages/core/src/llm/model/gateways/mastra.ts
@@ -4,7 +4,7 @@ import { MastraError } from '../../../error/index.js';
 import { PROVIDER_REGISTRY } from '../provider-registry.js';
 import { MastraModelGateway } from './base.js';
 import type { ProviderConfig, GatewayLanguageModel } from './base.js';
-import { MASTRA_USER_AGENT } from './constants.js';
+import { GATEWAY_AUTH_HEADER, MASTRA_USER_AGENT } from './constants.js';
 
 export interface MastraGatewayConfig {
   apiKey?: string;
@@ -78,7 +78,7 @@ export class MastraGateway extends MastraModelGateway {
         baseURL,
         headers: {
           'User-Agent': MASTRA_USER_AGENT,
-          'X-Mastra-Authorization': `Bearer ${apiKey}`,
+          [GATEWAY_AUTH_HEADER]: `Bearer ${apiKey}`,
           ...headers,
         },
         fetch: this.config.customFetch as any,
@@ -86,13 +86,13 @@ export class MastraGateway extends MastraModelGateway {
     }
 
     if (this.config?.customFetch) {
-      // Non-Anthropic OAuth path: gateway key in X-Mastra-Authorization, customFetch owns Authorization
+      // Non-Anthropic OAuth path: gateway key in GATEWAY_AUTH_HEADER, customFetch owns Authorization
       return createOpenRouter({
         apiKey: 'oauth-gateway-placeholder',
         baseURL,
         headers: {
           'User-Agent': MASTRA_USER_AGENT,
-          'X-Mastra-Authorization': `Bearer ${apiKey}`,
+          [GATEWAY_AUTH_HEADER]: `Bearer ${apiKey}`,
           ...headers,
         },
         fetch: this.config.customFetch,

--- a/packages/core/src/llm/model/gateways/mastra.ts
+++ b/packages/core/src/llm/model/gateways/mastra.ts
@@ -1,3 +1,4 @@
+import { createAnthropic } from '@ai-sdk/anthropic-v5';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider-v5';
 import { MastraError } from '../../../error/index.js';
 import { PROVIDER_REGISTRY } from '../provider-registry.js';
@@ -5,12 +6,22 @@ import { MastraModelGateway } from './base.js';
 import type { ProviderConfig, GatewayLanguageModel } from './base.js';
 import { MASTRA_USER_AGENT } from './constants.js';
 
+export interface MastraGatewayConfig {
+  apiKey?: string;
+  baseUrl?: string;
+  customFetch?: typeof globalThis.fetch;
+}
+
 export class MastraGateway extends MastraModelGateway {
   readonly id = 'mastra';
   readonly name = 'Mastra Gateway';
 
+  constructor(private config?: MastraGatewayConfig) {
+    super();
+  }
+
   private getBaseUrl(): string {
-    return process.env['MASTRA_GATEWAY_URL'] || 'https://server.mastra.ai';
+    return this.config?.baseUrl ?? process.env['MASTRA_GATEWAY_URL'] ?? 'https://server.mastra.ai';
   }
 
   async fetchProviders(): Promise<Record<string, ProviderConfig>> {
@@ -34,7 +45,7 @@ export class MastraGateway extends MastraModelGateway {
   }
 
   async getApiKey(): Promise<string> {
-    const apiKey = process.env['MASTRA_GATEWAY_API_KEY'];
+    const apiKey = this.config?.apiKey ?? process.env['MASTRA_GATEWAY_API_KEY'];
     if (!apiKey) {
       throw new MastraError({
         id: 'MASTRA_GATEWAY_NO_API_KEY',
@@ -60,6 +71,35 @@ export class MastraGateway extends MastraModelGateway {
     const baseURL = `${this.getBaseUrl()}/v1`;
     const fullModelId = `${providerId}/${modelId}`;
 
+    if (this.config?.customFetch && providerId === 'anthropic') {
+      // Anthropic OAuth path: use native Anthropic SDK (sends /messages, not /chat/completions)
+      return createAnthropic({
+        apiKey: 'oauth-gateway-placeholder',
+        baseURL,
+        headers: {
+          'User-Agent': MASTRA_USER_AGENT,
+          'X-Mastra-Authorization': `Bearer ${apiKey}`,
+          ...headers,
+        },
+        fetch: this.config.customFetch as any,
+      })(modelId) as unknown as GatewayLanguageModel;
+    }
+
+    if (this.config?.customFetch) {
+      // Non-Anthropic OAuth path: gateway key in X-Mastra-Authorization, customFetch owns Authorization
+      return createOpenRouter({
+        apiKey: 'oauth-gateway-placeholder',
+        baseURL,
+        headers: {
+          'User-Agent': MASTRA_USER_AGENT,
+          'X-Mastra-Authorization': `Bearer ${apiKey}`,
+          ...headers,
+        },
+        fetch: this.config.customFetch,
+      }).chat(fullModelId) as unknown as GatewayLanguageModel;
+    }
+
+    // API key path: gateway key goes via Authorization (standard flow)
     return createOpenRouter({
       apiKey,
       baseURL,


### PR DESCRIPTION
## What

Integrates the Mastra Gateway (`MastraGateway` in `packages/core`) with `mastracode` so models can be routed through `server.mastra.ai`.

## Changes

### `packages/core`
- Extend `MastraGateway` with `MastraGatewayConfig` (`apiKey`, `baseUrl`, `customFetch`)
- Anthropic OAuth path uses `createAnthropic` (sends `/messages`) instead of `createOpenRouter` (`/chat/completions`)
- Non-Anthropic OAuth uses `createOpenRouter` with `X-Memory-Gateway-Authorization` header
- Export `MastraGatewayConfig` type and `GATEWAY_AUTH_HEADER` constant
- Extract `GATEWAY_AUTH_HEADER` constant for gateway auth header name

### `mastracode`
- Add `/memory-gateway` TUI command for API key and base URL configuration
- Extract `buildAnthropicOAuthFetch` and `buildOpenAICodexOAuthFetch` as reusable functions
- Export `claudeCodeMiddleware`, `createCodexMiddleware`, `THINKING_LEVEL_TO_REASONING_EFFORT` for use in gateway path
- Wire `resolveModel` to route through gateway when API key is stored
- Anthropic OAuth + gateway builds model directly with `claudeCodeMiddleware` + `promptCacheMiddleware`
- OpenAI Codex OAuth + gateway builds model directly with `createCodexMiddleware` (instructions, store:false, reasoningEffort)
- Skip local observational memory when gateway is active
- Add `memoryGateway` settings to `GlobalSettings`
- Surface gateway-backed providers to onboarding (`startupAccess`, `buildProviderAccess`)
- `modelAuthChecker` returns authenticated when gateway key is present
- Support `MASTRA_GATEWAY_API_KEY` env var as fallback (not just `AuthStorage`)
- `/memory-gateway clear` resets stale base URL

## Auth header strategy

| Scenario | `Authorization` | `X-Memory-Gateway-Authorization` |
|---|---|---|
| OAuth (Anthropic/OpenAI) | OAuth token (via customFetch) | Gateway API key |
| API key only | Gateway API key | — |

## Known limitation

`/memory-gateway` takes effect for model routing immediately, but memory mode (local vs gateway) is set at startup and requires a restart to switch.

## Test plan

- 16 core gateway tests pass (`mastra.test.ts`)
- 32 mastracode model tests pass (`model.test.ts`)
- 12 settings tests pass (`settings.test.ts`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/memory-gateway` command to configure Mastra Gateway API key and base URL settings.
  * Memory Gateway integration enables model routing through Mastra Gateway with OAuth support for Claude Max and OpenAI Codex.
  * Gateway-backed providers automatically appear as authenticated in the model picker.

* **Tests**
  * Added comprehensive test coverage for Memory Gateway routing and OAuth configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->