### PR TITLE
fix(auth-studio): extract role from Bearer token verification

### DIFF
--- a/.changeset/fix-bearer-token-role.md
+++ b/.changeset/fix-bearer-token-role.md
@@ -1,0 +1,5 @@
+---
+"@mastra/auth-studio": patch
+---
+
+Fix Bearer token authentication to extract role from /auth/verify response. Previously, CLI tokens created via `mastra auth token create` would fail permission checks because the role was not being extracted, causing MastraRBACStudio to fall back to empty default permissions.

--- a/auth/studio/src/index.test.ts
+++ b/auth/studio/src/index.test.ts
@@ -47,6 +47,7 @@ const mockVerifyResponse = {
     lastName: '',
   },
   organizationId: 'org-2',
+  role: 'member',
 };
 
 // ---------------------------------------------------------------------------
@@ -148,6 +149,7 @@ describe('MastraAuthStudio', () => {
         email: 'bob@example.com',
         name: 'Bob',
         organizationId: 'org-2',
+        role: 'member',
       });
 
       // Should have called /auth/verify with the bearer token
@@ -175,6 +177,7 @@ describe('MastraAuthStudio', () => {
         email: 'bob@example.com',
         name: 'Bob',
         organizationId: 'org-2',
+        role: 'member',
       });
 
       expect(fetchSpy).toHaveBeenCalledTimes(2);

--- a/auth/studio/src/index.ts
+++ b/auth/studio/src/index.ts
@@ -423,6 +423,7 @@ export class MastraAuthStudio
           lastName: string;
         };
         organizationId: string;
+        role?: string;
       };
 
       return {
@@ -430,6 +431,7 @@ export class MastraAuthStudio
         email: data.user.email,
         name: [data.user.firstName, data.user.lastName].filter(Boolean).join(' ') || undefined,
         organizationId: data.organizationId,
+        role: data.role,
       };
     } catch {
       return null;


### PR DESCRIPTION
## Summary

`verifyBearerToken()` was not extracting the `role` field from the `/auth/verify` response, causing CLI tokens created via `mastra auth token create` to have no role. This meant `MastraRBACStudio` would fall back to `_default` permissions (empty array), causing "agents:execute" permission errors.

## Changes

- Added `role?: string` to the response type in `verifyBearerToken()`
- Extract and return `role` in the `StudioUser` object
- Updated tests to include `role` in mock responses and expectations

## Related

This fix requires a corresponding platform change to add `role` to the `/auth/verify` response for API keys (returns `role: 'member'` for API keys).

## Test Plan

- [x] Unit tests updated and passing
- [ ] Integration test with platform changes deployed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token-based authentication now correctly includes user role information, resolving missing-role issues that could cause incorrect permissions for token-created sessions.
* **Chores**
  * Patch release entry added to publish the fix for role extraction in bearer-token authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->