### PR TITLE
updated mastra server's splash page with curl request, and swagger-lite ui

### DIFF
--- a/packages/deployer/src/server/__tests__/option-studio-base.test.ts
+++ b/packages/deployer/src/server/__tests__/option-studio-base.test.ts
@@ -56,7 +56,7 @@ vi.mock('../handlers/restart-active-runs', () => ({
 }));
 
 vi.mock('../welcome', () => ({
-  html: '<html><body>Welcome to Mastra</body></html>',
+  welcomeHtml: () => '<html><body>Welcome to Mastra</body></html>',
 }));
 
 describe('Mastra Studio "studioBase" functionality', () => {

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -24,7 +24,7 @@ import { healthHandler } from './handlers/health';
 import { restartAllActiveWorkflowRunsHandler } from './handlers/restart-active-runs';
 import { rootHandler } from './handlers/root';
 import type { ServerBundleOptions } from './types';
-import { html } from './welcome';
+import { welcomeHtml } from './welcome';
 
 // Get studio path from env or default to ./studio relative to cwd
 const getStudioPath = () => {
@@ -462,7 +462,7 @@ export async function createHonoServer(
       return c.newResponse(indexHtml, 200, { 'Content-Type': 'text/html' });
     }
 
-    return c.newResponse(html, 200, { 'Content-Type': 'text/html' });
+    return c.newResponse(welcomeHtml(apiPrefix), 200, { 'Content-Type': 'text/html' });
   });
 
   if (options?.studio) {

--- a/packages/deployer/src/server/welcome.ts
+++ b/packages/deployer/src/server/welcome.ts
@@ -1,4 +1,5 @@
-export const html = `
+export function welcomeHtml(apiPrefix: string = '/api') {
+  return `
 <!doctype html>
 <html lang="en">
   <head>
@@ -261,7 +262,7 @@ export const html = `
             <span>List your agents</span>
             <button class="copy-btn" onclick="copyCode(this)">Copy</button>
           </div>
-          <pre class="curl-code" data-tpl="curl <base>/api/agents"><span class="c-cmd">curl</span> <span class="c-url" data-url="api/agents"></span></pre>
+          <pre class="curl-code" data-tpl="curl <base>${apiPrefix}/agents"><span class="c-cmd">curl</span> <span class="c-url" data-url="${apiPrefix.slice(1)}/agents"></span></pre>
         </div>
 
         <div class="curl-block">
@@ -269,7 +270,7 @@ export const html = `
             <span>Chat with an agent</span>
             <button class="copy-btn" onclick="copyCode(this)">Copy</button>
           </div>
-          <pre class="curl-code" data-tpl="curl -X POST <base>/api/agents/:agent-id/generate -H 'Content-Type: application/json' -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;Hello&quot;}]}'"><span class="c-cmd">curl</span> <span class="c-flag">-X POST</span> <span class="c-url" data-url="api/agents/:agent-id/generate"></span> \\
+          <pre class="curl-code" data-tpl="curl -X POST <base>${apiPrefix}/agents/:agent-id/generate -H 'Content-Type: application/json' -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;Hello&quot;}]}'"><span class="c-cmd">curl</span> <span class="c-flag">-X POST</span> <span class="c-url" data-url="${apiPrefix.slice(1)}/agents/:agent-id/generate"></span> \\
   <span class="c-flag">-H</span> <span class="c-str">'Content-Type: application/json'</span> \\
   <span class="c-flag">-d</span> <span class="c-str">'{"messages":[{"role":"user","content":"Hello"}]}'</span></pre>
         </div>
@@ -279,7 +280,7 @@ export const html = `
             <span>Stream an agent response</span>
             <button class="copy-btn" onclick="copyCode(this)">Copy</button>
           </div>
-          <pre class="curl-code" data-tpl="curl -N -X POST <base>/api/agents/:agent-id/stream -H 'Content-Type: application/json' -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;Hello&quot;}]}'"><span class="c-cmd">curl</span> <span class="c-flag">-N -X POST</span> <span class="c-url" data-url="api/agents/:agent-id/stream"></span> \\
+          <pre class="curl-code" data-tpl="curl -N -X POST <base>${apiPrefix}/agents/:agent-id/stream -H 'Content-Type: application/json' -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;Hello&quot;}]}'"><span class="c-cmd">curl</span> <span class="c-flag">-N -X POST</span> <span class="c-url" data-url="${apiPrefix.slice(1)}/agents/:agent-id/stream"></span> \\
   <span class="c-flag">-H</span> <span class="c-str">'Content-Type: application/json'</span> \\
   <span class="c-flag">-d</span> <span class="c-str">'{"messages":[{"role":"user","content":"Hello"}]}'</span></pre>
         </div>
@@ -291,56 +292,56 @@ export const html = `
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-get">GET</span>
-              <span class="endpoint-path">/api/agents</span>
+              <span class="endpoint-path">${apiPrefix}/agents</span>
             </div>
             <span class="endpoint-desc">List all agents</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-post">POST</span>
-              <span class="endpoint-path">/api/agents/:id/generate</span>
+              <span class="endpoint-path">${apiPrefix}/agents/:id/generate</span>
             </div>
             <span class="endpoint-desc">Generate a response</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-post">POST</span>
-              <span class="endpoint-path">/api/agents/:id/stream</span>
+              <span class="endpoint-path">${apiPrefix}/agents/:id/stream</span>
             </div>
             <span class="endpoint-desc">Stream a response</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-get">GET</span>
-              <span class="endpoint-path">/api/workflows</span>
+              <span class="endpoint-path">${apiPrefix}/workflows</span>
             </div>
             <span class="endpoint-desc">List all workflows</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-post">POST</span>
-              <span class="endpoint-path">/api/workflows/:id/start</span>
+              <span class="endpoint-path">${apiPrefix}/workflows/:id/start</span>
             </div>
             <span class="endpoint-desc">Run a workflow</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-get">GET</span>
-              <span class="endpoint-path">/api/tools</span>
+              <span class="endpoint-path">${apiPrefix}/tools</span>
             </div>
             <span class="endpoint-desc">List all tools</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-post">POST</span>
-              <span class="endpoint-path">/api/tools/:id/execute</span>
+              <span class="endpoint-path">${apiPrefix}/tools/:id/execute</span>
             </div>
             <span class="endpoint-desc">Execute a tool</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-get">GET</span>
-              <span class="endpoint-path">/api/memory/threads</span>
+              <span class="endpoint-path">${apiPrefix}/memory/threads</span>
             </div>
             <span class="endpoint-desc">List memory threads</span>
           </div>
@@ -402,3 +403,4 @@ export const html = `
   </body>
 </html>
 `;
+}

--- a/packages/deployer/src/server/welcome.ts
+++ b/packages/deployer/src/server/welcome.ts
@@ -5,7 +5,6 @@ export const html = `
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mastra Server</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/inter-ui/3.19.3/inter.min.css" />
     <style>
       * { box-sizing: border-box; }
 
@@ -14,7 +13,7 @@ export const html = `
         padding: 0;
         background-color: #0a0a0a;
         color: #e4e4e7;
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
         min-height: 100vh;
         line-height: 1.6;
       }

