### PR TITLE
feat(workspace): support custom language server registration in LSP config

### DIFF
--- a/.changeset/swift-actors-judge.md
+++ b/.changeset/swift-actors-judge.md
@@ -1,0 +1,26 @@
+---
+'@mastra/core': minor
+---
+
+Added support for custom language server registration via `servers` field in `LSPConfig`. Previously, only built-in languages (TypeScript, Python, Go, Rust, C/C++) were supported. Now you can register any language server for any language (PHP, Ruby, Java, Kotlin, Swift, Elixir, etc.) by providing a `CustomLSPServer` definition.
+
+**Example:**
+
+```typescript
+const workspace = new Workspace({
+  lsp: {
+    servers: {
+      phpactor: {
+        id: 'phpactor',
+        name: 'Phpactor Language Server',
+        languageIds: ['php'],
+        extensions: ['.php'],
+        markers: ['composer.json'],
+        command: 'phpactor language-server',
+      },
+    },
+  },
+});
+```
+
+Custom servers are merged with built-in servers and can also override them by using the same ID. Closes #14828.

--- a/.changeset/swift-actors-judge.md
+++ b/.changeset/swift-actors-judge.md
@@ -2,7 +2,7 @@
 '@mastra/core': minor
 ---
 
-Added support for custom language server registration via `servers` field in `LSPConfig`. Previously, only built-in languages (TypeScript, Python, Go, Rust, C/C++) were supported. Now you can register any language server for any language (PHP, Ruby, Java, Kotlin, Swift, Elixir, etc.) by providing a `CustomLSPServer` definition.
+Added support for custom language server registration via `servers` field in `LSPConfig`. Previously, only built-in languages (TypeScript, JavaScript, Python, Go, and Rust) were supported. Now you can register any language server for any language (PHP, Ruby, Java, Kotlin, Swift, Elixir, etc.) by providing a `CustomLSPServer` definition.
 
 **Example:**
 

--- a/.changeset/swift-actors-judge.md
+++ b/.changeset/swift-actors-judge.md
@@ -2,7 +2,7 @@
 '@mastra/core': minor
 ---
 
-Added support for custom language server registration via `servers` field in `LSPConfig`. Previously, only built-in languages (TypeScript, JavaScript, Python, Go, and Rust) were supported. Now you can register any language server for any language (PHP, Ruby, Java, Kotlin, Swift, Elixir, etc.) by providing a `CustomLSPServer` definition.
+Added support for custom language server registration with the `servers` field in `LSPConfig`. Previously, LSP inspection only worked with built-in server definitions for TypeScript, JavaScript, Python, Go, and Rust. You can now register additional language servers, such as PHP, Ruby, Java, Kotlin, Swift, or Elixir, by providing a `CustomLSPServer` definition.
 
 **Example:**
 

