### PR TITLE
feat(core): Add parentToolCalls to delegation hook contexts

### DIFF
--- a/.changeset/few-melons-follow.md
+++ b/.changeset/few-melons-follow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added parentToolCalls to delegation hook contexts (onDelegationStart, onDelegationComplete, messageFilter). Supervisor agents now expose the parent agent's tool call history — including tool names, arguments, and results — to all delegation hooks, enabling smarter routing and context-aware delegation decisions.

--- a/.changeset/few-melons-follow.md
+++ b/.changeset/few-melons-follow.md
@@ -2,4 +2,27 @@
 '@mastra/core': minor
 ---
 
-Added parentToolCalls to delegation hook contexts (onDelegationStart, onDelegationComplete, messageFilter). Supervisor agents now expose the parent agent's tool call history — including tool names, arguments, and results — to all delegation hooks, enabling smarter routing and context-aware delegation decisions.
+Added `parentToolCalls` to delegation hook contexts (`onDelegationStart`, `onDelegationComplete`, `messageFilter`). Supervisor agents now expose the parent agent's tool call history — including tool names, arguments, and results — to all delegation hooks, enabling smarter routing and context-aware delegation decisions.
+
+```ts
+await supervisor.generate('Search and analyze', {
+  delegation: {
+    onDelegationStart: (ctx) => {
+      const searched = ctx.parentToolCalls.some(tc => tc.name === 'search-db');
+      if (searched) {
+        return { proceed: true, modifiedPrompt: `Use these results: ${JSON.stringify(ctx.parentToolCalls.find(tc => tc.name === 'search-db')?.result)}` };
+      }
+      return { proceed: false, rejectionReason: 'No search performed yet' };
+    },
+    onDelegationComplete: (ctx) => {
+      console.log('Parent tools used:', ctx.parentToolCalls.map(tc => tc.name));
+    },
+    messageFilter: (ctx) => {
+      if (ctx.parentToolCalls.some(tc => tc.isError)) {
+        return ctx.messages.slice(-3);
+      }
+      return ctx.messages;
+    },
+  },
+});
+```

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -9,7 +9,13 @@ import type { Processor, ProcessOutputResultArgs } from '../../processors/index'
 import { InMemoryStore } from '../../storage';
 import { createTool } from '../../tools';
 import { Agent } from '../agent';
-import type { MessageFilterContext, DelegationCompleteContext, IterationCompleteContext } from '../agent.types';
+import type {
+  MessageFilterContext,
+  DelegationStartContext,
+  DelegationCompleteContext,
+  IterationCompleteContext,
+  ParentToolCall,
+} from '../agent.types';
 import type { MastraDBMessage } from '../message-list/state/types';
 
 // Helper: create a sub-agent with a fixed text response
@@ -3859,5 +3865,405 @@ describe('Supervisor Pattern - Sub-agent should not receive parent tool call ref
         }
       }
     }
