### PR TITLE
fix(core): stop leaking async_hooks through logger bundles + fix CI cache regression

### DIFF
--- a/.changeset/social-forks-flash.md
+++ b/.changeset/social-forks-flash.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed @mastra/core so async_hooks no longer leaks through the logger path in browser-facing bundles.
+Fixed a browser bundling issue where importing `@mastra/core` could pull in a Node-only dependency.

--- a/.changeset/social-forks-flash.md
+++ b/.changeset/social-forks-flash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed @mastra/core so async_hooks no longer leaks through the logger path in browser-facing bundles.

--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v4.2.0
       name: Install pnpm
       with:
         run_install: false

--- a/packages/core/src/logger/dual-logger.test.ts
+++ b/packages/core/src/logger/dual-logger.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import * as utils from '../observability/context-storage';
 import type { LoggerContext } from '../observability/types/logging';
+import * as utils from '../observability/utils';
 import { DualLogger } from './dual-logger';
 import type { IMastraLogger } from './logger';
 
@@ -227,7 +227,7 @@ describe('DualLogger', () => {
         },
       };
 
-      vi.spyOn(utils, 'getCurrentSpan').mockReturnValue(mockSpan as any);
+      vi.spyOn(utils, 'resolveCurrentSpan').mockReturnValue(mockSpan as any);
 
       const dual = new DualLogger(inner, () => vnext);
       dual.info('inside span', { key: 'value' });
@@ -242,7 +242,7 @@ describe('DualLogger', () => {
     });
 
     it('falls back to global loggerVNext when no span in context', () => {
-      vi.spyOn(utils, 'getCurrentSpan').mockReturnValue(undefined);
+      vi.spyOn(utils, 'resolveCurrentSpan').mockReturnValue(undefined);
 
       const dual = new DualLogger(inner, () => vnext);
       dual.info('no span', { key: 'value' });
@@ -255,7 +255,7 @@ describe('DualLogger', () => {
 
     it('falls back to global loggerVNext when span has no observabilityInstance', () => {
       const mockSpan = { observabilityInstance: undefined };
-      vi.spyOn(utils, 'getCurrentSpan').mockReturnValue(mockSpan as any);
+      vi.spyOn(utils, 'resolveCurrentSpan').mockReturnValue(mockSpan as any);
 
       const dual = new DualLogger(inner, () => vnext);
       dual.info('no instance', { key: 'value' });
@@ -273,7 +273,7 @@ describe('DualLogger', () => {
         },
       };
 
-      vi.spyOn(utils, 'getCurrentSpan').mockReturnValue(mockSpan as any);
+      vi.spyOn(utils, 'resolveCurrentSpan').mockReturnValue(mockSpan as any);
 
       const dual = new DualLogger(inner, () => vnext);
       const error = {

--- a/packages/core/src/logger/dual-logger.ts
+++ b/packages/core/src/logger/dual-logger.ts
@@ -1,6 +1,6 @@
 import type { MastraError } from '../error';
-import { getCurrentSpan } from '../observability/context-storage';
 import type { LoggerContext } from '../observability/types/logging';
+import { resolveCurrentSpan } from '../observability/utils';
 import type { LogLevel } from './constants';
 import type { IMastraLogger } from './logger';
 import type { BaseLogMessage, LoggerTransport } from './transport';
@@ -111,7 +111,7 @@ export class DualLogger implements IMastraLogger {
    */
   #resolveLoggerVNext(): LoggerContext | undefined {
     // Check for a span in async context (set by executeWithContext)
-    const span = getCurrentSpan();
+    const span = resolveCurrentSpan();
     if (span) {
       const correlated = span.observabilityInstance?.getLoggerContext?.(span);
       if (correlated) return correlated;

--- a/packages/core/src/observability/context-storage.ts
+++ b/packages/core/src/observability/context-storage.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { AnySpan } from './types';
+import { setCurrentSpanResolver } from './utils';
 
 /**
  * Ambient storage for the current span. Populated by executeWithContext/executeWithContextSync
@@ -16,6 +17,8 @@ const spanContextStorage = new AsyncLocalStorage<AnySpan>();
 export function getCurrentSpan(): AnySpan | undefined {
   return spanContextStorage.getStore();
 }
+
+setCurrentSpanResolver(getCurrentSpan);
 
 /**
  * Execute an async function within the span's tracing context if available.

--- a/packages/core/src/observability/utils.ts
+++ b/packages/core/src/observability/utils.ts
@@ -10,6 +10,15 @@ import { EntityType, SpanType } from './types';
 import type { Span, GetOrCreateSpanOptions, AnySpan } from './types';
 
 const entityTypeValues = new Set(Object.values(EntityType));
+let currentSpanResolver: (() => AnySpan | undefined) | undefined;
+
+export function setCurrentSpanResolver(resolver: (() => AnySpan | undefined) | undefined): void {
+  currentSpanResolver = resolver;
+}
+
+export function resolveCurrentSpan(): AnySpan | undefined {
+  return currentSpanResolver?.();
+}
 
 /**
  * Creates or gets a child span from existing tracing context or starts a new trace.

--- a/packages/core/src/test-utils/llm-mock.ts
+++ b/packages/core/src/test-utils/llm-mock.ts
@@ -2,6 +2,7 @@ import { simulateReadableStream } from '@internal/ai-sdk-v4';
 import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 
+import type { StreamObjectResult, StreamReturn } from '../llm/model/base.types';
 import { MastraLLMV1 } from '../llm/model/model';
 import { MastraLanguageModelV2Mock } from '../loop/test-utils/MastraLanguageModelV2Mock';
 


### PR DESCRIPTION
## Changes

### 1. Fix async_hooks leak in browser bundles

Fixes the `@mastra/core` bundling path that was still pulling in `async_hooks` through the logger and observability integration.

**Before:**
```ts
import { getCurrentSpan } from '@mastra/core/observability/context-storage'
// pulled in the Node-only context storage path
```

**After:**
```ts
import { resolveCurrentSpan } from '@mastra/core/observability/utils'
// keeps the logger path browser-safe
```

Also fixes the llm mock utility so the related core tests keep building cleanly.

### 2. Fix CI: pin pnpm/action-setup to v4.2.0

`pnpm/action-setup` v4.3.0 (which the floating `@v4` tag now points to) has a [known regression](https://github.com/pnpm/action-setup/issues/207) where `pnpm store path --silent` returns the shim directory (`/home/ubuntu/setup-pnpm/node_modules/.bin/store/v10`) instead of the real pnpm store. This causes `actions/setup-node` to fail with:

```
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

This was breaking all Combined store Tests jobs (cloudflare-d1, libsql, pinecone, couchbase) — including on `main`.

**Fix:** Pin `pnpm/action-setup` from `@v4` → `@v4.2.0` in `.github/actions/setup-pnpm-node/action.yaml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser bundling issue where importing @mastra/core could pull Node-only dependencies into browser-targeted bundles.

* **Chores**
  * Updated CI/CD workflow to use a pinned version of the pnpm action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->