### PR TITLE
fix(core): prevent duplicate OpenAI itemId errors from web search source chunks

### DIFF
--- a/.changeset/quiet-falcons-switch.md
+++ b/.changeset/quiet-falcons-switch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed duplicate OpenAI item ID errors when using web search. When OpenAI streams responses with web search citations, it interleaves source chunks with text, causing multiple message parts to share the same item ID. This resulted in 'Duplicate item found' errors on subsequent requests. The fix prevents text flushing on source chunks and merges any existing duplicate parts.

--- a/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
@@ -478,3 +478,104 @@ describe('sanitizeV5UIMessages — empty text part filtering', () => {
     expect(result[0]!.parts).toHaveLength(1);
   });
 });
+
+describe('sanitizeV5UIMessages — duplicate OpenAI itemId merging', () => {
+  const makeTextPart = (text: string, itemId?: string): AIV5Type.TextUIPart => ({
+    type: 'text',
+    text,
+    ...(itemId && {
+      providerMetadata: {
+        openai: { itemId },
+      },
+    }),
+  });
+
+  const makeMessage = (parts: AIV5Type.UIMessage['parts']): AIV5Type.UIMessage => ({
+    id: 'msg-1',
+    role: 'assistant',
+    parts,
+  });
+
+  it('should merge text parts with the same OpenAI itemId', () => {
+    const msg = makeMessage([makeTextPart('Hello ', 'msg_abc123'), makeTextPart('world!', 'msg_abc123')]);
+
+    const result = sanitizeV5UIMessages([msg], false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.parts).toHaveLength(1);
+    expect((result[0]!.parts[0] as AIV5Type.TextUIPart).text).toBe('Hello world!');
+    expect((result[0]!.parts[0] as any).providerMetadata?.openai?.itemId).toBe('msg_abc123');
+  });
+
+  it('should merge multiple text parts with the same itemId into one', () => {
+    const msg = makeMessage([
+      makeTextPart('Part 1. ', 'msg_abc123'),
+      makeTextPart('Part 2. ', 'msg_abc123'),
+      makeTextPart('Part 3.', 'msg_abc123'),
+    ]);
+
+    const result = sanitizeV5UIMessages([msg], false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.parts).toHaveLength(1);
+    expect((result[0]!.parts[0] as AIV5Type.TextUIPart).text).toBe('Part 1. Part 2. Part 3.');
+  });
+
+  it('should keep text parts with different itemIds separate', () => {
+    const msg = makeMessage([
+      makeTextPart('First response. ', 'msg_abc123'),
+      makeTextPart('Second response.', 'msg_def456'),
+    ]);
+
+    const result = sanitizeV5UIMessages([msg], false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.parts).toHaveLength(2);
+    expect((result[0]!.parts[0] as AIV5Type.TextUIPart).text).toBe('First response. ');
+    expect((result[0]!.parts[1] as AIV5Type.TextUIPart).text).toBe('Second response.');
+  });
+
+  it('should not merge text parts without itemIds', () => {
+    const msg = makeMessage([makeTextPart('No metadata 1. '), makeTextPart('No metadata 2.')]);
+
+    const result = sanitizeV5UIMessages([msg], false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.parts).toHaveLength(2);
+  });
+
+  it('should handle mixed parts: text with itemId, text without, and tool parts', () => {
+    const msg = makeMessage([
+      makeTextPart('With itemId part 1. ', 'msg_abc123'),
+      { type: 'tool-web_search', toolCallId: 'call-1', state: 'output-available', input: {}, output: {} } as any,
+      makeTextPart('With itemId part 2.', 'msg_abc123'),
+      makeTextPart('Without itemId.'),
+    ]);
+
+    const result = sanitizeV5UIMessages([msg], false);
+
+    expect(result).toHaveLength(1);
+    // Should have: merged text (itemId), tool, text (no itemId)
+    expect(result[0]!.parts).toHaveLength(3);
+    expect((result[0]!.parts[0] as AIV5Type.TextUIPart).text).toBe('With itemId part 1. With itemId part 2.');
+    expect(result[0]!.parts[1]!.type).toBe('tool-web_search');
+    expect((result[0]!.parts[2] as AIV5Type.TextUIPart).text).toBe('Without itemId.');
+  });
+
+  it('should handle web search scenario: multiple flushes from source chunks', () => {
+    // Simulates OpenAI web search streaming where source chunks trigger text flushes
+    const msg = makeMessage([
+      makeTextPart('According to recent sources, ', 'msg_websearch_001'),
+      makeTextPart('the answer is 42. ', 'msg_websearch_001'),
+      makeTextPart('This was confirmed by multiple studies.', 'msg_websearch_001'),
+    ]);
+
+    const result = sanitizeV5UIMessages([msg], false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.parts).toHaveLength(1);
+    expect((result[0]!.parts[0] as AIV5Type.TextUIPart).text).toBe(
+      'According to recent sources, the answer is 42. This was confirmed by multiple studies.',
+    );
+  });
+});

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -10,6 +10,62 @@ import type { AIV5Type } from '../types';
 import { ensureAnthropicCompatibleMessages } from '../utils/provider-compat';
 
 /**
+ * Merges text parts that share the same OpenAI itemId.
+ *
+ * When OpenAI streams a response with web search, it interleaves `source` chunks
+ * with text-deltas. If the streaming pipeline flushes text on these source chunks,
+ * it creates multiple text parts all sharing the same `providerMetadata.openai.itemId`.
+ *
+ * When these parts are later converted to model messages, each part with an itemId
+ * becomes an `item_reference` pointing to the same ID, causing OpenAI to reject
+ * the request with: "Duplicate item found with id msg_*"
+ *
+ * This function merges consecutive text parts with the same itemId into a single part,
+ * concatenating their text content and keeping the metadata from the first part.
+ */
+function mergeTextPartsWithDuplicateItemIds<T extends { type: string }>(parts: T[]): T[] {
+  const result: T[] = [];
+
+  for (const part of parts) {
+    // Only process text parts with OpenAI itemId
+    if (part.type !== 'text') {
+      result.push(part);
+      continue;
+    }
+
+    const textPart = part as T & { text: string; providerMetadata?: Record<string, unknown> };
+    const itemId = (textPart.providerMetadata?.openai as Record<string, unknown> | undefined)?.itemId as
+      | string
+      | undefined;
+    if (!itemId) {
+      result.push(part);
+      continue;
+    }
+
+    // Find an existing text part in result with the same itemId
+    const existingIndex = result.findIndex(p => {
+      if (p.type !== 'text') return false;
+      const existingTextPart = p as T & { providerMetadata?: Record<string, unknown> };
+      const existingItemId = (existingTextPart.providerMetadata?.openai as Record<string, unknown> | undefined)?.itemId;
+      return existingItemId === itemId;
+    });
+
+    if (existingIndex !== -1) {
+      // Merge: concatenate text into the existing part
+      const existing = result[existingIndex] as T & { text: string };
+      result[existingIndex] = {
+        ...existing,
+        text: existing.text + textPart.text,
+      };
+    } else {
+      result.push(part);
+    }
+  }
+
+  return result;
+}
+
+/**
  * Sanitizes AIV4 UI messages by filtering out incomplete tool calls.
  * Removes messages with empty parts arrays after sanitization.
  */