+  });
+
+  describe('parentToolCalls in delegation hooks', () => {
+    it('should provide parent tool call history in onDelegationStart', async () => {
+      let capturedContext: DelegationStartContext | undefined;
+
+      const regularTool = createTool({
+        id: 'search-db',
+        description: 'Search the database',
+        inputSchema: z.object({ query: z.string() }),
+        execute: async ({ query }) => ({ results: [`result for ${query}`] }),
+      });
+
+      const subAgent = makeSubAgent('analyst', 'Analysis complete.');
+
+      let callCount = 0;
+      const supervisorAgent = new Agent({
+        id: 'supervisor',
+        name: 'supervisor',
+        instructions: 'You search then delegate.',
+        model: new MockLanguageModelV2({
+          doGenerate: async () => {
+            callCount++;
+            if (callCount === 1) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                text: '',
+                content: [
+                  {
+                    type: 'tool-call' as const,
+                    toolCallId: 'tc-search-1',
+                    toolName: 'search-db',
+                    input: JSON.stringify({ query: 'sales data' }),
+                  },
+                ],
+                warnings: [],
+              };
+            }
+            if (callCount === 2) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                text: '',
+                content: [
+                  {
+                    type: 'tool-call' as const,
+                    toolCallId: 'tc-delegate-1',
+                    toolName: 'agent-analyst',
+                    input: JSON.stringify({ prompt: 'analyze sales data' }),
+                  },
+                ],
+                warnings: [],
+              };
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop' as const,
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              text: 'Done',
+              content: [{ type: 'text' as const, text: 'Done' }],
+              warnings: [],
+            };
+          },
+        }),
+        tools: { searchDb: regularTool },
+        agents: { analyst: subAgent },
+        memory: new MockMemory(),
+      });
+
+      await supervisorAgent.generate('Search and analyze', {
+        maxSteps: 5,
+        delegation: {
+          onDelegationStart: (ctx: DelegationStartContext) => {
+            capturedContext = ctx;
+            return { proceed: true };
+          },
+        },
+      });
+
+      expect(capturedContext).toBeDefined();
+      expect(capturedContext!.parentToolCalls).toBeDefined();
+      expect(capturedContext!.parentToolCalls.length).toBeGreaterThanOrEqual(1);
+
+      const searchCall = capturedContext!.parentToolCalls.find((tc: ParentToolCall) => tc.name === 'search-db');
+      expect(searchCall).toBeDefined();
+      expect(searchCall!.id).toBe('tc-search-1');
+      expect(searchCall!.result).toEqual({ results: ['result for sales data'] });
+    });
+
+    it('should provide parent tool call history in onDelegationComplete', async () => {
+      let capturedContext: DelegationCompleteContext | undefined;
+
+      const regularTool = createTool({
+        id: 'fetch-data',
+        description: 'Fetch data',
+        inputSchema: z.object({ source: z.string() }),
+        execute: async ({ source }) => ({ data: `data from ${source}` }),
+      });
+
+      const subAgent = makeSubAgent('reporter', 'Report ready.');
+
+      let callCount = 0;
+      const supervisorAgent = new Agent({
+        id: 'supervisor',
+        name: 'supervisor',
+        instructions: 'You fetch then delegate.',
+        model: new MockLanguageModelV2({
+          doGenerate: async () => {
+            callCount++;
+            if (callCount === 1) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                text: '',
+                content: [
+                  {
+                    type: 'tool-call' as const,
+                    toolCallId: 'tc-fetch-1',
+                    toolName: 'fetch-data',
+                    input: JSON.stringify({ source: 'api' }),
+                  },
+                ],
+                warnings: [],
+              };
+            }
+            if (callCount === 2) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                text: '',
+                content: [
+                  {
+                    type: 'tool-call' as const,
+                    toolCallId: 'tc-delegate-1',
+                    toolName: 'agent-reporter',
+                    input: JSON.stringify({ prompt: 'write report' }),
+                  },
+                ],
+                warnings: [],
+              };
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop' as const,
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              text: 'Done',
+              content: [{ type: 'text' as const, text: 'Done' }],
+              warnings: [],
+            };
+          },
+        }),
+        tools: { fetchData: regularTool },
+        agents: { reporter: subAgent },
+        memory: new MockMemory(),
+      });
+
+      await supervisorAgent.generate('Fetch and report', {
+        maxSteps: 5,
+        delegation: {
+          onDelegationComplete: (ctx: DelegationCompleteContext) => {
+            capturedContext = ctx;
+          },
+        },
+      });
+
+      expect(capturedContext).toBeDefined();
+      expect(capturedContext!.parentToolCalls).toBeDefined();
+
+      const fetchCall = capturedContext!.parentToolCalls.find((tc: ParentToolCall) => tc.name === 'fetch-data');
+      expect(fetchCall).toBeDefined();
+      expect(fetchCall!.id).toBe('tc-fetch-1');
+      expect(fetchCall!.result).toEqual({ data: 'data from api' });
+    });
+
+    it('should provide parent tool call history in messageFilter', async () => {
+      let capturedToolCalls: ParentToolCall[] | undefined;
+
+      const regularTool = createTool({
+        id: 'lookup',
+        description: 'Lookup info',
+        inputSchema: z.object({ key: z.string() }),
+        execute: async ({ key }) => ({ value: `info-${key}` }),
+      });
+
+      const subAgent = makeSubAgent('worker', 'Work done.');
+
+      let callCount = 0;
+      const supervisorAgent = new Agent({
+        id: 'supervisor',
+        name: 'supervisor',
+        instructions: 'You lookup then delegate.',
+        model: new MockLanguageModelV2({
+          doGenerate: async () => {
+            callCount++;
+            if (callCount === 1) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                text: '',
+                content: [
+                  {
+                    type: 'tool-call' as const,
+                    toolCallId: 'tc-lookup-1',
+                    toolName: 'lookup',
+                    input: JSON.stringify({ key: 'abc' }),
+                  },
+                ],
+                warnings: [],
+              };
+            }
+            if (callCount === 2) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                text: '',
+                content: [
+                  {
+                    type: 'tool-call' as const,
+                    toolCallId: 'tc-delegate-1',
+                    toolName: 'agent-worker',
+                    input: JSON.stringify({ prompt: 'do work' }),
+                  },
+                ],
+                warnings: [],
+              };
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop' as const,
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              text: 'Done',
+              content: [{ type: 'text' as const, text: 'Done' }],
+              warnings: [],
+            };
+          },
+        }),
+        tools: { lookup: regularTool },
+        agents: { worker: subAgent },
+        memory: new MockMemory(),
+      });
+
+      await supervisorAgent.generate('Lookup and work', {
+        maxSteps: 5,
+        delegation: {
+          messageFilter: (ctx: MessageFilterContext) => {
+            capturedToolCalls = ctx.parentToolCalls;
+            return ctx.messages;
+          },
+        },
+      });
+
+      expect(capturedToolCalls).toBeDefined();
+      const lookupCall = capturedToolCalls!.find((tc: ParentToolCall) => tc.name === 'lookup');
+      expect(lookupCall).toBeDefined();
+      expect(lookupCall!.id).toBe('tc-lookup-1');
+      expect(lookupCall!.result).toBeDefined();
+    });
+
+    it('should only contain the current delegation call when no prior regular tools were called', async () => {
+      let capturedToolCalls: ParentToolCall[] | undefined;
+
+      const subAgent = makeSubAgent('direct-agent', 'Direct response.');
+
+      const supervisorAgent = new Agent({
+        id: 'supervisor',
+        name: 'supervisor',
+        instructions: 'You delegate directly.',
+        model: makeSupervisorModel('directAgent', 'go directly'),
+        agents: { directAgent: subAgent },
+        memory: new MockMemory(),
+      });
+
+      await supervisorAgent.generate('Do it directly', {
+        maxSteps: 3,
+        delegation: {
+          onDelegationStart: (ctx: DelegationStartContext) => {
+            capturedToolCalls = ctx.parentToolCalls;
+            return { proceed: true };
+          },
+        },
+      });
+
+      expect(capturedToolCalls).toBeDefined();
+      const nonDelegationCalls = capturedToolCalls!.filter(
+        (tc: ParentToolCall) => !tc.name.startsWith('agent-') && !tc.name.startsWith('workflow-'),
+      );
+      expect(nonDelegationCalls).toEqual([]);
+    });
+
+    it('should include multiple parent tool calls with their respective results', async () => {
+      let capturedToolCalls: ParentToolCall[] | undefined;
+
+      const toolA = createTool({
+        id: 'tool-a',
+        description: 'Tool A',
+        inputSchema: z.object({ x: z.string() }),
+        execute: async ({ x }) => ({ a: x }),
+      });
+
+      const toolB = createTool({
+        id: 'tool-b',
+        description: 'Tool B',
+        inputSchema: z.object({ y: z.number() }),
+        execute: async ({ y }) => ({ b: y * 2 }),
+      });
+
+      const subAgent = makeSubAgent('final-agent', 'Final.');
+
+      let callCount = 0;
+      const supervisorAgent = new Agent({
+        id: 'supervisor',
+        name: 'supervisor',
+        instructions: 'You use multiple tools then delegate.',
+        model: new MockLanguageModelV2({
+          doGenerate: async () => {
+            callCount++;
+            if (callCount === 1) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                text: '',
+                content: [
+                  {
+                    type: 'tool-call' as const,
+                    toolCallId: 'tc-a-1',
+                    toolName: 'tool-a',
+                    input: JSON.stringify({ x: 'hello' }),
+                  },
+                  {
+                    type: 'tool-call' as const,
+                    toolCallId: 'tc-b-1',
+                    toolName: 'tool-b',
+                    input: JSON.stringify({ y: 5 }),
+                  },
+                ],
+                warnings: [],
+              };
+            }
+            if (callCount === 2) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                text: '',
+                content: [
+                  {
+                    type: 'tool-call' as const,
+                    toolCallId: 'tc-delegate-1',
+                    toolName: 'agent-finalAgent',
+                    input: JSON.stringify({ prompt: 'finalize' }),
+                  },
+                ],
+                warnings: [],
+              };
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop' as const,
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              text: 'All done',
+              content: [{ type: 'text' as const, text: 'All done' }],
+              warnings: [],
+            };
+          },
+        }),
+        tools: { toolA, toolB },
+        agents: { finalAgent: subAgent },
+        memory: new MockMemory(),
+      });
+
+      await supervisorAgent.generate('Use tools then delegate', {
+        maxSteps: 5,
+        delegation: {
+          onDelegationStart: (ctx: DelegationStartContext) => {
+            capturedToolCalls = ctx.parentToolCalls;
+            return { proceed: true };
+          },
+        },
+      });
+
+      expect(capturedToolCalls).toBeDefined();
+      expect(capturedToolCalls!.length).toBeGreaterThanOrEqual(2);
+
+      const callA = capturedToolCalls!.find((tc: ParentToolCall) => tc.name === 'tool-a');
+      const callB = capturedToolCalls!.find((tc: ParentToolCall) => tc.name === 'tool-b');
+
+      expect(callA).toBeDefined();
+      expect(callA!.result).toEqual({ a: 'hello' });
+
+      expect(callB).toBeDefined();
+      expect(callB!.result).toEqual({ b: 10 });
+    });
   });
 });

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -4130,7 +4130,7 @@ describe('Supervisor Pattern - Sub-agent should not receive parent tool call ref
       expect(lookupCall!.result).toBeDefined();
     });
 
