### PR TITLE
feat(playground-ui): allow ClickHouse VNext for metrics dashboard

### DIFF
--- a/packages/playground-ui/src/domains/metrics/components/metrics-dashboard.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/metrics-dashboard.tsx
@@ -12,7 +12,7 @@ import { EmptyState } from '@/ds/components/EmptyState';
 import { MetricsFlexGrid } from '@/ds/components/MetricsFlexGrid';
 
 const ANALYTICS_OBSERVABILITY_TYPES = new Set([
-  // 'ObservabilityStorageClickhouse',
+  'ObservabilityStorageClickhouseVNext',
   'ObservabilityStorageDuckDB',
   'ObservabilityInMemory',
 ]);
@@ -33,7 +33,7 @@ export function MetricsDashboard() {
         <EmptyState
           iconSlot={<CircleSlashIcon />}
           titleSlot="Metrics are not available with your current storage"
-          descriptionSlot="Metrics require DuckDB or in-memory storage for observability. ClickHouse support is coming soon. Relational databases (PostgreSQL, LibSQL) do not support metrics collection. To enable metrics on an existing project, switch the observability storage in the Mastra configuration."
+          descriptionSlot="Metrics require ClickHouse, DuckDB, or in-memory storage for observability. Relational databases (PostgreSQL, LibSQL) do not support metrics collection. To enable metrics on an existing project, switch the observability storage in the Mastra configuration."
           actionSlot={
             <Button
               variant="ghost"


### PR DESCRIPTION
## What

Add `ObservabilityStorageClickhouseVNext` to the `ANALYTICS_OBSERVABILITY_TYPES` allowlist in the metrics dashboard so it renders correctly when using ClickHouse observability storage.

## Changes

- Added `ObservabilityStorageClickhouseVNext` to the storage type allowlist
- Updated the fallback description to reflect that ClickHouse now supports metrics (was: "ClickHouse support is coming soon")

## Context

The server reports `constructor.name` of the observability storage instance, and the UI checks it against `ANALYTICS_OBSERVABILITY_TYPES`. `ObservabilityStorageClickhouseVNext` was missing from this set, so the metrics dashboard showed a "not available" message even though the storage fully supports metrics.

## Test plan

- Configure `ObservabilityStorageClickhouseVNext` as the observability storage
- Open Studio → Metrics page
- Verify the metrics dashboard renders instead of the "not available" empty state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics support expanded to include ClickHouse V-Next storage type, now available alongside DuckDB and in-memory backends for improved storage flexibility.

* **Documentation**
  * Revised empty state messaging to provide clear guidance on supported storage backends: ClickHouse, DuckDB, and in-memory storage are now required for metrics functionality, with updated language removing outdated "support coming soon" references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->