### PR TITLE
fix(core): handle binary file data in AIV4/AIV5 adapter toUIMessage

### DIFF
--- a/.changeset/fix-adapter-binary-file-data.md
+++ b/.changeset/fix-adapter-binary-file-data.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix crash in AIV4/AIV5 adapter `toUIMessage` when file part data is binary (Uint8Array/ArrayBuffer) or a URL object instead of a string. This can happen when processing attachments from channel adapters (e.g. video/audio files from Discord, Slack).

--- a/packages/core/src/agent/message-list/adapters/AIV4Adapter-file-data.test.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV4Adapter-file-data.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import type { MastraDBMessage } from '../state/types';
+
+import { AIV4Adapter } from './AIV4Adapter';
+
+/**
+ * Tests for file part data handling in AIV4Adapter.toUIMessage.
+ *
+ * part.data is typed as string but may be Uint8Array, ArrayBuffer, or URL
+ * at runtime (e.g. from channel attachment fetches). The adapter must handle
+ * all of these without crashing.
+ */
+describe('AIV4Adapter.toUIMessage — file part data handling', () => {
+  const makeDbMessage = (parts: MastraDBMessage['content']['parts']): MastraDBMessage => ({
+    id: 'msg-1',
+    role: 'user',
+    createdAt: new Date(),
+    content: {
+      format: 2,
+      parts,
+    },
+  });
+
+  it('should handle string file data (base64)', () => {
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: 'aGVsbG8=',
+        mimeType: 'application/octet-stream',
+      } as any,
+    ]);
+
+    const uiMsg = AIV4Adapter.toUIMessage(dbMsg);
+
+    expect(uiMsg.experimental_attachments).toHaveLength(1);
+    expect(uiMsg.experimental_attachments![0].url).toContain('data:application/octet-stream;base64,');
+    expect(uiMsg.experimental_attachments![0].contentType).toBe('application/octet-stream');
+  });
+
+  it('should handle string file data (data URI)', () => {
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: 'data:video/mp4;base64,AAAA',
+        mimeType: 'video/mp4',
+      } as any,
+    ]);
+
+    const uiMsg = AIV4Adapter.toUIMessage(dbMsg);
+
+    expect(uiMsg.experimental_attachments).toHaveLength(1);
+    expect(uiMsg.experimental_attachments![0].url).toBe('data:video/mp4;base64,AAAA');
+  });
+
+  it('should handle string file data (URL string)', () => {
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: 'https://cdn.discord.com/attachments/123/456/video.mp4',
+        mimeType: 'video/mp4',
+      } as any,
+    ]);
+
+    const uiMsg = AIV4Adapter.toUIMessage(dbMsg);
+
+    expect(uiMsg.experimental_attachments).toHaveLength(1);
+    expect(uiMsg.experimental_attachments![0].url).toBe('https://cdn.discord.com/attachments/123/456/video.mp4');
+  });
+
+  it('should handle Uint8Array file data without crashing', () => {
+    const binary = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: binary,
+        mimeType: 'video/mp4',
+      } as any,
+    ]);
+
+    const uiMsg = AIV4Adapter.toUIMessage(dbMsg);
+
+    expect(uiMsg.experimental_attachments).toHaveLength(1);
+    expect(uiMsg.experimental_attachments![0].url).toContain('data:video/mp4;base64,');
+    expect(uiMsg.experimental_attachments![0].contentType).toBe('video/mp4');
+  });
+
+  it('should handle ArrayBuffer file data without crashing', () => {
+    const buffer = new ArrayBuffer(4);
+    new Uint8Array(buffer).set([0x00, 0x01, 0x02, 0x03]);
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: buffer,
+        mimeType: 'audio/mpeg',
+      } as any,
+    ]);
+
+    const uiMsg = AIV4Adapter.toUIMessage(dbMsg);
+
+    expect(uiMsg.experimental_attachments).toHaveLength(1);
+    expect(uiMsg.experimental_attachments![0].url).toContain('data:audio/mpeg;base64,');
+  });
+
+  it('should handle URL object file data', () => {
+    const url = new URL('https://cdn.discord.com/attachments/123/456/video.mp4');
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: url,
+        mimeType: 'video/mp4',
+      } as any,
+    ]);
+
+    const uiMsg = AIV4Adapter.toUIMessage(dbMsg);
+
+    expect(uiMsg.experimental_attachments).toHaveLength(1);
+    expect(uiMsg.experimental_attachments![0].url).toBe('https://cdn.discord.com/attachments/123/456/video.mp4');
+  });
+});

