### PR TITLE
fix(ai-sdk): prevent OOM from cumulative data-tool-agent payloads

### DIFF
--- a/.changeset/light-garlics-occur.md
+++ b/.changeset/light-garlics-occur.md
@@ -2,4 +2,4 @@
 '@mastra/ai-sdk': patch
 ---
 
-Fixed out-of-memory crash during supervisor/nested agent streaming. The data-tool-agent stream events were growing exponentially due to recursive step nesting and cumulative tool data not being reset between steps. Resolves #14932.
+Fixed nested-agent streaming payload growth that could exhaust memory and crash Node in multi-step runs. Resolves #14932.

--- a/.changeset/light-garlics-occur.md
+++ b/.changeset/light-garlics-occur.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed out-of-memory crash during supervisor/nested agent streaming. The data-tool-agent stream events were growing exponentially due to recursive step nesting and cumulative tool data not being reset between steps. Resolves #14932.

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformAgent } from '../transformers';
+
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/14932
+ *
+ * transformAgent() emits `data-tool-agent` with the full cumulative buffered
+ * state on every change. Two compounding problems cause explosive growth:
+ *
+ * 1. `step-finish` creates stepResult via `{ ...stepRun }`, which copies
+ *    stepRun.steps (all previous step results). Each stepResult therefore
+ *    contains a nested copy of all prior stepResults — recursively.
+ *
+ * 2. toolCalls, toolResults, and text are never reset between steps, so
+ *    step N's snapshot contains ALL tool data from steps 0..N.
+ *
+ * Together these cause data-tool-agent payloads to grow super-quadratically,
+ * driving Node into OOM on any multi-step nested agent run.
+ */
+describe('transformAgent cumulative growth (issue #14932)', () => {
+  function makePayload(type: string, runId: string, payload: any) {
+    return { type, runId, payload } as any;
+  }
+
+  function simulateMultiStepAgentRun(numSteps: number) {
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'test-run';
+
+    // Start the agent run
+    transformAgent(makePayload('start', runId, { id: 'agent-1' }), bufferedSteps);
+
+    const emissions: any[] = [];
+
+    for (let step = 0; step < numSteps; step++) {
+      // Each step: emit a text delta + a tool call + a tool result
+      transformAgent(
+        makePayload('text-delta', runId, { text: `Step ${step} response text. `.repeat(10) }),
+        bufferedSteps,
+      );
+
+      transformAgent(
+        makePayload('tool-call', runId, {
+          type: 'tool-call',
+          toolCallId: `call-${step}`,
+          toolName: `tool_${step}`,
+          args: { input: `data for step ${step}`.repeat(20) },
+          payload: { dynamic: false },
+        }),
+        bufferedSteps,
+      );
+
+      transformAgent(
+        makePayload('tool-result', runId, {
+          type: 'tool-result',
+          toolCallId: `call-${step}`,
+          toolName: `tool_${step}`,
+          result: { output: `Result from step ${step}. `.repeat(50) },
+          payload: { dynamic: false },
+        }),
+        bufferedSteps,
+      );
+
+      // Emit step-finish
+      const result = transformAgent(
+        makePayload('step-finish', runId, {
+          id: `step-${step}`,
+          stepResult: { reason: 'tool-calls', warnings: [] },
+          output: { usage: { inputTokens: 100, outputTokens: 100, totalTokens: 200 } },
+          metadata: { timestamp: new Date(), modelId: 'test-model' },
+        }),
+        bufferedSteps,
+      );
+
+      emissions.push(result);
+    }
+
+    return { emissions, bufferedSteps, runId };
+  }
+
+  it('step-finish stepResult should NOT contain nested copies of prior steps', () => {
+    const { bufferedSteps, runId } = simulateMultiStepAgentRun(5);
+    const finalState = bufferedSteps.get(runId);
+
+    // After 5 steps, finalState.steps should have 5 entries
+    expect(finalState.steps).toHaveLength(5);
+
+    // Each stepResult should NOT contain a nested `steps` array with copies
+    // of all prior steps. If it does, we have the recursive nesting bug.
+    for (let i = 0; i < finalState.steps.length; i++) {
+      const stepResult = finalState.steps[i];
+      // stepResult should not carry a `steps` property (or it should be empty/undefined)
+      // because stepResults represent a single step, not the full run history.
+      const nestedSteps = stepResult.steps;
+      expect(
+        nestedSteps === undefined || nestedSteps.length === 0,
+        `stepResult[${i}] contains ${nestedSteps?.length ?? 0} nested steps — ` +
+          `this is the recursive nesting bug from issue #14932. ` +
+          `stepResult should not embed prior step history.`,
+      ).toBe(true);
+    }
+  });
+
+  it('stepResult toolCalls/toolResults should only contain data from that step, not cumulative', () => {
+    const { bufferedSteps, runId } = simulateMultiStepAgentRun(5);
+    const finalState = bufferedSteps.get(runId);
+
+    for (let i = 0; i < finalState.steps.length; i++) {
+      const stepResult = finalState.steps[i];
+
+      // Each step added exactly 1 tool call and 1 tool result.
+      // If the step contains more, cumulative state is leaking across steps.
+      expect(
+        stepResult.toolCalls.length,
+        `stepResult[${i}] has ${stepResult.toolCalls.length} toolCalls but should have 1. ` +
+          `Cumulative toolCalls are leaking across steps (issue #14932).`,
+      ).toBe(1);
+
+      expect(
+        stepResult.toolResults.length,
+        `stepResult[${i}] has ${stepResult.toolResults.length} toolResults but should have 1. ` +
+          `Cumulative toolResults are leaking across steps (issue #14932).`,
+      ).toBe(1);
+    }
+  });
+
+  it('top-level text remains cumulative across steps for consumer compatibility', () => {
+    const { bufferedSteps, runId } = simulateMultiStepAgentRun(3);
+    const finalState = bufferedSteps.get(runId);
+
+    // text is intentionally kept cumulative at the top level because
+    // documented consumers read `data.text` (e.g. ai-sdk-ui guide).
+    // It should contain text from all 3 steps.
+    for (let i = 0; i < 3; i++) {
+      expect(finalState.text).toContain(`Step ${i} response text.`);
+    }
+  });
+
+  it('data-tool-agent payload size should grow linearly with steps, not super-quadratically', () => {
+    const { emissions } = simulateMultiStepAgentRun(10);
+
+    const sizes = emissions.map((e: any) => JSON.stringify(e).length);
+
+    // With N steps:
+    // - Linear growth: size_N ≈ size_1 * N (each step adds a fixed amount)
+    // - Quadratic+ growth: size_N ≈ size_1 * N^2 or worse
+    //
+    // We check that the last emission is at most 3x the size of a linear
+    // extrapolation from the first emission. The actual buggy behavior
+    // produces ratios of 50x-100x+ at 10 steps.
+    const firstSize = sizes[0]!;
+    const lastSize = sizes[sizes.length - 1]!;
+    const numSteps = sizes.length;
+
+    // Linear expectation: lastSize ≈ firstSize * numSteps
+    const linearExpected = firstSize * numSteps;
+    const ratio = lastSize / linearExpected;
+
+    expect(
+      ratio,
+      `data-tool-agent payload at step ${numSteps} is ${lastSize} bytes, ` +
+        `but linear growth predicts ~${linearExpected} bytes (ratio: ${ratio.toFixed(1)}x). ` +
+        `This super-linear growth causes OOM in supervisor agent streaming (issue #14932).`,
+    ).toBeLessThan(3);
+  });
+});

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
@@ -6,17 +6,16 @@ import { transformAgent } from '../transformers';
  * Regression test for https://github.com/mastra-ai/mastra/issues/14932
  *
  * transformAgent() emits `data-tool-agent` with the full cumulative buffered
