### PR TITLE
adding initial /all-the-smoke slash command for feedback

### DIFF
--- a/.claude/commands/all-the-smoke.md
+++ b/.claude/commands/all-the-smoke.md
@@ -1,0 +1,1 @@
+../../.mastracode/commands/all-the-smoke.md

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -180,7 +180,7 @@ Based on the selected LLM provider, check for the required API key:
 
 ### Step 4: Start the Development Server
 
-Navigate to the project directory and start the dev server:
+Navigate to the generated project directory and start the dev server:
 
 ```sh
 cd <directory>/<project-name>
@@ -188,6 +188,44 @@ cd <directory>/<project-name>
 ```
 
 The server typically starts on `http://localhost:4111`. Wait for the server to be ready before proceeding.
+
+### Step 4.5: Use the Persistent Smoke Runner
+
+Do **not** install Playwright into each generated `create-mastra` app.
+
+Instead, keep a reusable harness in:
+
+```sh
+.mastracode/smoke-runner/
+```
+
+Install it once:
+
+```sh
+cd .mastracode/smoke-runner
+npm install
+npx playwright install chromium
+```
+
+Prefer the automated orchestrator for full end-to-end runs:
+
+```sh
+cd .mastracode/smoke-runner && \
+SMOKE_AUTOMATION_CONFIG='{"domains":["agents","networks"],"provider":"openai","packageManager":"npm","tag":"latest","openScreenshots":true}' \
+node run-smoke.mjs
+```
+
+This flow creates the app inside `.mastracode/tmp-smoke/runs/<run-id>/app`, injects the network test fixtures, starts the dev server, runs Playwright, opens the screenshots in Finder, and cleans up only the generated app when the run passes.
+
+The lower-level harness is still available when the app is already running:
+
+```sh
+cd .mastracode/smoke-runner && \
+SMOKE_RUN_CONFIG='{"baseUrl":"http://localhost:4111","domains":["agents","networks"],"screenshotDir":"../tmp-smoke/runs/<run-id>/screenshots"}' \
+node smoke-test.mjs
+```
+
+Only the generated app under `.mastracode/tmp-smoke/runs/<run-id>/app` is disposable.
 
 ### Step 5: Smoke Test the Studio
 
@@ -318,9 +356,10 @@ After completing all tests, provide a summary:
 | Step           | Action                                                                                                |
 | -------------- | ----------------------------------------------------------------------------------------------------- |
 | Create Project | `cd <directory> && npx create-mastra@<tag> <name> -c agents,tools,workflows,scorers -l <provider> -e` |
-| Install Deps   | Automatic during creation                                                                             |
+| Install Deps   | Automatic during creation for the generated app; Playwright stays installed in `.mastracode/smoke-runner` |
 | Set Env Vars   | Check global env first, then `.env`, ask user only if needed                                          |
 | Start Server   | `cd <directory>/<name> && npm run dev`                                                                |
+| Run Harness    | `cd .mastracode/smoke-runner && SMOKE_RUN_CONFIG='{"baseUrl":"http://localhost:4111",...}' node smoke-test.mjs` |
 | Studio URL     | `http://localhost:4111`                                                                               |
 
 ## Troubleshooting