--- a/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
@@ -86,20 +86,25 @@ export class AIV4Adapter {
     if (sourceParts.length) {
       for (const part of sourceParts) {
         if (part.type === `file`) {
-          // Normalize part.data to ensure it's a valid URL or data URI
+          // Normalize part.data to ensure it's a valid URL or data URI.
+          // part.data is typed as string but may be Uint8Array/URL at runtime.
+          const rawData: unknown = part.data;
           let normalizedUrl: string;
-          if (typeof part.data === 'string') {
-            const categorized = categorizeFileData(part.data, part.mimeType);
+
+          if (typeof rawData === 'string') {
+            const categorized = categorizeFileData(rawData, part.mimeType);
             if (categorized.type === 'raw') {
-              // Raw base64 - convert to data URI
-              normalizedUrl = createDataUri(part.data, part.mimeType || 'application/octet-stream');
+              normalizedUrl = createDataUri(rawData, part.mimeType || 'application/octet-stream');
             } else {
-              // Already a URL or data URI
-              normalizedUrl = part.data;
+              normalizedUrl = rawData;
             }
+          } else if (rawData instanceof Uint8Array || rawData instanceof ArrayBuffer) {
+            const base64 = convertDataContentToBase64String(rawData);
+            normalizedUrl = createDataUri(base64, part.mimeType || 'application/octet-stream');
+          } else if (rawData instanceof URL) {
+            normalizedUrl = rawData.toString();
           } else {
-            // It's a non-string (shouldn't happen in practice for file parts, but handle it)
-            normalizedUrl = part.data;
+            continue; // Unknown data type — skip
           }
 
           experimentalAttachments.push({

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter-file-data.test.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter-file-data.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { MastraDBMessage } from '../state/types';
+
+import { AIV5Adapter } from './AIV5Adapter';
+
+/**
+ * Tests for file part data handling in AIV5Adapter.toUIMessage.
+ *
+ * part.data is typed as string but may be Uint8Array, ArrayBuffer, or URL
+ * at runtime (e.g. from channel attachment fetches). The adapter must handle
+ * all of these without crashing.
+ */
+describe('AIV5Adapter.toUIMessage — file part data handling', () => {
+  const makeDbMessage = (parts: MastraDBMessage['content']['parts']): MastraDBMessage => ({
+    id: 'msg-1',
+    role: 'user',
+    createdAt: new Date(),
+    content: {
+      format: 2,
+      parts,
+    },
+  });
+
+  it('should handle string file data (base64)', () => {
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: 'aGVsbG8=',
+        mimeType: 'application/octet-stream',
+      } as any,
+    ]);
+
+    const uiMsg = AIV5Adapter.toUIMessage(dbMsg);
+
+    const filePart = uiMsg.parts.find(p => p.type === 'file') as any;
+    expect(filePart).toBeDefined();
+    expect(filePart.url).toContain('data:application/octet-stream;base64,');
+  });
+
+  it('should handle string file data (data URI)', () => {
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: 'data:video/mp4;base64,AAAA',
+        mimeType: 'video/mp4',
+      } as any,
+    ]);
+
+    const uiMsg = AIV5Adapter.toUIMessage(dbMsg);
+
+    const filePart = uiMsg.parts.find(p => p.type === 'file') as any;
+    expect(filePart).toBeDefined();
+    expect(filePart.url).toContain('data:');
+    expect(filePart.mediaType).toBe('video/mp4');
+  });
+
+  it('should handle string file data (URL string)', () => {
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: 'https://cdn.discord.com/attachments/123/456/video.mp4',
+        mimeType: 'video/mp4',
+      } as any,
+    ]);
+
+    const uiMsg = AIV5Adapter.toUIMessage(dbMsg);
+
+    const filePart = uiMsg.parts.find(p => p.type === 'file') as any;
+    expect(filePart).toBeDefined();
+    expect(filePart.url).toBe('https://cdn.discord.com/attachments/123/456/video.mp4');
+    expect(filePart.mediaType).toBe('video/mp4');
+  });
+
+  it('should handle Uint8Array file data without crashing', () => {
+    const binary = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: binary,
+        mimeType: 'video/mp4',
+      } as any,
+    ]);
+
+    const uiMsg = AIV5Adapter.toUIMessage(dbMsg);
+
+    const filePart = uiMsg.parts.find(p => p.type === 'file') as any;
+    expect(filePart).toBeDefined();
+    expect(filePart.url).toContain('data:video/mp4;base64,');
+    expect(filePart.mediaType).toBe('video/mp4');
+  });
+
+  it('should handle ArrayBuffer file data without crashing', () => {
+    const buffer = new ArrayBuffer(4);
+    new Uint8Array(buffer).set([0x00, 0x01, 0x02, 0x03]);
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: buffer,
+        mimeType: 'audio/mpeg',
+      } as any,
+    ]);
+
+    const uiMsg = AIV5Adapter.toUIMessage(dbMsg);
+
+    const filePart = uiMsg.parts.find(p => p.type === 'file') as any;
+    expect(filePart).toBeDefined();
+    expect(filePart.url).toContain('data:audio/mpeg;base64,');
+    expect(filePart.mediaType).toBe('audio/mpeg');
+  });
+
+  it('should handle URL object file data', () => {
+    const url = new URL('https://cdn.discord.com/attachments/123/456/video.mp4');
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: url,
+        mimeType: 'video/mp4',
+      } as any,
+    ]);
+
+    const uiMsg = AIV5Adapter.toUIMessage(dbMsg);
+
+    const filePart = uiMsg.parts.find(p => p.type === 'file') as any;
+    expect(filePart).toBeDefined();
+    expect(filePart.url).toBe('https://cdn.discord.com/attachments/123/456/video.mp4');
+    expect(filePart.mediaType).toBe('video/mp4');
+  });
+
+  it('should skip unknown data types gracefully', () => {
+    const dbMsg = makeDbMessage([
+      {
+        type: 'file',
+        data: 12345,
+        mimeType: 'video/mp4',
+      } as any,
+    ]);
+
+    const uiMsg = AIV5Adapter.toUIMessage(dbMsg);
+
+    const filePart = uiMsg.parts.find(p => p.type === 'file');
+    expect(filePart).toBeUndefined();
+  });
+});

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
@@ -2,6 +2,7 @@ import type { ToolInvocationUIPart } from '@ai-sdk/ui-utils-v5';
 import * as AIV5 from '@internal/ai-sdk-v5';
 
 import { MastraError, ErrorDomain, ErrorCategory } from '../../../error';
