### PR TITLE
fix(server): accept null trajectory expectations in dataset schema

### DIFF
--- a/.changeset/hungry-banks-invite.md
+++ b/.changeset/hungry-banks-invite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed dataset schema to accept null values for trajectory expectations, matching what the database stores and what the UI sends

--- a/packages/server/src/server/schemas/datasets.ts
+++ b/packages/server/src/server/schemas/datasets.ts
@@ -168,6 +168,7 @@ const trajectoryExpectationSchema = z
     maxRetriesPerTool: z.number().int().optional().describe('Maximum retries per tool before penalizing (default: 2)'),
   })
   .optional()
+  .nullable()
   .describe('Expected trajectory configuration for trajectory scoring');
 
 // Dataset item source tracking


### PR DESCRIPTION
The `trajectoryExpectationSchema` in the dataset schemas was missing `.nullable()`, so Zod rejected `null` values that the DB stores and the UI sends.

Added `.nullable()` so the schema now accepts `undefined`, `null`, or a valid object:

```ts
const trajectoryExpectationSchema = z
  .object({ /* ... */ })
  .optional()
  .nullable()  // <-- added
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed dataset validation to properly accept null or empty trajectory expectations. The schema now aligns with database storage and UI submission behavior, eliminating validation errors when this field is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->