### PR TITLE
fix(server): Improve Responses API json_object response with jsonPromptInjection

### DIFF
--- a/.changeset/fruity-kids-report.md
+++ b/.changeset/fruity-kids-report.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed OpenAI Responses API json_object mode so agent-backed responses return JSON output correctly.

--- a/docs/src/content/en/reference/client-js/responses.mdx
+++ b/docs/src/content/en/reference/client-js/responses.mdx
@@ -144,7 +144,7 @@ Use `text.format` when you want JSON output.
 - `json_object` enables JSON mode.
 - `json_schema` enables schema-constrained structured output.
 
-Mastra routes both through the agent's structured output path and still returns the JSON in the normal assistant message text output.
+Mastra returns the JSON in the normal assistant message text output. Use `json_schema` when you need strict schema enforcement. Use `json_object` when you only need valid JSON output.
 
 ```typescript
 const response = await client.responses.create({

--- a/docs/src/content/en/reference/client-js/responses.mdx
+++ b/docs/src/content/en/reference/client-js/responses.mdx
@@ -144,7 +144,7 @@ Use `text.format` when you want JSON output.
 - `json_object` enables JSON mode.
 - `json_schema` enables schema-constrained structured output.
 
-Mastra returns the JSON in the normal assistant message text output. Use `json_schema` when you need strict schema enforcement. Use `json_object` when you only need valid JSON output.
+Both formats return JSON in the assistant message content. Use `json_schema` when you need strict schema enforcement. Use `json_object` when you only need valid JSON output.
 
 ```typescript
 const response = await client.responses.create({

--- a/packages/server/src/server/handlers/responses.test.ts
+++ b/packages/server/src/server/handlers/responses.test.ts
@@ -320,6 +320,7 @@ describe('Responses Handlers', () => {
             type: 'object',
             additionalProperties: true,
           },
+          jsonPromptInjection: true,
         },
       }),
     );
@@ -401,6 +402,7 @@ describe('Responses Handlers', () => {
             type: 'object',
             additionalProperties: true,
           },
+          jsonPromptInjection: true,
         },
       }),
     );

--- a/packages/server/src/server/handlers/responses.ts
+++ b/packages/server/src/server/handlers/responses.ts
@@ -126,6 +126,7 @@ function createStructuredOutput(text: CreateResponseBody['text']) {
     case 'json_object':
       return {
         schema: JSON_OBJECT_RESPONSE_SCHEMA,
+        jsonPromptInjection: true,
       };
     case 'json_schema':
       return {


### PR DESCRIPTION
## Summary
- add `jsonPromptInjection: true` for `json_object` structured output in the Responses handler
- update the v2 generate and stream handler tests to match the new structured output options
- clarify the client responses docs and include a patch changeset for `@mastra/server`

## Verification
- `pnpm i`
- `pnpm turbo build`
- `pnpm --dir packages/server test src/server/handlers/responses.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON output generation for agent-backed responses when using the json_object response mode, ensuring valid JSON is returned reliably.

* **Documentation**
  * Updated structured JSON response guidance, clarifying json_object behavior and when to use json_schema for strict schema enforcement versus json_object for producing valid JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->