### PR TITLE
fix(core): propagate stream pipeline errors in WorkflowRunOutput

### DIFF
--- a/packages/core/src/stream/RunOutput.test.ts
+++ b/packages/core/src/stream/RunOutput.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { ReadableStream } from 'node:stream/web';
+import { WorkflowRunOutput } from './RunOutput';
+import type { WorkflowStreamEvent } from './types';
+import { ChunkFrom } from './types';
+
+function createErrorStream(error: Error): ReadableStream<WorkflowStreamEvent> {
+  return new ReadableStream<WorkflowStreamEvent>({
+    start(controller) {
+      controller.enqueue({
+        type: 'workflow-step-output',
+        runId: 'test-run',
+        from: ChunkFrom.WORKFLOW,
+        payload: {
+          stepId: 'step-1',
+          output: { type: 'text-delta', payload: { textDelta: 'partial' } },
+        },
+      } as WorkflowStreamEvent);
+
+      controller.error(error);
+    },
+  });
+}
+
+function createNormalStream(): ReadableStream<WorkflowStreamEvent> {
+  return new ReadableStream<WorkflowStreamEvent>({
+    start(controller) {
+      controller.enqueue({
+        type: 'workflow-step-output',
+        runId: 'test-run',
+        from: ChunkFrom.WORKFLOW,
+        payload: {
+          stepId: 'step-1',
+          output: { type: 'text-delta', payload: { textDelta: 'hello' } },
+        },
+      } as WorkflowStreamEvent);
+
+      controller.close();
+    },
+  });
+}
+
+describe('WorkflowRunOutput', () => {
+  describe('stream pipeline error handling', () => {
+    it('should set status to failed when stream errors', async () => {
+      const streamError = new Error('S3 connection dropped');
+      const output = new WorkflowRunOutput({
+        runId: 'test-run',
+        workflowId: 'test-workflow',
+        stream: createErrorStream(streamError),
+      });
+
+      // Wait for the stream pipeline to process
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(output.status).toBe('failed');
+    });
+
+    it('should reject the result promise when stream errors', async () => {
+      const streamError = new Error('network failure');
+      const output = new WorkflowRunOutput({
+        runId: 'test-run',
+        workflowId: 'test-workflow',
+        stream: createErrorStream(streamError),
+      });
+
+      await expect(output.result).rejects.toThrow('network failure');
+    });
+
+    it('should emit workflow-finish with failed status when stream errors', async () => {
+      const streamError = new Error('stream broke');
+      const output = new WorkflowRunOutput({
+        runId: 'test-run',
+        workflowId: 'test-workflow',
+        stream: createErrorStream(streamError),
+      });
+
+      const chunks: WorkflowStreamEvent[] = [];
+      const reader = output.fullStream.getReader();
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+        }
+      } catch {
+        // stream may error
+      }
+
+      const finishChunk = chunks.find(c => c.type === 'workflow-finish');
+      expect(finishChunk).toBeDefined();
+      expect(finishChunk!.payload).toMatchObject({
+        workflowStatus: 'failed',
+        metadata: {
+          errorMessage: 'stream broke',
+        },
+      });
+    });
+
+    it('should resolve usage even when stream errors', async () => {
+      const streamError = new Error('oops');
+      const output = new WorkflowRunOutput({
+        runId: 'test-run',
+        workflowId: 'test-workflow',
+        stream: createErrorStream(streamError),
+      });
+
+      const usage = await output.usage;
+      expect(usage).toMatchObject({
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      });
+    });
+
+    it('should complete normally when stream succeeds', async () => {
+      const output = new WorkflowRunOutput({
+        runId: 'test-run',
+        workflowId: 'test-workflow',
+        stream: createNormalStream(),
+      });
+
+      // Wait for stream to finish
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(output.status).toBe('success');
+    });
+
+    it('should handle resume stream errors the same way', async () => {
+      const output = new WorkflowRunOutput({
+        runId: 'test-run',
+        workflowId: 'test-workflow',
+        stream: createNormalStream(),
+      });
+
+      // Wait for normal stream to finish
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(output.status).toBe('success');
+
+      // Resume with an erroring stream
+      const resumeError = new Error('resume connection lost');
+      output.resume(createErrorStream(resumeError));
+
+      await expect(output.result).rejects.toThrow('resume connection lost');
+      expect(output.status).toBe('failed');
+    });
+  });
+});

