### PR TITLE
fix(core): prevent resourceId from being overwritten to NULL in loop/foreach/parallel/conditional   workflows

### DIFF
--- a/.changeset/fix-loop-resourceid-null.md
+++ b/.changeset/fix-loop-resourceid-null.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed resourceId being overwritten to NULL during workflow execution of loop, foreach, parallel, and conditional steps. The resourceId set via `createRun()` is now correctly preserved throughout the entire workflow lifecycle.

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -292,6 +292,7 @@ export async function executeEntry(
     execResults = await engine.executeParallel({
       workflowId,
       runId,
+      resourceId,
       entry,
       prevStep,
       stepResults,
@@ -403,6 +404,7 @@ export async function executeEntry(
     execResults = await engine.executeConditional({
       workflowId,
       runId,
+      resourceId,
       entry,
       prevOutput,
       stepResults,
@@ -423,6 +425,7 @@ export async function executeEntry(
     execResults = await engine.executeLoop({
       workflowId,
       runId,
+      resourceId,
       entry,
       prevStep,
       prevOutput,
@@ -444,6 +447,7 @@ export async function executeEntry(
     execResults = await engine.executeForeach({
       workflowId,
       runId,
+      resourceId,
       entry,
       prevStep,
       prevOutput,

--- a/workflows/_test-utils/src/domains/storage.ts
+++ b/workflows/_test-utils/src/domains/storage.ts
@@ -413,7 +413,6 @@ export function createStorageTests(ctx: WorkflowTestContext, registry?: Workflow
         const runId = `storage-resourceid-loop-test-${Date.now()}`;
         const resourceId = 'user-loop-456';
 
-        // Spy on persistWorkflowSnapshot to capture every intermediate call
         const storage = ctx.getStorage?.();
         const workflowsStore = storage ? await (storage as any).getStore('workflows') : undefined;
         const persistSpy = workflowsStore
@@ -423,9 +422,6 @@ export function createStorageTests(ctx: WorkflowTestContext, registry?: Workflow
         await execute(workflow, { value: 0 }, { runId, resourceId });
 
         if (persistSpy) {
-          // Every call to persistWorkflowSnapshot must include the correct resourceId.
-          // Before the fix, calls originating from executeLoop passed resourceId as undefined
-          // because executeEntry didn't forward it, which caused PG to overwrite it to NULL.
           const calls = persistSpy.mock.calls;
           expect(calls.length).toBeGreaterThan(0);
           for (const [args] of calls) {

--- a/workflows/_test-utils/src/domains/storage.ts
+++ b/workflows/_test-utils/src/domains/storage.ts
@@ -415,9 +415,7 @@ export function createStorageTests(ctx: WorkflowTestContext, registry?: Workflow
 
         const storage = ctx.getStorage?.();
         const workflowsStore = storage ? await (storage as any).getStore('workflows') : undefined;
-        const persistSpy = workflowsStore
-          ? vi.spyOn(workflowsStore, 'persistWorkflowSnapshot')
-          : undefined;
+        const persistSpy = workflowsStore ? vi.spyOn(workflowsStore, 'persistWorkflowSnapshot') : undefined;
 
         await execute(workflow, { value: 0 }, { runId, resourceId });
 

--- a/workflows/_test-utils/src/domains/storage.ts
+++ b/workflows/_test-utils/src/domains/storage.ts
@@ -214,6 +214,39 @@ export function createStorageWorkflows(ctx: WorkflowCreatorContext) {
     };
   }
 
+  // Test: should preserve resourceId through loop (dountil) execution
+  {
+    const loopStepAction = vi.fn().mockImplementation(async ({ inputData }) => {
+      const value = (inputData?.value ?? 0) + 1;
+      return { value };
+    });
+
+    const loopStep = createStep({
+      id: 'loopStep',
+      execute: loopStepAction,
+      inputSchema: z.object({ value: z.number().optional() }),
+      outputSchema: z.object({ value: z.number() }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'storage-resourceid-loop-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ value: z.number() }),
+      options: { validateInputs: false },
+    });
+
+    workflow
+      .dountil(loopStep, async ({ inputData }) => {
+        return (inputData?.value ?? 0) >= 3;
+      })
+      .commit();
+
+    workflows['storage-resourceid-loop-workflow'] = {
+      workflow,
+      mocks: { loopStepAction },
+    };
+  }
+
   // Test: should use shouldPersistSnapshot option
   {
     const step1Action = vi.fn().mockResolvedValue({ result: 'success1' });
@@ -369,6 +402,37 @@ export function createStorageTests(ctx: WorkflowTestContext, registry?: Workflow
         const { runs } = await (workflow as any).listWorkflowRuns({ resourceId });
         expect(runs).toHaveLength(1);
         expect(runs[0]?.resourceId).toBe(resourceId);
+      },
+    );
+
+    it.skipIf(skipTests.storageResourceIdLoop)(
+      'should pass resourceId in every persistWorkflowSnapshot call during loop execution',
+      async () => {
+        const { workflow } = registry!['storage-resourceid-loop-workflow']!;
+
+        const runId = `storage-resourceid-loop-test-${Date.now()}`;
+        const resourceId = 'user-loop-456';
+
+        // Spy on persistWorkflowSnapshot to capture every intermediate call
+        const storage = ctx.getStorage?.();
+        const workflowsStore = storage ? await (storage as any).getStore('workflows') : undefined;
+        const persistSpy = workflowsStore
+          ? vi.spyOn(workflowsStore, 'persistWorkflowSnapshot')
+          : undefined;
+
+        await execute(workflow, { value: 0 }, { runId, resourceId });
+
+        if (persistSpy) {
+          // Every call to persistWorkflowSnapshot must include the correct resourceId.
+          // Before the fix, calls originating from executeLoop passed resourceId as undefined
+          // because executeEntry didn't forward it, which caused PG to overwrite it to NULL.
+          const calls = persistSpy.mock.calls;
+          expect(calls.length).toBeGreaterThan(0);
+          for (const [args] of calls) {
+            expect(args.resourceId).toBe(resourceId);
+          }
+          persistSpy.mockRestore();
+        }
       },
     );
 

--- a/workflows/_test-utils/src/domains/storage.ts
+++ b/workflows/_test-utils/src/domains/storage.ts
@@ -230,7 +230,7 @@ export function createStorageWorkflows(ctx: WorkflowCreatorContext) {
 
     const workflow = createWorkflow({
       id: 'storage-resourceid-loop-workflow',
-      inputSchema: z.object({}),
+      inputSchema: z.object({ value: z.number().optional() }),
       outputSchema: z.object({ value: z.number() }),
       options: { validateInputs: false },
     });
@@ -421,14 +421,13 @@ export function createStorageTests(ctx: WorkflowTestContext, registry?: Workflow
 
         await execute(workflow, { value: 0 }, { runId, resourceId });
 
-        if (persistSpy) {
-          const calls = persistSpy.mock.calls;
-          expect(calls.length).toBeGreaterThan(0);
-          for (const [args] of calls) {
-            expect(args.resourceId).toBe(resourceId);
-          }
-          persistSpy.mockRestore();
+        expect(persistSpy).toBeDefined();
+        const calls = persistSpy!.mock.calls;
+        expect(calls.length).toBeGreaterThan(0);
+        for (const [args] of calls) {
+          expect(args.resourceId).toBe(resourceId);
         }
+        persistSpy!.mockRestore();
       },
     );
 

--- a/workflows/_test-utils/src/types.ts
+++ b/workflows/_test-utils/src/types.ts
@@ -343,6 +343,8 @@ export type SkippableTest =
   | 'diRequestContextBeforeSuspension'
   // Storage - resourceId preservation on resume
   | 'storageResourceIdResume'
+  // Storage - resourceId preservation through loop execution
+  | 'storageResourceIdLoop'
   // Storage - shouldPersistSnapshot option
   | 'storageShouldPersistSnapshot'
   // Time travel to a non-existent step should fail


### PR DESCRIPTION
### Summary
- Fixes `executeEntry` in the default execution engine to pass `resourceId` to all entry type handlers
(`executeLoop`, `executeForeach`, `executeParallel`, `executeConditional`), matching the existing
`executeStep` behavior
- Previously, only the `"step"` branch passed `resourceId`, causing all other branches to call
`persistWorkflowSnapshot` with `undefined`, which the PG store's `ON CONFLICT DO UPDATE` clause wrote as
`NULL` — erasing the value set during `createRun()`

### Root Cause
In `packages/core/src/workflows/handlers/entry.ts`, the `executeEntry` function destructured
`resourceId` from its params but omitted it when calling four handler functions. Each handler already
accepted and forwarded `resourceId` internally — the only gap was at the call site.

### Test Plan
- [x] All 261 existing workflow unit tests pass
- [x] TypeScript compiles cleanly (pre-existing errors in unrelated file)
- [ ] Verify with a `.dountil()` / `.dowhile()` workflow that `resourceId` persists in the snapshot
after loop iterations
- [ ] Verify with `.parallel()`, `.branch()`, and `.foreach()` workflows that `resourceId` is preserved

Closes #14954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the resource ID could be reset to NULL during workflow execution (loops, foreach, parallel, conditional). The resource ID now remains preserved for the full workflow lifecycle.

* **Tests**
  * Added a workflow and test that validate the resource ID is persisted across loop iterations and recorded correctly during snapshot persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->