### PR TITLE
fix(core): resolve skills by path when location includes /SKILL.md suffix

### DIFF
--- a/.changeset/kind-dancers-rescue.md
+++ b/.changeset/kind-dancers-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed skill path resolution when disambiguating same-named skills. The `skill` tool now correctly resolves skills by path when the location includes the `/SKILL.md` suffix. Fixes #14918.

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -1562,6 +1562,43 @@ External instructions.`;
 
       warnSpy.mockRestore();
     });
+
+    it('should resolve skill by path with /SKILL.md suffix (issue #14918)', async () => {
+      // The SkillsProcessor tells the LLM to use the "location" field
+      // (which is `${skill.path}/SKILL.md`) to disambiguate same-named skills.
+      // #resolveByPath must accept paths that include the trailing /SKILL.md.
+      const shadowSkillMd = `---
+name: test-skill
+description: Shadow copy of the test skill
+license: MIT
+---
+
+Shadow instructions.`;
+
+      const filesystem = createMockFilesystem({
+        'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+        'custom-skills/test-skill/SKILL.md': shadowSkillMd,
+      });
+
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['skills', 'custom-skills'],
+      });
+
+      // get() by exact path works without /SKILL.md (baseline)
+      const specific = await skills.get('skills/test-skill');
+      expect(specific?.instructions).toContain('This is the test skill instructions.');
+
+      // get() by path WITH /SKILL.md suffix — this is what the LLM sends
+      // because SkillsProcessor.formatLocation() returns `${skill.path}/SKILL.md`
+      const specificWithSuffix = await skills.get('skills/test-skill/SKILL.md');
+      expect(specificWithSuffix).not.toBeNull();
+      expect(specificWithSuffix?.instructions).toContain('This is the test skill instructions.');
+
+      const shadowWithSuffix = await skills.get('custom-skills/test-skill/SKILL.md');
+      expect(shadowWithSuffix).not.toBeNull();
+      expect(shadowWithSuffix?.instructions).toContain('Shadow instructions.');
+    });
   });
 
   describe('direct skill path discovery', () => {

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -163,10 +163,13 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
   /**
    * Resolve a skill by exact path (escape hatch for disambiguation).
    * Searches across all candidate arrays.
+   * Accepts paths with or without a trailing `/SKILL.md` suffix, since
+   * SkillsProcessor.formatLocation() exposes `${path}/SKILL.md` to the LLM.
    */
   #resolveByPath(skillPath: string): InternalSkill | null {
+    const normalized = skillPath.replace(/\/SKILL\.md$/, '');
     for (const candidates of this.#skills.values()) {
-      const match = candidates.find(s => s.path === skillPath);
+      const match = candidates.find(s => s.path === normalized);
       if (match) return match;
     }
     return null;


### PR DESCRIPTION
When multiple skills share the same name, the `SkillsProcessor` tells the LLM to disambiguate using the `location` field, which looks like `skills/weather/SKILL.md`. But `#resolveByPath` only matched against the directory path (`skills/weather`), so the lookup always failed.

The fix normalizes the path by stripping a trailing `/SKILL.md` before matching. Added a regression test for this case.

Fixes #14918 in a slightly different way than proposed by the issue contributor in https://github.com/mastra-ai/mastra/pull/14917 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where skills with identical names located in different directories could not be correctly resolved and loaded when referenced by the system. The skill resolver now properly handles path references that include the `/SKILL.md` suffix, improving reliability when loading skills from various locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->