### PR TITLE
feat(playground-ui): extract MainSidebarTrigger into composable component

### DIFF
--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-root.tsx
@@ -1,33 +1,13 @@
-import { KeyboardIcon, PanelRightIcon } from 'lucide-react';
-import { useEffect } from 'react';
 import { useMainSidebar } from './main-sidebar-context';
-import { MainSidebarNavSeparator } from './main-sidebar-nav-separator';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { cn } from '@/lib/utils';
 
 export type MainSidebarRootProps = {
   children: React.ReactNode;
   className?: string;
-  footerSlot?: React.ReactNode;
 };
-export function MainSidebarRoot({ children, className, footerSlot }: MainSidebarRootProps) {
+export function MainSidebarRoot({ children, className }: MainSidebarRootProps) {
   const { state, toggleSidebar } = useMainSidebar();
   const isCollapsed = state === 'collapsed';
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.ctrlKey && event.key === 'b') {
-        event.preventDefault();
-        toggleSidebar();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [toggleSidebar]);
 
   return (
     <div
@@ -42,41 +22,6 @@ export function MainSidebarRoot({ children, className, footerSlot }: MainSidebar
       )}
     >
       {children}
-
-      <div className="bg-surface1 grid sticky bottom-0 pb-3">
-        <MainSidebarNavSeparator />
-        <div className="flex items-center justify-end gap-1">
-          {!isCollapsed && footerSlot}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={toggleSidebar}
-                className={cn(
-                  'inline-flex w-auto items-center text-neutral3 h-8 px-3 rounded-md',
-                  'hover:bg-surface4 hover:text-neutral5',
-                  'transition-all duration-normal ease-out-custom',
-                  'focus:outline-hidden focus:ring-1 focus:ring-accent1 focus:shadow-focus-ring',
-                  '[&_svg]:w-4 [&_svg]:h-4 [&_svg]:text-neutral3 [&_svg]:transition-transform [&_svg]:duration-normal',
-                )}
-                aria-label="Toggle sidebar"
-              >
-                <PanelRightIcon
-                  className={cn({
-                    'rotate-180': isCollapsed,
-                  })}
-                />
-              </button>
-            </TooltipTrigger>
-
-            <TooltipContent>
-              Toggle Sidebar
-              <div className="flex items-center gap-1 [&>svg]:w-[1em] [&>svg]:h-[1em]">
-                <KeyboardIcon /> Ctrl+B
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
 
       <button
         onClick={toggleSidebar}

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-trigger.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-trigger.tsx
@@ -1,0 +1,61 @@
+import { KeyboardIcon, PanelRightIcon } from 'lucide-react';
+import { useEffect } from 'react';
+import { useMainSidebar } from './main-sidebar-context';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
+import { cn } from '@/lib/utils';
+
+export type MainSidebarTriggerProps = {
+  className?: string;
+};
+
+export function MainSidebarTrigger({ className }: MainSidebarTriggerProps) {
+  const { state, toggleSidebar } = useMainSidebar();
+  const isCollapsed = state === 'collapsed';
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.ctrlKey && event.key === 'b') {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [toggleSidebar]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={toggleSidebar}
+          className={cn(
+            'inline-flex w-auto items-center text-neutral3 h-8 px-3 rounded-md',
+            'hover:bg-surface4 hover:text-neutral5',
+            'transition-all duration-normal ease-out-custom',
+            'focus:outline-hidden focus:ring-1 focus:ring-accent1 focus:shadow-focus-ring',
+            '[&_svg]:w-4 [&_svg]:h-4 [&_svg]:text-neutral3 [&_svg]:transition-transform [&_svg]:duration-normal',
+            className,
+          )}
+          aria-label="Toggle sidebar"
+        >
+          <PanelRightIcon
+            className={cn({
+              'rotate-180': isCollapsed,
+            })}
+          />
+        </button>
+      </TooltipTrigger>
+
+      <TooltipContent>
+        Toggle Sidebar
+        <div className="flex items-center gap-1 [&>svg]:w-[1em] [&>svg]:h-[1em]">
+          <KeyboardIcon /> Ctrl+B
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.tsx
@@ -6,11 +6,13 @@ import { MainSidebarNavList } from './main-sidebar-nav-list';
 import { MainSidebarNavSection } from './main-sidebar-nav-section';
 import { MainSidebarNavSeparator } from './main-sidebar-nav-separator';
 import { MainSidebarRoot } from './main-sidebar-root';
+import { MainSidebarTrigger } from './main-sidebar-trigger';
 
 export { MainSidebarProvider, type SidebarState } from './main-sidebar-context';
 export { useMainSidebar, useMaybeSidebar } from './main-sidebar-context';
 export { type NavLink } from './main-sidebar-nav-link';
 export { type NavSection } from './main-sidebar-nav-section';
+export { MainSidebarTrigger } from './main-sidebar-trigger';
 
 export const MainSidebar = Object.assign(MainSidebarRoot, {
   Bottom: MainSidebarBottom,
@@ -20,4 +22,5 @@ export const MainSidebar = Object.assign(MainSidebarRoot, {
   NavHeader: MainSidebarNavHeader,
   NavList: MainSidebarNavList,
   NavSeparator: MainSidebarNavSeparator,
+  Trigger: MainSidebarTrigger,
 });

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -338,6 +338,10 @@ export function AppSidebar() {
             <MastraVersionFooter collapsed={false} />
           </>
         )}
+        <MainSidebar.NavSeparator />
+        <div className="flex justify-end pb-3">
+          <MainSidebar.Trigger />
+        </div>
       </MainSidebar.Bottom>
     </MainSidebar>
   );


### PR DESCRIPTION
## What

Extract the sidebar toggle button from `MainSidebarRoot` into a standalone `MainSidebarTrigger` component, making it composable and positionable by external consumers.

## Changes

- **New**: `MainSidebarTrigger` component (`main-sidebar-trigger.tsx`) — contains the toggle button, tooltip, and `Ctrl+B` keyboard shortcut
- **Modified**: `MainSidebarRoot` — removed hardcoded trigger, `footerSlot` prop, and keyboard shortcut listener
- **Modified**: `MainSidebar` compound component — added `Trigger` property and named export
- **Modified**: Playground `AppSidebar` — renders `<MainSidebar.Trigger />` explicitly in the bottom section

## Usage

```tsx
// Via compound component
<MainSidebar.Trigger />

// Or direct import
import { MainSidebarTrigger } from '@mastra/playground-ui';
<MainSidebarTrigger className="my-position" />
```

## Test plan

- `pnpm build:playground-ui` — compiles
- `pnpm --filter ./packages/playground build` — compiles
- Playground sidebar visually unchanged: trigger at bottom-right, Ctrl+B works, collapse/expand works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the main sidebar toggle component for improved maintainability. The sidebar toggle button and Ctrl+B keyboard shortcut functionality remain unchanged and continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->