### PR TITLE
feat(release): add rolling hotfix workflow

### DIFF
--- a/.changeset/few-penguins-share.md
+++ b/.changeset/few-penguins-share.md
@@ -1,0 +1,5 @@
+---
+'@internal/changeset-cli': patch
+---
+
+Improved the hotfix release automation to validate merge-back safety before publishing and to handle hotfix PR input/tracking data more safely.

--- a/.changeset/swift-phones-marry.md
+++ b/.changeset/swift-phones-marry.md
@@ -1,5 +1,0 @@
----
-mastra: patch
----
-
-Added a rolling hotfix workflow that can build and publish release branches from the latest tagged release, then merge the published hotfix back into `main` automatically.

--- a/.changeset/swift-phones-marry.md
+++ b/.changeset/swift-phones-marry.md
@@ -1,0 +1,5 @@
+---
+mastra: patch
+---
+
+Added a rolling hotfix workflow that can build and publish release branches from the latest tagged release, then merge the published hotfix back into `main` automatically.

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,0 +1,85 @@
+name: Hotfix
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: 'Comma or whitespace separated merged PR numbers'
+        required: true
+        type: string
+      hotfix_branch:
+        description: 'Hotfix branch name'
+        required: false
+        type: string
+        default: hotfix/current
+      publish_now:
+        description: 'Publish immediately after updating the hotfix branch'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  hotfix:
+    if: ${{ github.repository == 'mastra-ai/mastra' }}
+    runs-on: ubuntu-latest
+    outputs:
+      hotfix_branch: ${{ steps.hotfix.outputs.hotfix_branch }}
+      hotfix_pr_url: ${{ steps.hotfix.outputs.hotfix_pr_url }}
+    steps:
+      - name: Initial checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Dane App Auth
+        id: app-auth
+        uses: ./.github/actions/app-auth
+        with:
+          app-id: ${{ vars.DANE_APP_ID }}
+          private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+
+      - name: Re-checkout with app token
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-auth.outputs.token }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Setup pnpm and Node.js
+        uses: ./.github/actions/setup-pnpm-node
+
+      - name: Build hotfix branch
+        id: hotfix
+        run: pnpm tsx packages/_changeset-cli/src/git/hotfix.ts "${{ github.event.inputs.pr_numbers }}" --branch "${{ github.event.inputs.hotfix_branch }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+          HUSKY: 0
+
+      - name: Summarize hotfix branch
+        run: |
+          echo "Hotfix branch: ${{ steps.hotfix.outputs.hotfix_branch }}"
+          echo "Tracking PR: ${{ steps.hotfix.outputs.hotfix_pr_url }}"
+
+      - name: Trigger hotfix publish
+        if: ${{ github.event.inputs.publish_now == 'true' }}
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.app-auth.outputs.token }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'npm-publish.yml',
+              ref: 'main',
+              inputs: {
+                publish_type: 'hotfix',
+                hotfix_branch: `${{ steps.hotfix.outputs.hotfix_branch }}`,
+                dry_run: 'false',
+              },
+            });

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -56,10 +56,12 @@ jobs:
 
       - name: Build hotfix branch
         id: hotfix
-        run: pnpm tsx packages/_changeset-cli/src/git/hotfix.ts "${{ github.event.inputs.pr_numbers }}" --branch "${{ github.event.inputs.hotfix_branch }}"
+        run: pnpm tsx packages/_changeset-cli/src/git/hotfix.ts "$PR_NUMBERS" --branch "$HOTFIX_BRANCH"
         env:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           HUSKY: 0
+          PR_NUMBERS: ${{ github.event.inputs.pr_numbers }}
+          HOTFIX_BRANCH: ${{ github.event.inputs.hotfix_branch }}
 
       - name: Summarize hotfix branch
         run: |
@@ -69,6 +71,8 @@ jobs:
       - name: Trigger hotfix publish
         if: ${{ github.event.inputs.publish_now == 'true' }}
         uses: actions/github-script@v8
+        env:
+          HOTFIX_BRANCH: ${{ steps.hotfix.outputs.hotfix_branch }}
         with:
           github-token: ${{ steps.app-auth.outputs.token }}
           script: |
