### PR TITLE
feat(mastracode): mask sensitive input fields in TUI dialogs

### DIFF
--- a/.changeset/huge-eels-appear.md
+++ b/.changeset/huge-eels-appear.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Mask sensitive input fields (API keys, credentials, connection strings) in TUI dialogs so they display as asterisks instead of plaintext

--- a/.changeset/huge-eels-appear.md
+++ b/.changeset/huge-eels-appear.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Mask sensitive input fields (API keys, credentials, connection strings) in TUI dialogs so they display as asterisks instead of plaintext
+Mask sensitive input fields (API keys, credentials, connection strings) in settings and login dialogs so they display as asterisks instead of plaintext

--- a/mastracode/src/tui/components/api-key-dialog.ts
+++ b/mastracode/src/tui/components/api-key-dialog.ts
@@ -4,9 +4,10 @@
  * Allows entering a key or cancelling to proceed without one.
  */
 
-import { Box, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable } from '@mariozechner/pi-tui';
 import { theme } from '../theme.js';
+import { MaskedInput } from './masked-input.js';
 
 export interface ApiKeyDialogOptions {
   /** Provider name shown in the title (e.g., "Google") */
@@ -20,7 +21,7 @@ export interface ApiKeyDialogOptions {
 }
 
 export class ApiKeyDialogComponent extends Box implements Focusable {
-  private input: Input;
+  private input: MaskedInput;
   private onSubmit: (key: string) => void;
   private onCancel: () => void;
 
@@ -51,7 +52,7 @@ export class ApiKeyDialogComponent extends Box implements Focusable {
     this.addChild(new Spacer(1));
 
     // Input
-    this.input = new Input();
+    this.input = new MaskedInput();
     this.input.onSubmit = (value: string) => {
       const trimmed = value.trim();
       if (trimmed) {

--- a/mastracode/src/tui/components/login-dialog.ts
+++ b/mastracode/src/tui/components/login-dialog.ts
@@ -3,14 +3,15 @@
  */
 
 import { exec } from 'node:child_process';
-import { Box, Container, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import { getOAuthProviders } from '../../auth/index.js';
 import { theme } from '../theme.js';
+import { MaskedInput } from './masked-input.js';
 
 export class LoginDialogComponent extends Box implements Focusable {
   private contentContainer: Container;
-  private input: Input;
+  private input: MaskedInput;
   private tui: TUI;
   private abortController = new AbortController();
   private inputResolver?: (value: string) => void;
@@ -47,7 +48,7 @@ export class LoginDialogComponent extends Box implements Focusable {
     this.addChild(this.contentContainer);
 
     // Input (always present, used when needed)
-    this.input = new Input();
+    this.input = new MaskedInput();
     this.input.onSubmit = () => {
       if (this.inputResolver) {
         this.inputResolver(this.input.getValue());

--- a/mastracode/src/tui/components/masked-input.ts
+++ b/mastracode/src/tui/components/masked-input.ts
@@ -47,9 +47,11 @@ export class MaskedInput implements Component, Focusable {
   render(width: number): string[] {
     // Temporarily swap the value to masked characters, render, then restore.
     const real = this.input.getValue();
-    this.input.setValue('*'.repeat(real.length));
-    const lines = this.input.render(width);
-    this.input.setValue(real);
-    return lines;
+    try {
+      this.input.setValue('*'.repeat(real.length));
+      return this.input.render(width);
+    } finally {
+      this.input.setValue(real);
+    }
   }
 }

--- a/mastracode/src/tui/components/masked-input.ts
+++ b/mastracode/src/tui/components/masked-input.ts
@@ -1,0 +1,55 @@
+/**
+ * MaskedInput - wraps pi-tui's Input to obscure displayed text with asterisks.
+ * The actual value is preserved; only the rendered output is masked.
+ */
+
+import { Input } from '@mariozechner/pi-tui';
+import type { Component, Focusable } from '@mariozechner/pi-tui';
+
+export class MaskedInput implements Component, Focusable {
+  private input: Input;
+
+  get focused(): boolean {
+    return this.input.focused;
+  }
+  set focused(value: boolean) {
+    this.input.focused = value;
+  }
+
+  set onSubmit(fn: ((value: string) => void) | undefined) {
+    this.input.onSubmit = fn;
+  }
+
+  set onEscape(fn: (() => void) | undefined) {
+    this.input.onEscape = fn;
+  }
+
+  constructor() {
+    this.input = new Input();
+  }
+
+  getValue(): string {
+    return this.input.getValue();
+  }
+
+  setValue(value: string): void {
+    this.input.setValue(value);
+  }
+
+  handleInput(data: string): void {
+    this.input.handleInput(data);
+  }
+
+  invalidate(): void {
+    this.input.invalidate();
+  }
+
+  render(width: number): string[] {
+    // Temporarily swap the value to masked characters, render, then restore.
+    const real = this.input.getValue();
+    this.input.setValue('*'.repeat(real.length));
+    const lines = this.input.render(width);
+    this.input.setValue(real);
+    return lines;
+  }
+}

--- a/mastracode/src/tui/components/settings.ts
+++ b/mastracode/src/tui/components/settings.ts
@@ -6,11 +6,12 @@
  * Changes apply immediately — Esc closes the panel.
  */
 
-import { Box, Container, Input, SelectList, SettingsList, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, SelectList, SettingsList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, SettingItem } from '@mariozechner/pi-tui';
 import type { StorageBackend } from '../../onboarding/settings.js';
 import type { NotificationMode } from '../notify.js';
 import { theme, getSettingsListTheme, getSelectListTheme } from '../theme.js';
+import { MaskedInput } from './masked-input.js';
 import { getThinkingLevelsForModel } from './thinking-settings.js';
 
 // =============================================================================
@@ -66,7 +67,7 @@ class StorageBackendSubmenu extends Container {
   private phase: 'select' | 'connection' = 'select';
   private pendingBackend: StorageBackend = 'libsql';
   private selectList: SelectList;
-  private input!: Input;
+  private input!: MaskedInput;
   private onDone: (backend: StorageBackend, connectionUrl?: string) => void;
   private onBack: () => void;
   private currentPgConnectionString: string;
@@ -129,7 +130,7 @@ class StorageBackendSubmenu extends Container {
     }
     this.addChild(new Spacer(1));
 
-    this.input = new Input();
+    this.input = new MaskedInput();
     const currentValue = this.pendingBackend === 'pg' ? this.currentPgConnectionString : this.currentLibsqlUrl;
     if (currentValue) {
       this.input.setValue(currentValue);


### PR DESCRIPTION
API keys, credentials, and connection strings now display as asterisks instead of plaintext in the api-key, login, and settings dialogs.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TUI dialogs now mask sensitive inputs with asterisks — applies to API keys, login credentials, and database connection strings.
  * Masking is enabled across login, API-key entry, and storage/connection settings to prevent visual exposure of secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->