--- a/packages/deployer/src/server/welcome.ts
+++ b/packages/deployer/src/server/welcome.ts
@@ -4,102 +4,402 @@ export const html = `
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Welcome to Mastra</title>
+    <title>Mastra Server</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/inter-ui/3.19.3/inter.min.css" />
     <style>
+      * { box-sizing: border-box; }
+
       body {
         margin: 0;
         padding: 0;
-        background-color: #0d0d0d;
-        color: #ffffff;
-        font-family:
-          'Inter',
-          -apple-system,
-          BlinkMacSystemFont,
-          system-ui,
-          sans-serif;
+        background-color: #0a0a0a;
+        color: #e4e4e7;
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
         min-height: 100vh;
-        display: flex;
-        flex-direction: column;
-      }
-
-      main {
-        flex: 1;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        padding: 2rem;
-        text-align: center;
-      }
-
-      h1 {
-        font-size: 4rem;
-        font-weight: 600;
-        margin: 0 0 1rem 0;
-        background: linear-gradient(to right, #fff, #ccc);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        line-height: 1.2;
-      }
-
-      .subtitle {
-        color: #9ca3af;
-        font-size: 1.25rem;
-        max-width: 600px;
-        margin: 0 auto 3rem auto;
         line-height: 1.6;
       }
 
-      .docs-link {
-        background-color: #1a1a1a;
-        padding: 1rem 2rem;
-        border-radius: 0.5rem;
+      .page {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 3rem 1.5rem 4rem;
+      }
+
+      header {
+        margin-bottom: 2.5rem;
+      }
+
+      header h1 {
+        font-size: 1.75rem;
+        font-weight: 600;
+        margin: 0 0 0.25rem;
+        color: #fff;
+      }
+
+      header p {
+        color: #71717a;
+        font-size: 0.9rem;
+        margin: 0;
+      }
+
+      .status-bar {
         display: flex;
         align-items: center;
-        gap: 1rem;
-        font-family: monospace;
-        font-size: 1rem;
-        color: #ffffff;
+        gap: 0.5rem;
+        margin-top: 1rem;
+        font-size: 0.8rem;
+        color: #a1a1aa;
+      }
+
+      .status-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: #22c55e;
+        flex-shrink: 0;
+      }
+
+      section {
+        margin-bottom: 2rem;
+      }
+
+      section h2 {
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #71717a;
+        margin: 0 0 0.75rem;
+      }
+
+      .card {
+        background: #18181b;
+        border: 1px solid #27272a;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+
+      .card + .card {
+        margin-top: 0.75rem;
+      }
+
+      .card-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.75rem 1rem;
+        gap: 0.75rem;
+      }
+
+      .card-row + .card-row {
+        border-top: 1px solid #27272a;
+      }
+
+      .card-row-left {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        min-width: 0;
+      }
+
+      .method {
+        font-family: 'SF Mono', SFMono-Regular, ui-monospace, Menlo, monospace;
+        font-size: 0.7rem;
+        font-weight: 600;
+        padding: 2px 6px;
+        border-radius: 4px;
+        flex-shrink: 0;
+      }
+
+      .method-get { background: #052e16; color: #4ade80; }
+      .method-post { background: #172554; color: #60a5fa; }
+
+      .endpoint-path {
+        font-family: 'SF Mono', SFMono-Regular, ui-monospace, Menlo, monospace;
+        font-size: 0.8rem;
+        color: #d4d4d8;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .endpoint-desc {
+        font-size: 0.75rem;
+        color: #71717a;
+        flex-shrink: 0;
+      }
+
+      .curl-block {
+        position: relative;
+        background: #111113;
+        border: 1px solid #27272a;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+
+      .curl-block + .curl-block {
+        margin-top: 0.75rem;
+      }
+
+      .curl-label {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 1rem;
+        border-bottom: 1px solid #27272a;
+        font-size: 0.75rem;
+        color: #a1a1aa;
+      }
+
+      .copy-btn {
+        background: none;
+        border: 1px solid #3f3f46;
+        border-radius: 4px;
+        color: #a1a1aa;
+        font-size: 0.7rem;
+        padding: 2px 8px;
+        cursor: pointer;
+        font-family: inherit;
+        transition: all 0.15s;
+      }
+
+      .copy-btn:hover {
+        background: #27272a;
+        color: #e4e4e7;
+      }
+
+      .curl-code {
+        padding: 0.75rem 1rem;
+        font-family: 'SF Mono', SFMono-Regular, ui-monospace, Menlo, monospace;
+        font-size: 0.8rem;
+        line-height: 1.5;
+        color: #d4d4d8;
+        overflow-x: auto;
+        white-space: pre;
+        margin: 0;
+      }
+
+      .curl-code .c-cmd { color: #a78bfa; }
+      .curl-code .c-flag { color: #60a5fa; }
+      .curl-code .c-url { color: #fbbf24; }
+      .curl-code .c-str { color: #4ade80; }
+
+      .links-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.75rem;
+      }
+
+      .link-card {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.875rem 1rem;
+        background: #18181b;
+        border: 1px solid #27272a;
+        border-radius: 8px;
+        color: #d4d4d8;
         text-decoration: none;
-        transition: background-color 0.2s;
+        font-size: 0.85rem;
+        transition: all 0.15s;
       }
 
-      .docs-link:hover {
-        background-color: #252525;
+      .link-card:hover {
+        background: #1f1f23;
+        border-color: #3f3f46;
+        color: #fff;
       }
 
-      .arrow-icon {
-        transition: transform 0.2s;
+      .link-icon {
+        flex-shrink: 0;
+        width: 18px;
+        height: 18px;
+        color: #71717a;
       }
 
-      .docs-link:hover .arrow-icon {
-        transform: translateX(4px);
+      .link-card:hover .link-icon { color: #a1a1aa; }
+
+      footer {
+        margin-top: 3rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid #1c1c1f;
+        font-size: 0.75rem;
+        color: #52525b;
+      }
+
+      @media (max-width: 480px) {
+        .page { padding: 2rem 1rem 3rem; }
+        header h1 { font-size: 1.5rem; }
+        .links-grid { grid-template-columns: 1fr; }
+        .endpoint-desc { display: none; }
       }
     </style>
   </head>
   <body>
-    <main>
-      <h1>Welcome to Mastra</h1>
-      <p class="subtitle">
-        Prototype and productionize AI features with a modern JS/TS stack.
-      </p>
+    <div class="page">
+      <header>
+        <h1>Mastra Server</h1>
+        <p>Your server is running. Use the endpoints below to get started.</p>
+        <div class="status-bar">
+          <span class="status-dot"></span>
+          <span id="base-url"></span>
+        </div>
+      </header>
 
-      <a href="https://mastra.ai/docs" class="docs-link">
-        Browse the docs
-        <svg
-          class="arrow-icon"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          <path d="M5 12h14M12 5l7 7-7 7" />
-        </svg>
-      </a>
-    </main>
+      <section>
+        <h2>Quick Start</h2>
+
+        <div class="curl-block">
+          <div class="curl-label">
+            <span>Check server health</span>
+            <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+          </div>
+          <pre class="curl-code" data-tpl="curl <base>/health"><span class="c-cmd">curl</span> <span class="c-url" data-url="health"></span></pre>
+        </div>
+
+        <div class="curl-block">
+          <div class="curl-label">
+            <span>List your agents</span>
+            <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+          </div>
+          <pre class="curl-code" data-tpl="curl <base>/api/agents"><span class="c-cmd">curl</span> <span class="c-url" data-url="api/agents"></span></pre>
+        </div>
+
+        <div class="curl-block">
+          <div class="curl-label">
+            <span>Chat with an agent</span>
+            <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+          </div>
+          <pre class="curl-code" data-tpl="curl -X POST <base>/api/agents/:agent-id/generate -H 'Content-Type: application/json' -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;Hello&quot;}]}'"><span class="c-cmd">curl</span> <span class="c-flag">-X POST</span> <span class="c-url" data-url="api/agents/:agent-id/generate"></span> \\
+  <span class="c-flag">-H</span> <span class="c-str">'Content-Type: application/json'</span> \\
+  <span class="c-flag">-d</span> <span class="c-str">'{"messages":[{"role":"user","content":"Hello"}]}'</span></pre>
+        </div>
+
+        <div class="curl-block">
+          <div class="curl-label">
+            <span>Stream an agent response</span>
+            <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+          </div>
+          <pre class="curl-code" data-tpl="curl -N -X POST <base>/api/agents/:agent-id/stream -H 'Content-Type: application/json' -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;Hello&quot;}]}'"><span class="c-cmd">curl</span> <span class="c-flag">-N -X POST</span> <span class="c-url" data-url="api/agents/:agent-id/stream"></span> \\
+  <span class="c-flag">-H</span> <span class="c-str">'Content-Type: application/json'</span> \\
+  <span class="c-flag">-d</span> <span class="c-str">'{"messages":[{"role":"user","content":"Hello"}]}'</span></pre>
+        </div>
+      </section>
+
+      <section>
+        <h2>API Endpoints</h2>
+        <div class="card">
+          <div class="card-row">
+            <div class="card-row-left">
+              <span class="method method-get">GET</span>
+              <span class="endpoint-path">/api/agents</span>
+            </div>
+            <span class="endpoint-desc">List all agents</span>
+          </div>
+          <div class="card-row">
+            <div class="card-row-left">
+              <span class="method method-post">POST</span>
+              <span class="endpoint-path">/api/agents/:id/generate</span>
+            </div>
+            <span class="endpoint-desc">Generate a response</span>
+          </div>
+          <div class="card-row">
+            <div class="card-row-left">
+              <span class="method method-post">POST</span>
+              <span class="endpoint-path">/api/agents/:id/stream</span>
+            </div>
+            <span class="endpoint-desc">Stream a response</span>
+          </div>
+          <div class="card-row">
+            <div class="card-row-left">
+              <span class="method method-get">GET</span>
+              <span class="endpoint-path">/api/workflows</span>
+            </div>
+            <span class="endpoint-desc">List all workflows</span>
+          </div>
+          <div class="card-row">
+            <div class="card-row-left">
+              <span class="method method-post">POST</span>
+              <span class="endpoint-path">/api/workflows/:id/start</span>
+            </div>
+            <span class="endpoint-desc">Run a workflow</span>
+          </div>
+          <div class="card-row">
+            <div class="card-row-left">
+              <span class="method method-get">GET</span>
+              <span class="endpoint-path">/api/tools</span>
+            </div>
+            <span class="endpoint-desc">List all tools</span>
+          </div>
+          <div class="card-row">
+            <div class="card-row-left">
+              <span class="method method-post">POST</span>
+              <span class="endpoint-path">/api/tools/:id/execute</span>
+            </div>
+            <span class="endpoint-desc">Execute a tool</span>
+          </div>
+          <div class="card-row">
+            <div class="card-row-left">
+              <span class="method method-get">GET</span>
+              <span class="endpoint-path">/api/memory/threads</span>
+            </div>
+            <span class="endpoint-desc">List memory threads</span>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Resources</h2>
+        <div class="links-grid">
+          <a href="https://mastra.ai/docs" target="_blank" class="link-card">
+            <svg class="link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+            Documentation
+          </a>
+          <a href="https://mastra.ai/docs/server-db/custom-api-routes" target="_blank" class="link-card">
+            <svg class="link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 18l6-6-6-6"/><path d="M8 6l-6 6 6 6"/></svg>
+            Custom API Routes
+          </a>
+          <a href="https://mastra.ai/docs/agents/overview" target="_blank" class="link-card">
+            <svg class="link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v4m0 14v4m-7.8-15.4 2.8 2.8m9.6 9.6 2.8 2.8M1 12h4m14 0h4M4.2 19.8l2.8-2.8m9.6-9.6 2.8-2.8"/></svg>
+            Agents Guide
+          </a>
+          <a href="https://mastra.ai/docs/workflows/overview" target="_blank" class="link-card">
+            <svg class="link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 3 21 3 21 8"/><line x1="4" y1="20" x2="21" y2="3"/><polyline points="21 16 21 21 16 21"/><line x1="15" y1="15" x2="21" y2="21"/><line x1="4" y1="4" x2="9" y2="9"/></svg>
+            Workflows Guide
+          </a>
+        </div>
+      </section>
+
+      <footer>
+        Powered by <a href="https://mastra.ai" target="_blank" style="color:#71717a;">Mastra</a>
+      </footer>
+    </div>
+
+    <script>
+      (function() {
+        var base = location.origin;
+        document.getElementById('base-url').textContent = base;
+
+        var els = document.querySelectorAll('[data-url]');
+        for (var i = 0; i < els.length; i++) {
+          els[i].textContent = base + '/' + els[i].getAttribute('data-url');
+        }
+
+        var tpls = document.querySelectorAll('[data-tpl]');
+        for (var i = 0; i < tpls.length; i++) {
+          tpls[i].setAttribute('data-tpl', tpls[i].getAttribute('data-tpl').replace(/<base>/g, base));
+        }
+      })();
+
+      function copyCode(btn) {
+        var pre = btn.closest('.curl-block').querySelector('.curl-code');
+        var text = pre.getAttribute('data-tpl');
+        navigator.clipboard.writeText(text).then(function() {
+          btn.textContent = 'Copied!';
+          setTimeout(function() { btn.textContent = 'Copy'; }, 1500);
+        });
+      }
+    </script>
   </body>
 </html>
 `;

