### PR TITLE
fix(core): use path to directory where SKILL.md file is instead of to file itself

### DIFF
--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -105,7 +105,7 @@ export class SkillsProcessor implements Processor<'skills-processor'> {
    * Format skill location (path to SKILL.md file)
    */
   private formatLocation(skill: Skill): string {
-    return `${skill.path}/SKILL.md`;
+    return skill.path;
   }
 
   /**


### PR DESCRIPTION
https://github.com/mastra-ai/mastra/blob/9a43b476465e86c9aca381c2831066b5c33c999a/packages/core/src/processors/processors/skills.ts#L108

The `skill` tool tries to lookup a skill by name or location, but the location in the list of skills is the path to the SKILL.md file, not including the file's name. Lookup based on location fail currently because of this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the location field in available-skill metadata to reference skill paths directly instead of constructed file paths. This affects how skill locations are displayed in XML, JSON, and Markdown formatted outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->