### PR TITLE
fix(workspace): chunk large files before embedding

### DIFF
--- a/.changeset/wicked-words-look.md
+++ b/.changeset/wicked-words-look.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workspace file indexing to automatically chunk large files before embedding. Files exceeding the embedding model token limit were previously silently skipped, leaving the vector store empty and causing search failures. Large files are now split into overlapping line-based chunks, each indexed separately with correct line-range tracking back to the original file.

--- a/.changeset/wicked-words-look.md
+++ b/.changeset/wicked-words-look.md
@@ -2,4 +2,7 @@
 '@mastra/core': patch
 ---
 
-Fixed workspace file indexing to automatically chunk large files before embedding. Files exceeding the embedding model token limit were previously silently skipped, leaving the vector store empty and causing search failures. Large files are now split into overlapping line-based chunks, each indexed separately with correct line-range tracking back to the original file.
+Fixed workspace file indexing so vector search works out of the box.
+
+- Large files that exceeded the embedding model token limit were previously silently skipped, leaving the vector store empty and causing search failures. Large files are now split into overlapping line-based chunks, each indexed separately with correct line-range tracking back to the original file.
+- The vector index is now created automatically before the first upsert. Previously, backends that require an explicit `createIndex` call (e.g. LibSQL) would leave the table uncreated, causing `no such table` errors on search. Workspaces with `vectorStore` + `embedder` + `autoIndexPaths` configured now work without any manual setup.

--- a/packages/core/src/workspace/search/search-engine.test.ts
+++ b/packages/core/src/workspace/search/search-engine.test.ts
@@ -627,7 +627,8 @@ describe('splitIntoChunks', () => {
     }
   });
 
-  it('should handle a single very long line', () => {
+  it('should not split a single very long line (splits only on line boundaries)', () => {
+    // Splits only on line boundaries; single-line files stay as one chunk.
     const text = 'x'.repeat(10000);
     const chunks = splitIntoChunks(text, { maxChunkChars: 4000 });
 

--- a/packages/core/src/workspace/search/search-engine.test.ts
+++ b/packages/core/src/workspace/search/search-engine.test.ts
@@ -581,6 +581,7 @@ Third line has learning too`;
             upsert: vi.fn(async () => {}),
             query: vi.fn(async () => []),
             deleteVector: mockDeleteVector,
+            deleteVectors: vi.fn(async () => {}),
           } as any,
           embedder: vi.fn(async () => [1, 2, 3]),
           indexName: 'test-index',
@@ -596,6 +597,39 @@ Third line has learning too`;
       expect(mockDeleteVector).toHaveBeenCalledTimes(2);
       expect(mockDeleteVector).toHaveBeenCalledWith({ indexName: 'test-index', id: 'file.txt#chunk-0' });
       expect(mockDeleteVector).toHaveBeenCalledWith({ indexName: 'test-index', id: 'file.txt#chunk-1' });
+    });
+  });
+
+  describe('removeSource', () => {
+    it('should remove source doc, chunks, and sourceFile vectors', async () => {
+      const mockDeleteVector = vi.fn(async () => {});
+      const mockDeleteVectors = vi.fn(async () => {});
+      const engine = new SearchEngine({
+        vector: {
+          vectorStore: {
+            upsert: vi.fn(async () => {}),
+            query: vi.fn(async () => []),
+            deleteVector: mockDeleteVector,
+            deleteVectors: mockDeleteVectors,
+          } as any,
+          embedder: vi.fn(async () => [1, 2, 3]),
+          indexName: 'test-index',
+        },
+      });
+
+      await engine.index({ id: 'file.txt', content: 'full file content' });
+      await engine.index({ id: 'file.txt#chunk-0', content: 'chunk zero', metadata: { sourceFile: 'file.txt' } });
+      await engine.index({ id: 'file.txt#chunk-1', content: 'chunk one', metadata: { sourceFile: 'file.txt' } });
+
+      await engine.removeSource('file.txt');
+
+      expect(mockDeleteVector).toHaveBeenCalledWith({ indexName: 'test-index', id: 'file.txt' });
+      expect(mockDeleteVector).toHaveBeenCalledWith({ indexName: 'test-index', id: 'file.txt#chunk-0' });
+      expect(mockDeleteVector).toHaveBeenCalledWith({ indexName: 'test-index', id: 'file.txt#chunk-1' });
+      expect(mockDeleteVectors).toHaveBeenCalledWith({
+        indexName: 'test-index',
+        filter: { sourceFile: 'file.txt' },
+      });
     });
   });
 });

