### PR TITLE
fix: use .optional() instead of .nullish() in sub-agent tool input schema

### DIFF
--- a/.changeset/fix-agent-schema-optional-gemini.md
+++ b/.changeset/fix-agent-schema-optional-gemini.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed sub-agent tool input schema to use `.optional()` instead of `.nullish()` for optional fields (`threadId`, `resourceId`, `instructions`, `maxSteps`). The previous `.nullish()` produced `anyOf: [T, {type: "null"}]` in JSON Schema, which Google Gemini's function calling API rejects. Using `.optional()` generates clean JSON Schema without `anyOf`, while the execute handler already handles null values via falsy checks so OpenAI compatibility is preserved.

--- a/packages/core/src/agent/__tests__/tools.test.ts
+++ b/packages/core/src/agent/__tests__/tools.test.ts
@@ -1395,10 +1395,10 @@ describe('sub-agent prompt input normalization (GitHub #14154)', () => {
   // by CoreToolBuilder.createExecute) must normalize it before validation fails.
   const agentInputSchema = z.object({
     prompt: z.string().describe('The prompt to send to the agent'),
-    threadId: z.string().nullish().describe('Thread ID'),
-    resourceId: z.string().nullish().describe('Resource ID'),
-    instructions: z.string().nullish().describe('Additional instructions'),
-    maxSteps: z.number().min(3).nullish().describe('Max steps'),
+    threadId: z.string().optional().describe('Thread ID'),
+    resourceId: z.string().optional().describe('Resource ID'),
+    instructions: z.string().optional().describe('Additional instructions'),
+    maxSteps: z.number().min(3).optional().describe('Max steps'),
   });
 
   it('should normalize "query" to "prompt" through validateToolInput', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2926,16 +2926,18 @@ export class Agent<
       for (const [agentName, agent] of Object.entries(agents)) {
         const agentInputSchema = z.object({
           prompt: z.string().describe('The prompt to send to the agent'),
-          // Using .nullish() instead of .optional() because OpenAI sends null for unfilled optional fields
-          threadId: z.string().nullish().describe('Thread ID for conversation continuity for memory messages'),
-          resourceId: z.string().nullish().describe('Resource/user identifier for memory messages'),
+          // Using .optional() (not .nullish()) so the JSON Schema for tool calling avoids anyOf:[T,null]
+          // constructs that break Google Gemini function calling. The execute handler already coerces
+          // null to undefined via falsy checks, so OpenAI sending null for unfilled fields is safe.
+          threadId: z.string().optional().describe('Thread ID for conversation continuity for memory messages'),
+          resourceId: z.string().optional().describe('Resource/user identifier for memory messages'),
           instructions: z
             .string()
-            .nullish()
+            .optional()
             .describe(
               'Additional instructions to append to the agent instructions. Only provide if you have specific guidance beyond what the agent already knows. Leave empty in most cases.',
             ),
-          maxSteps: z.number().min(3).nullish().describe('Maximum number of execution steps for the sub-agent'),
+          maxSteps: z.number().min(3).optional().describe('Maximum number of execution steps for the sub-agent'),
           // using minimum of 3 to ensure if the agent has a tool call, the llm gets executed again after the tool call step, using the tool call result
           // to return a proper llm response
         });


### PR DESCRIPTION
Fixes #15076

## Problem

The `agentInputSchema` in `listAgentTools` used `.nullish()` for optional fields (`threadId`, `resourceId`, `instructions`, `maxSteps`). This generates JSON Schema with `anyOf: [{type: "string"}, {type: "null"}]` constructs, which Google Gemini's function calling API does not support. Gemini rejects any tool schema containing `anyOf`, causing all auto-generated sub-agent tools to fail with:

```
GenerateContentRequest.tools[0].function_declarations[N].parameters.required[0]: property is not defined
```

## Solution

Changed `.nullish()` to `.optional()` for all optional fields in `agentInputSchema`. `.optional()` produces clean JSON Schema (just `{type: "string"}`) without `anyOf`.

The `execute` handler already guards these fields with falsy checks (`inputData.threadId || undefined`, `inputData.threadId ? ...`), so null values sent by OpenAI for unfilled optional fields are safely coerced to `undefined` — no behavior change for OpenAI users.

## Testing

- Updated the mirrored schema in `packages/core/src/agent/__tests__/tools.test.ts` to match.
- Existing unit tests pass with the schema change.
- The fix matches the workaround confirmed working by the issue reporter (replacing `.nullish()` with `.optional()` via `pnpm patch`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sub-agent tool compatibility with Google Gemini's function calling API by adjusting how optional input fields are defined in the tool schema for improved provider compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->