--- a/packages/deployer/src/server/welcome.ts
+++ b/packages/deployer/src/server/welcome.ts
@@ -394,8 +394,16 @@ export function welcomeHtml(apiPrefix: string = '/api') {
       function copyCode(btn) {
         var pre = btn.closest('.curl-block').querySelector('.curl-code');
         var text = pre.getAttribute('data-tpl');
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+          btn.textContent = 'Unavailable';
+          setTimeout(function() { btn.textContent = 'Copy'; }, 1500);
+          return;
+        }
         navigator.clipboard.writeText(text).then(function() {
           btn.textContent = 'Copied!';
+          setTimeout(function() { btn.textContent = 'Copy'; }, 1500);
+        }).catch(function() {
+          btn.textContent = 'Failed';
           setTimeout(function() { btn.textContent = 'Copy'; }, 1500);
         });
       }

--- a/packages/deployer/src/server/welcome.ts
+++ b/packages/deployer/src/server/welcome.ts
@@ -1,4 +1,7 @@
 export function welcomeHtml(apiPrefix: string = '/api') {
+  // Normalize: ensure single leading slash, no trailing slash
+  const prefix = '/' + apiPrefix.replace(/^\/+|\/+$/g, '');
+  const prefixNoSlash = prefix.slice(1);
   return `
 <!doctype html>
 <html lang="en">
@@ -262,7 +265,7 @@ export function welcomeHtml(apiPrefix: string = '/api') {
             <span>List your agents</span>
             <button class="copy-btn" onclick="copyCode(this)">Copy</button>
           </div>
-          <pre class="curl-code" data-tpl="curl <base>${apiPrefix}/agents"><span class="c-cmd">curl</span> <span class="c-url" data-url="${apiPrefix.slice(1)}/agents"></span></pre>
+          <pre class="curl-code" data-tpl="curl <base>${prefix}/agents"><span class="c-cmd">curl</span> <span class="c-url" data-url="${prefixNoSlash}/agents"></span></pre>
         </div>
 
         <div class="curl-block">
@@ -270,7 +273,7 @@ export function welcomeHtml(apiPrefix: string = '/api') {
             <span>Chat with an agent</span>
             <button class="copy-btn" onclick="copyCode(this)">Copy</button>
           </div>
-          <pre class="curl-code" data-tpl="curl -X POST <base>${apiPrefix}/agents/:agent-id/generate -H 'Content-Type: application/json' -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;Hello&quot;}]}'"><span class="c-cmd">curl</span> <span class="c-flag">-X POST</span> <span class="c-url" data-url="${apiPrefix.slice(1)}/agents/:agent-id/generate"></span> \\
+          <pre class="curl-code" data-tpl="curl -X POST <base>${prefix}/agents/:agent-id/generate -H 'Content-Type: application/json' -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;Hello&quot;}]}'"><span class="c-cmd">curl</span> <span class="c-flag">-X POST</span> <span class="c-url" data-url="${prefixNoSlash}/agents/:agent-id/generate"></span> \\
   <span class="c-flag">-H</span> <span class="c-str">'Content-Type: application/json'</span> \\
   <span class="c-flag">-d</span> <span class="c-str">'{"messages":[{"role":"user","content":"Hello"}]}'</span></pre>
         </div>
@@ -280,7 +283,7 @@ export function welcomeHtml(apiPrefix: string = '/api') {
             <span>Stream an agent response</span>
             <button class="copy-btn" onclick="copyCode(this)">Copy</button>
           </div>
-          <pre class="curl-code" data-tpl="curl -N -X POST <base>${apiPrefix}/agents/:agent-id/stream -H 'Content-Type: application/json' -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;Hello&quot;}]}'"><span class="c-cmd">curl</span> <span class="c-flag">-N -X POST</span> <span class="c-url" data-url="${apiPrefix.slice(1)}/agents/:agent-id/stream"></span> \\
+          <pre class="curl-code" data-tpl="curl -N -X POST <base>${prefix}/agents/:agent-id/stream -H 'Content-Type: application/json' -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;Hello&quot;}]}'"><span class="c-cmd">curl</span> <span class="c-flag">-N -X POST</span> <span class="c-url" data-url="${prefixNoSlash}/agents/:agent-id/stream"></span> \\
   <span class="c-flag">-H</span> <span class="c-str">'Content-Type: application/json'</span> \\
   <span class="c-flag">-d</span> <span class="c-str">'{"messages":[{"role":"user","content":"Hello"}]}'</span></pre>
         </div>
@@ -292,56 +295,56 @@ export function welcomeHtml(apiPrefix: string = '/api') {
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-get">GET</span>
-              <span class="endpoint-path">${apiPrefix}/agents</span>
+              <span class="endpoint-path">${prefix}/agents</span>
             </div>
             <span class="endpoint-desc">List all agents</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-post">POST</span>
-              <span class="endpoint-path">${apiPrefix}/agents/:id/generate</span>
+              <span class="endpoint-path">${prefix}/agents/:id/generate</span>
             </div>
             <span class="endpoint-desc">Generate a response</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-post">POST</span>
-              <span class="endpoint-path">${apiPrefix}/agents/:id/stream</span>
+              <span class="endpoint-path">${prefix}/agents/:id/stream</span>
             </div>
             <span class="endpoint-desc">Stream a response</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-get">GET</span>
-              <span class="endpoint-path">${apiPrefix}/workflows</span>
+              <span class="endpoint-path">${prefix}/workflows</span>
             </div>
             <span class="endpoint-desc">List all workflows</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-post">POST</span>
-              <span class="endpoint-path">${apiPrefix}/workflows/:id/start</span>
+              <span class="endpoint-path">${prefix}/workflows/:id/start</span>
             </div>
             <span class="endpoint-desc">Run a workflow</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-get">GET</span>
-              <span class="endpoint-path">${apiPrefix}/tools</span>
+              <span class="endpoint-path">${prefix}/tools</span>
             </div>
             <span class="endpoint-desc">List all tools</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-post">POST</span>
-              <span class="endpoint-path">${apiPrefix}/tools/:id/execute</span>
+              <span class="endpoint-path">${prefix}/tools/:id/execute</span>
             </div>
             <span class="endpoint-desc">Execute a tool</span>
           </div>
           <div class="card-row">
             <div class="card-row-left">
               <span class="method method-get">GET</span>
-              <span class="endpoint-path">${apiPrefix}/memory/threads</span>
+              <span class="endpoint-path">${prefix}/memory/threads</span>
             </div>
             <span class="endpoint-desc">List memory threads</span>
           </div>

--- a/packages/deployer/src/server/welcome.ts
+++ b/packages/deployer/src/server/welcome.ts
@@ -351,19 +351,19 @@ export function welcomeHtml(apiPrefix: string = '/api') {
       <section>
         <h2>Resources</h2>
         <div class="links-grid">
-          <a href="https://mastra.ai/docs" target="_blank" class="link-card">
+          <a href="https://mastra.ai/docs" target="_blank" rel="noopener noreferrer" class="link-card">
             <svg class="link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
             Documentation
           </a>
-          <a href="https://mastra.ai/docs/server-db/custom-api-routes" target="_blank" class="link-card">
+          <a href="https://mastra.ai/docs/server-db/custom-api-routes" target="_blank" rel="noopener noreferrer" class="link-card">
             <svg class="link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 18l6-6-6-6"/><path d="M8 6l-6 6 6 6"/></svg>
             Custom API Routes
           </a>
-          <a href="https://mastra.ai/docs/agents/overview" target="_blank" class="link-card">
+          <a href="https://mastra.ai/docs/agents/overview" target="_blank" rel="noopener noreferrer" class="link-card">
             <svg class="link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v4m0 14v4m-7.8-15.4 2.8 2.8m9.6 9.6 2.8 2.8M1 12h4m14 0h4M4.2 19.8l2.8-2.8m9.6-9.6 2.8-2.8"/></svg>
             Agents Guide
           </a>
-          <a href="https://mastra.ai/docs/workflows/overview" target="_blank" class="link-card">
+          <a href="https://mastra.ai/docs/workflows/overview" target="_blank" rel="noopener noreferrer" class="link-card">
             <svg class="link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 3 21 3 21 8"/><line x1="4" y1="20" x2="21" y2="3"/><polyline points="21 16 21 21 16 21"/><line x1="15" y1="15" x2="21" y2="21"/><line x1="4" y1="4" x2="9" y2="9"/></svg>
             Workflows Guide
           </a>
@@ -371,7 +371,7 @@ export function welcomeHtml(apiPrefix: string = '/api') {
       </section>
 
       <footer>
-        Powered by <a href="https://mastra.ai" target="_blank" style="color:#71717a;">Mastra</a>
+        Powered by <a href="https://mastra.ai" target="_blank" rel="noopener noreferrer" style="color:#71717a;">Mastra</a>
       </footer>
     </div>
 


### PR DESCRIPTION
## Description

When we deploy Mastra Server, the splash page is quite basic - I've replaced it with one that more explicitly indicates that an actual server is running, includes cURL request samples, and a swagger-lite UI that shows the user a couple of API endpoints they should think about exploring. It's an improvement over what was there before; would love to know what other things to add, or remove.

Here is the previous view:

<img width="1902" height="1066" alt="Screenshot 2026-04-03 at 6 52 35 PM" src="https://github.com/user-attachments/assets/36f990fb-6705-4a91-ae3d-599fde6c2d00" />


And here is the new view:

<img width="1890" height="1149" alt="Screenshot 2026-04-03 at 7 48 23 PM" src="https://github.com/user-attachments/assets/0b3e2570-aa17-4fd8-99a4-2e8b84588013" />


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned server dashboard showing Server Status/base URL
  * Quick Start section with multiple copyable curl command cards (per-command Copy button)
  * API Endpoints list with method badges and descriptions
  * Resources grid linking to documentation and a footer

* **Improvements**
  * Enhanced layout and clearer route information
  * Copy-to-clipboard now provides success/failure/unavailable feedback
<!-- end of auto-generated comment: release notes by coderabbit.ai -->