+import { convertDataContentToBase64String } from '../prompt/data-content';
 import { categorizeFileData, createDataUri, parseDataUri } from '../prompt/image-utils';
 import type { MastraDBMessage, MastraMessageContentV2, MastraMessagePart, MessageSource } from '../state/types';
 import type { AIV5Type } from '../types';
@@ -217,32 +218,51 @@ export class AIV5Adapter {
             }
             parts.push(v5UIPart);
           } else {
-            let filePartData: string;
             let extractedMimeType = part.mimeType;
+            let dataUri: string;
 
-            if (typeof part.data === 'string') {
-              const parsed = parseDataUri(part.data);
+            // part.data is typed as string but may be a Uint8Array/ArrayBuffer at
+            // runtime (e.g. from channel attachment fetches). Handle defensively.
+            const rawData: unknown = part.data;
+
+            if (typeof rawData === 'string') {
+              const parsed = parseDataUri(rawData);
 
               if (parsed.isDataUri) {
-                filePartData = parsed.base64Content;
                 if (parsed.mimeType) {
                   extractedMimeType = extractedMimeType || parsed.mimeType;
                 }
+                const finalMimeType = extractedMimeType || 'image/png';
+                dataUri = parsed.base64Content.startsWith('data:')
+                  ? parsed.base64Content
+                  : createDataUri(parsed.base64Content, finalMimeType);
+              } else if (rawData.startsWith('data:')) {
+                dataUri = rawData;
               } else {
-                filePartData = part.data;
+                dataUri = createDataUri(rawData, extractedMimeType || 'image/png');
               }
+            } else if (rawData instanceof Uint8Array || rawData instanceof ArrayBuffer) {
+              // Binary data — convert to base64 data URI
+              const base64 = convertDataContentToBase64String(rawData);
+              dataUri = createDataUri(base64, extractedMimeType || 'application/octet-stream');
+            } else if (rawData instanceof URL) {
+              // URL object — use directly
+              const v5UIPart: AIV5Type.FileUIPart = {
+                type: 'file' as const,
+                url: rawData.toString(),
+                mediaType: extractedMimeType || 'application/octet-stream',
+              };
+              if (part.providerMetadata) {
+                v5UIPart.providerMetadata = part.providerMetadata;
+              }
+              parts.push(v5UIPart);
+              continue;
             } else {
-              filePartData = part.data;
+              // Unknown data type — skip to avoid crashes
+              continue;
             }
 
             const finalMimeType = extractedMimeType || 'image/png';
-
-            let dataUri: string;
-            if (typeof filePartData === 'string' && filePartData.startsWith('data:')) {
-              dataUri = filePartData;
-            } else {
-              dataUri = createDataUri(filePartData, finalMimeType);
-            }
 
             const v5UIPart: AIV5Type.FileUIPart = {
               type: 'file' as const,


### PR DESCRIPTION
## Problem

Both `AIV4Adapter.toUIMessage` and `AIV5Adapter.toUIMessage` crash when `part.data` is a `Uint8Array`, `ArrayBuffer`, or `URL` object instead of a string. The `MastraMessagePart` file type declares `data: string`, but at runtime binary data can flow through (e.g. from channel attachment fetches or any code path that stores raw binary in a file part).

The crash manifests as:
```
TypeError: base64Content.startsWith is not a function
```

## Fix

Widen to `unknown` and branch by runtime type:
- **`string`** — existing behavior (parse data URI, categorize, etc.)
- **`Uint8Array` / `ArrayBuffer`** — convert to base64 via `convertDataContentToBase64String`, then create a data URI
- **`URL`** — use `.toString()` directly
- **Unknown types** — skip gracefully (AIV5) / skip (AIV4)

## Test Plan

- 13 new tests across `AIV4Adapter-file-data.test.ts` and `AIV5Adapter-file-data.test.ts`
- Covers: string (base64, data URI, URL), `Uint8Array`, `ArrayBuffer`, `URL` object, unknown types
- All 20 adapter tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the AIV4/AIV5 adapter when handling file attachments provided as binary data or URL objects instead of strings. The adapter now properly converts different data formats and gracefully skips unrecognized types.

* **Tests**
  * Added comprehensive test coverage for file data handling across multiple data types including base64 strings, data URIs, plain URLs, binary data, and URL objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->