### PR TITLE
fix(core): preserve providerMetadata on assistant file parts for Gemini round-trips

### DIFF
--- a/.changeset/chatty-frogs-brush.md
+++ b/.changeset/chatty-frogs-brush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed providerMetadata (e.g. Gemini thoughtSignature) being lost on assistant file parts during multi-turn conversations. This resolves 'Image part is missing a thought_signature' errors when round-tripping model-generated images with Gemini 3.x models.

--- a/packages/core/src/agent/message-list/conversion/output-converter-file-metadata.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-file-metadata.test.ts
@@ -156,4 +156,34 @@ describe('aiV5UIMessagesToAIV5ModelMessages — assistant file providerMetadata'
     expect(firstFile.providerOptions).toEqual({ google: { thoughtSignature: 'cat-sig' } });
     expect(secondFile.providerOptions).toEqual({ google: { thoughtSignature: 'dog-sig' } });
   });
+
+  it('aligns metadata correctly when some file parts lack providerMetadata', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      makeUserMessage('draw two images'),
+      makeAssistantMessage([
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,first...',
+          // No providerMetadata on the first file part
+        },
+        {
+          type: 'file',
+          mediaType: 'image/jpeg',
+          url: 'data:image/jpeg;base64,second...',
+          providerMetadata: { google: { thoughtSignature: 'sig-2' } },
+        },
+      ]),
+    ];
+
+    const result = aiV5UIMessagesToAIV5ModelMessages(messages, []);
+    const assistantMsg = result.find(m => m.role === 'assistant');
+    const fileParts = (assistantMsg!.content as any[]).filter((p: any) => p.type === 'file');
+
+    expect(fileParts).toHaveLength(2);
+    // First file had no metadata — should remain without providerOptions
+    expect(fileParts[0].providerOptions).toBeUndefined();
+    // Second file's metadata must land on the correct (second) part
+    expect(fileParts[1].providerOptions).toEqual({ google: { thoughtSignature: 'sig-2' } });
+  });
 });

