### PR TITLE
fix(core): add entityName to workflow span creation

### DIFF
--- a/.changeset/wide-peaches-tie.md
+++ b/.changeset/wide-peaches-tie.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workflow spans missing entityName, which caused the metrics dashboard to show 'unknown' for workflow trace volume

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2946,6 +2946,7 @@ export class Run<
       name: `workflow run: '${this.workflowId}'`,
       entityType: EntityType.WORKFLOW_RUN,
       entityId: this.workflowId,
+      entityName: this.workflowId,
       input: inputData,
       metadata: {
         resourceId: this.resourceId,
@@ -3722,6 +3723,7 @@ export class Run<
       name: `workflow run: '${this.workflowId}' (resumed)`,
       entityType: EntityType.WORKFLOW_RUN,
       entityId: this.workflowId,
+      entityName: this.workflowId,
       input: resumeDataToUse,
       metadata: {
         resourceId: this.resourceId,
@@ -3861,6 +3863,7 @@ export class Run<
       name: `workflow run: '${this.workflowId}'`,
       entityType: EntityType.WORKFLOW_RUN,
       entityId: this.workflowId,
+      entityName: this.workflowId,
       metadata: {
         resourceId: this.resourceId,
         runId: this.runId,
@@ -3995,6 +3998,7 @@ export class Run<
       input: inputData,
       entityType: EntityType.WORKFLOW_RUN,
       entityId: this.workflowId,
+      entityName: this.workflowId,
       metadata: {
         resourceId: this.resourceId,
         runId: this.runId,


### PR DESCRIPTION
Workflow spans were missing `entityName` in the `getOrCreateSpan` calls across all 4 creation sites (execute, resume, restart, and the 4th path). This caused the correlation context to have `entityName: undefined`, which meant the metrics dashboard showed "unknown" in the workflow trace volume tab.

The fix adds `entityName: this.workflowId` to match how agents already set `entityName: this.name`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow trace volume displaying as "unknown" in the metrics dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->