### PR TITLE
ix(core): prevent requestContext reserved keys from leaking into sub-agent memory

### DIFF
--- a/.changeset/green-impalas-slide.md
+++ b/.changeset/green-impalas-slide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed sub-agent memory isolation when threadId and resourceId are set via requestContext reserved keys (`mastra__threadId`, `mastra__resourceId`). Previously, these values leaked from the parent agent's requestContext into sub-agent calls, causing sub-agents to write messages to the parent's thread instead of their own isolated thread. The reserved keys are now saved and cleared before sub-agent execution, and restored afterward.

--- a/.changeset/green-impalas-slide.md
+++ b/.changeset/green-impalas-slide.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed sub-agent memory isolation when threadId and resourceId are set via requestContext reserved keys (`mastra__threadId`, `mastra__resourceId`). Previously, these values leaked from the parent agent's requestContext into sub-agent calls, causing sub-agents to write messages to the parent's thread instead of their own isolated thread. The reserved keys are now saved and cleared before sub-agent execution, and restored afterward.
+Fixed sub-agent memory isolation so sub-agents no longer inherit parent requestContext keys and write to their own threads when `mastra__threadId` or `mastra__resourceId` are set.

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -6,6 +6,7 @@ import { z } from 'zod/v4';
 import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
 import type { Processor, ProcessOutputResultArgs } from '../../processors/index';
+import { RequestContext, MASTRA_THREAD_ID_KEY, MASTRA_RESOURCE_ID_KEY } from '../../request-context';
 import { InMemoryStore } from '../../storage';
 import { createTool } from '../../tools';
 import { Agent } from '../agent';
@@ -3230,6 +3231,128 @@ describe('Supervisor Pattern - Message history transfer to sub-agents', () => {
         expect(allSavedContent).not.toContain('I live in Paris');
       }
     }
+  });
+
+  it('should isolate sub-agent memory when threadId and resourceId are set via requestContext reserved keys', async () => {
+    const subAgentMockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+        content: [{ type: 'text', text: 'Sub-agent response' }],
+        warnings: [],
+      }),
+    });
+
+    const memoryStore = new InMemoryStore();
+    const subAgentMemory = new MockMemory({ storage: memoryStore });
+
+    const subAgent = new Agent({
+      id: 'sub-agent-reserved-keys-test',
+      name: 'Sub Agent Reserved Keys Test',
+      description: 'A sub-agent for testing reserved key isolation',
+      instructions: 'Answer questions.',
+      model: subAgentMockModel,
+      memory: subAgentMemory,
+    });
+
+    let supervisorCallCount = 0;
+    const resourceId = randomUUID();
+    const threadId = randomUUID();
+
+    const supervisorAgent = new Agent({
+      id: 'supervisor-reserved-keys',
+      name: 'Supervisor Reserved Keys',
+      instructions: 'Delegate to sub-agent.',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => {
+          supervisorCallCount++;
+          if (supervisorCallCount === 1) {
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              text: '',
+              content: [
+                {
+                  type: 'tool-call' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'agent-subAgent',
+                  input: JSON.stringify({ prompt: 'What is my name?', threadId, resourceId }),
+                },
+              ],
+              warnings: [],
+            };
+          }
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            content: [{ type: 'text', text: 'Sub-agent says: Sub-agent response' }],
+            warnings: [],
+          };
+        },
+      }),
+      agents: { subAgent },
+      memory: new MockMemory(),
+    });
+
+    // Set reserved keys on requestContext (simulates middleware + body merge)
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_THREAD_ID_KEY, threadId);
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, resourceId);
+
+    await supervisorAgent.generate([{ role: 'user', content: 'What is my name?' }], {
+      maxSteps: 3,
+      requestContext,
+      memory: {
+        resource: resourceId,
+        thread: threadId,
+      },
+    });
+
+    // Sub-agent should have its own isolated thread, not the parent's
+    const subAgentResourceId = `${resourceId}-subAgent`;
+    const memoryStorage = await subAgentMemory.storage.getStore('memory');
+    expect(memoryStorage).toBeDefined();
+
+    if (memoryStorage) {
+      const allThreadsResult = await memoryStorage.listThreads({ filter: { resourceId: subAgentResourceId } });
+      const allThreads = allThreadsResult.threads;
+
+      // Sub-agent should have its own thread
+      expect(allThreads.length).toBeGreaterThan(0);
+
+      const subAgentThread = allThreads[0];
+      expect(subAgentThread).toBeDefined();
+
+      if (subAgentThread) {
+        // Sub-agent thread ID should NOT be the parent's thread ID
+        expect(subAgentThread.id).not.toBe(threadId);
+
+        const subAgentMessages = await memoryStorage.listMessages({
+          threadId: subAgentThread.id,
+          perPage: 100,
+        });
+
+        expect(subAgentMessages.messages.length).toBeGreaterThanOrEqual(2);
+
+        // First message should be the delegation prompt
+        expect(subAgentMessages.messages[0].role).toBe('user');
+        const userContent =
+          typeof subAgentMessages.messages[0].content === 'string'
+            ? subAgentMessages.messages[0].content
+            : JSON.stringify(subAgentMessages.messages[0].content);
+        expect(userContent).toContain('What is my name');
+
+        // Second message should be the sub-agent's response
+        expect(subAgentMessages.messages[1].role).toBe('assistant');
+      }
+    }
+
+    // Verify reserved keys are restored for the parent after sub-agent execution
+    expect(requestContext.get(MASTRA_THREAD_ID_KEY)).toBe(threadId);
+    expect(requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBe(resourceId);
   });
 
   describe('Sub-agent instructions merge', () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3121,6 +3121,13 @@ export class Agent<
                       }
                     }
 