--- a/.mastracode/commands/all-the-smoke.md
+++ b/.mastracode/commands/all-the-smoke.md
@@ -1,0 +1,188 @@
+# All The Smoke - Automated Studio Smoke Testing
+
+You are an automated smoke tester for Mastra Studio. Your job is to use **Playwright headless browser** automation to navigate the studio, interact with UI elements, and verify that everything works correctly - just like a QA engineer would, but faster and more thorough.
+
+## Step 1: Determine Test Target
+
+Ask the user:
+
+1. **Is a dev server already running?** If yes, ask for the URL (default: `http://localhost:4111`). If no, offer to set one up using the `/smoke-test` skill first.
+2. **Which domains do you want to smoke test?**
+
+Read all `.md` files from `.mastracode/smoke-domains/` (excluding `README.md`) to discover available domains. Present them as a numbered list:
+
+```
+Available smoke test domains:
+
+  [0] ALL - Run every domain
+  [1] agents - Agent listing, detail views, and chat
+  [2] networks - Agent network mode coordination
+  [3] tools - Tool listing and execution
+  [4] workflows - Workflow listing, graph view, and execution
+  [5] observability - Traces and timeline views
+  [6] scorers - Scorer listing and detail views
+  [7] navigation - Home page, routing, and general navigation
+  [8] settings - Settings page
+  [9] extras - Templates, processors, MCP servers, request context
+  ... (any additional domains added by engineers)
+
+Which domains? (comma-separated numbers, or 0 for all):
+```
+
+The list should be dynamically generated from whatever `.md` files exist in the `smoke-domains/` folder. Each file's YAML frontmatter `name` and `description` fields determine the display name and summary.
+
+## Step 2: Load Domain Instructions
+
+For each selected domain, read its corresponding `.md` file from `.mastracode/smoke-domains/`. Each file contains:
+- The routes to visit
+- Step-by-step interaction instructions
+- Expected behaviors to verify
+- Known issues to watch for
+
+## Step 3: Execute Tests with Playwright
+
+### Setup
+
+Use the persistent Playwright harness in `.mastracode/smoke-runner/`.
+
+Install Playwright there once and reuse it across runs:
+
+```sh
+cd .mastracode/smoke-runner
+npm install
+npx playwright install chromium
+```
+
+Create each fresh `create-mastra` test app under:
+
+```sh
+.mastracode/tmp-smoke/runs/<run-id>/app
+```
+
+Store per-run screenshots under:
+
+```sh
+.mastracode/tmp-smoke/runs/<run-id>/screenshots
+```
+
+### Writing the Test Script
+
+Reuse the persistent `smoke-test.mjs` script from `.mastracode/smoke-runner/` and pass it the base URL, selected domains, and screenshot directory for the current run.
+
+The reusable script should:
+
+1. Launches a **headless Chromium** browser via Playwright
+2. Creates a page with a `1440x900` viewport
+3. Listens for browser console errors
+
+**Critical: Wait strategy** — Do NOT use `waitUntil: 'networkidle'` for Mastra Studio pages. The studio maintains persistent WebSocket/SSE connections that prevent `networkidle` from resolving. Instead use:
+
+```js
+await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+await page.waitForTimeout(3000); // Allow hydration
+```
+
+For each selected domain, the script should:
+
+1. **Navigate** to each route using `domcontentloaded` wait strategy
+2. **Find elements** using cascading selectors (try specific selectors first, fall back to generic):
+   - `textarea` → `input[type="text"]` → `[contenteditable="true"]`
+   - `button[type="submit"]` → `button:has-text("Submit")` → `button:has-text("Run")`
+3. **Interact** with UI elements (click, fill, submit)
+4. **Poll for responses** instead of waiting for specific selectors — the studio's DOM structure may vary:
+   ```js
+   for (let i = 0; i < maxRetries; i++) {
+     await page.waitForTimeout(5000);
+     const content = await page.content();
+     if (content.includes(expectedText)) break;
+   }
+   ```
+5. **Screenshot** at each major checkpoint to the per-run screenshots directory, e.g. `.mastracode/tmp-smoke/runs/<run-id>/screenshots/`
+6. **Record** pass/fail for each test item
+7. **Continue on failure** — catch errors per-test, don't let one failure abort the run
+
+### Execution
+
+Prefer the automated orchestrator, which creates a fresh app, wires in the network fixtures, starts the dev server, runs the reusable Playwright harness, opens the screenshots in Finder, and then deletes only the generated app on success:
+
+```sh
+cd .mastracode/smoke-runner && \
+SMOKE_AUTOMATION_CONFIG='{"domains":["agents","networks"],"provider":"openai","packageManager":"npm","tag":"latest","openScreenshots":true}' \
+node run-smoke.mjs
+```
+
+The lower-level harness remains available when you already have a running target app:
+
+```sh
+cd .mastracode/smoke-runner && \
+SMOKE_RUN_CONFIG='{"baseUrl":"<url>","domains":["agents"],"screenshotDir":"../tmp-smoke/runs/<run-id>/screenshots"}' \
+node smoke-test.mjs
+```
+
+Use a long timeout (up to 10 minutes) since agent chat responses can take up to 90 seconds.
+
+### Key Routes and IDs
+
+These are the typical IDs from a `create-mastra` project with `-e` (examples):
+
+| Resource | Route | Notes |
+|----------|-------|-------|
+| Agent listing | `/agents` | |
+| Agent chat | `/agents/weather-agent/chat` | May redirect to `/chat/new` |
+| Tool listing | `/tools` | |
+| Tool detail | `/tools/get-weather` | Tool ID is `get-weather`, not `weatherTool` |
+| Workflow listing | `/workflows` | |
+| Workflow detail | `/workflows/weatherWorkflow` | |
+| Scorers | `/scorers` | |
+| Settings | `/settings` | |
+| Traces | `/traces` | Under observability |
+
+## Step 4: Report Results
+
+After all tests complete, provide a structured report:
+
+```
+## Smoke Test Report
+
+**Target**: <URL>
+**Date**: <date>
+**Domains tested**: <list>
+
+### Results Summary
+| Domain | Tests | Passed | Failed | Skipped |
+|--------|-------|--------|--------|---------|
+| ...    | ...   | ...    | ...    | ...     |
+
+### Failures (if any)
+For each failure:
+- **Domain**: <domain>
+- **Test**: <what was being tested>
+- **Expected**: <what should have happened>
+- **Actual**: <what actually happened>
+- **Screenshot**: <reference>
+
+### Flaky Tests (if any)
+- ...
+
+### Notes
+- ...
+```
+
+After displaying the report, **read the key screenshots** (agent listing, chat response, tool execution, workflow execution) to visually verify results.
+
+## Step 5: Cleanup
+
+If all tests passed:
+
+1. **Open the per-run screenshots directory in Finder** so the results are easy to review immediately
+2. **Kill the generated app's dev server**
+3. **Delete only the generated `create-mastra` app directory**: `rm -rf .mastracode/tmp-smoke/runs/<run-id>/app`
+4. **Keep** the per-run screenshots unless the user asks to remove them
+5. **Do not delete** `.mastracode/smoke-runner/`, its `package.json`, or its Playwright installation
+6. **Confirm cleanup** to the user
+
+If any tests failed, **leave the generated app and per-run artifacts in place** for debugging, and still open the screenshots directory in Finder.
+
+## Adding New Domains
+
+Engineers can add new smoke test domains by creating a `.md` file in `.mastracode/smoke-domains/`. See `.mastracode/smoke-domains/README.md` for the template and guidelines.