@@ -79,7 +83,7 @@ jobs:
               ref: 'main',
               inputs: {
                 publish_type: 'hotfix',
-                hotfix_branch: `${{ steps.hotfix.outputs.hotfix_branch }}`,
+                hotfix_branch: process.env.HOTFIX_BRANCH,
                 dry_run: 'false',
               },
             });

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -245,6 +245,20 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Validate hotfix merge back into main
+        run: |
+          git fetch origin main
+          git checkout -B hotfix-merge-check origin/main
+          if git merge --no-commit --no-ff "origin/$HOTFIX_BRANCH"; then
+            git merge --abort
+          else
+            git merge --abort || true
+            echo "Hotfix branch cannot be merged cleanly back into origin/main."
+            exit 1
+          fi
+        env:
+          HOTFIX_BRANCH: ${{ github.event.inputs.hotfix_branch }}
+
       - name: Publish packages
         if: ${{ !inputs.dry_run }}
         run: pnpm publish -r --access public --no-git-checks
@@ -267,10 +281,11 @@ jobs:
         run: |
           git fetch origin main
           git checkout -B hotfix-main origin/main
-          git merge --no-ff -m 'chore: merge hotfix release into main' "origin/${{ github.event.inputs.hotfix_branch }}"
+          git merge --no-ff -m 'chore: merge hotfix release into main' "origin/$HOTFIX_BRANCH"
           git push origin HEAD:main
         env:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+          HOTFIX_BRANCH: ${{ github.event.inputs.hotfix_branch }}
 
       - name: Close tracking PR
         if: ${{ !inputs.dry_run }}
@@ -302,9 +317,10 @@ jobs:
 
       - name: Delete hotfix branch
         if: ${{ !inputs.dry_run }}
-        run: git push origin --delete "${{ github.event.inputs.hotfix_branch }}"
+        run: git push origin --delete "$HOTFIX_BRANCH"
         env:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+          HOTFIX_BRANCH: ${{ github.event.inputs.hotfix_branch }}
 
   enter_prerelease:
     needs: stable

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,9 +16,14 @@ on:
           - prerelease
           - stable
           - snapshot
+          - hotfix
         default: prerelease
       tag:
         description: 'npm tag (for snapshot: custom tag, otherwise auto-determined)'
+        required: false
+        type: string
+      hotfix_branch:
+        description: 'Hotfix branch to publish'
         required: false
         type: string
       dry_run:
@@ -202,6 +207,104 @@ jobs:
         run: |
           pnpm changeset-cli tag
           git push origin --tags
