### PR TITLE
fix(deployer): preserve node_modules after generating npm lockfile

### DIFF
--- a/.changeset/angry-mirrors-knock.md
+++ b/.changeset/angry-mirrors-knock.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed `mastra build` deleting `node_modules` from the output directory, which caused `mastra start` and `wrangler dev` to fail with missing module errors (e.g. `hono`, `bufferutil`, `pino`).

--- a/.changeset/angry-mirrors-knock.md
+++ b/.changeset/angry-mirrors-knock.md
@@ -2,4 +2,4 @@
 '@mastra/deployer': patch
 ---
 
-Fixed `mastra build` deleting `node_modules` from the output directory, which caused `mastra start` and `wrangler dev` to fail with missing module errors (e.g. `hono`, `bufferutil`, `pino`).
+Fixed `mastra build` so deploy output keeps its installed dependencies, preventing `mastra start` and `wrangler dev` from failing on missing packages.

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -150,9 +150,13 @@ export abstract class Bundler extends MastraBundler {
   private async generateNpmLockfile(outputDir: string): Promise<void> {
     const nodeModules = join(outputDir, 'node_modules');
     const nodeModulesTmp = join(outputDir, 'node_modules.__tmp');
+    let movedNodeModules = false;
     try {
       // Move node_modules aside — pnpm's symlink layout confuses npm's arborist
-      await fsExtra.move(nodeModules, nodeModulesTmp, { overwrite: true }).catch(() => {});
+      if (await fsExtra.pathExists(nodeModules)) {
+        await fsExtra.move(nodeModules, nodeModulesTmp, { overwrite: true });
+        movedNodeModules = true;
+      }
       execSync('npm install --package-lock-only --force', {
         cwd: outputDir,
         stdio: 'pipe',
@@ -162,8 +166,10 @@ export abstract class Bundler extends MastraBundler {
       this.logger.warn('Failed to generate package-lock.json — deploy will fall back to npm install');
     } finally {
       // Restore node_modules so runtime resolution works
-      await rm(nodeModules, { recursive: true, force: true }).catch(() => {});
-      await fsExtra.move(nodeModulesTmp, nodeModules, { overwrite: true }).catch(() => {});
+      if (movedNodeModules) {
+        await rm(nodeModules, { recursive: true, force: true });
+        await fsExtra.move(nodeModulesTmp, nodeModules, { overwrite: true });
+      }
     }
   }
 

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -143,13 +143,16 @@ export abstract class Bundler extends MastraBundler {
    * can use `npm ci` instead of `npm install`, skipping version resolution entirely.
    * This is a lockfile-only operation — no packages are downloaded.
    *
-   * Removes node_modules first because pnpm's symlink-based layout confuses
-   * npm's arborist when it tries to read the existing tree.
+   * Temporarily moves node_modules out of the way because pnpm's symlink-based
+   * layout confuses npm's arborist, then restores it afterwards so that
+   * `mastra start` (or wrangler) can still resolve dependencies at runtime.
    */
   private async generateNpmLockfile(outputDir: string): Promise<void> {
+    const nodeModules = join(outputDir, 'node_modules');
+    const nodeModulesTmp = join(outputDir, 'node_modules.__tmp');
     try {
-      // Remove node_modules first — pnpm's symlink layout confuses npm's arborist
-      await rm(join(outputDir, 'node_modules'), { recursive: true, force: true }).catch(() => {});
+      // Move node_modules aside — pnpm's symlink layout confuses npm's arborist
+      await fsExtra.move(nodeModules, nodeModulesTmp, { overwrite: true }).catch(() => {});
       execSync('npm install --package-lock-only --force', {
         cwd: outputDir,
         stdio: 'pipe',
@@ -157,6 +160,10 @@ export abstract class Bundler extends MastraBundler {
       });
     } catch {
       this.logger.warn('Failed to generate package-lock.json — deploy will fall back to npm install');
+    } finally {
+      // Restore node_modules so runtime resolution works
+      await rm(nodeModules, { recursive: true, force: true }).catch(() => {});
+      await fsExtra.move(nodeModulesTmp, nodeModules, { overwrite: true }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
## Summary

`generateNpmLockfile` (introduced in #15067) was deleting `node_modules` from `.mastra/output` to work around pnpm's symlink layout confusing npm's arborist during lockfile generation, but **never restored them**. This broke three E2E test suites and the `mastra start` command:

| E2E Test | Error | Root Cause |
|---|---|---|
| `no-bundling` | `Module not found: "hono"` | `node_modules` deleted, `node index.mjs` can't resolve deps |
| `monorepo` | `Cannot find package 'bufferutil'` | Same — missing `node_modules` |
| `deployers` | `wrangler dev` timeout | `wrangler`'s esbuild can't resolve `pino`/`pino-pretty` |

## Fix

Instead of permanently deleting `node_modules`, we now:
1. **Move** `node_modules` to a temp path (`node_modules.__tmp`)
2. Run `npm install --package-lock-only --force` (lockfile-only, no downloads)
3. **Restore** `node_modules` from the temp path in a `finally` block

This preserves the lockfile generation feature for deploy targets while keeping runtime resolution intact for `mastra start` and `wrangler dev`.

## Test Plan

- `packages/deployer` builds cleanly (`pnpm build:lib`)
- `tsc --noEmit` passes
- All 362 deployer tests pass
- CI E2E tests should now pass consistently (no more intermittent failures based on turbo cache staleness)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the build process removed installed dependencies from the deploy output, causing subsequent start/dev workflows to fail due to missing modules. The build now preserves dependencies so local development and deployment commands run reliably, preventing missing-package errors and improving post-build runtime stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->