### PR TITLE
fix(hono): use variable-based dynamic import for @hono/node-ws

### DIFF
--- a/.github/workflows/secrets.e2e.yml
+++ b/.github/workflows/secrets.e2e.yml
@@ -48,6 +48,7 @@ jobs:
               - '!(**/*.md)stores/**'
               - '!(**/*.md)client-sdks/**'
               - '!(**/*.md)deployers/**'
+              - '!(**/*.md)server-adapters/**'
               - '.github/workflows/secrets.e2e.yml'
 
   skip-tests:

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -97,6 +97,7 @@
     "@babel/core": "^7.29.0",
     "@babel/preset-typescript": "^7.28.5",
     "@babel/traverse": "^7.29.0",
+    "@hono/node-ws": "^1.3.0",
     "@mastra/server": "workspace:*",
     "@optimize-lodash/rollup-plugin": "^5.1.0",
     "@rollup/plugin-alias": "6.0.0",
@@ -119,7 +120,8 @@
     "rollup-plugin-esbuild": "^6.2.1",
     "strip-json-comments": "^5.0.3",
     "tinyglobby": "^0.2.15",
-    "typescript-paths": "^1.5.1"
+    "typescript-paths": "^1.5.1",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.11",

--- a/packages/playground/src/pages/agents/agent/index.tsx
+++ b/packages/playground/src/pages/agents/agent/index.tsx
@@ -123,8 +123,12 @@ function Agent() {
       <AgentSettingsProvider agentId={agentId!} defaultSettings={defaultSettings}>
         <SchemaRequestContextProvider>
           <WorkingMemoryProvider agentId={agentId!} threadId={actualThreadId!} resourceId={agentId!}>
-            <BrowserToolCallsProvider key={`browser-${actualThreadId}`}>
-              <BrowserSessionProvider key={`session-${actualThreadId}`} agentId={agentId!} threadId={actualThreadId!}>
+            <BrowserToolCallsProvider key={`browser-${agentId}-${actualThreadId}`}>
+              <BrowserSessionProvider
+                key={`session-${agentId}-${actualThreadId}`}
+                agentId={agentId!}
+                threadId={actualThreadId!}
+              >
                 <ThreadInputProvider>
                   <ObservationalMemoryProvider>
                     <ActivatedSkillsProvider key={`${agentId}-${actualThreadId}`}>

--- a/packages/playground/src/pages/agents/agent/session.tsx
+++ b/packages/playground/src/pages/agents/agent/session.tsx
@@ -12,6 +12,8 @@ import {
   ActivatedSkillsProvider,
   SchemaRequestContextProvider,
   MainContentLayout,
+  BrowserToolCallsProvider,
+  BrowserSessionProvider,
 } from '@mastra/playground-ui';
 import type { AgentSettingsType } from '@mastra/playground-ui';
 import { useEffect, useMemo } from 'react';
@@ -100,30 +102,34 @@ function AgentSession() {
       <AgentSettingsProvider agentId={agentId!} defaultSettings={defaultSettings}>
         <SchemaRequestContextProvider>
           <WorkingMemoryProvider agentId={agentId!} threadId={actualThreadId} resourceId={agentId!}>
-            <ThreadInputProvider>
-              <ObservationalMemoryProvider>
-                <ActivatedSkillsProvider>
-                  <MainContentLayout>
-                    <SessionHeader />
-                    <div className="grid overflow-y-auto relative bg-surface1 h-full pt-6">
-                      <AgentChat
-                        key={actualThreadId}
-                        agentId={agentId!}
-                        agentName={agent?.name}
-                        modelVersion={agent?.modelVersion}
-                        threadId={actualThreadId}
-                        memory={hasMemory}
-                        refreshThreadList={handleRefreshThreadList}
-                        modelList={agent?.modelList}
-                        messageId={messageId}
-                        isNewThread={isNewThread}
-                        hideModelSwitcher
-                      />
-                    </div>
-                  </MainContentLayout>
-                </ActivatedSkillsProvider>
-              </ObservationalMemoryProvider>
-            </ThreadInputProvider>
+            <BrowserToolCallsProvider key={`browser-${actualThreadId}`}>
+              <BrowserSessionProvider key={`session-${actualThreadId}`} agentId={agentId!} threadId={actualThreadId}>
+                <ThreadInputProvider>
+                  <ObservationalMemoryProvider>
+                    <ActivatedSkillsProvider>
+                      <MainContentLayout>
+                        <SessionHeader />
+                        <div className="grid overflow-y-auto relative bg-surface1 h-full pt-6">
+                          <AgentChat
+                            key={actualThreadId}
+                            agentId={agentId!}
+                            agentName={agent?.name}
+                            modelVersion={agent?.modelVersion}
+                            threadId={actualThreadId}
+                            memory={hasMemory}
+                            refreshThreadList={handleRefreshThreadList}
+                            modelList={agent?.modelList}
+                            messageId={messageId}
+                            isNewThread={isNewThread}
+                            hideModelSwitcher
+                          />
+                        </div>
+                      </MainContentLayout>
+                    </ActivatedSkillsProvider>
+                  </ObservationalMemoryProvider>
+                </ThreadInputProvider>
+              </BrowserSessionProvider>
+            </BrowserToolCallsProvider>
           </WorkingMemoryProvider>
         </SchemaRequestContextProvider>
       </AgentSettingsProvider>

--- a/packages/playground/src/pages/agents/agent/session.tsx
+++ b/packages/playground/src/pages/agents/agent/session.tsx
@@ -102,8 +102,12 @@ function AgentSession() {
       <AgentSettingsProvider agentId={agentId!} defaultSettings={defaultSettings}>
         <SchemaRequestContextProvider>
           <WorkingMemoryProvider agentId={agentId!} threadId={actualThreadId} resourceId={agentId!}>
-            <BrowserToolCallsProvider key={`browser-${actualThreadId}`}>
-              <BrowserSessionProvider key={`session-${actualThreadId}`} agentId={agentId!} threadId={actualThreadId}>
+            <BrowserToolCallsProvider key={`browser-${agentId}-${actualThreadId}`}>
+              <BrowserSessionProvider
+                key={`session-${agentId}-${actualThreadId}`}
+                agentId={agentId!}
+                threadId={actualThreadId}
+              >
                 <ThreadInputProvider>
                   <ObservationalMemoryProvider>
                     <ActivatedSkillsProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3170,6 +3170,9 @@ importers:
       '@babel/traverse':
         specifier: ^7.29.0
         version: 7.29.0
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.11(hono@4.12.8))(bufferutil@4.1.0)(hono@4.12.8)
       '@mastra/server':
         specifier: workspace:*
         version: link:../server
@@ -3239,6 +3242,9 @@ importers:
       typescript-paths:
         specifier: ^1.5.1
         version: 1.5.1(typescript@5.9.3)
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0(bufferutil@4.1.0)
     devDependencies:
       '@hono/node-server':
         specifier: ^1.19.11

--- a/server-adapters/hono/src/browser-stream/index.ts
+++ b/server-adapters/hono/src/browser-stream/index.ts
@@ -1,3 +1,4 @@
+import type { createNodeWebSocket as CreateNodeWebSocket } from '@hono/node-ws';
 import { handleInputMessage, ViewerRegistry } from '@mastra/server/browser-stream';
 import type { BrowserStreamConfig, BrowserStreamResult } from '@mastra/server/browser-stream';
 import type { Env, Hono, Schema } from 'hono';
@@ -37,10 +38,12 @@ export async function setupBrowserStream<E extends Env, S extends Schema, B exte
   app: Hono<E, S, B>,
   config: BrowserStreamConfig,
 ): Promise<BrowserStreamResult | null> {
-  // Dynamic import to avoid bundling ws into user code
-  let createNodeWebSocket;
+  // Dynamic import to avoid bundling ws into non-Node environments (e.g. Cloudflare Workers).
+  // The variable-based specifier prevents bundlers from resolving the module at build time.
+  let createNodeWebSocket: typeof CreateNodeWebSocket;
   try {
-    const honoNodeWs = await import('@hono/node-ws');
+    const mod = '@hono/node-ws';
+    const honoNodeWs = await import(/* @vite-ignore */ /* webpackIgnore: true */ mod);
     createNodeWebSocket = honoNodeWs.createNodeWebSocket;
   } catch {
     console.warn(

--- a/server-adapters/hono/src/browser-stream/index.ts
+++ b/server-adapters/hono/src/browser-stream/index.ts
@@ -46,10 +46,8 @@ export async function setupBrowserStream<E extends Env, S extends Schema, B exte
     const honoNodeWs = await import(/* @vite-ignore */ /* webpackIgnore: true */ mod);
     createNodeWebSocket = honoNodeWs.createNodeWebSocket;
   } catch {
-    console.warn(
-      '[Browser Streaming] Disabled - @hono/node-ws not available. ' +
-        'Install ws package to enable browser streaming in Studio.',
-    );
+    // @hono/node-ws is not available (e.g. no ws package installed).
+    // This is expected in non-Node environments — silently disable browser streaming.
     return null;
   }
 


### PR DESCRIPTION
## Problem

The `feat(browser)` PR (#14938) added `setupBrowserStream` to the deployer server, which introduced several issues:

### 1. Cloudflare Workers bundle failure

`setupBrowserStream` used a static string in its dynamic import:

```js
const honoNodeWs = await import('@hono/node-ws');
```

Bundlers (Rollup/wrangler) can resolve static-string dynamic imports at build time. This pulled the Node-only `@hono/node-ws` and `ws` packages into the Cloudflare Workers bundle, preventing the server from initializing — causing `/api/tools` to return 404 HTML instead of JSON.

### 2. Browser streaming broken for all Node users

`@mastra/hono` (which contains `setupBrowserStream`) is a **devDependency** of `@mastra/deployer` — it gets bundled into the deployer dist at build time. But the dynamic `import('@hono/node-ws')` resolves at **runtime** from the user's `node_modules`. Since `@hono/node-ws` and `ws` were never listed as runtime dependencies of the deployer, they were never installed for users. The catch block logged a warning but browser streaming was disabled for everyone.

### 3. E2E monorepo test failure

The `console.warn` in the catch block wrote to stderr, which the monorepo E2E test treats as a fatal error (any non-punycode stderr causes rejection).

### 4. Missing CI coverage

`server-adapters/` was not in the E2E workflow's paths-filter, so changes to `@mastra/hono` skipped E2E tests entirely.

## Changes

### `server-adapters/hono/src/browser-stream/index.ts`

- **Variable-based dynamic import**: Use `const mod = '@hono/node-ws'; await import(mod)` so bundlers cannot statically analyze the import. This is the same pattern used for `chat` in `chat-lazy.ts` and `execa` in the sandbox module.
- **`import type` for type safety**: Add `import type { createNodeWebSocket }` to preserve TypeScript inference without affecting the bundle.
- **Remove `console.warn`**: The catch path now only fires in genuinely unsupported environments (Cloudflare/edge) where telling the user to "install ws" would be wrong advice. Silently return `null` instead.

### `packages/deployer/package.json`

- **Add `@hono/node-ws` and `ws` as runtime dependencies**: So the dynamic import can actually resolve at runtime for Node users running `mastra dev` / `mastra start`.

### `.github/workflows/secrets.e2e.yml`

- **Add `server-adapters/**` to E2E paths-filter**: Changes to `@mastra/hono` now trigger E2E tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced session management in the agent playground with improved context handling.

* **Chores**
  * Added Node.js WebSocket support dependencies.
  * Updated E2E test coverage for server adapter changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->