### PR TITLE
fix(playground-ui): replace dialog top-left slide with fade-from-bottom animation

### DIFF
--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -44,8 +44,8 @@ const DialogContent = React.forwardRef<
         'data-[state=open]:animate-in data-[state=closed]:animate-out',
         'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-        'data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]',
-        'data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+        'data-[state=closed]:slide-out-to-bottom-4',
+        'data-[state=open]:slide-in-from-bottom-4',
         className,
       )}
       {...props}


### PR DESCRIPTION
## What

Fixes the dialog animation in playground-ui which was entering from the top-left corner due to conflicting slide and centering transforms.

## Changes

**File**: `packages/playground-ui/src/ds/components/Dialog/dialog.tsx`

- Removed `slide-in-from-left-1/2` / `slide-in-from-top-[48%]` — these fought with the `translate-x-[-50%] translate-y-[-50%]` centering, causing a diagonal entry
- Added `slide-in-from-bottom-4` / `slide-out-to-bottom-4` — a subtle 1rem vertical slide for a clean fade-up animation

Fade and zoom animations are unchanged.

## Test Plan

- `pnpm build:playground-ui` passes
- Dialogs animate in smoothly with fade + zoom + gentle upward slide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Dialog animation transitions to use bottom-based slide animations for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->