### PR TITLE
feat(cli): add server deploy command

### DIFF
--- a/.changeset/cli-server-deploy.md
+++ b/.changeset/cli-server-deploy.md
@@ -1,0 +1,5 @@
+---
+'mastra': minor
+---
+
+Added `mastra server deploy` command for deploying to Mastra Server. Builds, zips, and uploads your project with environment variable support and deploy polling.

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -84,7 +84,7 @@ export function parseEnvFile(content: string): Record<string, string> {
 
 async function readEnvVars(projectDir: string): Promise<Record<string, string>> {
   const vars: Record<string, string> = {};
-  for (const envFile of ['.env.production', '.env.local', '.env']) {
+  for (const envFile of ['.env', '.env.local', '.env.production']) {
     try {
       const content = await readFile(join(projectDir, envFile), 'utf-8');
       Object.assign(vars, parseEnvFile(content));
@@ -189,10 +189,16 @@ async function resolveProject(
     };
   }
 
-  // Auto-create from package name
+  // Check if a project already exists matching the package name before creating
   const name = defaultName;
   if (!name) {
     throw new Error('Could not determine project name from package.json. Use --project to specify one.');
+  }
+
+  const existing = await fetchServerProjects(token, orgId);
+  const match = existing.find(proj => proj.name === name || proj.slug === name);
+  if (match) {
+    return { projectId: match.id, projectName: match.name, projectSlug: match.slug ?? match.name };
   }
 
   const project = await createServerProject(token, orgId, name);
@@ -209,9 +215,6 @@ export async function serverDeployAction(
 ) {
   const targetDir = resolve(dir || process.cwd());
   const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);
-  if (isHeadless && (!process.env.MASTRA_ORG_ID || !process.env.MASTRA_PROJECT_ID)) {
-    throw new Error('MASTRA_ORG_ID and MASTRA_PROJECT_ID are required when MASTRA_API_TOKEN is set');
-  }
   const autoAccept = opts.yes ?? isHeadless;
 
   p.intro('mastra server deploy');
@@ -230,7 +233,15 @@ export async function serverDeployAction(
   // Step 2: Load existing project config
   const projectConfig = await loadProjectConfig(targetDir, opts.config);
 
-  // Step 3: Resolve org
+  // Step 3: Resolve org — flags and config are checked before requiring env vars
+  const hasOrg = Boolean(process.env.MASTRA_ORG_ID || opts.org || projectConfig?.organizationId);
+  const hasProject = Boolean(process.env.MASTRA_PROJECT_ID || opts.project || projectConfig?.projectId);
+  if (isHeadless && (!hasOrg || !hasProject)) {
+    throw new Error(
+      'MASTRA_ORG_ID and MASTRA_PROJECT_ID (or --org/--project flags, or .mastra-project.json) are required when MASTRA_API_TOKEN is set',
+    );
+  }
+
   const { orgId, orgName } = await resolveOrg(token, projectConfig, opts.org);
 
   // Step 4: Resolve project

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -1,0 +1,332 @@
+import { execSync } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { mkdir, rm, stat, access, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import * as p from '@clack/prompts';
+import archiver from 'archiver';
+import { fetchOrgs } from '../auth/api.js';
+import { MASTRA_STUDIO_URL } from '../auth/client.js';
+import { getToken, getCurrentOrgId } from '../auth/credentials.js';
+import { loadProjectConfig, saveProjectConfig } from '../studio/project-config.js';
+import { fetchServerProjects, createServerProject, uploadServerDeploy, pollServerDeploy } from './platform-api.js';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+function getPackageName(projectDir: string): string | null {
+  try {
+    const raw = execSync('node -p "require(\'./package.json\').name"', {
+      cwd: projectDir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return raw.startsWith('@') ? (raw.split('/')[1] ?? raw) : raw;
+  } catch {
+    return null;
+  }
+}
+
+function runBuild(projectDir: string): void {
+  const localMastra = join(projectDir, 'node_modules', '.bin', 'mastra');
+  p.log.step('Running mastra build...');
+  try {
+    execSync(`"${localMastra}" build`, {
+      cwd: projectDir,
+      stdio: 'inherit',
+      env: { ...process.env, NODE_ENV: 'production' },
+    });
+  } catch {
+    throw new Error('mastra build failed');
+  }
+  console.info('');
+}
+
+async function zipOutput(projectDir: string): Promise<string> {
+  const outputDir = join(projectDir, '.mastra', 'output');
+  const tmpDir = join(tmpdir(), 'mastra-deploy');
+  await mkdir(tmpDir, { recursive: true });
+  const zipPath = join(tmpDir, `server-deploy-${Date.now()}.zip`);
+
+  return new Promise((resolvePromise, reject) => {
+    const output = createWriteStream(zipPath);
+    const archive = archiver('zip', { zlib: { level: 6 } });
+
+    output.on('close', () => resolvePromise(zipPath));
+    archive.on('error', reject);
+
+    archive.pipe(output);
+    // Ship only the pre-built .mastra/output + package.json for dependency metadata
+    archive.glob('**', { cwd: outputDir, ignore: ['node_modules/**'] }, { prefix: '.mastra/output' });
+    archive.file(join(projectDir, 'package.json'), { name: 'package.json' });
+    void archive.finalize();
+  });
+}
+
+export function parseEnvFile(content: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    let key = trimmed.slice(0, eqIdx).trim();
+    if (key.startsWith('export ')) key = key.slice(7).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (key) vars[key] = value;
+  }
+  return vars;
+}
+
+async function readEnvVars(projectDir: string): Promise<Record<string, string>> {
+  const vars: Record<string, string> = {};
+  for (const envFile of ['.env.production', '.env.local', '.env']) {
+    try {
+      const content = await readFile(join(projectDir, envFile), 'utf-8');
+      Object.assign(vars, parseEnvFile(content));
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
+  }
+  return vars;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Resolve org                                                       */
+/* ------------------------------------------------------------------ */
+
+async function resolveOrg(
+  token: string,
+  projectConfig: { organizationId?: string } | null,
+  flagOrg?: string,
+): Promise<{ orgId: string; orgName: string }> {
+  const envOrgId = process.env.MASTRA_ORG_ID;
+  if (envOrgId) {
+    return { orgId: envOrgId, orgName: envOrgId };
+  }
+
+  if (flagOrg) {
+    const orgs = await fetchOrgs(token);
+    const match = orgs.find(o => o.id === flagOrg);
+    return { orgId: flagOrg, orgName: match?.name ?? flagOrg };
+  }
+
+  if (projectConfig?.organizationId) {
+    const orgs = await fetchOrgs(token);
+    const match = orgs.find(o => o.id === projectConfig.organizationId);
+    if (match) {
+      return { orgId: match.id, orgName: match.name };
+    }
+  }
+
+  const currentOrgId = await getCurrentOrgId();
+  const orgs = await fetchOrgs(token);
+
+  if (currentOrgId) {
+    const match = orgs.find(o => o.id === currentOrgId);
+    if (match) {
+      return { orgId: match.id, orgName: match.name };
+    }
+  }
+
+  if (orgs.length === 1) {
+    return { orgId: orgs[0]!.id, orgName: orgs[0]!.name };
+  }
+
+  if (orgs.length === 0) {
+    throw new Error(`No organizations found. Create one at ${MASTRA_STUDIO_URL}`);
+  }
+
+  const selected = await p.select({
+    message: 'Select an organization',
+    options: orgs.map(o => ({ value: o.id, label: `${o.name} (${o.id})` })),
+  });
+
+  if (p.isCancel(selected)) {
+    p.cancel('Deploy cancelled.');
+    process.exit(0);
+  }
+
+  const selectedOrg = orgs.find(o => o.id === selected)!;
+  return { orgId: selectedOrg.id, orgName: selectedOrg.name };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Resolve project                                                   */
+/* ------------------------------------------------------------------ */
+
+async function resolveProject(
+  token: string,
+  orgId: string,
+  projectConfig: { projectId?: string; projectName?: string; projectSlug?: string; organizationId?: string } | null,
+  flagProject?: string,
+  defaultName?: string | null,
+): Promise<{ projectId: string; projectName: string; projectSlug: string }> {
+  const envProjectId = process.env.MASTRA_PROJECT_ID;
+  if (envProjectId) {
+    return { projectId: envProjectId, projectName: envProjectId, projectSlug: envProjectId };
+  }
+
+  if (flagProject) {
+    const projects = await fetchServerProjects(token, orgId);
+    const match = projects.find(proj => proj.slug === flagProject || proj.id === flagProject);
+    if (match) {
+      return { projectId: match.id, projectName: match.name, projectSlug: match.slug ?? match.name };
+    }
+    return { projectId: flagProject, projectName: flagProject, projectSlug: flagProject };
+  }
+
+  if (projectConfig?.projectId && projectConfig.organizationId === orgId) {
+    return {
+      projectId: projectConfig.projectId,
+      projectName: projectConfig.projectName ?? projectConfig.projectId,
+      projectSlug: projectConfig.projectSlug ?? projectConfig.projectName ?? projectConfig.projectId,
+    };
+  }
+
+  // Auto-create from package name
+  const name = defaultName;
+  if (!name) {
+    throw new Error('Could not determine project name from package.json. Use --project to specify one.');
+  }
+
+  const project = await createServerProject(token, orgId, name);
+  return { projectId: project.id, projectName: project.name, projectSlug: project.slug ?? project.name };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main deploy action                                                */
+/* ------------------------------------------------------------------ */
+
+export async function serverDeployAction(
+  dir: string | undefined,
+  opts: { org?: string; project?: string; yes?: boolean; config?: string },
+) {
+  const targetDir = resolve(dir || process.cwd());
+  const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);
+  if (isHeadless && (!process.env.MASTRA_ORG_ID || !process.env.MASTRA_PROJECT_ID)) {
+    throw new Error('MASTRA_ORG_ID and MASTRA_PROJECT_ID are required when MASTRA_API_TOKEN is set');
+  }
+  const autoAccept = opts.yes ?? isHeadless;
+
+  p.intro('mastra server deploy');
+
+  const packageName = getPackageName(targetDir);
+
+  // Step 1: Auth
+  let token: string;
+  try {
+    token = await getToken();
+  } catch {
+    p.log.error(`Authentication failed. Run: mastra auth login`);
+    process.exit(1);
+  }
+
+  // Step 2: Load existing project config
+  const projectConfig = await loadProjectConfig(targetDir, opts.config);
+
+  // Step 3: Resolve org
+  const { orgId, orgName } = await resolveOrg(token, projectConfig, opts.org);
+
+  // Step 4: Resolve project
+  const { projectId, projectName, projectSlug } = await resolveProject(
+    token,
+    orgId,
+    projectConfig,
+    opts.project,
+    packageName,
+  );
+
+  // Step 5: Confirmation
+  const isAlreadyLinked = projectConfig?.projectId === projectId && projectConfig?.organizationId === orgId;
+
+  if (!isAlreadyLinked) {
+    p.note(
+      [`Organization:  ${orgName}`, `Project:       ${projectName}`, `Directory:     ${targetDir}`].join('\n'),
+      'Deploy settings',
+    );
+
+    if (!autoAccept) {
+      const confirmed = await p.confirm({
+        message: 'Deploy with these settings?',
+      });
+
+      if (p.isCancel(confirmed) || !confirmed) {
+        p.cancel('Deploy cancelled.');
+        process.exit(0);
+      }
+    }
+
+    await saveProjectConfig(
+      targetDir,
+      {
+        projectId,
+        projectName,
+        projectSlug,
+        organizationId: orgId,
+      },
+      opts.config,
+    );
+    p.log.success(`Saved ${opts.config || '.mastra-project.json'}`);
+  } else {
+    p.log.info(`Organization: ${orgName} (${orgId})`);
+    p.log.info(`Project: ${projectName} (${projectId})`);
+  }
+
+  // Step 6: Build + Zip + Upload + Poll
+  const s = p.spinner();
+
+  runBuild(targetDir);
+
+  // Verify build output exists
+  const outputEntry = join(targetDir, '.mastra', 'output', 'index.mjs');
+  try {
+    await access(outputEntry);
+  } catch {
+    throw new Error('.mastra/output/index.mjs not found — did the build succeed?');
+  }
+
+  s.start('Zipping build artifact...');
+  const zipPath = await zipOutput(targetDir);
+  const zipStat = await stat(zipPath);
+  const sizeKB = zipStat.size / 1024;
+  const sizeLabel = sizeKB > 1024 ? `${(sizeKB / 1024).toFixed(1)}MB` : `${sizeKB.toFixed(1)}KB`;
+  s.stop(`Created ${sizeLabel} archive`);
+
+  s.start('Reading environment variables...');
+  const envVars = await readEnvVars(targetDir);
+  const envCount = Object.keys(envVars).length;
+  if (envCount > 0) {
+    s.stop(`Found ${envCount} env var(s)`);
+  } else {
+    s.stop('No .env file found');
+  }
+
+  s.start('Uploading...');
+  const zipBuffer = await readFile(zipPath);
+  const deployResult = await uploadServerDeploy(token, orgId, projectId, zipBuffer, {
+    projectName,
+    envVars: envCount > 0 ? envVars : undefined,
+  });
+  s.stop(`Deploy accepted: ${deployResult.id}`);
+
+  await rm(zipPath, { force: true });
+
+  p.log.step('Streaming deploy logs...');
+  const finalStatus = await pollServerDeploy(deployResult.id, token, orgId);
+
+  if (finalStatus.status === 'running') {
+    p.outro(`Deploy succeeded! ${finalStatus.instanceUrl}`);
+  } else if (finalStatus.status === 'failed') {
+    p.log.error(`Deploy failed: ${finalStatus.error}`);
+    process.exit(1);
+  } else {
+    p.log.warning(`Deploy ended with status: ${finalStatus.status}`);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -168,13 +168,20 @@ async function pollServerLogs(deployId: string, token: string, orgId: string, si
 
   let printedBuild = 0;
   let printedDeploy = 0;
-  const client = createApiClient(token, orgId);
+  let currentToken = token;
+  let client = createApiClient(currentToken, orgId);
 
   while (!signal.aborted) {
     try {
-      const { data } = await client.GET('/v1/server/deploys/{id}/logs', {
+      const { data, response } = await client.GET('/v1/server/deploys/{id}/logs', {
         params: { path: { id: deployId } },
       });
+
+      if (response.status === 401) {
+        currentToken = await getToken();
+        client = createApiClient(currentToken, orgId);
+        continue;
+      }
 
       if (data) {
         const newBuild = data.buildLogs.slice(printedBuild);

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -1,0 +1,198 @@
+import { createApiClient, throwApiError } from '../auth/client.js';
+import { getToken } from '../auth/credentials.js';
+import type { paths } from '../platform-api.js';
+
+type ServerProjectsResponse = paths['/v1/server/projects']['get'] extends {
+  responses: { 200: { content: { 'application/json': infer T } } };
+}
+  ? T
+  : never;
+export type ServerProject = ServerProjectsResponse extends { projects: (infer P)[] } ? P : never;
+
+type ServerDeployResponse = paths['/v1/server/deploys/{id}']['get'] extends {
+  responses: { 200: { content: { 'application/json': infer T } } };
+}
+  ? T
+  : never;
+export type ServerDeployStatus = ServerDeployResponse;
+
+export async function fetchServerProjects(token: string, orgId: string): Promise<ServerProject[]> {
+  const client = createApiClient(token, orgId);
+  const { data, error, response } = await client.GET('/v1/server/projects');
+
+  if (error) {
+    throwApiError('Failed to fetch server projects', response.status);
+  }
+
+  return data.projects;
+}
+
+export async function createServerProject(token: string, orgId: string, name: string): Promise<ServerProject> {
+  const client = createApiClient(token, orgId);
+  const { data, error, response } = await client.POST('/v1/server/projects', {
+    body: { name },
+  });
+
+  if (error) {
+    throwApiError(`Failed to create server project — ${error.detail ?? 'unknown error'}`, response.status);
+  }
+
+  return data.project;
+}
+
+export async function fetchServerDeployStatus(
+  deployId: string,
+  token: string,
+  orgId?: string,
+): Promise<ServerDeployStatus> {
+  const client = createApiClient(token, orgId);
+  const { data, error, response } = await client.GET('/v1/server/deploys/{id}', {
+    params: { path: { id: deployId } },
+  });
+
+  if (error) {
+    throwApiError('Failed to fetch server deploy status', response.status);
+  }
+
+  return data;
+}
+
+export async function uploadServerDeploy(
+  token: string,
+  orgId: string,
+  projectId: string,
+  zipBuffer: Buffer,
+  meta?: { projectName?: string; envVars?: Record<string, string> },
+): Promise<{ id: string; status: string }> {
+  const client = createApiClient(token, orgId);
+
+  // Step 1: Create the deploy — returns upload URL
+  const { data, error, response } = await client.POST('/v1/server/deploys', {
+    body: { projectId, projectName: meta?.projectName, envVars: meta?.envVars },
+  });
+
+  if (error) {
+    throwApiError('Deploy failed', response.status);
+  }
+
+  const { id, uploadUrl } = data;
+
+  if (!uploadUrl) {
+    throw new Error('No upload URL returned');
+  }
+
+  // Step 2: Upload artifact to the signed URL
+  if (uploadUrl.startsWith('file://')) {
+    const { writeFile } = await import('node:fs/promises');
+    const { fileURLToPath } = await import('node:url');
+    await writeFile(fileURLToPath(uploadUrl), Buffer.from(zipBuffer));
+  } else {
+    const uploadResp = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/zip' },
+      body: new Uint8Array(zipBuffer),
+    });
+    if (!uploadResp.ok) {
+      throw new Error(`Artifact upload failed: ${uploadResp.status} ${uploadResp.statusText}`);
+    }
+  }
+
+  // Step 3: Notify API that upload is complete → triggers build pipeline
+  const { error: completeError, response: completeResponse } = await client.POST(
+    '/v1/server/deploys/{id}/upload-complete',
+    { params: { path: { id } } },
+  );
+
+  if (completeError) {
+    throwApiError('Upload confirmation failed', completeResponse.status);
+  }
+
+  return { id, status: 'queued' };
+}
+
+export async function pollServerDeploy(
+  deployId: string,
+  token: string,
+  orgId: string,
+  maxWaitMs = 600000, // 10 minutes — server builds take longer
+): Promise<ServerDeployStatus> {
+  const start = Date.now();
+  let lastStatus = '';
+  let currentToken = token;
+
+  let client = createApiClient(currentToken, orgId);
+
+  // Poll for build + deploy logs in the background
+  const logAbort = new AbortController();
+  pollServerLogs(deployId, currentToken, orgId, logAbort.signal).catch(() => {});
+
+  try {
+    while (Date.now() - start < maxWaitMs) {
+      const { data, error, response } = await client.GET('/v1/server/deploys/{id}', {
+        params: { path: { id: deployId } },
+      });
+
+      if (error) {
+        if (response.status === 401) {
+          currentToken = await getToken();
+          client = createApiClient(currentToken, orgId);
+          continue;
+        }
+        throwApiError('Poll failed', response.status);
+      }
+
+      if (data.status !== lastStatus) {
+        lastStatus = data.status;
+      }
+
+      const terminal = ['running', 'failed', 'crashed', 'cancelled', 'stopped'];
+      if (terminal.includes(data.status)) {
+        return data;
+      }
+
+      await new Promise(r => setTimeout(r, 5000));
+    }
+
+    throw new Error('Deploy timed out');
+  } finally {
+    logAbort.abort();
+  }
+}
+
+/**
+ * Poll the server deploy logs endpoint and print new log lines.
+ * Server deploys don't have SSE streaming — we poll the JSON endpoint.
+ */
+async function pollServerLogs(deployId: string, token: string, orgId: string, signal: AbortSignal): Promise<void> {
+  await new Promise(r => setTimeout(r, 3000));
+
+  let printedBuild = 0;
+  let printedDeploy = 0;
+  const client = createApiClient(token, orgId);
+
+  while (!signal.aborted) {
+    try {
+      const { data } = await client.GET('/v1/server/deploys/{id}/logs', {
+        params: { path: { id: deployId } },
+      });
+
+      if (data) {
+        const newBuild = data.buildLogs.slice(printedBuild);
+        for (const line of newBuild) {
+          process.stdout.write(`${line}\n`);
+        }
+        printedBuild = data.buildLogs.length;
+
+        const newDeploy = data.deployLogs.slice(printedDeploy);
+        for (const line of newDeploy) {
+          process.stdout.write(`${line}\n`);
+        }
+        printedDeploy = data.deployLogs.length;
+      }
+    } catch {
+      // Ignore errors during log polling — deploy status polling is the source of truth
+    }
+
+    await new Promise(r => setTimeout(r, 5000));
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ import { listOrgsAction, switchOrgAction } from './commands/auth/orgs';
 import { createTokenAction, listTokensAction, revokeTokenAction } from './commands/auth/tokens';
 import { whoamiAction } from './commands/auth/whoami';
 import { COMPONENTS, LLMProvider } from './commands/init/utils';
+import { serverDeployAction } from './commands/server/deploy';
 import { deployAction } from './commands/studio/deploy';
 import { deploysAction } from './commands/studio/deploy-list';
 import { logsAction } from './commands/studio/deploy-logs';
@@ -253,6 +254,19 @@ const authTokens = authCommand.command('tokens').description('Manage API tokens'
 authTokens.command('create <name>').description('Create a new API token').action(wrapAction(createTokenAction));
 
 authTokens.command('revoke <token-id>').description('Revoke an API token').action(wrapAction(revokeTokenAction));
+
+// ---- Server commands ----
+
+const serverCommand = program.command('server').description('Manage Mastra Server deployments');
+
+serverCommand
+  .command('deploy [dir]')
+  .description('Deploy to Mastra Server')
+  .option('--org <id>', 'Organization ID')
+  .option('--project <id>', 'Project ID')
+  .option('-y, --yes', 'Auto-accept defaults without confirmation')
+  .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
+  .action(wrapAction(serverDeployAction));
 
 program.parse(process.argv);
 


### PR DESCRIPTION
## Summary

Add `mastra server deploy` for deploying to Mastra Server.

### New subcommand

- `mastra server deploy [dir]` — build, zip, and upload to Mastra Server
  - `--org <id>` — organization ID
  - `--project <id>` — project ID  
  - `-y, --yes` — auto-accept defaults
  - `-c, --config <file>` — custom project config path

### How it works

1. Authenticates via `getToken()`
2. Resolves org and project (env vars → flags → .mastra-project.json → interactive)
3. Builds with `mastra build`
4. Zips `.mastra/output/` directory
5. Uploads via platform API (signed URL)
6. Polls for deploy completion, streaming logs

Reuses `project-config` and auth modules from the studio deploy PR (#15067).

### New files

- `packages/cli/src/commands/server/deploy.ts` — deploy action + helpers
- `packages/cli/src/commands/server/platform-api.ts` — server deploy API client

## Test plan

- All 203 CLI tests pass (`pnpm test:cli`)
- Typecheck clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mastra server deploy` CLI to build, package, and upload projects for deployment.
  * Supports env vars from `.env`, `.env.local`, `.env.production`.
  * Interactive and non-interactive flows for selecting or creating target organization/project; accepts --org, --project, -y/--yes, and -c/--config.
  * Real-time deployment status polling with live log output and upload progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->