### PR TITLE
fix(cli): close login server connections to prevent create-mastra from hanging

### DIFF
--- a/.changeset/swift-games-brush.md
+++ b/.changeset/swift-games-brush.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed `create-mastra` hanging after project creation on the gateway login path by properly closing the HTTP server and all keep-alive connections

--- a/packages/cli/src/commands/auth/auth.test.ts
+++ b/packages/cli/src/commands/auth/auth.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 /*  Mocks                                                              */
 /* ------------------------------------------------------------------ */
 
+const mockPlatformFetch = vi.fn();
+
 vi.mock('./client.js', () => ({
   MASTRA_PLATFORM_API_URL: 'http://localhost:9999',
   createApiClient: vi.fn(() => ({
@@ -15,6 +17,7 @@ vi.mock('./client.js', () => ({
     if (orgId) h['x-organization-id'] = orgId;
     return h;
   }),
+  platformFetch: (...args: unknown[]) => mockPlatformFetch(...args),
 }));
 
 const mockGetToken = vi.fn().mockResolvedValue('test-token');
@@ -165,23 +168,20 @@ describe('listOrgsAction', () => {
 
 describe('createTokenAction', () => {
   it('creates a token and displays the secret', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            token: {
-              id: 't1',
-              name: 'ci-token',
-              obfuscatedValue: 'msk_***',
-              lastUsedAt: null,
-              createdAt: '2025-01-01',
-            },
-            secret: 'msk_secret_value',
-          }),
-      }),
-    );
+    mockPlatformFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          token: {
+            id: 't1',
+            name: 'ci-token',
+            obfuscatedValue: 'msk_***',
+            lastUsedAt: null,
+            createdAt: '2025-01-01',
+          },
+          secret: 'msk_secret_value',
+        }),
+    });
 
     const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const { createTokenAction } = await import('./tokens.js');
@@ -205,18 +205,15 @@ describe('createTokenAction', () => {
 
 describe('listTokensAction', () => {
   it('lists tokens', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            tokens: [
-              { id: 't1', name: 'ci-token', obfuscatedValue: 'msk_***abc', lastUsedAt: null, createdAt: '2025-01-01' },
-            ],
-          }),
-      }),
-    );
+    mockPlatformFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          tokens: [
+            { id: 't1', name: 'ci-token', obfuscatedValue: 'msk_***abc', lastUsedAt: null, createdAt: '2025-01-01' },
+          ],
+        }),
+    });
 
     const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const { listTokensAction } = await import('./tokens.js');
@@ -229,13 +226,10 @@ describe('listTokensAction', () => {
   });
 
   it('shows message when no tokens exist', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ tokens: [] }),
-      }),
-    );
+    mockPlatformFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ tokens: [] }),
+    });
 
     const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const { listTokensAction } = await import('./tokens.js');
@@ -249,7 +243,7 @@ describe('listTokensAction', () => {
 
 describe('revokeTokenAction', () => {
   it('revokes a token', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: true }));
+    mockPlatformFetch.mockResolvedValueOnce({ ok: true });
 
     const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const { revokeTokenAction } = await import('./tokens.js');
@@ -262,14 +256,11 @@ describe('revokeTokenAction', () => {
   });
 
   it('throws on failed revocation', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        text: () => Promise.resolve('not found'),
-      }),
-    );
+    mockPlatformFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('not found'),
+    });
 
     const { revokeTokenAction } = await import('./tokens.js');
     await expect(revokeTokenAction('bad-id')).rejects.toThrow('Failed to revoke token: 404');

