### PR TITLE
fix(deployer): move browser stream setup to createNodeServer

### DIFF
--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -163,18 +163,6 @@ export async function createHonoServer(
     }
   }
 
-  // Browser stream WebSocket setup - MUST be before CORS middleware
-  // to avoid "can't modify immutable headers" error on WebSocket upgrade
-  // This is async because it dynamically imports @hono/node-ws to avoid
-  // bundling ws into user code. Returns null if ws is not available.
-  const browserStreamSetup = await setupBrowserStream(app, {
-    getToolset: (agentId: string) => {
-      // Look up agent and return its browser toolset if configured
-      const agent = mastra.getAgentById(agentId);
-      return agent?.browser;
-    },
-  });
-
   //Global cors config
   if (server?.cors === false) {
     app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000));
@@ -484,16 +472,24 @@ export async function createHonoServer(
     );
   }
 
-  // Attach injectWebSocket to app for backwards compatibility
-  // Consumers can use app directly, and optionally call app.injectWebSocket(server) for browser streaming
-  (app as any).injectWebSocket = browserStreamSetup?.injectWebSocket;
-
   return app;
 }
 
 export async function createNodeServer(mastra: Mastra, options: ServerBundleOptions = { tools: {} }) {
   const app = await createHonoServer(mastra, options);
-  const injectWebSocket = (app as any).injectWebSocket;
+
+  // Browser stream WebSocket setup - Node.js only
+  // This is placed here (not in createHonoServer) so that non-Node deployers
+  // like Cloudflare don't attempt to bundle @hono/node-ws and ws
+  const browserStreamSetup = await setupBrowserStream(app, {
+    getToolset: (agentId: string) => {
+      // Look up agent and return its browser toolset if configured
+      const agent = mastra.getAgentById(agentId);
+      return agent?.browser;
+    },
+  });
+  const injectWebSocket = browserStreamSetup?.injectWebSocket;
+
   const serverOptions = mastra.getServer();
   const apiPrefix = serverOptions?.apiPrefix ?? '/api';
 

--- a/packages/playground/src/pages/agents/agent/index.tsx
+++ b/packages/playground/src/pages/agents/agent/index.tsx
@@ -123,8 +123,12 @@ function Agent() {
       <AgentSettingsProvider agentId={agentId!} defaultSettings={defaultSettings}>
         <SchemaRequestContextProvider>
           <WorkingMemoryProvider agentId={agentId!} threadId={actualThreadId!} resourceId={agentId!}>
-            <BrowserToolCallsProvider key={`browser-${actualThreadId}`}>
-              <BrowserSessionProvider key={`session-${actualThreadId}`} agentId={agentId!} threadId={actualThreadId!}>
+            <BrowserToolCallsProvider key={`browser-${agentId}-${actualThreadId}`}>
+              <BrowserSessionProvider
+                key={`session-${agentId}-${actualThreadId}`}
+                agentId={agentId!}
+                threadId={actualThreadId!}
+              >
                 <ThreadInputProvider>
                   <ObservationalMemoryProvider>
                     <ActivatedSkillsProvider key={`${agentId}-${actualThreadId}`}>

--- a/packages/playground/src/pages/agents/agent/session.tsx
+++ b/packages/playground/src/pages/agents/agent/session.tsx
@@ -12,6 +12,8 @@ import {
   ActivatedSkillsProvider,
   SchemaRequestContextProvider,
   MainContentLayout,
+  BrowserToolCallsProvider,
+  BrowserSessionProvider,
 } from '@mastra/playground-ui';
 import type { AgentSettingsType } from '@mastra/playground-ui';
 import { useEffect, useMemo } from 'react';
@@ -100,30 +102,38 @@ function AgentSession() {
       <AgentSettingsProvider agentId={agentId!} defaultSettings={defaultSettings}>
         <SchemaRequestContextProvider>
           <WorkingMemoryProvider agentId={agentId!} threadId={actualThreadId} resourceId={agentId!}>
-            <ThreadInputProvider>
-              <ObservationalMemoryProvider>
-                <ActivatedSkillsProvider>
-                  <MainContentLayout>
-                    <SessionHeader />
-                    <div className="grid overflow-y-auto relative bg-surface1 h-full pt-6">
-                      <AgentChat
-                        key={actualThreadId}
-                        agentId={agentId!}
-                        agentName={agent?.name}
-                        modelVersion={agent?.modelVersion}
-                        threadId={actualThreadId}
-                        memory={hasMemory}
-                        refreshThreadList={handleRefreshThreadList}
-                        modelList={agent?.modelList}
-                        messageId={messageId}
-                        isNewThread={isNewThread}
-                        hideModelSwitcher
-                      />
-                    </div>
-                  </MainContentLayout>
-                </ActivatedSkillsProvider>
-              </ObservationalMemoryProvider>
-            </ThreadInputProvider>
+            <BrowserToolCallsProvider key={`browser-${agentId}-${actualThreadId}`}>
+              <BrowserSessionProvider
+                key={`session-${agentId}-${actualThreadId}`}
+                agentId={agentId!}
+                threadId={actualThreadId}
+              >
+                <ThreadInputProvider>
+                  <ObservationalMemoryProvider>
+                    <ActivatedSkillsProvider>
+                      <MainContentLayout>
+                        <SessionHeader />
+                        <div className="grid overflow-y-auto relative bg-surface1 h-full pt-6">
+                          <AgentChat
+                            key={actualThreadId}
+                            agentId={agentId!}
+                            agentName={agent?.name}
+                            modelVersion={agent?.modelVersion}
+                            threadId={actualThreadId}
+                            memory={hasMemory}
+                            refreshThreadList={handleRefreshThreadList}
+                            modelList={agent?.modelList}
+                            messageId={messageId}
+                            isNewThread={isNewThread}
+                            hideModelSwitcher
+                          />
+                        </div>
+                      </MainContentLayout>
+                    </ActivatedSkillsProvider>
+                  </ObservationalMemoryProvider>
+                </ThreadInputProvider>
+              </BrowserSessionProvider>
+            </BrowserToolCallsProvider>
           </WorkingMemoryProvider>
         </SchemaRequestContextProvider>
       </AgentSettingsProvider>


### PR DESCRIPTION
## Summary

Alternative approach to fixing the E2E Cloudflare test failures. Instead of using a variable-based dynamic import to prevent bundling, this moves the `setupBrowserStream()` call from `createHonoServer()` to `createNodeServer()`.

## How it works

- `createHonoServer()` is used by **both** Node.js and Cloudflare deployers
- `createNodeServer()` is **only** used by Node.js

By moving browser stream setup to `createNodeServer()`, Cloudflare never attempts to call `setupBrowserStream()`, so tree-shaking removes the `@hono/node-ws` and `ws` code from Cloudflare bundles entirely.

## Tradeoffs vs Caleb's PR #14997

| Aspect | This PR | Caleb's PR #14997 |
|--------|---------|-------------------|
| Cloudflare | ✅ Works (code tree-shaken out) | ✅ Works (dynamic import not bundled) |
| Node browser streaming | ✅ Works out of box (ws bundled) | ⚠️ Requires user to install `@hono/node-ws` and `ws` |
| Bundle size | Larger (includes ws) | Smaller (ws not bundled) |

## Also includes

- Fix for AgentSession page missing BrowserSessionProvider
- Include agentId in browser provider keys

## Test plan

- E2E deployers tests should pass (Cloudflare)
- E2E kitchen-sink tests should pass (session page fix)
- Browser streaming should work in Node without extra deps