-    it('should only contain the current delegation call when no prior regular tools were called', async () => {
+    it('should be empty when no prior tools were called before delegation', async () => {
       let capturedToolCalls: ParentToolCall[] | undefined;
 
       const subAgent = makeSubAgent('direct-agent', 'Direct response.');
@@ -4155,12 +4155,7 @@ describe('Supervisor Pattern - Sub-agent should not receive parent tool call ref
       });
 
       expect(capturedToolCalls).toBeDefined();
-      expect(capturedToolCalls!.length).toBeGreaterThan(0);
-      expect(capturedToolCalls!.some((tc: ParentToolCall) => tc.name.startsWith('agent-'))).toBe(true);
-      const nonDelegationCalls = capturedToolCalls!.filter(
-        (tc: ParentToolCall) => !tc.name.startsWith('agent-') && !tc.name.startsWith('workflow-'),
-      );
-      expect(nonDelegationCalls).toEqual([]);
+      expect(capturedToolCalls).toEqual([]);
     });
 
     it('should include multiple parent tool calls with their respective results', async () => {

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -4155,6 +4155,8 @@ describe('Supervisor Pattern - Sub-agent should not receive parent tool call ref
       });
 
       expect(capturedToolCalls).toBeDefined();
+      expect(capturedToolCalls!.length).toBeGreaterThan(0);
+      expect(capturedToolCalls!.some((tc: ParentToolCall) => tc.name.startsWith('agent-'))).toBe(true);
       const nonDelegationCalls = capturedToolCalls!.filter(
         (tc: ParentToolCall) => !tc.name.startsWith('agent-') && !tc.name.startsWith('workflow-'),
       );

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2713,10 +2713,20 @@ export class Agent<
           if (part?.type === 'tool-call' && part.toolCallId) {
             if (excludeToolCallId && part.toolCallId === excludeToolCallId) continue;
             const rawArgs = part.args || part.input || {};
+            let parsedArgs: Record<string, unknown>;
+            if (typeof rawArgs === 'string') {
+              try {
+                parsedArgs = JSON.parse(rawArgs);
+              } catch {
+                parsedArgs = {};
+              }
+            } else {
+              parsedArgs = rawArgs as Record<string, unknown>;
+            }
             toolCalls.set(part.toolCallId, {
               id: part.toolCallId,
               name: part.toolName || '',
-              args: (typeof rawArgs === 'string' ? JSON.parse(rawArgs) : rawArgs) as Record<string, unknown>,
+              args: parsedArgs,
             });
           }
         }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2702,7 +2702,7 @@ export class Agent<
    * tool-role messages. This method pairs them by toolCallId into a single list.
    * @internal
    */
-  private extractParentToolCalls(messages: MastraDBMessage[]): ParentToolCall[] {
+  private extractParentToolCalls(messages: MastraDBMessage[], excludeToolCallId?: string): ParentToolCall[] {
     const toolCalls = new Map<string, ParentToolCall>();
 
     for (const message of messages) {
@@ -2711,10 +2711,12 @@ export class Agent<
         if (!Array.isArray(parts)) continue;
         for (const part of parts) {
           if (part?.type === 'tool-call' && part.toolCallId) {
+            if (excludeToolCallId && part.toolCallId === excludeToolCallId) continue;
+            const rawArgs = part.args || part.input || {};
             toolCalls.set(part.toolCallId, {
               id: part.toolCallId,
               name: part.toolName || '',
-              args: (part.args || part.input || {}) as Record<string, unknown>,
+              args: (typeof rawArgs === 'string' ? JSON.parse(rawArgs) : rawArgs) as Record<string, unknown>,
             });
           }
         }
@@ -2820,8 +2822,10 @@ export class Agent<
             // Get messages from context - available at tool execution time
             const contextMessages = (context?.agent?.messages || []) as MastraDBMessage[];
 
-            // Extract parent tool calls before stripping — hooks need this visibility
-            const parentToolCalls = this.extractParentToolCalls(contextMessages);
+            // Extract parent tool calls before stripping — hooks need this visibility.
+            // Exclude the current delegation tool call so parentToolCalls only
+            // contains calls made prior to this delegation.
+            const parentToolCalls = this.extractParentToolCalls(contextMessages, toolCallId);
 
             // Strip tool call/result parts from the context.
             const sanitizedMessages = this.stripParentToolParts(contextMessages);

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -82,6 +82,7 @@ import type {
   DelegationConfig,
   DelegationStartContext,
   DelegationCompleteContext,
+  ParentToolCall,
 } from './agent.types';
 import { MessageList } from './message-list';
 import type { MessageInput, MessageListInput, UIMessageWithMetadata, MastraDBMessage } from './message-list';
@@ -2694,6 +2695,53 @@ export class Agent<
   }
 
   /**
+   * Extracts tool calls and their results from raw conversation messages.
+   *
+   * Tool calls appear as parts with type 'tool-call' inside assistant messages.
+   * Their corresponding results appear as parts with type 'tool-result' inside
+   * tool-role messages. This method pairs them by toolCallId into a single list.
+   * @internal
+   */
+  private extractParentToolCalls(messages: MastraDBMessage[]): ParentToolCall[] {
+    const toolCalls = new Map<string, ParentToolCall>();
+
+    for (const message of messages) {
+      if (message.role === 'assistant') {
+        const parts = Array.isArray(message.content) ? message.content : (message.content as any)?.parts;
+        if (!Array.isArray(parts)) continue;
+        for (const part of parts) {
+          if (part?.type === 'tool-call' && part.toolCallId) {
+            toolCalls.set(part.toolCallId, {
+              id: part.toolCallId,
+              name: part.toolName || '',
+              args: (part.args || part.input || {}) as Record<string, unknown>,
+            });
+          }
+        }
+      }
+
+      if ((message as any).role === 'tool') {
+        const parts = Array.isArray(message.content) ? message.content : (message.content as any)?.parts;
+        if (!Array.isArray(parts)) continue;
+        for (const part of parts) {
+          if (part?.type === 'tool-result' && part.toolCallId) {
+            const existing = toolCalls.get(part.toolCallId);
+            if (existing) {
+              const raw = part.result ?? part.output;
+              existing.result = raw != null && typeof raw === 'object' && 'value' in raw ? raw.value : raw;
+              if (part.isError != null) {
+                existing.isError = part.isError;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return Array.from(toolCalls.values());
+  }
+
+  /**
    * Retrieves and converts agent tools to CoreTool format.
    * @internal
    */
@@ -2772,6 +2820,9 @@ export class Agent<
             // Get messages from context - available at tool execution time
             const contextMessages = (context?.agent?.messages || []) as MastraDBMessage[];
 
+            // Extract parent tool calls before stripping — hooks need this visibility
+            const parentToolCalls = this.extractParentToolCalls(contextMessages);
+
             // Strip tool call/result parts from the context.
             const sanitizedMessages = this.stripParentToolParts(contextMessages);
 
@@ -2800,6 +2851,7 @@ export class Agent<
               parentAgentName: this.name,
               toolCallId,
               messages: sanitizedMessages,
+              parentToolCalls,
             };
 
             // Generate sub-agent thread and resource IDs early (before any rejection)
@@ -3009,6 +3061,7 @@ export class Agent<
                     parentAgentId: this.id,
                     parentAgentName: this.name,
                     toolCallId,
+                    parentToolCalls,
                   });
                 } catch (filterError) {
                   this.logger.error('messageFilter error', { agent: this.name, error: filterError });
@@ -3311,6 +3364,7 @@ export class Agent<
                     parentAgentId: this.id,
                     parentAgentName: this.name,
                     messages: fullSubAgentMessages,
+                    parentToolCalls,
                     bail: () => {
                       bailed = true;
                     },
@@ -3386,6 +3440,7 @@ export class Agent<
                     parentAgentId: this.id,
                     parentAgentName: this.name,
                     messages: fullSubAgentMessages,
+                    parentToolCalls,
                     bail: () => {
                       bailed = true;
                     },

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2729,6 +2729,40 @@ export class Agent<
               args: parsedArgs,
             });
           }
+
+          // AI SDK v4 stores tool results inline as tool-invocation parts
+          if (part?.type === 'tool-invocation' && part.toolInvocation) {
+            const inv = part.toolInvocation;
+            if (excludeToolCallId && inv.toolCallId === excludeToolCallId) continue;
+            if (inv.state === 'result') {
+              const existing = toolCalls.get(inv.toolCallId);
+              if (existing) {
+                existing.result = inv.result;
+                if (inv.isError != null) {
+                  existing.isError = inv.isError;
+                }
+              } else {
+                const rawArgs = inv.args || {};
+                let parsedArgs: Record<string, unknown>;
+                if (typeof rawArgs === 'string') {
+                  try {
+                    parsedArgs = JSON.parse(rawArgs);
+                  } catch {
+                    parsedArgs = {};
+                  }
+                } else {
+                  parsedArgs = rawArgs as Record<string, unknown>;
+                }
+                toolCalls.set(inv.toolCallId, {
+                  id: inv.toolCallId,
+                  name: inv.toolName || '',
+                  args: parsedArgs,
+                  result: inv.result,
+                  isError: inv.isError,
+                });
+              }
+            }
+          }
         }
       }
 

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -38,6 +38,22 @@ export type StreamIsTaskCompleteConfig = IsTaskCompleteConfig;
 // ============================================================================
 
 /**
+ * A tool call made by the parent agent, paired with its result when available.
+ */
+export interface ParentToolCall {
+  /** Tool call ID from the LLM */
+  id: string;
+  /** Name of the tool that was called */
+  name: string;
+  /** Arguments passed to the tool */
+  args: Record<string, unknown>;
+  /** Result returned by the tool (undefined if not yet resolved) */
+  result?: unknown;
+  /** Whether the tool call resulted in an error */
+  isError?: boolean;
+}
+
+/**
  * Context passed to the messageFilter callback.
  * Contains everything needed to decide which parent messages to share with the sub-agent.
  */
@@ -64,6 +80,8 @@ export interface MessageFilterContext {
   parentAgentName: string;
   /** Tool call ID from the LLM */
   toolCallId: string;
+  /** Tool calls made by the parent agent prior to this delegation, with their results */
+  parentToolCalls: ParentToolCall[];
 }
 
 /**
@@ -100,6 +118,8 @@ export interface DelegationStartContext {
   toolCallId: string;
   /** Messages accumulated so far */
   messages: MastraDBMessage[];
+  /** Tool calls made by the parent agent prior to this delegation, with their results */
+  parentToolCalls: ParentToolCall[];
 }
 
 /**
@@ -160,6 +180,8 @@ export interface DelegationCompleteContext {
   parentAgentName: string;
   /** Messages accumulated so far (including the delegation result) */
   messages: MastraDBMessage[];