+                    if (savedThreadIdKey !== undefined) {
+                      requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
+                    }
+                    if (savedResourceIdKey !== undefined) {
+                      requestContext.set(MASTRA_RESOURCE_ID_KEY, savedResourceIdKey);
+                    }
+
                     return {
                       text: `[Delegation Rejected] ${rejectionMessage}`,
                       subAgentThreadId,
@@ -3296,6 +3303,12 @@ export class Agent<
                 }
 
                 if (generateResult.finishReason === 'suspended') {
+                  if (savedThreadIdKey !== undefined) {
+                    requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
+                  }
+                  if (savedResourceIdKey !== undefined) {
+                    requestContext.set(MASTRA_RESOURCE_ID_KEY, savedResourceIdKey);
+                  }
                   return suspend?.(generateResult.suspendPayload, {
                     resumeSchema: generateResult.resumeSchema,
                     runId: generateResult.runId,
@@ -3437,6 +3450,12 @@ export class Agent<
                 }
 
                 if (requireToolApproval || suspendedPayload || resumeSchema) {
+                  if (savedThreadIdKey !== undefined) {
+                    requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
+                  }
+                  if (savedResourceIdKey !== undefined) {
+                    requestContext.set(MASTRA_RESOURCE_ID_KEY, savedResourceIdKey);
+                  }
                   return suspend?.(suspendedPayload, {
                     resumeSchema,
                     requireToolApproval,
@@ -3551,7 +3570,6 @@ export class Agent<
               if (savedMastraMemory !== undefined) {
                 requestContext.set('MastraMemory', savedMastraMemory);
               }
-              // Restore reserved thread/resource keys for the parent agent
               if (savedThreadIdKey !== undefined) {
                 requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
               }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3005,6 +3005,19 @@ export class Agent<
             // see the correct context on subsequent steps.
             const savedMastraMemory = requestContext.get('MastraMemory');
 
+            // Save and clear reserved thread/resource keys so they don't override the
+            // sub-agent's isolated memory config. These keys take precedence over the
+            // memory option in generate/stream, so leaving them would cause the
+            // sub-agent to write to the parent's thread instead of its own.
+            const savedThreadIdKey = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
+            const savedResourceIdKey = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+            if (savedThreadIdKey !== undefined) {
+              requestContext.delete(MASTRA_THREAD_ID_KEY);
+            }
+            if (savedResourceIdKey !== undefined) {
+              requestContext.delete(MASTRA_RESOURCE_ID_KEY);
+            }
+
             if (
               (methodType === 'generate' ||
                 methodType === 'generateLegacy' ||
@@ -3538,6 +3551,13 @@ export class Agent<
               if (savedMastraMemory !== undefined) {
                 requestContext.set('MastraMemory', savedMastraMemory);
               }
+              // Restore reserved thread/resource keys for the parent agent
+              if (savedThreadIdKey !== undefined) {
+                requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
+              }
+              if (savedResourceIdKey !== undefined) {
+                requestContext.set(MASTRA_RESOURCE_ID_KEY, savedResourceIdKey);
+              }
 
               return result;
             } catch (err) {
@@ -3611,11 +3631,16 @@ export class Agent<
                 }
               }
 
-              // Wrap error in MastraError
               // Restore even on error so the parent's retry/fallback logic
               // sees the correct memory context
               if (savedMastraMemory !== undefined) {
                 requestContext.set('MastraMemory', savedMastraMemory);
+              }
+              if (savedThreadIdKey !== undefined) {
+                requestContext.set(MASTRA_THREAD_ID_KEY, savedThreadIdKey);
+              }
+              if (savedResourceIdKey !== undefined) {
+                requestContext.set(MASTRA_RESOURCE_ID_KEY, savedResourceIdKey);
               }
 
               const mastraError = new MastraError(


### PR DESCRIPTION
## Description

When `mastra__threadId` and `mastra__resourceId` are set on the `requestContext` (via middleware or body merge), these reserved keys leaked into sub-agent calls during supervisor delegation.  

This caused the sub-agent to write messages to the parent's thread instead of its own isolated thread, resulting in duplicate messages in the chat history.

The fix saves and clears these reserved keys before sub-agent execution, and restores them afterward — matching the existing save/restore pattern already used for `MastraMemory`.

## Related Issue(s)

Fixes #15007

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sub-agent memory isolation improved in supervisor workflows: parent agent context no longer overrides sub-agent memory threads/resources, ensuring sub-agents store memory independently.

* **Tests**
  * Added integration test validating sub-agent memory isolation and that parent context is preserved after delegation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->