--- a/packages/core/src/workspace/search/search-engine.test.ts
+++ b/packages/core/src/workspace/search/search-engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-import { SearchEngine } from './search-engine';
+import { SearchEngine, splitIntoChunks } from './search-engine';
 import type { Embedder } from './search-engine';
 
 describe('SearchEngine', () => {
@@ -541,5 +541,114 @@ Third line has learning too`;
       expect(chunk1Result?.lineRange).toEqual({ start: 1, end: 1 });
       expect(chunk2Result?.lineRange).toEqual({ start: 50, end: 50 });
     });
+  });
+
+  describe('removeByPrefix', () => {
+    it('should remove all BM25 documents matching a prefix', async () => {
+      const engine = new SearchEngine({ bm25: {} });
+
+      await engine.index({ id: 'file.txt#chunk-0', content: 'first chunk content' });
+      await engine.index({ id: 'file.txt#chunk-1', content: 'second chunk content' });
+      await engine.index({ id: 'other.txt', content: 'other content' });
+
+      await engine.removeByPrefix('file.txt#');
+
+      const results = await engine.search('content');
+      expect(results).toHaveLength(1);
+      expect(results[0]?.id).toBe('other.txt');
+    });
+
+    it('should not remove documents that do not match the prefix', async () => {
+      const engine = new SearchEngine({ bm25: {} });
+
+      await engine.index({ id: 'a.txt#chunk-0', content: 'alpha' });
+      await engine.index({ id: 'b.txt#chunk-0', content: 'beta' });
+
+      await engine.removeByPrefix('a.txt#');
+
+      const results = await engine.search('alpha');
+      expect(results).toHaveLength(0);
+
+      const remaining = await engine.search('beta');
+      expect(remaining).toHaveLength(1);
+    });
+  });
+});
+
+describe('splitIntoChunks', () => {
+  it('should return a single chunk for short text', () => {
+    const chunks = splitIntoChunks('hello world');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.content).toBe('hello world');
+    expect(chunks[0]?.startLine).toBe(1);
+  });
+
+  it('should split text that exceeds maxChunkChars', () => {
+    const line = 'a'.repeat(50);
+    const lines = Array.from({ length: 20 }, () => line);
+    const text = lines.join('\n');
+
+    const chunks = splitIntoChunks(text, { maxChunkChars: 200, overlapLines: 0 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+
+    const reassembled = chunks.map(c => c.content).join('\n');
+    expect(reassembled).toBe(text);
+  });
+
+  it('should produce overlapping chunks when overlapLines > 0', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line-${i + 1}`);
+    const text = lines.join('\n');
+
+    const chunks = splitIntoChunks(text, { maxChunkChars: 60, overlapLines: 2 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (let i = 1; i < chunks.length; i++) {
+      const prevLines = chunks[i - 1]!.content.split('\n');
+      const currLines = chunks[i]!.content.split('\n');
+      const prevTail = prevLines.slice(-2);
+      const currHead = currLines.slice(0, 2);
+      expect(currHead).toEqual(prevTail);
+    }
+  });
+
+  it('should set correct startLine for each chunk', () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `line-${i + 1}`);
+    const text = lines.join('\n');
+
+    const chunks = splitIntoChunks(text, { maxChunkChars: 40, overlapLines: 0 });
+
+    expect(chunks[0]?.startLine).toBe(1);
+
+    for (const chunk of chunks) {
+      const expectedLine = text.split('\n').indexOf(chunk.content.split('\n')[0]!) + 1;
+      expect(chunk.startLine).toBe(expectedLine);
+    }
+  });
+
+  it('should handle a single very long line', () => {
+    const text = 'x'.repeat(10000);
+    const chunks = splitIntoChunks(text, { maxChunkChars: 4000 });
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.content).toBe(text);
+  });
+
+  it('should handle empty text', () => {
+    const chunks = splitIntoChunks('');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.content).toBe('');
+  });
+
+  it('should not produce empty chunks', () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `line ${i}`);
+    const text = lines.join('\n');
+
+    const chunks = splitIntoChunks(text, { maxChunkChars: 100, overlapLines: 2 });
+
+    for (const chunk of chunks) {
+      expect(chunk.content.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/packages/core/src/workspace/search/search-engine.test.ts
+++ b/packages/core/src/workspace/search/search-engine.test.ts
@@ -171,6 +171,43 @@ Line 3`;
       });
     });
 
+    it('should call createIndex once before the first upsert with the embedding dimension', async () => {
+      const mockCreateIndex = vi.fn(async () => {});
+      const store: any = {
+        upsert: vi.fn(async () => {}),
+        query: vi.fn(async () => []),
+        deleteVector: vi.fn(async () => {}),
+        createIndex: mockCreateIndex,
+      };
+      const localEngine = new SearchEngine({
+        vector: { vectorStore: store, embedder: mockEmbedder, indexName: 'test-index' },
+      });
+
+      await localEngine.index({ id: 'doc1', content: 'Hello world' });
+      await localEngine.index({ id: 'doc2', content: 'Another doc' });
+
+      expect(mockCreateIndex).toHaveBeenCalledTimes(1);
+      expect(mockCreateIndex).toHaveBeenCalledWith({ indexName: 'test-index', dimension: 3 });
+      expect(store.upsert).toHaveBeenCalledTimes(2);
+    });
+
+    it('should still upsert when createIndex throws (index already exists)', async () => {
+      const store: any = {
+        upsert: vi.fn(async () => {}),
+        query: vi.fn(async () => []),
+        deleteVector: vi.fn(async () => {}),
+        createIndex: vi.fn(async () => {
+          throw new Error('index already exists');
+        }),
+      };
+      const localEngine = new SearchEngine({
+        vector: { vectorStore: store, embedder: mockEmbedder, indexName: 'test-index' },
+      });
+
+      await expect(localEngine.index({ id: 'doc1', content: 'Hello world' })).resolves.toBeUndefined();
+      expect(store.upsert).toHaveBeenCalledTimes(1);
+    });
+
     it('should search vector store', async () => {
       mockVectorStore.query.mockResolvedValue([
         { id: 'doc1', score: 0.95, metadata: { id: 'doc1', text: 'Hello world' } },

--- a/packages/core/src/workspace/search/search-engine.test.ts
+++ b/packages/core/src/workspace/search/search-engine.test.ts
@@ -208,6 +208,38 @@ Line 3`;
       expect(store.upsert).toHaveBeenCalledTimes(1);
     });
 
