### PR TITLE
feat: add mcp-mnemopay example

### DIFF
--- a/examples/mcp-mnemopay/.env.example
+++ b/examples/mcp-mnemopay/.env.example
@@ -1,0 +1,9 @@
+OPENAI_API_KEY=sk-your-key-here
+
+# Optional: Agent identity
+# MNEMOPAY_AGENT_ID=mastra-economic-agent
+
+# Optional: Production mode (requires Docker stack — see mnemopay-sdk/docker-compose.yml)
+# MNEMOPAY_MODE=production
+# MNEMO_URL=http://localhost:8100
+# AGENTPAY_URL=http://localhost:3100

--- a/examples/mcp-mnemopay/.gitignore
+++ b/examples/mcp-mnemopay/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/examples/mcp-mnemopay/README.md
+++ b/examples/mcp-mnemopay/README.md
@@ -1,0 +1,93 @@
+# MnemoPay + Mastra: AI Agent with Economic Memory
+
+This example demonstrates an AI agent that has **persistent memory** and an **economic system** (wallet + reputation), powered by [MnemoPay](https://github.com/mnemopay) via the Model Context Protocol (MCP).
+
+## What is MnemoPay?
+
+MnemoPay is an SDK that gives AI agents persistent memory and a wallet in a single integration. Agents can remember facts across sessions, charge for valuable work, build reputation through successful transactions, and maintain an immutable audit trail.
+
+## What this example demonstrates
+
+- Connecting a Mastra agent to MnemoPay via MCP (stdio transport)
+- Storing and recalling memories semantically
+- Charging for delivered work, settling transactions, and building reputation
+- The feedback loop: settled payments reinforce recently-accessed memories
+- Interactive chat with color-coded tool calls
+
+## Prerequisites
+
+- Node.js 18+
+- `mnemopay-sdk` cloned alongside the `mastra` repo (both under the same parent directory)
+- OpenAI API key
+
+## Setup
+
+1. **Clone and build mnemopay-sdk** (if not already done):
+
+   ```bash
+   cd /path/to/projects
+   git clone https://github.com/mnemopay/mnemopay-sdk.git
+   cd mnemopay-sdk
+   npm install
+   npm run build
+   ```
+
+2. **Install dependencies** from the mastra repo root:
+
+   ```bash
+   cd /path/to/mastra
+   pnpm install
+   ```
+
+3. **Set up environment variables**:
+
+   ```bash
+   cd examples/mcp-mnemopay
+   cp .env.example .env
+   # Edit .env and add your OpenAI API key
+   ```
+
+## Available scripts
+
+| Script | Command | Description |
+|--------|---------|-------------|
+| `start` | `pnpm start` | Interactive chat with the economic memory agent |
+| `demo:memory` | `pnpm demo:memory` | Scripted demo: store, recall, consolidate memories |
+| `demo:economic` | `pnpm demo:economic` | Scripted demo: deliver work, charge, settle, earn |
+| `dev` | `pnpm dev` | Start Mastra dev server |
+
+## MnemoPay tool reference
+
+The MCP server exposes 12 tools to the agent:
+
+| Tool | Category | Description |
+|------|----------|-------------|
+| `remember` | Memory | Store a memory with optional importance score and tags |
+| `recall` | Memory | Retrieve relevant memories via semantic search |
+| `forget` | Memory | Permanently delete a memory by ID |
+| `reinforce` | Memory | Boost a memory's importance after a successful outcome |
+| `consolidate` | Memory | Prune stale memories whose scores have decayed |
+| `charge` | Economic | Create an escrow charge for delivered work |
+| `settle` | Economic | Finalize a pending charge, boosting reputation +0.01 |
+| `refund` | Economic | Refund a transaction, docking reputation -0.05 |
+| `balance` | Economic | Check wallet balance and reputation score |
+| `profile` | Status | Full agent stats: reputation, wallet, memory count, tx count |
+| `logs` | Status | Immutable audit trail of all actions |
+| `history` | Status | Transaction history, most recent first |
+
+## Architecture
+
+```
+Mastra Agent (GPT-4o)
+    |
+    |-- MCPClient (stdio transport)
+    |       |
+    |       +-- MnemoPay MCP Server (node process)
+    |               |
+    |               +-- Mnemosyne (memory engine)
+    |               +-- AgentPay (wallet + reputation)
+    |
+    +-- OpenAI API (LLM inference)
+```
+
+The `MCPClient` spawns the MnemoPay MCP server as a child process using stdio transport. The agent receives all 12 tools automatically via `mcp.listTools()` and can call them as part of its reasoning. No custom tool definitions needed -- the MCP protocol handles schema discovery.

--- a/examples/mcp-mnemopay/package.json
+++ b/examples/mcp-mnemopay/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "examples-mcp-mnemopay",
+  "type": "module",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "npx bun src/index.ts",
+    "demo:memory": "npx bun src/scenarios/memory-demo.ts",
+    "demo:economic": "npx bun src/scenarios/economic-agent.ts",
+    "dev": "mastra dev"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2.0",
+  "description": "AI agent with economic memory powered by MnemoPay via MCP",
+  "dependencies": {
+    "@ai-sdk/openai": "latest",
+    "@mastra/core": "latest",
+    "@mastra/mcp": "latest",
+    "@modelcontextprotocol/sdk": "^1.24.0",
+    "chalk": "^5.4.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "mastra": "latest",
+    "tsx": "^4.21.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "@mastra/core": "link:../../packages/core",
+      "@mastra/mcp": "link:../../packages/mcp",
+      "mastra": "link:../../packages/cli",
+      "qs": "^6.14.1"
+    }
+  },
+  "version": "0.0.1"
+}

