### PR TITLE
fix(core): filter empty text parts from user messages before LLM call

### DIFF
--- a/.changeset/cyan-lemons-travel.md
+++ b/.changeset/cyan-lemons-travel.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Anthropic API rejection of empty user text content blocks.
+
+User messages containing only empty text parts (e.g., `{ type: 'text', text: '' }`) are now filtered out before being sent to the LLM. This prevents the "text content blocks must be non-empty" error that could occur when corrupted messages existed in the database.
+
+Note: The root cause of how these empty user messages get persisted is still under investigation.

--- a/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
@@ -412,3 +412,69 @@ describe('addStartStepPartsForAIV5 — client/provider tool splitting', () => {
     expect(partTypes).toEqual(['tool-find_files', 'tool-execute_command']);
   });
 });
+
+/**
+ * Tests for empty text part filtering in sanitizeV5UIMessages.
+ *
+ * Empty text parts can appear in stored messages due to various edge cases.
+ * When sent to LLM providers like Anthropic, these cause API errors:
+ * "Invalid request: messages: text content blocks must be non-empty"
+ */
+describe('sanitizeV5UIMessages — empty text part filtering', () => {
+  it('should filter out user messages that contain only empty text parts', () => {
+    const userMsgWithEmptyText: AIV5Type.UIMessage = {
+      id: 'msg-empty-user',
+      role: 'user',
+      parts: [{ type: 'text', text: '' }],
+    };
+
+    const result = sanitizeV5UIMessages([userMsgWithEmptyText], true);
+
+    // User message with only empty text should be removed entirely
+    expect(result).toHaveLength(0);
+  });
+
+  it('should filter out empty text parts from user messages with other content', () => {
+    const userMsgWithMixedParts: AIV5Type.UIMessage = {
+      id: 'msg-mixed-user',
+      role: 'user',
+      parts: [
+        { type: 'text', text: '' },
+        { type: 'text', text: 'Hello' },
+      ],
+    };
+
+    const result = sanitizeV5UIMessages([userMsgWithMixedParts], true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.parts).toHaveLength(1);
+    expect(result[0]!.parts[0]).toEqual({ type: 'text', text: 'Hello' });
+  });
+
+  it('should filter out user messages with whitespace-only text parts', () => {
+    const userMsgWithWhitespace: AIV5Type.UIMessage = {
+      id: 'msg-whitespace-user',
+      role: 'user',
+      parts: [{ type: 'text', text: '   ' }],
+    };
+
+    const result = sanitizeV5UIMessages([userMsgWithWhitespace], true);
+
+    // User message with only whitespace text should be removed
+    expect(result).toHaveLength(0);
+  });
+
+  it('should preserve assistant messages with only empty text parts (placeholder messages)', () => {
+    const assistantMsgWithEmptyText: AIV5Type.UIMessage = {
+      id: 'msg-empty-assistant',
+      role: 'assistant',
+      parts: [{ type: 'text', text: '' }],
+    };
+
+    const result = sanitizeV5UIMessages([assistantMsgWithEmptyText], true);
+
+    // Assistant message with only empty text should be preserved as placeholder
+    expect(result).toHaveLength(1);
+    expect(result[0]!.parts).toHaveLength(1);
+  });
+});

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -93,9 +93,14 @@ export function sanitizeV5UIMessages(
           return false;
         }
 
-        // Filter out empty text parts to handle legacy data from before this filtering was implemented
-        // But preserve them if they are the only parts (legitimate placeholder messages)
+        // Filter out empty text parts to handle legacy data from before this filtering was implemented.
+        // For assistant messages, preserve empty text parts if they are the only parts (placeholder messages).
+        // For user messages, always filter them out — Anthropic rejects empty user text content blocks.
         if (p.type === 'text' && (!('text' in p) || p.text === '' || p.text?.trim() === '')) {
+          // Always filter empty text parts from user messages
+          if (m.role === 'user') return false;
+
+          // For non-user messages, only filter if there are other non-empty parts
           const hasNonEmptyParts = m.parts.some(
             part => !(part.type === 'text' && (!('text' in part) || part.text === '' || part.text?.trim() === '')),
           );


### PR DESCRIPTION
## Description

User messages containing only empty text parts (e.g., `{ type: 'text', text: '' }`) were causing Anthropic API to reject requests with the error: "text content blocks must be non-empty".

This fix modifies `sanitizeV5UIMessages` to filter out empty text parts from user messages before sending to the LLM. Previously, empty text parts were preserved if they were the "only" parts in a message (intended for placeholder messages), but this logic didn't account for user messages where empty text is never valid.

**Root cause note:** The root cause of how these empty user messages get persisted to the database is still under investigation. This fix prevents the API error but is a defensive measure.

## Related Issue(s)

Internal report from team - blank user messages appearing in DB after `data-om-status` markers

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue where empty text content blocks in user messages would cause the Anthropic API to reject requests. The system now automatically filters out empty content blocks before sending messages to the LLM, preventing "text content blocks must be non-empty" API errors that could interrupt conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->