--- a/.mastracode/smoke-domains/README.md
+++ b/.mastracode/smoke-domains/README.md
@@ -1,0 +1,52 @@
+# Smoke Test Domains
+
+This folder contains domain-specific smoke test instructions for Mastra Studio. Each `.md` file defines a test domain that can be selected when running `/all-the-smoke`.
+
+## How to add a new domain
+
+1. Create a new `.md` file in this folder (e.g., `my-feature.md`)
+2. Use the template below
+3. Commit and push - the domain will automatically appear in `/all-the-smoke`
+
+## Template
+
+```markdown
+---
+name: my-feature
+description: Short description shown in the domain picker
+---
+
+# My Feature
+
+## Routes
+
+- `/my-feature` - Main listing page
+- `/my-feature/:id` - Detail view
+
+## Tests
+
+### Feature loads correctly
+1. Navigate to `/my-feature`
+2. Verify the page heading is visible
+3. Screenshot
+
+### Feature interaction works
+1. Click on the first item in the list
+2. Verify detail view loads
+3. Fill in the input field with "test value"
+4. Click Submit
+5. Verify output appears
+6. Screenshot
+
+## Known Issues
+- (optional) Document any known flaky behaviors or workarounds
+```
+
+## Guidelines
+
+- **Be specific**: Write instructions that a browser automation agent can follow literally. "Click the blue button" is better than "interact with the form."
+- **Include selectors when helpful**: If a button or input is hard to find, mention its label text, placeholder, or test ID.
+- **Add expected wait times**: If something takes a while (e.g., AI responses), say so.
+- **Document known issues**: If something is flaky or has a workaround, note it so the tester doesn't flag false positives.
+- **Keep routes up to date**: If the studio routing changes, update your domain file.
+- **One domain per file**: Don't combine unrelated features. It's fine to have small files.

--- a/.mastracode/smoke-domains/agents.md
+++ b/.mastracode/smoke-domains/agents.md
@@ -1,0 +1,42 @@
+---
+name: agents
+description: Agent listing, detail views, and chat
+---
+
+# Agents
+
+## Routes
+
+- `/agents` - Agent listing page
+- `/agents/<agentId>/chat` - Agent detail and chat view
+
+## Tests
+
+### Agent listing loads
+1. Navigate to `/agents`
+2. Verify at least one agent is listed (the example weather agent)
+3. Screenshot
+
+### Agent detail view loads
+1. Click on an agent to view its details
+2. Verify the agent overview panel loads with agent name and description
+3. Verify model settings panel is visible
+4. Screenshot
+
+### Agent chat works
+1. From the agent detail view, locate the chat input
+2. Send a test message: "Hello, can you help me?"
+3. Wait up to 30 seconds for a response
+4. Verify a response appears in the chat thread
+5. Screenshot the conversation
+
+### Agent chat handles follow-up
+1. Send a follow-up message: "What can you do?"
+2. Wait up to 30 seconds for a response
+3. Verify the response appears below the first exchange
+4. Screenshot
+
+## Known Issues
+
+- First message after server start may be slower due to cold start
+- If the API key is invalid, the chat will show an error - this is expected behavior, not a bug

--- a/.mastracode/smoke-domains/extras.md
+++ b/.mastracode/smoke-domains/extras.md
@@ -1,0 +1,42 @@
+---
+name: extras
+description: Templates, processors, MCP servers, request context
+---
+
+# Extras
+
+These are secondary pages that should load correctly but may show empty states in a fresh project.
+
+## Routes
+
+- `/templates` - Templates gallery
+- `/processors` - Processors listing
+- `/mcps` - MCP servers listing
+- `/request-context` - Request context JSON editor
+
+## Tests
+
+### Templates page loads
+1. Navigate to `/templates`
+2. Verify the page loads (should show a gallery of starter templates)
+3. Screenshot
+
+### Processors page loads
+1. Navigate to `/processors`
+2. Verify the page loads (empty state is OK for a fresh project)
+3. Screenshot
+
+### MCP Servers page loads
+1. Navigate to `/mcps`
+2. Verify the page loads (empty state is OK for a fresh project)
+3. Screenshot
+
+### Request Context page loads
+1. Navigate to `/request-context`
+2. Verify the page loads with a JSON editor or similar interface
+3. Screenshot
+
+## Known Issues
+
+- These pages may all show empty states in a newly created project - that's expected
+- Templates page content depends on available templates in the registry

