### PR TITLE
fix(cli): use mastra/ model prefix in scorer sample for gateway

### DIFF
--- a/.changeset/wide-suns-switch.md
+++ b/.changeset/wide-suns-switch.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed scorer sample to use the mastra/ model prefix when using the Memory Gateway. Previously, scorers generated during project creation would use the bare provider model string instead of routing through the gateway.

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -338,8 +338,13 @@ export async function writeToolSample(destPath: string) {
   await fileService.copyStarterFile('tools.ts', destPath);
 }
 
-export async function writeScorersSample(llmProvider: LLMProvider, destPath: string) {
-  const modelString = getModelIdentifier(llmProvider);
+export async function writeScorersSample(
+  llmProvider: LLMProvider,
+  destPath: string,
+  connectionMethod: ConnectionMethod = 'direct',
+) {
+  const rawModel = getModelIdentifier(llmProvider);
+  const modelString = connectionMethod === 'gateway' ? `mastra/${rawModel}` : rawModel;
   const content = `import { z } from 'zod';
 import { createToolCallAccuracyScorerCode } from '@mastra/evals/scorers/prebuilt';
 import { createCompletenessScorer } from '@mastra/evals/scorers/prebuilt';
@@ -450,7 +455,7 @@ export async function writeCodeSampleForComponents(
     case 'workflows':
       return writeWorkflowSample(destPath);
     case 'scorers':
-      return writeScorersSample(llmprovider, destPath);
+      return writeScorersSample(llmprovider, destPath, connectionMethod);
     default:
       return '';
   }


### PR DESCRIPTION
The `translationScorer` generated during `create mastra` was using the bare model string (e.g. `openai/gpt-5-mini`) instead of routing through the gateway (`mastra/openai/gpt-5-mini`). Now `writeScorersSample` receives `connectionMethod` and prefixes accordingly.