### PR TITLE
fix(playground): fix infinite loop on scorer detail page when clicking score rows

### DIFF
--- a/.changeset/lazy-cases-make.md
+++ b/.changeset/lazy-cases-make.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground': patch
+---
+
+Fixed infinite loop on scorer detail page that caused the browser to hang when clicking a score row. The URL and component state now sync without fighting each other.

--- a/.changeset/lazy-cases-make.md
+++ b/.changeset/lazy-cases-make.md
@@ -1,5 +1,0 @@
----
-'@mastra/playground': patch
----
-
-Fixed infinite loop on scorer detail page that caused the browser to hang when clicking a score row. The URL and component state now sync without fighting each other.

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -35,9 +35,10 @@ import { cn } from '@/lib/utils';
 export default function Scorer() {
   const { scorerId } = useParams()! as { scorerId: string };
   const [searchParams, setSearchParams] = useSearchParams();
-  const [selectedScoreId, setSelectedScoreId] = useState<string | undefined>();
+  const scoreIdFromUrl = searchParams.get('scoreId') ?? undefined;
+  const [selectedScoreId, setSelectedScoreId] = useState<string | undefined>(scoreIdFromUrl);
   const [scoresPage, setScoresPage] = useState<number>(0);
-  const [dialogIsOpen, setDialogIsOpen] = useState<boolean>(false);
+  const [dialogIsOpen, setDialogIsOpen] = useState<boolean>(!!scoreIdFromUrl);
 
   const [selectedEntityOption, setSelectedEntityOption] = useState<EntityOptions | undefined>({
     value: 'all',
@@ -156,50 +157,25 @@ export default function Scorer() {
     });
   };
 
+  // Sync URL → state when scoreId in URL changes externally (e.g. browser back/forward)
   useEffect(() => {
-    const scoreIdFromUrl = searchParams.get('scoreId');
+    const urlScoreId = searchParams.get('scoreId') ?? undefined;
 
-    if (!scoreIdFromUrl) {
-      if (selectedScoreId) {
-        setSelectedScoreId(undefined);
-      }
-      if (dialogIsOpen) {
-        setDialogIsOpen(false);
-      }
+    if (urlScoreId === selectedScoreId) return;
+
+    if (!urlScoreId) {
+      setSelectedScoreId(undefined);
+      setDialogIsOpen(false);
       return;
     }
 
-    const matchingScore = scores.find(score => score.id === scoreIdFromUrl);
+    const matchingScore = scores.find(score => score.id === urlScoreId);
     if (!matchingScore) return;
 
-    if (selectedScoreId !== scoreIdFromUrl) {
-      setSelectedScoreId(scoreIdFromUrl);
-    }
-
-    if (!dialogIsOpen) {
-      setDialogIsOpen(true);
-    }
-  }, [dialogIsOpen, scores, searchParams, selectedScoreId]);
-
-  useEffect(() => {
-    const currentScoreId = searchParams.get('scoreId');
-
-    if (selectedScoreId ? currentScoreId === selectedScoreId : !currentScoreId) {
-      return;
-    }
-
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev);
-
-      if (selectedScoreId) {
-        next.set('scoreId', selectedScoreId);
-      } else {
-        next.delete('scoreId');
-      }
-
-      return next;
-    });
-  }, [searchParams, selectedScoreId, setSearchParams]);
+    setSelectedScoreId(urlScoreId);
+    setDialogIsOpen(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, scores]);
 
   if (scorerError && is403ForbiddenError(scorerError)) {
     return (
@@ -230,10 +206,28 @@ export default function Scorer() {
   const handleScoreClick = (id: string) => {
     setSelectedScoreId(id);
     setDialogIsOpen(true);
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      next.set('scoreId', id);
+      return next;
+    });
   };
 
-  const toNextScore = getToNextEntryFn({ entries: scores, id: selectedScoreId, update: setSelectedScoreId });
-  const toPreviousScore = getToPreviousEntryFn({ entries: scores, id: selectedScoreId, update: setSelectedScoreId });
+  const updateSelectedScoreId = (id: string | undefined) => {
+    setSelectedScoreId(id);
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      if (id) {
+        next.set('scoreId', id);
+      } else {
+        next.delete('scoreId');
+      }
+      return next;
+    });
+  };
+
+  const toNextScore = getToNextEntryFn({ entries: scores, id: selectedScoreId, update: updateSelectedScoreId });
+  const toPreviousScore = getToPreviousEntryFn({ entries: scores, id: selectedScoreId, update: updateSelectedScoreId });
 
   return (
     <>
@@ -320,6 +314,11 @@ export default function Scorer() {
         onClose={() => {
           setDialogIsOpen(false);
           setSelectedScoreId(undefined);
+          setSearchParams(prev => {
+            const next = new URLSearchParams(prev);
+            next.delete('scoreId');
+            return next;
+          });
         }}
         onNext={toNextScore}
         onPrevious={toPreviousScore}


### PR DESCRIPTION
The two `useEffect` hooks added in #14970 for deep-linking scoreId between the URL and component state were fighting each other — `setSearchParams` produced a new `searchParams` reference each render, re-triggering both effects in an infinite loop. Chrome's `Throttling navigation to prevent the browser from hanging` error confirmed it.

Replaced with a single URL→state effect (for browser back/forward) and direct URL updates in the event handlers (`handleScoreClick`, `onClose`, next/prev navigation). No behavioral change — deep links still work, the page just doesn't hang anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an infinite loop on the scorer detail page that was causing the browser to hang when users clicked on a score row.
* Improved state management by synchronizing URL parameters with component state, preventing conflicting updates and ensuring consistent navigation throughout the scorer interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->