--- a/.mastracode/smoke-domains/navigation.md
+++ b/.mastracode/smoke-domains/navigation.md
@@ -1,0 +1,37 @@
+---
+name: navigation
+description: Home page, routing, and general navigation
+---
+
+# Navigation
+
+## Routes
+
+- `/` - Home/root (should redirect)
+- `/agents` - Default landing after redirect
+
+## Tests
+
+### Studio loads from root
+1. Navigate to the root URL (`/`)
+2. Verify the page loads without errors
+3. Verify redirection to `/agents` (or the default landing page)
+4. Screenshot
+
+### Sidebar navigation works
+1. Verify the sidebar/navigation menu is visible
+2. Click on each main nav item and verify the corresponding page loads:
+   - Agents
+   - Workflows
+   - Tools
+   - Scorers
+   - Observability
+3. Screenshot at least one navigation transition
+
+### Page titles are correct
+1. As you navigate between pages, verify each page has an appropriate heading or title
+2. No page should show "undefined" or blank titles
+
+## Known Issues
+
+- Initial load may show a brief loading state before redirect completes

--- a/.mastracode/smoke-domains/networks.md
+++ b/.mastracode/smoke-domains/networks.md
@@ -1,0 +1,39 @@
+---
+name: networks
+description: Agent network mode coordination
+---
+
+# Networks
+
+Requires a network agent to be configured (an agent with `agents` property and `memory`). The `/smoke-test` skill sets up a `planner-network` agent for this purpose.
+
+## Routes
+
+- `/agents/planner-network/chat` - Network agent chat view
+
+## Tests
+
+### Network agent is listed
+1. Navigate to `/agents`
+2. Verify the `planner-network` agent (or equivalent network agent) appears in the list
+3. Screenshot
+
+### Network mode can be selected
+1. Navigate to `/agents/planner-network/chat`
+2. Look for the Chat Method settings
+3. Select "Network" mode
+4. Verify the mode switches (UI should indicate network mode is active)
+5. Screenshot
+
+### Network coordination works
+1. With Network mode selected, send a message: "What activities can I do in Tokyo based on the weather?"
+2. Wait up to 60 seconds for the full network coordination to complete
+3. Verify network coordination indicators appear (e.g., shows which sub-agent is being called)
+4. Verify a final combined response appears
+5. Screenshot
+
+## Known Issues
+
+- Network mode requires `memory` on the agent - if missing, it will error
+- Network coordination can take longer than single-agent chat (30-60 seconds)
+- The sub-agent indicators may flash quickly - screenshot timing matters

--- a/.mastracode/smoke-domains/observability.md
+++ b/.mastracode/smoke-domains/observability.md
@@ -1,0 +1,37 @@
+---
+name: observability
+description: Traces and timeline views
+---
+
+# Observability
+
+Best tested AFTER running agent chats, tool executions, or workflows, since those generate the trace data that appears here.
+
+## Routes
+
+- `/observability` - Traces listing page
+
+## Tests
+
+### Traces listing loads
+1. Navigate to `/observability`
+2. Verify the traces list loads
+3. If previous tests generated activity, verify at least one trace is shown
+4. Screenshot
+
+### Trace detail view
+1. Click on a trace in the list to view its details
+2. Verify the timeline view loads showing steps and timing
+3. Verify individual spans/steps are visible with duration information
+4. Screenshot
+
+### Trace data is meaningful
+1. In the trace detail view, verify that span names correspond to actual operations (e.g., agent calls, tool executions)
+2. Verify timing data is present and reasonable (not zero or negative)
+3. Screenshot
+
+## Known Issues
+
+- If no agents, tools, or workflows have been run yet, the traces list will be empty - this is expected
+- Trace data may take a moment to appear after an operation completes
+- Run the agents/tools/workflows domains first for best results

--- a/.mastracode/smoke-domains/scorers.md
+++ b/.mastracode/smoke-domains/scorers.md
@@ -1,0 +1,31 @@
+---
+name: scorers
+description: Scorer listing and detail views
+---
+
+# Scorers
+
+## Routes
+
+- `/scorers` - Scorer listing page
+- `/scorers/<scorerName>` - Scorer detail view
+
+## Tests
+
+### Scorer listing loads
+1. Navigate to `/scorers`
+2. Verify the scorers list loads (should show 3 example scorers if created with `-e`)
+3. Screenshot
+
+### Scorer detail view loads
+1. Navigate directly to `/scorers/completeness-scorer` using URL navigation (do NOT click - use direct URL)
+2. Verify the scorer detail page loads with:
+   - Scorer name
+   - Description
+   - Scores table or configuration
+3. Screenshot
+
+## Known Issues
+
+- **Use direct URL navigation** for scorer details - clicking from the list has client-side routing timing issues with browser automation
+- Scorer names in URLs are kebab-case versions of the display names

--- a/.mastracode/smoke-domains/settings.md
+++ b/.mastracode/smoke-domains/settings.md
@@ -1,0 +1,26 @@
+---
+name: settings
+description: Settings page
+---
+
+# Settings
+
+## Routes
+
+- `/settings` - Settings page
+
+## Tests
+
+### Settings page loads
+1. Navigate to `/settings`
+2. Verify the settings page loads without errors
+3. Verify settings sections/panels are visible
+4. Screenshot
+
+### Settings are readable
+1. Verify that configuration values are displayed (not blank or error states)
+2. Screenshot
+
+## Known Issues
+
+- Settings page content depends on the Mastra configuration - some sections may be empty in a fresh project