- * state on every change. Two compounding problems cause explosive growth:
+ * state on every change. Three compounding problems caused explosive growth:
  *
- * 1. `step-finish` creates stepResult via `{ ...stepRun }`, which copies
- *    stepRun.steps (all previous step results). Each stepResult therefore
- *    contains a nested copy of all prior stepResults — recursively.
+ * 1. `step-finish` spread the full `stepRun` (including `steps[]`) into each
+ *    stepResult, creating recursive nesting.
  *
- * 2. toolCalls, toolResults, and text are never reset between steps, so
- *    step N's snapshot contains ALL tool data from steps 0..N.
+ * 2. toolCalls, toolResults, sources, and files accumulated across steps
+ *    without being reset, so step N contained ALL data from steps 0..N.
  *
- * Together these cause data-tool-agent payloads to grow super-quadratically,
- * driving Node into OOM on any multi-step nested agent run.
+ * 3. text and reasoning were copied cumulatively into each step result,
+ *    making steps[i].text contain text from steps 0..i (O(N²) storage).
  */
 describe('transformAgent cumulative growth (issue #14932)', () => {
   function makePayload(type: string, runId: string, payload: any) {
@@ -27,7 +26,6 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
     const bufferedSteps = new Map<string, any>();
     const runId = 'test-run';
 
-    // Start the agent run
     transformAgent(makePayload('start', runId, { id: 'agent-1' }), bufferedSteps);
 
     const emissions: any[] = [];
@@ -37,7 +35,6 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
     }
 
     for (let step = 0; step < numSteps; step++) {
-      // Each step: text delta + reasoning + source + file + tool call + tool result
       collect(
         transformAgent(
           makePayload('text-delta', runId, { text: `Step ${step} response text. `.repeat(10) }),
@@ -89,7 +86,6 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
         ),
       );
 
-      // Emit step-finish
       collect(
         transformAgent(
           makePayload('step-finish', runId, {
@@ -106,142 +102,73 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
     return { emissions, bufferedSteps, runId };
   }
 
-  it('step-finish stepResult should NOT contain nested copies of prior steps', () => {
+  it('stepResults should not contain nested copies of prior steps', () => {
     const { bufferedSteps, runId } = simulateMultiStepAgentRun(5);
     const finalState = bufferedSteps.get(runId);
 
-    // After 5 steps, finalState.steps should have 5 entries
     expect(finalState.steps).toHaveLength(5);
 
-    // Each stepResult should NOT contain a nested `steps` array with copies
-    // of all prior steps. If it does, we have the recursive nesting bug.
     for (let i = 0; i < finalState.steps.length; i++) {
-      const stepResult = finalState.steps[i];
-      // stepResult should not carry a `steps` property (or it should be empty/undefined)
-      // because stepResults represent a single step, not the full run history.
-      const nestedSteps = stepResult.steps;
+      const nestedSteps = finalState.steps[i].steps;
       expect(
         nestedSteps === undefined || nestedSteps.length === 0,
-        `stepResult[${i}] contains ${nestedSteps?.length ?? 0} nested steps — ` +
-          `this is the recursive nesting bug from issue #14932. ` +
-          `stepResult should not embed prior step history.`,
+        `stepResult[${i}] contains ${nestedSteps?.length ?? 0} nested steps — recursive nesting bug`,
       ).toBe(true);
     }
   });
 
-  it('stepResult toolCalls/toolResults should only contain data from that step, not cumulative', () => {
+  it('per-step fields (toolCalls, toolResults, sources, files) should not accumulate across steps', () => {
     const { bufferedSteps, runId } = simulateMultiStepAgentRun(5);
     const finalState = bufferedSteps.get(runId);
 
     for (let i = 0; i < finalState.steps.length; i++) {
-      const stepResult = finalState.steps[i];
+      const s = finalState.steps[i];
 
-      // Each step added exactly 1 tool call and 1 tool result.
-      // If the step contains more, cumulative state is leaking across steps.
-      expect(
-        stepResult.toolCalls.length,
-        `stepResult[${i}] has ${stepResult.toolCalls.length} toolCalls but should have 1. ` +
-          `Cumulative toolCalls are leaking across steps (issue #14932).`,
-      ).toBe(1);
+      // Each step emitted exactly 1 of each — more means cumulative leakage
+      expect(s.toolCalls, `stepResult[${i}].toolCalls`).toHaveLength(1);
+      expect(s.toolResults, `stepResult[${i}].toolResults`).toHaveLength(1);
+      expect(s.sources, `stepResult[${i}].sources`).toHaveLength(1);
+      expect(s.files, `stepResult[${i}].files`).toHaveLength(1);
 
-      expect(
-        stepResult.toolResults.length,
-        `stepResult[${i}] has ${stepResult.toolResults.length} toolResults but should have 1. ` +
-          `Cumulative toolResults are leaking across steps (issue #14932).`,
-      ).toBe(1);
+      // Verify correct step ownership
+      expect(s.sources[0].id).toBe(`src-${i}`);
+      expect(s.files[0].name).toBe(`file-${i}.txt`);
     }
   });
 
-  it('top-level text remains cumulative across steps for consumer compatibility', () => {
-    const { bufferedSteps, runId } = simulateMultiStepAgentRun(3);
-    const finalState = bufferedSteps.get(runId);
-
-    // text is intentionally kept cumulative at the top level because
-    // documented consumers read `data.text` (e.g. ai-sdk-ui guide).
-    // It should contain text from all 3 steps.
-    for (let i = 0; i < 3; i++) {
-      expect(finalState.text).toContain(`Step ${i} response text.`);
-    }
-  });
-
-  it('stepResult sources and files should only contain data from that step, not cumulative', () => {
+  it('per-step text and reasoning should be isolated; top-level should stay cumulative', () => {
     const { bufferedSteps, runId } = simulateMultiStepAgentRun(5);
     const finalState = bufferedSteps.get(runId);
 
-    for (let i = 0; i < finalState.steps.length; i++) {
-      const stepResult = finalState.steps[i];
-
-      // Each step added exactly 1 source and 1 file.
-      expect(
-        stepResult.sources.length,
-        `stepResult[${i}] has ${stepResult.sources.length} sources but should have 1.`,
-      ).toBe(1);
-      expect(stepResult.sources[0].id).toBe(`src-${i}`);
-
-      expect(stepResult.files.length, `stepResult[${i}] has ${stepResult.files.length} files but should have 1.`).toBe(
-        1,
-      );
-      expect(stepResult.files[0].name).toBe(`file-${i}.txt`);
-    }
-  });
-
-  it('stepResult reasoning should be per-step while top-level reasoning stays cumulative', () => {
-    const { bufferedSteps, runId } = simulateMultiStepAgentRun(5);
-    const finalState = bufferedSteps.get(runId);
-
-    // Top-level reasoning should contain entries from all steps
-    expect(finalState.reasoning).toHaveLength(5);
+    // Top-level text and reasoning must be cumulative (consumers read data.text)
     for (let i = 0; i < 5; i++) {
+      expect(finalState.text).toContain(`Step ${i} response text.`);
       expect(finalState.reasoning[i]).toBe(`Reasoning for step ${i}. `);
     }
 
-    // Each stepResult should contain only its own reasoning
+    // Each stepResult should contain only its own text and reasoning
     for (let i = 0; i < finalState.steps.length; i++) {
-      const stepResult = finalState.steps[i];
-      expect(
-        stepResult.reasoning,
-        `stepResult[${i}].reasoning should have 1 entry, got ${stepResult.reasoning.length}`,
-      ).toHaveLength(1);
-      expect(stepResult.reasoning[0]).toBe(`Reasoning for step ${i}. `);
-      expect(stepResult.reasoningText).toBe(`Reasoning for step ${i}. `);
-    }
-  });
+      const s = finalState.steps[i];
 
-  it("stepResult text and reasoning should only contain that step's content, not cumulative", () => {
-    const { bufferedSteps, runId } = simulateMultiStepAgentRun(5);
-    const finalState = bufferedSteps.get(runId);
-
-    for (let i = 0; i < finalState.steps.length; i++) {
-      const stepResult = finalState.steps[i];
-
-      // Each step's text should only contain its own content
-      expect(stepResult.text, `stepResult[${i}].text should contain "Step ${i}" content`).toContain(
-        `Step ${i} response text.`,
-      );
-
-      // And should NOT contain text from other steps
+      expect(s.text).toContain(`Step ${i} response text.`);
       for (let j = 0; j < finalState.steps.length; j++) {
         if (j !== i) {
-          expect(
-            stepResult.text,
-            `stepResult[${i}].text should not contain Step ${j} text — ` +
-              `cumulative text is leaking into per-step results`,
-          ).not.toContain(`Step ${j} response text.`);
+          expect(s.text, `stepResult[${i}].text leaks Step ${j} text`).not.toContain(`Step ${j} response text.`);
         }
       }
+
+      expect(s.reasoning, `stepResult[${i}].reasoning`).toHaveLength(1);
+      expect(s.reasoning[0]).toBe(`Reasoning for step ${i}. `);
+      expect(s.reasoningText).toBe(`Reasoning for step ${i}. `);
     }
   });
 
-  it('structured object should be preserved after step-finish, not reset to null', () => {
+  it('structured object should be preserved after step-finish', () => {
     const bufferedSteps = new Map<string, any>();
     const runId = 'test-run';
 
     transformAgent(makePayload('start', runId, { id: 'agent-1' }), bufferedSteps);
-
-    // Emit a structured object result
     transformAgent({ type: 'object-result', runId, object: { key: 'value', nested: { a: 1 } } } as any, bufferedSteps);
-
-    // Finish the step
     transformAgent(
       makePayload('step-finish', runId, {
         id: 'step-0',
@@ -252,51 +179,25 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
       bufferedSteps,
     );
 
-    const state = bufferedSteps.get(runId);
-    // object is last-write-wins and should NOT be cleared on step-finish
-    expect(state.object).toEqual({ key: 'value', nested: { a: 1 } });
+    expect(bufferedSteps.get(runId).object).toEqual({ key: 'value', nested: { a: 1 } });
   });
 
-  it('data-tool-agent payload size should grow linearly with steps, not super-quadratically', () => {
+  it('payload size should grow linearly, not super-quadratically', () => {
     const { emissions } = simulateMultiStepAgentRun(10);
-
     const sizes = emissions.map((e: any) => JSON.stringify(e).length);
 
-    // With N steps:
-    // - Linear growth: size_N ≈ size_1 * N (each step adds a fixed amount)
-    // - Quadratic+ growth: size_N ≈ size_1 * N^2 or worse
-    //
-    // We check that the last emission is at most 3x the size of a linear
-    // extrapolation from the first emission. The actual buggy behavior
-    // produces ratios of 50x-100x+ at 10 steps.
-    const firstSize = sizes[0]!;
-    const lastSize = sizes[sizes.length - 1]!;
-    const numSteps = sizes.length;
+    // Linear: lastSize ≈ firstSize * N. The original bug produced 50-100x+ ratios.
+    const ratio = sizes[sizes.length - 1]! / (sizes[0]! * sizes.length);
 
-    // Linear expectation: lastSize ≈ firstSize * numSteps
-    const linearExpected = firstSize * numSteps;
-    const ratio = lastSize / linearExpected;
-
-    expect(
-      ratio,
-      `data-tool-agent payload at step ${numSteps} is ${lastSize} bytes, ` +
-        `but linear growth predicts ~${linearExpected} bytes (ratio: ${ratio.toFixed(1)}x). ` +
-        `This super-linear growth causes OOM in supervisor agent streaming (issue #14932).`,
-    ).toBeLessThan(3);
+    expect(ratio, `Payload growth ratio ${ratio.toFixed(1)}x exceeds linear expectation`).toBeLessThan(3);
   });
 
-  it('emitted data-tool-agent payloads should not contain internal tracking fields', () => {
+  it('emitted payloads should not contain internal tracking fields', () => {
     const { emissions } = simulateMultiStepAgentRun(3);
 
     for (const emission of emissions) {
-      const data = emission.data;
-      expect(data).not.toHaveProperty('_textOffset');
-      expect(data).not.toHaveProperty('_reasoningOffset');
-
-      // Also verify they don't appear in the serialized JSON sent over the wire
-      const serialized = JSON.stringify(emission);
-      expect(serialized).not.toContain('_textOffset');
-      expect(serialized).not.toContain('_reasoningOffset');
+      expect(emission.data).not.toHaveProperty('_textOffset');
+      expect(emission.data).not.toHaveProperty('_reasoningOffset');
     }
   });
 });

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
@@ -213,4 +213,19 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
         `This super-linear growth causes OOM in supervisor agent streaming (issue #14932).`,
     ).toBeLessThan(3);
   });
+
+  it('emitted data-tool-agent payloads should not contain internal tracking fields', () => {
+    const { emissions } = simulateMultiStepAgentRun(3);
+
+    for (const emission of emissions) {
+      const data = emission.data;
+      expect(data).not.toHaveProperty('_textOffset');
+      expect(data).not.toHaveProperty('_reasoningOffset');
+
+      // Also verify they don't appear in the serialized JSON sent over the wire
+      const serialized = JSON.stringify(emission);
+      expect(serialized).not.toContain('_textOffset');
+      expect(serialized).not.toContain('_reasoningOffset');
+    }
+  });
 });

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
@@ -32,47 +32,75 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
 
     const emissions: any[] = [];
 
+    function collect(result: any) {
+      if (result) emissions.push(result);
+    }
+
     for (let step = 0; step < numSteps; step++) {
-      // Each step: emit a text delta + a tool call + a tool result
-      transformAgent(
-        makePayload('text-delta', runId, { text: `Step ${step} response text. `.repeat(10) }),
-        bufferedSteps,
+      // Each step: text delta + reasoning + source + file + tool call + tool result
+      collect(
+        transformAgent(
+          makePayload('text-delta', runId, { text: `Step ${step} response text. `.repeat(10) }),
+          bufferedSteps,
+        ),
       );
 
-      transformAgent(
-        makePayload('tool-call', runId, {
-          type: 'tool-call',
-          toolCallId: `call-${step}`,
-          toolName: `tool_${step}`,
-          args: { input: `data for step ${step}`.repeat(20) },
-          payload: { dynamic: false },
-        }),
-        bufferedSteps,
+      collect(
+        transformAgent(makePayload('reasoning-delta', runId, { text: `Reasoning for step ${step}. ` }), bufferedSteps),
       );
 
-      transformAgent(
-        makePayload('tool-result', runId, {
-          type: 'tool-result',
-          toolCallId: `call-${step}`,
-          toolName: `tool_${step}`,
-          result: { output: `Result from step ${step}. `.repeat(50) },
-          payload: { dynamic: false },
-        }),
-        bufferedSteps,
+      collect(
+        transformAgent(
+          makePayload('source', runId, { id: `src-${step}`, url: `https://example.com/${step}` }),
+          bufferedSteps,
+        ),
+      );
+
+      collect(
+        transformAgent(
+          makePayload('file', runId, { name: `file-${step}.txt`, content: `content-${step}` }),
+          bufferedSteps,
+        ),
+      );
+
+      collect(
+        transformAgent(
+          makePayload('tool-call', runId, {
+            type: 'tool-call',
+            toolCallId: `call-${step}`,
+            toolName: `tool_${step}`,
+            args: { input: `data for step ${step}`.repeat(20) },
+            payload: { dynamic: false },
+          }),
+          bufferedSteps,
+        ),
+      );
+
+      collect(
+        transformAgent(
+          makePayload('tool-result', runId, {
+            type: 'tool-result',
+            toolCallId: `call-${step}`,
+            toolName: `tool_${step}`,
+            result: { output: `Result from step ${step}. `.repeat(50) },
+            payload: { dynamic: false },
+          }),
+          bufferedSteps,
+        ),
       );
 
       // Emit step-finish
-      const result = transformAgent(
-        makePayload('step-finish', runId, {
-          id: `step-${step}`,
-          stepResult: { reason: 'tool-calls', warnings: [] },
-          output: { usage: { inputTokens: 100, outputTokens: 100, totalTokens: 200 } },
-          metadata: { timestamp: new Date(), modelId: 'test-model' },
-        }),
-        bufferedSteps,
+      collect(
+        transformAgent(
+          makePayload('step-finish', runId, {
+            id: `step-${step}`,
+            stepResult: { reason: 'tool-calls', warnings: [] },
+            output: { usage: { inputTokens: 100, outputTokens: 100, totalTokens: 200 } },
+            metadata: { timestamp: new Date(), modelId: 'test-model' },
+          }),
+          bufferedSteps,
+        ),
       );
-
-      emissions.push(result);
     }
 
     return { emissions, bufferedSteps, runId };
@@ -133,6 +161,49 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
     // It should contain text from all 3 steps.
     for (let i = 0; i < 3; i++) {
       expect(finalState.text).toContain(`Step ${i} response text.`);
+    }
+  });
+
+  it('stepResult sources and files should only contain data from that step, not cumulative', () => {
+    const { bufferedSteps, runId } = simulateMultiStepAgentRun(5);
+    const finalState = bufferedSteps.get(runId);
+
+    for (let i = 0; i < finalState.steps.length; i++) {
+      const stepResult = finalState.steps[i];
+
+      // Each step added exactly 1 source and 1 file.
+      expect(
+        stepResult.sources.length,
+        `stepResult[${i}] has ${stepResult.sources.length} sources but should have 1.`,
+      ).toBe(1);
+      expect(stepResult.sources[0].id).toBe(`src-${i}`);
+
+      expect(stepResult.files.length, `stepResult[${i}] has ${stepResult.files.length} files but should have 1.`).toBe(
+        1,
+      );
+      expect(stepResult.files[0].name).toBe(`file-${i}.txt`);
+    }
+  });
+
+  it('stepResult reasoning should be per-step while top-level reasoning stays cumulative', () => {
+    const { bufferedSteps, runId } = simulateMultiStepAgentRun(5);
+    const finalState = bufferedSteps.get(runId);
+
+    // Top-level reasoning should contain entries from all steps
+    expect(finalState.reasoning).toHaveLength(5);
+    for (let i = 0; i < 5; i++) {
+      expect(finalState.reasoning[i]).toBe(`Reasoning for step ${i}. `);
+    }
+
+    // Each stepResult should contain only its own reasoning
+    for (let i = 0; i < finalState.steps.length; i++) {
+      const stepResult = finalState.steps[i];
+      expect(
+        stepResult.reasoning,
+        `stepResult[${i}].reasoning should have 1 entry, got ${stepResult.reasoning.length}`,
+      ).toHaveLength(1);
+      expect(stepResult.reasoning[0]).toBe(`Reasoning for step ${i}. `);
+      expect(stepResult.reasoningText).toBe(`Reasoning for step ${i}. `);
     }
   });
 

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-cumulative-growth.test.ts
@@ -136,6 +136,56 @@ describe('transformAgent cumulative growth (issue #14932)', () => {
     }
   });
 
+  it("stepResult text and reasoning should only contain that step's content, not cumulative", () => {
+    const { bufferedSteps, runId } = simulateMultiStepAgentRun(5);
+    const finalState = bufferedSteps.get(runId);
+
+    for (let i = 0; i < finalState.steps.length; i++) {
+      const stepResult = finalState.steps[i];
+
+      // Each step's text should only contain its own content
+      expect(stepResult.text, `stepResult[${i}].text should contain "Step ${i}" content`).toContain(
+        `Step ${i} response text.`,
+      );
+
+      // And should NOT contain text from other steps
+      for (let j = 0; j < finalState.steps.length; j++) {
+        if (j !== i) {
+          expect(
+            stepResult.text,
+            `stepResult[${i}].text should not contain Step ${j} text — ` +
+              `cumulative text is leaking into per-step results`,
+          ).not.toContain(`Step ${j} response text.`);
+        }
+      }
+    }
+  });
+
+  it('structured object should be preserved after step-finish, not reset to null', () => {
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'test-run';
+
+    transformAgent(makePayload('start', runId, { id: 'agent-1' }), bufferedSteps);
+
+    // Emit a structured object result
+    transformAgent({ type: 'object-result', runId, object: { key: 'value', nested: { a: 1 } } } as any, bufferedSteps);
+
+    // Finish the step
+    transformAgent(
+      makePayload('step-finish', runId, {
+        id: 'step-0',
+        stepResult: { reason: 'tool-calls', warnings: [] },
+        output: { usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 } },
+        metadata: { timestamp: new Date(), modelId: 'test-model' },
+      }),
+      bufferedSteps,
+    );
+
+    const state = bufferedSteps.get(runId);
+    // object is last-write-wins and should NOT be cleared on step-finish
+    expect(state.object).toEqual({ key: 'value', nested: { a: 1 } });
+  });
+
   it('data-tool-agent payload size should grow linearly with steps, not super-quadratically', () => {
     const { emissions } = simulateMultiStepAgentRun(10);
 

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -515,13 +515,24 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
       break;
     case 'step-finish': {
       const stepRun = ensureAgentRunState(bufferedSteps, payload.runId!);
-      // Exclude `steps` from the stepResult to avoid recursive nesting where
-      // each stepResult embeds copies of all prior stepResults (issue #14932).
-      const { steps: _steps, ...stepRunWithoutSteps } = stepRun;
+      // Exclude `steps` and internal offset trackers from the stepResult to
+      // avoid recursive nesting where each stepResult embeds copies of all
+      // prior stepResults (issue #14932).
+      const { steps: _steps, _textOffset, _reasoningOffset, ...stepRunWithoutSteps } = stepRun;
+
+      // Derive per-step text and reasoning using tracked offsets so each
+      // stepResult only contains its own content, not the cumulative run state.
+      const textOffset: number = _textOffset || 0;
+      const reasoningOffset: number = _reasoningOffset || 0;
+      const stepText = stepRun.text.slice(textOffset);
+      const stepReasoning: string[] = stepRun.reasoning.slice(reasoningOffset);
+
       const stepResult = {
         ...stepRunWithoutSteps,
+        text: stepText,
+        reasoning: stepReasoning,
         stepType: stepRun.steps.length === 0 ? 'initial' : 'tool-result',
-        reasoningText: stepRun.reasoning.join(''),
+        reasoningText: stepReasoning.join(''),
         staticToolCalls: stepRun.toolCalls.filter(
           (part: any) => part.type === 'tool-call' && part.payload?.dynamic === false,
         ),
@@ -548,18 +559,21 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
 
       // Reset per-step structural fields so the next step starts fresh instead
       // of carrying forward all prior toolCalls/toolResults (issue #14932).
-      // Text and reasoning are kept cumulative — they are lightweight O(n) strings
-      // that documented consumers read from the top-level `data.text` field.
+      // Text and reasoning stay cumulative at the run level (consumers read
+      // `data.text`); offsets track where the next step's content begins.
+      // `object` is last-write-wins, so it is NOT reset — clearing it would
+      // lose structured output from the completed step.
       bufferedSteps.set(payload.runId!, {
         ...stepRun,
         sources: [],
         files: [],
         toolCalls: [],
         toolResults: [],
-        object: null,
         usage: payload.payload.output.usage,
         warnings: payload.payload.stepResult.warnings || [],
         steps: [...stepRun.steps, stepResult],
+        _textOffset: stepRun.text.length,
+        _reasoningOffset: stepRun.reasoning.length,
       });
       hasChanged = true;
       break;

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -515,8 +515,11 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
       break;
     case 'step-finish': {
       const stepRun = ensureAgentRunState(bufferedSteps, payload.runId!);
+      // Exclude `steps` from the stepResult to avoid recursive nesting where
+      // each stepResult embeds copies of all prior stepResults (issue #14932).
+      const { steps: _steps, ...stepRunWithoutSteps } = stepRun;
       const stepResult = {
-        ...stepRun,
+        ...stepRunWithoutSteps,
         stepType: stepRun.steps.length === 0 ? 'initial' : 'tool-result',
         reasoningText: stepRun.reasoning.join(''),
         staticToolCalls: stepRun.toolCalls.filter(
@@ -543,8 +546,17 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
         },
       };
 
+      // Reset per-step structural fields so the next step starts fresh instead
+      // of carrying forward all prior toolCalls/toolResults (issue #14932).
+      // Text and reasoning are kept cumulative — they are lightweight O(n) strings
+      // that documented consumers read from the top-level `data.text` field.
       bufferedSteps.set(payload.runId!, {
         ...stepRun,
+        sources: [],
+        files: [],
+        toolCalls: [],
+        toolResults: [],
+        object: null,
         usage: payload.payload.output.usage,
         warnings: payload.payload.stepResult.warnings || [],
         steps: [...stepRun.steps, stepResult],

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -583,10 +583,12 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
   }
 
   if (hasChanged) {
+    // Strip internal offset trackers so they don't leak over the wire.
+    const { _textOffset: _to, _reasoningOffset: _ro, ...data } = bufferedSteps.get(payload.runId!)!;
     return {
       type: 'data-tool-agent',
       id: payload.runId!,
-      data: bufferedSteps.get(payload.runId!),
+      data,
     } satisfies AgentDataPart;
   }
   return null;


### PR DESCRIPTION
## Description

Fixes exponential growth of `data-tool-agent` stream events during supervisor/nested agent streaming that caused Node OOM crashes. Three compounding bugs in `transformAgent()`:

1. `step-finish` spread the full `stepRun` (including `steps[]`) into each `stepResult`, creating recursive nesting where each step embedded copies of all prior steps.
2. `toolCalls`, `toolResults`, `sources`, and `files` accumulated across steps without being reset, so step N contained all data from steps 0..N.
3. `text` and `reasoning` were copied cumulatively into each step result, making `steps[i].text` contain all text from steps 0..i instead of only step i's content. This caused O(N²) storage in the steps array and inaccurate per-step history.

Together these caused ~121x payload blowup at 10 steps and Node OOM at ~13 steps.

### Fix

- Exclude `steps` from stepResult spread to prevent recursive nesting
- Reset per-step structural fields (`toolCalls`, `toolResults`, `sources`, `files`) after each `step-finish`
- Track `_textOffset` / `_reasoningOffset` to slice per-step text and reasoning into step results while keeping run-level `data.text` and `data.reasoning` cumulative for documented consumers
- Preserve `object` after step-finish (it's last-write-wins, not accumulative — resetting it discarded valid structured output)
- Strip internal offset trackers from emitted payloads so they don't leak over the wire

## Related Issue(s)

Fixes #14932

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan

- [x] Step results do not contain nested copies of prior steps
- [x] Per-step `toolCalls`, `toolResults`, `sources`, `files` contain only that step's data
- [x] Per-step `text` and `reasoning` contain only that step's content
- [x] Top-level `text` and `reasoning` remain cumulative across steps
- [x] Structured `object` preserved after step-finish
- [x] `_textOffset` / `_reasoningOffset` never appear in emitted payloads
- [x] Payload size grows linearly with steps (ratio < 3x), not super-quadratically
- [x] All intermediate frames (text-delta, reasoning-delta, source, file, tool-call, tool-result) captured in size assertions

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable — N/A, internal streaming fix)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an out-of-memory crash in Node occurring during nested agent streaming in multi-step runs. This was caused by exponentially growing stream events from recursive step nesting and cumulative tool data not being properly cleared between steps.

* **Tests**
  * Added regression tests for multi-step agent streaming to ensure proper memory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->