### PR TITLE
fix(mastracode): disable MCP tool result timeout for long-running tools

### DIFF
--- a/.changeset/eager-frogs-dig.md
+++ b/.changeset/eager-frogs-dig.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Disabled MCP tool result timeout in MastraCode to allow for long running tools

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -8,6 +8,8 @@ import type { MastraMCPServerDefinition } from '@mastra/mcp';
 import { loadMcpConfig, getProjectMcpPath, getGlobalMcpPath, getClaudeSettingsPath } from './config.js';
 import type { McpConfig, McpHttpServerConfig, McpServerConfig, McpServerStatus, McpSkippedServer } from './types.js';
 
+const MASTRACODE_MCP_TIMEOUT_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
 /** Summary of MCP initialization result. */
 export interface McpInitResult {
   connected: McpServerStatus[];
@@ -141,6 +143,7 @@ export function createMcpManager(projectDir: string, extraServers?: Record<strin
     client = new MCPClient({
       id: 'mastra-code-mcp',
       servers: buildServerDefs(servers),
+      timeout: MASTRACODE_MCP_TIMEOUT_MS,
     });
 
     // Use listToolsetsWithErrors() to get tools grouped by server name,


### PR DESCRIPTION
MCP tool calls in MastraCode were timing out for long-running tools. This sets the default MCP timeout to 7 days (effectively infinite) so tool operations can take as long as they need.

The MCP SDK doesn't support `Infinity`, `0`, or `undefined` for disabling timeouts, so a large finite value is the workaround.

I have some tools that require me to perform an action and they kept timing out, extending this makes mcp tool results have similar constraints to regular mastra tools 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Extended MCP tool timeout to enable long-running operations to complete successfully without premature interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->