--- a/.mastracode/smoke-domains/tools.md
+++ b/.mastracode/smoke-domains/tools.md
@@ -1,0 +1,45 @@
+---
+name: tools
+description: Tool listing and execution
+---
+
+# Tools
+
+## Routes
+
+- `/tools` - Tool listing page
+- `/tools/<toolName>` - Tool detail and execution view
+
+## Tests
+
+### Tool listing loads
+1. Navigate to `/tools`
+2. Verify the tools list loads with at least one tool (should show `weatherTool`)
+3. Screenshot
+
+### Tool detail view loads
+1. Click on `weatherTool` to open its detail page
+2. Verify the tool name and description are visible
+3. Verify an input form is displayed with the expected fields
+4. Screenshot
+
+### Tool execution works
+1. On the `weatherTool` detail page, find the city input field
+2. Enter "Tokyo" as the city value
+3. Click the Submit button
+4. Wait up to 15 seconds for execution to complete
+5. Verify JSON output appears with weather data (should contain temperature, condition, or similar fields)
+6. Screenshot the result
+
+### Tool handles different inputs
+1. Clear the previous input
+2. Enter "London" as the city value
+3. Click Submit
+4. Wait for execution to complete
+5. Verify new JSON output appears (different from the Tokyo result)
+6. Screenshot
+
+## Known Issues
+
+- Tool execution depends on the tool's implementation - the example weatherTool returns mock data
+- If the tool has required fields that aren't filled, submission should show validation errors

--- a/.mastracode/smoke-domains/workflows.md
+++ b/.mastracode/smoke-domains/workflows.md
@@ -1,0 +1,44 @@
+---
+name: workflows
+description: Workflow listing, graph view, and execution
+---
+
+# Workflows
+
+## Routes
+
+- `/workflows` - Workflow listing page
+- `/workflows/<workflowName>` - Workflow detail and execution view
+
+## Tests
+
+### Workflow listing loads
+1. Navigate to `/workflows`
+2. Verify the workflows list loads with at least one workflow (should show `weatherWorkflow`)
+3. Screenshot
+
+### Workflow detail and graph view
+1. Click on `weatherWorkflow` to open its detail page
+2. Verify the visual graph displays showing workflow steps
+3. Verify step nodes are visible and connected
+4. Screenshot
+
+### Workflow execution works
+1. On the workflow detail page, find the city input field
+2. Enter "London" as the input value
+3. Click the Run button
+4. Wait up to 30 seconds for execution to complete
+5. Verify workflow steps show success indicators (green checkmarks or similar)
+6. Screenshot
+
+### Workflow output is viewable
+1. After successful execution, click to view the JSON output modal/panel
+2. Verify execution details with timing information appear
+3. Verify the output contains weather-related data
+4. Screenshot
+
+## Known Issues
+
+- Workflow graph rendering can take a moment after page load
+- Long-running workflows may need extra wait time
+- The output modal may need to be scrolled to see all data

--- a/.mastracode/smoke-runner/README.md
+++ b/.mastracode/smoke-runner/README.md
@@ -1,0 +1,25 @@
+# Smoke Runner
+
+Reusable Playwright harness for `/all-the-smoke`.
+
+## Purpose
+
+This directory is intentionally persistent across smoke-test runs.
+
+Keep in place:
+- `package.json`
+- Playwright dependency installation
+- reusable smoke scripts/helpers
+- `run-smoke.mjs` orchestrator
+
+Delete per run:
+- generated `create-mastra` apps under `../tmp-smoke/runs/<run-id>/`
+- dev servers started for those generated apps
+- per-run screenshots/output unless intentionally preserved for debugging
+
+## Expected structure
+
+- `.mastracode/smoke-runner/` - reusable harness
+- `.mastracode/smoke-runner/run-smoke.mjs` - end-to-end orchestrator
+- `.mastracode/tmp-smoke/runs/<run-id>/app/` - disposable created app
+- `.mastracode/tmp-smoke/runs/<run-id>/screenshots/` - per-run screenshots preserved for review

--- a/.mastracode/smoke-runner/package-lock.json
+++ b/.mastracode/smoke-runner/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "mastra-smoke-runner",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mastra-smoke-runner",
+      "dependencies": {
+        "playwright": "^1.55.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/.mastracode/smoke-runner/package.json
+++ b/.mastracode/smoke-runner/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mastra-smoke-runner",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node smoke-test.mjs",
+    "run": "node run-smoke.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.55.0"
+  }
+}