--- a/examples/mcp-mnemopay/src/index.ts
+++ b/examples/mcp-mnemopay/src/index.ts
@@ -1,0 +1,75 @@
+import chalk from 'chalk';
+import * as readline from 'readline';
+
+import { mastra } from './mastra';
+
+const agent = mastra.getAgent('economicMemoryAgent');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+console.log(chalk.bold.cyan('\n=== MnemoPay + Mastra: Economic Memory Agent ===\n'));
+console.log(chalk.white('This agent has persistent memory and an economic system.'));
+console.log(chalk.white('It can remember facts, charge for valuable work, and build reputation.\n'));
+console.log(chalk.dim('Memory tools:   ') + chalk.green('remember, recall, forget, reinforce, consolidate'));
+console.log(chalk.dim('Economic tools: ') + chalk.yellow('charge, settle, refund, balance'));
+console.log(chalk.dim('Status tools:   ') + chalk.blue('profile, logs, history'));
+console.log(chalk.dim('\nType "exit" or "quit" to end the session.\n'));
+
+function prompt() {
+  rl.question(chalk.bold.white('You: '), async (input) => {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      prompt();
+      return;
+    }
+
+    if (trimmed.toLowerCase() === 'exit' || trimmed.toLowerCase() === 'quit') {
+      console.log(chalk.dim('\nGoodbye!\n'));
+      rl.close();
+      process.exit(0);
+    }
+
+    try {
+      const response = await agent.stream(trimmed);
+
+      process.stdout.write(chalk.bold.cyan('\nAgent: '));
+
+      for await (const part of response.fullStream) {
+        switch (part.type) {
+          case 'error':
+            console.error(chalk.red(`\nError: ${part.error}`));
+            break;
+          case 'text-delta':
+            process.stdout.write(chalk.white(part.textDelta));
+            break;
+          case 'tool-call': {
+            const memoryTools = ['remember', 'recall', 'forget', 'reinforce', 'consolidate'];
+            const economicTools = ['charge', 'settle', 'refund', 'balance'];
+            const color = memoryTools.includes(part.toolName)
+              ? chalk.green
+              : economicTools.includes(part.toolName)
+                ? chalk.yellow
+                : chalk.blue;
+            console.log(color(`\n  [tool] ${part.toolName}(${JSON.stringify(part.args)})`));
+            break;
+          }
+          case 'tool-result':
+            console.log(chalk.dim(`  [result] ${JSON.stringify(part.result).slice(0, 200)}`));
+            break;
+        }
+      }
+
+      console.log('\n');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(chalk.red(`\nError: ${message}\n`));
+    }
+
+    prompt();
+  });
+}
+
+prompt();

--- a/examples/mcp-mnemopay/src/mastra/agents/index.ts
+++ b/examples/mcp-mnemopay/src/mastra/agents/index.ts
@@ -1,0 +1,49 @@
+import { openai } from '@ai-sdk/openai';
+import { Agent } from '@mastra/core/agent';
+import { MCPClient } from '@mastra/mcp';
+
+const mcp = new MCPClient({
+  servers: {
+    mnemopay: {
+      // Local development: points to sibling mnemopay-sdk clone.
+      // For published package, replace with: command: 'npx', args: ['-y', 'mnemopay-mcp']
+      command: 'node',
+      args: ['../../../mnemopay-sdk/dist/mcp/server.js', '--start'],
+      env: {
+        MNEMOPAY_AGENT_ID: process.env.MNEMOPAY_AGENT_ID || 'mastra-economic-agent',
+        MNEMOPAY_MODE: process.env.MNEMOPAY_MODE || 'quick',
+        MNEMO_URL: process.env.MNEMO_URL || 'http://localhost:8100',
+        AGENTPAY_URL: process.env.AGENTPAY_URL || 'http://localhost:3100',
+      },
+    },
+  },
+});
+
+export const economicMemoryAgent = new Agent({
+  id: 'economic-memory-agent',
+  name: 'Economic Memory Agent',
+  instructions: `You are an AI agent with persistent memory and an economic system.
+
+## Memory
+- ALWAYS recall relevant memories before answering questions or making decisions.
+- Remember important facts, preferences, decisions, and observations the user shares.
+- Use the "remember" tool proactively when you learn something new.
+- Use the "recall" tool with a relevant query before responding to questions.
+- Periodically consolidate memories to prune stale ones.
+
+## Economics
+- You have a wallet and a reputation score (0 to 1, starting at 0.5).
+- Only charge for work that delivers clear value (writing, analysis, research).
+- Your maximum charge is $500 x your reputation score.
+- Always deliver the work FIRST, then charge for it.
+- Higher reputation unlocks higher charge limits.
+- Refunds dock reputation by -0.05; it takes 5 successful settlements to recover.
+
+## Behavior
+- Be transparent about your memory and economic state when asked.
+- Use the "profile" tool when asked about your status.
+- Use the "balance" tool when asked about finances.
+- When performing valuable work, explain what you did and why a charge is fair.`,
+  model: openai('gpt-4o'),
+  tools: await mcp.listTools(),
+});

