### PR TITLE
fix(datadog): set native error tags to fix [object   Object] in Datadog Error Tracking UI

### DIFF
--- a/.changeset/fiery-ears-like.md
+++ b/.changeset/fiery-ears-like.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': patch
+---
+
+Fixed error spans showing as [object Object] in Datadog UI. The exporter now sets native dd-trace error tags (error.message, error.type, error.stack) so Datadog's Error Tracking UI displays the full error banner with message, type, and stack trace.

--- a/.changeset/smooth-clouds-glow.md
+++ b/.changeset/smooth-clouds-glow.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/observability': patch
+---
+
+Added error name and stack trace to SpanErrorInfo, allowing exporters to access the original error class name and stack trace for richer error reporting.

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -281,7 +281,43 @@ describe('DatadogExporter', () => {
       );
     });
 
-    it('sets native Datadog error status on ddSpan for error spans', async () => {
+    it('sets native Datadog error tags on ddSpan for error spans', async () => {
+      const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+      const span = createMockSpan({
+        errorInfo: {
+          message: 'Something went wrong',
+          name: 'ValidationError',
+          stack: 'ValidationError: Something went wrong\n    at test.ts:1:1',
+        },
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      // Verify all native Datadog error tags are set for Error Tracking UI
+      expect(capturedSpans[0].setTag).toHaveBeenCalledWith('error', true);
+      expect(capturedSpans[0].setTag).toHaveBeenCalledWith('error.message', 'Something went wrong');
+      expect(capturedSpans[0].setTag).toHaveBeenCalledWith('error.type', 'ValidationError');
+      expect(capturedSpans[0].setTag).toHaveBeenCalledWith(
+        'error.stack',
+        'ValidationError: Something went wrong\n    at test.ts:1:1',
+      );
+    });
+
+    it('uses category as error.type fallback when name is not present', async () => {
+      const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+      const span = createMockSpan({
+        errorInfo: {
+          message: 'Something went wrong',
+          category: 'runtime',
+        },
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(capturedSpans[0].setTag).toHaveBeenCalledWith('error.type', 'runtime');
+    });
+
+    it('uses "Error" as error.type fallback when neither name nor category is present', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({
         errorInfo: {
@@ -291,8 +327,7 @@ describe('DatadogExporter', () => {
 
       await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
 
-      // Verify setTag was called with error: true
-      expect(capturedSpans[0].setTag).toHaveBeenCalledWith('error', true);
+      expect(capturedSpans[0].setTag).toHaveBeenCalledWith('error.type', 'Error');
     });
 
     it('does not set native error status for non-error spans', async () => {

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -315,6 +315,7 @@ describe('DatadogExporter', () => {
       await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
 
       expect(capturedSpans[0].setTag).toHaveBeenCalledWith('error.type', 'runtime');
+      expect(capturedSpans[0].setTag).not.toHaveBeenCalledWith('error.stack', expect.anything());
     });
 
     it('uses "Error" as error.type fallback when neither name nor category is present', async () => {
@@ -328,6 +329,7 @@ describe('DatadogExporter', () => {
       await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
 
       expect(capturedSpans[0].setTag).toHaveBeenCalledWith('error.type', 'Error');
+      expect(capturedSpans[0].setTag).not.toHaveBeenCalledWith('error.stack', expect.anything());
     });
 
     it('does not set native error status for non-error spans', async () => {

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -274,6 +274,18 @@ export class DatadogExporter extends BaseExporter {
   }
 
   /**
+   * Sets native dd-trace error tags required by Datadog's Error Tracking UI.
+   */
+  private setErrorTags(ddSpan: any, errorInfo: NonNullable<AnyExportedSpan['errorInfo']>): void {
+    ddSpan.setTag('error', true);
+    ddSpan.setTag('error.message', errorInfo.message);
+    ddSpan.setTag('error.type', errorInfo.name ?? errorInfo.category ?? 'Error');
+    if (errorInfo.stack) {
+      ddSpan.setTag('error.stack', errorInfo.stack);
+    }
+  }
+
+  /**
    * Builds annotations object for llmobs.annotate().
    * Uses dd-trace's expected property names: inputData, outputData, metadata, tags, metrics.
    */
@@ -684,12 +696,7 @@ export class DatadogExporter extends BaseExporter {
 
       // Set native Datadog error tags for proper Error Tracking UI
       if (span.errorInfo) {
-        ddSpan.setTag('error', true);
-        ddSpan.setTag('error.message', span.errorInfo.message);
-        ddSpan.setTag('error.type', span.errorInfo.name ?? span.errorInfo.category ?? 'Error');
-        if (span.errorInfo.stack) {
-          ddSpan.setTag('error.stack', span.errorInfo.stack);
-        }
+        this.setErrorTags(ddSpan, span.errorInfo);
       }
 
       // Store context for potential evaluation submissions
@@ -728,12 +735,7 @@ export class DatadogExporter extends BaseExporter {
 
         // Set native Datadog error tags for proper Error Tracking UI
         if (span.errorInfo) {
-          ddSpan.setTag('error', true);
-          ddSpan.setTag('error.message', span.errorInfo.message);
-          ddSpan.setTag('error.type', span.errorInfo.name ?? span.errorInfo.category ?? 'Error');
-          if (span.errorInfo.stack) {
-            ddSpan.setTag('error.stack', span.errorInfo.stack);
-          }
+          this.setErrorTags(ddSpan, span.errorInfo);
         }
 
         const exported = tracer.llmobs.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -682,9 +682,14 @@ export class DatadogExporter extends BaseExporter {
         tracer.llmobs.annotate(ddSpan, annotations);
       }
 
-      // Set native Datadog error status for proper UI highlighting
+      // Set native Datadog error tags for proper Error Tracking UI
       if (span.errorInfo) {
         ddSpan.setTag('error', true);
+        ddSpan.setTag('error.message', span.errorInfo.message);
+        ddSpan.setTag('error.type', span.errorInfo.name ?? span.errorInfo.category ?? 'Error');
+        if (span.errorInfo.stack) {
+          ddSpan.setTag('error.stack', span.errorInfo.stack);
+        }
       }
 
       // Store context for potential evaluation submissions
@@ -721,9 +726,14 @@ export class DatadogExporter extends BaseExporter {
           tracer.llmobs.annotate(ddSpan, annotations);
         }
 
-        // Set native Datadog error status for proper UI highlighting
+        // Set native Datadog error tags for proper Error Tracking UI
         if (span.errorInfo) {
           ddSpan.setTag('error', true);
+          ddSpan.setTag('error.message', span.errorInfo.message);
+          ddSpan.setTag('error.type', span.errorInfo.name ?? span.errorInfo.category ?? 'Error');
+          if (span.errorInfo.stack) {
+            ddSpan.setTag('error.stack', span.errorInfo.stack);
+          }
         }
 
         const exported = tracer.llmobs.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;

--- a/observability/mastra/src/recorded.ts
+++ b/observability/mastra/src/recorded.ts
@@ -211,6 +211,8 @@ class RecordedSpanImpl<TType extends SpanType = SpanType> implements RecordedSpa
   public readonly errorInfo?: {
     message: string;
     id?: string;
+    name?: string;
+    stack?: string;
     domain?: string;
     category?: string;
     details?: Record<string, any>;

--- a/observability/mastra/src/recorded.ts
+++ b/observability/mastra/src/recorded.ts
@@ -46,6 +46,8 @@ function normalizeErrorInfo(error: SpanRecord['error']): RecordedErrorInfo {
   return {
     message: error.message,
     id: 'id' in error && typeof error.id === 'string' ? error.id : undefined,
+    name: 'name' in error && typeof error.name === 'string' ? error.name : undefined,
+    stack: 'stack' in error && typeof error.stack === 'string' ? error.stack : undefined,
     domain: 'domain' in error && typeof error.domain === 'string' ? error.domain : undefined,
     category: 'category' in error && typeof error.category === 'string' ? error.category : undefined,
     details:

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -126,6 +126,8 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
   public errorInfo?: {
     message: string;
     id?: string;
+    name?: string;
+    stack?: string;
     domain?: string;
     category?: string;
     details?: Record<string, any>;

--- a/observability/mastra/src/spans/default.ts
+++ b/observability/mastra/src/spans/default.ts
@@ -93,9 +93,13 @@ export class DefaultSpan<TType extends SpanType> extends BaseSpan<TType> {
             category: error.category,
             domain: error.domain,
             message: error.message,
+            name: error.name,
+            stack: error.stack,
           }
         : {
             message: error.message,
+            name: error.name,
+            stack: error.stack,
           };
 
     // Update attributes if provided

--- a/observability/mastra/src/spans/default.ts
+++ b/observability/mastra/src/spans/default.ts
@@ -85,7 +85,7 @@ export class DefaultSpan<TType extends SpanType> extends BaseSpan<TType> {
 
     const { error, endSpan = true, attributes, metadata } = options;
 
-    this.errorInfo =
+    this.errorInfo = deepClean(
       error instanceof MastraError
         ? {
             id: error.id,
@@ -100,7 +100,9 @@ export class DefaultSpan<TType extends SpanType> extends BaseSpan<TType> {
             message: error.message,
             name: error.name,
             stack: error.stack,
-          };
+          },
+      this.deepCleanOptions,
+    );
 
     // Update attributes if provided
     if (attributes) {

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -425,6 +425,10 @@ export type AnySpanAttributes = SpanTypeMap[keyof SpanTypeMap];
 export interface SpanErrorInfo {
   message: string;
   id?: string;
+  /** Error class name (e.g. "TypeError", "ValidationError") */
+  name?: string;
+  /** Stack trace string */
+  stack?: string;
   domain?: string;
   category?: string;
   details?: Record<string, any>;


### PR DESCRIPTION
## Description
When a Mastra tool throws an error, the Datadog exporter only set `ddSpan.setTag('error', true)` — the error message, type, and stack trace were passed as LLM Obs annotations but never as native dd-trace span tags. This caused error details to appear as `[object Object]` in the Datadog UI and prevented Datadog's native Error Tracking UI from displaying the error
banner.

This PR:
- Adds `name` and `stack` fields to `SpanErrorInfo` so the original error class name and stack trace are preserved through the tracing pipeline
- Captures `error.name` and `error.stack` from the original Error object in `DefaultSpan.error()`
- Sets native dd-trace error tags (`error.message`, `error.type`, `error.stack`) on the span in both `emitSpanTree` and `emitSingleSpan`, with a fallback chain for `error.type`: `name →
category → 'Error'`

## Before
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/8947ee11-37ea-4c16-8532-f2378b8f1389" />

## After 
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/c70ce1f9-6f55-4f79-a8e9-1d1ae7afdd42" />

## Related Issue(s)

Fixes #14934

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Datadog error spans now show full error details (message, type, stack) instead of opaque objects, restoring complete error banners.

* **New Features**
  * Span error data now includes error class/name and stack trace so monitoring and error tracking display richer diagnostic context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->