### PR TITLE
fix(core): prevent MessageList sort from breaking message order with mixed timestamp sources

### DIFF
--- a/.changeset/better-regions-sin.md
+++ b/.changeset/better-regions-sin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed message reordering when mixing input messages (Date.now() timestamps) with memory messages (old DB timestamps). The full-array sort in MessageList.addOne() could move historical assistant messages before current user messages, breaking the user/assistant alternating pattern and causing consecutive user messages to be merged.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1003,7 +1003,15 @@ export class MessageList {
             if (messageV2.createdAt <= existingMessage.createdAt) {
               messageV2.createdAt = new Date(existingMessage.createdAt.getTime() + 1);
             }
-            this.messages.push(messageV2);
+            // Insert at the correct chronological position so that removing the
+            // full-array sort does not leave split-off messages out of order.
+            const splitTime = messageV2.createdAt.getTime();
+            const splitIdx = this.messages.findIndex(m => m.createdAt.getTime() > splitTime);
+            if (splitIdx === -1) {
+              this.messages.push(messageV2);
+            } else {
+              this.messages.splice(splitIdx, 0, messageV2);
+            }
           }
           // If no new parts, don't add anything (the sealed message already has all the content)
         } else {

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1018,21 +1018,34 @@ export class MessageList {
           if (shouldMergeIntoExisting) {
             MessageMerger.merge(existingMessage, messageV2);
             this.pushMessageToSource(existingMessage, messageSource);
-            // Sort messages and return early — existingMessage stays in messages[] and its Sets
-            this.messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
             return this;
+          }
+          // Preserve the newer createdAt so that replacing a message with one
+          // that has an older DB timestamp does not shift it before other messages.
+          if (existingMessage.createdAt > messageV2.createdAt) {
+            messageV2.createdAt = existingMessage.createdAt;
           }
           this.messages[existingIndex] = messageV2;
         }
       } else if (!exists) {
-        this.messages.push(messageV2);
+        if (messageSource === `memory`) {
+          // Insert memory messages at their chronological position instead of
+          // appending and sorting. A full-array sort breaks ordering when memory
+          // messages carry old DB timestamps while input messages use Date.now().
+          const insertTime = messageV2.createdAt.getTime();
+          const insertIndex = this.messages.findIndex(m => m.createdAt.getTime() > insertTime);
+          if (insertIndex === -1) {
+            this.messages.push(messageV2);
+          } else {
+            this.messages.splice(insertIndex, 0, messageV2);
+          }
+        } else {
+          this.messages.push(messageV2);
+        }
       }
 
       this.pushMessageToSource(messageV2, messageSource);
     }
-
-    // make sure messages are always stored in order of when they were created!
-    this.messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
     return this;
   }

--- a/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
@@ -614,13 +614,12 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
 
       const result = messageList.get.all.db();
       const roles = result.map(m => m.role);
+      const texts = result.map(m => m.content?.parts?.[0]?.text);
 
-      for (let i = 1; i < roles.length; i++) {
-        if (roles[i] === 'user' && roles[i - 1] === 'user') {
-          const texts = result.map(m => m.content?.parts?.[0]?.text);
-          throw new Error(`Consecutive user messages at index ${i - 1},${i}: ${JSON.stringify(texts)}`);
-        }
-      }
+      // The older user message should be inserted before the assistant (chronological)
+      // and the input user message should remain at the end
+      expect(roles).toEqual(['user', 'assistant', 'user']);
+      expect(texts).toEqual(['Previous question', 'Hi! How can I help?', 'Hello, how are you?']);
     });
   });
 });

--- a/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
@@ -476,4 +476,151 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
       expect(texts).toEqual(['First', 'Second', 'Third', 'Fourth']);
     });
   });