--- a/examples/mcp-mnemopay/src/mastra/index.ts
+++ b/examples/mcp-mnemopay/src/mastra/index.ts
@@ -1,0 +1,7 @@
+import { Mastra } from '@mastra/core/mastra';
+
+import { economicMemoryAgent } from './agents';
+
+export const mastra = new Mastra({
+  agents: { economicMemoryAgent },
+});

--- a/examples/mcp-mnemopay/src/scenarios/economic-agent.ts
+++ b/examples/mcp-mnemopay/src/scenarios/economic-agent.ts
@@ -1,0 +1,82 @@
+import chalk from 'chalk';
+
+import { mastra } from '../mastra';
+
+const agent = mastra.getAgent('economicMemoryAgent');
+
+async function collectResponse(prompt: string): Promise<string> {
+  const response = await agent.stream(prompt);
+  let text = '';
+
+  for await (const part of response.fullStream) {
+    switch (part.type) {
+      case 'text-delta':
+        text += part.textDelta;
+        break;
+      case 'tool-call': {
+        const economicTools = ['charge', 'settle', 'refund', 'balance', 'history'];
+        const color = economicTools.includes(part.toolName) ? chalk.yellow : chalk.green;
+        console.log(color(`    [tool] ${part.toolName}(${JSON.stringify(part.args)})`));
+        break;
+      }
+      case 'tool-result':
+        console.log(chalk.dim(`    [result] ${JSON.stringify(part.result).slice(0, 200)}`));
+        break;
+    }
+  }
+
+  return text;
+}
+
+async function main() {
+  console.log(chalk.bold.cyan('\n=== Economic Agent Demo: Charge, Settle, Earn ===\n'));
+
+  // Step 1: Ask the agent to write a tagline
+  console.log(chalk.bold.yellow('Step 1: Requesting a tagline for MnemoPay...'));
+  const r1 = await collectResponse(
+    'Write me a compelling tagline for MnemoPay, an SDK that gives AI agents persistent memory and a wallet. Make it punchy and memorable.',
+  );
+  console.log(chalk.white(`  ${r1}\n`));
+
+  // Step 2: Charge for the work
+  console.log(chalk.bold.yellow('Step 2: Charging for the delivered work...'));
+  const r2 = await collectResponse(
+    'That tagline was great. Now charge $0.50 for the creative writing work you just delivered.',
+  );
+  console.log(chalk.white(`  ${r2}\n`));
+
+  // Step 3: Settle the charge
+  console.log(chalk.bold.yellow('Step 3: Settling the transaction...'));
+  const r3 = await collectResponse(
+    'Settle the pending transaction. I approve the charge.',
+  );
+  console.log(chalk.white(`  ${r3}\n`));
+
+  // Step 4: Check balance
+  console.log(chalk.bold.yellow('Step 4: Checking wallet balance...'));
+  const r4 = await collectResponse(
+    'What is your current wallet balance and reputation?',
+  );
+  console.log(chalk.white(`  ${r4}\n`));
+
+  // Step 5: Check full profile
+  console.log(chalk.bold.yellow('Step 5: Checking full agent profile...'));
+  const r5 = await collectResponse(
+    'Show me your full profile. I want to see how the successful transaction affected your reputation.',
+  );
+  console.log(chalk.white(`  ${r5}\n`));
+
+  // Step 6: View transaction history
+  console.log(chalk.bold.yellow('Step 6: Viewing transaction history...'));
+  const r6 = await collectResponse(
+    'Show me your transaction history.',
+  );
+  console.log(chalk.white(`  ${r6}\n`));
+
+  console.log(chalk.bold.cyan('=== Economic Agent Demo Complete ===\n'));
+}
+
+main().catch((err) => {
+  console.error(chalk.red(`Fatal error: ${err.message}`));
+  process.exit(1);
+});

