### PR TITLE
fix(studio): wrap long unbroken text in user chat message bubble

### DIFF
--- a/packages/playground-ui/src/lib/ai-ui/messages/user-messages.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/messages/user-messages.tsx
@@ -44,7 +44,7 @@ export const UserMessage = () => {
       data-message-index={message?.index}
     >
       <DatasetSaveAction />
-      <div className="max-w-[366px] px-5 py-3 text-neutral6 text-ui-lg leading-ui-lg rounded-lg bg-surface3">
+      <div className="max-w-[366px] break-words px-5 py-3 text-neutral6 text-ui-lg leading-ui-lg rounded-lg bg-surface3">
         <MessagePrimitive.Parts
           components={{
             File: p => {


### PR DESCRIPTION
 ## Description

  User messages in the agent chat view overflow horizontally outside their bubble when the
   message contains a long unbroken string (e.g. no spaces). Fixed by adding `break-words`
   (`overflow-wrap: break-word`) to the user message bubble in `packages/playground-ui`.
   
 ## Screenshots

  **Before**
<img width="867" height="180" alt="image" src="https://github.com/user-attachments/assets/b2bbacd7-7384-4954-95c2-1262b76f02f9" />


  **After**
<img width="1031" height="225" alt="image" src="https://github.com/user-attachments/assets/921c2e9d-08bf-48ba-a1da-d084f714c43c" />


  ## Related Issue(s)

  No related issue found.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Checklist

  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping in user messages to prevent overflow of long content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->