### PR TITLE
feat(cli): add studio deploy command

### DIFF
--- a/.changeset/cli-studio-deploy.md
+++ b/.changeset/cli-studio-deploy.md
@@ -1,0 +1,6 @@
+---
+'mastra': minor
+'@mastra/deployer': patch
+---
+
+Added `mastra studio deploy` command for deploying studio to the Mastra platform. Includes `deploy`, `deploy list`, `deploy status`, `deploy logs`, and `projects` subcommands. Also generates a `package-lock.json` during build for faster deploys.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@expo/devcert": "^1.2.1",
+    "archiver": "^7.0.1",
     "@mastra/deployer": "workspace:^",
     "@mastra/loggers": "workspace:^",
     "commander": "^14.0.3",
@@ -77,6 +78,7 @@
     "@internal/playground": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
+    "@types/archiver": "^6.0.3",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "22.19.15",
     "@types/semver": "^7.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -78,7 +78,7 @@
     "@internal/playground": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
-    "@types/archiver": "^6.0.3",
+    "@types/archiver": "^7.0.0",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "22.19.15",
     "@types/semver": "^7.7.1",

--- a/packages/cli/src/commands/studio/deploy-commands.test.ts
+++ b/packages/cli/src/commands/studio/deploy-commands.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+const mockGetToken = vi.fn().mockResolvedValue('test-token');
+const mockGetCurrentOrgId = vi.fn().mockResolvedValue('org-1');
+
+vi.mock('../auth/credentials.js', () => ({
+  getToken: mockGetToken,
+  getCurrentOrgId: mockGetCurrentOrgId,
+  validateOrgAccess: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockFetchProjects = vi.fn();
+const mockFetchDeployStatus = vi.fn();
+
+vi.mock('./platform-api.js', () => ({
+  fetchProjects: mockFetchProjects,
+  fetchDeployStatus: mockFetchDeployStatus,
+}));
+
+vi.mock('../auth/client.js', () => ({
+  MASTRA_PLATFORM_API_URL: 'http://localhost:9999',
+  createApiClient: vi.fn(() => ({
+    GET: vi.fn().mockResolvedValue({ data: { logs: 'log line 1\nlog line 2' } }),
+  })),
+  authHeaders: vi.fn((token: string, orgId?: string) => {
+    const h: Record<string, string> = { Authorization: `Bearer ${token}` };
+    if (orgId) h['x-organization-id'] = orgId;
+    return h;
+  }),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockGetToken.mockResolvedValue('test-token');
+  mockGetCurrentOrgId.mockResolvedValue('org-1');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/* ------------------------------------------------------------------ */
+/*  deploy list                                                        */
+/* ------------------------------------------------------------------ */
+
+describe('deploysAction', () => {
+  it('lists projects with deploy status', async () => {
+    mockFetchProjects.mockResolvedValue([
+      {
+        id: 'p1',
+        name: 'App 1',
+        organizationId: 'org-1',
+        latestDeployId: 'd1',
+        latestDeployStatus: 'running',
+        instanceUrl: 'https://app1.example.com',
+      },
+      {
+        id: 'p2',
+        name: 'App 2',
+        organizationId: 'org-1',
+        latestDeployId: null,
+        latestDeployStatus: null,
+        instanceUrl: null,
+      },
+    ]);
+
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { deploysAction } = await import('./deploy-list.js');
+    await deploysAction();
+
+    const output = spy.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('App 1');
+    expect(output).toContain('App 2');
+    expect(output).toContain('https://app1.example.com');
+    spy.mockRestore();
+  });
+
+  it('shows message when no deploys', async () => {
+    mockFetchProjects.mockResolvedValue([]);
+
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { deploysAction } = await import('./deploy-list.js');
+    await deploysAction();
+
+    const output = spy.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('No deploys');
+    spy.mockRestore();
+  });
+
+  it('exits when no org selected', async () => {
+    mockGetCurrentOrgId.mockResolvedValue(null);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { deploysAction } = await import('./deploy-list.js');
+    await expect(deploysAction()).rejects.toThrow('process.exit');
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    mockExit.mockRestore();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  deploy status                                                      */
+/* ------------------------------------------------------------------ */
+
+describe('statusAction', () => {
+  it('displays deploy status', async () => {
+    mockFetchDeployStatus.mockResolvedValue({
+      id: 'd1',
+      status: 'running',
+      instanceUrl: 'https://example.com',
+      error: null,
+      projectName: 'My App',
+      createdAt: '2025-06-01T00:00:00Z',
+    });
+
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { statusAction } = await import('./deploy-status.js');
+    await statusAction('d1', {});
+
+    const output = spy.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('d1');
+    expect(output).toContain('running');
+    expect(output).toContain('My App');
+    expect(output).toContain('https://example.com');
+    spy.mockRestore();
+  });
+
+  it('displays error info for failed deploy', async () => {
+    mockFetchDeployStatus.mockResolvedValue({
+      id: 'd2',
+      status: 'failed',
+      instanceUrl: null,
+      error: 'build failed',
+      projectName: 'My App',
+      createdAt: '2025-06-01T00:00:00Z',
+    });
+
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { statusAction } = await import('./deploy-status.js');
+    await statusAction('d2', {});
+
+    const output = spy.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('failed');
+    expect(output).toContain('build failed');
+    spy.mockRestore();
+  });
+
+  it('exits when no org selected', async () => {
+    mockGetCurrentOrgId.mockResolvedValue(null);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { statusAction } = await import('./deploy-status.js');
+    await expect(statusAction('d1', {})).rejects.toThrow('process.exit');
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    mockExit.mockRestore();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  deploy logs                                                        */
+/* ------------------------------------------------------------------ */
+
+describe('logsAction', () => {
+  it('exits when no org selected', async () => {
+    mockGetCurrentOrgId.mockResolvedValue(null);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { logsAction } = await import('./deploy-logs.js');
+    await expect(logsAction('d1', {})).rejects.toThrow('process.exit');
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    mockExit.mockRestore();
+  });
+});

--- a/packages/cli/src/commands/studio/deploy-list.ts
+++ b/packages/cli/src/commands/studio/deploy-list.ts
@@ -1,0 +1,41 @@
+import { getToken, getCurrentOrgId, validateOrgAccess } from '../auth/credentials.js';
+import { fetchProjects } from './platform-api.js';
+
+const statusIcon: Record<string, string> = {
+  starting: '🚀',
+  running: '✅',
+  stopped: '⏹️',
+  failed: '❌',
+  unknown: '❓',
+};
+
+export async function deploysAction() {
+  const token = await getToken();
+  const orgId = await getCurrentOrgId();
+  if (!orgId) {
+    console.error('No organization selected. Run: mastra auth login');
+    process.exit(1);
+  }
+
+  await validateOrgAccess(token, orgId);
+
+  const projects = await fetchProjects(token, orgId);
+
+  if (projects.length === 0) {
+    console.info('No deploys found.');
+    return;
+  }
+
+  for (const project of projects) {
+    const status = project.latestDeployStatus ?? 'none';
+    const icon = statusIcon[status] ?? '❓';
+    const url = project.instanceUrl ?? '';
+
+    console.info(`${icon} ${project.name} (${project.id})`);
+    console.info(`   Latest:   ${project.latestDeployId ?? 'none'} — ${status}`);
+    if (url) {
+      console.info(`   URL:      ${url}`);
+    }
+    console.info('');
+  }
+}

--- a/packages/cli/src/commands/studio/deploy-logs.ts
+++ b/packages/cli/src/commands/studio/deploy-logs.ts
@@ -1,0 +1,82 @@
+import { authHeaders, createApiClient, MASTRA_PLATFORM_API_URL, platformFetch } from '../auth/client.js';
+import { getToken, getCurrentOrgId, validateOrgAccess } from '../auth/credentials.js';
+
+async function getLogs(deployId: string, tail: string | undefined, token: string, orgId: string) {
+  const client = createApiClient(token, orgId);
+  const { data, error } = await client.GET('/v1/studio/deploys/{id}/logs', {
+    params: {
+      path: { id: deployId },
+      query: tail ? { tail } : undefined,
+    },
+  });
+
+  if (error) {
+    throw new Error(`Failed to fetch logs: ${error.detail}`);
+  }
+
+  if (data.logs) {
+    process.stdout.write(data.logs);
+  } else {
+    console.info('(no logs available)');
+  }
+}
+
+async function streamLogs(deployId: string, token: string, orgId: string) {
+  const url = `${MASTRA_PLATFORM_API_URL}/v1/studio/deploys/${deployId}/logs/stream`;
+
+  const resp = await platformFetch(url, {
+    headers: {
+      ...authHeaders(token, orgId),
+      Accept: 'text/event-stream',
+    },
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Failed to stream logs: ${resp.status} — ${text}`);
+  }
+
+  if (!resp.body) {
+    throw new Error('No response body for log stream');
+  }
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+
+  // Handle Ctrl+C gracefully
+  process.on('SIGINT', () => {
+    void reader.cancel();
+    process.exit(0);
+  });
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    const chunk = decoder.decode(value, { stream: true });
+    // Parse SSE data lines
+    for (const line of chunk.split('\n')) {
+      if (line.startsWith('data:')) {
+        const data = line.slice(5).trimStart();
+        process.stdout.write(data + '\n');
+      }
+    }
+  }
+}
+
+export async function logsAction(deployId: string, opts: { follow?: boolean; tail?: string }) {
+  const token = await getToken();
+  const orgId = await getCurrentOrgId();
+  if (!orgId) {
+    console.error('No organization selected. Run: mastra auth login');
+    process.exit(1);
+  }
+
+  await validateOrgAccess(token, orgId);
+
+  if (opts.follow) {
+    await streamLogs(deployId, token, orgId);
+  } else {
+    await getLogs(deployId, opts.tail, token, orgId);
+  }
+}

--- a/packages/cli/src/commands/studio/deploy-logs.ts
+++ b/packages/cli/src/commands/studio/deploy-logs.ts
@@ -42,6 +42,7 @@ async function streamLogs(deployId: string, token: string, orgId: string) {
 
   const reader = resp.body.getReader();
   const decoder = new TextDecoder();
+  let buffer = '';
 
   // Handle Ctrl+C gracefully
   process.on('SIGINT', () => {
@@ -53,9 +54,11 @@ async function streamLogs(deployId: string, token: string, orgId: string) {
     const { done, value } = await reader.read();
     if (done) break;
 
-    const chunk = decoder.decode(value, { stream: true });
-    // Parse SSE data lines
-    for (const line of chunk.split('\n')) {
+    buffer += decoder.decode(value, { stream: true });
+    // Parse SSE data lines, keeping any incomplete trailing line in the buffer
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+    for (const line of lines) {
       if (line.startsWith('data:')) {
         const data = line.slice(5).trimStart();
         process.stdout.write(data + '\n');

--- a/packages/cli/src/commands/studio/deploy-status.ts
+++ b/packages/cli/src/commands/studio/deploy-status.ts
@@ -1,0 +1,64 @@
+import { getToken, getCurrentOrgId, validateOrgAccess } from '../auth/credentials.js';
+import type { DeployInfo } from './platform-api.js';
+import { fetchDeployStatus } from './platform-api.js';
+
+function printDeploy(deploy: DeployInfo) {
+  const statusIcon: Record<string, string> = {
+    starting: '🚀',
+    running: '✅',
+    stopped: '⏹️',
+    failed: '❌',
+    unknown: '❓',
+  };
+  const icon = statusIcon[deploy.status] ?? '❓';
+
+  console.info(`${icon} Deploy ${deploy.id}`);
+  console.info(`   Status:   ${deploy.status}`);
+  if (deploy.projectName) {
+    console.info(`   Project:  ${deploy.projectName}`);
+  }
+  if (deploy.instanceUrl) {
+    console.info(`   URL:      ${deploy.instanceUrl}`);
+  }
+  if (deploy.error) {
+    console.info(`   Error:    ${deploy.error}`);
+  }
+  if (deploy.createdAt) {
+    console.info(`   Created:  ${deploy.createdAt}`);
+  }
+}
+
+export async function statusAction(deployId: string, opts: { watch?: boolean }) {
+  const token = await getToken();
+  const orgId = await getCurrentOrgId();
+  if (!orgId) {
+    console.error('No organization selected. Run: mastra auth login');
+    process.exit(1);
+  }
+
+  await validateOrgAccess(token, orgId);
+
+  if (opts.watch) {
+    let lastStatus = '';
+    console.info(`Watching deploy ${deployId}...\n`);
+
+    while (true) {
+      const deploy = await fetchDeployStatus(deployId, token, orgId);
+
+      if (deploy.status !== lastStatus) {
+        printDeploy(deploy);
+        console.info('');
+        lastStatus = deploy.status;
+      }
+
+      if (deploy.status === 'running' || deploy.status === 'failed' || deploy.status === 'stopped') {
+        break;
+      }
+
+      await new Promise(r => setTimeout(r, 1000));
+    }
+  } else {
+    const deploy = await fetchDeployStatus(deployId, token, orgId);
+    printDeploy(deploy);
+  }
+}

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock all external dependencies
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  log: { step: vi.fn(), info: vi.fn(), success: vi.fn(), warn: vi.fn() },
+  note: vi.fn(),
+  confirm: vi.fn(),
+  select: vi.fn(),
+  isCancel: vi.fn(() => false),
+  cancel: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+}));
+
+vi.mock('archiver', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../auth/credentials.js', () => ({
+  getToken: vi.fn().mockResolvedValue('test-token'),
+  getCurrentOrgId: vi.fn().mockResolvedValue('org-1'),
+}));
+
+vi.mock('../auth/api.js', () => ({
+  fetchOrgs: vi.fn().mockResolvedValue([{ id: 'org-1', name: 'Test Org', role: 'admin', isCurrent: true }]),
+}));
+
+vi.mock('./platform-api.js', () => ({
+  fetchProjects: vi.fn().mockResolvedValue([]),
+  createProject: vi.fn().mockResolvedValue({ id: 'proj-1', name: 'my-app' }),
+  uploadDeploy: vi.fn().mockResolvedValue({ id: 'deploy-1', status: 'starting' }),
+  pollDeploy: vi.fn().mockResolvedValue({ id: 'deploy-1', status: 'running', instanceUrl: 'https://example.com' }),
+}));
+
+vi.mock('./project-config.js', () => ({
+  loadProjectConfig: vi.fn().mockResolvedValue(null),
+  saveProjectConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+afterEach(() => {
+  delete process.env.MASTRA_API_TOKEN;
+  delete process.env.MASTRA_ORG_ID;
+  delete process.env.MASTRA_PROJECT_ID;
+});
+
+describe('parseEnvFile', () => {
+  it('parses simple key=value pairs', async () => {
+    const { parseEnvFile } = await import('./deploy.js');
+
+    const result = parseEnvFile('FOO=bar\nBAZ=qux');
+    expect(result).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  it('ignores comments and empty lines', async () => {
+    const { parseEnvFile } = await import('./deploy.js');
+
+    const result = parseEnvFile('# comment\n\nFOO=bar\n  # another comment\n');
+    expect(result).toEqual({ FOO: 'bar' });
+  });
+
+  it('handles double-quoted values', async () => {
+    const { parseEnvFile } = await import('./deploy.js');
+
+    const result = parseEnvFile('FOO="hello world"\nBAR="with spaces"');
+    expect(result).toEqual({ FOO: 'hello world', BAR: 'with spaces' });
+  });
+
+  it('handles single-quoted values', async () => {
+    const { parseEnvFile } = await import('./deploy.js');
+
+    const result = parseEnvFile("FOO='hello world'");
+    expect(result).toEqual({ FOO: 'hello world' });
+  });
+
+  it('handles values with equals signs', async () => {
+    const { parseEnvFile } = await import('./deploy.js');
+
+    const result = parseEnvFile('DB_URL=postgres://host:5432/db?sslmode=require');
+    expect(result).toEqual({ DB_URL: 'postgres://host:5432/db?sslmode=require' });
+  });
+
+  it('ignores lines without equals sign', async () => {
+    const { parseEnvFile } = await import('./deploy.js');
+
+    const result = parseEnvFile('FOO=bar\nINVALID_LINE\nBAZ=qux');
+    expect(result).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  it('returns empty object for empty content', async () => {
+    const { parseEnvFile } = await import('./deploy.js');
+
+    const result = parseEnvFile('');
+    expect(result).toEqual({});
+  });
+
+  it('trims whitespace from keys and values', async () => {
+    const { parseEnvFile } = await import('./deploy.js');
+
+    const result = parseEnvFile('  FOO  =  bar  ');
+    expect(result).toEqual({ FOO: 'bar' });
+  });
+
+  it('strips export prefix from keys', async () => {
+    const { parseEnvFile } = await import('./deploy.js');
+
+    const result = parseEnvFile('export FOO=bar\nexport BAZ="qux"');
+    expect(result).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+});
+
+describe('deployAction', () => {
+  it('throws when headless mode missing required env vars', async () => {
+    process.env.MASTRA_API_TOKEN = 'headless-token';
+    // Missing MASTRA_ORG_ID and MASTRA_PROJECT_ID
+    vi.resetModules();
+
+    const { deployAction } = await import('./deploy.js');
+
+    await expect(deployAction(undefined, {})).rejects.toThrow(
+      'MASTRA_ORG_ID and MASTRA_PROJECT_ID are required when MASTRA_API_TOKEN is set',
+    );
+  });
+
+  it('throws when headless mode missing MASTRA_PROJECT_ID', async () => {
+    process.env.MASTRA_API_TOKEN = 'headless-token';
+    process.env.MASTRA_ORG_ID = 'org-1';
+    // Missing MASTRA_PROJECT_ID
+    vi.resetModules();
+
+    const { deployAction } = await import('./deploy.js');
+
+    await expect(deployAction(undefined, {})).rejects.toThrow(
+      'MASTRA_ORG_ID and MASTRA_PROJECT_ID are required when MASTRA_API_TOKEN is set',
+    );
+  });
+});

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -1,0 +1,386 @@
+import { execSync } from 'node:child_process';
+import { createWriteStream, readFileSync } from 'node:fs';
+import { mkdir, rm, stat, access, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import * as p from '@clack/prompts';
+import archiver from 'archiver';
+import { fetchOrgs } from '../auth/api.js';
+import { MASTRA_STUDIO_URL } from '../auth/client.js';
+import { getToken, getCurrentOrgId } from '../auth/credentials.js';
+import { fetchProjects, createProject, uploadDeploy, pollDeploy } from './platform-api.js';
+import { loadProjectConfig, saveProjectConfig } from './project-config.js';
+
+function elapsed(ms: number): string {
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+function getPackageName(projectDir: string): string | null {
+  try {
+    const raw = execSync('node -p "require(\'./package.json\').name"', {
+      cwd: projectDir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    // Strip org scope if present (e.g. @org/my-app → my-app)
+    return raw.startsWith('@') ? (raw.split('/')[1] ?? raw) : raw;
+  } catch {
+    return null;
+  }
+}
+
+function getGitBranch(projectDir: string): string | null {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd: projectDir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function getMastraVersion(projectDir: string): string | null {
+  try {
+    const pkgPath = join(projectDir, 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    return deps['mastra'] ?? null;
+  } catch {
+    return null;
+  }
+}
+function runBuild(projectDir: string): void {
+  const localMastra = join(projectDir, 'node_modules', '.bin', 'mastra');
+  p.log.step('Running mastra build...');
+  try {
+    execSync(`"${localMastra}" build`, {
+      cwd: projectDir,
+      stdio: 'inherit',
+      env: { ...process.env, NODE_ENV: 'production' },
+    });
+  } catch {
+    throw new Error('mastra build failed');
+  }
+  console.info('');
+}
+
+async function zipOutput(projectDir: string): Promise<string> {
+  const outputDir = join(projectDir, '.mastra', 'output');
+  const tmpDir = join(tmpdir(), 'mastra-deploy');
+  await mkdir(tmpDir, { recursive: true });
+  const zipPath = join(tmpDir, `deploy-${Date.now()}.zip`);
+
+  return new Promise((resolvePromise, reject) => {
+    const output = createWriteStream(zipPath);
+    const archive = archiver('zip', { zlib: { level: 6 } });
+
+    output.on('close', () => resolvePromise(zipPath));
+    archive.on('error', reject);
+
+    archive.pipe(output);
+    archive.glob('**', { cwd: outputDir, ignore: ['node_modules/**'] }, { prefix: 'output' });
+    void archive.finalize();
+  });
+}
+
+export function parseEnvFile(content: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    let key = trimmed.slice(0, eqIdx).trim();
+    if (key.startsWith('export ')) key = key.slice(7).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (key) vars[key] = value;
+  }
+  return vars;
+}
+
+async function readEnvVars(projectDir: string): Promise<Record<string, string>> {
+  const vars: Record<string, string> = {};
+  for (const envFile of ['.env.production', '.env.local', '.env']) {
+    try {
+      const content = await readFile(join(projectDir, envFile), 'utf-8');
+      Object.assign(vars, parseEnvFile(content));
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
+  }
+  return vars;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Resolve org                                                       */
+/* ------------------------------------------------------------------ */
+
+async function resolveOrg(
+  token: string,
+  projectConfig: { organizationId?: string } | null,
+  flagOrg?: string,
+): Promise<{ orgId: string; orgName: string }> {
+  // 0. MASTRA_ORG_ID env var (CI/CD headless path)
+  const envOrgId = process.env.MASTRA_ORG_ID;
+  if (envOrgId) {
+    return { orgId: envOrgId, orgName: envOrgId };
+  }
+
+  // 1. CLI flag
+  if (flagOrg) {
+    const orgs = await fetchOrgs(token);
+    const match = orgs.find(o => o.id === flagOrg);
+    return { orgId: flagOrg, orgName: match?.name ?? flagOrg };
+  }
+
+  // 2. project.json (only if user is a member of that org)
+  if (projectConfig?.organizationId) {
+    const orgs = await fetchOrgs(token);
+    const match = orgs.find(o => o.id === projectConfig.organizationId);
+    if (match) {
+      return { orgId: match.id, orgName: match.name };
+    }
+  }
+
+  // 3. credentials currentOrgId
+  const currentOrgId = await getCurrentOrgId();
+  const orgs = await fetchOrgs(token);
+
+  if (currentOrgId) {
+    const match = orgs.find(o => o.id === currentOrgId);
+    if (match) {
+      return { orgId: match.id, orgName: match.name };
+    }
+  }
+
+  // 4. Auto-select if only 1 org
+  if (orgs.length === 1) {
+    return { orgId: orgs[0]!.id, orgName: orgs[0]!.name };
+  }
+
+  // 5. Interactive picker
+  if (orgs.length === 0) {
+    throw new Error(`You have no organizations. Please create one at ${MASTRA_STUDIO_URL}`);
+  }
+
+  const selected = await p.select({
+    message: 'Select an organization',
+    options: orgs.map(o => ({ value: o.id, label: `${o.name} (${o.id})` })),
+  });
+
+  if (p.isCancel(selected)) {
+    p.cancel('Deploy cancelled.');
+    process.exit(0);
+  }
+
+  const selectedOrg = orgs.find(o => o.id === selected)!;
+  return { orgId: selectedOrg.id, orgName: selectedOrg.name };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Resolve project                                                   */
+/* ------------------------------------------------------------------ */
+
+async function resolveProject(
+  token: string,
+  orgId: string,
+  projectConfig: { projectId?: string; projectName?: string; projectSlug?: string; organizationId?: string } | null,
+  flagProject?: string,
+  defaultName?: string | null,
+): Promise<{ projectId: string; projectName: string; projectSlug: string }> {
+  // 0. MASTRA_PROJECT_ID env var (CI/CD headless path)
+  const envProjectId = process.env.MASTRA_PROJECT_ID;
+  if (envProjectId) {
+    return { projectId: envProjectId, projectName: envProjectId, projectSlug: envProjectId };
+  }
+
+  // 1. CLI flag — match by slug first, then id
+  if (flagProject) {
+    const projects = await fetchProjects(token, orgId);
+    const match = projects.find(proj => proj.slug === flagProject || proj.id === flagProject);
+    if (match) {
+      return { projectId: match.id, projectName: match.name, projectSlug: match.slug ?? match.name };
+    }
+    return { projectId: flagProject, projectName: flagProject, projectSlug: flagProject };
+  }
+
+  // 2. project.json (only if same org)
+  if (projectConfig?.projectId && projectConfig.organizationId === orgId) {
+    return {
+      projectId: projectConfig.projectId,
+      projectName: projectConfig.projectName ?? projectConfig.projectId,
+      projectSlug: projectConfig.projectSlug ?? projectConfig.projectName ?? projectConfig.projectId,
+    };
+  }
+
+  // 3. Auto-create from package name
+  const name = defaultName;
+  if (!name) {
+    throw new Error('Could not determine project name from package.json. Use --project to specify one.');
+  }
+
+  const project = await createProject(token, orgId, name);
+  return { projectId: project.id, projectName: project.name, projectSlug: project.slug ?? project.name };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main deploy action                                                */
+/* ------------------------------------------------------------------ */
+
+export async function deployAction(
+  dir: string | undefined,
+  opts: { org?: string; project?: string; yes?: boolean; config?: string; skipBuild?: boolean },
+) {
+  const targetDir = resolve(dir || process.cwd());
+  const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);
+  if (isHeadless && (!process.env.MASTRA_ORG_ID || !process.env.MASTRA_PROJECT_ID)) {
+    throw new Error('MASTRA_ORG_ID and MASTRA_PROJECT_ID are required when MASTRA_API_TOKEN is set');
+  }
+  const autoAccept = opts.yes ?? isHeadless;
+
+  p.intro('mastra studio deploy');
+
+  // Gather context
+  const packageName = getPackageName(targetDir);
+  const gitBranch = getGitBranch(targetDir);
+  const mastraVersion = getMastraVersion(targetDir);
+
+  // Step 1: Auth
+  const token = await getToken();
+
+  // Step 2: Load existing project config
+  const projectConfig = await loadProjectConfig(targetDir, opts.config);
+
+  // Step 3: Resolve org
+  const { orgId, orgName } = await resolveOrg(token, projectConfig, opts.org);
+
+  // Step 4: Resolve project (pass packageName as default for new project creation)
+  const { projectId, projectName, projectSlug } = await resolveProject(
+    token,
+    orgId,
+    projectConfig,
+    opts.project,
+    packageName,
+  );
+
+  // Step 5: Confirmation — show settings and let user verify (skipped with -y or if already linked)
+  const isAlreadyLinked = projectConfig?.projectId === projectId && projectConfig?.organizationId === orgId;
+
+  if (!isAlreadyLinked) {
+    p.note(
+      [
+        `Organization:  ${orgName}`,
+        `Project:       ${projectName}`,
+        `Directory:     ${targetDir}`,
+        ...(gitBranch ? [`Git branch:    ${gitBranch}`] : []),
+        ...(mastraVersion ? [`Mastra:        ${mastraVersion}`] : []),
+      ].join('\n'),
+      'Deploy settings',
+    );
+
+    if (!autoAccept) {
+      const confirmed = await p.confirm({
+        message: 'Deploy with these settings?',
+      });
+
+      if (p.isCancel(confirmed) || !confirmed) {
+        p.cancel('Deploy cancelled.');
+        process.exit(0);
+      }
+    }
+
+    // Save the project link
+    await saveProjectConfig(
+      targetDir,
+      {
+        projectId,
+        projectName,
+        projectSlug,
+        organizationId: orgId,
+      },
+      opts.config,
+    );
+    p.log.success(`Saved ${opts.config || '.mastra-project.json'}`);
+  } else {
+    // Already linked — just show a summary line
+    p.log.info(`Organization: ${orgName} (${orgId})`);
+    p.log.info(`Project: ${projectName} (${projectId})`);
+    if (gitBranch) p.log.info(`Git branch: ${gitBranch}`);
+    if (mastraVersion) p.log.info(`Mastra: ${mastraVersion}`);
+  }
+
+  // Step 6: Build + Zip + Upload + Poll
+  const s = p.spinner();
+  const tTotal = performance.now();
+
+  let t: number;
+
+  if (opts.skipBuild) {
+    p.log.step('Skipping build (--skip-build)');
+  } else {
+    t = performance.now();
+    runBuild(targetDir);
+    p.log.step(`Build completed (${elapsed(performance.now() - t)})`);
+  }
+
+  // Verify build output exists
+  const outputEntry = join(targetDir, '.mastra', 'output', 'index.mjs');
+  try {
+    await access(outputEntry);
+  } catch {
+    throw new Error('.mastra/output/index.mjs not found — did the build succeed?');
+  }
+
+  t = performance.now();
+  s.start('Zipping build artifact...');
+  const zipPath = await zipOutput(targetDir);
+  const zipStat = await stat(zipPath);
+  const sizeKB = zipStat.size / 1024;
+  const sizeLabel = sizeKB > 1024 ? `${(sizeKB / 1024).toFixed(1)}MB` : `${sizeKB.toFixed(1)}KB`;
+  s.stop(`Created ${sizeLabel} archive (${elapsed(performance.now() - t)})`);
+
+  s.start('Reading environment variables...');
+  const envVars = await readEnvVars(targetDir);
+  const envCount = Object.keys(envVars).length;
+  if (envCount > 0) {
+    s.stop(`Found ${envCount} env var(s)`);
+  } else {
+    s.stop('No .env file found');
+  }
+
+  t = performance.now();
+  s.start('Uploading...');
+  const zipBuffer = await readFile(zipPath);
+  const deployResult = await uploadDeploy(token, orgId, projectId, zipBuffer, {
+    gitBranch: gitBranch ?? undefined,
+    projectName,
+    envVars: envCount > 0 ? envVars : undefined,
+    mastraVersion: mastraVersion ?? undefined,
+  });
+  s.stop(`Uploaded (${elapsed(performance.now() - t)})`);
+
+  await rm(zipPath, { force: true });
+
+  p.log.step('Streaming deploy logs...');
+  const finalStatus = await pollDeploy(deployResult.id, token, orgId);
+
+  if (finalStatus.status === 'running') {
+    p.outro(`Deploy succeeded in ${elapsed(performance.now() - tTotal)}! ${finalStatus.instanceUrl}`);
+  } else if (finalStatus.status === 'failed') {
+    p.log.error(`Deploy failed: ${finalStatus.error}`);
+    process.exit(1);
+  } else {
+    p.log.warning(`Deploy ended with status: ${finalStatus.status}`);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/commands/studio/platform-api.test.ts
+++ b/packages/cli/src/commands/studio/platform-api.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockGET = vi.fn();
+const mockPOST = vi.fn();
+
+vi.mock('../auth/client.js', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    MASTRA_PLATFORM_API_URL: 'http://localhost:9999',
+    createApiClient: vi.fn(() => ({
+      GET: mockGET,
+      POST: mockPOST,
+    })),
+    authHeaders: vi.fn((token: string, orgId?: string) => {
+      const h: Record<string, string> = { Authorization: `Bearer ${token}` };
+      if (orgId) h['x-organization-id'] = orgId;
+      return h;
+    }),
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+describe('fetchProjects', () => {
+  it('returns project list on success', async () => {
+    const projects = [
+      {
+        id: 'p1',
+        name: 'App 1',
+        organizationId: 'org-1',
+        latestDeployId: null,
+        latestDeployStatus: null,
+        instanceUrl: null,
+        createdAt: null,
+        updatedAt: null,
+      },
+    ];
+    mockGET.mockResolvedValue({ data: { projects }, response: { status: 200 } });
+
+    const { fetchProjects } = await import('./platform-api.js');
+    const result = await fetchProjects('tok', 'org-1');
+
+    expect(result).toEqual(projects);
+    expect(mockGET).toHaveBeenCalledWith('/v1/studio/projects');
+  });
+
+  it('throws on error response with detail message', async () => {
+    mockGET.mockResolvedValue({
+      data: undefined,
+      error: { detail: 'Not a member of the specified organization' },
+      response: { status: 403 },
+    });
+
+    const { fetchProjects } = await import('./platform-api.js');
+    await expect(fetchProjects('tok', 'org-1')).rejects.toThrow('Not a member of the specified organization');
+  });
+
+  it('throws session expired message on 401', async () => {
+    mockGET.mockResolvedValue({ data: undefined, error: { detail: 'Invalid token' }, response: { status: 401 } });
+
+    const { fetchProjects } = await import('./platform-api.js');
+    await expect(fetchProjects('tok', 'org-1')).rejects.toThrow('Session expired. Run: mastra auth login');
+  });
+});
+
+describe('createProject', () => {
+  it('creates and returns a project', async () => {
+    const project = { id: 'p1', name: 'New App', organizationId: 'org-1' };
+    mockPOST.mockResolvedValue({ data: { project }, response: { status: 201 } });
+
+    const { createProject } = await import('./platform-api.js');
+    const result = await createProject('tok', 'org-1', 'New App');
+
+    expect(result).toEqual(project);
+    expect(mockPOST).toHaveBeenCalledWith('/v1/studio/projects', { body: { name: 'New App' } });
+  });
+
+  it('throws on error response', async () => {
+    mockPOST.mockResolvedValue({
+      data: undefined,
+      error: { detail: 'Project name already exists' },
+      response: { status: 409 },
+    });
+
+    const { createProject } = await import('./platform-api.js');
+    await expect(createProject('tok', 'org-1', 'Dup')).rejects.toThrow('Project name already exists');
+  });
+});
+
+describe('fetchDeployStatus', () => {
+  it('returns deploy info on success', async () => {
+    const deploy = { id: 'd1', status: 'running', instanceUrl: 'https://x.com', error: null };
+    mockGET.mockResolvedValue({ data: { deploy }, response: { status: 200 } });
+
+    const { fetchDeployStatus } = await import('./platform-api.js');
+    const result = await fetchDeployStatus('d1', 'tok', 'org-1');
+
+    expect(result).toEqual(deploy);
+    expect(mockGET).toHaveBeenCalledWith('/v1/studio/deploys/{id}', {
+      params: { path: { id: 'd1' } },
+    });
+  });
+
+  it('throws on error response', async () => {
+    mockGET.mockResolvedValue({ data: undefined, error: { error: 'not found' }, response: { status: 404 } });
+
+    const { fetchDeployStatus } = await import('./platform-api.js');
+    await expect(fetchDeployStatus('d1', 'tok')).rejects.toThrow('Failed to fetch deploy status: 404');
+  });
+});
+
+describe('uploadDeploy', () => {
+  it('creates deploy, uploads zip via signed URL, and confirms', async () => {
+    const mockFetch = vi.fn();
+
+    // POST /v1/studio/deploys → returns deploy with uploadUrl
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            deploy: { id: 'dep-1', status: 'starting', uploadUrl: 'https://storage.example.com/signed-url' },
+          }),
+      })
+      // PUT to signed URL
+      .mockResolvedValueOnce({ ok: true })
+      // POST upload-complete
+      .mockResolvedValueOnce({ ok: true });
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { uploadDeploy } = await import('./platform-api.js');
+    const result = await uploadDeploy('tok', 'org-1', 'proj-1', Buffer.from('zip-data'), {
+      gitBranch: 'main',
+      projectName: 'my-app',
+      envVars: { FOO: 'bar' },
+    });
+
+    expect(result).toMatchObject({ id: 'dep-1', status: 'starting' });
+
+    // 3 fetch calls: create, upload, confirm
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+
+    // First call: POST /v1/studio/deploys
+    const createCall = mockFetch.mock.calls[0]!;
+    expect(createCall[0]).toBe('http://localhost:9999/v1/studio/deploys');
+    expect(createCall[1].method).toBe('POST');
+
+    // Second call: PUT to signed URL
+    const uploadCall = mockFetch.mock.calls[1]!;
+    expect(uploadCall[0]).toBe('https://storage.example.com/signed-url');
+    expect(uploadCall[1].method).toBe('PUT');
+
+    // Third call: POST upload-complete
+    const completeCall = mockFetch.mock.calls[2]!;
+    expect(completeCall[0]).toBe('http://localhost:9999/v1/studio/deploys/dep-1/upload-complete');
+    expect(completeCall[1].method).toBe('POST');
+  });
+
+  it('throws when deploy creation fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.resolve({ detail: 'Internal server error' }),
+      }),
+    );
+
+    const { uploadDeploy } = await import('./platform-api.js');
+    await expect(uploadDeploy('tok', 'org-1', 'proj-1', Buffer.from('zip'))).rejects.toThrow('Internal server error');
+  });
+
+  it('throws when artifact upload fails', async () => {
+    const mockFetch = vi.fn();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            deploy: { id: 'dep-1', status: 'starting', uploadUrl: 'https://storage.example.com/signed-url' },
+          }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 403, statusText: 'Forbidden' });
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { uploadDeploy } = await import('./platform-api.js');
+    await expect(uploadDeploy('tok', 'org-1', 'proj-1', Buffer.from('zip'))).rejects.toThrow(
+      'Artifact upload failed: 403',
+    );
+  });
+});

--- a/packages/cli/src/commands/studio/platform-api.ts
+++ b/packages/cli/src/commands/studio/platform-api.ts
@@ -1,0 +1,210 @@
+import { authHeaders, createApiClient, MASTRA_PLATFORM_API_URL, platformFetch, throwApiError } from '../auth/client.js';
+
+export interface Project {
+  id: string;
+  name: string;
+  slug: string | null;
+  organizationId: string;
+  latestDeployId: string | null;
+  latestDeployStatus: string | null;
+  instanceUrl: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface DeployStatus {
+  id: string;
+  status: string;
+  instanceUrl: string | null;
+  error: string | null;
+}
+
+export async function fetchProjects(token: string, orgId: string): Promise<Project[]> {
+  const client = createApiClient(token, orgId);
+  const { data, error, response } = await client.GET('/v1/studio/projects');
+
+  if (error) {
+    throwApiError('Failed to fetch projects', response.status, error.detail);
+  }
+
+  return data.projects;
+}
+
+export async function createProject(token: string, orgId: string, name: string): Promise<Project> {
+  const client = createApiClient(token, orgId);
+  const { data, error, response } = await client.POST('/v1/studio/projects', {
+    body: { name },
+  });
+
+  if (error) {
+    throwApiError('Failed to create project', response.status, error.detail);
+  }
+
+  return data.project;
+}
+
+export interface DeployInfo {
+  id: string;
+  status: string;
+  instanceUrl: string | null;
+  error: string | null;
+  projectName?: string | null;
+  createdAt?: string | null;
+}
+
+export async function fetchDeployStatus(deployId: string, token: string, orgId?: string): Promise<DeployInfo> {
+  const client = createApiClient(token, orgId);
+  const { data, error, response } = await client.GET('/v1/studio/deploys/{id}', {
+    params: { path: { id: deployId } },
+  });
+
+  if (error) {
+    throwApiError('Failed to fetch deploy status', response.status, error.detail);
+  }
+
+  return data.deploy;
+}
+
+export async function uploadDeploy(
+  token: string,
+  orgId: string,
+  projectId: string,
+  zipBuffer: Buffer,
+  meta?: { gitBranch?: string; projectName?: string; envVars?: Record<string, string>; mastraVersion?: string },
+): Promise<{ id: string; status: string }> {
+  const headers: Record<string, string> = {
+    ...authHeaders(token, orgId),
+    'Content-Type': 'application/json',
+    'x-project-id': projectId,
+  };
+  if (meta?.gitBranch) headers['x-git-branch'] = meta.gitBranch;
+  if (meta?.projectName) headers['x-project-name'] = meta.projectName;
+  if (meta?.mastraVersion) headers['x-mastra-version'] = meta.mastraVersion;
+
+  // Step 1: Create the deploy with optional envVars
+  const createResp = await platformFetch(`${MASTRA_PLATFORM_API_URL}/v1/studio/deploys`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ envVars: meta?.envVars }),
+  });
+  if (!createResp.ok) {
+    const body = (await createResp.json().catch(() => ({}))) as { detail?: string };
+    throwApiError('Deploy failed', createResp.status, body.detail);
+  }
+  const { deploy } = (await createResp.json()) as {
+    deploy: { id: string; status: string; uploadUrl: string };
+  };
+
+  if (deploy.uploadUrl.startsWith('file://')) {
+    // Local FS artifact store — write zip directly to disk
+    const { writeFile } = await import('node:fs/promises');
+    const { fileURLToPath } = await import('node:url');
+    await writeFile(fileURLToPath(deploy.uploadUrl), Buffer.from(zipBuffer));
+  } else {
+    // GCS flow — upload zip directly to GCS via signed URL
+    const uploadResp = await fetch(deploy.uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/zip' },
+      body: new Uint8Array(zipBuffer),
+    });
+    if (!uploadResp.ok) {
+      throw new Error(`Artifact upload failed: ${uploadResp.status} ${uploadResp.statusText}`);
+    }
+  }
+
+  // Notify API that upload is complete → triggers deploy pipeline
+  const completeResp = await platformFetch(
+    `${MASTRA_PLATFORM_API_URL}/v1/studio/deploys/${deploy.id}/upload-complete`,
+    {
+      method: 'POST',
+      headers: authHeaders(token, orgId),
+    },
+  );
+  if (!completeResp.ok) {
+    const body = (await completeResp.json().catch(() => ({}))) as { detail?: string };
+    throwApiError('Upload confirmation failed', completeResp.status, body.detail);
+  }
+
+  return deploy;
+}
+
+async function streamDeployLogs(deployId: string, token: string, orgId: string, signal: AbortSignal): Promise<void> {
+  // Small delay to let the deploy pipeline start before requesting logs
+  await new Promise(r => setTimeout(r, 2000));
+
+  const url = `${MASTRA_PLATFORM_API_URL}/v1/studio/deploys/${deployId}/logs/stream`;
+
+  const resp = await platformFetch(url, {
+    headers: authHeaders(token, orgId),
+    signal,
+  });
+
+  if (!resp.ok || !resp.body) return;
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (!signal.aborted) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (line.startsWith('data:')) {
+        const data = line.slice(5).trim();
+        if (data) {
+          process.stdout.write(`${data}\n`);
+        }
+      }
+    }
+  }
+}
+
+export async function pollDeploy(
+  deployId: string,
+  token: string,
+  orgId: string,
+  maxWaitMs = 600000,
+): Promise<DeployStatus> {
+  const start = Date.now();
+  let lastStatus = '';
+
+  // Start streaming logs in the background via SSE
+  const logAbort = new AbortController();
+  streamDeployLogs(deployId, token, orgId, logAbort.signal).catch(() => {});
+
+  const client = createApiClient(token, orgId);
+
+  try {
+    while (Date.now() - start < maxWaitMs) {
+      const { data, error, response } = await client.GET('/v1/studio/deploys/{id}', {
+        params: { path: { id: deployId } },
+      });
+
+      if (error) {
+        throwApiError('Poll failed', response.status, error.detail);
+      }
+
+      const { deploy } = data;
+
+      if (deploy.status !== lastStatus) {
+        lastStatus = deploy.status;
+      }
+
+      if (deploy.status === 'running' || deploy.status === 'failed') {
+        return deploy;
+      }
+
+      await new Promise(r => setTimeout(r, 2000));
+    }
+
+    throw new Error('Deploy timed out');
+  } finally {
+    logAbort.abort();
+  }
+}

--- a/packages/cli/src/commands/studio/platform-api.ts
+++ b/packages/cli/src/commands/studio/platform-api.ts
@@ -196,7 +196,7 @@ export async function pollDeploy(
         lastStatus = deploy.status;
       }
 
-      if (deploy.status === 'running' || deploy.status === 'failed') {
+      if (deploy.status === 'running' || deploy.status === 'failed' || deploy.status === 'stopped') {
         return deploy;
       }
 

--- a/packages/cli/src/commands/studio/project-config.test.ts
+++ b/packages/cli/src/commands/studio/project-config.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadProjectConfig, saveProjectConfig, PROJECT_CONFIG_FILE } from './project-config';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'mastra-project-config-test-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('loadProjectConfig', () => {
+  it('returns null when no config file exists', async () => {
+    const result = await loadProjectConfig(tempDir);
+    expect(result).toBeNull();
+  });
+
+  it('loads config from default .mastra-project.json', async () => {
+    const config = {
+      projectId: 'proj-1',
+      projectName: 'My App',
+      organizationId: 'org-1',
+    };
+
+    writeFileSync(join(tempDir, PROJECT_CONFIG_FILE), JSON.stringify(config, null, 2));
+
+    const result = await loadProjectConfig(tempDir);
+    expect(result).toEqual(config);
+  });
+
+  it('loads config from custom file path', async () => {
+    const config = {
+      projectId: 'proj-1',
+      projectName: 'My App',
+      organizationId: 'org-1',
+    };
+
+    writeFileSync(join(tempDir, 'custom-config.json'), JSON.stringify(config, null, 2));
+
+    const result = await loadProjectConfig(tempDir, 'custom-config.json');
+    expect(result).toEqual(config);
+  });
+
+  it('loads config from absolute path', async () => {
+    const config = {
+      projectId: 'proj-1',
+      projectName: 'My App',
+      organizationId: 'org-1',
+    };
+
+    const absolutePath = join(tempDir, 'absolute-config.json');
+    writeFileSync(absolutePath, JSON.stringify(config, null, 2));
+
+    const result = await loadProjectConfig(tempDir, absolutePath);
+    expect(result).toEqual(config);
+  });
+});
+
+describe('saveProjectConfig', () => {
+  it('writes config to default .mastra-project.json', async () => {
+    const config = {
+      projectId: 'proj-1',
+      projectName: 'My App',
+      organizationId: 'org-1',
+    };
+
+    await saveProjectConfig(tempDir, config);
+
+    const content = readFileSync(join(tempDir, PROJECT_CONFIG_FILE), 'utf-8');
+    const parsed = JSON.parse(content);
+
+    expect(parsed).toEqual(config);
+  });
+
+  it('writes config to custom file path', async () => {
+    const config = {
+      projectId: 'proj-1',
+      projectName: 'My App',
+      organizationId: 'org-1',
+    };
+
+    await saveProjectConfig(tempDir, config, 'custom-config.json');
+
+    const content = readFileSync(join(tempDir, 'custom-config.json'), 'utf-8');
+    const parsed = JSON.parse(content);
+
+    expect(parsed).toEqual(config);
+  });
+
+  it('writes pretty-printed JSON with trailing newline', async () => {
+    const config = {
+      projectId: 'proj-1',
+      projectName: 'My App',
+      organizationId: 'org-1',
+    };
+
+    await saveProjectConfig(tempDir, config);
+
+    const raw = readFileSync(join(tempDir, PROJECT_CONFIG_FILE), 'utf-8');
+
+    expect(raw).toBe(JSON.stringify(config, null, 2) + '\n');
+    expect(raw.endsWith('\n')).toBe(true);
+  });
+
+  it('overwrites existing project config', async () => {
+    const config1 = { projectId: 'proj-1', projectName: 'App 1', organizationId: 'org-1' };
+    const config2 = { projectId: 'proj-2', projectName: 'App 2', organizationId: 'org-2' };
+
+    await saveProjectConfig(tempDir, config1);
+    await saveProjectConfig(tempDir, config2);
+
+    const result = await loadProjectConfig(tempDir);
+    expect(result).toEqual(config2);
+  });
+});

--- a/packages/cli/src/commands/studio/project-config.ts
+++ b/packages/cli/src/commands/studio/project-config.ts
@@ -1,0 +1,31 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
+
+export const PROJECT_CONFIG_FILE = '.mastra-project.json';
+
+export interface ProjectConfig {
+  projectId: string;
+  projectName: string;
+  projectSlug?: string;
+  organizationId: string;
+}
+
+function resolveConfigPath(dir: string, configFile?: string): string {
+  if (configFile) {
+    return isAbsolute(configFile) ? configFile : join(dir, configFile);
+  }
+  return join(dir, PROJECT_CONFIG_FILE);
+}
+
+export async function loadProjectConfig(dir: string, configFile?: string): Promise<ProjectConfig | null> {
+  try {
+    const data = await readFile(resolveConfigPath(dir, configFile), 'utf-8');
+    return JSON.parse(data) as ProjectConfig;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveProjectConfig(dir: string, config: ProjectConfig, configFile?: string): Promise<void> {
+  await writeFile(resolveConfigPath(dir, configFile), JSON.stringify(config, null, 2) + '\n');
+}

--- a/packages/cli/src/commands/studio/projects.ts
+++ b/packages/cli/src/commands/studio/projects.ts
@@ -1,0 +1,80 @@
+import * as p from '@clack/prompts';
+import { fetchOrgs } from '../auth/api.js';
+import { getToken, getCurrentOrgId } from '../auth/credentials.js';
+import { fetchProjects, createProject } from './platform-api.js';
+
+/**
+ * Resolve the current org, auto-selecting if only one exists.
+ */
+async function resolveCurrentOrg(token: string): Promise<{ orgId: string; orgName: string }> {
+  const currentOrgId = await getCurrentOrgId();
+  const orgs = await fetchOrgs(token);
+
+  if (currentOrgId) {
+    const match = orgs.find(o => o.id === currentOrgId);
+    if (match) return { orgId: match.id, orgName: match.name };
+  }
+
+  if (orgs.length === 1) {
+    return { orgId: orgs[0]!.id, orgName: orgs[0]!.name };
+  }
+
+  if (orgs.length === 0) {
+    throw new Error('No organizations found.');
+  }
+
+  const selected = await p.select({
+    message: 'Select an organization',
+    options: orgs.map(o => ({ value: o.id, label: `${o.name} (${o.id})` })),
+  });
+
+  if (p.isCancel(selected)) {
+    p.cancel('Cancelled.');
+    process.exit(0);
+  }
+
+  const org = orgs.find(o => o.id === selected)!;
+  return { orgId: org.id, orgName: org.name };
+}
+
+export async function listProjectsAction() {
+  const token = await getToken();
+  const { orgId, orgName } = await resolveCurrentOrg(token);
+  const projects = await fetchProjects(token, orgId);
+
+  console.info(`\nProjects in ${orgName}:\n`);
+
+  if (projects.length === 0) {
+    console.info('  No projects yet. Run: mastra studio projects create\n');
+    return;
+  }
+
+  for (const proj of projects) {
+    const status = proj.latestDeployStatus ? ` [${proj.latestDeployStatus}]` : '';
+    console.info(`  ${proj.name}${status}`);
+    console.info(`    ID: ${proj.id}`);
+    if (proj.instanceUrl) {
+      console.info(`    URL: ${proj.instanceUrl}`);
+    }
+  }
+  console.info('');
+}
+
+export async function createProjectAction() {
+  const token = await getToken();
+  const { orgId, orgName } = await resolveCurrentOrg(token);
+
+  const name = await p.text({
+    message: `Project name (in ${orgName})`,
+    placeholder: 'my-mastra-app',
+    validate: v => (!v || v.trim().length === 0 ? 'Name is required' : undefined),
+  });
+
+  if (p.isCancel(name)) {
+    p.cancel('Cancelled.');
+    process.exit(0);
+  }
+
+  const project = await createProject(token, orgId, name as string);
+  console.info(`\nCreated project: ${project.name} (${project.id})\n`);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,11 @@ import { listOrgsAction, switchOrgAction } from './commands/auth/orgs';
 import { createTokenAction, listTokensAction, revokeTokenAction } from './commands/auth/tokens';
 import { whoamiAction } from './commands/auth/whoami';
 import { COMPONENTS, LLMProvider } from './commands/init/utils';
+import { deployAction } from './commands/studio/deploy';
+import { deploysAction } from './commands/studio/deploy-list';
+import { logsAction } from './commands/studio/deploy-logs';
+import { statusAction } from './commands/studio/deploy-status';
+import { listProjectsAction, createProjectAction } from './commands/studio/projects';
 import { parseComponents, parseLlmProvider, parseMcp, parseSkills } from './commands/utils';
 
 function wrapAction(fn: (...args: any[]) => Promise<void>): (...args: any[]) => void {
@@ -165,9 +170,9 @@ program
   )
   .action(startProject);
 
-program
+const studioCommand = program
   .command('studio')
-  .description('Start the Mastra studio')
+  .description('Manage Mastra Studio')
   .option('-p, --port <port>', 'Port to run the studio on (default: 3000)')
   .option('-e, --env <env>', 'Custom env file to include in the studio')
   .option('-h, --server-host <serverHost>', 'Host of the Mastra API server (default: localhost)')
@@ -176,6 +181,38 @@ program
   .option('--server-api-prefix <serverApiPrefix>', 'API route prefix of the Mastra server (default: /api)')
   .option('--request-context-presets <file>', 'Path to request context presets JSON file')
   .action(startStudio);
+
+const deployCommand = studioCommand
+  .command('deploy [dir]')
+  .description('Deploy studio')
+  .option('--org <id>', 'Organization ID')
+  .option('--project <id>', 'Project ID')
+  .option('-y, --yes', 'Auto-accept defaults without confirmation')
+  .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
+  .option('--skip-build', 'Skip the build step and use existing .mastra/output')
+  .action(wrapAction(deployAction));
+
+deployCommand.command('list').description('List deployed studios').action(wrapAction(deploysAction));
+
+deployCommand
+  .command('status <deploy-id>')
+  .description('Show deploy status')
+  .option('-w, --watch', 'Watch for status changes')
+  .action(wrapAction(statusAction));
+
+deployCommand
+  .command('logs <deploy-id>')
+  .description('Show deploy logs')
+  .option('-f, --follow', 'Stream logs in real time')
+  .option('--tail <n>', 'Number of recent log lines')
+  .action(wrapAction(logsAction));
+
+const studioProjects = studioCommand
+  .command('projects')
+  .description('Manage studio projects')
+  .action(wrapAction(listProjectsAction));
+
+studioProjects.command('create').description('Create a new project').action(wrapAction(createProjectAction));
 
 program
   .command('migrate')

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { stat, writeFile } from 'node:fs/promises';
+import { rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, posix } from 'node:path';
 import { MastraBundler } from '@mastra/core/bundler';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
@@ -148,7 +148,9 @@ export abstract class Bundler extends MastraBundler {
    */
   private async generateNpmLockfile(outputDir: string): Promise<void> {
     try {
-      execSync('rm -rf node_modules && npm install --package-lock-only --force 2>/dev/null', {
+      // Remove node_modules first — pnpm's symlink layout confuses npm's arborist
+      await rm(join(outputDir, 'node_modules'), { recursive: true, force: true }).catch(() => {});
+      execSync('npm install --package-lock-only --force', {
         cwd: outputDir,
         stdio: 'pipe',
         timeout: 60_000,

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { stat, writeFile } from 'node:fs/promises';
 import { dirname, join, posix } from 'node:path';
@@ -135,6 +136,26 @@ export abstract class Bundler extends MastraBundler {
     deps.__setLogger(this.logger);
 
     await deps.install({ dir: join(outputDirectory, this.outputDir) });
+  }
+
+  /**
+   * Generate a package-lock.json for the output directory so that deploy targets
+   * can use `npm ci` instead of `npm install`, skipping version resolution entirely.
+   * This is a lockfile-only operation — no packages are downloaded.
+   *
+   * Removes node_modules first because pnpm's symlink-based layout confuses
+   * npm's arborist when it tries to read the existing tree.
+   */
+  private async generateNpmLockfile(outputDir: string): Promise<void> {
+    try {
+      execSync('rm -rf node_modules && npm install --package-lock-only --force 2>/dev/null', {
+        cwd: outputDir,
+        stdio: 'pipe',
+        timeout: 60_000,
+      });
+    } catch {
+      this.logger.warn('Failed to generate package-lock.json — deploy will fall back to npm install');
+    }
   }
 
   protected async copyPublic(mastraDir: string, outputDirectory: string) {
@@ -439,8 +460,11 @@ export const tools = [${toolsExports.join(', ')}]`,
 
       this.logger.info('Installing dependencies');
       await this.installDependencies(outputDirectory, projectRoot);
-
       this.logger.info('Done installing dependencies');
+
+      this.logger.info('Generating package-lock.json for deploy');
+      await this.generateNpmLockfile(join(outputDirectory, this.outputDir));
+      this.logger.info('Done generating package-lock.json');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new MastraError(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2701,6 +2701,9 @@ importers:
       '@mastra/loggers':
         specifier: workspace:^
         version: link:../loggers
+      archiver:
+        specifier: ^7.0.1
+        version: 7.0.1
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -2768,6 +2771,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../core
+      '@types/archiver':
+        specifier: ^6.0.3
+        version: 6.0.4
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -14822,6 +14828,9 @@ packages:
   '@types/accepts@1.3.7':
     resolution: {integrity: sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==}
 
+  '@types/archiver@6.0.4':
+    resolution: {integrity: sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==}
+
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
@@ -15139,6 +15148,9 @@ packages:
 
   '@types/readable-stream@4.0.21':
     resolution: {integrity: sha512-19eKVv9tugr03IgfXlA9UVUVRbW6IuqRO5B92Dl4a6pT7K8uaGrNS0GkxiZD0BOk6PLuXl5FhWl//eX/pzYdTQ==}
+
+  '@types/readdir-glob@1.1.5':
+    resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
 
   '@types/request@2.48.13':
     resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
@@ -23691,9 +23703,6 @@ packages:
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
-
-  streamx@2.23.0:
-    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
@@ -35959,6 +35968,10 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
+  '@types/archiver@6.0.4':
+    dependencies:
+      '@types/readdir-glob': 1.1.5
+
   '@types/argparse@1.0.38': {}
 
   '@types/aria-query@5.0.4': {}
@@ -36353,6 +36366,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/readable-stream@4.0.21':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@types/readdir-glob@1.1.5':
     dependencies:
       '@types/node': 22.19.15
 
@@ -47075,15 +47092,6 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
-  streamx@2.23.0:
-    dependencies:
-      events-universal: 1.0.1
-      fast-fifo: 1.3.2
-      text-decoder: 1.2.3
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
   streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
@@ -47092,7 +47100,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-    optional: true
 
   strict-event-emitter@0.5.1: {}
 
@@ -47375,7 +47382,7 @@ snapshots:
     dependencies:
       b4a: 1.7.3
       fast-fifo: 1.3.2
-      streamx: 2.23.0
+      streamx: 2.25.0
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2772,8 +2772,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@types/archiver':
-        specifier: ^6.0.3
-        version: 6.0.4
+        specifier: ^7.0.0
+        version: 7.0.0
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -14828,8 +14828,8 @@ packages:
   '@types/accepts@1.3.7':
     resolution: {integrity: sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==}
 
-  '@types/archiver@6.0.4':
-    resolution: {integrity: sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==}
+  '@types/archiver@7.0.0':
+    resolution: {integrity: sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -35968,7 +35968,7 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
-  '@types/archiver@6.0.4':
+  '@types/archiver@7.0.0':
     dependencies:
       '@types/readdir-glob': 1.1.5
 


### PR DESCRIPTION
## Summary

Add `mastra studio deploy` for deploying studio to the Mastra platform.

### New subcommands

- `mastra studio deploy [dir]` — build, zip, and upload studio
- `mastra studio deploy list` — list deployed studios
- `mastra studio deploy status <id>` — show deploy status (with `--watch`)
- `mastra studio deploy logs <id>` — view deploy logs (with `--follow`)
- `mastra studio projects` — list studio projects
- `mastra studio projects create` — create a new project

### Deployer change

Generates a `package-lock.json` during build so deploy targets can use `npm ci` instead of `npm install`, skipping version resolution.

### New dependencies

- `archiver` — zip creation for deploy uploads
- `@types/archiver` — type definitions

## Test plan

- All 203 CLI tests pass (`pnpm test:cli`)
- Typecheck clean for both `packages/cli` and `packages/deployer`
- New test files: `deploy.test.ts`, `deploy-commands.test.ts`, `platform-api.test.ts`, `project-config.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mastra studio deploy` for end-to-end deployments with org/project options and non-interactive/headless support
  * New management subcommands: `deploy list` (projects & deploy status), `deploy status` (single/ watch mode), `deploy logs` (streaming with follow/tail)
  * Added `mastra studio projects` for creating/managing projects
  * Builds now generate package-lock.json to speed up deploys
<!-- end of auto-generated comment: release notes by coderabbit.ai -->