### PR TITLE
fix(voice-openai-realtime): pass requestContext in execution context instead of tool input 

### DIFF
--- a/.changeset/fix-openai-realtime-request-context.md
+++ b/.changeset/fix-openai-realtime-request-context.md
@@ -2,4 +2,4 @@
 '@mastra/voice-openai-realtime': patch
 ---
 
-Fix requestContext not being propagated to tool executions in voice/STS mode. The requestContext passed to `voice.connect({ requestContext })` was incorrectly placed in the first argument (tool input) instead of the second argument (execution context) when calling `tool.execute()`, causing tools to receive an empty RequestContext.
+Fix requestContext propagation to tool executions during OpenAI Realtime voice sessions. Tools now correctly receive the caller's request context passed via `voice.connect({ requestContext })`.

--- a/.changeset/fix-openai-realtime-request-context.md
+++ b/.changeset/fix-openai-realtime-request-context.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-openai-realtime': patch
+---
+
+Fix requestContext not being propagated to tool executions in voice/STS mode. The requestContext passed to `voice.connect({ requestContext })` was incorrectly placed in the first argument (tool input) instead of the second argument (execution context) when calling `tool.execute()`, causing tools to receive an empty RequestContext.

--- a/voice/openai-realtime-api/src/index.ts
+++ b/voice/openai-realtime-api/src/index.ts
@@ -649,13 +649,11 @@ export class OpenAIRealtimeVoice extends MastraVoice {
         });
       }
 
-      const result = await tool?.execute?.(
-        { context, requestContext: this.requestContext },
-        {
-          toolCallId: output.call_id,
-          messages: [],
-        },
-      );
+      const result = await tool?.execute?.(context, {
+        toolCallId: output.call_id,
+        messages: [],
+        requestContext: this.requestContext,
+      });
 
       this.emit('tool-call-result', {
         toolCallId: output.call_id,


### PR DESCRIPTION
## Description

`voice.connect({ requestContext })` was not propagating the `RequestContext` to tool executions in OpenAI Realtime (STS) mode. Tools received an empty `RequestContext` instead of the one passed at connect time.

**Root cause:**  
In `handleFunctionCall()`, `requestContext` was passed as part of the **1st argument** (tool input data) instead of the **2nd argument** (execution context) when calling `tool.execute()`.  
This caused the core tool wrapper to never see it and fall back to a new empty `RequestContext`.

**Fix:**  
Moved `requestContext` from the **1st argument** to the **2nd argument**, aligning with how **Gemini Live** and `agent.stream()` already handle it correctly.

---

## Related Issue(s)

Fixes #15032

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

---

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the OpenAI Realtime voice integration where the context supplied via voice.connect() was not being forwarded to tools; tools now correctly receive the caller’s requestContext during execution, improving context-aware tool behavior and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->