+
+  hotfix:
+    if: |
+      github.repository == 'mastra-ai/mastra' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.publish_type == 'hotfix'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Initial checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Dane App Auth
+        id: app-auth
+        uses: ./.github/actions/app-auth
+        with:
+          app-id: ${{ vars.DANE_APP_ID }}
+          private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+
+      - name: Re-checkout with app token
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-auth.outputs.token }}
+          ref: ${{ github.event.inputs.hotfix_branch }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Setup pnpm and Node.js
+        uses: ./.github/actions/setup-pnpm-node
+
+      - name: Ensure npm 11.5.1+ for OIDC
+        run: npm install -g npm@latest
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Publish packages
+        if: ${{ !inputs.dry_run }}
+        run: pnpm publish -r --access public --no-git-checks
+        env:
+          NPM_CONFIG_PROVENANCE: true
+          REQUIRE_PACKAGE_DOCS: 'true'
+
+      - name: Publish packages - dry run
+        if: ${{ inputs.dry_run }}
+        run: pnpm publish -r --dry-run --access public --no-git-checks
+
+      - name: Add tags
+        if: ${{ !inputs.dry_run }}
+        run: |
+          pnpm changeset-cli tag
+          git push origin --tags
+
+      - name: Merge hotfix branch into main
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git fetch origin main
+          git checkout -B hotfix-main origin/main
+          git merge --no-ff -m 'chore: merge hotfix release into main' "origin/${{ github.event.inputs.hotfix_branch }}"
+          git push origin HEAD:main
+        env:
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+
+      - name: Close tracking PR
+        if: ${{ !inputs.dry_run }}
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.app-auth.outputs.token }}
+          script: |
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:${context.payload.inputs.hotfix_branch}`,
+              base: 'main',
+              per_page: 100,
+            });
+
+            const trackingPr = pullRequests[0];
+            if (!trackingPr) {
+              core.info(`No open tracking PR found for ${context.payload.inputs.hotfix_branch}`);
+              return;
+            }
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: trackingPr.number,
+              state: 'closed',
+            });
+
+      - name: Delete hotfix branch
+        if: ${{ !inputs.dry_run }}
+        run: git push origin --delete "${{ github.event.inputs.hotfix_branch }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
 
   enter_prerelease:
     needs: stable

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   version:
     # Only run on the main repository, not on forks
-    if: ${{ github.repository == 'mastra-ai/mastra' }}
+    if: |
+      github.repository == 'mastra-ai/mastra' &&
+      !startsWith(github.event.head_commit.message, 'chore: merge hotfix release into main')
     runs-on: ubuntu-latest
     steps:
       - name: Initial checkout

--- a/packages/_changeset-cli/src/git/hotfix.ts
+++ b/packages/_changeset-cli/src/git/hotfix.ts
@@ -1,0 +1,328 @@
+/* eslint-disable no-console */
+import 'dotenv/config';
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import { Octokit } from '@octokit/rest';
+import { defineCommand, runMain } from 'citty';
+
+if (!process.env.GITHUB_TOKEN) {
+  throw new Error(`GITHUB_TOKEN environment variable must be set.`);
+}
+
+const owner = 'mastra-ai';
+const repo = 'mastra';
+const baseBranch = 'main';
+const defaultHotfixBranch = 'hotfix/current';
+const hotfixCommitMessage = 'chore: hotfix version packages';
+const hotfixPrTitle = 'chore: hotfix release';
+
+const octokit = new Octokit({
+  auth: `token ${process.env.GITHUB_TOKEN}`,
+});
+
+type HotfixPullRequest = {
+  number: number;
+  mergeCommitSha: string;
+  title: string;
+  url: string;
+};
+
+function run(
+  command: string,
+  args: string[],
+  options?: { stdio?: 'inherit' | 'pipe'; env?: NodeJS.ProcessEnv },
+): string {
+  return childProcess.execFileSync(command, args, {
+    encoding: 'utf-8',
+    stdio: options?.stdio === 'inherit' ? 'inherit' : 'pipe',
+    env: options?.env,
+  });
+}
+
+function tryRun(command: string, args: string[]): { success: boolean; output: string } {
+  try {
+    return {
+      success: true,
+      output: run(command, args),
+    };
+  } catch (error) {
+    if (error instanceof Error && 'stdout' in error) {
+      return {
+        success: false,
+        output: String(error.stdout ?? ''),
+      };
+    }
+
+    return {
+      success: false,
+      output: '',
+    };
+  }
+}
+
+function setGithubOutput(name: string, value: string) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+
+function normalizePrNumbers(prNumbers: string): number[] {
+  const normalized = prNumbers
+    .split(/[\s,]+/)
+    .map(value => value.trim())
+    .filter(Boolean)
+    .map(value => Number.parseInt(value, 10));
+
+  if (normalized.length === 0 || normalized.some(value => Number.isNaN(value))) {
+    throw new Error(`Please provide one or more valid pull request numbers.`);
+  }
+
+  return Array.from(new Set(normalized));
+}
+
+function remoteBranchExists(branch: string): boolean {
+  const result = tryRun('git', ['ls-remote', '--heads', 'origin', branch]);
+  return result.success && result.output.trim().length > 0;
+}
+
+function getLatestTag(): { name: string; commitSha: string } {
+  const tags = run('git', ['for-each-ref', '--sort=-creatordate', '--format=%(refname:short)', 'refs/tags'])
+    .split('\n')
+    .map(tag => tag.trim())
+    .filter(Boolean);
+
+  const latestTag = tags[0];
+
+  if (!latestTag) {
+    throw new Error(`No release tags found. Cannot determine hotfix base.`);
+  }
+
+  const commitSha = run('git', ['rev-list', '-n', '1', latestTag]).trim();
+
+  if (!commitSha) {
+    throw new Error(`Unable to resolve commit for tag ${latestTag}.`);
+  }
+
+  return { name: latestTag, commitSha };
+}
+
+function checkoutHotfixBranch(branch: string, latestTagCommitSha: string) {
+  run('git', ['fetch', 'origin', baseBranch, '--tags'], { stdio: 'inherit' });
+
+  if (remoteBranchExists(branch)) {
+    run('git', ['fetch', 'origin', branch], { stdio: 'inherit' });
+    run('git', ['checkout', '-B', branch, `origin/${branch}`], { stdio: 'inherit' });
+    return;
+  }
+
+  run('git', ['checkout', '-B', branch, latestTagCommitSha], { stdio: 'inherit' });
+}
+
+async function getMergedPullRequest(prNumber: number): Promise<HotfixPullRequest> {
+  const prDetails = await octokit.pulls.get({
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+
+  if (!prDetails.data.merged_at) {
+    throw new Error(`PR #${prNumber} is not merged.`);
+  }
+
+  if (!prDetails.data.merge_commit_sha) {
+    throw new Error(`PR #${prNumber} does not have a merge commit SHA.`);
+  }
+
+  return {
+    number: prNumber,
+    mergeCommitSha: prDetails.data.merge_commit_sha,
+    title: prDetails.data.title,
+    url: prDetails.data.html_url,
+  };
+}
+
+function hasCherryPickedMergeCommit(mergeCommitSha: string): boolean {
+  const result = tryRun('git', ['log', '--format=%B', '--grep', mergeCommitSha, 'HEAD']);
+  return result.success && result.output.includes(mergeCommitSha);
+}
+
+function cherryPickCommit(mergeCommitSha: string) {
+  const commitWithParents = run('git', ['rev-list', '--parents', '-n', '1', mergeCommitSha]).trim().split(/\s+/);
+  const parentCount = Math.max(commitWithParents.length - 1, 0);
+  const args = ['cherry-pick'];
+
+  if (parentCount > 1) {
+    args.push('-m', '1');
+  }
+
+  args.push('-x', mergeCommitSha);
+
+  run('git', args, { stdio: 'inherit' });
+}
+
+function commitVersionChanges(): boolean {
+  run('pnpm', ['changeset-cli', 'version'], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      HUSKY: '0',
+    },
+  });
+
+  const status = run('git', ['status', '--porcelain']).trim();
+  if (!status) {
+    return false;
+  }
+
+  run('git', ['add', '-A'], { stdio: 'inherit' });
+  run('git', ['commit', '-m', hotfixCommitMessage, '--no-verify'], { stdio: 'inherit' });
+
+  return true;
+}
+
+async function createOrUpdateHotfixPr(branch: string, pullRequests: HotfixPullRequest[]) {
+  const body = ['## Hotfix source PRs', '', ...pullRequests.map(pr => `- #${pr.number} - ${pr.title}`)].join('\n');
+
+  const existingPullRequests = await octokit.pulls.list({
+    owner,
+    repo,
+    state: 'open',
+    head: `${owner}:${branch}`,
+    base: baseBranch,
+    per_page: 100,
+  });
+
+  const existingPullRequest = existingPullRequests.data[0];
+
+  if (existingPullRequest) {
+    const updatedPullRequest = await octokit.pulls.update({
+      owner,
+      repo,
+      pull_number: existingPullRequest.number,
+      title: hotfixPrTitle,
+      body,
+    });
+
+    return updatedPullRequest.data;
+  }
+
+  const createdPullRequest = await octokit.pulls.create({
+    owner,
+    repo,
+    head: branch,
+    base: baseBranch,
+    title: hotfixPrTitle,
+    body,
+  });
+
+  return createdPullRequest.data;
+}
+
+async function commentOnSourcePullRequests(pullRequests: HotfixPullRequest[], branch: string, hotfixPrUrl: string) {
+  const body = `Added to hotfix branch \`${branch}\` and tracking PR ${hotfixPrUrl}`;
+
+  await Promise.all(
+    pullRequests.map(pr =>
+      octokit.issues.createComment({
+        owner,
+        repo,
+        issue_number: pr.number,
+        body,
+      }),
+    ),
+  );
+}
+
+async function hotfix({ prNumbers, branch }: { prNumbers: number[]; branch: string }) {
+  const latestTag = getLatestTag();
+  console.log(`Using latest release tag ${latestTag.name} (${latestTag.commitSha}) as hotfix base.`);
+
+  checkoutHotfixBranch(branch, latestTag.commitSha);
+
+  const mergedPullRequests = await Promise.all(prNumbers.map(prNumber => getMergedPullRequest(prNumber)));
+  const newlyCherryPickedPullRequests: HotfixPullRequest[] = [];
+
+  for (const pullRequest of mergedPullRequests) {
+    if (hasCherryPickedMergeCommit(pullRequest.mergeCommitSha)) {
+      console.log(`Skipping PR #${pullRequest.number}; merge commit already exists on ${branch}.`);
+      continue;
+    }
+
+    try {
+      cherryPickCommit(pullRequest.mergeCommitSha);
+      newlyCherryPickedPullRequests.push(pullRequest);
+    } catch (error) {
+      tryRun('git', ['cherry-pick', '--abort']);
+
+      await octokit.issues.createComment({
+        owner,
+        repo,
+        issue_number: pullRequest.number,
+        body: `Failed to add this PR to hotfix branch \`${branch}\`. Please resolve the cherry-pick manually.`,
+      });
+
+      throw error;
+    }
+  }
+
+  const createdVersionCommit = commitVersionChanges();
+
+  const hasBranchChanges = tryRun('git', ['rev-parse', '--verify', `origin/${branch}`]).success
+    ? run('git', ['rev-list', '--left-right', '--count', `origin/${branch}...HEAD`]).trim() !== '0\t0'
+    : run('git', ['rev-list', '--count', 'HEAD', `^${latestTag.commitSha}`]).trim() !== '0';
+
+  if (!hasBranchChanges && !createdVersionCommit) {
+    console.log(`No new hotfix changes to push for ${branch}.`);
+  } else {
+    run('git', ['push', '--set-upstream', 'origin', branch], { stdio: 'inherit' });
+  }
+
+  const hotfixPullRequest = await createOrUpdateHotfixPr(branch, mergedPullRequests);
+  await commentOnSourcePullRequests(mergedPullRequests, branch, hotfixPullRequest.html_url);
+
+  console.log(`Hotfix branch: ${branch}`);
+  console.log(`Hotfix PR: ${hotfixPullRequest.html_url}`);
+  setGithubOutput('hotfix_branch', branch);
+  setGithubOutput('hotfix_pr_url', hotfixPullRequest.html_url);
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'hotfix',
+    version: '1.0.0',
+    description: 'Create or update a rolling hotfix branch from merged pull requests.',
+  },
+  args: {
+    prs: {
+      type: 'positional',
+      description: 'Comma or whitespace separated pull request numbers',
+      required: true,
+    },
+    branch: {
+      type: 'string',
+      description: 'Hotfix branch name',
+      required: false,
+      default: defaultHotfixBranch,
+    },
+  },
+  setup() {
+    console.log('Starting hotfix script.');
+  },
+  async run({ args }) {
+    try {
+      await hotfix({
+        prNumbers: normalizePrNumbers(String(args.prs)),
+        branch: String(args.branch || defaultHotfixBranch),
+      });
+    } catch (error) {
+      console.error(error);
+      process.exit(1);
+    } finally {
+      console.log('Hotfix script completed.');
+    }
+  },
+});
+
+void runMain(main);

