### PR TITLE
docs: refine Responses and Conversations API wording

### DIFF
--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -54,8 +54,8 @@ The Mastra Client SDK exposes all resources served by the Mastra Server.
 - **[Tools](/reference/client-js/tools)**: Executed and managed tools.
 - **[Workflows](/reference/client-js/workflows)**: Trigger workflows and track their execution.
 - **[Vectors](/reference/client-js/vectors)**: Use vector embeddings for semantic search.
-- **[Responses](/reference/client-js/responses)**: Call the OpenAI Responses API through Mastra agents. This API is currently experimental.
-- **[Conversations](/reference/client-js/conversations)**: Work with OpenAI Responses API conversations and their stored item history. This API is currently experimental.
+- **[Responses](/reference/client-js/responses)**: Use Mastra Agents as a Responses API with an OpenAI-compatible, agent-backed interface. This API is currently experimental.
+- **[Conversations](/reference/client-js/conversations)**: Work with the stored conversation threads and item history behind Mastra Agents as a Responses API. This API is currently experimental.
 - **[Logs](/reference/client-js/logs)**: View logs and debug system behavior.
 - **[Telemetry](/reference/client-js/telemetry)**: View app performance and trace activity.
 

--- a/docs/src/content/en/docs/server/mastra-server.mdx
+++ b/docs/src/content/en/docs/server/mastra-server.mdx
@@ -72,7 +72,7 @@ The OpenAPI and Swagger endpoints are disabled in production by default. To enab
 
 ## OpenAI Responses API
 
-Mastra exposes OpenAI-compatible Responses and Conversations routes. These routes are agent-backed adapters over Mastra agents, memory, and storage, so requests run through the selected Mastra agent instead of acting as a raw provider proxy.
+Mastra exposes OpenAI-compatible Responses and Conversations routes that let you use Mastra Agents as a Responses API. These routes are agent-backed adapters over Mastra agents, memory, and storage, so requests run through the selected Mastra agent instead of acting as a raw provider proxy.
 
 These APIs are currently experimental.
 

--- a/docs/src/content/en/reference/client-js/conversations.mdx
+++ b/docs/src/content/en/reference/client-js/conversations.mdx
@@ -7,7 +7,7 @@ packages:
 
 # OpenAI Responses API Conversations
 
-The OpenAI Responses API Conversations surface provides methods to create, retrieve, delete, and inspect thread-backed conversations in Mastra.
+The OpenAI Responses API Conversations surface gives you the conversation-management side of Mastra Agents as a Responses API. It provides methods to create, retrieve, delete, and inspect thread-backed conversations in Mastra.
 
 This API follows up on the [OpenAI Responses API](/reference/client-js/responses). Stored Responses calls return `conversation_id`, and in Mastra that value is the raw memory `threadId`. Use `client.conversations` when you want to work with that thread directly.
 

--- a/docs/src/content/en/reference/client-js/responses.mdx
+++ b/docs/src/content/en/reference/client-js/responses.mdx
@@ -7,7 +7,7 @@ packages:
 
 # OpenAI Responses API
 
-The OpenAI Responses API provides methods to create, retrieve, stream, and delete OpenAI-compatible responses through Mastra agents.
+This OpenAI-compatible, agent-backed interface lets you use Mastra Agents as a Responses API. It provides methods to create, retrieve, stream, and delete responses through Mastra agents.
 
 These routes are agent-backed adapters over Mastra agents, memory, and storage. Use `agent_id` to select the Mastra agent that should handle the request. You can pass `model` to override the agent's configured model for a single request, or omit it to use the model already configured on the agent.
 


### PR DESCRIPTION
## Summary
- update Responses and Conversations docs to use "Mastra Agents as a Responses API" where it fits naturally
- keep the wording clear that the interface is OpenAI-compatible and agent-backed
- keep the detailed request and response contract in the dedicated reference pages

## Testing
- pnpm exec prettier --check docs/src/content/en/docs/server/mastra-client.mdx docs/src/content/en/docs/server/mastra-server.mdx docs/src/content/en/reference/client-js/responses.mdx docs/src/content/en/reference/client-js/conversations.mdx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Mastra Client SDK documentation to better explain how Responses and Conversations APIs leverage Mastra Agents with an OpenAI-compatible interface.
  * Updated OpenAI Responses API reference documentation across multiple guides for improved clarity on agent-backed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->