### PR TITLE
fixed race condition and traceId nullability in scoring

### DIFF
--- a/.changeset/bumpy-crabs-tan.md
+++ b/.changeset/bumpy-crabs-tan.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed score and feedback emission to support live correlation context and unanchored annotations.

--- a/.changeset/little-experts-decide.md
+++ b/.changeset/little-experts-decide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/duckdb': patch
+---
+
+Fixed DuckDB observability migrations to support nullable score and feedback trace IDs on existing installs.

--- a/.changeset/loud-lights-draw.md
+++ b/.changeset/loud-lights-draw.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed score and feedback annotations being dropped before spans flush by emitting from live correlation context when available. Scores and feedback can now also be stored without a trace ID when only contextual metadata is available.

--- a/observability/mastra/src/default.ts
+++ b/observability/mastra/src/default.ts
@@ -4,6 +4,7 @@ import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { RegisteredLogger } from '@mastra/core/logger';
 import type { IMastraLogger } from '@mastra/core/logger';
 import type {
+  CorrelationContext,
   ConfigSelector,
   ConfigSelectorOptions,
   FeedbackInput,
@@ -21,6 +22,8 @@ import type { ObservabilityInstanceConfig, ObservabilityRegistryConfig } from '.
 import { CloudExporter, DefaultExporter } from './exporters';
 import { BaseObservabilityInstance, DefaultObservabilityInstance } from './instances';
 import {
+  buildFeedbackEvent,
+  buildScoreEvent,
   buildRecordedFeedbackEventFromTrace,
   buildRecordedScoreEventFromTrace,
   hydrateRecordedTrace,
@@ -210,7 +213,31 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
     });
   }
 
