### PR TITLE
feat(memory): expose loadUnobservedMessages as public method on ObservationalMemory

### DIFF
--- a/.changeset/shiny-parks-stop.md
+++ b/.changeset/shiny-parks-stop.md
@@ -1,0 +1,14 @@
+---
+'@mastra/memory': minor
+---
+
+Added `loadUnobservedMessages({ threadId, resourceId? })` as a public method on `ObservationalMemory`.
+
+This lets external consumers (e.g. the Mastra gateway proxy) load previously-stored messages that haven't been observed yet, without having to reimplement the internal storage query and part-level filtering logic. The method fetches the OM record, queries storage for messages after the `lastObservedAt` cursor, and applies part-level filtering so partially-observed messages only return their unobserved parts.
+
+```ts
+const unobserved = await om.loadUnobservedMessages({
+  threadId: 'thread-123',
+  resourceId: 'user-456',
+});
+```

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -1515,7 +1515,7 @@ export class ObservationalMemory {
    * In resource scope mode, loads messages for the entire resource (all threads).
    * In thread scope mode, loads messages for just the current thread.
    */
-  private async loadUnobservedMessages(
+  private async loadMessagesFromStorage(
     threadId: string,
     resourceId: string | undefined,
     lastObservedAt?: Date,
@@ -2470,7 +2470,7 @@ ${formattedMessages}
     if (opts.messages) {
       unobservedMessages = this.getUnobservedMessages(opts.messages, record);
     } else {
-      const rawMessages = await this.loadUnobservedMessages(
+      const rawMessages = await this.loadMessagesFromStorage(
         threadId,
         resourceId,
         record.lastObservedAt ? new Date(record.lastObservedAt) : undefined,
@@ -2625,6 +2625,28 @@ ${formattedMessages}
   }
 
   /**
+   * Load unobserved messages from storage for a thread/resource.
+   *
+   * Fetches the OM record, queries storage for messages after the
+   * lastObservedAt cursor, then applies part-level filtering so
+   * partially-observed messages only include their unobserved parts.
+   *
+   * Use this when you need to load stored conversation history that
+   * hasn't been observed yet (e.g. in a stateless gateway proxy that
+   * only receives the latest message from the HTTP request).
+   */
+  async loadUnobservedMessages(opts: { threadId: string; resourceId?: string }): Promise<MastraDBMessage[]> {
+    const { threadId, resourceId } = opts;
+    const record = await this.getOrCreateRecord(threadId, resourceId);
+    const rawMessages = await this.loadMessagesFromStorage(
+      threadId,
+      resourceId,
+      record.lastObservedAt ? new Date(record.lastObservedAt) : undefined,
+    );
+    return this.getUnobservedMessages(rawMessages, record);
+  }
+
+  /**
    * Create a buffered observation chunk without merging into active observations.
    *
    * Loads unobserved messages from storage (filtered by the buffer cursor to avoid
@@ -2731,7 +2753,7 @@ ${formattedMessages}
       if (opts.messages) {
         candidateMessages = this.getUnobservedMessages(opts.messages, record, { excludeBuffered: true });
       } else {
-        const rawMessages = await this.loadUnobservedMessages(
+        const rawMessages = await this.loadMessagesFromStorage(
           threadId,
           resourceId,
           record.lastObservedAt ? new Date(record.lastObservedAt) : undefined,
@@ -3062,7 +3084,7 @@ ${formattedMessages}
 
       const unobservedMessages = messages
         ? this.getUnobservedMessages(messages, freshRecord)
-        : await this.loadUnobservedMessages(
+        : await this.loadMessagesFromStorage(
             threadId,
             resourceId,
             freshRecord.lastObservedAt ? new Date(freshRecord.lastObservedAt) : undefined,


### PR DESCRIPTION
## Summary

- Exposes `loadUnobservedMessages({ threadId, resourceId? })` as a public method on `ObservationalMemory`, allowing external consumers (e.g. the Mastra gateway proxy) to load stored messages that haven't been observed yet without reimplementing the internal storage query and part-level filtering logic.
- Renames the existing private method to `loadMessagesFromStorage` to avoid a name collision, and adds a new public wrapper that composes `getOrCreateRecord` → storage query → `getUnobservedMessages` part-level filtering.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `loadUnobservedMessages()` method to retrieve previously stored messages that remain unobserved, with optional filtering by thread and resource identifiers for targeted message access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->