### PR TITLE
fix: don't default to 'simple' auth in example agent

### DIFF
--- a/examples/agent/src/mastra/auth/index.ts
+++ b/examples/agent/src/mastra/auth/index.ts
@@ -15,7 +15,7 @@
 
 import type { AuthResult, AuthProviderType } from './types';
 
-const AUTH_PROVIDER: AuthProviderType = (process.env.AUTH_PROVIDER as AuthProviderType) || 'simple';
+const AUTH_PROVIDER: AuthProviderType = (process.env.AUTH_PROVIDER as AuthProviderType);
 
 async function initAuth(): Promise<AuthResult> {
   switch (AUTH_PROVIDER) {


### PR DESCRIPTION
## Summary

Removes the default fallback to `'simple'` for `AUTH_PROVIDER` in the example agent's auth config. When `AUTH_PROVIDER` is not set, it should be `undefined` rather than silently defaulting to `'simple'`, which required auth even when none was intended.

## Changes

- **`examples/agent/src/mastra/auth/index.ts`** — Removed `|| 'simple'` fallback from the `AUTH_PROVIDER` constant so auth is not required by default.

## Test Plan

- Verify the example agent starts without setting `AUTH_PROVIDER` and does not enforce auth.
- Verify setting `AUTH_PROVIDER=simple` still works as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed automatic default authentication provider initialization when configuration is not explicitly provided. Applications must now explicitly set authentication provider configuration to enable authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->