### PR TITLE
fix(core): skip provider-defined tools when extending schema for auto-resume

### DIFF
--- a/.changeset/fix-provider-tool-schema.md
+++ b/.changeset/fix-provider-tool-schema.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": patch
+---
+
+fix(core): skip provider-defined tools when extending schema for auto-resume
+
+Provider-defined tools (e.g., `openai.tools.webSearch()`, `google.tools.googleSearch()`) have a special lazy schema that doesn't work with `standardSchemaToJSONSchema()`. When `autoResumeSuspendedTools` is enabled, CoreToolBuilder tries to extend tool schemas with `suspendedToolRunId` and `resumeData` fields, which was crashing for provider tools.

--- a/.changeset/fix-provider-tool-schema.md
+++ b/.changeset/fix-provider-tool-schema.md
@@ -2,6 +2,4 @@
 "@mastra/core": patch
 ---
 
-fix(core): skip provider-defined tools when extending schema for auto-resume
-
-Provider-defined tools (e.g., `openai.tools.webSearch()`, `google.tools.googleSearch()`) have a special lazy schema that doesn't work with `standardSchemaToJSONSchema()`. When `autoResumeSuspendedTools` is enabled, CoreToolBuilder tries to extend tool schemas with `suspendedToolRunId` and `resumeData` fields, which was crashing for provider tools.
+Fixed a crash when using provider-defined tools (like `openai.tools.webSearch()`) with `autoResumeSuspendedTools` enabled.

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -1,10 +1,11 @@
-import type { ProviderDefinedTool } from '@internal/external-types';
+import { openai } from '@ai-sdk/openai-v6';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { SpanType } from '../../observability';
 import type { AnySpan } from '../../observability';
 import { RequestContext } from '../../request-context';
 import { createTool } from '../../tools';
