### PR TITLE
docs: fix templates reference page title

### DIFF
--- a/docs/src/content/en/reference/templates/overview.mdx
+++ b/docs/src/content/en/reference/templates/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference: LLM provider API keys (choose one or more) | Templates"
+title: "Reference: Templates overview | Templates"
 description: "Complete guide to creating, using, and contributing Mastra templates"
 packages:
   - "@mastra/core"
@@ -11,10 +11,10 @@ This reference provides comprehensive information about Mastra templates, includ
 
 Mastra templates are pre-built project structures that demonstrate specific use cases and patterns. They provide:
 
-- **Working examples** - Complete, functional Mastra applications
-- **Best practices** - Proper project structure and coding conventions
-- **Educational resources** - Learn Mastra patterns through real implementations
-- **Quickstarts** - Bootstrap projects faster than building from scratch
+- **Working examples**: Complete, functional Mastra applications
+- **Best practices**: Proper project structure and coding conventions
+- **Educational resources**: Learn Mastra patterns through real implementations
+- **Quickstarts**: Bootstrap projects faster than building from scratch
 
 ## Using templates
 
@@ -22,7 +22,7 @@ Mastra templates are pre-built project structures that demonstrate specific use 
 
 Install a template using the `create-mastra` command:
 
-```bash
+```sh npm2yarn
 npx create-mastra@latest --template template-name
 ```
 
@@ -48,19 +48,33 @@ After installation:
 
 1. **Install dependencies** (if not done automatically):
 
-   ```bash
+   ```sh npm2yarn
    npm install
    ```
 
 1. **Start development server**:
 
-   ```bash
+   ```sh npm2yarn
    npm run dev
    ```
 
-### Template Structure
+### Template structure
 
 All templates follow this standardized structure:
+
+```
+your-template/
+├── src/
+│   └── mastra/
+│       ├── agents/       # Agent definitions
+│       ├── tools/        # Tool definitions
+│       ├── workflows/    # Workflow definitions
+│       └── index.ts      # Main Mastra config
+├── .env.example          # Required environment variables
+├── package.json
+├── tsconfig.json
+└── README.md
+```
 
 ## Creating templates
 
@@ -132,12 +146,12 @@ const agent = new Agent({
 
 Templates must be:
 
-- **Single projects** - Not monorepos with multiple applications
-- **Framework-free** - No Next.js, Express, or other web framework boilerplate
-- **Mastra-focused** - Demonstrate Mastra functionality without additional layers
-- **Mergeable** - Structure code for seamless integration into existing projects
-- **Node.js compatible** - Support Node.js v22.13.0 and later
-- **ESM modules** - Use ES modules (`"type": "module"` in package.json)
+- **Single projects**: Not monorepos with multiple applications
+- **Framework-free**: No Next.js, Express, or other web framework boilerplate
+- **Mastra-focused**: Demonstrate Mastra functionality without additional layers
+- **Mergeable**: Structure code for seamless integration into existing projects
+- **Node.js compatible**: Support Node.js v22.13.0 and later
+- **ESM modules**: Use ES modules (`"type": "module"` in package.json)
 
 ### Documentation Requirements
 


### PR DESCRIPTION
## Description

Fix multiple issues on the templates reference page (`docs/src/content/en/reference/templates/overview.mdx`):

- **Title bug**: The frontmatter `title` field incorrectly read `"Reference: LLM provider API keys (choose one or more) | Templates"` — this was accidentally copied from a code comment inside the `.env.example` block in the same file. Updated to `"Reference: Templates overview | Templates"` to match the `Reference: $NAME | $CATEGORY` pattern used across all reference pages.
- **Incomplete section**: The "Template structure" section had a heading and one sentence but no actual content below it. Added a directory tree showing the standardized template layout.
- **List formatting**: Changed bullet list separators from ` - ` to `:` per the docs styleguide (`STYLEGUIDE.md`).
- **npm2yarn**: Added `npm2yarn` specifier to `npx`, `npm install`, and `npm run dev` code blocks so Docusaurus renders package manager tabs (npm/yarn/pnpm/bun) per the docs styleguide.

## Related Issue(s)

NA

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Templates overview page with improved formatting and enhanced clarity
  * Added directory tree visualization to illustrate expected template folder structure
  * Refined content presentation and standardized command examples for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->