### PR TITLE
feat(cli): read local env vars on server deploy

### DIFF
--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -64,6 +64,38 @@ async function zipOutput(projectDir: string): Promise<string> {
   });
 }
 
+export function parseEnvFile(content: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    let key = trimmed.slice(0, eqIdx).trim();
+    if (key.startsWith('export ')) key = key.slice(7).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (key) vars[key] = value;
+  }
+  return vars;
+}
+
+async function readEnvVars(projectDir: string): Promise<Record<string, string>> {
+  const vars: Record<string, string> = {};
+  for (const envFile of ['.env.production', '.env.local', '.env']) {
+    try {
+      const content = await readFile(join(projectDir, envFile), 'utf-8');
+      Object.assign(vars, parseEnvFile(content));
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
+  }
+  return vars;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Resolve org                                                       */
 /* ------------------------------------------------------------------ */
@@ -266,10 +298,20 @@ export async function serverDeployAction(
   const sizeLabel = sizeKB > 1024 ? `${(sizeKB / 1024).toFixed(1)}MB` : `${sizeKB.toFixed(1)}KB`;
   s.stop(`Created ${sizeLabel} archive`);
 
+  s.start('Reading environment variables...');
+  const envVars = await readEnvVars(targetDir);
+  const envCount = Object.keys(envVars).length;
+  if (envCount > 0) {
+    s.stop(`Found ${envCount} env var(s)`);
+  } else {
+    s.stop('No .env file found');
+  }
+
   s.start('Uploading...');
   const zipBuffer = await readFile(zipPath);
   const deployResult = await uploadServerDeploy(token, orgId, projectId, zipBuffer, {
     projectName,
+    envVars: envCount > 0 ? envVars : undefined,
   });
   s.stop(`Deploy accepted: ${deployResult.id}`);
 

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -62,13 +62,13 @@ export async function uploadServerDeploy(
   orgId: string,
   projectId: string,
   zipBuffer: Buffer,
-  meta?: { projectName?: string },
+  meta?: { projectName?: string; envVars?: Record<string, string> },
 ): Promise<{ id: string; status: string }> {
   const client = createApiClient(token, orgId);
 
   // Step 1: Create the deploy — returns upload URL
   const { data, error, response } = await client.POST('/v1/server/deploys', {
-    body: { projectId, projectName: meta?.projectName },
+    body: { projectId, projectName: meta?.projectName, envVars: meta?.envVars },
   });
 
   if (error) {


### PR DESCRIPTION
## Summary

When running `mastra server deploy`, the CLI now reads local `.env` files and passes them to the platform API. The server seeds these into the project on first deploy only.

## Changes

- **`packages/cli/src/commands/server/deploy.ts`**: Added `parseEnvFile()` and `readEnvVars()` functions, env reading step with spinner feedback
- **`packages/cli/src/commands/server/platform-api.ts`**: Updated `uploadServerDeploy()` to accept and pass `envVars`

## Env File Priority

Reads in order (later files override earlier):
1. `.env.production`
2. `.env.local`
3. `.env`

## Related

Platform API changes: https://github.com/mastra-ai/platform/pull/403

## Test Plan

- `pnpm build:cli` — builds successfully
- `pnpm --filter ./packages/cli typecheck` — passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication system: login, logout, token management, and organization switching.
  * Added Studio deploy command with deployment tracking, status monitoring, and log streaming.
  * Added server deploy capability for Mastra Server deployments.
  * Added gateway integration with automatic project provisioning during setup.
  * Added observability setup flow for Mastra Cloud tracing.

* **Bug Fixes**
  * Fixed create-mastra hanging on gateway login path.

* **Chores**
  * Updated dependencies and environment variable configuration.
  * Added deploy scripts to project templates.
  * Renamed gateway environment variables for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->