### PR TITLE
fix(core): fully isolate async_hooks from shared chunks

### DIFF
--- a/.changeset/loud-tigers-march.md
+++ b/.changeset/loud-tigers-march.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fully isolate `async_hooks` from shared chunks so importing `@mastra/core` in browser bundles never pulls in the Node-only dependency

--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -22,19 +22,22 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4.2.0
+    # Let pnpm/action-setup handle store caching instead of actions/setup-node.
+    # setup-node's cache: 'pnpm' runs `pnpm store path --silent` which returns
+    # a bogus path on self-hosted runners where pnpm is installed into
+    # ~/setup-pnpm/node_modules/.bin/.
+    - uses: pnpm/action-setup@v4
       name: Install pnpm
       with:
         run_install: false
         package_json_file: ${{ inputs.package-json-file || 'package.json' }}
+        cache: ${{ inputs.package-manager-cache == 'true' }}
+        cache_dependency_path: ${{ inputs.cache-dependency-path || 'pnpm-lock.yaml' }}
 
     - name: Setup Node.js 22.x
       uses: actions/setup-node@v6
       with:
         node-version: 22.13.0
-        cache: 'pnpm'
-        cache-dependency-path: ${{ inputs.cache-dependency-path || 'pnpm-lock.yaml' }}
-        package-manager-cache: ${{ inputs.package-manager-cache == 'true' }}
 
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -23,7 +23,7 @@ import type {
   ScorerTargetScope,
   Span,
 } from '../observability';
-import { executeWithContext } from '../observability/context-storage';
+import { executeWithContext } from '../observability/utils';
 import { RequestContext } from '../request-context';
 import type { PublicSchema } from '../schema';
 import { toStandardSchema, standardSchemaToJSONSchema } from '../schema';

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -7,7 +7,7 @@ import { loop } from '../../loop';
 import type { LoopOptions } from '../../loop/types';
 import type { Mastra } from '../../mastra';
 import { SpanType, resolveObservabilityContext } from '../../observability';
-import { executeWithContextSync } from '../../observability/context-storage';
+import { executeWithContextSync } from '../../observability/utils';
 import type { MastraModelOutput } from '../../stream/base/output';
 import type { ModelManagerModelConfig } from '../../stream/types';
 import { delay } from '../../utils';

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -22,7 +22,7 @@ import { MastraBase } from '../../base';
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import type { Mastra } from '../../mastra';
 import { SpanType, resolveObservabilityContext } from '../../observability';
-import { executeWithContext, executeWithContextSync } from '../../observability/context-storage';
+import { executeWithContext, executeWithContextSync } from '../../observability/utils';
 import { toStandardSchema, standardSchemaToJSONSchema, isStandardSchemaWithJSON } from '../../schema';
 import type { ZodSchema } from '../../schema';
 import { convertV4Usage } from '../../stream/aisdk/v4/usage';

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -13,7 +13,7 @@ import type { MastraLanguageModel, SharedProviderOptions } from '../../../llm/mo
 import type { IMastraLogger } from '../../../logger';
 import { ConsoleLogger } from '../../../logger';
 import { createObservabilityContext, SpanType } from '../../../observability';
-import { executeWithContextSync } from '../../../observability/context-storage';
+import { executeWithContextSync } from '../../../observability/utils';
 import type { ProcessorStreamWriter } from '../../../processors/index';
 import { PrepareStepProcessor } from '../../../processors/processors/prepare-step';
 import { ProcessorRunner } from '../../../processors/runner';

