### PR TITLE
fix(core): emit step-start/step-finish in processOutputStream

### DIFF
--- a/.changeset/olive-apes-take.md
+++ b/.changeset/olive-apes-take.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed step-start and step-finish stream parts not being emitted in processOutputStream. Output processors now receive these lifecycle events, allowing developers to log, inspect, or act on step boundaries in their processOutputStream handlers.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -777,17 +777,6 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                     warnings = warningsFromStream;
                     request = requestFromStream || {};
                     rawResponse = rawResponseFromStream;
-
-                    safeEnqueue(controller, {
-                      runId,
-                      from: ChunkFrom.AGENT,
-                      type: 'step-start',
-                      payload: {
-                        request: request || {},
-                        warnings: warnings || [],
-                        messageId: currentStep.messageId,
-                      },
-                    });
                   },
                   shouldThrowError: !isLastModel,
                 }),
@@ -827,6 +816,30 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           }
 
           try {
+            if (outputWriter) {
+              await outputWriter({
+                runId,
+                from: ChunkFrom.AGENT,
+                type: 'step-start',
+                payload: {
+                  request: request || {},
+                  warnings: warnings || [],
+                  messageId: currentStep.messageId,
+                },
+              } as ChunkType);
+            } else {
+              safeEnqueue(controller, {
+                runId,
+                from: ChunkFrom.AGENT,
+                type: 'step-start',
+                payload: {
+                  request: request || {},
+                  warnings: warnings || [],
+                  messageId: currentStep.messageId,
+                },
+              });
+            }
+
             const collectedChunks = await processOutputStream({
               outputStream,
               includeRawChunks,

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -2,7 +2,6 @@ import { randomUUID } from 'node:crypto';
 import type { StepResult, ToolSet } from '@internal/ai-sdk-v5';
 import type { MastraDBMessage } from '../../../memory';
 import { InternalSpans } from '../../../observability';
-import { safeEnqueue } from '../../../stream/base';
 import type { ChunkType } from '../../../stream/types';
 import { ChunkFrom } from '../../../stream/types';
 import { createWorkflow } from '../../../workflows';
@@ -237,12 +236,10 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
       const shouldEmitStepFinish = typedInputData.stepResult?.reason !== 'tripwire' || hasSteps;
 
       if (shouldEmitStepFinish) {
-        // Only enqueue if controller is still open
-        safeEnqueue(controller, {
+        await outputWriter({
           type: 'step-finish',
           runId,
           from: ChunkFrom.AGENT,
-          // @ts-expect-error TODO: Look into the proper types for this
           payload: typedInputData,
         });
       }

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -35,13 +35,14 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
       // Normalize requestContext so data-chunk processors and the agentic loop share the same instance
       const requestContext = rest.requestContext ?? new RequestContext();
 
-      // Create a ProcessorRunner for data-* chunks so they go through output processors
+      // Create a ProcessorRunner for non-model chunks (data-*, step-start, step-finish)
       const hasOutputProcessors = rest.outputProcessors && rest.outputProcessors.length > 0;
       const dataChunkProcessorRunner = hasOutputProcessors
         ? new ProcessorRunner({
             outputProcessors: rest.outputProcessors,
             logger: rest.logger || new ConsoleLogger({ level: 'error' }),
             agentName: agentId || 'unknown',
+            processorStates: rest.processorStates,
           })
         : undefined;
       const dataChunkProcessorStates = hasOutputProcessors ? new Map<string, ProcessorState>() : undefined;
@@ -54,12 +55,55 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
       };
 
       const outputWriter = async (chunk: ChunkType<OUTPUT>) => {
+        if (chunk.type === 'step-start' || chunk.type === 'step-finish') {
+          if (dataChunkProcessorRunner) {
+            const {
+              part: processed,
+              blocked,
+              reason,
+              tripwireOptions,
+              processorId,
+            } = await dataChunkProcessorRunner.processPart(
+              chunk,
+              (rest.processorStates ?? dataChunkProcessorStates!) as Map<string, ProcessorState<OUTPUT>>,
+              undefined,
+              requestContext,
+              messageList,
+              0,
+              dataChunkStreamWriter,
+            );
+
+            if (blocked) {
+              safeEnqueue(controller, {
+                type: 'tripwire',
+                runId,
+                from: ChunkFrom.AGENT,
+                payload: {
+                  reason: reason || 'Output processor blocked content',
+                  retry: tripwireOptions?.retry,
+                  metadata: tripwireOptions?.metadata,
+                  processorId,
+                },
+              } as ChunkType<OUTPUT>);
+              return;
+            }
+
+            if (processed) {
+              safeEnqueue(controller, processed as ChunkType<OUTPUT>);
+            }
+            return;
+          }
+
+          safeEnqueue(controller, chunk);
+          return;
+        }
+
         // Handle data-* chunks (custom data chunks from writer.custom())
         // These need to be persisted to storage, not just streamed
         // Transient chunks are streamed to the client but not saved to the DB
         if (chunk.type.startsWith('data-')) {
           // Run data-* chunks through output processors before persisting
-          let processedChunk = chunk;
+          let processedChunk: ChunkType<OUTPUT> = chunk;
           if (dataChunkProcessorRunner) {
             const {
               part: processed,

--- a/packages/core/src/processors/output-processor-tool-execution.test.ts
+++ b/packages/core/src/processors/output-processor-tool-execution.test.ts
@@ -223,13 +223,110 @@ describe('Output Processor State Persistence Across Tool Execution', () => {
     expect(finishChunks.length).toBe(1);
 
     const toolCallIndex = capturedChunks.findIndex(c => c.type === 'tool-call');
-    expect(toolCallIndex).toBe(1); // Should be the second chunk (after response-metadata)
+    expect(toolCallIndex).toBe(2); // After step-start and response-metadata
 
     // Verify state accumulation works
-    expect(capturedChunks[0]!.type).toBe('response-metadata');
-    expect(capturedChunks[0]!.accumulatedTypes).toEqual(['response-metadata']);
+    expect(capturedChunks[0]!.type).toBe('step-start');
+    expect(capturedChunks[0]!.accumulatedTypes).toEqual(['step-start']);
 
-    expect(capturedChunks[1]!.type).toBe('tool-call');
-    expect(capturedChunks[1]!.accumulatedTypes).toEqual(['response-metadata', 'tool-call']);
+    expect(capturedChunks[1]!.type).toBe('response-metadata');
+    expect(capturedChunks[1]!.accumulatedTypes).toEqual(['step-start', 'response-metadata']);
+
+    expect(capturedChunks[2]!.type).toBe('tool-call');
+    expect(capturedChunks[2]!.accumulatedTypes).toEqual(['step-start', 'response-metadata', 'tool-call']);
+  });
+});
+
+describe('Output Processor Step Lifecycle Chunks', () => {
+  it('should deliver step-start and step-finish chunks to processOutputStream across tool-calling steps', async () => {
+    const capturedTypes: string[] = [];
+
+    class LifecycleCapturingProcessor implements Processor {
+      readonly id = 'lifecycle-capturing-processor';
+      readonly name = 'Lifecycle Capturing Processor';
+
+      async processOutputStream({ part }: any) {
+        capturedTypes.push(part.type);
+        return part;
+      }
+    }
+
+    const echoTool = createTool({
+      id: 'echoTool',
+      description: 'A test tool that echoes input',
+      inputSchema: z.object({ text: z.string() }),
+      execute: async inputData => `Echo: ${inputData.text}`,
+    });
+
+    const mockModel = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        const hasToolResults = prompt.some(
+          (msg: any) =>
+            msg.role === 'tool' ||
+            (Array.isArray(msg.content) && msg.content.some((c: any) => c.type === 'tool-result')),
+        );
+
+        if (!hasToolResults) {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-lifecycle',
+                toolName: 'echoTool',
+                input: JSON.stringify({ text: 'hi' }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        }
+
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Echo: hi' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+          ]),
+          rawCall: { rawPrompt: [], rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'lifecycle-test-agent',
+      name: 'Lifecycle Test Agent',
+      instructions: 'Test agent for step lifecycle chunks',
+      model: mockModel as any,
+      tools: { echoTool },
+      outputProcessors: [new LifecycleCapturingProcessor()],
+    });
+
+    const stream = await agent.stream('Call echoTool with text "hi"', { maxSteps: 5 });
+    for await (const _chunk of stream.fullStream) {
+      // consume stream
+    }
+
+    const stepStartCount = capturedTypes.filter(t => t === 'step-start').length;
+    const stepFinishCount = capturedTypes.filter(t => t === 'step-finish').length;
+
+    expect(stepStartCount).toBe(2);
+    expect(stepFinishCount).toBe(2);
+
+    const firstStepStart = capturedTypes.indexOf('step-start');
+    const toolCallIdx = capturedTypes.indexOf('tool-call');
+    const firstStepFinish = capturedTypes.indexOf('step-finish');
+    expect(firstStepStart).toBeLessThan(toolCallIdx);
+    expect(toolCallIdx).toBeLessThan(firstStepFinish);
   });
 });


### PR DESCRIPTION
## Description

step-start and step-finish stream parts were not being emitted in `processOutputStream`.   These lifecycle chunks were being sent directly to the stream controller, bypassing the  output processor pipeline entirely. This meant any output processor using  `processOutputStream` could never observe step boundaries.

The fix routes `step-start` and `step-finish` through the same `outputWriter` gateway that   already handles `data-*` chunks, using the shared `processorStates` map so processor state   remains consistent between model chunks and step lifecycle chunks.

## Related Issue(s)

Fixes #15033

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: This PR makes the "step started" and "step finished" messages go through the same output-processing pipeline as regular model output so any output processors can see when a step begins and ends. That fixes missing step-boundary events in streams and updates tests to confirm the behavior.

* **Bug fix**
  * Route 'step-start' and 'step-finish' lifecycle chunks through the existing outputWriter → ProcessorRunner pipeline (using the shared processorStates) instead of enqueueing them directly to the controller. This ensures processors observing processOutputStream receive step lifecycle events and keep consistent processor state between model chunks and step lifecycle chunks.
  * If a processor blocks a lifecycle chunk, emit a tripwire chunk (reason/retry/metadata/processorId) and halt further handling for that chunk; otherwise enqueue the processed result (fall back to original chunk if no processed content).

* **Behavior / Control flow**
  * Moved the 'step-start' emission out of the model onResult callback to before processOutputStream runs and route it via outputWriter (awaiting outputWriter when provided). Similarly, step-finish now awaits outputWriter when emitting. This can cause the loop to wait for the writer/processor to complete.
  * Data-* chunk processing remains handled by the same pipeline and processorStates map; non-model lifecycle chunks are now processed equivalently to data chunks.

* **Tests**
  * Updated the existing "Output Processor State Persistence Across Tool Execution" test to reflect the new ordering where step-start appears earlier, shifting chunk indices and accumulatedTypes expectations.
  * Added "Output Processor Step Lifecycle Chunks" tests that register a processor recording processOutputStream chunk types and assert exactly two step-start and two step-finish chunks are delivered, and that the first step-start precedes the first tool-call which precedes the first step-finish.

* **Other**
  * Added a changeset entry documenting the patch for @mastra/core.

Fixes: #15033
<!-- end of auto-generated comment: release notes by coderabbit.ai -->