@@ -129,9 +185,14 @@ export function sanitizeV5UIMessages(
 
       if (!safeParts.length) return false;
 
+      // Merge text parts with duplicate OpenAI itemIds to prevent "Duplicate item found" errors.
+      // This can happen when streaming flushes text multiple times for the same response
+      // (e.g., when source citations are interleaved with text-deltas).
+      const mergedParts = mergeTextPartsWithDuplicateItemIds(safeParts);
+
       const sanitized = {
         ...m,
-        parts: safeParts.map(part => {
+        parts: mergedParts.map(part => {
           // When OpenAI reasoning was stripped, clear openai metadata from ALL remaining
           // parts so the SDK sends inline content instead of item_reference. This covers:
           //   - providerMetadata.openai on text/reasoning parts (msg_*/rs_* itemIds)

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -118,6 +118,10 @@ async function processOutputStream<OUTPUT = undefined>({
       // Alternative solution: in message list allow combining text deltas together when the message source is "response" and the text parts are directly next to each other
       // simple solution for now is to not flush text deltas on response-metadata
       chunk.type !== 'response-metadata' &&
+      // Don't flush on source chunks - OpenAI web search interleaves source citations
+      // with text-deltas, all sharing the same itemId. Flushing creates multiple parts
+      // with duplicate itemIds, causing "Duplicate item found" errors on the next request.
+      chunk.type !== 'source' &&
       runState.state.isStreaming
     ) {
       if (runState.state.textDeltas.length) {


### PR DESCRIPTION
## Problem

When OpenAI streams a response with web search, it interleaves `source` chunks with text-deltas, all sharing the same `providerMetadata.openai.itemId`. Our streaming pipeline in `llm-execution-step.ts` was flushing text on these source chunks, creating multiple text parts with the same itemId.

When these parts were later converted to model messages via `convertToModelMessages`, each part with an itemId became an `item_reference` pointing to the same ID, causing OpenAI to reject the request with:

```
Duplicate item found with id msg_*. Remove duplicate items from your input and try again.
```

## Root Cause

GPT-5.4 streams web search responses like this:
```
tool-call(web_search)
tool-result
text-start -> stores providerMetadata.openai.itemId in runState
text-delta -> "Some text about the web result"
source -> citation link -> triggers messageList.add() with accumulated text + runState.providerMetadata
text-delta -> "More text, same itemId but now a new part"
source -> another citation
text-delta -> "Even more text"
text-end -> messageList.add() another part with same itemId
```

This creates one message with multiple text parts all sharing the same `itemId`. On the next request, each part becomes a separate `item_reference` to the same ID → duplicate error.

## Solution

This fix addresses the issue in two places:

1. **llm-execution-step.ts**: Don't flush text deltas on `source` chunks. This prevents the problem from occurring in the first place.

2. **output-converter.ts**: Merge text parts with duplicate itemIds before sending to the LLM. This is a defensive fix that:
   - Handles any existing broken message history
   - Protects against similar issues from other chunk types in the future

## Test Plan

- Existing output-converter tests pass
- Core tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a web-search streaming issue where interleaved citation/source segments could create duplicate entries and cause subsequent request failures. Streamed text and citation segments that share the same identifier are now consolidated and emitted as a single message, preventing duplicate-entry errors and improving reliability of streamed web search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->