### PR TITLE
fix(core): Corrupt multi-step message tracking behavior

### DIFF
--- a/.changeset/fix-corrupt-message-tracking.md
+++ b/.changeset/fix-corrupt-message-tracking.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-fix(processors): prevent applyMessagesToMessageList from corrupting response message tracking when processor returns unchanged messages
+Fixed an issue where multi-step assistant responses could disappear after refresh when an output processor returned messages unchanged.

--- a/.changeset/fix-corrupt-message-tracking.md
+++ b/.changeset/fix-corrupt-message-tracking.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+fix(processors): prevent applyMessagesToMessageList from corrupting response message tracking when processor returns unchanged messages

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -2045,4 +2045,161 @@ describe('ProcessorRunner', () => {
       expect(stateInOutputResult.errorInfo).toEqual({ toolName: 'myTool', error: 'something broke' });
     });
   });
+
+  describe('applyMessagesToMessageList', () => {
+    it('should preserve response message tracking when processor returns unchanged messages', () => {
+      // Simulate: add a response message, then call applyMessagesToMessageList
+      // with the same objects (no-op processor). The response tracking must survive.
+      const msg = createMessage('assistant reply', 'assistant');
+      messageList.add(msg, 'response');
+
+      const allBefore = messageList.get.all.db();
+      expect(allBefore).toHaveLength(1);
+      expect(messageList.get.response.db()).toHaveLength(1);
+
+      const check = messageList.makeMessageSourceChecker();
+      const idsBeforeProcessing = allBefore.map(m => m.id);
+
+      // Processor returns the exact same array/objects — common no-op case
+      ProcessorRunner.applyMessagesToMessageList(allBefore, messageList, idsBeforeProcessing, check, 'response');
+
+      // Response tracking must still work
+      expect(messageList.get.response.db()).toHaveLength(1);
+      expect(messageList.get.response.db()[0].id).toBe(msg.id);
+    });
+
+    it('should preserve response tracking for merged multi-step messages with same ID', () => {
+      // Simulate the specific bug scenario: step 1 and step 2 content merged into
+      // a single assistant message (same ID), then a processOutputStep processor
+      // returns messages unchanged.
+      const mergedMsg = createMessage('step1 + step2 content', 'assistant');
+      messageList.add(mergedMsg, 'response');
+
+      const allBefore = messageList.get.all.db();
+      const check = messageList.makeMessageSourceChecker();
+      const idsBeforeProcessing = allBefore.map(m => m.id);
+
+      // No-op processor: returns exact same objects
+      ProcessorRunner.applyMessagesToMessageList(allBefore, messageList, idsBeforeProcessing, check, 'response');
+
+      const responseAfter = messageList.get.response.db();
+      expect(responseAfter).toHaveLength(1);
+      expect(responseAfter[0].id).toBe(mergedMsg.id);
+    });
+
+    it('should still replace messages when processor returns a different object with the same ID', () => {
+      const original = createMessage('original', 'assistant');
+      messageList.add(original, 'response');
+
+      const allBefore = messageList.get.all.db();
+      const check = messageList.makeMessageSourceChecker();
+      const idsBeforeProcessing = allBefore.map(m => m.id);
+
+      // Processor returns a new object with the same ID but different content
+      const replaced = {
+        ...original,
+        content: {
+          format: 2 as const,
+          parts: [{ type: 'text' as const, text: 'replaced content' }],
+        },
+      };
+
+      ProcessorRunner.applyMessagesToMessageList([replaced], messageList, idsBeforeProcessing, check, 'response');
+
+      const allAfter = messageList.get.all.db();
+      expect(allAfter).toHaveLength(1);
+      // The message should have been replaced
+      const textPart = allAfter[0].content.parts?.[0];
+      expect(textPart?.type).toBe('text');
+      expect((textPart as any).text).toBe('replaced content');
+    });
+
+    it('should handle deleted messages correctly', () => {
+      const msg1 = createMessage('msg1', 'user');
+      const msg2 = createMessage('msg2', 'assistant');
+      messageList.add(msg1, 'input');
+      messageList.add(msg2, 'response');
+
+      const allBefore = messageList.get.all.db();
+      expect(allBefore).toHaveLength(2);
+
+      const check = messageList.makeMessageSourceChecker();
+      const idsBeforeProcessing = allBefore.map(m => m.id);
+
+      // Processor deletes msg1 by omitting it
+      ProcessorRunner.applyMessagesToMessageList([msg2], messageList, idsBeforeProcessing, check, 'response');
+
+      const allAfter = messageList.get.all.db();
+      expect(allAfter).toHaveLength(1);
+      expect(allAfter[0].id).toBe(msg2.id);
+    });
+
+    it('should handle new messages added by processor', () => {
+      const original = createMessage('original', 'user');
+      messageList.add(original, 'input');
+
+      const allBefore = messageList.get.all.db();
+      const check = messageList.makeMessageSourceChecker();
+      const idsBeforeProcessing = allBefore.map(m => m.id);
+
+      // New message with a different role to avoid MessageMerger merging them
+      const newMsg = createMessage('new from processor', 'assistant');
+
+      ProcessorRunner.applyMessagesToMessageList(
+        [original, newMsg],
+        messageList,
+        idsBeforeProcessing,
+        check,
+        'response',
+      );
+
+      const allAfter = messageList.get.all.db();
+      expect(allAfter).toHaveLength(2);
+      expect(allAfter.map(m => m.id)).toContain(original.id);
+      expect(allAfter.map(m => m.id)).toContain(newMsg.id);
+    });
+
+    it('should preserve input message tracking for unchanged input messages', () => {
+      const userMsg = createMessage('user question', 'user');
+      messageList.add(userMsg, 'input');
+
+      const allBefore = messageList.get.all.db();
+      const check = messageList.makeMessageSourceChecker();
+      const idsBeforeProcessing = allBefore.map(m => m.id);
+
+      // No-op: return same objects
+      ProcessorRunner.applyMessagesToMessageList(allBefore, messageList, idsBeforeProcessing, check, 'input');
+
+      expect(messageList.get.all.db()).toHaveLength(1);
+      expect(messageList.get.all.db()[0].id).toBe(userMsg.id);
+    });
+
+    it('should handle mixed unchanged and new messages', () => {
+      const existing = createMessage('existing', 'user');
+      messageList.add(existing, 'input');
+
+      const response = createMessage('response', 'assistant');
+      messageList.add(response, 'response');
+
+      const allBefore = messageList.get.all.db();
+      const check = messageList.makeMessageSourceChecker();
+      const idsBeforeProcessing = allBefore.map(m => m.id);
+
+      // Processor keeps both unchanged and adds a new user message
+      const newMsg = createMessage('added by processor', 'user');
+
+      ProcessorRunner.applyMessagesToMessageList(
+        [existing, response, newMsg],
+        messageList,
+        idsBeforeProcessing,
+        check,
+        'response',
+      );
+
+      const allAfter = messageList.get.all.db();
+      expect(allAfter).toHaveLength(3);
+      // Existing response should still be tracked
+      expect(messageList.get.response.db().map(m => m.id)).toContain(response.id);
+    });
+  });
 });

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -1293,8 +1293,19 @@ export class ProcessorRunner {
       messageList.removeByIds(deletedIds);
     }
 