+
+  describe('Mixed input/memory timestamp ordering', () => {
+    it('should not reorder messages when memory messages have older timestamps than input messages', () => {
+      const messageList = new MessageList();
+
+      messageList.add(
+        [
+          { role: 'user' as const, content: [{ type: 'text' as const, text: 'Hello' }] },
+          {
+            role: 'assistant' as const,
+            content: [{ type: 'text' as const, text: 'Hi there!' }],
+          },
+          { role: 'user' as const, content: [{ type: 'text' as const, text: 'What can you do?' }] },
+        ],
+        'input',
+      );
+
+      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+      const memoryAssistant: MastraDBMessage = {
+        id: 'memory-assistant-1',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'I am a helpful assistant (observation added)' }],
+        },
+        createdAt: fiveMinutesAgo,
+      };
+      messageList.add(memoryAssistant, 'memory');
+
+      const result = messageList.get.all.db();
+
+      // No consecutive user messages should appear
+      for (let i = 1; i < result.length; i++) {
+        if (result[i].role === result[i - 1]?.role && result[i].role !== 'assistant') {
+          throw new Error(
+            `Consecutive ${result[i].role} messages at index ${i - 1} and ${i}: ` +
+              `"${result[i - 1]?.content?.parts?.[0]?.text}" and "${result[i].content?.parts?.[0]?.text}"`,
+          );
+        }
+      }
+    });
+
+    it('should preserve user/assistant alternation when shouldReplace fires with old DB timestamps', () => {
+      const messageList = new MessageList();
+      const now = Date.now();
+
+      const inputUser: MastraDBMessage = {
+        id: 'msg-user-1',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+        createdAt: new Date(now),
+      };
+      const inputAssistant: MastraDBMessage = {
+        id: 'msg-assistant-1',
+        role: 'assistant',
+        content: { format: 2, parts: [{ type: 'text', text: 'Hi!' }] },
+        createdAt: new Date(now + 1),
+      };
+      const inputUser2: MastraDBMessage = {
+        id: 'msg-user-2',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'What can you do?' }] },
+        createdAt: new Date(now + 2),
+      };
+
+      messageList.add([inputUser, inputAssistant, inputUser2], 'input');
+
+      // Memory loads same assistant with old timestamp + different content (triggers shouldReplace)
+      const memoryAssistant: MastraDBMessage = {
+        id: 'msg-assistant-1',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            { type: 'text', text: 'Hi!' },
+            { type: 'text', text: '[observation: user greeted]' },
+          ],
+        },
+        createdAt: new Date(now - 300000), // 5 minutes ago
+      };
+      messageList.add(memoryAssistant, 'memory');
+
+      const result = messageList.get.all.db();
+      const roles = result.map(m => m.role);
+      expect(roles).toEqual(['user', 'assistant', 'user']);
+
+      // Content should be updated via shouldReplace
+      const assistantMsg = result.find(m => m.role === 'assistant');
+      expect(assistantMsg?.content.parts).toHaveLength(2);
+
+      // createdAt should be the newer timestamp from the input message
+      expect(assistantMsg?.createdAt.getTime()).toBeGreaterThanOrEqual(now);
+    });
+
+    it('should handle useChat without createdAt combined with observational memory', () => {
+      const messageList = new MessageList();
+
+      // V5 UI messages without createdAt
+      messageList.add(
+        [
+          {
+            id: 'ui-1',
+            role: 'user' as const,
+            parts: [{ type: 'text' as const, text: 'Hello, how are you?' }],
+          },
+        ],
+        'input',
+      );
+
+      const oldTime = new Date('2026-03-31T10:00:00.000Z');
+      messageList.add(
+        {
+          id: 'db-assistant-1',
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: 'Hi! How can I help?' }],
+          },
+          createdAt: oldTime,
+        } as MastraDBMessage,
+        'memory',
+      );
+
+      messageList.add(
+        {
+          id: 'db-user-prev',
+          role: 'user',
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: 'Previous question' }],
+          },
+          createdAt: new Date(oldTime.getTime() - 1000),
+        } as MastraDBMessage,
+        'memory',
+      );
+
+      const result = messageList.get.all.db();
+      const roles = result.map(m => m.role);
+
+      for (let i = 1; i < roles.length; i++) {
+        if (roles[i] === 'user' && roles[i - 1] === 'user') {
+          const texts = result.map(m => m.content?.parts?.[0]?.text);
+          throw new Error(`Consecutive user messages at index ${i - 1},${i}: ${JSON.stringify(texts)}`);
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Description

  `MessageList.addOne()` sorted all messages by `createdAt` after every insertion. When input messages from
  the frontend (AI SDK v6's `useChat`) have no `createdAt` and receive `Date.now()` timestamps, while memory
   messages retain their old DB timestamps, the sort reorders the old assistant message before the newer
  user messages. This breaks the user/assistant alternating pattern, causing `makePushOrCombine` to merge
  consecutive user messages and `ensureGeminiCompatibleMessages` to inject a dummy `"."` user message.

  **Changes:**
  - Removed the two `this.messages.sort()` calls in `addOne()` that caused the reordering
  - Memory messages are now inserted at their chronological position via `findIndex` + `splice` instead of
  append + sort
  - When `shouldReplace` fires, the newer `createdAt` is preserved so a DB message's old timestamp does not
  regress an input message's position

  ## Related Issue(s)

  Fixes #14912
  Related to #14907

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message reordering when mixing newly-supplied input messages with previously persisted memory messages, preserving chronological order and correct user/assistant alternation.

* **Tests**
  * Added tests covering mixed input/memory timestamp scenarios, replacement cases, and edge conditions to validate ordering, role alternation, and message updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->