### PR TITLE
fix(e2e): prevent dev server test from hanging indefinitely

### DIFF
--- a/e2e-tests/create-mastra/create-mastra.test.ts
+++ b/e2e-tests/create-mastra/create-mastra.test.ts
@@ -63,17 +63,28 @@ describe('create mastra', () => {
 
         await new Promise<void>((resolve, reject) => {
           console.log('waiting for server to start');
+
+          const timeout = setTimeout(() => {
+            reject(new Error('Dev server did not start in time'));
+          }, 30000); // 30s safety
+
           proc!.stderr?.on('data', data => {
             const output = data?.toString() ?? '';
             console.error(output);
-            const errorPatterns = ['Error', 'ERR', 'failed', 'ENOENT', 'MODULE_NOT_FOUND'];
-            if (errorPatterns.some(pattern => output.toLowerCase().includes(pattern.toLowerCase()))) {
-              reject(new Error('failed to start dev: ' + data?.toString()));
+
+            const errorPatterns = ['error', 'err', 'failed', 'enoent', 'module_not_found'];
+            if (errorPatterns.some(pattern => output.toLowerCase().includes(pattern))) {
+              clearTimeout(timeout);
+              reject(new Error('failed to start dev: ' + output));
             }
           });
+
           proc!.stdout?.on('data', data => {
-            console.log(data?.toString());
-            if (data?.toString()?.includes(`http://localhost:${port}`)) {
+            const output = data?.toString() ?? '';
+            console.log(output);
+
+            if (output.includes(`http://localhost:${port}`)) {
+              clearTimeout(timeout);
               resolve();
             }
           });
@@ -84,7 +95,7 @@ describe('create mastra', () => {
 
     afterAll(async () => {
       if (proc) {
-        proc.kill();
+        proc.kill('SIGTERM');
       }
     });
 


### PR DESCRIPTION
## Description

Fixes a potential infinite hang in the create-mastra e2e test.

The dev server startup logic relied on stdout/stderr events without any timeout.
If the server failed to start without emitting expected output, the test could hang indefinitely.

This change adds a timeout fallback and ensures proper cleanup on resolve/reject.

## Related Issue(s)

Fixes #14956

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [x] Test update

## Checklist

* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have addressed all Coderabbit comments on this PR