--- a/docs/src/content/en/docs/workspace/lsp.mdx
+++ b/docs/src/content/en/docs/workspace/lsp.mdx
@@ -92,9 +92,9 @@ const workspace = new Workspace({
   lsp: {
     diagnosticTimeout: 4000,
     initTimeout: 8000,
-    disableServers: ['pyright'],
+    disableServers: ['eslint'],
     binaryOverrides: {
-      typescript: '/custom/path/to/typescript-language-server',
+      typescript: '/custom/path/to/typescript-language-server --stdio',
     },
     searchPaths: ['/opt/homebrew/bin'],
   },
@@ -140,7 +140,7 @@ Each custom server definition requires these fields:
 | `id` | Unique identifier for the server |
 | `name` | Human-readable name shown in logs |
 | `languageIds` | Language Server Protocol (LSP) language identifiers this server handles |
-| `extensions` | File extensions (including the dot) that map to this server's language |
+| `extensions` | File extensions (including the dot) that map to this server. Each extension resolves to the first entry in `languageIds` |
 | `markers` | Files or directories that identify the project root (e.g. `composer.json`, `Gemfile`) |
 | `command` | Full command string to start the server |
 

--- a/docs/src/content/en/docs/workspace/lsp.mdx
+++ b/docs/src/content/en/docs/workspace/lsp.mdx
@@ -15,10 +15,11 @@ LSP inspection gives workspace-backed agents semantic code intelligence. When yo
 
 Use LSP inspection when your agent needs semantic code understanding instead of plain-text search alone:
 
-- Inspect TypeScript or JavaScript symbols and their inferred types
+- Inspect symbols and their inferred types in any supported language
 - Find where a symbol is declared before editing related code
 - Explore implementations across a codebase without manually tracing every file
 - Combine semantic inspection with `view` and `search_content` for faster navigation
+- Add LSP support for additional languages by [registering custom language servers](#custom-language-servers)
 
 ## Basic usage
 
@@ -107,9 +108,78 @@ Use custom configuration when you need to:
 - Point Mastra at custom language server binaries
 - Add extra binary search paths in constrained environments
 
+## Custom language servers
+
+By default, Mastra includes built-in support for TypeScript, JavaScript, Python, Go, and Rust. To use LSP inspection with other languages (e.g. PHP, Ruby, Java, Kotlin, Swift, Elixir), register a custom language server via the `servers` field:
+
+```typescript title="src/mastra/workspaces.ts"
+import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace'
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  sandbox: new LocalSandbox({ workingDirectory: './workspace' }),
+  lsp: {
+    servers: {
+      phpactor: {
+        id: 'phpactor',
+        name: 'Phpactor Language Server',
+        languageIds: ['php'],
+        extensions: ['.php'],
+        markers: ['composer.json'],
+        command: 'phpactor language-server',
+      },
+    },
+  },
+})
+```
+
+Each custom server definition requires these fields:
+
+| Field | Description |
+| - | - |
+| `id` | Unique identifier for the server |
+| `name` | Human-readable name shown in logs |
+| `languageIds` | Language Server Protocol (LSP) language identifiers this server handles |
+| `extensions` | File extensions (including the dot) that map to this server's language |
+| `markers` | Files or directories that identify the project root (e.g. `composer.json`, `Gemfile`) |
+| `command` | Full command string to start the server |
+
+You can also pass optional `initializationOptions` to send custom settings during the LSP handshake.
+
+Custom servers are merged with built-in servers. To replace a built-in server, use the same `id` (e.g. `id: 'go'` replaces the built-in Go server). Register multiple servers to support several languages at once:
+
+```typescript title="src/mastra/workspaces.ts"
+import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace'
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  sandbox: new LocalSandbox({ workingDirectory: './workspace' }),
+  lsp: {
+    servers: {
+      phpactor: {
+        id: 'phpactor',
+        name: 'Phpactor Language Server',
+        languageIds: ['php'],
+        extensions: ['.php'],
+        markers: ['composer.json'],
+        command: 'phpactor language-server',
+      },
+      solargraph: {
+        id: 'solargraph',
+        name: 'Solargraph',
+        languageIds: ['ruby'],
+        extensions: ['.rb', '.erb'],
+        markers: ['Gemfile'],
+        command: 'solargraph stdio',
+      },
+    },
+  },
+})
+```
+
 ## Requirements and limitations
 
-- LSP inspection only works for file types with a matching language server
+- LSP inspection only works for file types with a matching built-in or custom language server
 - The `path` you inspect must resolve inside the workspace filesystem or allowed paths
 - External package inspection may resolve to declaration files such as `.d.ts` instead of runtime source files
 - `lsp_inspect` complements `view` and `search_content`, but does not replace reading implementation code when you need full context

--- a/docs/src/content/en/docs/workspace/lsp.mdx
+++ b/docs/src/content/en/docs/workspace/lsp.mdx
@@ -140,9 +140,11 @@ Each custom server definition requires these fields:
 | `id` | Unique identifier for the server |
 | `name` | Human-readable name shown in logs |
 | `languageIds` | Language Server Protocol (LSP) language identifiers this server handles |
-| `extensions` | File extensions (including the dot) that map to this server. Each extension resolves to the first entry in `languageIds` |
+| `extensions` | File extensions, including the dot |
 | `markers` | Files or directories that identify the project root (e.g. `composer.json`, `Gemfile`) |
 | `command` | Full command string to start the server |
+
+When a server has multiple language IDs, Mastra maps each extension to the first entry in `languageIds`.
 
 You can also pass optional `initializationOptions` to send custom settings during the LSP handshake.
 

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -2,7 +2,7 @@
 export * from './workspace';
 
 // LSP
-export type { LSPConfig, LSPDiagnostic, DiagnosticSeverity, LSPServerDef } from './lsp/types';
+export type { CustomLSPServer, LSPConfig, LSPDiagnostic, DiagnosticSeverity, LSPServerDef } from './lsp/types';
 
 // Built-in Providers
 export { LocalFilesystem, type LocalFilesystemOptions } from './filesystem';

--- a/packages/core/src/workspace/lsp/index.ts
+++ b/packages/core/src/workspace/lsp/index.ts
@@ -1,5 +1,5 @@
 // Types (browser-safe)
-export type { LSPConfig, LSPDiagnostic, DiagnosticSeverity, LSPServerDef } from './types';
+export type { CustomLSPServer, LSPConfig, LSPDiagnostic, DiagnosticSeverity, LSPServerDef } from './types';
 
 // Language mapping (browser-safe)
 export { LANGUAGE_EXTENSIONS, getLanguageId } from './language';
@@ -8,6 +8,7 @@ export { LANGUAGE_EXTENSIONS, getLanguageId } from './language';
 export { isLSPAvailable, loadLSPDeps, LSPClient } from './client';
 export {
   BUILTIN_SERVERS,
+  buildCustomExtensions,
   buildServerDefs,
   findProjectRoot,
   findProjectRootAsync,

--- a/packages/core/src/workspace/lsp/language.test.ts
+++ b/packages/core/src/workspace/lsp/language.test.ts
@@ -99,4 +99,31 @@ describe('getLanguageId', () => {
     expect(getLanguageId('/src/app.test.ts')).toBe('typescript');
     expect(getLanguageId('/src/utils.spec.js')).toBe('javascript');
   });
+
+  describe('with customExtensions', () => {
+    const customExtensions = { '.php': 'php', '.rb': 'ruby' };
+
+    it('returns custom language ID for registered extension', () => {
+      expect(getLanguageId('/src/App.php', customExtensions)).toBe('php');
+      expect(getLanguageId('/src/app.rb', customExtensions)).toBe('ruby');
+    });
+
+    it('falls back to built-in extensions when custom map has no match', () => {
+      expect(getLanguageId('/src/app.ts', customExtensions)).toBe('typescript');
+      expect(getLanguageId('/src/main.py', customExtensions)).toBe('python');
+    });
+
+    it('custom extensions override built-in extensions', () => {
+      const overrides = { '.ts': 'custom-typescript' };
+      expect(getLanguageId('/src/app.ts', overrides)).toBe('custom-typescript');
+    });
+
+    it('returns undefined for unknown extension even with custom map', () => {
+      expect(getLanguageId('/src/data.xyz', customExtensions)).toBeUndefined();
+    });
+
+    it('works with empty custom extensions', () => {
+      expect(getLanguageId('/src/app.ts', {})).toBe('typescript');
+    });
+  });
 });

--- a/packages/core/src/workspace/lsp/language.ts
+++ b/packages/core/src/workspace/lsp/language.ts
@@ -60,10 +60,13 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
 /**
  * Get the LSP language ID for a file path based on its extension.
  * Returns undefined if the extension is not recognized.
+ *
+ * When `customExtensions` is provided, it is checked first, allowing
+ * custom servers to register new file extensions or override built-in mappings.
  */
-export function getLanguageId(filePath: string): string | undefined {
+export function getLanguageId(filePath: string, customExtensions?: Record<string, string>): string | undefined {
   const dotIndex = filePath.lastIndexOf('.');
   if (dotIndex === -1) return undefined;
   const ext = filePath.substring(dotIndex);
-  return LANGUAGE_EXTENSIONS[ext];
+  return customExtensions?.[ext] ?? LANGUAGE_EXTENSIONS[ext];
 }

--- a/packages/core/src/workspace/lsp/manager.test.ts
+++ b/packages/core/src/workspace/lsp/manager.test.ts
@@ -43,6 +43,7 @@ vi.mock('./client', () => ({
 }));
 
 vi.mock('./servers', () => ({
+  buildCustomExtensions: vi.fn().mockReturnValue({}),
   buildServerDefs: vi.fn().mockReturnValue({
     typescript: {
       id: 'typescript',
@@ -120,6 +121,7 @@ describe('LSPManager', () => {
 
     // Re-establish server mocks (resetAllMocks clears vi.mock factory implementations)
     const servers = await import('./servers');
+    (servers.buildCustomExtensions as ReturnType<typeof vi.fn>).mockReturnValue({});
     (servers.buildServerDefs as ReturnType<typeof vi.fn>).mockReturnValue({
       typescript: {
         id: 'typescript',
@@ -255,7 +257,12 @@ describe('LSPManager', () => {
 
       await restrictedManager.getClient('/project/src/app.ts');
 
-      expect(getServersForFile).toHaveBeenCalledWith('/project/src/app.ts', ['eslint'], expect.any(Object));
+      expect(getServersForFile).toHaveBeenCalledWith(
+        '/project/src/app.ts',
+        ['eslint'],
+        expect.any(Object),
+        expect.any(Object),
+      );
       await restrictedManager.shutdownAll();
     });
   });
@@ -734,6 +741,108 @@ describe('LSPManager', () => {
       ]);
       const result2 = await manager.getDiagnostics('/project/src/app.ts', 'content2');
       expect(result2.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ==========================================================================
+  // Custom server registration
+  // ==========================================================================
+
+  describe('custom server registration', () => {
+    const phpConfig = {
+      servers: {
+        phpactor: {
+          id: 'phpactor',
+          name: 'Phpactor Language Server',
+          languageIds: ['php'],
+          extensions: ['.php'],
+          markers: ['composer.json'],
+          command: 'phpactor language-server',
+        },
+      },
+    };
+
+    const phpServerDef = {
+      id: 'phpactor',
+      name: 'Phpactor Language Server',
+      languageIds: ['php'],
+      markers: ['composer.json'],
+      command: () => 'phpactor language-server',
+    };
+
+    async function setupPhpMocks() {
+      const servers = await import('./servers');
+
+      (servers.buildCustomExtensions as ReturnType<typeof vi.fn>).mockReturnValue({ '.php': 'php' });
+      (servers.buildServerDefs as ReturnType<typeof vi.fn>).mockReturnValue({
+        typescript: {
+          id: 'typescript',
+          name: 'TypeScript Language Server',
+          languageIds: ['typescript', 'typescriptreact'],
+          markers: ['tsconfig.json', 'package.json'],
+          command: () => 'typescript-language-server --stdio',
+        },
+        phpactor: phpServerDef,
+      });
+      (servers.getServersForFile as ReturnType<typeof vi.fn>).mockImplementation((filePath: string) => {
+        if (filePath.endsWith('.php')) return [phpServerDef];
+        if (filePath.endsWith('.ts') || filePath.endsWith('.tsx')) {
+          return [
+            {
+              id: 'typescript',
+              name: 'TypeScript Language Server',
+              languageIds: ['typescript', 'typescriptreact'],
+              markers: ['tsconfig.json', 'package.json'],
+              command: () => 'typescript-language-server --stdio',
+            },
+          ];
+        }
+        return [];
+      });
+      (servers.walkUp as ReturnType<typeof vi.fn>).mockReturnValue('/project');
+    }
+
+    it('supports custom servers for new file extensions', async () => {
+      await setupPhpMocks();
+
+      const customManager = new LSPManager(mockProcessManager, '/project', phpConfig);
+
+      const client = await customManager.getClient('/project/src/App.php');
+      expect(client).not.toBeNull();
+
+      await customManager.shutdownAll();
+    });
+
+    it('returns diagnostics for custom server file types', async () => {
+      await setupPhpMocks();
+
+      mockWaitForDiagnostics.mockResolvedValueOnce([
+        { severity: 1, message: 'Undefined variable $foo', range: { start: { line: 5, character: 10 } } },
+      ]);
+
+      const customManager = new LSPManager(mockProcessManager, '/project', phpConfig);
+
+      const diagnostics = await customManager.getDiagnostics('/project/src/App.php', '<?php echo $foo;');
+      expect(diagnostics).not.toBeNull();
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics![0]!.message).toBe('Undefined variable $foo');
+      expect(diagnostics![0]!.severity).toBe('error');
+
+      await customManager.shutdownAll();
+    });
+
+    it('custom servers coexist with built-in servers', async () => {
+      await setupPhpMocks();
+
+      const customManager = new LSPManager(mockProcessManager, '/project', phpConfig);
+
+      const phpClient = await customManager.getClient('/project/src/App.php');
+      const tsClient = await customManager.getClient('/project/src/app.ts');
+
+      expect(phpClient).not.toBeNull();
+      expect(tsClient).not.toBeNull();
+
+      await customManager.shutdownAll();
     });
   });
 

--- a/packages/core/src/workspace/lsp/manager.ts
+++ b/packages/core/src/workspace/lsp/manager.ts
@@ -15,7 +15,7 @@ import path from 'node:path';
 import type { SandboxProcessManager } from '../sandbox/process-manager';
 import { LSPClient } from './client';
 import { getLanguageId } from './language';
-import { buildServerDefs, getServersForFile, walkUp, walkUpAsync } from './servers';
+import { buildCustomExtensions, buildServerDefs, getServersForFile, walkUp, walkUpAsync } from './servers';
 import type { DiagnosticSeverity, LSPConfig, LSPDiagnostic, LSPServerDef } from './types';
 
 /** Map LSP DiagnosticSeverity (numeric) to our string severity */
@@ -42,6 +42,7 @@ export class LSPManager {
   private _root: string;
   private config: LSPConfig;
   private serverDefs: Record<string, LSPServerDef>;
+  private customExtensions: Record<string, string>;
   private filesystem?: {
     exists(path: string): Promise<boolean>;
   };
@@ -58,6 +59,7 @@ export class LSPManager {
     this._root = root;
     this.config = config;
     this.serverDefs = buildServerDefs(config);
+    this.customExtensions = buildCustomExtensions(config.servers);
     this.filesystem = filesystem;
   }
 
@@ -159,7 +161,7 @@ export class LSPManager {
    * Returns null if no server is available.
    */
   async getClient(filePath: string): Promise<LSPClient | null> {
-    const servers = getServersForFile(filePath, this.config.disableServers, this.serverDefs);
+    const servers = getServersForFile(filePath, this.config.disableServers, this.serverDefs, this.customExtensions);
     if (servers.length === 0) return null;
 
     // Prefer well-known language servers
@@ -207,7 +209,7 @@ export class LSPManager {
     const client = await this.getClient(filePath);
     if (!client) return null;
 
-    const languageId = getLanguageId(filePath);
+    const languageId = getLanguageId(filePath, this.customExtensions);
     if (!languageId) return null;
 
     // Open the file (content doesn't matter for position queries, but server may need it)
@@ -239,7 +241,7 @@ export class LSPManager {
       const client = await this.getClient(filePath);
       if (!client) return null;
 
-      const languageId = getLanguageId(filePath);
+      const languageId = getLanguageId(filePath, this.customExtensions);
       if (!languageId) return [];
 
       // Open + change → triggers diagnostics
@@ -274,12 +276,12 @@ export class LSPManager {
    * Individual server failures don't block other servers.
    */
   async getDiagnosticsMulti(filePath: string, content: string): Promise<LSPDiagnostic[]> {
-    const servers = getServersForFile(filePath, this.config.disableServers, this.serverDefs);
+    const servers = getServersForFile(filePath, this.config.disableServers, this.serverDefs, this.customExtensions);
     if (servers.length === 0) return [];
 
     const release = await this.acquireFileLock(filePath);
     try {
-      const languageId = getLanguageId(filePath);
+      const languageId = getLanguageId(filePath, this.customExtensions);
       if (!languageId) return [];
 
       const allDiagnostics: LSPDiagnostic[] = [];

--- a/packages/core/src/workspace/lsp/servers.test.ts
+++ b/packages/core/src/workspace/lsp/servers.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   BUILTIN_SERVERS,
+  buildCustomExtensions,
   buildServerDefs,
   findProjectRoot,
   findProjectRootAsync,
@@ -553,14 +554,229 @@ describe('buildServerDefs', () => {
       const servers = getServersForFile('/project/app.ts', undefined, customDefs);
       const ts = servers.find(s => s.id === 'typescript');
       expect(ts).toBeDefined();
-      // The command should use the override
       expect(ts!.command('/any/root')).toBe('/custom/tls --stdio');
     });
 
     it('falls back to BUILTIN_SERVERS when no defs provided', () => {
       const servers = getServersForFile('/project/app.ts');
-      // Should still return servers from BUILTIN_SERVERS
       expect(servers.some(s => s.id === 'typescript')).toBe(true);
+    });
+  });
+
+  describe('custom servers via config.servers', () => {
+    const phpServer = {
+      id: 'phpactor',
+      name: 'Phpactor Language Server',
+      languageIds: ['php'],
+      extensions: ['.php'],
+      markers: ['composer.json'],
+      command: 'phpactor language-server',
+    };
+
+    it('merges custom server into buildServerDefs result', () => {
+      const defs = buildServerDefs({ servers: { phpactor: phpServer } });
+      expect(defs.phpactor).toBeDefined();
+      expect(defs.phpactor!.id).toBe('phpactor');
+      expect(defs.phpactor!.name).toBe('Phpactor Language Server');
+      expect(defs.phpactor!.languageIds).toEqual(['php']);
+      expect(defs.phpactor!.markers).toEqual(['composer.json']);
+    });
+
+    it('custom server command is a constant string wrapped as a function', () => {
+      const defs = buildServerDefs({ servers: { phpactor: phpServer } });
+      expect(defs.phpactor!.command('/any/root')).toBe('phpactor language-server');
+    });
+
+    it('preserves built-in servers alongside custom servers', () => {
+      const defs = buildServerDefs({ servers: { phpactor: phpServer } });
+      expect(defs.typescript).toBeDefined();
+      expect(defs.python).toBeDefined();
+      expect(defs.go).toBeDefined();
+      expect(defs.rust).toBeDefined();
+      expect(defs.phpactor).toBeDefined();
+    });
+
+    it('custom server overrides built-in with same ID', () => {
+      const customGo = {
+        id: 'go',
+        name: 'Custom Go Server',
+        languageIds: ['go'],
+        extensions: ['.go'],
+        markers: ['go.mod'],
+        command: '/custom/gopls serve',
+      };
+      const defs = buildServerDefs({ servers: { go: customGo } });
+      expect(defs.go!.name).toBe('Custom Go Server');
+      expect(defs.go!.command('/any')).toBe('/custom/gopls serve');
+    });
+
+    it('custom server with initializationOptions exposes initialization()', () => {
+      const serverWithInit = {
+        ...phpServer,
+        initializationOptions: { storagePath: '/tmp/phpactor' },
+      };
+      const defs = buildServerDefs({ servers: { phpactor: serverWithInit } });
+      expect(defs.phpactor!.initialization).toBeDefined();
+      expect(defs.phpactor!.initialization!('/any')).toEqual({ storagePath: '/tmp/phpactor' });
+    });
+
+    it('custom server without initializationOptions has no initialization()', () => {
+      const defs = buildServerDefs({ servers: { phpactor: phpServer } });
+      expect(defs.phpactor!.initialization).toBeUndefined();
+    });
+
+    it('multiple custom servers can be registered', () => {
+      const rubyServer = {
+        id: 'solargraph',
+        name: 'Solargraph',
+        languageIds: ['ruby'],
+        extensions: ['.rb'],
+        markers: ['Gemfile'],
+        command: 'solargraph stdio',
+      };
+      const defs = buildServerDefs({ servers: { phpactor: phpServer, solargraph: rubyServer } });
+      expect(defs.phpactor).toBeDefined();
+      expect(defs.solargraph).toBeDefined();
+    });
+  });
+
+  describe('buildCustomExtensions', () => {
+    it('builds extension map from custom servers', () => {
+      const servers = {
+        phpactor: {
+          id: 'phpactor',
+          name: 'Phpactor',
+          languageIds: ['php'],
+          extensions: ['.php', '.phtml'],
+          markers: ['composer.json'],
+          command: 'phpactor language-server',
+        },
+      };
+      const extensions = buildCustomExtensions(servers);
+      expect(extensions['.php']).toBe('php');
+      expect(extensions['.phtml']).toBe('php');
+    });
+
+    it('returns empty object when no servers provided', () => {
+      expect(buildCustomExtensions(undefined)).toEqual({});
+      expect(buildCustomExtensions({})).toEqual({});
+    });
+
+    it('maps extensions from multiple servers', () => {
+      const servers = {
+        phpactor: {
+          id: 'phpactor',
+          name: 'Phpactor',
+          languageIds: ['php'],
+          extensions: ['.php'],
+          markers: ['composer.json'],
+          command: 'phpactor language-server',
+        },
+        solargraph: {
+          id: 'solargraph',
+          name: 'Solargraph',
+          languageIds: ['ruby'],
+          extensions: ['.rb', '.erb'],
+          markers: ['Gemfile'],
+          command: 'solargraph stdio',
+        },
+      };
+      const extensions = buildCustomExtensions(servers);
+      expect(extensions['.php']).toBe('php');
+      expect(extensions['.rb']).toBe('ruby');
+      expect(extensions['.erb']).toBe('ruby');
+    });
+
+    it('skips servers with empty languageIds', () => {
+      const servers = {
+        broken: {
+          id: 'broken',
+          name: 'Broken',
+          languageIds: [],
+          extensions: ['.brk'],
+          markers: [],
+          command: 'broken-server',
+        },
+      };
+      const extensions = buildCustomExtensions(servers);
+      expect(extensions['.brk']).toBeUndefined();
+    });
+  });
+
+  describe('getServersForFile with customExtensions', () => {
+    it('finds custom server for custom extension', () => {
+      const defs = buildServerDefs({
+        servers: {
+          phpactor: {
+            id: 'phpactor',
+            name: 'Phpactor',
+            languageIds: ['php'],
+            extensions: ['.php'],
+            markers: ['composer.json'],
+            command: 'phpactor language-server',
+          },
+        },
+      });
+      const customExtensions = { '.php': 'php' };
+      const servers = getServersForFile('/project/src/App.php', undefined, defs, customExtensions);
+      expect(servers).toHaveLength(1);
+      expect(servers[0]!.id).toBe('phpactor');
+    });
+
+    it('returns empty for unknown extension even with custom defs', () => {
+      const defs = buildServerDefs({
+        servers: {
+          phpactor: {
+            id: 'phpactor',
+            name: 'Phpactor',
+            languageIds: ['php'],
+            extensions: ['.php'],
+            markers: ['composer.json'],
+            command: 'phpactor language-server',
+          },
+        },
+      });
+      const servers = getServersForFile('/project/data.xyz', undefined, defs, { '.php': 'php' });
+      expect(servers).toEqual([]);
+    });
+
+    it('custom extensions work alongside built-in extensions', () => {
+      const defs = buildServerDefs({
+        servers: {
+          phpactor: {
+            id: 'phpactor',
+            name: 'Phpactor',
+            languageIds: ['php'],
+            extensions: ['.php'],
+            markers: ['composer.json'],
+            command: 'phpactor language-server',
+          },
+        },
+      });
+      const customExtensions = { '.php': 'php' };
+
+      const phpServers = getServersForFile('/project/App.php', undefined, defs, customExtensions);
+      expect(phpServers.some(s => s.id === 'phpactor')).toBe(true);
+
+      const tsServers = getServersForFile('/project/app.ts', undefined, defs, customExtensions);
+      expect(tsServers.some(s => s.id === 'typescript')).toBe(true);
+    });
+
+    it('disabled servers are filtered from custom servers too', () => {
+      const defs = buildServerDefs({
+        servers: {
+          phpactor: {
+            id: 'phpactor',
+            name: 'Phpactor',
+            languageIds: ['php'],
+            extensions: ['.php'],
+            markers: ['composer.json'],
+            command: 'phpactor language-server',
+          },
+        },
+      });
+      const servers = getServersForFile('/project/App.php', ['phpactor'], defs, { '.php': 'php' });
+      expect(servers).toEqual([]);
     });
   });
 });

--- a/packages/core/src/workspace/lsp/servers.ts
+++ b/packages/core/src/workspace/lsp/servers.ts
@@ -168,6 +168,10 @@ export async function findProjectRootAsync(
 /**
  * Build an extension → language ID map from custom server definitions.
  * Each extension is mapped to the first language ID of the server that declares it.
+ *
+ * When multiple servers declare the same extension, the last server wins
+ * (iteration order of `Object.values`). A warning is emitted on collision
+ * so the user can spot misconfiguration.
  */
 export function buildCustomExtensions(servers?: Record<string, CustomLSPServer>): Record<string, string> {
   if (!servers) return {};
@@ -176,6 +180,12 @@ export function buildCustomExtensions(servers?: Record<string, CustomLSPServer>)
     const languageId = server.languageIds[0];
     if (!languageId) continue;
     for (const ext of server.extensions) {
+      const existing = extensions[ext];
+      if (existing && existing !== languageId) {
+        console.warn(
+          `[LSP] Extension "${ext}" is claimed by language "${existing}" and "${languageId}" (server "${server.id}") — using "${languageId}"`,
+        );
+      }
       extensions[ext] = languageId;
     }
   }

--- a/packages/core/src/workspace/lsp/servers.ts
+++ b/packages/core/src/workspace/lsp/servers.ts
@@ -193,8 +193,7 @@ export function buildCustomExtensions(servers?: Record<string, CustomLSPServer>)
 }
 
 /**
- * Convert a user-provided `CustomLSPServer` into an internal `LSPServerDef`.
- * Wraps the plain command string into the function signature expected internally.
+ * Convert a public custom server config to an internal server definition.
  */
 function toServerDef(custom: CustomLSPServer): LSPServerDef {
   return {
@@ -311,7 +310,6 @@ export function buildServerDefs(config?: LSPConfig): Record<string, LSPServerDef
     },
   };
 
-  // Merge custom servers — custom definitions override built-ins with the same ID
   if (config?.servers) {
     for (const custom of Object.values(config.servers)) {
       builtins[custom.id] = toServerDef(custom);
@@ -331,7 +329,7 @@ export const BUILTIN_SERVERS: Record<string, LSPServerDef> = buildServerDefs();
  * Get all server definitions that can handle the given file.
  * Filters by language ID match only — the manager resolves the root and checks command availability.
  * Pass `defs` to use config-aware server definitions from `buildServerDefs()`.
- * Pass `customExtensions` to recognise file extensions registered by custom servers.
+ * Pass `customExtensions` to recognize file extensions registered by custom servers.
  */
 export function getServersForFile(
   filePath: string,

--- a/packages/core/src/workspace/lsp/servers.ts
+++ b/packages/core/src/workspace/lsp/servers.ts
@@ -13,7 +13,7 @@ import { dirname, join, parse } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { getLanguageId } from './language';
-import type { LSPConfig, LSPServerDef } from './types';
+import type { CustomLSPServer, LSPConfig, LSPServerDef } from './types';
 
 /** Check if a binary exists on PATH. */
 function whichSync(binary: string): boolean {
@@ -166,6 +166,38 @@ export async function findProjectRootAsync(
 }
 
 /**
+ * Build an extension → language ID map from custom server definitions.
+ * Each extension is mapped to the first language ID of the server that declares it.
+ */
+export function buildCustomExtensions(servers?: Record<string, CustomLSPServer>): Record<string, string> {
+  if (!servers) return {};
+  const extensions: Record<string, string> = {};
+  for (const server of Object.values(servers)) {
+    const languageId = server.languageIds[0];
+    if (!languageId) continue;
+    for (const ext of server.extensions) {
+      extensions[ext] = languageId;
+    }
+  }
+  return extensions;
+}
+
+/**
+ * Convert a user-provided `CustomLSPServer` into an internal `LSPServerDef`.
+ * Wraps the plain command string into the function signature expected internally.
+ */
+function toServerDef(custom: CustomLSPServer): LSPServerDef {
+  return {
+    id: custom.id,
+    name: custom.name,
+    languageIds: custom.languageIds,
+    markers: custom.markers,
+    command: () => custom.command,
+    initialization: custom.initializationOptions ? () => custom.initializationOptions! : undefined,
+  };
+}
+
+/**
  * Build a set of server definitions that incorporate LSP config overrides.
  *
  * Resolution order per server:
@@ -178,11 +210,14 @@ export async function findProjectRootAsync(
  *
  * `config.searchPaths` also extends TypeScript module resolution
  * (used to locate typescript/lib/tsserver.js when it lives outside the project).
+ *
+ * When `config.servers` is provided, custom servers are merged after built-in
+ * definitions. Custom servers with the same ID as a built-in will replace it.
  */
 export function buildServerDefs(config?: LSPConfig): Record<string, LSPServerDef> {
   const { binaryOverrides, searchPaths, packageRunner } = config ?? {};
 
-  return {
+  const builtins: Record<string, LSPServerDef> = {
     typescript: {
       id: 'typescript',
       name: 'TypeScript Language Server',
@@ -265,6 +300,15 @@ export function buildServerDefs(config?: LSPConfig): Record<string, LSPServerDef
       },
     },
   };
+
+  // Merge custom servers — custom definitions override built-ins with the same ID
+  if (config?.servers) {
+    for (const custom of Object.values(config.servers)) {
+      builtins[custom.id] = toServerDef(custom);
+    }
+  }
+
+  return builtins;
 }
 
 /**
@@ -277,13 +321,15 @@ export const BUILTIN_SERVERS: Record<string, LSPServerDef> = buildServerDefs();
  * Get all server definitions that can handle the given file.
  * Filters by language ID match only — the manager resolves the root and checks command availability.
  * Pass `defs` to use config-aware server definitions from `buildServerDefs()`.
+ * Pass `customExtensions` to recognise file extensions registered by custom servers.
  */
 export function getServersForFile(
   filePath: string,
   disabledServers?: string[],
   defs?: Record<string, LSPServerDef>,
+  customExtensions?: Record<string, string>,
 ): LSPServerDef[] {
-  const languageId = getLanguageId(filePath);
+  const languageId = getLanguageId(filePath, customExtensions);
   if (!languageId) return [];
 
   const disabled = new Set(disabledServers ?? []);

--- a/packages/core/src/workspace/lsp/types.ts
+++ b/packages/core/src/workspace/lsp/types.ts
@@ -12,20 +12,7 @@
 /**
  * User-provided definition for a custom language server.
  *
- * Unlike the internal `LSPServerDef`, the command is a plain string
- * (not a function) — the framework wraps it internally.
- *
- * @example
- * ```typescript
- * const phpServer: CustomLSPServer = {
- *   id: 'phpactor',
- *   name: 'Phpactor Language Server',
- *   languageIds: ['php'],
- *   extensions: ['.php'],
- *   markers: ['composer.json'],
- *   command: 'phpactor language-server',
- * };
- * ```
+ * Unlike `LSPServerDef`, `command` is a plain string. Mastra wraps it internally.
  */
 export interface CustomLSPServer {
   /** Unique identifier for this server (e.g. 'phpactor', 'intelephense'). */
@@ -39,7 +26,7 @@ export interface CustomLSPServer {
 
   /**
    * File extensions (including the dot) that map to this server's language IDs.
-   * Registered into the extension → language ID map so `getLanguageId()` recognises them.
+   * Registered into the extension → language ID map so `getLanguageId()` recognizes them.
    * The first `languageIds` entry is used for each extension.
    */
   extensions: string[];

--- a/packages/core/src/workspace/lsp/types.ts
+++ b/packages/core/src/workspace/lsp/types.ts
@@ -10,6 +10,51 @@
 // =============================================================================
 
 /**
+ * User-provided definition for a custom language server.
+ *
+ * Unlike the internal `LSPServerDef`, the command is a plain string
+ * (not a function) — the framework wraps it internally.
+ *
+ * @example
+ * ```typescript
+ * const phpServer: CustomLSPServer = {
+ *   id: 'phpactor',
+ *   name: 'Phpactor Language Server',
+ *   languageIds: ['php'],
+ *   extensions: ['.php'],
+ *   markers: ['composer.json'],
+ *   command: 'phpactor language-server',
+ * };
+ * ```
+ */
+export interface CustomLSPServer {
+  /** Unique identifier for this server (e.g. 'phpactor', 'intelephense'). */
+  id: string;
+
+  /** Human-readable name shown in logs and error messages. */
+  name: string;
+
+  /** LSP language identifiers this server handles (e.g. ['php']). */
+  languageIds: string[];
+
+  /**
+   * File extensions (including the dot) that map to this server's language IDs.
+   * Registered into the extension → language ID map so `getLanguageId()` recognises them.
+   * The first `languageIds` entry is used for each extension.
+   */
+  extensions: string[];
+
+  /** File/directory markers that identify the project root for this server (e.g. ['composer.json']). */
+  markers: string[];
+
+  /** Full command string to start the server (e.g. 'phpactor language-server'). */
+  command: string;
+
+  /** Optional initialization options sent to the server during the LSP handshake. */
+  initializationOptions?: Record<string, unknown>;
+}
+
+/**
  * Configuration for LSP diagnostics in a workspace.
  */
 export interface LSPConfig {
@@ -53,6 +98,33 @@ export interface LSPConfig {
    * - `'bunx'` — no extra flags needed
    */
   packageRunner?: string;
+
+  /**
+   * Custom language server definitions for languages not built in.
+   *
+   * Keys are server IDs; values define the server, its supported extensions, and its command.
+   * Custom servers are merged with built-in servers — custom definitions take precedence
+   * when IDs collide, allowing you to replace a built-in server entirely.
+   *
+   * @example
+   * ```typescript
+   * const workspace = new Workspace({
+   *   lsp: {
+   *     servers: {
+   *       phpactor: {
+   *         id: 'phpactor',
+   *         name: 'Phpactor Language Server',
+   *         languageIds: ['php'],
+   *         extensions: ['.php'],
+   *         markers: ['composer.json'],
+   *         command: 'phpactor language-server',
+   *       },
+   *     },
+   *   },
+   * });
+   * ```
+   */
+  servers?: Record<string, CustomLSPServer>;
 }
 
 // =============================================================================

--- a/packages/core/src/workspace/lsp/types.ts
+++ b/packages/core/src/workspace/lsp/types.ts
@@ -102,7 +102,8 @@ export interface LSPConfig {
   /**
    * Custom language server definitions for languages not built in.
    *
-   * Keys are server IDs; values define the server, its supported extensions, and its command.
+   * Values define the server, its supported extensions, and its command.
+   * The record key is for readability only — the server's `id` field is used internally.
    * Custom servers are merged with built-in servers — custom definitions take precedence
    * when IDs collide, allowing you to replace a built-in server entirely.
    *


### PR DESCRIPTION
## Description

Add support for custom language server registration via the `servers` field in `LSPConfig`.
Previously, only built-in languages (TypeScript, JavaScript, Python, Go, Rust) were supported by the LSP system. Users working with other languages (PHP, Ruby, Java, Kotlin, Swift, Elixir, etc.) had no way to register a language server — `lsp_inspect` would return "No language server available for files of this type."

Now users can register any language server through config:

```typescript
const workspace = new Workspace({
  lsp: {
    servers: {
      phpactor: {
        id: 'phpactor',
        name: 'Phpactor Language Server',
        languageIds: ['php'],
        extensions: ['.php'],
        markers: ['composer.json'],
        command: 'phpactor language-server',
      },
    },
  },
});
```

Custom servers are merged with built-in servers and can also override them by using the same ID. No new dependencies are introduced — this is purely configuration plumbing through the existing LSP client infrastructure.

## Related Issue(s)

Fixes #14828

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [ ] Test update

## Checklist

* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: You can now declare your own language servers (e.g., PHP, Ruby) in the LSP settings so the editor treats those file types like built-in languages (go-to, hover, diagnostics, etc.).

Summary

- What changed
  - LSPConfig gained an optional servers?: Record<string, CustomLSPServer> allowing user-provided language server definitions.
  - Added CustomLSPServer type: { id, name, languageIds, extensions, markers, command, initializationOptions? }.
  - Custom servers are merged into built-in server definitions; a custom server with the same id overrides the built-in.
  - Added buildCustomExtensions(servers?) to produce an extension→languageId map from custom servers; conflicts warn and later servers win.
  - Added toServerDef converter to adapt CustomLSPServer → LSPServerDef (wraps command and optional initializationOptions).
  - buildServerDefs now merges custom servers into the built-in map by id.
  - getServersForFile and getLanguageId gained an optional customExtensions parameter and now honor custom extension mappings.
  - LSPManager stores this.customExtensions (built from config.servers) and passes it into server lookup and language-id resolution.
  - Public exports updated to include CustomLSPServer and buildCustomExtensions.
  - Documentation (docs/workspace/lsp.mdx) and a changeset were added with examples (phpactor).
  - Tests added/expanded across language, servers, and manager tests to cover custom extension mapping, server merging/overriding, initializationOptions handling, and LSPManager behavior for custom-file types.

- Rationale / linked issue
  - Implements the API requested in issue #14828 so Workspace LSP can support arbitrary languages by letting users register servers instead of relying solely on hardcoded built-ins.

- Backwards compatibility & migration
  - No new runtime dependencies. Existing behavior is unchanged when no custom servers are provided. Custom servers can intentionally replace built-ins by using the same id.

- Notes for reviewers
  - Confirm merge/override semantics (custom id overwrites built-in) are acceptable.
  - Confirm the console.warn behavior on extension claim conflicts is the desired UX.
  - Docs/tests are included, but the original PR checklist notes documentation/tests updates may need review for completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->