### PR TITLE
fix(core): auto-retry on assistant message prefill error

### DIFF
--- a/.changeset/pretty-items-wear.md
+++ b/.changeset/pretty-items-wear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed assistant message prefill error crashing sessions. When a model does not support assistant message prefill, the harness now automatically retries with a user message instead of failing.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1372,6 +1372,20 @@ export class Harness<TState = {}> {
           requestContext: requestContextInput,
         });
         this.emit({ type: 'agent_end', reason: 'error' });
+      } else if (
+        error instanceof Error &&
+        /does not support assistant message prefill|must end with a user message/i.test(error.message)
+      ) {
+        this.emit({
+          type: 'error',
+          error: new Error('Model does not support assistant message prefill. Retrying with a user message.'),
+          retryable: true,
+        });
+        this.followUpQueue.push({
+          content: '[System] Continue where you left off.',
+          requestContext: requestContextInput,
+        });
+        this.emit({ type: 'agent_end', reason: 'error' });
       } else {
         const err = error instanceof Error ? error : new Error(String(error));
         this.emit({ type: 'error', error: err });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1382,7 +1382,7 @@ export class Harness<TState = {}> {
           retryable: true,
         });
         this.followUpQueue.push({
-          content: '[System] Continue where you left off.',
+          content: '<system-reminder>There was an API error, please continue.</system-reminder>',
           requestContext: requestContextInput,
         });
         this.emit({ type: 'agent_end', reason: 'error' });


### PR DESCRIPTION
When a model doesn't support assistant message prefill (conversation ends with an assistant message), the harness now catches the error and automatically retries by sending a `[System] Continue where you left off.` user message. This follows the same pattern already used for the "Tool not found" auto-retry.

Previously this would just crash the session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session crashes caused by assistant message prefill incompatibilities: the app now automatically detects models that don't support assistant prefill and retries using a user-prefill fallback so runs no longer fail.
  * Outcome: more reliable conversations, preserved follow-up prompts, and fewer interrupted sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->