--- a/packages/core/src/agent/message-list/conversion/output-converter-file-metadata.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-file-metadata.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import type { AIV5Type } from '../types';
+import { aiV5UIMessagesToAIV5ModelMessages } from './output-converter';
+
+/**
+ * Tests that providerMetadata on assistant file parts (e.g. Gemini's
+ * thoughtSignature) survives the UI → Model message conversion.
+ *
+ * The vendored AI SDK v5 convertToModelMessages drops providerMetadata
+ * from assistant file parts. restoreAssistantFileProviderMetadata
+ * (called inside aiV5UIMessagesToAIV5ModelMessages) patches this.
+ */
+describe('aiV5UIMessagesToAIV5ModelMessages — assistant file providerMetadata', () => {
+  const makeAssistantMessage = (parts: AIV5Type.UIMessage['parts']): AIV5Type.UIMessage => ({
+    id: 'msg-assistant',
+    role: 'assistant',
+    parts,
+  });
+
+  const makeUserMessage = (text: string): AIV5Type.UIMessage => ({
+    id: 'msg-user',
+    role: 'user',
+    parts: [{ type: 'text', text }],
+  });
+
+  it('preserves providerMetadata on a single assistant file part', () => {
+    const thoughtSignature = 'abc123-signature';
+    const messages: AIV5Type.UIMessage[] = [
+      makeUserMessage('draw a cat'),
+      makeAssistantMessage([
+        { type: 'text', text: 'Here is a cat:' },
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,iVBOR...',
+          providerMetadata: {
+            google: { thoughtSignature },
+          },
+        },
+      ]),
+    ];
+
+    const result = aiV5UIMessagesToAIV5ModelMessages(messages, []);
+    const assistantMsg = result.find(m => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+
+    const fileParts = (assistantMsg!.content as any[]).filter((p: any) => p.type === 'file');
+    expect(fileParts).toHaveLength(1);
+    expect(fileParts[0].providerOptions).toEqual({
+      google: { thoughtSignature },
+    });
+  });
+
+  it('preserves providerMetadata on multiple assistant file parts', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      makeUserMessage('draw two images'),
+      makeAssistantMessage([
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,first...',
+          providerMetadata: { google: { thoughtSignature: 'sig-1' } },
+        },
+        { type: 'text', text: 'And another:' },
+        {
+          type: 'file',
+          mediaType: 'image/jpeg',
+          url: 'data:image/jpeg;base64,second...',
+          providerMetadata: { google: { thoughtSignature: 'sig-2' } },
+        },
+      ]),
+    ];
+
+    const result = aiV5UIMessagesToAIV5ModelMessages(messages, []);
+    const assistantMsg = result.find(m => m.role === 'assistant');
+    const fileParts = (assistantMsg!.content as any[]).filter((p: any) => p.type === 'file');
+
+    expect(fileParts).toHaveLength(2);
+    expect(fileParts[0].providerOptions).toEqual({ google: { thoughtSignature: 'sig-1' } });
+    expect(fileParts[1].providerOptions).toEqual({ google: { thoughtSignature: 'sig-2' } });
+  });
+
+  it('does not overwrite existing providerOptions on file parts', () => {
+    // If the SDK ever fixes this upstream, our post-processing should not clobber
+    const messages: AIV5Type.UIMessage[] = [
+      makeUserMessage('hello'),
+      makeAssistantMessage([
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,abc...',
+          providerMetadata: { google: { thoughtSignature: 'from-ui' } },
+        },
+      ]),
+    ];
+
+    const result = aiV5UIMessagesToAIV5ModelMessages(messages, []);
+    const assistantMsg = result.find(m => m.role === 'assistant');
+    const fileParts = (assistantMsg!.content as any[]).filter((p: any) => p.type === 'file');
+
+    // Should have providerOptions set (either from SDK or our restoration)
+    expect(fileParts[0].providerOptions).toBeDefined();
+  });
+
+  it('leaves messages unchanged when no assistant file parts have providerMetadata', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      makeUserMessage('hello'),
+      makeAssistantMessage([
+        { type: 'text', text: 'Hi there!' },
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,abc...',
+          // No providerMetadata
+        },
+      ]),
+    ];
+
+    const result = aiV5UIMessagesToAIV5ModelMessages(messages, []);
+    const assistantMsg = result.find(m => m.role === 'assistant');
+    const fileParts = (assistantMsg!.content as any[]).filter((p: any) => p.type === 'file');
+
+    expect(fileParts).toHaveLength(1);
+    expect(fileParts[0].providerOptions).toBeUndefined();
+  });
+
+  it('handles multiple assistant messages with file parts across conversation', () => {
+    const messages: AIV5Type.UIMessage[] = [
+      makeUserMessage('draw a cat'),
+      makeAssistantMessage([
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,cat...',
+          providerMetadata: { google: { thoughtSignature: 'cat-sig' } },
+        },
+      ]),
+      makeUserMessage('now draw a dog'),
+      makeAssistantMessage([
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,dog...',
+          providerMetadata: { google: { thoughtSignature: 'dog-sig' } },
+        },
+      ]),
+    ];
+
+    const result = aiV5UIMessagesToAIV5ModelMessages(messages, []);
+    const assistantMsgs = result.filter(m => m.role === 'assistant');
+    expect(assistantMsgs).toHaveLength(2);
+
+    const firstFile = (assistantMsgs[0].content as any[]).find((p: any) => p.type === 'file');
+    const secondFile = (assistantMsgs[1].content as any[]).find((p: any) => p.type === 'file');
+
+    expect(firstFile.providerOptions).toEqual({ google: { thoughtSignature: 'cat-sig' } });
+    expect(secondFile.providerOptions).toEqual({ google: { thoughtSignature: 'dog-sig' } });
+  });
+});

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -291,6 +291,53 @@ export function aiV4UIMessagesToAIV4CoreMessages(messages: UIMessageV4[]): CoreM
 }
 
 /**
+ * Restores `providerOptions` on assistant file parts after `convertToModelMessages`.
+ *
+ * The vendored AI SDK v5 `convertToModelMessages` drops `providerMetadata` from
+ * assistant file parts (fixed in v6 but not backported). This causes providers
+ * like Google Gemini to reject round-tripped responses that require metadata
+ * (e.g. `thoughtSignature` on generated images).
+ *
+ * We collect all `providerMetadata` values from assistant `file` UI parts in
+ * order, then walk the model messages and assign them to assistant `file` parts
+ * in the same order. The ordering is guaranteed to be preserved.
+ */
+function restoreAssistantFileProviderMetadata(
+  modelMessages: AIV5Type.ModelMessage[],
+  uiMessages: AIV5Type.UIMessage[],
+): AIV5Type.ModelMessage[] {
+  // Collect providerMetadata from assistant file UI parts in order
+  const fileMetadata: AIV5Type.ProviderMetadata[] = [];
+  for (const msg of uiMessages) {
+    if (msg.role !== 'assistant') continue;
+    for (const part of msg.parts) {
+      if (part.type === 'file' && part.providerMetadata) {
+        fileMetadata.push(part.providerMetadata);
+      }
+    }
+  }
+
+  if (fileMetadata.length === 0) return modelMessages;
+
+  // Walk model messages and restore providerOptions on assistant file parts
+  let metadataIndex = 0;
+  return modelMessages.map(msg => {
+    if (msg.role !== 'assistant' || typeof msg.content === 'string') return msg;
+
+    let modified = false;
+    const content = msg.content.map(part => {
+      if (part.type !== 'file' || metadataIndex >= fileMetadata.length) return part;
+      const metadata = fileMetadata[metadataIndex++];
+      if (part.providerOptions) return part; // already has it
+      modified = true;
+      return { ...part, providerOptions: metadata };
+    });
+
+    return modified ? { ...msg, content } : msg;
+  });
+}
+
+/**
  * Converts AIV5 UI messages to AIV5 Model messages.
  * Handles sanitization, step-start insertion, provider options restoration, and Anthropic compatibility.
  *
@@ -305,7 +352,8 @@ export function aiV5UIMessagesToAIV5ModelMessages(
 ): AIV5Type.ModelMessage[] {
   const sanitized = sanitizeV5UIMessages(messages, filterIncompleteToolCalls);
   const preprocessed = addStartStepPartsForAIV5(sanitized);
-  const result = AIV5.convertToModelMessages(preprocessed);
+
+  const result = restoreAssistantFileProviderMetadata(AIV5.convertToModelMessages(preprocessed), preprocessed);
 
   // Restore message-level providerOptions from metadata.providerMetadata
   // This preserves providerOptions through the DB → UI → Model conversion

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -306,18 +306,20 @@ function restoreAssistantFileProviderMetadata(
   modelMessages: AIV5Type.ModelMessage[],
   uiMessages: AIV5Type.UIMessage[],
 ): AIV5Type.ModelMessage[] {
-  // Collect providerMetadata from assistant file UI parts in order
-  const fileMetadata: AIV5Type.ProviderMetadata[] = [];
+  // Collect providerMetadata from ALL assistant file UI parts in order,
+  // using undefined as a placeholder for parts without metadata so that
+  // the indices stay aligned with the model-side file parts.
+  const fileMetadata: (AIV5Type.ProviderMetadata | undefined)[] = [];
   for (const msg of uiMessages) {
     if (msg.role !== 'assistant') continue;
     for (const part of msg.parts) {
-      if (part.type === 'file' && part.providerMetadata) {
-        fileMetadata.push(part.providerMetadata);
+      if (part.type === 'file') {
+        fileMetadata.push(part.providerMetadata ?? undefined);
       }
     }
   }
 
-  if (fileMetadata.length === 0) return modelMessages;
+  if (fileMetadata.length === 0 || fileMetadata.every(m => m == null)) return modelMessages;
 
   // Walk model messages and restore providerOptions on assistant file parts
   let metadataIndex = 0;
@@ -328,7 +330,7 @@ function restoreAssistantFileProviderMetadata(
     const content = msg.content.map(part => {
       if (part.type !== 'file' || metadataIndex >= fileMetadata.length) return part;
       const metadata = fileMetadata[metadataIndex++];
-      if (part.providerOptions) return part; // already has it
+      if (part.providerOptions || !metadata) return part;
       modified = true;
       return { ...part, providerOptions: metadata };
     });

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -438,7 +438,7 @@ export class MessageList {
         // Check if any messages have image/file content that needs processing
         const hasImageOrFileContent = modelMessages.some(
           message =>
-            message.role === 'user' &&
+            (message.role === 'user' || message.role === 'assistant') &&
             typeof message.content !== 'string' &&
             message.content.some(part => part.type === 'image' || part.type === 'file'),
         );
@@ -468,6 +468,20 @@ export class MessageList {
                 content: convertedContent,
                 providerOptions: message.providerOptions,
               } as AIV5Type.ModelMessage;
+            }
+
+            if (message.role === 'assistant' && typeof message.content !== 'string') {
+              const convertedContent = message.content.map(part => {
+                if (part.type === 'file') {
+                  return convertImageFilePart(part, downloadedAssets);
+                }
+                return part;
+              });
+
+              return {
+                ...message,
+                content: convertedContent,
+              };
             }
 
             return message;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -398,6 +398,7 @@ async function processOutputStream<OUTPUT = undefined>({
                   // @ts-expect-error - data type mismatch, see TODO
                   data: chunk.payload.data, // TODO: incorrect string type
                   mimeType: chunk.payload.mimeType,
+                  ...(chunk.payload.providerMetadata ? { providerMetadata: chunk.payload.providerMetadata } : {}),
                 },
               ],
               ...buildResponseModelMetadata(runState),

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -201,7 +201,8 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
         },
       };
 
-    case 'file':
+    case 'file': {
+      const pm = (value as any).providerMetadata;
       return {
         type: 'file',
         runId: ctx.runId,
@@ -210,8 +211,10 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
           data: value.data,
           base64: typeof value.data === 'string' ? value.data : undefined,
           mimeType: value.mediaType,
+          providerMetadata: pm,
         },
       };
+    }
 
     case 'tool-call': {
       let toolCallInput: Record<string, any> | undefined = undefined;
@@ -429,24 +432,30 @@ export function convertMastraChunkToAISDKv5<OUTPUT = undefined>({
           providerMetadata: chunk.payload.providerMetadata,
         };
       }
-    case 'file':
-      if (mode === 'generate') {
-        return {
-          type: 'file',
-          file: new DefaultGeneratedFile({
-            data: chunk.payload.data,
-            mediaType: chunk.payload.mimeType,
-          }),
-        };
+    case 'file': {
+      const filePart =
+        mode === 'generate'
+          ? {
+              type: 'file' as const,
+              file: new DefaultGeneratedFile({
+                data: chunk.payload.data,
+                mediaType: chunk.payload.mimeType,
+              }),
+            }
+          : {
+              type: 'file' as const,
+              file: new DefaultGeneratedFileWithType({
+                data: chunk.payload.data,
+                mediaType: chunk.payload.mimeType,
+              }),
+            };
+
+      if (chunk.payload.providerMetadata) {
+        (filePart as any).providerMetadata = chunk.payload.providerMetadata;
       }
 
-      return {
-        type: 'file',
-        file: new DefaultGeneratedFileWithType({
-          data: chunk.payload.data,
-          mediaType: chunk.payload.mimeType,
-        }),
-      };
+      return filePart;
+    }
     case 'tool-call':
       return {
         type: 'tool-call',

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -211,7 +211,7 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
           data: value.data,
           base64: typeof value.data === 'string' ? value.data : undefined,
           mimeType: value.mediaType,
-          providerMetadata: pm,
+          ...(pm != null ? { providerMetadata: pm } : {}),
         },
       };
     }


### PR DESCRIPTION
## Summary

When models like Gemini 3.1 generate images, they attach a `thoughtSignature` in `providerMetadata` that must be round-tripped in subsequent conversation turns. This metadata was being lost at multiple points in the pipeline, causing:

- `Image part is missing a thought_signature` — Google API rejects the request
- `Base64 decoding failed` — `data:` URI prefix not stripped for assistant file parts

## Changes

### 1. `llm-execution-step.ts` — Primary fix
Persist `providerMetadata` from file stream chunks into `MastraDBMessage` parts. This was the main loss point — the `source` chunk handler already did this correctly, but `file` chunks did not.

### 2. `output-converter.ts` — AI SDK v5 workaround
Added `restoreAssistantFileProviderMetadata()` to re-apply metadata after AI SDK v5's `convertToModelMessages` drops it from assistant file parts. This is a known upstream bug fixed in v6 but not backported to v5.

### 3. `message-list.ts` — Data URI stripping
Extended `llmPrompt()` to also process assistant file parts through `convertImageFilePart`, which strips `data:` URI prefixes. Previously only `user` role messages were processed, so model-generated images stored as data URIs would fail on the next turn.

### 4. `transform.ts` — Stream metadata passthrough
Carry `providerMetadata` through both forward (AI SDK → Mastra) and reverse (Mastra → AI SDK) stream transforms for file chunks.

## Test Plan

- 5 new unit tests in `output-converter-file-metadata.test.ts`
- All 335 message-list tests pass
- All 7 adapter tests pass
- Manually verified multi-turn Gemini image generation round-trips in Mastra Studio (generate → describe → generate again)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve provider metadata for assistant file parts across message conversions, streaming, and chunk handling so file/provider options remain intact.
  * Apply file/image processing to assistant messages as well as user messages to prevent metadata loss during conversion.

* **Tests**
  * Added tests verifying assistant file parts retain provider metadata through conversions and across multiple assistant messages.

* **Chores**
  * Added a changeset documenting a patch release for provider metadata preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->