### PR TITLE
feat: add from, to, and offset params to getObservationalMemoryHistory

### DIFF
--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -380,6 +380,14 @@ export class MastraClient extends BaseResource {
     const queryParams = new URLSearchParams({ agentId: params.agentId });
     if (params.resourceId) queryParams.set('resourceId', params.resourceId);
     if (params.threadId) queryParams.set('threadId', params.threadId);
+    if (params.from) {
+      queryParams.set('from', params.from instanceof Date ? params.from.toISOString() : params.from);
+    }
+    if (params.to) {
+      queryParams.set('to', params.to instanceof Date ? params.to.toISOString() : params.to);
+    }
+    if (params.offset != null) queryParams.set('offset', String(params.offset));
+    if (params.limit != null) queryParams.set('limit', String(params.limit));
     const queryString = queryParams.toString();
     return this.request(
       `/memory/observational-memory?${queryString}${requestContextQueryString(params.requestContext, '&')}`,

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -2071,6 +2071,10 @@ export interface GetObservationalMemoryParams {
   agentId: string;
   resourceId?: string;
   threadId?: string;
+  from?: Date | string;
+  to?: Date | string;
+  offset?: number;
+  limit?: number;
   requestContext?: RequestContext | Record<string, any>;
 }
 

--- a/examples/agent/src/mastra/auth/index.ts
+++ b/examples/agent/src/mastra/auth/index.ts
@@ -15,7 +15,7 @@
 
 import type { AuthResult, AuthProviderType } from './types';
 
-const AUTH_PROVIDER: AuthProviderType = (process.env.AUTH_PROVIDER as AuthProviderType);
+const AUTH_PROVIDER: AuthProviderType = process.env.AUTH_PROVIDER as AuthProviderType;
 
 async function initAuth(): Promise<AuthResult> {
   switch (AUTH_PROVIDER) {

--- a/examples/agent/src/mastra/auth/types.ts
+++ b/examples/agent/src/mastra/auth/types.ts
@@ -11,4 +11,12 @@ export interface AuthResult {
   auth?: unknown; // Better Auth instance (only for better-auth provider)
 }
 
-export type AuthProviderType = 'simple' | 'better-auth' | 'workos' | 'cloud' | 'composite' | 'auth0-okta' | 'okta' | 'studio';
+export type AuthProviderType =
+  | 'simple'
+  | 'better-auth'
+  | 'workos'
+  | 'cloud'
+  | 'composite'
+  | 'auth0-okta'
+  | 'okta'
+  | 'studio';

--- a/packages/core/src/storage/domains/memory/base.ts
+++ b/packages/core/src/storage/domains/memory/base.ts
@@ -13,6 +13,7 @@ import type {
   StorageCloneThreadInput,
   StorageCloneThreadOutput,
   ObservationalMemoryRecord,
+  ObservationalMemoryHistoryOptions,
   CreateObservationalMemoryInput,
   UpdateActiveObservationsInput,
   UpdateBufferedObservationsInput,
@@ -183,6 +184,7 @@ export abstract class MemoryStorage extends StorageDomain {
     _threadId: string | null,
     _resourceId: string,
     _limit?: number,
+    _options?: ObservationalMemoryHistoryOptions,
   ): Promise<ObservationalMemoryRecord[]> {
     throw new Error(`Observational memory is not implemented by this storage adapter (${this.constructor.name}).`);
   }

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -15,6 +15,7 @@ import type {
   StorageCloneThreadOutput,
   ThreadCloneMetadata,
   ObservationalMemoryRecord,
+  ObservationalMemoryHistoryOptions,
   BufferedObservationChunk,
   CreateObservationalMemoryInput,
   UpdateActiveObservationsInput,
@@ -776,9 +777,21 @@ export class InMemoryMemory extends MemoryStorage {
     threadId: string | null,
     resourceId: string,
     limit?: number,
+    options?: ObservationalMemoryHistoryOptions,
   ): Promise<ObservationalMemoryRecord[]> {
     const key = this.getObservationalMemoryKey(threadId, resourceId);
-    const records = this.db.observationalMemory.get(key) ?? [];
+    let records = this.db.observationalMemory.get(key) ?? [];
+
+    if (options?.from) {
+      records = records.filter(r => r.createdAt >= options.from!);
+    }
+    if (options?.to) {
+      records = records.filter(r => r.createdAt <= options.to!);
+    }
+    if (options?.offset != null) {
+      records = records.slice(options.offset);
+    }
+
     return limit != null ? records.slice(0, limit) : records;
   }
 

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1020,6 +1020,17 @@ export interface BufferedObservationChunkInput {
  * - lastReflectionAt: createdAt of most recent reflection record
  * - previousGeneration: record with next-oldest createdAt
  */
+
+/** Options for filtering observational memory history queries. */
+export interface ObservationalMemoryHistoryOptions {
+  /** Only return records created at or after this date */
+  from?: Date;
+  /** Only return records created at or before this date */
+  to?: Date;
+  /** Number of records to skip (for pagination) */
+  offset?: number;
+}
+
 export interface ObservationalMemoryRecord {
   // Identity
   /** Unique record ID */

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -684,6 +684,517 @@ describe('Storage Operations', () => {
       const history = await storage.getObservationalMemoryHistory(threadId, resourceId, 2);
       expect(history.length).toBe(2);
     });
+
+    it('should filter by from date', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      const midpoint = new Date();
+      await new Promise(r => setTimeout(r, 50));
+
+      const gen2 = await storage.createReflectionGeneration({
+        currentRecord: initial,
+        reflection: '- Reflection after midpoint',
+        tokenCount: 50,
+      });
+
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, { from: midpoint });
+      expect(history.length).toBe(1);
+      expect(history[0]!.id).toBe(gen2.id);
+    });
+
+    it('should filter by to date', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      const midpoint = new Date();
+      await new Promise(r => setTimeout(r, 50));
+
+      await storage.createReflectionGeneration({
+        currentRecord: initial,
+        reflection: '- Reflection after midpoint',
+        tokenCount: 50,
+      });
+
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, { to: midpoint });
+      expect(history.length).toBe(1);
+      expect(history[0]!.id).toBe(initial.id);
+    });
+
+    it('should support offset', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      let current = initial;
+      for (let i = 0; i < 3; i++) {
+        current = await storage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: `- Reflection ${i + 1}`,
+          tokenCount: 50,
+        });
+      }
+
+      // 4 records total (gen 0-3), offset 2 skips 2 newest
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, { offset: 2 });
+      expect(history.length).toBe(2);
+      expect(history[0]!.generationCount).toBe(1);
+      expect(history[1]!.generationCount).toBe(0);
+    });
+
+    it('should support offset with limit', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      let current = initial;
+      for (let i = 0; i < 3; i++) {
+        current = await storage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: `- Reflection ${i + 1}`,
+          tokenCount: 50,
+        });
+      }
+
+      // offset 1, limit 2: skip newest, take next 2
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, 2, { offset: 1 });
+      expect(history.length).toBe(2);
+      expect(history[0]!.generationCount).toBe(2);
+      expect(history[1]!.generationCount).toBe(1);
+    });
+
+    it('should return all records when empty options object is passed', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await storage.createReflectionGeneration({
+        currentRecord: initial,
+        reflection: '- Reflection 1',
+        tokenCount: 50,
+      });
+
+      const withEmptyOptions = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, {});
+      const withoutOptions = await storage.getObservationalMemoryHistory(threadId, resourceId);
+
+      expect(withEmptyOptions.length).toBe(2);
+      expect(withEmptyOptions.length).toBe(withoutOptions.length);
+      expect(withEmptyOptions.map(r => r.id)).toEqual(withoutOptions.map(r => r.id));
+    });
+
+    it('should return empty array when from is in the future', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await storage.createReflectionGeneration({
+        currentRecord: initial,
+        reflection: '- Reflection 1',
+        tokenCount: 50,
+      });
+
+      const futureDate = new Date(Date.now() + 86_400_000);
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, {
+        from: futureDate,
+      });
+
+      expect(history).toEqual([]);
+    });
+
+    it('should return empty array when to is far in the past', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await storage.createReflectionGeneration({
+        currentRecord: initial,
+        reflection: '- Reflection 1',
+        tokenCount: 50,
+      });
+
+      const pastDate = new Date('2000-01-01T00:00:00Z');
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, {
+        to: pastDate,
+      });
+
+      expect(history).toEqual([]);
+    });
+
+    it('should return empty array when offset exceeds total records', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await storage.createReflectionGeneration({
+        currentRecord: initial,
+        reflection: '- Reflection 1',
+        tokenCount: 50,
+      });
+
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, { offset: 10 });
+
+      expect(history).toEqual([]);
+    });
+
+    it('should treat offset 0 the same as no offset', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      let current = initial;
+      for (let i = 0; i < 2; i++) {
+        current = await storage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: `- Reflection ${i + 1}`,
+          tokenCount: 50,
+        });
+      }
+
+      const withOffset0 = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, { offset: 0 });
+      const withoutOffset = await storage.getObservationalMemoryHistory(threadId, resourceId);
+
+      expect(withOffset0.length).toBe(3);
+      expect(withOffset0.map(r => r.id)).toEqual(withoutOffset.map(r => r.id));
+    });
+
+    it('should preserve reverse chronological order when filtering by from', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      const midpoint = new Date();
+      await new Promise(r => setTimeout(r, 50));
+
+      let current = initial;
+      for (let i = 0; i < 3; i++) {
+        current = await storage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: `- Reflection ${i + 1}`,
+          tokenCount: 50,
+        });
+      }
+
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, { from: midpoint });
+
+      expect(history.length).toBe(3);
+      expect(history[0]!.generationCount).toBeGreaterThan(history[1]!.generationCount);
+      expect(history[1]!.generationCount).toBeGreaterThan(history[2]!.generationCount);
+    });
+
+    it('should preserve reverse chronological order when using offset', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      let current = initial;
+      for (let i = 0; i < 4; i++) {
+        current = await storage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: `- Reflection ${i + 1}`,
+          tokenCount: 50,
+        });
+      }
+
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, { offset: 1 });
+
+      expect(history.length).toBe(4);
+      for (let i = 0; i < history.length - 1; i++) {
+        expect(history[i]!.generationCount).toBeGreaterThan(history[i + 1]!.generationCount);
+      }
+    });
+
+    it('should combine from + to + limit correctly', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      const rangeStart = new Date();
+      await new Promise(r => setTimeout(r, 50));
+
+      let current = initial;
+      for (let i = 0; i < 3; i++) {
+        current = await storage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: `- Reflection ${i + 1}`,
+          tokenCount: 50,
+        });
+      }
+
+      await new Promise(r => setTimeout(r, 50));
+      const rangeEnd = new Date();
+      await new Promise(r => setTimeout(r, 50));
+
+      await storage.createReflectionGeneration({
+        currentRecord: current,
+        reflection: '- After range',
+        tokenCount: 50,
+      });
+
+      // 3 records in range, but limit to 2
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, 2, {
+        from: rangeStart,
+        to: rangeEnd,
+      });
+
+      expect(history.length).toBe(2);
+      expect(history[0]!.generationCount).toBe(3);
+      expect(history[1]!.generationCount).toBe(2);
+    });
+
+    it('should combine from + to + offset correctly', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      const rangeStart = new Date();
+      await new Promise(r => setTimeout(r, 50));
+
+      let current = initial;
+      for (let i = 0; i < 3; i++) {
+        current = await storage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: `- Reflection ${i + 1}`,
+          tokenCount: 50,
+        });
+      }
+
+      await new Promise(r => setTimeout(r, 50));
+      const rangeEnd = new Date();
+      await new Promise(r => setTimeout(r, 50));
+
+      await storage.createReflectionGeneration({
+        currentRecord: current,
+        reflection: '- After range',
+        tokenCount: 50,
+      });
+
+      // 3 records in range, skip the newest 1
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, {
+        from: rangeStart,
+        to: rangeEnd,
+        offset: 1,
+      });
+
+      expect(history.length).toBe(2);
+      expect(history[0]!.generationCount).toBe(2);
+      expect(history[1]!.generationCount).toBe(1);
+    });
+
+    it('should combine from + to + offset + limit for full pagination', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      const rangeStart = new Date();
+      await new Promise(r => setTimeout(r, 50));
+
+      let current = initial;
+      for (let i = 0; i < 4; i++) {
+        current = await storage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: `- Reflection ${i + 1}`,
+          tokenCount: 50,
+        });
+      }
+
+      await new Promise(r => setTimeout(r, 50));
+      const rangeEnd = new Date();
+      await new Promise(r => setTimeout(r, 50));
+
+      await storage.createReflectionGeneration({
+        currentRecord: current,
+        reflection: '- After range',
+        tokenCount: 50,
+      });
+
+      // 4 records in range (gen 4,3,2,1 desc), offset 1, limit 2 => gen 3, gen 2
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, 2, {
+        from: rangeStart,
+        to: rangeEnd,
+        offset: 1,
+      });
+
+      expect(history.length).toBe(2);
+      expect(history[0]!.generationCount).toBe(3);
+      expect(history[1]!.generationCount).toBe(2);
+    });
+
+    it('should paginate correctly using offset + limit across multiple pages', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      // Create 6 records total (gen 0..5)
+      let current = initial;
+      for (let i = 0; i < 5; i++) {
+        current = await storage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: `- Reflection ${i + 1}`,
+          tokenCount: 50,
+        });
+      }
+
+      const pageSize = 2;
+
+      // Page 1: offset 0, limit 2 => gen 5, 4
+      const page1 = await storage.getObservationalMemoryHistory(threadId, resourceId, pageSize, { offset: 0 });
+      expect(page1.length).toBe(2);
+      expect(page1[0]!.generationCount).toBe(5);
+      expect(page1[1]!.generationCount).toBe(4);
+
+      // Page 2: offset 2, limit 2 => gen 3, 2
+      const page2 = await storage.getObservationalMemoryHistory(threadId, resourceId, pageSize, { offset: 2 });
+      expect(page2.length).toBe(2);
+      expect(page2[0]!.generationCount).toBe(3);
+      expect(page2[1]!.generationCount).toBe(2);
+
+      // Page 3: offset 4, limit 2 => gen 1, 0
+      const page3 = await storage.getObservationalMemoryHistory(threadId, resourceId, pageSize, { offset: 4 });
+      expect(page3.length).toBe(2);
+      expect(page3[0]!.generationCount).toBe(1);
+      expect(page3[1]!.generationCount).toBe(0);
+
+      // Page 4: offset 6, limit 2 => empty
+      const page4 = await storage.getObservationalMemoryHistory(threadId, resourceId, pageSize, { offset: 6 });
+      expect(page4).toEqual([]);
+
+      // All pages combined should cover all 6 records with no duplicates
+      const allIds = [...page1, ...page2, ...page3].map(r => r.id);
+      expect(new Set(allIds).size).toBe(6);
+    });
+
+    it('should return correct results when limit exceeds available records after offset', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      let current = initial;
+      for (let i = 0; i < 2; i++) {
+        current = await storage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: `- Reflection ${i + 1}`,
+          tokenCount: 50,
+        });
+      }
+
+      // offset 2 leaves only 1 record, but limit is 10
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, 10, { offset: 2 });
+      expect(history.length).toBe(1);
+      expect(history[0]!.generationCount).toBe(0);
+    });
+
+    it('should return correct results when limit exceeds available records after date filtering', async () => {
+      const initial = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await new Promise(r => setTimeout(r, 50));
+      const midpoint = new Date();
+      await new Promise(r => setTimeout(r, 50));
+
+      await storage.createReflectionGeneration({
+        currentRecord: initial,
+        reflection: '- After midpoint',
+        tokenCount: 50,
+      });
+
+      // Limit 100 but only 1 record matches
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, 100, { from: midpoint });
+      expect(history.length).toBe(1);
+    });
+
+    it('should handle offset on a single record', async () => {
+      await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      // offset 0 on single record returns it
+      const withOffset0 = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, { offset: 0 });
+      expect(withOffset0.length).toBe(1);
+
+      // offset 1 on single record returns nothing
+      const withOffset1 = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, { offset: 1 });
+      expect(withOffset1).toEqual([]);
+    });
+
+    it('should return empty array when from equals to and no record matches', async () => {
+      await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      const exactDate = new Date('2099-06-15T12:00:00.000Z');
+      const history = await storage.getObservationalMemoryHistory(threadId, resourceId, undefined, {
+        from: exactDate,
+        to: exactDate,
+      });
+
+      expect(history).toEqual([]);
+    });
   });
 
   describe('clearObservationalMemory', () => {

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -7,7 +7,7 @@ import type { ObservabilityContext } from '@mastra/core/observability';
 import type { ProcessorStreamWriter } from '@mastra/core/processors';
 import { MessageHistory } from '@mastra/core/processors';
 import type { RequestContext } from '@mastra/core/request-context';
-import type { MemoryStorage, ObservationalMemoryRecord } from '@mastra/core/storage';
+import type { MemoryStorage, ObservationalMemoryRecord, ObservationalMemoryHistoryOptions } from '@mastra/core/storage';
 import xxhash from 'xxhash-wasm';
 
 import { BufferingCoordinator } from './buffering-coordinator';
@@ -3213,9 +3213,14 @@ ${formattedMessages}
   /**
    * Get observation history (previous generations)
    */
-  async getHistory(threadId: string, resourceId?: string, limit?: number): Promise<ObservationalMemoryRecord[]> {
+  async getHistory(
+    threadId: string,
+    resourceId?: string,
+    limit?: number,
+    options?: ObservationalMemoryHistoryOptions,
+  ): Promise<ObservationalMemoryRecord[]> {
     const ids = this.getStorageIds(threadId, resourceId);
-    return this.storage.getObservationalMemoryHistory(ids.threadId, ids.resourceId, limit);
+    return this.storage.getObservationalMemoryHistory(ids.threadId, ids.resourceId, limit, options);
   }
 
   /**

--- a/packages/server/src/server/handlers/gateway-memory-client.ts
+++ b/packages/server/src/server/handlers/gateway-memory-client.ts
@@ -190,11 +190,14 @@ export class GatewayMemoryClient {
 
   async getObservationHistory(
     threadId: string,
-    params: { resourceId?: string; limit?: number },
+    params: { resourceId?: string; limit?: number; from?: Date; to?: Date; offset?: number },
   ): Promise<{ records: GatewayOMRecord[] }> {
     const query = new URLSearchParams();
     if (params.resourceId) query.set('resourceId', params.resourceId);
     if (params.limit != null) query.set('limit', String(params.limit));
+    if (params.from) query.set('from', params.from.toISOString());
+    if (params.to) query.set('to', params.to.toISOString());
+    if (params.offset != null) query.set('offset', String(params.offset));
     const qs = query.toString();
     try {
       return await this.request(`${this.threadPath(threadId)}/observations/history${qs ? '?' + qs : ''}`);

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -526,7 +526,7 @@ export const GET_OBSERVATIONAL_MEMORY_ROUTE = createRoute({
   description: 'Returns the current observational memory record and optional history for a resource/thread',
   tags: ['Memory'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, resourceId, threadId, requestContext }) => {
+  handler: async ({ mastra, agentId, resourceId, threadId, from, to, offset, limit, requestContext }) => {
     try {
       // Verify agent has OM enabled
       const agent = await getAgentFromContext({ mastra, agentId, requestContext });
@@ -534,13 +534,16 @@ export const GET_OBSERVATIONAL_MEMORY_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Agent not found' });
       }
 
+      const historyLimit = limit ?? 5;
+      const historyOptions = { from, to, offset };
+
       // Gateway OM: proxy to gateway API
       if (await isGatewayAgentAsync(agent)) {
         const gwClient = getGatewayClient();
         if (gwClient && resourceId && threadId) {
           const [recordResult, historyResult] = await Promise.all([
             gwClient.getObservationRecord(threadId, resourceId),
-            gwClient.getObservationHistory(threadId, { resourceId, limit: 5 }),
+            gwClient.getObservationHistory(threadId, { resourceId, limit: historyLimit, from, to, offset }),
           ]);
           return {
             record: recordResult.record ? toLocalOMRecord(recordResult.record) : null,
@@ -585,8 +588,13 @@ export const GET_OBSERVATIONAL_MEMORY_ROUTE = createRoute({
       // Get current record
       const record = await memoryStore.getObservationalMemory(omThreadId, effectiveResourceId);
 
-      // Get history (last 5 generations)
-      const history = await memoryStore.getObservationalMemoryHistory(omThreadId, effectiveResourceId, 5);
+      // Get history
+      const history = await memoryStore.getObservationalMemoryHistory(
+        omThreadId,
+        effectiveResourceId,
+        historyLimit,
+        historyOptions,
+      );
 
       return {
         record: record ?? null,

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -564,6 +564,10 @@ export const getObservationalMemoryQuerySchema = z.object({
   agentId: z.string(),
   resourceId: z.string().optional(),
   threadId: z.string().optional(),
+  from: z.coerce.date().optional(),
+  to: z.coerce.date().optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  limit: z.coerce.number().int().min(1).optional(),
 });
 
 /**

--- a/stores/_test-utils/src/domains/memory/observational-memory.ts
+++ b/stores/_test-utils/src/domains/memory/observational-memory.ts
@@ -184,6 +184,632 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
 
         expect(history.length).toBe(2);
       });
+
+      it('should filter by from date', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Create initial record
+        const first = await memoryStorage.initializeObservationalMemory(input);
+
+        // Small delay to ensure distinct timestamps
+        await new Promise(r => setTimeout(r, 50));
+        const midpoint = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Create reflection generation after midpoint
+        const second = await memoryStorage.createReflectionGeneration({
+          currentRecord: first,
+          reflection: 'Reflection after midpoint',
+          tokenCount: 100,
+        });
+
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          from: midpoint,
+        });
+
+        expect(history.length).toBe(1);
+        expect(history[0]!.id).toBe(second.id);
+      });
+
+      it('should filter by to date', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Create initial record
+        const first = await memoryStorage.initializeObservationalMemory(input);
+
+        // Small delay to ensure distinct timestamps
+        await new Promise(r => setTimeout(r, 50));
+        const midpoint = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Create reflection generation after midpoint
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: first,
+          reflection: 'Reflection after midpoint',
+          tokenCount: 100,
+        });
+
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          to: midpoint,
+        });
+
+        expect(history.length).toBe(1);
+        expect(history[0]!.id).toBe(first.id);
+      });
+
+      it('should filter by from and to date combined', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Create initial record
+        const first = await memoryStorage.initializeObservationalMemory(input);
+
+        await new Promise(r => setTimeout(r, 50));
+        const rangeStart = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Create 2nd record inside the range
+        const second = await memoryStorage.createReflectionGeneration({
+          currentRecord: first,
+          reflection: 'Reflection in range',
+          tokenCount: 100,
+        });
+
+        await new Promise(r => setTimeout(r, 50));
+        const rangeEnd = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Create 3rd record outside the range
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: second,
+          reflection: 'Reflection after range',
+          tokenCount: 100,
+        });
+
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          from: rangeStart,
+          to: rangeEnd,
+        });
+
+        expect(history.length).toBe(1);
+        expect(history[0]!.id).toBe(second.id);
+      });
+
+      it('should support offset', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Create initial record + 3 reflections = 4 records total
+        const first = await memoryStorage.initializeObservationalMemory(input);
+        let current = first;
+        for (let i = 0; i < 3; i++) {
+          current = await memoryStorage.createReflectionGeneration({
+            currentRecord: current,
+            reflection: `Reflection ${i + 1}`,
+            tokenCount: 100,
+          });
+        }
+
+        // Offset 2 should skip the 2 newest records (reverse chronological order)
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, { offset: 2 });
+
+        expect(history.length).toBe(2);
+        // Should have the 2 oldest records (generationCount 1 and 0)
+        expect(history[0]!.generationCount).toBe(1);
+        expect(history[1]!.generationCount).toBe(0);
+      });
+
+      it('should support offset with limit', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Create initial record + 3 reflections = 4 records total
+        const first = await memoryStorage.initializeObservationalMemory(input);
+        let current = first;
+        for (let i = 0; i < 3; i++) {
+          current = await memoryStorage.createReflectionGeneration({
+            currentRecord: current,
+            reflection: `Reflection ${i + 1}`,
+            tokenCount: 100,
+          });
+        }
+
+        // Offset 1, limit 2: skip newest, take next 2
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, 2, { offset: 1 });
+
+        expect(history.length).toBe(2);
+        expect(history[0]!.generationCount).toBe(2);
+        expect(history[1]!.generationCount).toBe(1);
+      });
+
+      it('should return all records when empty options object is passed', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        const first = await memoryStorage.initializeObservationalMemory(input);
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: first,
+          reflection: 'Reflection 1',
+          tokenCount: 100,
+        });
+
+        const withEmptyOptions = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {});
+        const withoutOptions = await memoryStorage.getObservationalMemoryHistory(null, resourceId);
+
+        expect(withEmptyOptions.length).toBe(2);
+        expect(withEmptyOptions.length).toBe(withoutOptions.length);
+        expect(withEmptyOptions.map(r => r.id)).toEqual(withoutOptions.map(r => r.id));
+      });
+
+      it('should return empty array when from is in the future', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        const first = await memoryStorage.initializeObservationalMemory(input);
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: first,
+          reflection: 'Reflection 1',
+          tokenCount: 100,
+        });
+
+        const futureDate = new Date(Date.now() + 86_400_000); // +1 day
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          from: futureDate,
+        });
+
+        expect(history).toEqual([]);
+      });
+
+      it('should return empty array when to is far in the past', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        const first = await memoryStorage.initializeObservationalMemory(input);
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: first,
+          reflection: 'Reflection 1',
+          tokenCount: 100,
+        });
+
+        const pastDate = new Date('2000-01-01T00:00:00Z');
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          to: pastDate,
+        });
+
+        expect(history).toEqual([]);
+      });
+
+      it('should return empty array when offset exceeds total records', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        const first = await memoryStorage.initializeObservationalMemory(input);
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: first,
+          reflection: 'Reflection 1',
+          tokenCount: 100,
+        });
+
+        // 2 records total, offset 10 should return nothing
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, { offset: 10 });
+
+        expect(history).toEqual([]);
+      });
+
+      it('should treat offset 0 the same as no offset', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        const first = await memoryStorage.initializeObservationalMemory(input);
+        let current = first;
+        for (let i = 0; i < 2; i++) {
+          current = await memoryStorage.createReflectionGeneration({
+            currentRecord: current,
+            reflection: `Reflection ${i + 1}`,
+            tokenCount: 100,
+          });
+        }
+
+        const withOffset0 = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          offset: 0,
+        });
+        const withoutOffset = await memoryStorage.getObservationalMemoryHistory(null, resourceId);
+
+        expect(withOffset0.length).toBe(3);
+        expect(withOffset0.map(r => r.id)).toEqual(withoutOffset.map(r => r.id));
+      });
+
+      it('should preserve reverse chronological order when filtering by from', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        const first = await memoryStorage.initializeObservationalMemory(input);
+
+        await new Promise(r => setTimeout(r, 50));
+        const midpoint = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Create 3 more records after midpoint
+        let current = first;
+        const afterIds: string[] = [];
+        for (let i = 0; i < 3; i++) {
+          current = await memoryStorage.createReflectionGeneration({
+            currentRecord: current,
+            reflection: `Reflection ${i + 1}`,
+            tokenCount: 100,
+          });
+          afterIds.push(current.id);
+        }
+
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          from: midpoint,
+        });
+
+        expect(history.length).toBe(3);
+        // Newest first (generationCount descending)
+        expect(history[0]!.generationCount).toBeGreaterThan(history[1]!.generationCount);
+        expect(history[1]!.generationCount).toBeGreaterThan(history[2]!.generationCount);
+      });
+
+      it('should preserve reverse chronological order when using offset', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Create 5 records total
+        const first = await memoryStorage.initializeObservationalMemory(input);
+        let current = first;
+        for (let i = 0; i < 4; i++) {
+          current = await memoryStorage.createReflectionGeneration({
+            currentRecord: current,
+            reflection: `Reflection ${i + 1}`,
+            tokenCount: 100,
+          });
+        }
+
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, { offset: 1 });
+
+        expect(history.length).toBe(4);
+        for (let i = 0; i < history.length - 1; i++) {
+          expect(history[i]!.generationCount).toBeGreaterThan(history[i + 1]!.generationCount);
+        }
+      });
+
+      it('should combine from + to + limit correctly', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Record before range
+        const first = await memoryStorage.initializeObservationalMemory(input);
+
+        await new Promise(r => setTimeout(r, 50));
+        const rangeStart = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // 3 records inside range
+        let current = first;
+        for (let i = 0; i < 3; i++) {
+          current = await memoryStorage.createReflectionGeneration({
+            currentRecord: current,
+            reflection: `Reflection ${i + 1}`,
+            tokenCount: 100,
+          });
+        }
+
+        await new Promise(r => setTimeout(r, 50));
+        const rangeEnd = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Record after range
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: 'After range',
+          tokenCount: 100,
+        });
+
+        // 3 records in range, but limit to 2
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, 2, {
+          from: rangeStart,
+          to: rangeEnd,
+        });
+
+        expect(history.length).toBe(2);
+        // Should be the 2 newest within the range
+        expect(history[0]!.generationCount).toBe(3);
+        expect(history[1]!.generationCount).toBe(2);
+      });
+
+      it('should combine from + to + offset correctly', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Record before range
+        const first = await memoryStorage.initializeObservationalMemory(input);
+
+        await new Promise(r => setTimeout(r, 50));
+        const rangeStart = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // 3 records inside range
+        let current = first;
+        for (let i = 0; i < 3; i++) {
+          current = await memoryStorage.createReflectionGeneration({
+            currentRecord: current,
+            reflection: `Reflection ${i + 1}`,
+            tokenCount: 100,
+          });
+        }
+
+        await new Promise(r => setTimeout(r, 50));
+        const rangeEnd = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Record after range
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: 'After range',
+          tokenCount: 100,
+        });
+
+        // 3 records in range, skip the newest 1
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          from: rangeStart,
+          to: rangeEnd,
+          offset: 1,
+        });
+
+        expect(history.length).toBe(2);
+        // Skipped gen 3 (newest in range), should have gen 2 and gen 1
+        expect(history[0]!.generationCount).toBe(2);
+        expect(history[1]!.generationCount).toBe(1);
+      });
+
+      it('should combine from + to + offset + limit for full pagination', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Record before range
+        const first = await memoryStorage.initializeObservationalMemory(input);
+
+        await new Promise(r => setTimeout(r, 50));
+        const rangeStart = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // 4 records inside range (gen 1..4)
+        let current = first;
+        for (let i = 0; i < 4; i++) {
+          current = await memoryStorage.createReflectionGeneration({
+            currentRecord: current,
+            reflection: `Reflection ${i + 1}`,
+            tokenCount: 100,
+          });
+        }
+
+        await new Promise(r => setTimeout(r, 50));
+        const rangeEnd = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Record after range
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: current,
+          reflection: 'After range',
+          tokenCount: 100,
+        });
+
+        // 4 records in range (gen 4,3,2,1 in desc order), offset 1, limit 2 => gen 3, gen 2
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, 2, {
+          from: rangeStart,
+          to: rangeEnd,
+          offset: 1,
+        });
+
+        expect(history.length).toBe(2);
+        expect(history[0]!.generationCount).toBe(3);
+        expect(history[1]!.generationCount).toBe(2);
+      });
+
+      it('should work with thread-scoped records (non-null threadId)', async () => {
+        const scopedThreadId = `thread-${randomUUID()}`;
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ threadId: scopedThreadId, resourceId, scope: 'thread' });
+
+        const first = await memoryStorage.initializeObservationalMemory(input);
+
+        await new Promise(r => setTimeout(r, 50));
+        const midpoint = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        const second = await memoryStorage.createReflectionGeneration({
+          currentRecord: first,
+          reflection: 'Thread-scoped reflection',
+          tokenCount: 100,
+        });
+
+        // from filter with thread-scoped lookup
+        const fromHistory = await memoryStorage.getObservationalMemoryHistory(scopedThreadId, resourceId, undefined, {
+          from: midpoint,
+        });
+        expect(fromHistory.length).toBe(1);
+        expect(fromHistory[0]!.id).toBe(second.id);
+
+        // to filter with thread-scoped lookup
+        const toHistory = await memoryStorage.getObservationalMemoryHistory(scopedThreadId, resourceId, undefined, {
+          to: midpoint,
+        });
+        expect(toHistory.length).toBe(1);
+        expect(toHistory[0]!.id).toBe(first.id);
+
+        // offset with thread-scoped lookup
+        const offsetHistory = await memoryStorage.getObservationalMemoryHistory(scopedThreadId, resourceId, undefined, {
+          offset: 1,
+        });
+        expect(offsetHistory.length).toBe(1);
+        expect(offsetHistory[0]!.id).toBe(first.id);
+      });
+
+      it('should not return records from a different resource when filtering', async () => {
+        const resourceIdA = `resource-a-${randomUUID()}`;
+        const resourceIdB = `resource-b-${randomUUID()}`;
+
+        // Create records for resource A
+        const firstA = await memoryStorage.initializeObservationalMemory(
+          createSampleOMInput({ resourceId: resourceIdA }),
+        );
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: firstA,
+          reflection: 'Resource A reflection',
+          tokenCount: 100,
+        });
+
+        // Create records for resource B
+        const firstB = await memoryStorage.initializeObservationalMemory(
+          createSampleOMInput({ resourceId: resourceIdB }),
+        );
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: firstB,
+          reflection: 'Resource B reflection',
+          tokenCount: 100,
+        });
+
+        // Query resource A — should only get resource A's records
+        const historyA = await memoryStorage.getObservationalMemoryHistory(null, resourceIdA, undefined, { offset: 0 });
+        expect(historyA.length).toBe(2);
+        expect(historyA.every(r => r.resourceId === resourceIdA)).toBe(true);
+
+        // Query resource B with date filter — should only get resource B's records
+        const pastDate = new Date('2000-01-01T00:00:00Z');
+        const historyB = await memoryStorage.getObservationalMemoryHistory(null, resourceIdB, undefined, {
+          from: pastDate,
+        });
+        expect(historyB.length).toBe(2);
+        expect(historyB.every(r => r.resourceId === resourceIdB)).toBe(true);
+      });
+
+      it('should return empty array when from equals to and no record has that exact timestamp', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        await memoryStorage.initializeObservationalMemory(input);
+
+        // Use a timestamp that definitely doesn't match any record
+        const exactDate = new Date('2099-06-15T12:00:00.000Z');
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          from: exactDate,
+          to: exactDate,
+        });
+
+        expect(history).toEqual([]);
+      });
+
+      it('should handle offset on a single record', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Only 1 record
+        await memoryStorage.initializeObservationalMemory(input);
+
+        // offset 0 on single record returns it
+        const withOffset0 = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          offset: 0,
+        });
+        expect(withOffset0.length).toBe(1);
+
+        // offset 1 on single record returns nothing
+        const withOffset1 = await memoryStorage.getObservationalMemoryHistory(null, resourceId, undefined, {
+          offset: 1,
+        });
+        expect(withOffset1).toEqual([]);
+      });
+
+      it('should paginate correctly using offset + limit across multiple pages', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // Create 6 records total (gen 0..5)
+        const first = await memoryStorage.initializeObservationalMemory(input);
+        let current = first;
+        for (let i = 0; i < 5; i++) {
+          current = await memoryStorage.createReflectionGeneration({
+            currentRecord: current,
+            reflection: `Reflection ${i + 1}`,
+            tokenCount: 100,
+          });
+        }
+
+        const pageSize = 2;
+
+        // Page 1: offset 0, limit 2 => gen 5, 4
+        const page1 = await memoryStorage.getObservationalMemoryHistory(null, resourceId, pageSize, { offset: 0 });
+        expect(page1.length).toBe(2);
+        expect(page1[0]!.generationCount).toBe(5);
+        expect(page1[1]!.generationCount).toBe(4);
+
+        // Page 2: offset 2, limit 2 => gen 3, 2
+        const page2 = await memoryStorage.getObservationalMemoryHistory(null, resourceId, pageSize, { offset: 2 });
+        expect(page2.length).toBe(2);
+        expect(page2[0]!.generationCount).toBe(3);
+        expect(page2[1]!.generationCount).toBe(2);
+
+        // Page 3: offset 4, limit 2 => gen 1, 0
+        const page3 = await memoryStorage.getObservationalMemoryHistory(null, resourceId, pageSize, { offset: 4 });
+        expect(page3.length).toBe(2);
+        expect(page3[0]!.generationCount).toBe(1);
+        expect(page3[1]!.generationCount).toBe(0);
+
+        // Page 4: offset 6, limit 2 => empty
+        const page4 = await memoryStorage.getObservationalMemoryHistory(null, resourceId, pageSize, { offset: 6 });
+        expect(page4).toEqual([]);
+
+        // All pages combined should cover all 6 records with no duplicates
+        const allIds = [...page1, ...page2, ...page3].map(r => r.id);
+        expect(new Set(allIds).size).toBe(6);
+      });
+
+      it('should return correct results when limit exceeds available records after offset', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        // 3 records total
+        const first = await memoryStorage.initializeObservationalMemory(input);
+        let current = first;
+        for (let i = 0; i < 2; i++) {
+          current = await memoryStorage.createReflectionGeneration({
+            currentRecord: current,
+            reflection: `Reflection ${i + 1}`,
+            tokenCount: 100,
+          });
+        }
+
+        // offset 2 leaves only 1 record, but limit is 10
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, 10, { offset: 2 });
+        expect(history.length).toBe(1);
+        expect(history[0]!.generationCount).toBe(0);
+      });
+
+      it('should return correct results when limit exceeds available records after date filtering', async () => {
+        const resourceId = `resource-${randomUUID()}`;
+        const input = createSampleOMInput({ resourceId });
+
+        const first = await memoryStorage.initializeObservationalMemory(input);
+
+        await new Promise(r => setTimeout(r, 50));
+        const midpoint = new Date();
+        await new Promise(r => setTimeout(r, 50));
+
+        // Only 1 record after midpoint
+        await memoryStorage.createReflectionGeneration({
+          currentRecord: first,
+          reflection: 'After midpoint',
+          tokenCount: 100,
+        });
+
+        // Limit 100 but only 1 record matches
+        const history = await memoryStorage.getObservationalMemoryHistory(null, resourceId, 100, {
+          from: midpoint,
+        });
+        expect(history.length).toBe(1);
+      });
     });
 
     describe('updateActiveObservations', () => {

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -1533,7 +1533,7 @@ export class MemoryLibSQL extends MemoryStorage {
       const lookupKey = this.getOMKey(threadId, resourceId);
 
       const conditions = [`"lookupKey" = ?`];
-      const args: unknown[] = [lookupKey];
+      const args: InValue[] = [lookupKey];
 
       if (options?.from) {
         conditions.push(`"createdAt" >= ?`);

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -15,6 +15,7 @@ import type {
   StorageCloneThreadOutput,
   ThreadCloneMetadata,
   ObservationalMemoryRecord,
+  ObservationalMemoryHistoryOptions,
   BufferedObservationChunk,
   CreateObservationalMemoryInput,
   UpdateActiveObservationsInput,
@@ -1526,14 +1527,32 @@ export class MemoryLibSQL extends MemoryStorage {
     threadId: string | null,
     resourceId: string,
     limit: number = 10,
+    options?: ObservationalMemoryHistoryOptions,
   ): Promise<ObservationalMemoryRecord[]> {
     try {
       const lookupKey = this.getOMKey(threadId, resourceId);
-      const result = await this.#client.execute({
-        // Use generationCount DESC for reliable ordering (incremented for each new record)
-        sql: `SELECT * FROM "${OM_TABLE}" WHERE "lookupKey" = ? ORDER BY "generationCount" DESC LIMIT ?`,
-        args: [lookupKey, limit],
-      });
+
+      const conditions = [`"lookupKey" = ?`];
+      const args: unknown[] = [lookupKey];
+
+      if (options?.from) {
+        conditions.push(`"createdAt" >= ?`);
+        args.push(options.from.toISOString());
+      }
+      if (options?.to) {
+        conditions.push(`"createdAt" <= ?`);
+        args.push(options.to.toISOString());
+      }
+
+      args.push(limit);
+      let sql = `SELECT * FROM "${OM_TABLE}" WHERE ${conditions.join(' AND ')} ORDER BY "generationCount" DESC LIMIT ?`;
+
+      if (options?.offset != null) {
+        args.push(options.offset);
+        sql += ` OFFSET ?`;
+      }
+
+      const result = await this.#client.execute({ sql, args });
       if (!result.rows) return [];
       return result.rows.map(row => this.parseOMRow(row));
     } catch (error) {

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -32,6 +32,7 @@ import type {
   StorageCloneThreadOutput,
   ThreadCloneMetadata,
   ObservationalMemoryRecord,
+  ObservationalMemoryHistoryOptions,
   BufferedObservationChunk,
   CreateObservationalMemoryInput,
   UpdateActiveObservationsInput,
@@ -1412,11 +1413,25 @@ export class MemoryStorageMongoDB extends MemoryStorage {
     threadId: string | null,
     resourceId: string,
     limit: number = 10,
+    options?: ObservationalMemoryHistoryOptions,
   ): Promise<ObservationalMemoryRecord[]> {
     try {
       const lookupKey = this.getOMKey(threadId, resourceId);
       const collection = await this.getCollection(OM_TABLE);
-      const docs = await collection.find({ lookupKey }).sort({ generationCount: -1 }).limit(limit).toArray();
+
+      const filter: Record<string, unknown> = { lookupKey };
+      if (options?.from || options?.to) {
+        const createdAtFilter: Record<string, unknown> = {};
+        if (options.from) createdAtFilter['$gte'] = options.from;
+        if (options.to) createdAtFilter['$lte'] = options.to;
+        filter['createdAt'] = createdAtFilter;
+      }
+
+      let cursor = collection.find(filter).sort({ generationCount: -1 });
+      if (options?.offset != null) {
+        cursor = cursor.skip(options.offset);
+      }
+      const docs = await cursor.limit(limit).toArray();
       return docs.map((doc: any) => this.parseOMDocument(doc));
     } catch (error) {
       throw new MastraError(

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -47,6 +47,7 @@ import type {
   StorageCloneThreadOutput,
   ThreadCloneMetadata,
   ObservationalMemoryRecord,
+  ObservationalMemoryHistoryOptions,
   BufferedObservationChunk,
   CreateObservationalMemoryInput,
   UpdateActiveObservationsInput,
@@ -1793,6 +1794,7 @@ export class MemoryPG extends MemoryStorage {
     threadId: string | null,
     resourceId: string,
     limit: number = 10,
+    options?: ObservationalMemoryHistoryOptions,
   ): Promise<ObservationalMemoryRecord[]> {
     try {
       const lookupKey = this.getOMKey(threadId, resourceId);
@@ -1800,10 +1802,32 @@ export class MemoryPG extends MemoryStorage {
         indexName: OM_TABLE,
         schemaName: getSchemaName(this.#schema),
       });
-      const result = await this.#db.client.manyOrNone(
-        `SELECT * FROM ${tableName} WHERE "lookupKey" = $1 ORDER BY "generationCount" DESC LIMIT $2`,
-        [lookupKey, limit],
-      );
+
+      const conditions = [`"lookupKey" = $1`];
+      const params: unknown[] = [lookupKey];
+      let paramIndex = 2;
+
+      if (options?.from) {
+        conditions.push(`"createdAt" >= $${paramIndex}`);
+        params.push(options.from);
+        paramIndex++;
+      }
+      if (options?.to) {
+        conditions.push(`"createdAt" <= $${paramIndex}`);
+        params.push(options.to);
+        paramIndex++;
+      }
+
+      params.push(limit);
+      let sql = `SELECT * FROM ${tableName} WHERE ${conditions.join(' AND ')} ORDER BY "generationCount" DESC LIMIT $${paramIndex}`;
+      paramIndex++;
+
+      if (options?.offset != null) {
+        params.push(options.offset);
+        sql += ` OFFSET $${paramIndex}`;
+      }
+
+      const result = await this.#db.client.manyOrNone(sql, params);
       if (!result) return [];
       return result.map(row => this.parseOMRow(row));
     } catch (error) {


### PR DESCRIPTION
## Summary

Add optional `from` (Date), `to` (Date), and `offset` (number) parameters to `getObservationalMemoryHistory` across the full stack, enabling date-range filtering and cursor-based pagination of observation history.

## Changes

### Type & contract
- New `ObservationalMemoryHistoryOptions` interface in `packages/core/src/storage/types.ts`
- Updated base class signature with 4th optional `options` argument (non-breaking)

### Storage adapters
- **In-memory**: JS array `.filter()` + `.slice()`
- **PostgreSQL**: Dynamic SQL with `WHERE createdAt >=/<= $N` + `OFFSET`
- **LibSQL**: Same SQL pattern with ISO string date params
- **MongoDB**: `$gte`/`$lte` filter + `.skip()`

### Server
- Added `from`, `to`, `offset`, `limit` to query schema with coercion
- Handler destructures and forwards to storage
- Gateway client serializes dates as ISO strings in URLSearchParams

### Client SDK
- Added fields to `GetObservationalMemoryParams` (supports `Date | string`)
- Client method serializes and sends as query params

### Memory package
- Updated `ObservationalMemory.getHistory()` wrapper to accept and forward options

## Test plan

**22 test cases per location** (`stores/_test-utils` shared suite + `packages/memory` unit tests):

| Category | Coverage |
|---|---|
| Date filtering | `from` only, `to` only, `from` + `to` range |
| Offset | offset only, offset + limit |
| Edge cases | empty options `{}`, future `from` → empty, past `to` → empty, offset > total → empty, offset 0 == no offset, matching `from` == `to` → empty, single record |
| Ordering | reverse chronological preserved with `from` filter, preserved with offset |
| Combinations | `from`+`to`+`limit`, `from`+`to`+`offset`, `from`+`to`+`offset`+`limit` |
| Pagination | multi-page walk (6 records, page size 2), no duplicates |
| Boundary | limit exceeds available after offset/date filter |
| Isolation | no cross-resource contamination, thread-scoped with all filters |

**Results**: 925 tests passed, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observational memory history now supports date-range filtering and pagination with optional `from`, `to`, `offset`, and `limit` parameters across all storage backends.

* **Tests**
  * Added comprehensive test coverage for temporal filtering, pagination, and edge-case behavior.

* **Chores**
  * Code formatting and refactoring improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->