--- a/packages/_changeset-cli/src/git/hotfix.ts
+++ b/packages/_changeset-cli/src/git/hotfix.ts
@@ -27,6 +27,8 @@ type HotfixPullRequest = {
   url: string;
 };
 
+type TrackedHotfixPullRequest = Pick<HotfixPullRequest, 'number' | 'title'>;
+
 function run(
   command: string,
   args: string[],
@@ -69,13 +71,25 @@ function setGithubOutput(name: string, value: string) {
 }
 
 function normalizePrNumbers(prNumbers: string): number[] {
-  const normalized = prNumbers
+  const tokens = prNumbers
     .split(/[\s,]+/)
     .map(value => value.trim())
-    .filter(Boolean)
-    .map(value => Number.parseInt(value, 10));
+    .filter(Boolean);
 
-  if (normalized.length === 0 || normalized.some(value => Number.isNaN(value))) {
+  const normalized = tokens.map(value => {
+    if (!/^\d+$/.test(value)) {
+      throw new Error(`Please provide one or more valid pull request numbers.`);
+    }
+
+    const parsedValue = Number(value);
+    if (!Number.isSafeInteger(parsedValue) || parsedValue <= 0) {
+      throw new Error(`Please provide one or more valid pull request numbers.`);
+    }
+
+    return parsedValue;
+  });
+
+  if (normalized.length === 0) {
     throw new Error(`Please provide one or more valid pull request numbers.`);
   }
 
@@ -182,9 +196,37 @@ function commitVersionChanges(): boolean {
   return true;
 }
 
-async function createOrUpdateHotfixPr(branch: string, pullRequests: HotfixPullRequest[]) {
-  const body = ['## Hotfix source PRs', '', ...pullRequests.map(pr => `- #${pr.number} - ${pr.title}`)].join('\n');
+function parseTrackedPullRequests(body: string | null | undefined): TrackedHotfixPullRequest[] {
+  if (!body) {
+    return [];
+  }
 
+  const trackedPullRequests: TrackedHotfixPullRequest[] = [];
+
+  for (const line of body.split('\n')) {
+    const match = line.match(/^- #(\d+) - (.+)$/);
+
+    if (!match) {
+      continue;
+    }
+
+    const number = match[1];
+    const title = match[2];
+
+    if (!number || !title) {
+      continue;
+    }
+
+    trackedPullRequests.push({
+      number: Number(number),
+      title,
+    });
+  }
+
+  return trackedPullRequests;
+}
+
+async function createOrUpdateHotfixPr(branch: string, pullRequests: HotfixPullRequest[]) {
   const existingPullRequests = await octokit.pulls.list({
     owner,
     repo,
@@ -195,6 +237,19 @@ async function createOrUpdateHotfixPr(branch: string, pullRequests: HotfixPullRe
   });
 
   const existingPullRequest = existingPullRequests.data[0];
+  const trackedPullRequests = existingPullRequest ? parseTrackedPullRequests(existingPullRequest.body) : [];
+  const mergedPullRequests = [
+    ...trackedPullRequests,
+    ...pullRequests.map(pr => ({
+      number: pr.number,
+      title: pr.title,
+    })),
+  ].filter(
+    (pullRequest, index, array) => array.findIndex(existing => existing.number === pullRequest.number) === index,
+  );
+  const body = ['## Hotfix source PRs', '', ...mergedPullRequests.map(pr => `- #${pr.number} - ${pr.title}`)].join(
+    '\n',
+  );
 
   if (existingPullRequest) {
     const updatedPullRequest = await octokit.pulls.update({
@@ -279,8 +334,11 @@ async function hotfix({ prNumbers, branch }: { prNumbers: number[]; branch: stri
     run('git', ['push', '--set-upstream', 'origin', branch], { stdio: 'inherit' });
   }
 
-  const hotfixPullRequest = await createOrUpdateHotfixPr(branch, mergedPullRequests);
-  await commentOnSourcePullRequests(mergedPullRequests, branch, hotfixPullRequest.html_url);
+  const hotfixPullRequest = await createOrUpdateHotfixPr(branch, newlyCherryPickedPullRequests);
+
+  if (newlyCherryPickedPullRequests.length > 0) {
+    await commentOnSourcePullRequests(newlyCherryPickedPullRequests, branch, hotfixPullRequest.html_url);
+  }
 
   console.log(`Hotfix branch: ${branch}`);
   console.log(`Hotfix PR: ${hotfixPullRequest.html_url}`);


### PR DESCRIPTION
## Summary
- add a changeset-cli hotfix command that builds or updates a rolling hotfix branch from the latest release tag
- add a workflow_dispatch hotfix workflow and extend npm-publish with hotfix publish/merge-back automation
- skip the normal version-packages flow for the automated hotfix merge-back commit

## Testing
- pnpm exec prettier --check packages/_changeset-cli/src/git/hotfix.ts .github/workflows/hotfix.yml .github/workflows/npm-publish.yml .github/workflows/version-packages.yml
- pnpm --filter @internal/changeset-cli typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual Hotfix workflow to create and manage hotfix branches and tracking PRs.

* **Chores**
  * Integrated hotfix publishing into release workflows, including safe merge-back and optional publish flow.
  * Adjusted versioning workflow to skip running on automated hotfix-merge commits.

* **Documentation**
  * Added a changeset entry noting hotfix automation and merge-back safety improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->