### PR TITLE
fix(server): respect agent-configured memory storage in Responses and Conversations

### DIFF
--- a/.changeset/free-tables-relate.md
+++ b/.changeset/free-tables-relate.md
@@ -1,0 +1,7 @@
+---
+'@mastra/server': patch
+---
+
+Fixed Responses and Conversations to resolve stored data through the selected agent's memory store instead of assuming Mastra root memory storage.
+
+Responses and conversation retrieval, deletion, and continuation now follow the agent's configured memory storage, while still using Mastra root storage when that agent memory inherits it.

--- a/packages/server/src/server/handlers/conversations.test.ts
+++ b/packages/server/src/server/handlers/conversations.test.ts
@@ -11,6 +11,66 @@ import {
 } from './conversations';
 import { createTestServerContext } from './test-utils';
 
+class RootInjectedMockMemory extends MockMemory {
+  constructor() {
+    super();
+    this._storage = undefined;
+    this._hasOwnStorage = false;
+  }
+}
+
+function createMastraWithDedicatedAgentMemory() {
+  const rootStorage = new InMemoryStore();
+  const agentStorage = new InMemoryStore();
+  const memory = new MockMemory({ storage: agentStorage });
+  const agent = new Agent({
+    id: 'dedicated-agent',
+    name: 'dedicated-agent',
+    instructions: 'dedicated instructions',
+    model: {} as never,
+    memory,
+  });
+  const mastra = new Mastra({
+    logger: false,
+    storage: rootStorage,
+    agents: {
+      'dedicated-agent': agent,
+    },
+  });
+
+  return {
+    agent,
+    mastra,
+    memory,
+    rootStorage,
+  };
+}
+
+function createMastraWithAgentMemoryUsingRootStorage() {
+  const rootStorage = new InMemoryStore();
+  const memory = new RootInjectedMockMemory();
+  const agent = new Agent({
+    id: 'root-backed-agent',
+    name: 'root-backed-agent',
+    instructions: 'root-backed instructions',
+    model: {} as never,
+    memory,
+  });
+  const mastra = new Mastra({
+    logger: false,
+    storage: rootStorage,
+    agents: {
+      'root-backed-agent': agent,
+    },
+  });
+
+  return {
+    agent,
+    mastra,
+    rootStorage,
+  };
+}
+
 describe('Conversation Handlers', () => {
   let storage: InMemoryStore;
   let memory: MockMemory;
@@ -80,6 +140,7 @@ describe('Conversation Handlers', () => {
 
     const items = await GET_CONVERSATION_ITEMS_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'test-agent',
       conversationId: thread.id,
     });
 
@@ -179,6 +240,7 @@ describe('Conversation Handlers', () => {
 
     const items = await GET_CONVERSATION_ITEMS_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'test-agent',
       conversationId: thread.id,
     });
 
@@ -201,6 +263,7 @@ describe('Conversation Handlers', () => {
 
     const conversation = await GET_CONVERSATION_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'test-agent',
       conversationId: thread.id,
     });
 
@@ -222,6 +285,7 @@ describe('Conversation Handlers', () => {
 
     const deleted = await DELETE_CONVERSATION_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'test-agent',
       conversationId: thread.id,
     });
 
@@ -234,10 +298,125 @@ describe('Conversation Handlers', () => {
     await expect(
       GET_CONVERSATION_ROUTE.handler({
         ...createTestServerContext({ mastra }),
+        agent_id: 'test-agent',
         conversationId: thread.id,
       }),
     ).rejects.toMatchObject({
       status: 404,
+    });
+  });
+
+  it('retrieves, lists items, and deletes conversations from the agent memory store when Mastra root storage is different', async () => {
+    const dedicated = createMastraWithDedicatedAgentMemory();
+
+    const created = await CREATE_CONVERSATION_ROUTE.handler({
+      ...createTestServerContext({ mastra: dedicated.mastra }),
+      agent_id: 'dedicated-agent',
+      conversation_id: 'conv_dedicated',
+    });
+
+    await dedicated.memory.saveMessages({
+      messages: [
+        {
+          id: 'dedicated_msg_1',
+          threadId: 'conv_dedicated',
+          resourceId: 'conv_dedicated',
+          role: 'user',
+          type: 'text',
+          createdAt: new Date(),
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: 'Hello dedicated conversation' }],
+          },
+        },
+      ],
+    });
+
+    const rootMemoryStore = await dedicated.rootStorage.getStore('memory');
+    const rootThread = await rootMemoryStore!.getThreadById({ threadId: 'conv_dedicated' });
+    expect(rootThread).toBeNull();
+
+    const retrieved = await GET_CONVERSATION_ROUTE.handler({
+      ...createTestServerContext({ mastra: dedicated.mastra }),
+      agent_id: 'dedicated-agent',
+      conversationId: 'conv_dedicated',
+    });
+    expect(retrieved).toMatchObject({
+      id: created.id,
+      object: 'conversation',
+      thread: {
+        id: 'conv_dedicated',
+        resourceId: 'conv_dedicated',
+      },
+    });
+
+    const items = await GET_CONVERSATION_ITEMS_ROUTE.handler({
+      ...createTestServerContext({ mastra: dedicated.mastra }),
+      agent_id: 'dedicated-agent',
+      conversationId: 'conv_dedicated',
+    });
+    expect(items).toMatchObject({
+      object: 'list',
+      data: [
+        {
+          id: 'dedicated_msg_1',
+          type: 'message',
+          role: 'user',
+        },
+      ],
+    });
+
+    const deleted = await DELETE_CONVERSATION_ROUTE.handler({
+      ...createTestServerContext({ mastra: dedicated.mastra }),
+      agent_id: 'dedicated-agent',
+      conversationId: 'conv_dedicated',
+    });
+    expect(deleted).toEqual({
+      id: 'conv_dedicated',
+      object: 'conversation.deleted',
+      deleted: true,
+    });
+
+    await expect(
+      GET_CONVERSATION_ROUTE.handler({
+        ...createTestServerContext({ mastra: dedicated.mastra }),
+        agent_id: 'dedicated-agent',
+        conversationId: 'conv_dedicated',
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it('creates and retrieves conversations through agent memory when that memory inherits Mastra root storage', async () => {
+    const rootBacked = createMastraWithAgentMemoryUsingRootStorage();
+
+    const created = await CREATE_CONVERSATION_ROUTE.handler({
+      ...createTestServerContext({ mastra: rootBacked.mastra }),
+      agent_id: 'root-backed-agent',
+      conversation_id: 'conv_root_backed',
+    });
+
+    const rootMemoryStore = await rootBacked.rootStorage.getStore('memory');
+    const rootThread = await rootMemoryStore!.getThreadById({ threadId: 'conv_root_backed' });
+    expect(rootThread).toMatchObject({
+      id: 'conv_root_backed',
+      resourceId: 'conv_root_backed',
+    });
+
+    const retrieved = await GET_CONVERSATION_ROUTE.handler({
+      ...createTestServerContext({ mastra: rootBacked.mastra }),
+      agent_id: 'root-backed-agent',
+      conversationId: 'conv_root_backed',
+    });
+
+    expect(retrieved).toMatchObject({
+      id: created.id,
+      object: 'conversation',
+      thread: {
+        id: 'conv_root_backed',
+        resourceId: 'conv_root_backed',
+      },
     });
   });
 });

--- a/packages/server/src/server/handlers/conversations.test.ts
+++ b/packages/server/src/server/handlers/conversations.test.ts
@@ -140,7 +140,6 @@ describe('Conversation Handlers', () => {
 
     const items = await GET_CONVERSATION_ITEMS_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'test-agent',
       conversationId: thread.id,
     });
 
@@ -240,7 +239,6 @@ describe('Conversation Handlers', () => {
 
     const items = await GET_CONVERSATION_ITEMS_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'test-agent',
       conversationId: thread.id,
     });
 
@@ -263,7 +261,6 @@ describe('Conversation Handlers', () => {
 
     const conversation = await GET_CONVERSATION_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'test-agent',
       conversationId: thread.id,
     });
 
@@ -285,7 +282,6 @@ describe('Conversation Handlers', () => {
 
     const deleted = await DELETE_CONVERSATION_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'test-agent',
       conversationId: thread.id,
     });
 
@@ -298,7 +294,6 @@ describe('Conversation Handlers', () => {
     await expect(
       GET_CONVERSATION_ROUTE.handler({
         ...createTestServerContext({ mastra }),
-        agent_id: 'test-agent',
         conversationId: thread.id,
       }),
     ).rejects.toMatchObject({
@@ -338,7 +333,6 @@ describe('Conversation Handlers', () => {
 
     const retrieved = await GET_CONVERSATION_ROUTE.handler({
       ...createTestServerContext({ mastra: dedicated.mastra }),
-      agent_id: 'dedicated-agent',
       conversationId: 'conv_dedicated',
     });
     expect(retrieved).toMatchObject({
@@ -352,7 +346,6 @@ describe('Conversation Handlers', () => {
 
     const items = await GET_CONVERSATION_ITEMS_ROUTE.handler({
       ...createTestServerContext({ mastra: dedicated.mastra }),
-      agent_id: 'dedicated-agent',
       conversationId: 'conv_dedicated',
     });
     expect(items).toMatchObject({
@@ -368,7 +361,6 @@ describe('Conversation Handlers', () => {
 
     const deleted = await DELETE_CONVERSATION_ROUTE.handler({
       ...createTestServerContext({ mastra: dedicated.mastra }),
-      agent_id: 'dedicated-agent',
       conversationId: 'conv_dedicated',
     });
     expect(deleted).toEqual({
@@ -380,7 +372,6 @@ describe('Conversation Handlers', () => {
     await expect(
       GET_CONVERSATION_ROUTE.handler({
         ...createTestServerContext({ mastra: dedicated.mastra }),
-        agent_id: 'dedicated-agent',
         conversationId: 'conv_dedicated',
       }),
     ).rejects.toMatchObject({
@@ -406,7 +397,6 @@ describe('Conversation Handlers', () => {
 
     const retrieved = await GET_CONVERSATION_ROUTE.handler({
       ...createTestServerContext({ mastra: rootBacked.mastra }),
-      agent_id: 'root-backed-agent',
       conversationId: 'conv_root_backed',
     });
 

--- a/packages/server/src/server/handlers/conversations.ts
+++ b/packages/server/src/server/handlers/conversations.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
+import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
+import type { MemoryStorage } from '@mastra/core/storage';
 import { HTTPException } from '../http-exception';
 import {
+  conversationAgentQuerySchema,
   conversationDeletedSchema,
   conversationIdPathParams,
   conversationItemsListSchema,
@@ -13,7 +16,7 @@ import { createRoute } from '../server-adapter/routes/route-builder';
 import { getAgentFromSystem } from './agents';
 import { handleError } from './error';
 import { mapMastraMessagesToConversationItems } from './responses.adapter';
-import { getResponseMemoryStore } from './responses.storage';
+import { getAgentMemoryStore } from './responses.storage';
 import { getEffectiveResourceId } from './utils';
 
 /**
@@ -27,7 +30,7 @@ async function resolveConversationThread({
   requestContext,
 }: {
   conversationId: string;
-  memoryStore: NonNullable<Awaited<ReturnType<typeof getResponseMemoryStore>>>;
+  memoryStore: MemoryStorage;
   requestContext: RequestContext;
 }) {
   const thread = await memoryStore.getThreadById({ threadId: conversationId });
@@ -41,6 +44,25 @@ async function resolveConversationThread({
   }
 
   return thread;
+}
+
+async function resolveConversationMemoryStore({
+  mastra,
+  agentId,
+  requestContext,
+}: {
+  mastra: Mastra;
+  agentId: string;
+  requestContext: RequestContext;
+}) {
+  const agent = await getAgentFromSystem({ mastra, agentId });
+  const memoryStore = await getAgentMemoryStore({ agent, requestContext });
+
+  if (!memoryStore) {
+    throw new HTTPException(400, { message: `Memory storage is not configured for agent "${agent.id}"` });
+  }
+
+  return { agent, memoryStore };
 }
 
 function buildConversationObject({ thread }: { thread: ConversationObject['thread'] }): ConversationObject {
@@ -91,6 +113,9 @@ export const CREATE_CONVERSATION_ROUTE = createRoute({
       if (!memory) {
         throw new HTTPException(400, { message: `Agent "${agent.id}" does not have memory configured` });
       }
+      if (!(await getAgentMemoryStore({ agent, requestContext }))) {
+        throw new HTTPException(400, { message: `Memory storage is not configured for agent "${agent.id}"` });
+      }
 
       const threadId = conversation_id ?? randomUUID();
       const resourceId = getEffectiveResourceId(requestContext, resource_id) ?? threadId;
@@ -113,18 +138,23 @@ export const GET_CONVERSATION_ROUTE = createRoute({
   path: '/v1/conversations/:conversationId',
   responseType: 'json',
   pathParamSchema: conversationIdPathParams,
+  queryParamSchema: conversationAgentQuerySchema,
   responseSchema: conversationObjectSchema,
   summary: 'Retrieve a conversation',
   description: 'Returns a conversation object backed by a Mastra memory thread',
   tags: ['Responses'],
   requiresAuth: true,
   requiresPermission: 'agents:read',
-  handler: async ({ mastra, requestContext, conversationId }) => {
+  handler: async ({ mastra, requestContext, conversationId, agent_id }) => {
     try {
-      const memoryStore = await getResponseMemoryStore(mastra);
-      if (!memoryStore) {
-        throw new HTTPException(500, { message: 'Memory storage is not available' });
+      if (!mastra) {
+        throw new HTTPException(500, { message: 'Mastra instance is required for conversations' });
       }
+      const { memoryStore } = await resolveConversationMemoryStore({
+        mastra,
+        agentId: agent_id,
+        requestContext,
+      });
 
       const thread = await resolveConversationThread({ conversationId, memoryStore, requestContext });
 
@@ -140,18 +170,23 @@ export const GET_CONVERSATION_ITEMS_ROUTE = createRoute({
   path: '/v1/conversations/:conversationId/items',
   responseType: 'json',
   pathParamSchema: conversationIdPathParams,
+  queryParamSchema: conversationAgentQuerySchema,
   responseSchema: conversationItemsListSchema,
   summary: 'List conversation items',
   description: 'Returns OpenAI-style conversation items derived from the stored thread messages',
   tags: ['Responses'],
   requiresAuth: true,
   requiresPermission: 'agents:read',
-  handler: async ({ mastra, requestContext, conversationId }) => {
+  handler: async ({ mastra, requestContext, conversationId, agent_id }) => {
     try {
-      const memoryStore = await getResponseMemoryStore(mastra);
-      if (!memoryStore) {
-        throw new HTTPException(500, { message: 'Memory storage is not available' });
+      if (!mastra) {
+        throw new HTTPException(500, { message: 'Mastra instance is required for conversations' });
       }
+      const { memoryStore } = await resolveConversationMemoryStore({
+        mastra,
+        agentId: agent_id,
+        requestContext,
+      });
 
       await resolveConversationThread({ conversationId, memoryStore, requestContext });
 
@@ -173,18 +208,23 @@ export const DELETE_CONVERSATION_ROUTE = createRoute({
   path: '/v1/conversations/:conversationId',
   responseType: 'json',
   pathParamSchema: conversationIdPathParams,
+  queryParamSchema: conversationAgentQuerySchema,
   responseSchema: conversationDeletedSchema,
   summary: 'Delete a conversation',
   description: 'Deletes a thread-backed conversation and its stored items',
   tags: ['Responses'],
   requiresAuth: true,
   requiresPermission: 'agents:delete',
-  handler: async ({ mastra, requestContext, conversationId }) => {
+  handler: async ({ mastra, requestContext, conversationId, agent_id }) => {
     try {
-      const memoryStore = await getResponseMemoryStore(mastra);
-      if (!memoryStore) {
-        throw new HTTPException(500, { message: 'Memory storage is not available' });
+      if (!mastra) {
+        throw new HTTPException(500, { message: 'Mastra instance is required for conversations' });
       }
+      const { memoryStore } = await resolveConversationMemoryStore({
+        mastra,
+        agentId: agent_id,
+        requestContext,
+      });
 
       await resolveConversationThread({ conversationId, memoryStore, requestContext });
 

--- a/packages/server/src/server/handlers/conversations.ts
+++ b/packages/server/src/server/handlers/conversations.ts
@@ -1,10 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import type { Mastra } from '@mastra/core/mastra';
-import type { RequestContext } from '@mastra/core/request-context';
-import type { MemoryStorage } from '@mastra/core/storage';
 import { HTTPException } from '../http-exception';
 import {
-  conversationAgentQuerySchema,
   conversationDeletedSchema,
   conversationIdPathParams,
   conversationItemsListSchema,
@@ -16,54 +12,8 @@ import { createRoute } from '../server-adapter/routes/route-builder';
 import { getAgentFromSystem } from './agents';
 import { handleError } from './error';
 import { mapMastraMessagesToConversationItems } from './responses.adapter';
-import { getAgentMemoryStore } from './responses.storage';
+import { findConversationThreadAcrossAgents, getAgentMemoryStore } from './responses.storage';
 import { getEffectiveResourceId } from './utils';
-
-/**
- * Resolves a stored conversation thread and enforces the caller's resource scope.
- * Conversations are persisted as memory threads, so all read/delete routes share
- * this lookup path.
- */
-async function resolveConversationThread({
-  conversationId,
-  memoryStore,
-  requestContext,
-}: {
-  conversationId: string;
-  memoryStore: MemoryStorage;
-  requestContext: RequestContext;
-}) {
-  const thread = await memoryStore.getThreadById({ threadId: conversationId });
-  if (!thread) {
-    throw new HTTPException(404, { message: `Conversation ${conversationId} was not found` });
-  }
-
-  const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-  if (effectiveResourceId && thread.resourceId !== effectiveResourceId) {
-    throw new HTTPException(404, { message: `Conversation ${conversationId} was not found` });
-  }
-
-  return thread;
-}
-
-async function resolveConversationMemoryStore({
-  mastra,
-  agentId,
-  requestContext,
-}: {
-  mastra: Mastra;
-  agentId: string;
-  requestContext: RequestContext;
-}) {
-  const agent = await getAgentFromSystem({ mastra, agentId });
-  const memoryStore = await getAgentMemoryStore({ agent, requestContext });
-
-  if (!memoryStore) {
-    throw new HTTPException(400, { message: `Memory storage is not configured for agent "${agent.id}"` });
-  }
-
-  return { agent, memoryStore };
-}
 
 function buildConversationObject({ thread }: { thread: ConversationObject['thread'] }): ConversationObject {
   return {
@@ -138,27 +88,20 @@ export const GET_CONVERSATION_ROUTE = createRoute({
   path: '/v1/conversations/:conversationId',
   responseType: 'json',
   pathParamSchema: conversationIdPathParams,
-  queryParamSchema: conversationAgentQuerySchema,
   responseSchema: conversationObjectSchema,
   summary: 'Retrieve a conversation',
   description: 'Returns a conversation object backed by a Mastra memory thread',
   tags: ['Responses'],
   requiresAuth: true,
   requiresPermission: 'agents:read',
-  handler: async ({ mastra, requestContext, conversationId, agent_id }) => {
+  handler: async ({ mastra, requestContext, conversationId }) => {
     try {
-      if (!mastra) {
-        throw new HTTPException(500, { message: 'Mastra instance is required for conversations' });
+      const match = await findConversationThreadAcrossAgents({ mastra, conversationId, requestContext });
+      if (!match) {
+        throw new HTTPException(404, { message: `Conversation ${conversationId} was not found` });
       }
-      const { memoryStore } = await resolveConversationMemoryStore({
-        mastra,
-        agentId: agent_id,
-        requestContext,
-      });
 
-      const thread = await resolveConversationThread({ conversationId, memoryStore, requestContext });
-
-      return buildConversationObject({ thread });
+      return buildConversationObject({ thread: match.thread });
     } catch (error) {
       return handleError(error, 'Error retrieving conversation');
     }
@@ -170,27 +113,20 @@ export const GET_CONVERSATION_ITEMS_ROUTE = createRoute({
   path: '/v1/conversations/:conversationId/items',
   responseType: 'json',
   pathParamSchema: conversationIdPathParams,
-  queryParamSchema: conversationAgentQuerySchema,
   responseSchema: conversationItemsListSchema,
   summary: 'List conversation items',
   description: 'Returns OpenAI-style conversation items derived from the stored thread messages',
   tags: ['Responses'],
   requiresAuth: true,
   requiresPermission: 'agents:read',
-  handler: async ({ mastra, requestContext, conversationId, agent_id }) => {
+  handler: async ({ mastra, requestContext, conversationId }) => {
     try {
-      if (!mastra) {
-        throw new HTTPException(500, { message: 'Mastra instance is required for conversations' });
+      const match = await findConversationThreadAcrossAgents({ mastra, conversationId, requestContext });
+      if (!match) {
+        throw new HTTPException(404, { message: `Conversation ${conversationId} was not found` });
       }
-      const { memoryStore } = await resolveConversationMemoryStore({
-        mastra,
-        agentId: agent_id,
-        requestContext,
-      });
 
-      await resolveConversationThread({ conversationId, memoryStore, requestContext });
-
-      const { messages } = await memoryStore.listMessages({
+      const { messages } = await match.memoryStore.listMessages({
         threadId: conversationId,
         page: 0,
         perPage: 1000,
@@ -208,27 +144,20 @@ export const DELETE_CONVERSATION_ROUTE = createRoute({
   path: '/v1/conversations/:conversationId',
   responseType: 'json',
   pathParamSchema: conversationIdPathParams,
-  queryParamSchema: conversationAgentQuerySchema,
   responseSchema: conversationDeletedSchema,
   summary: 'Delete a conversation',
   description: 'Deletes a thread-backed conversation and its stored items',
   tags: ['Responses'],
   requiresAuth: true,
   requiresPermission: 'agents:delete',
-  handler: async ({ mastra, requestContext, conversationId, agent_id }) => {
+  handler: async ({ mastra, requestContext, conversationId }) => {
     try {
-      if (!mastra) {
-        throw new HTTPException(500, { message: 'Mastra instance is required for conversations' });
+      const match = await findConversationThreadAcrossAgents({ mastra, conversationId, requestContext });
+      if (!match) {
+        throw new HTTPException(404, { message: `Conversation ${conversationId} was not found` });
       }
-      const { memoryStore } = await resolveConversationMemoryStore({
-        mastra,
-        agentId: agent_id,
-        requestContext,
-      });
 
-      await resolveConversationThread({ conversationId, memoryStore, requestContext });
-
-      await memoryStore.deleteThread({ threadId: conversationId });
+      await match.memoryStore.deleteThread({ threadId: conversationId });
 
       return buildConversationDeleted(conversationId);
     } catch (error) {

--- a/packages/server/src/server/handlers/responses.storage.ts
+++ b/packages/server/src/server/handlers/responses.storage.ts
@@ -1,4 +1,5 @@
 import type { Agent, MastraDBMessage } from '@mastra/core/agent';
+import type { Mastra } from '@mastra/core/mastra';
 import type { StorageThreadType } from '@mastra/core/memory';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { MemoryStorage } from '@mastra/core/storage';
@@ -180,7 +181,7 @@ export async function findResponseTurnRecord({
   }
 
   const metadata = readResponseTurnRecordMetadata(message);
-  if (!metadata) {
+  if (!metadata || metadata.agentId !== agent.id) {
     return null;
   }
 
@@ -198,6 +199,69 @@ export async function findResponseTurnRecord({
     .filter((storedMessage): storedMessage is MastraDBMessage => Boolean(storedMessage));
 
   return { metadata, message, messages: orderedMessages, thread, memoryStore };
+}
+
+export async function findResponseTurnRecordAcrossAgents({
+  mastra,
+  responseId,
+  requestContext,
+}: {
+  mastra: Mastra | undefined;
+  responseId: string;
+  requestContext: RequestContext;
+}): Promise<ResponseTurnRecord | null> {
+  if (!mastra) {
+    return null;
+  }
+
+  const agents = Object.values(mastra.listAgents()) as Agent<any, any, any, any>[];
+  for (const agent of agents) {
+    const match = await findResponseTurnRecord({ agent, responseId, requestContext });
+    if (match) {
+      return match;
+    }
+  }
+
+  return null;
+}
+
+export type ConversationThreadRecord = {
+  thread: StorageThreadType;
+  memoryStore: MemoryStorage;
+};
+
+export async function findConversationThreadAcrossAgents({
+  mastra,
+  conversationId,
+  requestContext,
+}: {
+  mastra: Mastra | undefined;
+  conversationId: string;
+  requestContext: RequestContext;
+}): Promise<ConversationThreadRecord | null> {
+  if (!mastra) {
+    return null;
+  }
+
+  const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
+  const agents = Object.values(mastra.listAgents()) as Agent<any, any, any, any>[];
+
+  for (const agent of agents) {
+    const memoryStore = await getAgentMemoryStore({ agent, requestContext });
+    if (!memoryStore) {
+      continue;
+    }
+
+    const thread = await memoryStore.getThreadById({ threadId: conversationId });
+    if (!thread) {
+      continue;
+    }
+
+    await validateThreadOwnership(thread, effectiveResourceId);
+    return { thread, memoryStore };
+  }
+
+  return null;
 }
 
 /**
@@ -343,5 +407,10 @@ export async function deleteResponseTurnRecord({
 }: {
   responseTurnRecord: ResponseTurnRecord;
 }): Promise<void> {
-  await responseTurnRecord.memoryStore.deleteMessages(responseTurnRecord.metadata.messageIds);
+  const messageIds =
+    responseTurnRecord.messages.length > 0
+      ? responseTurnRecord.messages.map(message => message.id)
+      : [responseTurnRecord.message.id];
+
+  await responseTurnRecord.memoryStore.deleteMessages(messageIds);
 }

--- a/packages/server/src/server/handlers/responses.storage.ts
+++ b/packages/server/src/server/handlers/responses.storage.ts
@@ -1,5 +1,4 @@
-import type { MastraDBMessage } from '@mastra/core/agent';
-import type { Mastra } from '@mastra/core/mastra';
+import type { Agent, MastraDBMessage } from '@mastra/core/agent';
 import type { StorageThreadType } from '@mastra/core/memory';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { MemoryStorage } from '@mastra/core/storage';
@@ -61,20 +60,29 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Resolves the memory storage used by response-turn records.
+ * Resolves the backing memory store for a specific agent.
+ *
+ * This follows the normal agent-memory path. `agent.getMemory()` injects Mastra
+ * root storage when the memory has no own storage, so this naturally prefers
+ * agent storage first and falls back to Mastra storage through the same codepath.
  */
-export async function getResponseMemoryStore(mastra: Mastra | undefined): Promise<MemoryStorage | null> {
-  const storage = mastra?.getStorage();
-  if (!storage) {
+export async function getAgentMemoryStore({
+  agent,
+  requestContext,
+}: {
+  agent: Agent<any, any, any, any>;
+  requestContext: RequestContext;
+}): Promise<MemoryStorage | null> {
+  const memory = await agent.getMemory({ requestContext });
+  if (!memory) {
     return null;
   }
 
-  const memoryStore = await storage.getStore('memory');
-  if (!memoryStore) {
+  try {
+    return (await memory.storage.getStore('memory')) ?? null;
+  } catch {
     return null;
   }
-
-  return memoryStore;
 }
 
 /**
@@ -151,15 +159,15 @@ function writeResponseTurnRecordMetadata(
  * reloading the full set of stored turn messages referenced by the metadata.
  */
 export async function findResponseTurnRecord({
-  mastra,
+  agent,
   responseId,
   requestContext,
 }: {
-  mastra: Mastra | undefined;
+  agent: Agent<any, any, any, any>;
   responseId: string;
   requestContext: RequestContext;
 }): Promise<ResponseTurnRecord | null> {
-  const memoryStore = await getResponseMemoryStore(mastra);
+  const memoryStore = await getAgentMemoryStore({ agent, requestContext });
   if (!memoryStore) {
     return null;
   }
@@ -256,19 +264,18 @@ export async function resolveResponseTurnMessagesForStorage({
  * the Responses object from thread-backed storage.
  */
 export async function persistResponseTurnRecord({
-  mastra,
+  memoryStore,
   responseId,
   metadata,
   threadContext,
   messages,
 }: {
-  mastra: Mastra | undefined;
+  memoryStore: MemoryStorage | null;
   responseId: string;
   metadata: ResponseTurnRecordMetadata;
   threadContext: ThreadExecutionContext;
   messages: MastraDBMessage[];
 }): Promise<void> {
-  const memoryStore = await getResponseMemoryStore(mastra);
   if (!memoryStore) {
     throw new HTTPException(500, { message: 'Memory storage was not available while storing the response' });
   }
@@ -332,19 +339,9 @@ export async function persistResponseTurnRecord({
  * Removes all persisted messages for a stored response-turn record.
  */
 export async function deleteResponseTurnRecord({
-  mastra,
-  responseId,
-  requestContext,
+  responseTurnRecord,
 }: {
-  mastra: Mastra | undefined;
-  responseId: string;
-  requestContext: RequestContext;
-}): Promise<boolean> {
-  const match = await findResponseTurnRecord({ mastra, responseId, requestContext });
-  if (!match) {
-    return false;
-  }
-
-  await match.memoryStore.deleteMessages(match.metadata.messageIds);
-  return true;
+  responseTurnRecord: ResponseTurnRecord;
+}): Promise<void> {
+  await responseTurnRecord.memoryStore.deleteMessages(responseTurnRecord.metadata.messageIds);
 }

--- a/packages/server/src/server/handlers/responses.test.ts
+++ b/packages/server/src/server/handlers/responses.test.ts
@@ -183,6 +183,94 @@ function mockAgentSpecVersion(agent: Agent, specificationVersion: 'v1' | 'v2' = 
   vi.spyOn(agent, 'getModel').mockResolvedValue({ specificationVersion } as never);
 }
 
+class RootInjectedMockMemory extends MockMemory {
+  constructor() {
+    super();
+    this._storage = undefined;
+    this._hasOwnStorage = false;
+  }
+}
+
+function createMastraWithDedicatedAgentMemory() {
+  const rootStorage = new InMemoryStore();
+  const agentStorage = new InMemoryStore();
+  const memory = new MockMemory({ storage: agentStorage });
+  const agent = new Agent({
+    id: 'dedicated-agent',
+    name: 'dedicated-agent',
+    instructions: 'dedicated instructions',
+    model: {} as never,
+    memory,
+  });
+  const mastra = new Mastra({
+    logger: false,
+    storage: rootStorage,
+    agents: {
+      'dedicated-agent': agent,
+    },
+  });
+
+  mockAgentSpecVersion(agent);
+
+  return {
+    agent,
+    mastra,
+    memory,
+    rootStorage,
+  };
+}
+
+function createMastraWithAgentMemoryUsingRootStorage() {
+  const rootStorage = new InMemoryStore();
+  const memory = new RootInjectedMockMemory();
+  const agent = new Agent({
+    id: 'root-backed-agent',
+    name: 'root-backed-agent',
+    instructions: 'root-backed instructions',
+    model: {} as never,
+    memory,
+  });
+  const mastra = new Mastra({
+    logger: false,
+    storage: rootStorage,
+    agents: {
+      'root-backed-agent': agent,
+    },
+  });
+
+  mockAgentSpecVersion(agent);
+
+  return {
+    agent,
+    mastra,
+    rootStorage,
+  };
+}
+
+function createMastraWithAgentMemoryWithoutStorage() {
+  const memory = new RootInjectedMockMemory();
+  const agent = new Agent({
+    id: 'agent-without-storage',
+    name: 'agent-without-storage',
+    instructions: 'agent-without-storage instructions',
+    model: {} as never,
+    memory,
+  });
+  const mastra = new Mastra({
+    logger: false,
+    agents: {
+      'agent-without-storage': agent,
+    },
+  });
+
+  mockAgentSpecVersion(agent);
+
+  return {
+    agent,
+    mastra,
+  };
+}
+
 describe('Responses Handlers', () => {
   let storage: InMemoryStore;
   let memory: MockMemory;
@@ -285,6 +373,7 @@ describe('Responses Handlers', () => {
 
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'test-agent',
       responseId: created.id,
     });
 
@@ -357,6 +446,7 @@ describe('Responses Handlers', () => {
     const created = await readJson(response);
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'test-agent',
       responseId: created.id,
     });
 
@@ -463,6 +553,7 @@ describe('Responses Handlers', () => {
 
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'test-agent',
       responseId: created.id,
     });
 
@@ -771,6 +862,19 @@ describe('Responses Handlers', () => {
     ).rejects.toThrow(HTTPException);
   });
 
+  it('requires agent_id when previous_response_id is provided', async () => {
+    await expect(
+      CREATE_RESPONSE_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        model: 'openai/gpt-5',
+        input: 'Second turn',
+        previous_response_id: 'resp_missing_agent',
+        store: true,
+        stream: false,
+      }),
+    ).rejects.toThrow(HTTPException);
+  });
+
   it('reuses the stored thread when previous_response_id is provided', async () => {
     const generateSpy = vi.spyOn(agent, 'generate');
     generateSpy.mockResolvedValue(createGenerateResult({ text: 'First response' }));
@@ -987,6 +1091,7 @@ describe('Responses Handlers', () => {
     const completedPayload = JSON.parse(completedLine!.slice('data: '.length)) as { response: { id: string } };
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'test-agent',
       responseId: completedPayload.response.id,
     });
 
@@ -1146,6 +1251,7 @@ describe('Responses Handlers', () => {
 
     const deleted = await DELETE_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'test-agent',
       responseId: created.id,
     });
 
@@ -1158,6 +1264,7 @@ describe('Responses Handlers', () => {
     await expect(
       GET_RESPONSE_ROUTE.handler({
         ...createTestServerContext({ mastra }),
+        agent_id: 'test-agent',
         responseId: created.id,
       }),
     ).rejects.toThrow(HTTPException);
@@ -1283,6 +1390,7 @@ describe('Responses Handlers', () => {
 
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'tool-agent',
       responseId: created.id,
     });
 
@@ -1358,6 +1466,7 @@ describe('Responses Handlers', () => {
     const created = await readJson(response);
     const deleted = await DELETE_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
+      agent_id: 'tool-agent',
       responseId: created.id,
     });
 
@@ -1370,8 +1479,151 @@ describe('Responses Handlers', () => {
     await expect(
       GET_RESPONSE_ROUTE.handler({
         ...createTestServerContext({ mastra }),
+        agent_id: 'tool-agent',
         responseId: created.id,
       }),
     ).rejects.toThrow(HTTPException);
+  });
+
+  it('stores and continues responses in the agent memory store when Mastra root storage is different', async () => {
+    const dedicated = createMastraWithDedicatedAgentMemory();
+    const generateSpy = vi.spyOn(dedicated.agent, 'generate');
+    generateSpy.mockResolvedValueOnce(createGenerateResult({ text: 'First dedicated response' }));
+
+    const firstResponse = (await CREATE_RESPONSE_ROUTE.handler({
+      ...createTestServerContext({ mastra: dedicated.mastra }),
+      model: 'openai/gpt-5',
+      agent_id: 'dedicated-agent',
+      input: 'First turn',
+      store: true,
+      stream: false,
+    })) as Response;
+
+    const firstCreated = await readJson(firstResponse);
+    const rootMemoryStore = await dedicated.rootStorage.getStore('memory');
+    const rootMessages = await rootMemoryStore!.listMessagesById({ messageIds: [firstCreated.id] });
+    expect(rootMessages.messages).toEqual([]);
+
+    generateSpy.mockResolvedValueOnce(createGenerateResult({ text: 'Second dedicated response' }));
+
+    await expect(
+      CREATE_RESPONSE_ROUTE.handler({
+        ...createTestServerContext({ mastra: dedicated.mastra }),
+        model: 'openai/gpt-5',
+        agent_id: 'dedicated-agent',
+        input: 'Second turn',
+        previous_response_id: firstCreated.id,
+        store: true,
+        stream: false,
+      }),
+    ).resolves.toBeInstanceOf(Response);
+
+    const firstCall = generateSpy.mock.calls[0]?.[1] as { memory?: { thread?: string; resource?: string } };
+    const secondCall = generateSpy.mock.calls[1]?.[1] as { memory?: { thread?: string; resource?: string } };
+
+    expect(secondCall.memory).toEqual(firstCall.memory);
+  });
+
+  it('retrieves and deletes stored responses from the agent memory store when Mastra root storage is different', async () => {
+    const dedicated = createMastraWithDedicatedAgentMemory();
+    vi.spyOn(dedicated.agent, 'generate').mockResolvedValue(
+      createGenerateResult({ text: 'Stored in dedicated memory' }),
+    );
+
+    const response = (await CREATE_RESPONSE_ROUTE.handler({
+      ...createTestServerContext({ mastra: dedicated.mastra }),
+      model: 'openai/gpt-5',
+      agent_id: 'dedicated-agent',
+      input: 'Hello',
+      store: true,
+      stream: false,
+    })) as Response;
+
+    const created = await readJson(response);
+
+    const retrieved = await GET_RESPONSE_ROUTE.handler({
+      ...createTestServerContext({ mastra: dedicated.mastra }),
+      agent_id: 'dedicated-agent',
+      responseId: created.id,
+    });
+    expect(retrieved).toMatchObject({
+      id: created.id,
+      object: 'response',
+      store: true,
+    });
+
+    const deleted = await DELETE_RESPONSE_ROUTE.handler({
+      ...createTestServerContext({ mastra: dedicated.mastra }),
+      agent_id: 'dedicated-agent',
+      responseId: created.id,
+    });
+    expect(deleted).toEqual({
+      id: created.id,
+      object: 'response',
+      deleted: true,
+    });
+
+    await expect(
+      GET_RESPONSE_ROUTE.handler({
+        ...createTestServerContext({ mastra: dedicated.mastra }),
+        agent_id: 'dedicated-agent',
+        responseId: created.id,
+      }),
+    ).rejects.toThrow(HTTPException);
+  });
+
+  it('stores responses through agent memory when that memory inherits Mastra root storage', async () => {
+    const rootBacked = createMastraWithAgentMemoryUsingRootStorage();
+    const generateSpy = vi.spyOn(rootBacked.agent, 'generate');
+    generateSpy.mockResolvedValueOnce(createGenerateResult({ text: 'First inherited response' }));
+
+    const firstResponse = (await CREATE_RESPONSE_ROUTE.handler({
+      ...createTestServerContext({ mastra: rootBacked.mastra }),
+      model: 'openai/gpt-5',
+      agent_id: 'root-backed-agent',
+      input: 'First turn',
+      store: true,
+      stream: false,
+    })) as Response;
+
+    const firstCreated = await readJson(firstResponse);
+    const rootMemoryStore = await rootBacked.rootStorage.getStore('memory');
+    const rootMessages = await rootMemoryStore!.listMessagesById({ messageIds: [firstCreated.id] });
+    expect(rootMessages.messages).toHaveLength(1);
+
+    generateSpy.mockResolvedValueOnce(createGenerateResult({ text: 'Second inherited response' }));
+
+    await CREATE_RESPONSE_ROUTE.handler({
+      ...createTestServerContext({ mastra: rootBacked.mastra }),
+      model: 'openai/gpt-5',
+      agent_id: 'root-backed-agent',
+      input: 'Second turn',
+      previous_response_id: firstCreated.id,
+      store: true,
+      stream: false,
+    });
+
+    const firstCall = generateSpy.mock.calls[0]?.[1] as { memory?: { thread?: string; resource?: string } };
+    const secondCall = generateSpy.mock.calls[1]?.[1] as { memory?: { thread?: string; resource?: string } };
+
+    expect(secondCall.memory).toEqual(firstCall.memory);
+  });
+
+  it('returns 400 when storing a response for an agent with memory but no storage', async () => {
+    const noStorage = createMastraWithAgentMemoryWithoutStorage();
+    vi.spyOn(noStorage.agent, 'generate').mockResolvedValue(createGenerateResult({ text: 'No storage response' }));
+
+    await expect(
+      CREATE_RESPONSE_ROUTE.handler({
+        ...createTestServerContext({ mastra: noStorage.mastra }),
+        model: 'openai/gpt-5',
+        agent_id: 'agent-without-storage',
+        input: 'Hello',
+        store: true,
+        stream: false,
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+    });
   });
 });

--- a/packages/server/src/server/handlers/responses.test.ts
+++ b/packages/server/src/server/handlers/responses.test.ts
@@ -373,7 +373,6 @@ describe('Responses Handlers', () => {
 
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'test-agent',
       responseId: created.id,
     });
 
@@ -446,7 +445,6 @@ describe('Responses Handlers', () => {
     const created = await readJson(response);
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'test-agent',
       responseId: created.id,
     });
 
@@ -553,7 +551,6 @@ describe('Responses Handlers', () => {
 
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'test-agent',
       responseId: created.id,
     });
 
@@ -1091,7 +1088,6 @@ describe('Responses Handlers', () => {
     const completedPayload = JSON.parse(completedLine!.slice('data: '.length)) as { response: { id: string } };
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'test-agent',
       responseId: completedPayload.response.id,
     });
 
@@ -1251,7 +1247,6 @@ describe('Responses Handlers', () => {
 
     const deleted = await DELETE_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'test-agent',
       responseId: created.id,
     });
 
@@ -1264,7 +1259,6 @@ describe('Responses Handlers', () => {
     await expect(
       GET_RESPONSE_ROUTE.handler({
         ...createTestServerContext({ mastra }),
-        agent_id: 'test-agent',
         responseId: created.id,
       }),
     ).rejects.toThrow(HTTPException);
@@ -1390,7 +1384,6 @@ describe('Responses Handlers', () => {
 
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'tool-agent',
       responseId: created.id,
     });
 
@@ -1466,7 +1459,6 @@ describe('Responses Handlers', () => {
     const created = await readJson(response);
     const deleted = await DELETE_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra }),
-      agent_id: 'tool-agent',
       responseId: created.id,
     });
 
@@ -1479,7 +1471,6 @@ describe('Responses Handlers', () => {
     await expect(
       GET_RESPONSE_ROUTE.handler({
         ...createTestServerContext({ mastra }),
-        agent_id: 'tool-agent',
         responseId: created.id,
       }),
     ).rejects.toThrow(HTTPException);
@@ -1543,7 +1534,6 @@ describe('Responses Handlers', () => {
 
     const retrieved = await GET_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra: dedicated.mastra }),
-      agent_id: 'dedicated-agent',
       responseId: created.id,
     });
     expect(retrieved).toMatchObject({
@@ -1554,7 +1544,6 @@ describe('Responses Handlers', () => {
 
     const deleted = await DELETE_RESPONSE_ROUTE.handler({
       ...createTestServerContext({ mastra: dedicated.mastra }),
-      agent_id: 'dedicated-agent',
       responseId: created.id,
     });
     expect(deleted).toEqual({
@@ -1566,7 +1555,6 @@ describe('Responses Handlers', () => {
     await expect(
       GET_RESPONSE_ROUTE.handler({
         ...createTestServerContext({ mastra: dedicated.mastra }),
-        agent_id: 'dedicated-agent',
         responseId: created.id,
       }),
     ).rejects.toThrow(HTTPException);

--- a/packages/server/src/server/handlers/responses.ts
+++ b/packages/server/src/server/handlers/responses.ts
@@ -2,10 +2,12 @@ import { randomUUID } from 'node:crypto';
 import type { Agent, MastraDBMessage } from '@mastra/core/agent';
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
+import type { MemoryStorage } from '@mastra/core/storage';
 import { HTTPException } from '../http-exception';
 import {
   createResponseBodySchema,
   deleteResponseSchema,
+  responseAgentQuerySchema,
   responseIdPathParams,
   responseObjectSchema,
 } from '../schemas/responses';
@@ -29,6 +31,7 @@ import {
 import {
   deleteResponseTurnRecord,
   findResponseTurnRecord,
+  getAgentMemoryStore,
   persistResponseTurnRecord,
   resolveResponseTurnMessagesForStorage,
 } from './responses.storage';
@@ -90,6 +93,7 @@ type FinalizedResponse = {
 
 type PreparedCreateResponseRequest = {
   agent: Agent<any, any, any, any>;
+  agentMemoryStore: MemoryStorage | null;
   configuredTools: ReturnType<typeof mapMastraToolsToResponseTools>;
   createdAt: number;
   didStore: boolean;
@@ -277,17 +281,13 @@ function createExecutionMemory(threadContext: ThreadExecutionContext | null) {
 async function resolveResponseAgent({
   mastra,
   agentId,
-  previousResponseTurnRecord,
 }: {
   mastra: Mastra | undefined;
   agentId?: string;
-  previousResponseTurnRecord: ResponseTurnRecord | null;
 }): Promise<Agent<any, any, any, any>> {
-  const resolvedAgentId = agentId ?? previousResponseTurnRecord?.metadata.agentId;
-
-  if (!resolvedAgentId) {
+  if (!agentId) {
     throw new HTTPException(400, {
-      message: 'Responses requests require an agent_id, or a previous_response_id from a stored agent-backed response',
+      message: 'Responses requests require an agent_id',
     });
   }
 
@@ -295,7 +295,24 @@ async function resolveResponseAgent({
     throw new HTTPException(500, { message: 'Mastra instance is required for agent-backed responses' });
   }
 
-  return getAgentFromSystem({ mastra, agentId: resolvedAgentId });
+  return getAgentFromSystem({ mastra, agentId });
+}
+
+async function resolveAgentMemoryStore({
+  agent,
+  requestContext,
+  errorMessage,
+}: {
+  agent: Agent<any, any, any, any>;
+  requestContext: RequestContext;
+  errorMessage: string;
+}): Promise<MemoryStorage> {
+  const agentMemoryStore = await getAgentMemoryStore({ agent, requestContext });
+  if (!agentMemoryStore) {
+    throw new HTTPException(400, { message: errorMessage });
+  }
+
+  return agentMemoryStore;
 }
 
 /**
@@ -469,7 +486,7 @@ async function resolveCompletedResponseState(
  * Stores the completed response when the request opted into memory-backed persistence.
  */
 async function storeCompletedResponse({
-  mastra,
+  agentMemoryStore,
   didStore,
   threadContext,
   responseId,
@@ -477,7 +494,7 @@ async function storeCompletedResponse({
   completedState,
   messages,
 }: {
-  mastra: Mastra | undefined;
+  agentMemoryStore: MemoryStorage | null;
   didStore: boolean;
   threadContext: ThreadExecutionContext | null;
   responseId: string;
@@ -490,7 +507,7 @@ async function storeCompletedResponse({
   }
 
   await persistResponseTurnRecord({
-    mastra,
+    memoryStore: agentMemoryStore,
     responseId,
     metadata: {
       ...metadata,
@@ -509,7 +526,7 @@ async function storeCompletedResponse({
  * Resolves the final response object and persists the stored response turn when needed.
  */
 async function finalizeResponse({
-  mastra,
+  agentMemoryStore,
   didStore,
   threadContext,
   result,
@@ -523,7 +540,7 @@ async function finalizeResponse({
   responseMetadata,
   fallbackText,
 }: {
-  mastra: Mastra | undefined;
+  agentMemoryStore: MemoryStorage | null;
   didStore: boolean;
   threadContext: ThreadExecutionContext | null;
   result: ResponseExecutionResult | ResponseStreamResult;
@@ -567,7 +584,7 @@ async function finalizeResponse({
   });
 
   await storeCompletedResponse({
-    mastra,
+    agentMemoryStore,
     didStore,
     threadContext,
     responseId,
@@ -593,27 +610,38 @@ async function prepareCreateResponseRequest({
   mastra: Mastra | undefined;
   requestContext: RequestContext;
 }): Promise<PreparedCreateResponseRequest> {
+  const executionInput = mapResponseInputToExecutionMessages(body.input) as AgentExecutionInput;
+  const agent = await resolveResponseAgent({
+    mastra,
+    agentId: body.agent_id,
+  });
+  const shouldStore = body.store ?? false;
+  const needsMemoryStore = shouldStore || Boolean(body.conversation_id) || Boolean(body.previous_response_id);
+  const agentMemoryStore = needsMemoryStore
+    ? await resolveAgentMemoryStore({
+        agent,
+        requestContext,
+        errorMessage: body.previous_response_id
+          ? 'previous_response_id requires the target agent to have memory storage configured'
+          : shouldStore
+            ? 'Stored responses require the target agent to have memory storage configured'
+            : 'conversation_id requires the target agent to have memory storage configured',
+      })
+    : null;
   const previousResponseTurnRecord = body.previous_response_id
-    ? await findResponseTurnRecord({ mastra, responseId: body.previous_response_id, requestContext })
+    ? await findResponseTurnRecord({ agent, responseId: body.previous_response_id, requestContext })
     : null;
 
   if (body.previous_response_id && !previousResponseTurnRecord) {
     throw new HTTPException(404, { message: `Stored response ${body.previous_response_id} was not found` });
   }
 
-  const executionInput = mapResponseInputToExecutionMessages(body.input) as AgentExecutionInput;
-  const agent = await resolveResponseAgent({
-    mastra,
-    agentId: body.agent_id,
-    previousResponseTurnRecord,
-  });
   const configuredTools = mapMastraToolsToResponseTools(
     (await Promise.resolve(agent.listTools({ requestContext }))) as Record<string, unknown>,
   );
 
   const responseId = createMessageId();
   const createdAt = Math.floor(Date.now() / 1000);
-  const shouldStore = body.store ?? false;
   const threadContext = await resolveThreadExecutionContext({
     agent,
     store: shouldStore,
@@ -632,6 +660,7 @@ async function prepareCreateResponseRequest({
 
   return {
     agent,
+    agentMemoryStore,
     configuredTools,
     createdAt,
     didStore,
@@ -657,22 +686,22 @@ async function prepareCreateResponseRequest({
  * the stored response-turn record when the stream finishes.
  */
 function createResponseEventStream({
+  agentMemoryStore,
   body,
   configuredTools,
   createdAt,
   didStore,
-  mastra,
   previousResponseTurnRecord,
   responseId,
   responseMetadata,
   streamResult,
   threadContext,
 }: {
+  agentMemoryStore: MemoryStorage | null;
   body: CreateResponseBody;
   configuredTools: ReturnType<typeof mapMastraToolsToResponseTools>;
   createdAt: number;
   didStore: boolean;
-  mastra: Mastra | undefined;
   previousResponseTurnRecord: ResponseTurnRecord | null;
   responseId: string;
   responseMetadata: Omit<
@@ -758,7 +787,7 @@ function createResponseEventStream({
         }
 
         const { completedState, response } = await finalizeResponse({
-          mastra,
+          agentMemoryStore,
           didStore,
           threadContext,
           result: streamResult,
@@ -829,6 +858,7 @@ export const CREATE_RESPONSE_ROUTE = createRoute({
     try {
       const {
         agent,
+        agentMemoryStore,
         configuredTools,
         createdAt,
         didStore,
@@ -853,7 +883,7 @@ export const CREATE_RESPONSE_ROUTE = createRoute({
         });
 
         const { response } = await finalizeResponse({
-          mastra,
+          agentMemoryStore,
           didStore,
           threadContext,
           result,
@@ -884,11 +914,11 @@ export const CREATE_RESPONSE_ROUTE = createRoute({
       });
 
       const stream = createResponseEventStream({
+        agentMemoryStore,
         body,
         configuredTools,
         createdAt,
         didStore,
-        mastra,
         previousResponseTurnRecord,
         responseId,
         responseMetadata,
@@ -915,15 +945,17 @@ export const GET_RESPONSE_ROUTE = createRoute({
   path: '/v1/responses/:responseId',
   responseType: 'json',
   pathParamSchema: responseIdPathParams,
+  queryParamSchema: responseAgentQuerySchema,
   responseSchema: responseObjectSchema,
   summary: 'Retrieve a stored response',
   description: 'Returns a previously stored response object',
   tags: ['Responses'],
   requiresAuth: true,
   requiresPermission: 'agents:read',
-  handler: async ({ mastra, requestContext, responseId }) => {
+  handler: async ({ mastra, requestContext, responseId, agent_id }) => {
     try {
-      const responseTurnRecord = await findResponseTurnRecord({ mastra, responseId, requestContext });
+      const agent = await resolveResponseAgent({ mastra, agentId: agent_id });
+      const responseTurnRecord = await findResponseTurnRecord({ agent, responseId, requestContext });
       if (!responseTurnRecord) {
         throw new HTTPException(404, { message: `Stored response ${responseId} was not found` });
       }
@@ -940,18 +972,22 @@ export const DELETE_RESPONSE_ROUTE = createRoute({
   path: '/v1/responses/:responseId',
   responseType: 'json',
   pathParamSchema: responseIdPathParams,
+  queryParamSchema: responseAgentQuerySchema,
   responseSchema: deleteResponseSchema,
   summary: 'Delete a stored response',
   description: 'Deletes a stored response so it can no longer be retrieved or chained',
   tags: ['Responses'],
   requiresAuth: true,
   requiresPermission: 'agents:delete',
-  handler: async ({ mastra, requestContext, responseId }) => {
+  handler: async ({ mastra, requestContext, responseId, agent_id }) => {
     try {
-      const deleted = await deleteResponseTurnRecord({ mastra, responseId, requestContext });
-      if (!deleted) {
+      const agent = await resolveResponseAgent({ mastra, agentId: agent_id });
+      const responseTurnRecord = await findResponseTurnRecord({ agent, responseId, requestContext });
+      if (!responseTurnRecord) {
         throw new HTTPException(404, { message: `Stored response ${responseId} was not found` });
       }
+
+      await deleteResponseTurnRecord({ responseTurnRecord });
 
       const response: DeleteResponse = {
         id: responseId,

--- a/packages/server/src/server/handlers/responses.ts
+++ b/packages/server/src/server/handlers/responses.ts
@@ -7,7 +7,6 @@ import { HTTPException } from '../http-exception';
 import {
   createResponseBodySchema,
   deleteResponseSchema,
-  responseAgentQuerySchema,
   responseIdPathParams,
   responseObjectSchema,
 } from '../schemas/responses';
@@ -31,6 +30,7 @@ import {
 import {
   deleteResponseTurnRecord,
   findResponseTurnRecord,
+  findResponseTurnRecordAcrossAgents,
   getAgentMemoryStore,
   persistResponseTurnRecord,
   resolveResponseTurnMessagesForStorage,
@@ -945,17 +945,15 @@ export const GET_RESPONSE_ROUTE = createRoute({
   path: '/v1/responses/:responseId',
   responseType: 'json',
   pathParamSchema: responseIdPathParams,
-  queryParamSchema: responseAgentQuerySchema,
   responseSchema: responseObjectSchema,
   summary: 'Retrieve a stored response',
   description: 'Returns a previously stored response object',
   tags: ['Responses'],
   requiresAuth: true,
   requiresPermission: 'agents:read',
-  handler: async ({ mastra, requestContext, responseId, agent_id }) => {
+  handler: async ({ mastra, requestContext, responseId }) => {
     try {
-      const agent = await resolveResponseAgent({ mastra, agentId: agent_id });
-      const responseTurnRecord = await findResponseTurnRecord({ agent, responseId, requestContext });
+      const responseTurnRecord = await findResponseTurnRecordAcrossAgents({ mastra, responseId, requestContext });
       if (!responseTurnRecord) {
         throw new HTTPException(404, { message: `Stored response ${responseId} was not found` });
       }
@@ -972,17 +970,15 @@ export const DELETE_RESPONSE_ROUTE = createRoute({
   path: '/v1/responses/:responseId',
   responseType: 'json',
   pathParamSchema: responseIdPathParams,
-  queryParamSchema: responseAgentQuerySchema,
   responseSchema: deleteResponseSchema,
   summary: 'Delete a stored response',
   description: 'Deletes a stored response so it can no longer be retrieved or chained',
   tags: ['Responses'],
   requiresAuth: true,
   requiresPermission: 'agents:delete',
-  handler: async ({ mastra, requestContext, responseId, agent_id }) => {
+  handler: async ({ mastra, requestContext, responseId }) => {
     try {
-      const agent = await resolveResponseAgent({ mastra, agentId: agent_id });
-      const responseTurnRecord = await findResponseTurnRecord({ agent, responseId, requestContext });
+      const responseTurnRecord = await findResponseTurnRecordAcrossAgents({ mastra, responseId, requestContext });
       if (!responseTurnRecord) {
         throw new HTTPException(404, { message: `Stored response ${responseId} was not found` });
       }

--- a/packages/server/src/server/schemas/conversations.ts
+++ b/packages/server/src/server/schemas/conversations.ts
@@ -6,6 +6,10 @@ export const conversationIdPathParams = z.object({
   conversationId: z.string().describe('Unique identifier for the conversation thread'),
 });
 
+export const conversationAgentQuerySchema = z.object({
+  agent_id: z.string().describe('Mastra agent ID that owns the conversation'),
+});
+
 export const createConversationBodySchema = z.object({
   agent_id: z.string().describe('Mastra agent ID used to create the conversation thread'),
   conversation_id: z.string().optional().describe('Optional conversation ID to use as the raw threadId'),

--- a/packages/server/src/server/schemas/conversations.ts
+++ b/packages/server/src/server/schemas/conversations.ts
@@ -6,10 +6,6 @@ export const conversationIdPathParams = z.object({
   conversationId: z.string().describe('Unique identifier for the conversation thread'),
 });
 
-export const conversationAgentQuerySchema = z.object({
-  agent_id: z.string().describe('Mastra agent ID that owns the conversation'),
-});
-
 export const createConversationBodySchema = z.object({
   agent_id: z.string().describe('Mastra agent ID used to create the conversation thread'),
   conversation_id: z.string().optional().describe('Optional conversation ID to use as the raw threadId'),

--- a/packages/server/src/server/schemas/responses.ts
+++ b/packages/server/src/server/schemas/responses.ts
@@ -4,6 +4,10 @@ export const responseIdPathParams = z.object({
   responseId: z.string().describe('Unique identifier for the stored response'),
 });
 
+export const responseAgentQuerySchema = z.object({
+  agent_id: z.string().describe('Mastra agent ID that owns the stored response'),
+});
+
 export const responseInputTextPartSchema = z.object({
   type: z.enum(['input_text', 'text', 'output_text']),
   text: z.string(),
@@ -54,12 +58,7 @@ export type ResponseTextConfig = z.infer<typeof responseTextSchema>;
 export const createResponseBodySchema = z
   .object({
     model: z.string().describe('Model identifier used to generate the response, such as openai/gpt-5'),
-    agent_id: z
-      .string()
-      .optional()
-      .describe(
-        'Mastra agent ID for the request. Required on initial requests; follow-up stored turns can omit it when using previous_response_id',
-      ),
+    agent_id: z.string().describe('Mastra agent ID for the request'),
     input: z.union([z.string(), z.array(responseInputMessageSchema)]),
     instructions: z.string().optional(),
     text: responseTextSchema
@@ -75,17 +74,7 @@ export const createResponseBodySchema = z
     store: z.boolean().optional().default(false),
     previous_response_id: z.string().optional(),
   })
-  .passthrough()
-  .superRefine((body, ctx) => {
-    if (!body.agent_id && !body.previous_response_id) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['agent_id'],
-        message:
-          'Responses requests require an agent_id, or a previous_response_id from a stored agent-backed response',
-      });
-    }
-  });
+  .passthrough();
 
 export type CreateResponseBody = z.infer<typeof createResponseBodySchema>;
 

--- a/packages/server/src/server/schemas/responses.ts
+++ b/packages/server/src/server/schemas/responses.ts
@@ -4,10 +4,6 @@ export const responseIdPathParams = z.object({
   responseId: z.string().describe('Unique identifier for the stored response'),
 });
 
-export const responseAgentQuerySchema = z.object({
-  agent_id: z.string().describe('Mastra agent ID that owns the stored response'),
-});
-
 export const responseInputTextPartSchema = z.object({
   type: z.enum(['input_text', 'text', 'output_text']),
   text: z.string(),

--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -657,10 +657,11 @@ export async function createDefaultTestContext(): Promise<AdapterTestContext> {
       });
     }
 
-    // Add test thread and messages to Mastra's storage for memory routes without agentId
-    // This is needed because when agentId is not provided, the handler falls back to storage directly
-    const memoryStore = await storage.getStore('memory');
-    if (memoryStore) {
+    const saveStoredResponseFixtures = async (memoryStore: Awaited<ReturnType<InMemoryStore['getStore']>>) => {
+      if (!memoryStore) {
+        return;
+      }
+
       await memoryStore.saveThread({
         thread: {
           id: 'test-thread',
@@ -711,7 +712,14 @@ export async function createDefaultTestContext(): Promise<AdapterTestContext> {
           },
         ],
       });
-    }
+    };
+
+    // Seed the root memory store for routes that resolve memory directly from Mastra storage.
+    await saveStoredResponseFixtures(await storage.getStore('memory'));
+
+    // Seed the agent memory store for Responses routes that now resolve stored responses
+    // through agent memory first and only inherit root storage via the agent-memory path.
+    await saveStoredResponseFixtures(await memory.storage.getStore('memory'));
   }
 
   return {


### PR DESCRIPTION
## Summary
- route stored Responses and Conversations data through the selected agent's memory store instead of assuming Mastra root memory storage
- require `agent_id` for response and conversation retrieval/deletion so lookup stays on a single resolved agent
- keep the normal agent-memory fallback behavior by using `agent.getMemory()` and its injected Mastra storage when needed

## Testing
- `pnpm --filter ./packages/server exec vitest run src/server/handlers/responses.test.ts src/server/handlers/conversations.test.ts`
- `pnpm --filter ./packages/server exec tsc --noEmit`
- `pnpm build:server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Responses and conversations now resolve and operate against the correct agent-configured memory store (improving isolation) and return 404/400 appropriately when records or storage are missing
  * Creation now requires an agent ID when storing or linking to prior responses

* **Tests**
  * Expanded tests covering cross-store scenarios: dedicated agent stores, root-inherited stores, missing storage, plus create/get/delete flows

* **Chores**
  * Added a changeset declaring a patch release
<!-- end of auto-generated comment: release notes by coderabbit.ai -->