### PR TITLE
fix(server): normalize MASTRA_GATEWAY_URL in gateway memory client

### DIFF
--- a/.changeset/two-socks-train.md
+++ b/.changeset/two-socks-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed gateway memory client failing with 404 when MASTRA_GATEWAY_URL includes a /v1 suffix (e.g. https://gateway-api.mastra.ai/v1). The URL is now normalized before appending the memory base path, matching how the model router handles the same variable.

--- a/packages/server/src/server/handlers/gateway-memory-client.ts
+++ b/packages/server/src/server/handlers/gateway-memory-client.ts
@@ -53,8 +53,8 @@ export class GatewayMemoryClient {
   private apiKey: string;
 
   constructor(baseUrl: string, apiKey: string) {
-    // Remove trailing slash and append /v1/memory base path
-    this.baseUrl = baseUrl.replace(/\/$/, '') + '/v1/memory';
+    // Strip trailing slashes and /v1 suffix so both URL forms resolve correctly
+    this.baseUrl = baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '') + '/v1/memory';
     this.apiKey = apiKey;
   }
 


### PR DESCRIPTION
The gateway memory client was building a double `/v1/v1/memory` path when `MASTRA_GATEWAY_URL` included a `/v1` suffix (e.g. `https://gateway-api.mastra.ai/v1`). The model router already strips this suffix before re-appending it, but the memory client didn't.

Now both forms work:
- `MASTRA_GATEWAY_URL=https://gateway-api.mastra.ai`
- `MASTRA_GATEWAY_URL=https://gateway-api.mastra.ai/v1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where gateway memory client configuration with URLs ending in `/v1` would result in 404 errors. The system now properly normalizes these URLs to prevent conflicting path structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->