--- a/packages/cli/src/commands/auth/credentials.ts
+++ b/packages/cli/src/commands/auth/credentials.ts
@@ -117,8 +117,10 @@ export async function login(): Promise<Credentials> {
     organizationId: string;
   }>((resolve, reject) => {
     const timeout = setTimeout(() => {
-      server.close();
-      reject(new Error('Login timed out (60s)'));
+      server.close(() => {
+        reject(new Error('Login timed out (60s)'));
+      });
+      server.closeAllConnections();
     }, 60000);
 
     server.on('request', (req, res) => {
@@ -138,7 +140,7 @@ export async function login(): Promise<Credentials> {
 
         const user = JSON.parse(decodeURIComponent(userParam));
 
-        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.writeHead(200, { 'Content-Type': 'text/html', Connection: 'close' });
         res.end(
           `<html><body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
             <div style="text-align:center">
@@ -149,8 +151,10 @@ export async function login(): Promise<Credentials> {
         );
 
         clearTimeout(timeout);
-        server.close();
-        resolve({ token, refreshToken, user, organizationId: orgId });
+        server.close(() => {
+          resolve({ token, refreshToken, user, organizationId: orgId });
+        });
+        server.closeAllConnections();
       }
     });
   });

--- a/packages/cli/src/commands/auth/login.test.ts
+++ b/packages/cli/src/commands/auth/login.test.ts
@@ -1,0 +1,136 @@
+import { execSync } from 'node:child_process';
+import http from 'node:http';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Stub out side-effects so login() doesn't open a browser or write to disk.
+vi.mock('./client.js', () => ({
+  MASTRA_PLATFORM_API_URL: 'http://localhost:0',
+  createApiClient: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', async importOriginal => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockRejectedValue(new Error('ENOENT')),
+    unlink: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// Prevent openBrowser from actually opening anything.
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+const execSyncMock = vi.mocked(execSync);
+
+/** Extract the port from the execSync call that openBrowser makes. */
+function extractPort(): number {
+  for (const call of execSyncMock.mock.calls) {
+    const cmd = String(call[0]);
+    const match = cmd.match(/cli_port=(\d+)/);
+    if (match) return Number(match[1]);
+  }
+  throw new Error('Could not find cli_port in execSync calls');
+}
+
+/** Send a simulated OAuth callback to the login server. */
+function sendCallback(port: number, params: Record<string, string>): Promise<{ status: number; body: string }> {
+  const qs = new URLSearchParams(params).toString();
+  return new Promise((resolve, reject) => {
+    http
+      .get(`http://127.0.0.1:${port}/callback?${qs}`, res => {
+        let body = '';
+        res.on('data', (chunk: Buffer) => (body += chunk));
+        res.on('end', () => resolve({ status: res.statusCode!, body }));
+      })
+      .on('error', reject);
+  });
+}
+
+const validParams = {
+  token: 'test-token',
+  refresh_token: 'test-refresh',
+  user: encodeURIComponent(JSON.stringify({ id: 'u1', email: 'test@test.com', firstName: 'A', lastName: 'B' })),
+  org: 'org-1',
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  execSyncMock.mockReset();
+});
+
+describe('login() server lifecycle', () => {
+  it('returns credentials after a valid callback', async () => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { login } = await import('./credentials.js');
+
+    const loginPromise = login();
+
+    // Wait for the server to start and openBrowser to be called.
+    await vi.waitFor(() => {
+      extractPort();
+    });
+    const port = extractPort();
+
+    await sendCallback(port, validParams);
+
+    const creds = await loginPromise;
+    expect(creds.token).toBe('test-token');
+    expect(creds.user.email).toBe('test@test.com');
+    expect(creds.organizationId).toBe('org-1');
+  });
+
+  it('closes all connections so the process can exit', async () => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.resetModules();
+    execSyncMock.mockReset();
+    const { login } = await import('./credentials.js');
+
+    const loginPromise = login();
+
+    await vi.waitFor(() => {
+      extractPort();
+    });
+    const port = extractPort();
+
+    const response = await sendCallback(port, validParams);
+    await loginPromise;
+
+    expect(response.body).toContain('Logged in!');
+
+    // The server should no longer be listening — new connections should fail.
+    await expect(
+      new Promise((resolve, reject) => {
+        const req = http.get(`http://127.0.0.1:${port}/`, resolve);
+        req.on('error', reject);
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('returns 400 when callback params are missing', async () => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.resetModules();
+    execSyncMock.mockReset();
+    const { login } = await import('./credentials.js');
+
+    const loginPromise = login();
+
+    await vi.waitFor(() => {
+      extractPort();
+    });
+    const port = extractPort();
+
+    // Send callback with missing params
+    const response = await sendCallback(port, { token: 'tok' });
+    expect(response.status).toBe(400);
+    expect(response.body).toContain('Login failed');
+
+    // Server should still be listening (waiting for a valid callback).
+    // Clean up by sending a valid callback.
+    await sendCallback(port, validParams);
+    await loginPromise;
+  });
+});


### PR DESCRIPTION
The `login()` HTTP server used during the gateway setup path leaves keep-alive connections open after the OAuth callback completes. This prevents the Node.js process from exiting, so `create-mastra` appears to hang after displaying the final "cd your-project && npm run dev" instructions.

This adds `Connection: close` on the response, calls `server.closeAllConnections()` to kill lingering sockets, and moves the resolve/reject into the `server.close()` callback so the promise only settles after the server is fully shut down.

Also adds tests for the login server lifecycle (valid callback, server teardown, 400 on missing params).