### PR TITLE
fix(cli): rename gateway env vars and use mastra/ model string

### DIFF
--- a/.changeset/tiny-streets-hug.md
+++ b/.changeset/tiny-streets-hug.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Renamed GATEWAY_URL and GATEWAY_API_KEY env vars to MASTRA_GATEWAY_URL and MASTRA_GATEWAY_API_KEY to match the mastra provider in core. Gateway agents now use the mastra/ model string directly instead of generating a shared.ts file.

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -166,8 +166,8 @@ async function setupGateway(projectName: string) {
     const escapedKey = shellQuote.quote([result.apiKey]);
     const escapedUrl = shellQuote.quote([MASTRA_GATEWAY_URL]);
 
-    await exec(`echo GATEWAY_URL=${escapedUrl} >> .env`);
-    await exec(`echo GATEWAY_API_KEY=${escapedKey} >> .env`);
+    await exec(`echo MASTRA_GATEWAY_URL=${escapedUrl} >> .env`);
+    await exec(`echo MASTRA_GATEWAY_API_KEY=${escapedKey} >> .env`);
 
     p.log.success(`Gateway project "${result.project.name}" provisioned`);
     p.log.info(`API key written to .env`);

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -15,7 +15,6 @@ import {
   writeAPIKey,
   writeClaudeMarkdown,
   writeCodeSample,
-  writeGatewaySharedFile,
   writeIndexFile,
 } from './utils';
 import type { Component, ConnectionMethod, LLMProvider } from './utils';
@@ -85,10 +84,6 @@ export const init = async ({
       initTasks.push(writeAPIKey({ provider: llmProvider, apiKey: llmApiKey }));
     }
 
-    if (connectionMethod === 'gateway') {
-      initTasks.push(writeGatewaySharedFile(dirPath));
-    }
-
     await Promise.all(initTasks);
 
     if (addExample) {
@@ -111,7 +106,7 @@ export const init = async ({
           await installWithFallback(depService, '@mastra/memory', packageVersionTag);
         }
       }
-      
+
       const needsDuckDB = (await depService.checkDependencies(['@mastra/duckdb'])) !== `ok`;
       if (needsDuckDB) {
         await depService.installPackages([`@mastra/duckdb${packageVersionTag}`]);
@@ -217,7 +212,7 @@ export const init = async ({
       p.note(`
       ${color.green('Mastra initialized successfully!')}
 
-      ${color.cyan('GATEWAY_URL')} and ${color.cyan('GATEWAY_API_KEY')} have been written to your ${color.cyan('.env')} file
+      ${color.cyan('MASTRA_GATEWAY_URL')} and ${color.cyan('MASTRA_GATEWAY_API_KEY')} have been written to your ${color.cyan('.env')} file
       `);
     } else if (!llmApiKey) {
       const key = await getAPIKey(llmProvider || 'openai');

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -67,7 +67,6 @@ export async function writeAgentSample(
   connectionMethod: ConnectionMethod = 'direct',
 ) {
   const modelString = getModelIdentifier(llmProvider);
-  const [, modelName] = modelString.split('/');
 
   const instructions = `
       You are a helpful weather assistant that provides accurate weather information and can help planning activities based on the weather.
@@ -84,14 +83,13 @@ export async function writeAgentSample(
       ${addExampleTool ? 'Use the weatherTool to fetch current weather data.' : ''}
 `;
 
-  const gatewayImport = connectionMethod === 'gateway' ? `import { gateway } from '../shared';\n` : '';
-  const modelValue = connectionMethod === 'gateway' ? `gateway.chatModel('${modelName}')` : `'${modelString}'`;
+  const modelValue = connectionMethod === 'gateway' ? `'mastra/${modelString}'` : `'${modelString}'`;
 
   const memoryImport = connectionMethod !== 'gateway' ? `import { Memory } from '@mastra/memory';\n` : '';
 
   const content = `
 import { Agent } from '@mastra/core/agent';
-${memoryImport}${gatewayImport}${addExampleTool ? `import { weatherTool } from '../tools/weather-tool';` : ''}
+${memoryImport}${addExampleTool ? `import { weatherTool } from '../tools/weather-tool';` : ''}
 ${addScorers ? `import { scorers } from '../scorers/weather-scorer';` : ''}
 
 export const weatherAgent = new Agent({
@@ -136,33 +134,6 @@ export const weatherAgent = new Agent({
   });
 
   await fs.writeFile(destPath, '');
-  await fs.writeFile(destPath, formattedContent);
-}
-
-export async function writeGatewayShared(dirPath: string) {
-  const content = `import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-
-/**
- * Memory Gateway provider — an OpenAI-compatible proxy with built-in
- * observational memory.  Configure GATEWAY_URL and GATEWAY_API_KEY in .env.
- *
- * Usage:
- *   import { gateway } from './shared';
- *   const model = gateway.chatModel('gpt-5-mini');
- */
-export const gateway = createOpenAICompatible({
-  name: 'mastra-gateway',
-  baseURL: process.env.GATEWAY_URL!,
-  apiKey: process.env.GATEWAY_API_KEY ?? '',
-});
-`;
-
-  const formattedContent = await prettier.format(content, {
-    parser: 'typescript',
-    singleQuote: true,
-  });
-
-  const destPath = path.join(dirPath, 'shared.ts');
   await fs.writeFile(destPath, formattedContent);
 }
 
@@ -489,19 +460,6 @@ export const createComponentsDir = async (dirPath: string, component: string) =>
   const componentPath = dirPath + `/${component}`;
 
   await fsExtra.ensureDir(componentPath);
-};
-
-export const writeGatewaySharedFile = async (dirPath: string) => {
-  const sharedPath = path.join(dirPath, 'shared.ts');
-  const content = `import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-
-export const gateway = createOpenAICompatible({
-  name: 'mastra-gateway',
-  baseURL: process.env.GATEWAY_URL!,
-  apiKey: process.env.GATEWAY_API_KEY!,
-});
-`;
-  await fs.writeFile(sharedPath, content);
 };
 
 export const writeIndexFile = async ({


### PR DESCRIPTION
Aligns the CLI-generated env vars with what `@mastra/core` expects:

- `GATEWAY_URL` → `MASTRA_GATEWAY_URL`
- `GATEWAY_API_KEY` → `MASTRA_GATEWAY_API_KEY`

Gateway agents now use the `mastra/` prefixed model string directly (e.g. `'mastra/openai/gpt-5-mini'`) instead of importing from a generated `shared.ts`. The `shared.ts` generation has been removed.