### PR TITLE
fix(observability): fall back to dot-to-dash model name normalization in pricing lookup

### DIFF
--- a/.changeset/pricing-model-dot-fallback.md
+++ b/.changeset/pricing-model-dot-fallback.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed pricing model lookup to fall back to dot-to-dash normalization for model names (e.g. `gpt-5.2` → `gpt-5-2`), resolving `no_matching_model` errors for Azure deployments

--- a/observability/mastra/src/metrics/pricing-registry.ts
+++ b/observability/mastra/src/metrics/pricing-registry.ts
@@ -73,7 +73,17 @@ export class PricingRegistry {
   }
 
   get(args: { provider: string; model: string }): PricingModel | null {
-    return this.pricingModels.get(makePricingKey(args)) ?? null;
+    const key = makePricingKey(args);
+    const exact = this.pricingModels.get(key);
+    if (exact) return exact;
+
+    // Fallback: dots → dashes in model name (e.g. "gpt-5.2" → "gpt-5-2")
+    const dashedKey = makePricingKey({ provider: args.provider, model: args.model.replace(/\./g, '-') });
+    if (dashedKey !== key) {
+      return this.pricingModels.get(dashedKey) ?? null;
+    }
+
+    return null;
   }
 }
 


### PR DESCRIPTION
## What

Some providers (e.g. Azure) use dots in model deployment names (`gpt-5.2`) while the embedded pricing data uses dashes (`gpt-5-2`). This causes `no_matching_model` errors and prevents cost estimation.

## Fix

When an exact `provider::model` key lookup fails in `PricingRegistry.get()`, try again with dots replaced by dashes in the model name before returning null.

## Test plan

- Existing tests pass (`pricing-registry.test.ts`, `estimator.test.ts`, `auto-extract.test.ts`)
- Verified against live ClickHouse data showing `azure.responses` + `gpt-5.2` with `{"error":"no_matching_model"}` — after fix, correctly resolves to `azure::gpt-5-2` pricing entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pricing model lookup to support alternative naming formats, resolving `no_matching_model` errors during Azure deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->