-    // Re-add messages with correct sources
+    // Build a lookup of messages currently in the list by ID.
+    // Skip the remove/re-add for messages that are already present
+    // with the same object reference — the processor either returned
+    // them unchanged or mutated them in-place (both are already
+    // reflected in the MessageList). This avoids corrupting the
+    // MessageStateManager's source Set tracking during the
+    // removeByIds → add round-trip.
+    const currentMessages = messageList.get.all.db();
+    const currentById = new Map(currentMessages.map(m => [m.id, m]));
     for (const message of messages) {
+      if (currentById.get(message.id) === message) {
+        continue;
+      }
       messageList.removeByIds([message.id]);
       if (message.role === 'system') {
         const systemText =

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -352,17 +352,14 @@ export class ProcessorRunner {
           }
         } else {
           if (processResult) {
-            const deletedIds = idsBeforeProcessing.filter(
-              (i: string) => !processResult.some((m: MastraDBMessage) => m.id === i),
+            ProcessorRunner.applyMessagesToMessageList(
+              processResult,
+              messageList,
+              idsBeforeProcessing,
+              check,
+              'response',
             );
-            if (deletedIds.length) {
-              messageList.removeByIds(deletedIds);
-            }
-            processableMessages = processResult || [];
-            for (const message of processResult) {
-              messageList.removeByIds([message.id]);
-              messageList.add(message, check.getSource(message) || 'response');
-            }
+            processableMessages = processResult;
           }
         }
 
@@ -1228,27 +1225,7 @@ export class ProcessorRunner {
           }
           // Processor returned the same messageList - mutations have been applied
         } else if (result) {
-          // Processor returned an array - apply changes to messageList
-          const deletedIds = idsBeforeProcessing.filter(
-            (i: string) => !result.some((m: MastraDBMessage) => m.id === i),
-          );
-          if (deletedIds.length) {
-            messageList.removeByIds(deletedIds);
-          }
-
-          // Re-add messages with correct sources
-          for (const message of result) {
-            messageList.removeByIds([message.id]);
-            if (message.role === 'system') {
-              const systemText =
-                (message.content.content as string | undefined) ??
-                message.content.parts?.map((p: any) => (p.type === 'text' ? p.text : '')).join('\n') ??
-                '';
-              messageList.addSystem(systemText);
-            } else {
-              messageList.add(message, check.getSource(message) || 'response');
-            }
-          }
+          ProcessorRunner.applyMessagesToMessageList(result, messageList, idsBeforeProcessing, check, 'response');
         }
 
         processorSpan?.end({


### PR DESCRIPTION
## Description

`ProcessorRunner.applyMessagesToMessageList` unconditionally removes every message from the `MessageList` by ID and re-adds it when a `processOutputStep` processor returns a `MastraDBMessage[]`. This corrupts the `MessageStateManager`'s `newResponseMessages` Set tracking, causing `messageList.get.response.db()` to return empty after the re-add. The result is that the final assistant text from step 2 streams correctly to the client but is missing on page refresh.

The bug only manifests when:
1. Step 1 and step 2 content are merged into a single assistant message (same ID — `rotateResponseMessageId` wasn't called because Observational Memory's token threshold wasn't reached)
2. A `processOutputStep` processor returns the messages array unchanged (common no-op case)
3. The `removeByIds` → `add` round-trip creates a new object reference that mismatches the Set

**Fix:** Before the loop, build a lookup of current messages by ID. Skip the remove/re-add for any message whose object reference is already in the `MessageList`. Only perform the remove/re-add for messages that are genuinely new or replaced (different object with the same ID).

## Related Issue(s)

Fixes #15049 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message-tracking corruption where multi-step assistant responses could be lost after refresh when processors returned unchanged messages.

* **Tests**
  * Added comprehensive tests ensuring message-list state remains correct across unchanged, merged, replaced, deleted, new, input-tracked, and mixed-message scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->