### PR TITLE
Revert HorizontalBars style changes

### DIFF
--- a/.changeset/wild-rules-train.md
+++ b/.changeset/wild-rules-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Reverted HorizontalBars layout to original inline style with label overlaid inside the bar and total displayed to the right

--- a/packages/playground-ui/src/ds/components/HorizontalBars/horizontal-bars.tsx
+++ b/packages/playground-ui/src/ds/components/HorizontalBars/horizontal-bars.tsx
@@ -36,18 +36,15 @@ export function HorizontalBars({
             </div>
           ))}
         </div>
+        <span className="shrink-0 text-ui-sm text-neutral2 pr-2">Total</span>
       </div>
       <div className="grid gap-3.5">
         {sorted.map(d => {
           const total = d.values.reduce((s, v) => s + v, 0);
 
           return (
-            <div key={d.name} className="grid gap-1">
-              <div className="flex items-center justify-between">
-                <span className="text-ui-sm text-neutral4 truncate">{d.name}</span>
-                <span className="text-ui-sm text-neutral4 tabular-nums shrink-0">{fmt(total)}</span>
-              </div>
-              <div className="relative h-5 w-full">
+            <div key={d.name} className="flex items-center gap-14 h-6 ">
+              <div className="relative h-full flex-1 min-w-0">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <div
@@ -99,7 +96,11 @@ export function HorizontalBars({
                     </div>
                   </TooltipContent>
                 </Tooltip>
+                <span className="absolute inset-y-0 left-2.5 flex items-center text-ui-sm text-neutral4 truncate z-10 pointer-events-none">
+                  {d.name}
+                </span>
               </div>
+              <span className="text-ui-md text-neutral4 tabular-nums shrink-0 pr-3">{fmt(total)}</span>
             </div>
           );
         })}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

now

<img width="1436" height="613" alt="CleanShot 2026-04-01 at 12 04 25" src="https://github.com/user-attachments/assets/0a1929a4-d736-4a1d-8471-73f5afb50bc2" />


reverted to the original shape


<img width="1436" height="616" alt="CleanShot 2026-04-01 at 12 04 36" src="https://github.com/user-attachments/assets/1c3505af-081c-4802-8ed2-6d02c8e6d8c3" />



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * HorizontalBars layout reverted to original inline styling.

* **New Features**
  * Added "Total" label to the chart header.

* **Style**
  * Label now displays overlaid within the bar.
  * Total values positioned to the right of each row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->