--- a/packages/core/src/stream/RunOutput.ts
+++ b/packages/core/src/stream/RunOutput.ts
@@ -149,9 +149,40 @@ export class WorkflowRunOutput<
         }),
       )
       .catch(reason => {
-        // eslint-disable-next-line no-console
-        console.log(' something went wrong', reason);
+        self.#handlePipelineError(reason);
       });
+  }
+
+  #handlePipelineError(reason: unknown) {
+    this.#streamError = reason instanceof Error ? reason : new Error(String(reason));
+    this.#status = 'failed';
+
+    this.#emitter.emit('chunk', {
+      type: 'workflow-finish',
+      runId: this.runId,
+      from: ChunkFrom.WORKFLOW,
+      payload: {
+        workflowStatus: this.#status,
+        metadata: {
+          error: this.#streamError,
+          errorMessage: this.#streamError.message,
+        },
+        output: {
+          usage: this.#usageCount,
+        },
+      },
+    });
+
+    this.#delayedPromises.usage.resolve(this.#usageCount);
+
+    Object.entries(this.#delayedPromises).forEach(([, promise]) => {
+      if (promise.status.type === 'pending') {
+        promise.reject(this.#streamError!);
+      }
+    });
+
+    this.#streamFinished = true;
+    this.#emitter.emit('finish');
   }
 
   #getDelayedPromise<T>(promise: DelayedPromise<T>): Promise<T> {
@@ -313,8 +344,7 @@ export class WorkflowRunOutput<
         }),
       )
       .catch(reason => {
-        // eslint-disable-next-line no-console
-        console.log(' something went wrong', reason);
+        self.#handlePipelineError(reason);
       });
   }
 


### PR DESCRIPTION
## Description

Was debugging a workflow that kept getting stuck in 'running' status after a transient stream failure and traced it to `WorkflowRunOutput`.

Both the constructor and `resume()` pipe the incoming `ReadableStream` into a `WritableStream` via `pipeTo()`. If the pipeline rejects (e.g. the source stream errors mid-transfer), the `.catch()` handler only does a `console.log`:

```ts
.catch(reason => {
  console.log(' something went wrong', reason);
});
```

Because `close()` on the `WritableStream` is never invoked on pipeline failure, none of the usual teardown runs:

- `#status` stays `'running'` instead of transitioning to `'failed'`
- `#streamFinished` stays `false`, so `fullStream` never closes
- `#delayedPromises.result` is never rejected, so `await output.result` hangs forever
- No `workflow-finish` chunk is emitted, so listeners never learn the workflow ended

The `close()` handler in the same file already implements the correct cleanup pattern — setting status, emitting the finish chunk, resolving/rejecting delayed promises, and emitting the `'finish'` event. The `rejectResults()` method also shows the intended error-state pattern.

**Before:** A stream pipeline error silently logs to console. `output.status` stays `'running'`, `output.result` hangs indefinitely, and `fullStream` never closes.

**After:** Stream pipeline errors properly transition the workflow to `'failed'` status, reject pending promises with the actual error, emit a `workflow-finish` chunk with error metadata, and close the `fullStream`. This matches the same cleanup logic that `close()` performs on normal completion.

The fix extracts the error-handling logic into `#handlePipelineError()` and calls it from both catch blocks (constructor and `resume()`).

## Related issues

N/A — found by reading the code

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite

Added `RunOutput.test.ts` with 6 tests covering:
- Status transitions to `'failed'` on stream error
- `result` promise rejects with the actual error
- `workflow-finish` chunk emitted with failed status and error metadata
- `usage` resolves even after stream error
- Normal success path still works
- `resume()` errors handled identically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in stream pipelines to properly detect and report failures with accurate status updates and comprehensive error messages.
  * Improved error recovery behavior to ensure graceful handling of stream pipeline failures while maintaining system state integrity and complete error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->