+    it('should retry createIndex on next write if previous createIndex/upsert path failed', async () => {
+      let createAttempts = 0;
+      let indexCreated = false;
+
+      const store: any = {
+        query: vi.fn(async () => []),
+        deleteVector: vi.fn(async () => {}),
+        createIndex: vi.fn(async () => {
+          createAttempts += 1;
+          if (createAttempts === 1) {
+            throw new Error('temporary create failure');
+          }
+          indexCreated = true;
+        }),
+        upsert: vi.fn(async () => {
+          if (!indexCreated) {
+            throw new Error('no such table');
+          }
+        }),
+      };
+
+      const localEngine = new SearchEngine({
+        vector: { vectorStore: store, embedder: mockEmbedder, indexName: 'test-index' },
+      });
+
+      await expect(localEngine.index({ id: 'doc1', content: 'Hello world' })).rejects.toThrow('no such table');
+      await expect(localEngine.index({ id: 'doc2', content: 'Another doc' })).resolves.toBeUndefined();
+
+      expect(store.createIndex).toHaveBeenCalledTimes(2);
+      expect(store.upsert).toHaveBeenCalledTimes(2);
+    });
+
     it('should search vector store', async () => {
       mockVectorStore.query.mockResolvedValue([
         { id: 'doc1', score: 0.95, metadata: { id: 'doc1', text: 'Hello world' } },

--- a/packages/core/src/workspace/search/search-engine.test.ts
+++ b/packages/core/src/workspace/search/search-engine.test.ts
@@ -572,6 +572,31 @@ Third line has learning too`;
       const remaining = await engine.search('beta');
       expect(remaining).toHaveLength(1);
     });
+
+    it('should delete matching vectors from the vector store', async () => {
+      const mockDeleteVector = vi.fn(async () => {});
+      const engine = new SearchEngine({
+        vector: {
+          vectorStore: {
+            upsert: vi.fn(async () => {}),
+            query: vi.fn(async () => []),
+            deleteVector: mockDeleteVector,
+          } as any,
+          embedder: vi.fn(async () => [1, 2, 3]),
+          indexName: 'test-index',
+        },
+      });
+
+      await engine.index({ id: 'file.txt#chunk-0', content: 'chunk zero' });
+      await engine.index({ id: 'file.txt#chunk-1', content: 'chunk one' });
+      await engine.index({ id: 'other.txt', content: 'other' });
+
+      await engine.removeByPrefix('file.txt#');
+
+      expect(mockDeleteVector).toHaveBeenCalledTimes(2);
+      expect(mockDeleteVector).toHaveBeenCalledWith({ indexName: 'test-index', id: 'file.txt#chunk-0' });
+      expect(mockDeleteVector).toHaveBeenCalledWith({ indexName: 'test-index', id: 'file.txt#chunk-1' });
+    });
   });
 });
 

--- a/packages/core/src/workspace/search/search-engine.test.ts
+++ b/packages/core/src/workspace/search/search-engine.test.ts
@@ -627,13 +627,15 @@ describe('splitIntoChunks', () => {
     }
   });
 
-  it('should not split a single very long line (splits only on line boundaries)', () => {
-    // Splits only on line boundaries; single-line files stay as one chunk.
+  it('should split a single very long line by character boundaries', () => {
     const text = 'x'.repeat(10000);
     const chunks = splitIntoChunks(text, { maxChunkChars: 4000 });
 
-    expect(chunks).toHaveLength(1);
-    expect(chunks[0]?.content).toBe(text);
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]?.content).toBe('x'.repeat(4000));
+    expect(chunks[1]?.content).toBe('x'.repeat(4000));
+    expect(chunks[2]?.content).toBe('x'.repeat(2000));
+    expect(chunks.every(c => c.startLine === 1)).toBe(true);
   });
 
   it('should handle empty text', () => {

--- a/packages/core/src/workspace/search/search-engine.ts
+++ b/packages/core/src/workspace/search/search-engine.ts
@@ -489,13 +489,13 @@ export class SearchEngine {
 
     if (!this.#vectorIndexReady) {
       // Some backends (e.g. LibSQLVector) require createIndex before upsert.
-      // createIndex is expected to be idempotent; failures are surfaced via upsert.
+      // createIndex is expected to be idempotent; we ignore errors here and let
+      // upsert determine whether the index is actually usable.
       try {
         await vectorStore.createIndex({ indexName, dimension: embedding.length });
       } catch {
-        // Already exists or not required by this backend — upsert will surface any real issue.
+        // Already exists, temporarily unavailable, or not required by backend.
       }
-      this.#vectorIndexReady = true;
     }
 
     await vectorStore.upsert({
@@ -510,6 +510,10 @@ export class SearchEngine {
       ],
       ids: [doc.id],
     });
+
+    // Mark index as ready only after a successful upsert so createIndex is retried
+    // on subsequent writes if the previous attempt did not produce a usable index.
+    this.#vectorIndexReady = true;
   }
 
   /**

--- a/packages/core/src/workspace/search/search-engine.ts
+++ b/packages/core/src/workspace/search/search-engine.ts
@@ -159,16 +159,25 @@ export function splitIntoChunks(text: string, options: ChunkOptions = {}): TextC
     let charCount = 0;
 
     while (end < lines.length) {
-      const lineLen = lines[end]!.length + (end > start ? 1 : 0); // +1 for newline separator
+      const lineLen = lines[end]!.length + (end > start ? 1 : 0);
       if (charCount + lineLen > maxChars && end > start) break;
       charCount += lineLen;
       end++;
     }
 
-    chunks.push({
-      content: lines.slice(start, end).join('\n'),
-      startLine: start + 1, // 1-indexed
-    });
+    const chunkContent = lines.slice(start, end).join('\n');
+
+    if (chunkContent.length <= maxChars) {
+      chunks.push({ content: chunkContent, startLine: start + 1 });
+    } else {
+      // Single line exceeds maxChars — split by character boundaries.
+      for (let offset = 0; offset < chunkContent.length; offset += maxChars) {
+        chunks.push({
+          content: chunkContent.slice(offset, offset + maxChars),
+          startLine: start + 1,
+        });
+      }
+    }
 
     const nextStart = end - overlapLines;
     start = nextStart <= start ? end : nextStart;
@@ -213,6 +222,9 @@ export class SearchEngine {
   /** Whether to use lazy vector indexing */
   #lazyVectorIndex: boolean;
 
+  /** All indexed document IDs (used for prefix-based removal across backends) */
+  #indexedIds: Set<string> = new Set();
+
   /** Documents pending vector indexing (for lazy mode) */
   #pendingVectorDocs: IndexDocument[] = [];
 
@@ -250,6 +262,8 @@ export class SearchEngine {
       metadata._startLineOffset = doc.startLineOffset;
     }
 
+    this.#indexedIds.add(doc.id);
+
     // BM25 indexing (always synchronous and immediate)
     if (this.#bm25Index) {
       this.#bm25Index.add(doc.id, doc.content, metadata);
@@ -282,6 +296,8 @@ export class SearchEngine {
    * Remove a document from the index
    */
   async remove(id: string): Promise<void> {
+    this.#indexedIds.delete(id);
+
     // Remove from BM25
     if (this.#bm25Index) {
       this.#bm25Index.remove(id);
@@ -310,14 +326,15 @@ export class SearchEngine {
    * Used to remove all chunks belonging to a single source document.
    */
   async removeByPrefix(prefix: string): Promise<void> {
-    const matchedIds: string[] = [];
+    const matchedIds = [...this.#indexedIds].filter(id => id.startsWith(prefix));
+
+    for (const id of matchedIds) {
+      this.#indexedIds.delete(id);
+    }
 
     if (this.#bm25Index) {
-      for (const id of this.#bm25Index.documentIds) {
-        if (id.startsWith(prefix)) {
-          matchedIds.push(id);
-          this.#bm25Index.remove(id);
-        }
+      for (const id of matchedIds) {
+        this.#bm25Index.remove(id);
       }
     }
 
@@ -343,6 +360,7 @@ export class SearchEngine {
    * Clear all indexed documents
    */
   clear(): void {
+    this.#indexedIds.clear();
     if (this.#bm25Index) {
       this.#bm25Index.clear();
     }

--- a/packages/core/src/workspace/search/search-engine.ts
+++ b/packages/core/src/workspace/search/search-engine.ts
@@ -231,6 +231,9 @@ export class SearchEngine {
   /** Whether vector index has been built (for lazy mode) */
   #vectorIndexBuilt: boolean = false;
 
+  /** Whether createIndex has been attempted on the vector store */
+  #vectorIndexReady: boolean = false;
+
   constructor(config: SearchEngineConfig = {}) {
     // Initialize BM25 if configured
     if (config.bm25 !== undefined) {
@@ -483,6 +486,17 @@ export class SearchEngine {
     const { vectorStore, embedder, indexName } = this.#vectorConfig;
 
     const embedding = await embedder(doc.content);
+
+    if (!this.#vectorIndexReady) {
+      // Some backends (e.g. LibSQLVector) require createIndex before upsert.
+      // createIndex is expected to be idempotent; failures are surfaced via upsert.
+      try {
+        await vectorStore.createIndex({ indexName, dimension: embedding.length });
+      } catch {
+        // Already exists or not required by this backend — upsert will surface any real issue.
+      }
+      this.#vectorIndexReady = true;
+    }
 
     await vectorStore.upsert({
       indexName,

--- a/packages/core/src/workspace/search/search-engine.ts
+++ b/packages/core/src/workspace/search/search-engine.ts
@@ -117,6 +117,67 @@ export interface SearchEngineConfig {
 }
 
 // =============================================================================
+// Chunking
+// =============================================================================
+
+const DEFAULT_MAX_CHUNK_CHARS = 4000;
+const DEFAULT_OVERLAP_LINES = 3;
+
+export interface ChunkOptions {
+  maxChunkChars?: number;
+  overlapLines?: number;
+}
+
+export interface TextChunk {
+  content: string;
+  startLine: number;
+}
+
+/**
+ * Split text into line-based chunks that stay within a character budget.
+ *
+ * Each chunk is formed by accumulating whole lines until adding the next line
+ * would exceed `maxChunkChars`. Adjacent chunks share `overlapLines` lines so
+ * that context around chunk boundaries is preserved for embedding quality.
+ *
+ * Returns the original text as a single chunk when it already fits.
+ */
+export function splitIntoChunks(text: string, options: ChunkOptions = {}): TextChunk[] {
+  const maxChars = options.maxChunkChars ?? DEFAULT_MAX_CHUNK_CHARS;
+  const overlapLines = options.overlapLines ?? DEFAULT_OVERLAP_LINES;
+
+  if (text.length <= maxChars) {
+    return [{ content: text, startLine: 1 }];
+  }
+
+  const lines = text.split('\n');
+  const chunks: TextChunk[] = [];
+  let start = 0;
+
+  while (start < lines.length) {
+    let end = start;
+    let charCount = 0;
+
+    while (end < lines.length) {
+      const lineLen = lines[end]!.length + (end > start ? 1 : 0); // +1 for newline separator
+      if (charCount + lineLen > maxChars && end > start) break;
+      charCount += lineLen;
+      end++;
+    }
+
+    chunks.push({
+      content: lines.slice(start, end).join('\n'),
+      startLine: start + 1, // 1-indexed
+    });
+
+    const nextStart = end - overlapLines;
+    start = nextStart <= start ? end : nextStart;
+  }
+
+  return chunks;
+}
+
+// =============================================================================
 // SearchEngine
 // =============================================================================
 
@@ -241,6 +302,30 @@ export class SearchEngine {
       if (this.#lazyVectorIndex) {
         this.#pendingVectorDocs = this.#pendingVectorDocs.filter(d => d.id !== id);
       }
+    }
+  }
+
+  /**
+   * Remove all documents whose ID starts with the given prefix.
+   * Used to remove all chunks belonging to a single source document.
+   */
+  async removeByPrefix(prefix: string): Promise<void> {
+    if (this.#bm25Index) {
+      const ids = this.#bm25Index.documentIds;
+      for (const id of ids) {
+        if (id.startsWith(prefix)) {
+          this.#bm25Index.remove(id);
+        }
+      }
+    }
+
+    if (this.#vectorConfig) {
+      if (this.#lazyVectorIndex) {
+        this.#pendingVectorDocs = this.#pendingVectorDocs.filter(d => !d.id.startsWith(prefix));
+      }
+      // Vector stores don't support prefix deletion natively, so we
+      // rely on the fact that chunk IDs are deterministic. Individual
+      // deleteVector calls are best-effort.
     }
   }
 

--- a/packages/core/src/workspace/search/search-engine.ts
+++ b/packages/core/src/workspace/search/search-engine.ts
@@ -143,8 +143,8 @@ export interface TextChunk {
  * Returns the original text as a single chunk when it already fits.
  */
 export function splitIntoChunks(text: string, options: ChunkOptions = {}): TextChunk[] {
-  const maxChars = options.maxChunkChars ?? DEFAULT_MAX_CHUNK_CHARS;
-  const overlapLines = options.overlapLines ?? DEFAULT_OVERLAP_LINES;
+  const maxChars = Math.max(1, Math.floor(options.maxChunkChars ?? DEFAULT_MAX_CHUNK_CHARS));
+  const overlapLines = Math.max(0, Math.floor(options.overlapLines ?? DEFAULT_OVERLAP_LINES));
 
   if (text.length <= maxChars) {
     return [{ content: text, startLine: 1 }];

--- a/packages/core/src/workspace/search/search-engine.ts
+++ b/packages/core/src/workspace/search/search-engine.ts
@@ -310,10 +310,12 @@ export class SearchEngine {
    * Used to remove all chunks belonging to a single source document.
    */
   async removeByPrefix(prefix: string): Promise<void> {
+    const matchedIds: string[] = [];
+
     if (this.#bm25Index) {
-      const ids = this.#bm25Index.documentIds;
-      for (const id of ids) {
+      for (const id of this.#bm25Index.documentIds) {
         if (id.startsWith(prefix)) {
+          matchedIds.push(id);
           this.#bm25Index.remove(id);
         }
       }
@@ -323,9 +325,17 @@ export class SearchEngine {
       if (this.#lazyVectorIndex) {
         this.#pendingVectorDocs = this.#pendingVectorDocs.filter(d => !d.id.startsWith(prefix));
       }
-      // Vector stores don't support prefix deletion natively, so we
-      // rely on the fact that chunk IDs are deterministic. Individual
-      // deleteVector calls are best-effort.
+
+      for (const id of matchedIds) {
+        try {
+          await this.#vectorConfig.vectorStore.deleteVector({
+            indexName: this.#vectorConfig.indexName,
+            id,
+          });
+        } catch {
+          // Vector may not exist, ignore
+        }
+      }
     }
   }
 

--- a/packages/core/src/workspace/search/search-engine.ts
+++ b/packages/core/src/workspace/search/search-engine.ts
@@ -357,6 +357,28 @@ export class SearchEngine {
   }
 
   /**
+   * Remove a source document and all of its chunked variants.
+   *
+   * This also attempts a metadata-based bulk delete for chunk vectors so stale
+   * chunk IDs from previous process runs are cleaned up in persistent stores.
+   */
+  async removeSource(sourceId: string): Promise<void> {
+    await this.remove(sourceId);
+    await this.removeByPrefix(`${sourceId}#chunk-`);
+
+    if (this.#vectorConfig) {
+      try {
+        await this.#vectorConfig.vectorStore.deleteVectors({
+          indexName: this.#vectorConfig.indexName,
+          filter: { sourceFile: sourceId } as VectorFilter,
+        });
+      } catch {
+        // Bulk delete/filter may not be supported by all vector backends.
+      }
+    }
+  }
+
+  /**
    * Clear all indexed documents
    */
   clear(): void {

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -48,8 +48,8 @@ import type { LSPConfig } from './lsp/types';
 import type { WorkspaceSandbox, OnMountHook } from './sandbox';
 import { LocalSandbox } from './sandbox/local-sandbox';
 import { MastraSandbox } from './sandbox/mastra-sandbox';
-import { SearchEngine } from './search';
 import type { BM25Config, Embedder, SearchOptions, SearchResult, IndexDocument } from './search';
+import { SearchEngine, splitIntoChunks } from './search';
 import type { WorkspaceSkills, SkillsResolver, SkillSource } from './skills';
 import { WorkspaceSkillsImpl, LocalSkillSource } from './skills';
 import type { WorkspaceToolsConfig } from './tools';
@@ -843,6 +843,8 @@ export class Workspace<
 
   /**
    * Index a single file for search. Skips files that can't be read as text.
+   * Large files are automatically split into chunks to stay within embedding
+   * model token limits.
    */
   private async indexFileForSearch(filePath: string): Promise<void> {
     let content: string;
@@ -853,10 +855,29 @@ export class Workspace<
       return;
     }
 
-    try {
-      await this._searchEngine!.index({ id: filePath, content });
-    } catch (error) {
-      this._logger?.warn(`Failed to index file "${filePath}" for search`, { error });
+    const chunks = splitIntoChunks(content);
+
+    if (chunks.length === 1) {
+      try {
+        await this._searchEngine!.index({ id: filePath, content });
+      } catch (error) {
+        this._logger?.warn(`Failed to index file "${filePath}" for search`, { error });
+      }
+      return;
+    }
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i]!;
+      try {
+        await this._searchEngine!.index({
+          id: `${filePath}#chunk-${i}`,
+          content: chunk.content,
+          startLineOffset: chunk.startLine,
+          metadata: { sourceFile: filePath },
+        });
+      } catch (error) {
+        this._logger?.warn(`Failed to index chunk ${i} of file "${filePath}" for search`, { error });
+      }
     }
   }
 

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -855,6 +855,9 @@ export class Workspace<
       return;
     }
 