+import { isProviderDefinedTool, isVercelTool } from '../toolchecks';
 import { CoreToolBuilder } from './builder';
 
 describe('MCP Tool Tracing', () => {
@@ -212,23 +213,24 @@ describe('MCP Tool Tracing', () => {
 });
 
 describe('Provider-defined Tool Handling', () => {
-  it('should not crash when autoResumeSuspendedTools is enabled with provider-defined tools', () => {
-    // Simulate a provider-defined tool like openai.tools.webSearch()
-    const providerTool: ProviderDefinedTool = {
-      type: 'provider-defined',
-      id: 'openai.web_search',
-      // Provider tools have a lazy inputSchema that returns an AI SDK Schema, not Zod
-      inputSchema: () => ({
-        '~standard': { vendor: 'openai', version: 1, validate: () => ({ value: {} }) },
-        // Note: no jsonSchema property - this is what caused the original crash
-      }),
-    };
+  it('should not crash when autoResumeSuspendedTools is enabled with openai.tools.webSearch()', () => {
+    const webSearchTool = openai.tools.webSearch({});
+
+    // Verify this is actually a provider-defined tool (v5 uses 'provider-defined', v6 uses 'provider')
+    expect(['provider-defined', 'provider']).toContain(webSearchTool.type);
+    expect(webSearchTool.id).toBe('openai.web_search');
+
+    // Verify isProviderDefinedTool detects it correctly
+    expect(isProviderDefinedTool(webSearchTool)).toBe(true);
+    // Verify isVercelTool does NOT match (so the schema extension code path would be entered without the fix)
+    expect(isVercelTool(webSearchTool as any)).toBe(false);
 
     // This should not throw - previously it crashed with:
     // TypeError: Cannot read properties of undefined (reading 'jsonSchema')
+    // because provider-defined tools have a lazy inputSchema that doesn't conform to standard schemas
     expect(() => {
       new CoreToolBuilder({
-        originalTool: providerTool,
+        originalTool: webSearchTool,
         options: {
           name: 'web_search',
           logger: {
@@ -238,36 +240,6 @@ describe('Provider-defined Tool Handling', () => {
             trackException: vi.fn(),
           } as any,
           description: 'Search the web',
-          requestContext: new RequestContext(),
-        },
-        autoResumeSuspendedTools: true,
-      });
-    }).not.toThrow();
-  });
-
-  it('should not attempt to extend schema for provider-defined tools', () => {
-    // Simulate a provider-defined tool with type: 'provider' (AI SDK v6 style)
-    const providerToolV6: ProviderDefinedTool = {
-      type: 'provider',
-      id: 'google.google_search',
-      inputSchema: () => ({
-        '~standard': { vendor: 'google', version: 1, validate: () => ({ value: {} }) },
-      }),
-    };
-
-    // This should not throw for v6-style provider tools either
-    expect(() => {
-      new CoreToolBuilder({
-        originalTool: providerToolV6,
-        options: {
-          name: 'google_search',
-          logger: {
-            debug: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-            trackException: vi.fn(),
-          } as any,
-          description: 'Search with Google',
           requestContext: new RequestContext(),
         },
         autoResumeSuspendedTools: true,

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -1,3 +1,4 @@
+import type { ProviderDefinedTool } from '@internal/external-types';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { SpanType } from '../../observability';
@@ -207,5 +208,70 @@ describe('MCP Tool Tracing', () => {
     const spanArgs = (mockAgentSpan.createChildSpan as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(spanArgs.attributes).not.toHaveProperty('mcpServer');
     expect(spanArgs.attributes).not.toHaveProperty('serverVersion');
+  });
+});
+
+describe('Provider-defined Tool Handling', () => {
+  it('should not crash when autoResumeSuspendedTools is enabled with provider-defined tools', () => {
+    // Simulate a provider-defined tool like openai.tools.webSearch()
+    const providerTool: ProviderDefinedTool = {
+      type: 'provider-defined',
+      id: 'openai.web_search',
+      // Provider tools have a lazy inputSchema that returns an AI SDK Schema, not Zod
+      inputSchema: () => ({
+        '~standard': { vendor: 'openai', version: 1, validate: () => ({ value: {} }) },
+        // Note: no jsonSchema property - this is what caused the original crash
+      }),
+    };
+
+    // This should not throw - previously it crashed with:
+    // TypeError: Cannot read properties of undefined (reading 'jsonSchema')
+    expect(() => {
+      new CoreToolBuilder({
+        originalTool: providerTool,
+        options: {
+          name: 'web_search',
+          logger: {
+            debug: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            trackException: vi.fn(),
+          } as any,
+          description: 'Search the web',
+          requestContext: new RequestContext(),
+        },
+        autoResumeSuspendedTools: true,
+      });
+    }).not.toThrow();
+  });
+
+  it('should not attempt to extend schema for provider-defined tools', () => {
+    // Simulate a provider-defined tool with type: 'provider' (AI SDK v6 style)
+    const providerToolV6: ProviderDefinedTool = {
+      type: 'provider',
+      id: 'google.google_search',
+      inputSchema: () => ({
+        '~standard': { vendor: 'google', version: 1, validate: () => ({ value: {} }) },
+      }),
+    };
+
+    // This should not throw for v6-style provider tools either
+    expect(() => {
+      new CoreToolBuilder({
+        originalTool: providerToolV6,
+        options: {
+          name: 'google_search',
+          logger: {
+            debug: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            trackException: vi.fn(),
+          } as any,
+          description: 'Search with Google',
+          requestContext: new RequestContext(),
+        },
+        autoResumeSuspendedTools: true,
+      });
+    }).not.toThrow();
   });
 });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -25,7 +25,7 @@ import {
 import type { AnySpan } from '../../observability';
 import { RequestContext } from '../../request-context';
 import { isStandardSchemaWithJSON, toStandardSchema, standardSchemaToJSONSchema } from '../../schema';
-import { isVercelTool } from '../../tools/toolchecks';
+import { isVercelTool, isProviderDefinedTool } from '../../tools/toolchecks';
 import type { ToolOptions } from '../../utils';
 import { safeStringify } from '../../utils';
 import { isZodObject } from '../../utils/zod-utils';
@@ -79,6 +79,7 @@ export class CoreToolBuilder extends MastraBase {
 
     if (
       !isVercelTool(this.originalTool) &&
+      !isProviderDefinedTool(this.originalTool) &&
       (input.autoResumeSuspendedTools ||
         (this.originalTool as unknown as ToolAction<any, any>).id?.startsWith('agent-') ||
         (this.originalTool as unknown as ToolAction<any, any>).id?.startsWith('workflow-'))


### PR DESCRIPTION
## Problem

When `autoResumeSuspendedTools` is enabled, `CoreToolBuilder` tries to extend tool schemas with `suspendedToolRunId` and `resumeData` fields. This crashes for provider-defined tools (e.g., `openai.tools.webSearch()`, `google.tools.googleSearch()`) with:

```
TypeError: Cannot read properties of undefined (reading 'jsonSchema')
```

Provider-defined tools have a special lazy schema that doesn't work with `standardSchemaToJSONSchema()`.

## Solution

Add `isProviderDefinedTool()` check alongside the existing `isVercelTool()` check to skip schema extension for these special tool types.

## Test Plan

- Verified tool tests pass (204 tests)
- Tested manually with `openai.tools.webSearch()` + `autoResumeSuspendedTools: true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the auto-resume feature when handling provider-defined tool schemas.

* **Tests**
  * Added tests to ensure provider-defined tools no longer trigger schema-extension failures during auto-resume.

* **Chores**
  * Added a changeset entry to prepare a patch release for the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->