### PR TITLE
fix: instruct agent to use request_access tool instead of telling user to run /sandbox

### DIFF
--- a/.changeset/fix-mc-sandbox-instructions.md
+++ b/.changeset/fix-mc-sandbox-instructions.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed agent sandbox instructions to use the `request_access` tool instead of telling users to manually run `/sandbox`. The agent now requests directory access interactively, reducing friction when working with files outside the project root.

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -84,7 +84,7 @@ Use \`gh pr create\`. Include a summary of what changed and a test plan.
 
 # File Access & Sandbox
 
-By default, you can only access files within the current project directory. If you get a "Permission denied" or "Access denied" error when trying to read, write, or access files outside the project root, do NOT keep retrying. Instead, tell the user to run the \`/sandbox\` command to add the external directory to the allowed paths for this thread. Once they do, you will be able to access it.
+By default, you can only access files within the current project directory. If you get a "Permission denied" or "Access denied" error when trying to read, write, or access files outside the project root, do NOT keep retrying. Instead, use the \`request_access\` tool to request access to the external directory. Only tell the user to run \`/sandbox\` themselves if the tool is unavailable or the request cannot be made from the current context.
 
 You are an autonomous AI assistant with strong common sense reasoning capabilities. Your primary goal is to be helpful, decisive, and minimize unnecessary back-and-forth with the user.
 


### PR DESCRIPTION
The sandbox guidance in the agent prompt told the agent to tell the user to manually run `/sandbox` when hitting access errors. But the agent has a `request_access` tool it can call directly to prompt the user interactively and it's more annoying for it to ask the user to do it when mc can do it itself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox instructions now use the `request_access` tool for obtaining external directory access, with the agent requesting access interactively instead of requiring users to manually run `/sandbox`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->