--- a/.mastracode/smoke-runner/run-smoke.mjs
+++ b/.mastracode/smoke-runner/run-smoke.mjs
@@ -1,0 +1,242 @@
+import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const runsRoot = path.resolve(repoRoot, '.mastracode', 'tmp-smoke', 'runs');
+const rootEnvPath = path.resolve(repoRoot, '.env');
+
+const config = JSON.parse(process.env.SMOKE_AUTOMATION_CONFIG ?? '{}');
+const runId = config.runId ?? new Date().toISOString().replace(/[:.]/g, '-');
+const packageManager = config.packageManager ?? 'npm';
+const provider = config.provider ?? 'openai';
+const tag = config.tag ?? 'latest';
+const domains = Array.isArray(config.domains) && config.domains.length ? config.domains : ['agents', 'networks'];
+const port = Number(config.port ?? 4111);
+const appName = config.appName ?? 'app';
+const keepArtifactsOnFailure = config.keepArtifactsOnFailure ?? true;
+const openScreenshots = config.openScreenshots ?? true;
+const runRoot = path.join(runsRoot, runId);
+const appRoot = path.join(runRoot, appName);
+const screenshotDir = path.join(runRoot, 'screenshots');
+const baseUrl = `http://localhost:${port}`;
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: { ...process.env, ...(options.env ?? {}) },
+      stdio: options.stdio ?? 'inherit',
+      shell: options.shell ?? false,
+    });
+
+    child.on('error', reject);
+    child.on('exit', code => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+    });
+  });
+}
+
+function startBackground(command, args, options = {}) {
+  const child = spawn(command, args, {
+    cwd: options.cwd,
+    env: { ...process.env, ...(options.env ?? {}) },
+    stdio: options.stdio ?? 'pipe',
+    shell: options.shell ?? false,
+  });
+
+  let output = '';
+  child.stdout?.on('data', chunk => {
+    const text = chunk.toString();
+    output += text;
+    process.stdout.write(text);
+  });
+  child.stderr?.on('data', chunk => {
+    const text = chunk.toString();
+    output += text;
+    process.stderr.write(text);
+  });
+
+  return { child, getOutput: () => output };
+}
+
+async function waitForServer(url, background, timeoutMs = 120000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {}
+    if (background.child.exitCode !== null) {
+      throw new Error(`Dev server exited before becoming ready.\n${background.getOutput()}`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  }
+  throw new Error(`Timed out waiting for dev server at ${url}.\n${background.getOutput()}`);
+}
+
+async function ensureDir(target) {
+  await fs.mkdir(target, { recursive: true });
+}
+
+async function copyRootEnv() {
+  if (!existsSync(rootEnvPath)) return;
+  await fs.copyFile(rootEnvPath, path.join(appRoot, '.env'));
+}
+
+async function scaffoldApp() {
+  await ensureDir(runRoot);
+  const args = ['create-mastra@' + tag, appName, '-c', 'agents,tools,workflows,scorers', '-l', provider, '-e'];
+  await runCommand('npx', args, { cwd: runRoot });
+  await copyRootEnv();
+}
+
+async function writeNetworkFiles() {
+  const agentsDir = path.join(appRoot, 'src', 'mastra', 'agents');
+  const indexPath = path.join(appRoot, 'src', 'mastra', 'index.ts');
+  const weatherAgentPath = path.join(agentsDir, 'weather-agent.ts');
+  const activityAgentPath = path.join(agentsDir, 'activity-agent.ts');
+  const plannerNetworkPath = path.join(agentsDir, 'planner-network.ts');
+
+  const observationalMemory = `new Memory({\n    options: {\n      lastMessages: 20,\n      semanticRecall: false,\n      generateTitle: false,\n      observationalMemory: {\n        model: 'openai/gpt-4o',\n      },\n    },\n  })`;
+
+  const weatherAgentSource = await fs.readFile(weatherAgentPath, 'utf8');
+  const updatedWeatherAgent = weatherAgentSource.replace('memory: new Memory(),', `memory: ${observationalMemory},`);
+  if (updatedWeatherAgent === weatherAgentSource) {
+    throw new Error('Failed to update weather-agent memory configuration');
+  }
+  await fs.writeFile(weatherAgentPath, updatedWeatherAgent);
+
+  await fs.writeFile(
+    activityAgentPath,
+    `import { Agent } from '@mastra/core/agent';\nimport { Memory } from '@mastra/memory';\n\nexport const activityAgent = new Agent({\n  id: 'activity-agent',\n  name: 'Activity Agent',\n  instructions:\n    'You suggest practical activities based on weather conditions, energy level, and city context. Keep suggestions concise and useful.',\n  model: 'openai/gpt-4o',\n  memory: ${observationalMemory},\n});\n`
+  );
+
+  await fs.writeFile(
+    plannerNetworkPath,
+    `import { Agent } from '@mastra/core/agent';\nimport { Memory } from '@mastra/memory';\nimport { weatherAgent } from './weather-agent';\nimport { activityAgent } from './activity-agent';\n\nexport const plannerNetwork = new Agent({\n  id: 'planner-network',\n  name: 'Planner Network',\n  instructions:\n    'Coordinate the weather agent and activity agent to recommend activities that fit the forecast. Respond with a final user-friendly answer.',\n  model: 'openai/gpt-4o',\n  agents: { weatherAgent, activityAgent },\n  memory: ${observationalMemory},\n});\n`
+  );
+
+  const indexSource = await fs.readFile(indexPath, 'utf8');
+  let updatedIndex = indexSource;
+  if (!updatedIndex.includes("./agents/activity-agent")) {
+    updatedIndex = updatedIndex.replace(
+      "import { weatherAgent } from './agents/weather-agent';",
+      "import { weatherAgent } from './agents/weather-agent';\nimport { activityAgent } from './agents/activity-agent';\nimport { plannerNetwork } from './agents/planner-network';"
+    );
+  }
+  updatedIndex = updatedIndex.replace('agents: { weatherAgent },', 'agents: { weatherAgent, activityAgent, plannerNetwork },');
+  if (updatedIndex === indexSource) {
+    throw new Error('Failed to register network agents in src/mastra/index.ts');
+  }
+  await fs.writeFile(indexPath, updatedIndex);
+}
+
+async function runHarness() {
+  await ensureDir(screenshotDir);
+  const jsonChunks = [];
+  await new Promise((resolve, reject) => {
+    const child = spawn('node', ['smoke-test.mjs'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        SMOKE_RUN_CONFIG: JSON.stringify({ baseUrl, domains, screenshotDir }),
+      },
+      stdio: ['inherit', 'pipe', 'inherit'],
+    });
+
+    child.stdout.on('data', chunk => {
+      const text = chunk.toString();
+      jsonChunks.push(text);
+      process.stdout.write(text);
+    });
+
+    child.on('error', reject);
+    child.on('exit', code => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`Smoke harness exited with code ${code}`));
+    });
+  });
+
+  const parsed = JSON.parse(jsonChunks.join('').trim());
+  return parsed;
+}
+
+async function openInFinder(target) {
+  await runCommand('open', [target], { cwd: repoRoot });
+}
+
+async function cleanupSucceededRun() {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      await fs.rm(appRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 250 });
+      return;
+    } catch (error) {
+      if (attempt === 4) throw error;
+      await new Promise(resolve => setTimeout(resolve, 500));
+    }
+  }
+}
+
+async function stopServer(server) {
+  if (!server?.child || server.child.exitCode !== null) return;
+  server.child.kill('SIGTERM');
+  await new Promise(resolve => setTimeout(resolve, 1500));
+  if (server.child.exitCode === null) {
+    server.child.kill('SIGKILL');
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+}
+
+async function main() {
+  let server;
+  let results;
+  try {
+    console.log(`==> Smoke run ${runId}`);
+    console.log(`==> Creating app in ${path.relative(repoRoot, appRoot)}`);
+    await scaffoldApp();
+    await writeNetworkFiles();
+
+    console.log(`==> Starting dev server on ${baseUrl}`);
+    server = startBackground(packageManager, ['run', 'dev'], { cwd: appRoot, env: { PORT: String(port) } });
+    await waitForServer(baseUrl, server);
+
+    console.log(`==> Running reusable smoke harness for domains: ${domains.join(', ')}`);
+    results = await runHarness();
+
+    const failed = results.results.filter(result => result.status !== 'passed');
+    console.log(`==> Screenshots: ${screenshotDir}`);
+    if (openScreenshots) {
+      await openInFinder(screenshotDir);
+    }
+
+    if (failed.length === 0) {
+      console.log('==> All smoke tests passed. Stopping dev server and cleaning up generated app only.');
+      await stopServer(server);
+      server = undefined;
+      await cleanupSucceededRun();
+    } else {
+      console.log('==> Smoke tests failed. Leaving generated app and artifacts in place for debugging.');
+    }
+
+    console.log(JSON.stringify({ runId, appRoot, screenshotDir, baseUrl, domains, failed: failed.length }, null, 2));
+  } finally {
+    await stopServer(server);
+
+    if (!results && !keepArtifactsOnFailure && existsSync(runRoot)) {
+      await fs.rm(runRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+await main();

--- a/.mastracode/smoke-runner/smoke-test.mjs
+++ b/.mastracode/smoke-runner/smoke-test.mjs
@@ -1,0 +1,155 @@
+import { chromium } from 'playwright';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const config = JSON.parse(process.env.SMOKE_RUN_CONFIG ?? '{}');
+
+if (!config.baseUrl) {
+  throw new Error('Missing SMOKE_RUN_CONFIG.baseUrl');
+}
+
+const baseUrl = config.baseUrl;
+const screenshotDir = path.resolve(config.screenshotDir ?? './screenshots');
+const domains = Array.isArray(config.domains) ? config.domains : [];
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+
+await fs.mkdir(screenshotDir, { recursive: true });
+
+const consoleErrors = [];
+page.on('console', msg => {
+  if (msg.type() === 'error') consoleErrors.push(msg.text());
+});
+page.on('pageerror', err => consoleErrors.push(String(err)));
+
+const results = [];
+
+const slug = value => value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+async function shot(name) {
+  const file = path.join(screenshotDir, `${String(results.length + 1).padStart(2, '0')}-${slug(name)}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  return file;
+}
+
+async function gotoStudio(route) {
+  await page.goto(`${baseUrl}${route}`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.waitForTimeout(3000);
+}
+
+async function findInput() {
+  for (const selector of ['textarea', 'input[type="text"]', '[contenteditable="true"]']) {
+    const locator = page.locator(selector).first();
+    if (await locator.count()) return locator;
+  }
+  throw new Error('No input found');
+}
+
+async function submitCurrentPage() {
+  for (const selector of ['button[type="submit"]', 'button:has-text("Submit")', 'button:has-text("Run")']) {
+    const button = page.locator(selector).first();
+    if (await button.count()) {
+      await button.click();
+      return;
+    }
+  }
+  await page.keyboard.press('Enter');
+}
+
+async function pollForText(expectedTexts, maxRetries = 12, delayMs = 5000) {
+  for (let i = 0; i < maxRetries; i++) {
+    const content = (await page.content()).toLowerCase();
+    if (expectedTexts.some(text => content.includes(text.toLowerCase()))) return true;
+    await page.waitForTimeout(delayMs);
+  }
+  return false;
+}
+
+async function record(domain, test, fn) {
+  const entry = { domain, test, status: 'passed', error: null, screenshot: null };
+  try {
+    await fn(entry);
+  } catch (error) {
+    entry.status = 'failed';
+    entry.error = error instanceof Error ? error.message : String(error);
+    try {
+      entry.screenshot = await shot(`${domain}-${test}-failure`);
+    } catch {}
+  }
+  results.push(entry);
+}
+
+async function runAgents() {
+  await record('agents', 'Agent listing loads', async entry => {
+    await gotoStudio('/agents');
+    const content = await page.content();
+    if (!content.includes('Weather Agent')) throw new Error('Weather Agent not listed');
+    entry.screenshot = await shot('agents-listing');
+  });
+
+  await record('agents', 'Agent detail view loads', async entry => {
+    await gotoStudio('/agents/weather-agent/chat');
+    const content = await page.content();
+    if (!content.includes('Weather Agent')) throw new Error('Weather Agent detail not visible');
+    if (!content.toLowerCase().includes('model')) throw new Error('Model settings panel not visible');
+    entry.screenshot = await shot('agents-detail');
+  });
+
+  await record('agents', 'Agent chat works', async entry => {
+    await gotoStudio('/agents/weather-agent/chat');
+    const input = await findInput();
+    await input.fill('Hello, can you help me?');
+    await submitCurrentPage();
+    const ok = await pollForText(['help', 'weather'], 8, 5000);
+    if (!ok) throw new Error('Agent response did not appear');
+    entry.screenshot = await shot('agents-chat-response');
+  });
+
+  await record('agents', 'Agent chat handles follow-up', async entry => {
+    const input = await findInput();
+    await input.fill('What can you do?');
+    await submitCurrentPage();
+    const ok = await pollForText(['can help', 'weather', 'tool'], 8, 5000);
+    if (!ok) throw new Error('Follow-up response did not appear');
+    entry.screenshot = await shot('agents-follow-up-response');
+  });
+}
+
+async function runNetworks() {
+  await record('networks', 'Network agent is listed', async entry => {
+    await gotoStudio('/agents');
+    const content = await page.content();
+    if (!content.includes('Planner Network')) throw new Error('Planner Network not listed');
+    entry.screenshot = await shot('networks-listing');
+  });
+
+  await record('networks', 'Network mode can be selected', async entry => {
+    await gotoStudio('/agents/planner-network/chat');
+    const before = await page.content();
+    const networkToggle = page.getByText('Network', { exact: true }).first();
+    if (await networkToggle.count()) await networkToggle.click();
+    const after = await page.content();
+    if (!after.includes('Planner Network') && !before.includes('Planner Network')) {
+      throw new Error('Planner Network chat page did not load');
+    }
+    entry.screenshot = await shot('networks-mode-selected');
+  });
+
+  await record('networks', 'Network coordination works', async entry => {
+    const input = await findInput();
+    await input.fill('What activities can I do in Tokyo based on the weather?');
+    await submitCurrentPage();
+    const ok = await pollForText(['tokyo', 'activity'], 12, 5000);
+    if (!ok) throw new Error('Network response did not appear');
+    entry.screenshot = await shot('networks-chat-response');
+  });
+}
+
+try {
+  if (domains.includes('agents')) await runAgents();
+  if (domains.includes('networks')) await runNetworks();
+
+  console.log(JSON.stringify({ baseUrl, domains, results, consoleErrors, screenshotDir }, null, 2));
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## Description

This is the code for the demo I gave earlier today, for the slash command `/all-the-smoke`. It's a good thing that i had a two-for-one demo promotion, because this one has a lot in common with the existing Claude skill /smoke-test which I believe has room for improvement. Running it locally with Claude Code Opus 4.6, it failed to initially detect that a Studio instance was running on localhost (which it was) and in-general took too long to finish with inconsistent results. Perhaps I wasn't running it correctly, but the time it took to run seemed excessive as it kept hitting various tool call timeouts.

This PR is meant to be a prototype, a jumping off point for discussing how we might want to 'productionize' smoke-testing. This command spins up a new mastra studio project with pnpm, and then walk through a few headless browser testing scenarios with Playwright based off of different Markdown files that detail the possible surface area of the runner to walk through. My thinking was that engineers who have greater visibility into different parts of the codebase would update the markdown with their specific smoke testing instruction set, so that if we wanted to walk through the entire application, it would have a bunch of high-signal test cases to work through. 

@roaminro you mentioned in the demo call that you had some Playwright automation set up that you use for smoke testing - what are your thoughts on this? What is your current approach towards using headless browser testing? Is Markdown the right medium? Is this even the right solution?

Again, it's a prototype, not production quality, but in my limited testing it worked a bit better (and faster) than the previous /smoke-test command.

## Related Issue(s)

NA

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