--- a/packages/core/src/observability/context-storage.ts
+++ b/packages/core/src/observability/context-storage.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { AnySpan } from './types';
-import { setCurrentSpanResolver } from './utils';
+import { setCurrentSpanResolver, setExecuteWithContext, setExecuteWithContextSync } from './utils';
 
 /**
  * Ambient storage for the current span. Populated by executeWithContext/executeWithContextSync
@@ -19,6 +19,8 @@ export function getCurrentSpan(): AnySpan | undefined {
 }
 
 setCurrentSpanResolver(getCurrentSpan);
+setExecuteWithContext(executeWithContext);
+setExecuteWithContextSync(executeWithContextSync);
 
 /**
  * Execute an async function within the span's tracing context if available.

--- a/packages/core/src/observability/utils.ts
+++ b/packages/core/src/observability/utils.ts
@@ -20,6 +20,47 @@ export function resolveCurrentSpan(): AnySpan | undefined {
   return currentSpanResolver?.();
 }
 
+// --- Lazy resolvers for executeWithContext / executeWithContextSync ---
+// The real implementations live in context-storage.ts (which imports AsyncLocalStorage).
+// context-storage.ts registers them at import time so that consumer code can call these
+// browser-safe wrappers without pulling async_hooks into shared chunks.
+
+type ExecuteWithContextFn = <T>(params: { span?: AnySpan; fn: () => Promise<T> }) => Promise<T>;
+type ExecuteWithContextSyncFn = <T>(params: { span?: AnySpan; fn: () => T }) => T;
+
+let executeWithContextImpl: ExecuteWithContextFn | undefined;
+let executeWithContextSyncImpl: ExecuteWithContextSyncFn | undefined;
+
+export function setExecuteWithContext(impl: ExecuteWithContextFn): void {
+  executeWithContextImpl = impl;
+}
+
+export function setExecuteWithContextSync(impl: ExecuteWithContextSyncFn): void {
+  executeWithContextSyncImpl = impl;
+}
+
+/**
+ * Execute an async function within a span's tracing context.
+ * Falls back to direct execution if no context-storage implementation is registered or no span exists.
+ */
+export async function executeWithContext<T>(params: { span?: AnySpan; fn: () => Promise<T> }): Promise<T> {
+  if (executeWithContextImpl) {
+    return executeWithContextImpl(params);
+  }
+  return params.fn();
+}
+
+/**
+ * Execute a sync function within a span's tracing context.
+ * Falls back to direct execution if no context-storage implementation is registered or no span exists.
+ */
+export function executeWithContextSync<T>(params: { span?: AnySpan; fn: () => T }): T {
+  if (executeWithContextSyncImpl) {
+    return executeWithContextSyncImpl(params);
+  }
+  return params.fn();
+}
+
 /**
  * Creates or gets a child span from existing tracing context or starts a new trace.
  * This helper consolidates the common pattern of creating spans that can either be:

--- a/packages/core/src/observability/utils.ts
+++ b/packages/core/src/observability/utils.ts
@@ -47,7 +47,11 @@ export async function executeWithContext<T>(params: { span?: AnySpan; fn: () => 
   if (executeWithContextImpl) {
     return executeWithContextImpl(params);
   }
-  return params.fn();
+  const { span, fn } = params;
+  if (span?.executeInContext) {
+    return span.executeInContext(fn);
+  }
+  return fn();
 }
 
 /**
@@ -58,7 +62,11 @@ export function executeWithContextSync<T>(params: { span?: AnySpan; fn: () => T 
   if (executeWithContextSyncImpl) {
     return executeWithContextSyncImpl(params);
   }
-  return params.fn();
+  const { span, fn } = params;
+  if (span?.executeInContextSync) {
+    return span.executeInContextSync(fn);
+  }
+  return fn();
 }
 
 /**

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -16,7 +16,7 @@ import { ErrorCategory, MastraError, ErrorDomain } from '../../error';
 import type { Mastra } from '../../mastra';
 import { SpanType, wrapMastra, EntityType, getOrCreateSpan, createObservabilityContext } from '../../observability';
 import type { AnySpan } from '../../observability';
-import { executeWithContext } from '../../observability/context-storage';
+import { executeWithContext } from '../../observability/utils';
 import { RequestContext } from '../../request-context';
 import { isStandardSchemaWithJSON, toStandardSchema, standardSchemaToJSONSchema } from '../../schema';
 import { isVercelTool, isProviderDefinedTool } from '../../tools/toolchecks';

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -8,7 +8,7 @@ import { RegisteredLogger } from '../../logger';
 import type { Mastra } from '../../mastra';
 import type { TracingContext } from '../../observability';
 import { createObservabilityContext } from '../../observability';
-import { executeWithContext } from '../../observability/context-storage';
+import { executeWithContext } from '../../observability/utils';
 import { ToolStream } from '../../tools/stream';
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from '../constants';
 import { getStepResult } from '../step';

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -14,7 +14,7 @@ import type { Event } from '../../events';
 import type { Mastra } from '../../mastra';
 import { EntityType, SpanType, createObservabilityContext, resolveObservabilityContext } from '../../observability';
 import type { ObservabilityContext } from '../../observability';
-import { executeWithContext } from '../../observability/context-storage';
+import { executeWithContext } from '../../observability/utils';
 import type { OutputResult, Processor } from '../../processors';
 import { ProcessorRunner, ProcessorState, ProcessorStepOutputSchema, ProcessorStepSchema } from '../../processors';
 import type { ProcessorStepOutput } from '../../processors/step-schema';

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -12,7 +12,7 @@ import {
   resolveObservabilityContext,
 } from '../../observability';
 import type { ObservabilityContext, Span } from '../../observability';
-import { executeWithContext } from '../../observability/context-storage';
+import { executeWithContext } from '../../observability/utils';
 import { ToolStream } from '../../tools/stream';
 import type { DynamicArgument } from '../../types';
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from '../constants';

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -25,7 +25,7 @@ import {
   getOrCreateSpan,
   resolveObservabilityContext,
 } from '../observability';
-import { executeWithContext } from '../observability/context-storage';
+import { executeWithContext } from '../observability/utils';
 import { ProcessorRunner, ProcessorState } from '../processors';
 import type { OutputResult, Processor, ProcessorStreamWriter } from '../processors';
 import { ProcessorStepOutputSchema, ProcessorStepInputSchema } from '../processors/step-schema';


### PR DESCRIPTION
## Follow-up to #15072

The previous fix moved `getCurrentSpan` behind a lazy resolver in `utils.ts`, but `executeWithContext` and `executeWithContextSync` were still imported directly from `context-storage.ts` by 9 files. This caused `AsyncLocalStorage` to leak into shared chunks (e.g. `chunk-2DKOLMVJ.js`) that get pulled into every entry point.

### Changes

#### async_hooks isolation
- Added lazy resolvers for `executeWithContext` and `executeWithContextSync` in `utils.ts` (same pattern as `resolveCurrentSpan`)
- Registered the real implementations in `context-storage.ts` on import
- Updated all 9 consumer files to import from `utils.ts` instead of `context-storage.ts`

#### CI cache fix
- Moved pnpm store caching from `actions/setup-node` (`cache: 'pnpm'`) to `pnpm/action-setup` (`cache: true`) in the `setup-pnpm-node` composite action
- `actions/setup-node@v6` runs `pnpm store path --silent` internally, which returns a bogus path on self-hosted Starsling runners where pnpm is installed into `~/setup-pnpm/node_modules/.bin/`
- `pnpm/action-setup` knows its own store location and caches it correctly
- Also removes the shell `run:` step that CodeQL flagged as untrusted code execution in a privileged context

### After this fix

`async_hooks` only appears in:
- `dist/observability/context-storage.js` / `.cjs` — the dedicated entry point
- `dist/test-utils/llm-mock.js` / `.cjs` — test utilities

No shared chunks reference `async_hooks` anymore.

### Verification

- `tsc --noEmit` passes
- `dual-logger.test.ts` (22 tests) passes
- `model.test.ts` (43 tests) passes
- Built dist verified with grep: no `async_hooks` in shared chunks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patch release: Node-only dependency (async_hooks) is fully isolated from browser bundles when importing the core package, reducing bundle size and preventing related runtime issues for browser consumers.
  * No public API or runtime behavior changes for existing integrations.

* **Refactor**
  * Observability wiring made more modular and injectable to centralize context-execution behavior without changing public interfaces.

* **Chores**
  * CI: stabilized pnpm setup and caching configuration for more consistent installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->