### PR TITLE
feat(playground): add contact link to Studio Resources page

### DIFF
--- a/.changeset/studio-sales-contact-link.md
+++ b/.changeset/studio-sales-contact-link.md
@@ -1,0 +1,5 @@
+---
+"@mastra/playground": patch
+---
+
+Added a "Talk to our Sales team" link to the Studio Resources page for custom demos and enterprise inquiries.

--- a/.changeset/studio-sales-contact-link.md
+++ b/.changeset/studio-sales-contact-link.md
@@ -1,5 +1,0 @@
----
-"@mastra/playground": patch
----
-
-Added a "Talk to our Sales team" link to the Studio Resources page for custom demos and enterprise inquiries.

--- a/packages/playground/src/pages/resources/index.tsx
+++ b/packages/playground/src/pages/resources/index.tsx
@@ -1,5 +1,5 @@
 import { EntityListPageLayout, MainHeader } from '@mastra/playground-ui';
-import { BookIcon, EarthIcon, MessageSquareIcon, ExternalLinkIcon, CloudUploadIcon } from 'lucide-react';
+import { BookIcon, EarthIcon, MessageSquareIcon, ExternalLinkIcon, CloudUploadIcon, BuildingIcon } from 'lucide-react';
 
 const resources = [
   {
@@ -35,6 +35,14 @@ const resources = [
     description: 'Running Mastra Studio locally? Deploy to the cloud so your team can collaborate.',
     icon: CloudUploadIcon,
     href: 'https://mastra.ai/cloud',
+    external: true,
+  },
+  {
+    title: 'Talk to our Sales team',
+    description:
+      'Get a custom demo, discuss on-prem deployments, and how we can help you accelerate getting agents into production.',
+    icon: BuildingIcon,
+    href: 'https://mastra.ai/contact?ref=studio',
     external: true,
   },
 ];


### PR DESCRIPTION
Adds a contact card to the Studio Resources page. Links to https://mastra.ai/contact?ref=studio so clicks from Studio can be tracked.

The card mentions custom demos, on-prem deployments, and getting agents into production — keeps the same card style as the existing resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Talk to our Sales team" card to the Resources Page, providing users with a convenient way to contact the sales team for custom demos and enterprise inquiries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->