### PR TITLE
fix(core): infer TState from stateSchema in createWorkflow

### DIFF
--- a/.changeset/fix-workflow-state-schema-inference.md
+++ b/.changeset/fix-workflow-state-schema-inference.md
@@ -1,0 +1,28 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `createWorkflow` to correctly infer `TState` from `stateSchema`, so `state` is properly typed in `dowhile`/`dountil` conditions instead of being typed as `unknown`.
+
+**Before:** Passing `stateSchema` to `createWorkflow` did not propagate the type to loop conditions.
+
+```ts
+const workflow = createWorkflow({
+  id: 'my-workflow',
+  inputSchema: z.object({}),
+  outputSchema: z.object({}),
+  stateSchema: z.object({ idx: z.number().default(0) }),
+});
+
+workflow.dowhile(myStep, async ({ state }) => {
+  return state.idx < 5; // Error: 'state' is of type 'unknown'
+});
+```
+
+**After:** `state` is correctly typed as the inferred schema type.
+
+```ts
+workflow.dowhile(myStep, async ({ state }) => {
+  return state.idx < 5; // state.idx is typed as number ✓
+});
+```

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -795,7 +795,7 @@ export type WorkflowConfig<
   description?: string | undefined;
   inputSchema: PublicSchema<TInput>;
   outputSchema: PublicSchema<TOutput>;
-  stateSchema?: PublicSchema<TState>;
+  stateSchema?: StandardSchemaWithJSON<TState>;
   /**
    * Optional schema for validating request context values.
    * When provided, the request context will be validated against this schema when the workflow starts.

--- a/packages/core/src/workflows/workflow-schema-types.test-d.ts
+++ b/packages/core/src/workflows/workflow-schema-types.test-d.ts
@@ -327,4 +327,58 @@ describe('Workflow schema type inference', () => {
       workflow.then(step);
     });
   });
+
+  describe('stateSchema type inference', () => {
+    it('should infer TState from stateSchema in createWorkflow', () => {
+      const stateSchema = z.object({
+        idx: z.number().default(0),
+        chunks: z.array(z.object({ text: z.string() })).optional(),
+      });
+
+      const myStep = createStep({
+        id: 'my-step',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        stateSchema,
+        execute: async ({ state }) => {
+          expectTypeOf(state.idx).toBeNumber();
+          return {};
+        },
+      });
+
+      const workflow = createWorkflow({
+        id: 'my-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        stateSchema,
+      });
+
+      workflow.then(myStep).dowhile(myStep, async ({ state }) => {
+        // state should be inferred from stateSchema, not unknown
+        expectTypeOf(state).not.toBeUnknown();
+        expectTypeOf(state.idx).toBeNumber();
+        return state.idx < (state.chunks?.length ?? 0);
+      });
+    });
+
+    it('should type state as unknown in dowhile when stateSchema is not provided', () => {
+      const myStep = createStep({
+        id: 'my-step',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        execute: async () => ({}),
+      });
+
+      const workflow = createWorkflow({
+        id: 'my-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+      });
+
+      workflow.then(myStep).dowhile(myStep, async ({ state }) => {
+        expectTypeOf(state).toBeUnknown();
+        return false;
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #14627

## Problem

When `stateSchema` is provided to `createWorkflow()`, the `TState` generic is not inferred from it. This causes the `state` parameter in `dowhile`/`dountil` condition callbacks (and branch conditions) to be typed as `unknown` instead of the schema's inferred type.

## Solution

Changed `WorkflowConfig.stateSchema` from `PublicSchema<TState>` to `StandardSchemaWithJSON<TState>`.

The root cause: `PublicSchema<TState>` is a union type that includes `JSONSchema7` (which has no type parameter). When TypeScript tries to infer `TState` from this union, the presence of the unparameterized `JSONSchema7` member prevents reliable inference, causing `TState` to fall back to its default of `unknown`.

`StandardSchemaWithJSON<TState>` is a simpler intersection type that allows TypeScript to directly infer `TState` — the same pattern already used in `createStep`, where `state` is correctly typed.

All existing callers pass Zod schemas (which implement the Standard Schema interface), so this is backwards-compatible. `toStandardSchema()` in the constructor still works since `StandardSchemaWithJSON` extends `PublicSchema`.

## Testing

Added type-level tests in `workflow-schema-types.test-d.ts` that verify:
1. `state` is correctly typed when `stateSchema` is provided to `createWorkflow`
2. `state` is `unknown` when `stateSchema` is not provided (expected behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved TypeScript type inference for workflow state parameters in loop conditions. The state object is now properly typed based on the provided state schema definition, enabling better IDE autocomplete, type checking, and developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->