+    // Clear stale chunks from a previous indexing pass.
+    await this._searchEngine!.removeByPrefix(`${filePath}#chunk-`);
+
     const chunks = splitIntoChunks(content);
 
     if (chunks.length === 1) {
@@ -865,6 +868,9 @@ export class Workspace<
       }
       return;
     }
+
+    // Clear the single-doc entry in case the file grew into multiple chunks.
+    await this._searchEngine!.remove(filePath);
 
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i]!;

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -855,8 +855,8 @@ export class Workspace<
       return;
     }
 
-    // Clear stale chunks from a previous indexing pass.
-    await this._searchEngine!.removeByPrefix(`${filePath}#chunk-`);
+    // Clear stale single-doc/chunked entries from previous indexing passes.
+    await this._searchEngine!.removeSource(filePath);
 
     const chunks = splitIntoChunks(content);
 
@@ -868,9 +868,6 @@ export class Workspace<
       }
       return;
     }
-
-    // Clear the single-doc entry in case the file grew into multiple chunks.
-    await this._searchEngine!.remove(filePath);
 
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i]!;

--- a/packages/playground/src/domains/workspace/components/search-panel.tsx
+++ b/packages/playground/src/domains/workspace/components/search-panel.tsx
@@ -37,8 +37,7 @@ const modeConfig: Record<SearchMode, { label: string; icon: React.ReactNode; col
 };
 
 function getWorkspaceSearchResultFileId(result: SearchResult): string {
-  const sourceFile = result.metadata?.sourceFile;
-  return typeof sourceFile === 'string' ? sourceFile : result.id.replace(/#chunk-\d+$/, '');
+  return result.id.replace(/#chunk-\d+$/, '');
 }
 
 export function SearchWorkspacePanel({

--- a/packages/playground/src/domains/workspace/components/search-panel.tsx
+++ b/packages/playground/src/domains/workspace/components/search-panel.tsx
@@ -36,6 +36,11 @@ const modeConfig: Record<SearchMode, { label: string; icon: React.ReactNode; col
   },
 };
 
+function getWorkspaceSearchResultFileId(result: SearchResult): string {
+  const sourceFile = result.metadata?.sourceFile;
+  return typeof sourceFile === 'string' ? sourceFile : result.id.replace(/#chunk-\d+$/, '');
+}
+
 export function SearchWorkspacePanel({
   onSearch,
   isSearching,
@@ -151,7 +156,7 @@ export function SearchWorkspacePanel({
                   key={`${result.id}-${index}`}
                   result={result}
                   rank={index + 1}
-                  onClick={() => onViewResult?.(result.id)}
+                  onClick={() => onViewResult?.(getWorkspaceSearchResultFileId(result))}
                 />
               ))}
             </ul>
@@ -170,6 +175,7 @@ interface WorkspaceSearchResultItemProps {
 
 function WorkspaceSearchResultItem({ result, rank, onClick }: WorkspaceSearchResultItemProps) {
   const scorePercent = Math.min(100, Math.max(0, result.score * 100));
+  const fileId = getWorkspaceSearchResultFileId(result);
 
   return (
     <li className="border-t border-border1 first:border-t-0">
@@ -178,7 +184,7 @@ function WorkspaceSearchResultItem({ result, rank, onClick }: WorkspaceSearchRes
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
             <FolderOpen className="h-3.5 w-3.5 text-neutral4 shrink-0" />
-            <span className="font-mono text-sm text-neutral6 truncate">{result.id}</span>
+            <span className="font-mono text-sm text-neutral6 truncate">{fileId}</span>
             <div className="flex items-center gap-1.5 shrink-0">
               <div className="w-12 h-1 rounded-full bg-surface2 overflow-hidden">
                 <div className="h-full rounded-full bg-accent1" style={{ width: `${scorePercent}%` }} />


### PR DESCRIPTION
## Description

Large files exceeding embedding model token limits were silently skipped during workspace auto-indexing. When all files in a workspace exceeded the limit, zero vectors were inserted, the vector store table was never created, and search calls crashed with `SQLITE_ERROR: no such table` (on LibSQLVector).

Files are now automatically split into overlapping line-based chunks before embedding. This uses the `startLineOffset` and `#adjustLineRange` infrastructure that already existed in the search engine but was never wired up.

- Small files (under 4000 chars) are indexed exactly as before — zero behavior change
- Large files are split at line boundaries with 3-line overlap between chunks for context continuity
- Each chunk is indexed with ID `filepath#chunk-N`, correct `startLineOffset`, and `sourceFile` metadata
- Per-chunk error handling: if one chunk fails to embed, the rest still get indexed

**Design decisions for reviewer:**
- `DEFAULT_MAX_CHUNK_CHARS = 4000` — conservative to stay well under the 8191 token limit of most embedding models. Open to adjusting.
- Chunk IDs use `filepath#chunk-N` format — only affects large files that were previously failing silently, so no existing working behavior is changed.

## Related Issue(s)

Fixes #14639

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Files that previously exceeded indexing limits are no longer skipped and are fully indexed.
  * Large files are split into overlapping chunks to ensure full coverage.
  * Line-range metadata is preserved so search results map back to original files.
  * Index removals now reliably target prior chunked entries to avoid stale results.

* **New Features**
  * Reindexing clears prior chunked entries and indexes per-chunk content with start-line offsets; single-chunk files remain indexed as whole files.

* **Tests**
  * Added unit tests for chunking behavior and removal-by-prefix indexing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->