+  /** Tool calls made by the parent agent prior to this delegation, with their results */
+  parentToolCalls: ParentToolCall[];
   /**
    * Call this function to stop all other concurrent delegations.
    * Only relevant when multiple tool calls are executed concurrently.

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -11,6 +11,7 @@ export type {
   InnerAgentExecutionOptions,
   MultiPrimitiveExecutionOptions,
   // Delegation hook types
+  ParentToolCall,
   DelegationStartContext,
   DelegationStartResult,
   OnDelegationStartHandler,


### PR DESCRIPTION
## Description

Adds `parentToolCalls` field to all three delegation hook contexts  (`onDelegationStart`, `onDelegationComplete`, `messageFilter`) in the  supervisor agent pattern.

This exposes the parent agent's tool call history — including tool names,  arguments, and results — so users can make smarter, context-aware delegation  decisions in their hook callbacks.

## Related Issue(s)

Fixes #14738

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supervisor delegation hooks now receive the parent agent’s prior tool call history (tool names, arguments, results, and error state) for context-aware routing, prompting, and message filtering.

* **Public API**
  * Added a new exported type describing parent tool call entries and surfaced it in delegation hook contexts.

* **Documentation**
  * Added changelog and examples showing conditional delegation, prompt updates from prior results, logging, and error-based filtering.

* **Tests**
  * Added integration tests validating parent tool call data is available to delegation hooks and message filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->