-  async addScore(args: { traceId: string; spanId?: string; score: ScoreInput }): Promise<void> {
+  async addScore(args: {
+    traceId?: string;
+    spanId?: string;
+    correlationContext?: CorrelationContext;
+    score: ScoreInput;
+  }): Promise<void> {
+    const targetTraceId = args.traceId ?? args.correlationContext?.traceId;
+    const targetSpanId = args.spanId ?? args.correlationContext?.spanId;
+
+    if (args.correlationContext) {
+      await this.#emitRecordedEvent(
+        buildScoreEvent({
+          ...(targetTraceId ? { traceId: targetTraceId } : {}),
+          ...(targetSpanId ? { spanId: targetSpanId } : {}),
+          correlationContext: args.correlationContext,
+          score: args.score,
+        }),
+      );
+      return;
+    }
+
+    if (!args.traceId) {
+      return;
+    }
+
     const trace = await this.#getStoredTrace(args.traceId);
     if (!trace) {
       return;
@@ -229,7 +256,31 @@ export class Observability extends MastraBase implements ObservabilityEntrypoint
     await this.#emitRecordedEvent(event);
   }
 
-  async addFeedback(args: { traceId: string; spanId?: string; feedback: FeedbackInput }): Promise<void> {
+  async addFeedback(args: {
+    traceId?: string;
+    spanId?: string;
+    correlationContext?: CorrelationContext;
+    feedback: FeedbackInput;
+  }): Promise<void> {
+    const targetTraceId = args.traceId ?? args.correlationContext?.traceId;
+    const targetSpanId = args.spanId ?? args.correlationContext?.spanId;
+
+    if (args.correlationContext) {
+      await this.#emitRecordedEvent(
+        buildFeedbackEvent({
+          ...(targetTraceId ? { traceId: targetTraceId } : {}),
+          ...(targetSpanId ? { spanId: targetSpanId } : {}),
+          correlationContext: args.correlationContext,
+          feedback: args.feedback,
+        }),
+      );
+      return;
+    }
+
+    if (!args.traceId) {
+      return;
+    }
+
     const trace = await this.#getStoredTrace(args.traceId);
     if (!trace) {
       return;

--- a/observability/mastra/src/exporters/test.ts
+++ b/observability/mastra/src/exporters/test.ts
@@ -435,7 +435,8 @@ export class TestExporter extends BaseExporter {
 
     if (this.#config.storeLogs) {
       const fb = event.feedback;
-      const logMessage = `[TestExporter] feedback: ${fb.feedbackType} from ${fb.source}=${fb.value} (trace: ${fb.traceId.slice(-8)}${fb.spanId ? `, span: ${fb.spanId.slice(-8)}` : ''})`;
+      const traceLabel = fb.traceId ? fb.traceId.slice(-8) : 'unanchored';
+      const logMessage = `[TestExporter] feedback: ${fb.feedbackType} from ${fb.source}=${fb.value} (trace: ${traceLabel}${fb.spanId ? `, span: ${fb.spanId.slice(-8)}` : ''})`;
       this.#debugLogs.push(logMessage);
     }
 
@@ -628,7 +629,9 @@ export class TestExporter extends BaseExporter {
       }
     }
     for (const event of this.#feedbackEvents) {
-      traceIds.add(event.feedback.traceId);
+      if (event.feedback.traceId) {
+        traceIds.add(event.feedback.traceId);
+      }
     }
     return Array.from(traceIds);
   }

--- a/observability/mastra/src/exporters/test.ts
+++ b/observability/mastra/src/exporters/test.ts
@@ -436,7 +436,8 @@ export class TestExporter extends BaseExporter {
     if (this.#config.storeLogs) {
       const fb = event.feedback;
       const traceLabel = fb.traceId ? fb.traceId.slice(-8) : 'unanchored';
-      const logMessage = `[TestExporter] feedback: ${fb.feedbackType} from ${fb.source}=${fb.value} (trace: ${traceLabel}${fb.spanId ? `, span: ${fb.spanId.slice(-8)}` : ''})`;
+      const feedbackSource = fb.feedbackSource ?? fb.source;
+      const logMessage = `[TestExporter] feedback: ${fb.feedbackType} from ${feedbackSource}=${fb.value} (trace: ${traceLabel}${fb.spanId ? `, span: ${fb.spanId.slice(-8)}` : ''})`;
       this.#debugLogs.push(logMessage);
     }
 

--- a/observability/mastra/src/recorded.test.ts
+++ b/observability/mastra/src/recorded.test.ts
@@ -333,6 +333,225 @@ describe('RecordedTrace', () => {
     );
   });
 
+  it('adds top-level annotations directly from provided correlation context', async () => {
+    const storage = new MockStore();
+    const onScoreEvent = vi.fn().mockResolvedValue(undefined);
+    const onFeedbackEvent = vi.fn().mockResolvedValue(undefined);
+
+    const mirrorExporter: ObservabilityExporter = {
+      name: 'mirror-exporter',
+      exportTracingEvent: vi.fn().mockResolvedValue(undefined),
+      onScoreEvent,
+      onFeedbackEvent,
+      flush: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mastra = new Mastra({
+      logger: false,
+      storage,
+      observability: new Observability({
+        configs: {
+          default: {
+            serviceName: 'test-service',
+            exporters: [new DefaultExporter(), mirrorExporter],
+          },
+        },
+      }),
+    });
+
+    const observabilityStore = await storage.getStore('observability');
+    expect(observabilityStore).toBeTruthy();
+
+    const correlationContext = {
+      traceId: 'trace-live',
+      spanId: 'span-live',
+      entityType: EntityType.TOOL,
+      entityId: 'tool-1',
+      entityName: 'tool-call',
+      parentEntityType: EntityType.AGENT,
+      parentEntityId: 'agent-1',
+      parentEntityName: 'agent-run',
+      rootEntityType: EntityType.WORKFLOW_RUN,
+      rootEntityId: 'workflow-1',
+      rootEntityName: 'workflow-root',
+      source: 'cloud',
+      serviceName: 'test-service',
+      experimentId: 'exp-live',
+      tags: ['prod', 'review'],
+    } as const;
+
+    await mastra.observability.addScore({
+      traceId: 'trace-live',
+      spanId: 'span-live',
+      correlationContext,
+      score: {
+        scorerId: 'content-similarity-scorer',
+        scoreSource: 'code',
+        score: 0.88,
+        reason: 'Fast scorer emitted directly from live span context',
+        metadata: { reviewer: 'qa' },
+      },
+    });
+
+    await mastra.observability.addFeedback({
+      traceId: 'trace-live',
+      spanId: 'span-live',
+      correlationContext,
+      feedback: {
+        feedbackSource: 'user',
+        feedbackType: 'thumbs',
+        value: 1,
+        feedbackUserId: 'user-123',
+        comment: 'Helpful',
+        metadata: { channel: 'chat' },
+      },
+    });
+
+    await mastra.observability.getDefaultInstance()?.flush();
+
+    const scores = await observabilityStore!.listScores({
+      filters: { traceId: 'trace-live' },
+      pagination: { page: 0, perPage: 10 },
+      orderBy: { field: 'timestamp', direction: 'ASC' },
+    });
+    const feedback = await observabilityStore!.listFeedback({
+      filters: { traceId: 'trace-live' },
+      pagination: { page: 0, perPage: 10 },
+      orderBy: { field: 'timestamp', direction: 'ASC' },
+    });
+
+    expect(scores.scores[0]).toMatchObject({
+      traceId: 'trace-live',
+      spanId: 'span-live',
+      scorerId: 'content-similarity-scorer',
+      scoreSource: 'code',
+      entityName: 'tool-call',
+      parentEntityName: 'agent-run',
+      rootEntityName: 'workflow-root',
+      executionSource: 'cloud',
+      experimentId: 'exp-live',
+      metadata: { reviewer: 'qa' },
+    });
+
+    expect(feedback.feedback[0]).toMatchObject({
+      traceId: 'trace-live',
+      spanId: 'span-live',
+      feedbackSource: 'user',
+      feedbackType: 'thumbs',
+      value: 1,
+      feedbackUserId: 'user-123',
+      entityName: 'tool-call',
+      parentEntityName: 'agent-run',
+      rootEntityName: 'workflow-root',
+      executionSource: 'cloud',
+      experimentId: 'exp-live',
+      metadata: { channel: 'chat' },
+    });
+
+    expect(onScoreEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        score: expect.objectContaining({
+          traceId: 'trace-live',
+          spanId: 'span-live',
+          correlationContext: expect.objectContaining({
+            entityName: 'tool-call',
+            parentEntityName: 'agent-run',
+            rootEntityName: 'workflow-root',
+          }),
+        }),
+      }),
+    );
+
+    expect(onFeedbackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedback: expect.objectContaining({
+          traceId: 'trace-live',
+          spanId: 'span-live',
+          correlationContext: expect.objectContaining({
+            entityName: 'tool-call',
+            parentEntityName: 'agent-run',
+            rootEntityName: 'workflow-root',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('allows top-level annotations without traceId when correlation context is provided', async () => {
+    const storage = new MockStore();
+
+    const mastra = new Mastra({
+      logger: false,
+      storage,
+      observability: new Observability({
+        configs: {
+          default: {
+            serviceName: 'test-service',
+            exporters: [new DefaultExporter()],
+          },
+        },
+      }),
+    });
+
+    const observabilityStore = await storage.getStore('observability');
+    expect(observabilityStore).toBeTruthy();
+
+    const correlationContext = {
+      entityType: EntityType.TOOL,
+      entityName: 'tool-call',
+      rootEntityType: EntityType.WORKFLOW_RUN,
+      rootEntityName: 'workflow-root',
+      source: 'cloud',
+      serviceName: 'test-service',
+    } as const;
+
+    await mastra.observability.addScore({
+      correlationContext,
+      score: {
+        scorerId: 'unanchored-scorer',
+        score: 0.5,
+      },
+    });
+
+    await mastra.observability.addFeedback({
+      correlationContext,
+      feedback: {
+        feedbackSource: 'user',
+        feedbackType: 'thumbs',
+        value: 1,
+      },
+    });
+
+    await mastra.observability.getDefaultInstance()?.flush();
+
+    const scores = await observabilityStore!.listScores({
+      pagination: { page: 0, perPage: 10 },
+      orderBy: { field: 'timestamp', direction: 'ASC' },
+    });
+    const feedback = await observabilityStore!.listFeedback({
+      pagination: { page: 0, perPage: 10 },
+      orderBy: { field: 'timestamp', direction: 'ASC' },
+    });
+
+    expect(scores.scores[0]).toMatchObject({
+      traceId: null,
+      scorerId: 'unanchored-scorer',
+      entityName: 'tool-call',
+      rootEntityName: 'workflow-root',
+      executionSource: 'cloud',
+    });
+
+    expect(feedback.feedback[0]).toMatchObject({
+      traceId: null,
+      feedbackSource: 'user',
+      feedbackType: 'thumbs',
+      entityName: 'tool-call',
+      rootEntityName: 'workflow-root',
+      executionSource: 'cloud',
+    });
+  });
+
   it('debug-logs and skips annotation when the recorded emit path is no longer wired', async () => {
     const emitRecordedEvent = vi.fn().mockResolvedValue(undefined);
     const debugRecordedAnnotationUnavailable = vi.fn();

--- a/observability/mastra/src/recorded.ts
+++ b/observability/mastra/src/recorded.ts
@@ -85,20 +85,20 @@ function buildCorrelationContext(
   };
 }
 
-export function buildRecordedScoreEvent(args: {
-  span: SpanRecord;
-  rootSpan: SpanRecord;
-  parent?: CorrelationParent;
-  score: ScoreInput;
+export function buildScoreEvent(args: {
+  traceId?: string;
   spanId?: string;
+  correlationContext?: CorrelationContext;
+  score: ScoreInput;
+  inheritedMetadata?: Record<string, any> | null;
 }): ScoreEvent {
-  const { span, rootSpan, parent, score, spanId } = args;
+  const { traceId, spanId, correlationContext, score, inheritedMetadata } = args;
 
   return {
     type: 'score',
     score: {
       timestamp: new Date(),
-      traceId: span.traceId,
+      traceId,
       spanId,
       scorerId: score.scorerId,
       scorerVersion: score.scorerVersion,
@@ -108,26 +108,26 @@ export function buildRecordedScoreEvent(args: {
       reason: score.reason,
       experimentId: score.experimentId,
       scoreTraceId: score.scoreTraceId,
-      correlationContext: buildCorrelationContext(span, rootSpan, parent),
-      metadata: mergeMetadata(span.metadata, score.metadata),
+      correlationContext,
+      metadata: mergeMetadata(inheritedMetadata, score.metadata),
     },
   };
 }
 
-export function buildRecordedFeedbackEvent(args: {
-  span: SpanRecord;
-  rootSpan: SpanRecord;
-  parent?: CorrelationParent;
-  feedback: FeedbackInput;
+export function buildFeedbackEvent(args: {
+  traceId?: string;
   spanId?: string;
+  correlationContext?: CorrelationContext;
+  feedback: FeedbackInput;
+  inheritedMetadata?: Record<string, any> | null;
 }): FeedbackEvent {
-  const { span, rootSpan, parent, feedback, spanId } = args;
+  const { traceId, spanId, correlationContext, feedback, inheritedMetadata } = args;
 
   return {
     type: 'feedback',
     feedback: {
       timestamp: new Date(),
-      traceId: span.traceId,
+      traceId,
       spanId,
       source: feedback.source,
       feedbackSource: feedback.feedbackSource,
@@ -138,8 +138,8 @@ export function buildRecordedFeedbackEvent(args: {
       comment: feedback.comment,
       sourceId: feedback.sourceId,
       experimentId: feedback.experimentId,
-      correlationContext: buildCorrelationContext(span, rootSpan, parent),
-      metadata: mergeMetadata(span.metadata, feedback.metadata),
+      correlationContext,
+      metadata: mergeMetadata(inheritedMetadata, feedback.metadata),
     },
   };
 }
@@ -162,12 +162,12 @@ export function buildRecordedScoreEventFromTrace(args: {
 
   const parent = span.parentSpanId ? findSpanById(args.trace.spans, span.parentSpanId) : undefined;
 
-  return buildRecordedScoreEvent({
-    span,
-    rootSpan,
-    parent,
-    score: args.score,
+  return buildScoreEvent({
+    traceId: span.traceId,
     spanId: args.spanId,
+    correlationContext: buildCorrelationContext(span, rootSpan, parent),
+    score: args.score,
+    inheritedMetadata: span.metadata,
   });
 }
 
@@ -184,12 +184,12 @@ export function buildRecordedFeedbackEventFromTrace(args: {
 
   const parent = span.parentSpanId ? findSpanById(args.trace.spans, span.parentSpanId) : undefined;
 
-  return buildRecordedFeedbackEvent({
-    span,
-    rootSpan,
-    parent,
-    feedback: args.feedback,
+  return buildFeedbackEvent({
+    traceId: span.traceId,
     spanId: args.spanId,
+    correlationContext: buildCorrelationContext(span, rootSpan, parent),
+    feedback: args.feedback,
+    inheritedMetadata: span.metadata,
   });
 }
 
@@ -271,12 +271,12 @@ class RecordedSpanImpl<TType extends SpanType = SpanType> implements RecordedSpa
     }
 
     await this.#emitRecordedEvent(
-      buildRecordedScoreEvent({
-        span: this.#raw,
-        rootSpan: this.#rootSpan,
-        parent: this.parent,
-        score,
+      buildScoreEvent({
+        traceId: this.#raw.traceId,
         spanId: this.id,
+        correlationContext: buildCorrelationContext(this.#raw, this.#rootSpan, this.parent),
+        score,
+        inheritedMetadata: this.#raw.metadata,
       }),
     );
   }
@@ -288,12 +288,12 @@ class RecordedSpanImpl<TType extends SpanType = SpanType> implements RecordedSpa
     }
 
     await this.#emitRecordedEvent(
-      buildRecordedFeedbackEvent({
-        span: this.#raw,
-        rootSpan: this.#rootSpan,
-        parent: this.parent,
-        feedback,
+      buildFeedbackEvent({
+        traceId: this.#raw.traceId,
         spanId: this.id,
+        correlationContext: buildCorrelationContext(this.#raw, this.#rootSpan, this.parent),
+        feedback,
+        inheritedMetadata: this.#raw.metadata,
       }),
     );
   }
@@ -340,10 +340,11 @@ class RecordedTraceImpl implements RecordedTrace {
     }
 
     await this.#emitRecordedEvent(
-      buildRecordedScoreEvent({
-        span: this.#rootRecord,
-        rootSpan: this.#rootRecord,
+      buildScoreEvent({
+        traceId: this.#rootRecord.traceId,
+        correlationContext: buildCorrelationContext(this.#rootRecord, this.#rootRecord),
         score,
+        inheritedMetadata: this.#rootRecord.metadata,
       }),
     );
   }
@@ -355,10 +356,11 @@ class RecordedTraceImpl implements RecordedTrace {
     }
 
     await this.#emitRecordedEvent(
-      buildRecordedFeedbackEvent({
-        span: this.#rootRecord,
-        rootSpan: this.#rootRecord,
+      buildFeedbackEvent({
+        traceId: this.#rootRecord.traceId,
+        correlationContext: buildCorrelationContext(this.#rootRecord, this.#rootRecord),
         feedback,
+        inheritedMetadata: this.#rootRecord.metadata,
       }),
     );
   }

--- a/packages/_internal-core/src/storage/domains/observability/feedback.ts
+++ b/packages/_internal-core/src/storage/domains/observability/feedback.ts
@@ -59,7 +59,7 @@ const feedbackRecordObjectSchema = z.object({
   timestamp: z.date().describe('When the feedback was recorded'),
 
   // Target
-  traceId: traceIdField,
+  traceId: traceIdField.nullish().describe('Trace that anchors the feedback target when available'),
   spanId: spanIdField.nullish().describe('Span ID this feedback applies to'),
 
   // Feedback data

--- a/packages/_internal-core/src/storage/domains/observability/scores.ts
+++ b/packages/_internal-core/src/storage/domains/observability/scores.ts
@@ -46,7 +46,7 @@ export const scoreRecordSchema = z
     timestamp: z.date().describe('When the score was recorded'),
 
     // Target
-    traceId: traceIdField,
+    traceId: traceIdField.nullish().describe('Trace that anchors the scored target when available'),
     spanId: spanIdField.nullish().describe('Span ID this score applies to'),
 
     // Score data

--- a/packages/core/src/evals/base.test.ts
+++ b/packages/core/src/evals/base.test.ts
@@ -327,7 +327,7 @@ describe('createScorer', () => {
       });
     });
 
-    it('should not emit addScore without a target trace id yet', async () => {
+    it('should emit addScore without a target trace id when unanchored scoring is allowed', async () => {
       const mockMastra = createMockMastra();
 
       const scorer = createScorer({
@@ -342,7 +342,17 @@ describe('createScorer', () => {
         scoreSource: 'experiment',
       });
 
-      expect(mockMastra.observability.addScore).not.toHaveBeenCalled();
+      expect(mockMastra.observability.addScore).toHaveBeenCalledWith({
+        score: {
+          scorerId: 'unanchored-scorer',
+          scorerName: 'unanchored-scorer',
+          scoreSource: 'experiment',
+          score: 0.75,
+          metadata: {
+            hasGroundTruth: false,
+          },
+        },
+      });
     });
 
     it('should include scoreTraceId when scorer tracing is enabled', async () => {
@@ -460,6 +470,48 @@ describe('createScorer', () => {
           metadata: {
             sessionId: 'session-1',
             inherited: true,
+            hasGroundTruth: false,
+          },
+        },
+      });
+    });
+
+    it('should emit addScore with correlation context even when targetTraceId is absent', async () => {
+      const mockMastra = createMockMastra();
+
+      const scorer = createScorer({
+        id: 'unanchored-contextual-scorer',
+        description: 'Unanchored contextual scorer',
+      }).generateScore(() => 0.67);
+
+      scorer.__registerMastra(mockMastra as any);
+
+      await scorer.run({
+        ...testData.scoringInput,
+        scoreSource: 'live',
+        targetCorrelationContext: {
+          entityName: 'tool-call',
+          parentEntityName: 'agent-run',
+          rootEntityName: 'workflow-root',
+          source: 'cloud',
+          serviceName: 'test-service',
+        },
+      });
+
+      expect(mockMastra.observability.addScore).toHaveBeenCalledWith({
+        correlationContext: {
+          entityName: 'tool-call',
+          parentEntityName: 'agent-run',
+          rootEntityName: 'workflow-root',
+          source: 'cloud',
+          serviceName: 'test-service',
+        },
+        score: {
+          scorerId: 'unanchored-contextual-scorer',
+          scorerName: 'unanchored-contextual-scorer',
+          scoreSource: 'live',
+          score: 0.67,
+          metadata: {
             hasGroundTruth: false,
           },
         },

--- a/packages/core/src/evals/base.test.ts
+++ b/packages/core/src/evals/base.test.ts
@@ -410,6 +410,62 @@ describe('createScorer', () => {
       });
     });
 
+    it('should forward live target correlation context and metadata to addScore', async () => {
+      const mockMastra = createMockMastra();
+
+      const scorer = createScorer({
+        id: 'contextual-scorer',
+        description: 'Contextual scorer',
+      }).generateScore(() => 0.91);
+
+      scorer.__registerMastra(mockMastra as any);
+
+      await scorer.run({
+        ...testData.scoringInput,
+        scoreSource: 'live',
+        targetTraceId: 'trace-live',
+        targetSpanId: 'span-live',
+        targetCorrelationContext: {
+          traceId: 'trace-live',
+          spanId: 'span-live',
+          entityName: 'tool-call',
+          parentEntityName: 'agent-run',
+          rootEntityName: 'workflow-root',
+          source: 'cloud',
+          serviceName: 'test-service',
+        },
+        targetMetadata: {
+          sessionId: 'session-1',
+          inherited: true,
+        },
+      });
+
+      expect(mockMastra.observability.addScore).toHaveBeenCalledWith({
+        traceId: 'trace-live',
+        spanId: 'span-live',
+        correlationContext: {
+          traceId: 'trace-live',
+          spanId: 'span-live',
+          entityName: 'tool-call',
+          parentEntityName: 'agent-run',
+          rootEntityName: 'workflow-root',
+          source: 'cloud',
+          serviceName: 'test-service',
+        },
+        score: {
+          scorerId: 'contextual-scorer',
+          scorerName: 'contextual-scorer',
+          scoreSource: 'live',
+          score: 0.91,
+          metadata: {
+            sessionId: 'session-1',
+            inherited: true,
+            hasGroundTruth: false,
+          },
+        },
+      });
+    });
+
     it('should not fail scorer.run when addScore throws', async () => {
       const mockMastra = createMockMastra({
         addScoreImpl: vi.fn().mockRejectedValue(new Error('observability failed')),

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -16,6 +16,7 @@ import {
   SpanType,
 } from '../observability';
 import type {
+  CorrelationContext,
   DefinitionSource,
   ObservabilityContext,
   ScorerScoreSource,
@@ -108,11 +109,17 @@ interface ScorerRun<TInput = any, TOutput = any> {
   /** Entity type of the scored target when known. */
   targetEntityType?: EntityType;
 
-  /** Trace anchor for the target being scored. Required today for observability.addScore(). */
+  /** Trace anchor for the target being scored when available. */
   targetTraceId?: string;
 
   /** Optional span anchor for the target being scored. */
   targetSpanId?: string;
+
+  /** Live correlation snapshot for the target span/trace when available. */
+  targetCorrelationContext?: CorrelationContext;
+
+  /** Live target metadata to merge into emitted score metadata when available. */
+  targetMetadata?: Record<string, unknown>;
 }
 
 // Prompt object definition with conditional typing
@@ -591,15 +598,19 @@ class MastraScorer<
 
     if (this.#mastra?.observability.addScore && typeof scorerResult.score === 'number') {
       try {
+        const targetTraceId = input.targetTraceId ?? input.targetCorrelationContext?.traceId;
+        const targetSpanId = input.targetSpanId ?? input.targetCorrelationContext?.spanId;
+
         // TODO: Remove this gate once @mastra/observability supports emitting
         // unanchored scores end-to-end without a target trace ID.
-        if (!input.targetTraceId) {
+        if (!targetTraceId) {
           return scorerResult;
         }
 
         await this.#mastra.observability.addScore({
-          traceId: input.targetTraceId,
-          ...(input.targetSpanId ? { spanId: input.targetSpanId } : {}),
+          traceId: targetTraceId,
+          ...(targetSpanId ? { spanId: targetSpanId } : {}),
+          ...(input.targetCorrelationContext ? { correlationContext: input.targetCorrelationContext } : {}),
           score: {
             scorerId: this.id,
             scorerName: this.name,
@@ -609,6 +620,7 @@ class MastraScorer<
             ...(typeof scorerResult.scoreTraceId === 'string' ? { scoreTraceId: scorerResult.scoreTraceId } : {}),
             ...(input.targetEntityType ? { targetEntityType: input.targetEntityType } : {}),
             metadata: {
+              ...(input.targetMetadata ?? {}),
               hasGroundTruth: input.groundTruth !== undefined,
               ...(input.targetScope ? { targetScope: input.targetScope } : {}),
               ...(this.source ? { scorerDefinition: this.source } : {}),

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -601,14 +601,8 @@ class MastraScorer<
         const targetTraceId = input.targetTraceId ?? input.targetCorrelationContext?.traceId;
         const targetSpanId = input.targetSpanId ?? input.targetCorrelationContext?.spanId;
 
-        // TODO: Remove this gate once @mastra/observability supports emitting
-        // unanchored scores end-to-end without a target trace ID.
-        if (!targetTraceId) {
-          return scorerResult;
-        }
-
         await this.#mastra.observability.addScore({
-          traceId: targetTraceId,
+          ...(targetTraceId ? { traceId: targetTraceId } : {}),
           ...(targetSpanId ? { spanId: targetSpanId } : {}),
           ...(input.targetCorrelationContext ? { correlationContext: input.targetCorrelationContext } : {}),
           score: {

--- a/packages/core/src/mastra/hook.test.ts
+++ b/packages/core/src/mastra/hook.test.ts
@@ -184,6 +184,62 @@ describe('createOnScorerHook', () => {
     );
   });
 
+  it('should pass live span correlation context and metadata into scorer.run', async () => {
+    const correlationContext = {
+      traceId: 'trace-live',
+      spanId: 'span-live',
+      entityName: 'agent-run',
+      rootEntityName: 'workflow-root',
+      source: 'cloud',
+      serviceName: 'test-service',
+    };
+
+    const hookData = {
+      runId: 'test-run',
+      scorer: { id: 'test-scorer' },
+      input: [{ message: 'test' }],
+      output: { result: 'test' },
+      source: 'LIVE' as const,
+      entity: { id: 'test-entity' },
+      entityType: 'AGENT' as const,
+      tracingContext: {
+        currentSpan: {
+          id: 'span-live',
+          traceId: 'trace-live',
+          isValid: true,
+          metadata: { sessionId: 'session-1', inherited: true },
+          getCorrelationContext: vi.fn().mockReturnValue(correlationContext),
+          observabilityInstance: {
+            getExporters: () => [],
+          },
+        },
+      },
+    };
+
+    const mockScorer = {
+      id: 'test-scorer',
+      name: 'test-scorer',
+      run: vi.fn().mockResolvedValue({ score: 0.8 }),
+    };
+
+    mockMastra.getAgentById.mockReturnValue({
+      listScorers: vi.fn().mockReturnValue({ 'test-scorer': { scorer: mockScorer } }),
+    });
+
+    await hook(hookData);
+
+    expect(mockScorer.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scoreSource: 'live',
+        targetScope: 'span',
+        targetTraceId: 'trace-live',
+        targetSpanId: 'span-live',
+        targetCorrelationContext: correlationContext,
+        targetMetadata: { sessionId: 'session-1', inherited: true },
+      }),
+    );
+  });
+
   it('should handle scorer not found without throwing', async () => {
     const hookData = {
       runId: 'test-run',

--- a/packages/core/src/mastra/hooks.ts
+++ b/packages/core/src/mastra/hooks.ts
@@ -56,6 +56,8 @@ export function createOnScorerHook(mastra: Mastra) {
       const currentSpan = hookData.tracingContext?.currentSpan;
       const traceId = currentSpan?.isValid ? currentSpan.traceId : undefined;
       const spanId = currentSpan?.isValid ? currentSpan.id : undefined;
+      const targetCorrelationContext = currentSpan?.isValid ? currentSpan.getCorrelationContext?.() : undefined;
+      const targetMetadata = currentSpan?.isValid && currentSpan.metadata ? { ...currentSpan.metadata } : undefined;
       const runResult = (await scorerToUse.scorer.run({
         ...rest,
         input,
@@ -65,6 +67,8 @@ export function createOnScorerHook(mastra: Mastra) {
         targetEntityType: toScorerTargetEntityType(entityType),
         targetTraceId: traceId,
         targetSpanId: spanId,
+        targetCorrelationContext,
+        targetMetadata,
       } as any)) as Record<string, unknown>;
 
       const payload = {

--- a/packages/core/src/observability/no-op.ts
+++ b/packages/core/src/observability/no-op.ts
@@ -1,6 +1,7 @@
 import type { Mastra } from '..';
 import type { IMastraLogger } from '../logger';
 import type {
+  CorrelationContext,
   ConfigSelector,
   ConfigSelectorOptions,
   Counter,
@@ -102,11 +103,21 @@ export class NoOpObservability implements ObservabilityEntrypoint {
     return null;
   }
 
-  async addScore(_args: { traceId?: string; spanId?: string; score: ScoreInput }): Promise<void> {
+  async addScore(_args: {
+    traceId?: string;
+    spanId?: string;
+    correlationContext?: CorrelationContext;
+    score: ScoreInput;
+  }): Promise<void> {
     return;
   }
 
-  async addFeedback(_args: { traceId: string; spanId?: string; feedback: FeedbackInput }): Promise<void> {
+  async addFeedback(_args: {
+    traceId?: string;
+    spanId?: string;
+    correlationContext?: CorrelationContext;
+    feedback: FeedbackInput;
+  }): Promise<void> {
     return;
   }
 

--- a/packages/core/src/observability/types/core.ts
+++ b/packages/core/src/observability/types/core.ts
@@ -281,8 +281,15 @@ export interface ObservabilityEntrypoint {
    *
    * `traceId` anchors the scored target when available.
    * Include `spanId` when the score is about a specific span.
+   * Include `correlationContext` to emit immediately from live span/trace state
+   * without rehydrating the target from storage first.
    */
-  addScore?(args: { traceId?: string; spanId?: string; score: ScoreInput }): Promise<void>;
+  addScore?(args: {
+    traceId?: string;
+    spanId?: string;
+    correlationContext?: CorrelationContext;
+    score: ScoreInput;
+  }): Promise<void>;
 
   /**
    * Add feedback to a persisted trace or span without hydrating a RecordedTrace.
@@ -290,8 +297,15 @@ export interface ObservabilityEntrypoint {
    *
    * `traceId` anchors the feedback target when available.
    * Include `spanId` when the feedback is about a specific span.
+   * Include `correlationContext` to emit immediately from live span/trace state
+   * without rehydrating the target from storage first.
    */
-  addFeedback?(args: { traceId: string; spanId?: string; feedback: FeedbackInput }): Promise<void>;
+  addFeedback?(args: {
+    traceId?: string;
+    spanId?: string;
+    correlationContext?: CorrelationContext;
+    feedback: FeedbackInput;
+  }): Promise<void>;
 
   // Registry management methods
   registerInstance(name: string, instance: ObservabilityInstance, isDefault?: boolean): void;

--- a/packages/core/src/observability/types/feedback.ts
+++ b/packages/core/src/observability/types/feedback.ts
@@ -65,8 +65,8 @@ export interface ExportedFeedback {
   /** When the feedback was recorded */
   timestamp: Date;
 
-  /** Trace that anchors the feedback target */
-  traceId: string;
+  /** Trace that anchors the feedback target when available */
+  traceId?: string;
 
   /** Span anchor when the feedback is about a specific span */
   spanId?: string;

--- a/packages/core/src/storage/domains/observability/feedback.test.ts
+++ b/packages/core/src/storage/domains/observability/feedback.test.ts
@@ -74,18 +74,17 @@ describe('Feedback Schemas', () => {
       expect(record.comment).toBeUndefined();
     });
 
-    it('rejects missing traceId', () => {
-      expect(() =>
-        feedbackRecordSchema.parse({
-          id: 'fb-4',
-          timestamp: now,
-          feedbackSource: 'user',
-          feedbackType: 'thumbs',
-          value: 1,
-          createdAt: now,
-          updatedAt: null,
-        }),
-      ).toThrow();
+    it('accepts unanchored feedback without traceId', () => {
+      const record = feedbackRecordSchema.parse({
+        id: 'fb-4',
+        timestamp: now,
+        feedbackSource: 'user',
+        feedbackType: 'thumbs',
+        value: 1,
+        createdAt: now,
+        updatedAt: null,
+      });
+      expect(record.traceId).toBeUndefined();
     });
   });
 

--- a/packages/core/src/storage/domains/observability/record-builders.test.ts
+++ b/packages/core/src/storage/domains/observability/record-builders.test.ts
@@ -294,6 +294,27 @@ describe('record-builders', () => {
         }),
       );
     });
+
+    it('allows unanchored scores without traceId', () => {
+      const timestamp = new Date('2026-01-01T00:00:00.000Z');
+      const event: ScoreEvent = {
+        type: 'score',
+        score: {
+          timestamp,
+          scorerId: 'judge-unanchored',
+          score: 0.42,
+        },
+      };
+
+      expect(buildScoreRecord(event)).toEqual(
+        expect.objectContaining({
+          traceId: null,
+          spanId: null,
+          scorerId: 'judge-unanchored',
+          score: 0.42,
+        }),
+      );
+    });
   });
 
   describe('buildFeedbackRecord', () => {
@@ -376,6 +397,29 @@ describe('record-builders', () => {
         expect.objectContaining({
           feedbackSource: 'legacy-api',
           source: 'legacy-api',
+        }),
+      );
+    });
+
+    it('allows unanchored feedback without traceId', () => {
+      const timestamp = new Date('2026-01-01T00:00:00.000Z');
+      const event: FeedbackEvent = {
+        type: 'feedback',
+        feedback: {
+          timestamp,
+          feedbackSource: 'user',
+          feedbackType: 'thumbs',
+          value: 1,
+        },
+      };
+
+      expect(buildFeedbackRecord(event)).toEqual(
+        expect.objectContaining({
+          traceId: null,
+          spanId: null,
+          feedbackSource: 'user',
+          feedbackType: 'thumbs',
+          value: 1,
         }),
       );
     });

--- a/packages/core/src/storage/domains/observability/record-builders.ts
+++ b/packages/core/src/storage/domains/observability/record-builders.ts
@@ -288,8 +288,7 @@ export function buildScoreRecord(event: ScoreEvent): CreateScoreRecord {
   const correlationFields = buildCorrelationRecordFields(s.correlationContext);
   return {
     timestamp: s.timestamp,
-    //TODO: update this and CreateScoreRecord to be able to handle a null traceId
-    traceId: s.traceId ?? s.correlationContext?.traceId ?? '',
+    traceId: s.traceId ?? s.correlationContext?.traceId ?? null,
     spanId: s.spanId ?? s.correlationContext?.spanId ?? null,
     scorerId: s.scorerId,
     scorerVersion: s.scorerVersion ?? null,

--- a/packages/core/src/storage/domains/observability/scores.test.ts
+++ b/packages/core/src/storage/domains/observability/scores.test.ts
@@ -57,17 +57,16 @@ describe('Score Schemas', () => {
       expect(record.reason).toBeUndefined();
     });
 
-    it('rejects missing traceId', () => {
-      expect(() =>
-        scoreRecordSchema.parse({
-          id: 'score-3',
-          timestamp: now,
-          scorerId: 'test',
-          score: 0.5,
-          createdAt: now,
-          updatedAt: null,
-        }),
-      ).toThrow();
+    it('accepts an unanchored score record without traceId', () => {
+      const record = scoreRecordSchema.parse({
+        id: 'score-3',
+        timestamp: now,
+        scorerId: 'test',
+        score: 0.5,
+        createdAt: now,
+        updatedAt: null,
+      });
+      expect(record.traceId).toBeUndefined();
     });
   });
 

--- a/packages/playground-ui/src/domains/agents/hooks/use-agent-trace-scores.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-agent-trace-scores.ts
@@ -51,6 +51,10 @@ export function useAgentTraceScores({ agentId, scorerId, enabled }: UseAgentTrac
     if (!allScores) return map;
 
     for (const score of allScores) {
+      if (!score.traceId) {
+        continue;
+      }
+
       const existing = map.get(score.traceId);
       if (existing) {
         existing.push(score);

--- a/stores/duckdb/src/storage/domains/observability/ddl.ts
+++ b/stores/duckdb/src/storage/domains/observability/ddl.ts
@@ -326,6 +326,7 @@ export const ALL_MIGRATIONS = [
   `ALTER TABLE score_events ADD COLUMN IF NOT EXISTS scope JSON`,
   `ALTER TABLE score_events ADD COLUMN IF NOT EXISTS source VARCHAR`,
   `ALTER TABLE score_events ADD COLUMN IF NOT EXISTS scoreSource VARCHAR`,
+  `ALTER TABLE score_events ALTER COLUMN traceId DROP NOT NULL`,
 
   // Feedback
   `ALTER TABLE feedback_events ADD COLUMN IF NOT EXISTS entityType VARCHAR`,
@@ -352,4 +353,5 @@ export const ALL_MIGRATIONS = [
   `ALTER TABLE feedback_events ADD COLUMN IF NOT EXISTS scope JSON`,
   `ALTER TABLE feedback_events ADD COLUMN IF NOT EXISTS source VARCHAR`,
   `ALTER TABLE feedback_events ADD COLUMN IF NOT EXISTS feedbackSource VARCHAR`,
+  `ALTER TABLE feedback_events ALTER COLUMN traceId DROP NOT NULL`,
 ];

--- a/stores/duckdb/src/storage/domains/observability/ddl.ts
+++ b/stores/duckdb/src/storage/domains/observability/ddl.ts
@@ -161,7 +161,7 @@ CREATE TABLE IF NOT EXISTS score_events (
   timestamp TIMESTAMP NOT NULL,
 
   -- IDs
-  traceId VARCHAR NOT NULL,
+  traceId VARCHAR,
   spanId VARCHAR,
   experimentId VARCHAR,
   scoreTraceId VARCHAR,
@@ -210,7 +210,7 @@ CREATE TABLE IF NOT EXISTS feedback_events (
   timestamp TIMESTAMP NOT NULL,
 
   -- IDs
-  traceId VARCHAR NOT NULL,
+  traceId VARCHAR,
   spanId VARCHAR,
   experimentId VARCHAR,
   -- Entity hierarchy

--- a/stores/duckdb/src/storage/domains/observability/feedback.ts
+++ b/stores/duckdb/src/storage/domains/observability/feedback.ts
@@ -162,7 +162,7 @@ function rowToFeedbackRecord(row: Record<string, unknown>): Record<string, unkno
 
   return {
     timestamp: toDate(row.timestamp),
-    traceId: row.traceId as string,
+    traceId: (row.traceId as string) ?? null,
     spanId: (row.spanId as string) ?? null,
     experimentId: (row.experimentId as string) ?? null,
     entityType: (row.entityType as string) ?? null,

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -904,6 +904,27 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(filtered.scores[0]!.scoreSource).toBe('manual');
     });
 
+    it('supports nullable traceId for scores at the storage boundary', async () => {
+      await storage.createScore({
+        score: {
+          timestamp: new Date('2026-01-01T00:00:00Z'),
+          traceId: null,
+          spanId: null,
+          scorerId: 'quality',
+          scoreSource: 'automated',
+          score: 0.9,
+          reason: null,
+          experimentId: null,
+          metadata: null,
+        } as any,
+      });
+
+      const result = await storage.listScores({});
+      expect(result.scores).toHaveLength(1);
+      expect(result.scores[0]!.traceId).toBeNull();
+      expect(result.scores[0]!.scoreSource).toBe('automated');
+    });
+
     it('supports score OLAP queries keyed by scorerId and optional scoreSource', async () => {
       await storage.batchCreateScores({
         scores: [
@@ -1067,6 +1088,28 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(filtered.feedback[0]!.traceId).toBe('trace-legacy-feedback');
       expect(filtered.feedback[0]!.source).toBe('manual');
       expect(filtered.feedback[0]!.feedbackSource).toBe('manual');
+    });
+
+    it('supports nullable traceId for feedback at the storage boundary', async () => {
+      await storage.createFeedback({
+        feedback: {
+          timestamp: new Date('2026-01-01T00:00:00Z'),
+          traceId: null,
+          spanId: null,
+          feedbackSource: 'manual',
+          feedbackType: 'rating',
+          value: 5,
+          comment: null,
+          experimentId: null,
+          sourceId: null,
+          metadata: null,
+        } as any,
+      });
+
+      const result = await storage.listFeedback({});
+      expect(result.feedback).toHaveLength(1);
+      expect(result.feedback[0]!.traceId).toBeNull();
+      expect(result.feedback[0]!.feedbackSource).toBe('manual');
     });
 
     it('batch creates and lists feedback', async () => {

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -376,6 +376,80 @@ describe('ObservabilityStorageDuckDB', () => {
     await legacyStore.db.close();
   });
 
+  it('relaxes legacy score and feedback traceId columns during init', async () => {
+    const legacyStore = new DuckDBStore({ path: ':memory:' });
+
+    await legacyStore.db.execute(`
+      CREATE TABLE score_events (
+        timestamp TIMESTAMP NOT NULL,
+        traceId VARCHAR NOT NULL,
+        spanId VARCHAR,
+        experimentId VARCHAR,
+        scoreTraceId VARCHAR,
+        scorerId VARCHAR NOT NULL,
+        scorerVersion VARCHAR,
+        source VARCHAR,
+        score DOUBLE NOT NULL,
+        reason VARCHAR,
+        metadata JSON
+      )
+    `);
+
+    await legacyStore.db.execute(`
+      CREATE TABLE feedback_events (
+        timestamp TIMESTAMP NOT NULL,
+        traceId VARCHAR NOT NULL,
+        spanId VARCHAR,
+        experimentId VARCHAR,
+        userId VARCHAR,
+        source VARCHAR,
+        feedbackType VARCHAR NOT NULL,
+        value VARCHAR NOT NULL,
+        comment VARCHAR,
+        metadata JSON
+      )
+    `);
+
+    await legacyStore.observability.init();
+
+    await legacyStore.observability.createScore({
+      score: {
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        traceId: null,
+        spanId: null,
+        scorerId: 'quality',
+        scoreSource: 'automated',
+        score: 0.8,
+        reason: null,
+        experimentId: null,
+        metadata: null,
+      } as any,
+    });
+
+    await legacyStore.observability.createFeedback({
+      feedback: {
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        traceId: null,
+        spanId: null,
+        feedbackSource: 'manual',
+        feedbackType: 'rating',
+        value: 5,
+        comment: null,
+        experimentId: null,
+        sourceId: null,
+        metadata: null,
+      } as any,
+    });
+
+    const scores = await legacyStore.observability.listScores({});
+    const feedback = await legacyStore.observability.listFeedback({});
+
+    expect(scores.scores[0]!.traceId).toBeNull();
+    expect(feedback.feedback[0]!.traceId).toBeNull();
+
+    await legacyStore.db.close();
+  });
+
   // ==========================================================================
   // Logs
   // ==========================================================================

--- a/stores/duckdb/src/storage/domains/observability/scores.ts
+++ b/stores/duckdb/src/storage/domains/observability/scores.ts
@@ -152,7 +152,7 @@ function toSeriesName(values: unknown[]): string {
 function rowToScoreRecord(row: Record<string, unknown>): Record<string, unknown> {
   return {
     timestamp: toDate(row.timestamp),
-    traceId: row.traceId as string,
+    traceId: (row.traceId as string) ?? null,
     spanId: (row.spanId as string) ?? null,
     experimentId: (row.experimentId as string) ?? null,
     scoreTraceId: (row.scoreTraceId as string) ?? null,


### PR DESCRIPTION
## Description

Fixes dropped observability score/feedback annotations by letting `mastra.observability.addScore()` and `addFeedback()` emit directly from live `correlationContext` instead of requiring persisted trace rehydration
first.

This PR also relaxes score/feedback storage to allow missing `traceId` when only contextual metadata is available, and updates DuckDB observability storage to round-trip nullable `traceId` values correctly.

## Related Issue(s)

Fixes the score/feedback race condition in observability where fast scorers could emit before the target span was persisted.  No issue was create.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Emit scores/feedback from live correlation context to avoid dropped annotations.
  * Allow storing/handling unanchored annotations (traceId optional/null) when only contextual metadata exists.
  * Preserve and forward correlation context and merged metadata in emitted observability payloads.

* **Tests**
  * Added extensive tests for live-emitted, unanchored, storage roundtrip, and hook propagation scenarios.

* **Chores**
  * Added release changesets and DB migration updates to support nullable trace IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->