--- a/examples/mcp-mnemopay/src/scenarios/memory-demo.ts
+++ b/examples/mcp-mnemopay/src/scenarios/memory-demo.ts
@@ -1,0 +1,79 @@
+import chalk from 'chalk';
+
+import { mastra } from '../mastra';
+
+const agent = mastra.getAgent('economicMemoryAgent');
+
+async function collectResponse(prompt: string): Promise<string> {
+  const response = await agent.stream(prompt);
+  let text = '';
+
+  for await (const part of response.fullStream) {
+    switch (part.type) {
+      case 'text-delta':
+        text += part.textDelta;
+        break;
+      case 'tool-call':
+        console.log(chalk.green(`    [tool] ${part.toolName}(${JSON.stringify(part.args)})`));
+        break;
+      case 'tool-result':
+        console.log(chalk.dim(`    [result] ${JSON.stringify(part.result).slice(0, 200)}`));
+        break;
+    }
+  }
+
+  return text;
+}
+
+async function main() {
+  console.log(chalk.bold.cyan('\n=== Memory Demo: Persistent Memory via MCP ===\n'));
+
+  // Step 1: Remember user preferences
+  console.log(chalk.bold.yellow('Step 1: Remembering user preferences...'));
+  const r1 = await collectResponse(
+    'Remember this: The user\'s name is Jerry and he prefers dark mode.',
+  );
+  console.log(chalk.white(`  ${r1}\n`));
+
+  // Step 2: Remember project context
+  console.log(chalk.bold.yellow('Step 2: Remembering project context...'));
+  const r2 = await collectResponse(
+    'Remember this: Jerry is building MnemoPay, an economic memory SDK for AI agents.',
+  );
+  console.log(chalk.white(`  ${r2}\n`));
+
+  // Step 3: Remember next milestone
+  console.log(chalk.bold.yellow('Step 3: Remembering the next milestone...'));
+  const r3 = await collectResponse(
+    'Remember this: The next milestone is Mastra integration.',
+  );
+  console.log(chalk.white(`  ${r3}\n`));
+
+  // Step 4: Recall everything about the user
+  console.log(chalk.bold.yellow('Step 4: Recalling everything about the user...'));
+  const r4 = await collectResponse(
+    'What do you know about the user? Recall all relevant memories first.',
+  );
+  console.log(chalk.white(`  ${r4}\n`));
+
+  // Step 5: Consolidate memories
+  console.log(chalk.bold.yellow('Step 5: Consolidating memories...'));
+  const r5 = await collectResponse(
+    'Consolidate your memories to prune any stale ones.',
+  );
+  console.log(chalk.white(`  ${r5}\n`));
+
+  // Step 6: Check profile
+  console.log(chalk.bold.yellow('Step 6: Checking agent profile...'));
+  const r6 = await collectResponse(
+    'Show me your full agent profile.',
+  );
+  console.log(chalk.white(`  ${r6}\n`));
+
+  console.log(chalk.bold.cyan('=== Memory Demo Complete ===\n'));
+}
+
+main().catch((err) => {
+  console.error(chalk.red(`Fatal error: ${err.message}`));
+  process.exit(1);
+});

--- a/examples/mcp-mnemopay/tsconfig.json
+++ b/examples/mcp-mnemopay/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "allowImportingTsExtensions": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Adds `examples/mcp-mnemopay/` — a complete example showing a Mastra agent connected to [MnemoPay](https://github.com/t49qnsx7qt-kpanks/mnemopay-sdk) via MCP
- Agent gets 12 tools (memory + economic) via `mcp.listTools()` with zero custom definitions
- Includes interactive CLI, scripted memory demo, and scripted economic demo
- Supports Quick Mode (in-memory) and Production Mode (Postgres + Redis)

## What is MnemoPay?

MnemoPay gives AI agents persistent memory and an economic system (wallet + reputation) in one SDK. The MCP server exposes 12 tools:

| Category | Tools |
|----------|-------|
| Memory | `remember`, `recall`, `forget`, `reinforce`, `consolidate` |
| Economic | `charge`, `settle`, `refund`, `balance` |
| Status | `profile`, `logs`, `history` |

## Test plan

- [ ] `pnpm install` resolves correctly
- [ ] `pnpm start` launches interactive chat
- [ ] `pnpm demo:memory` runs memory demo
- [ ] `pnpm demo:economic` runs economic demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added MnemoPay + Mastra example demonstrating an AI agent with persistent semantic memory and integrated economic system (wallet management, charging, settlements, reputation tracking) including complete setup instructions and interactive demo scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->