### PR TITLE
feat: add collapsible output for shell passthrough (! commands)

### DIFF
--- a/.changeset/social-impalas-walk.md
+++ b/.changeset/social-impalas-walk.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Added collapsible output for shell passthrough (! commands). Output now defaults to 20 lines with Ctrl+E to expand/collapse, matching the existing tool call output behavior.

--- a/mastracode/src/tui/__tests__/prune-chat.test.ts
+++ b/mastracode/src/tui/__tests__/prune-chat.test.ts
@@ -32,17 +32,22 @@ describe('pruneChatContainer', () => {
     const keptSlash = new SlashCommandComponent('kept', 'echo kept');
     const removedReminder = new SystemReminderComponent({ message: 'Removed body' });
     const keptReminder = new SystemReminderComponent({ message: 'Kept body' });
+    const removedShell = { id: 'removed-shell' };
+    const keptShell = { id: 'kept-shell' };
 
     state.chatContainer.children[10] = removedTool as any;
     state.chatContainer.children[20] = removedSlash as any;
     state.chatContainer.children[30] = removedReminder as any;
+    state.chatContainer.children[40] = removedShell as any;
     state.chatContainer.children[220] = keptTool as any;
     state.chatContainer.children[230] = keptSlash as any;
     state.chatContainer.children[240] = keptReminder as any;
+    state.chatContainer.children[245] = keptShell as any;
 
     state.allToolComponents = [removedTool as any, keptTool as any];
     state.allSlashCommandComponents = [removedSlash, keptSlash];
     state.allSystemReminderComponents = [removedReminder, keptReminder];
+    state.allShellComponents = [removedShell as any, keptShell as any];
 
     pruneChatContainer(state);
 
@@ -50,9 +55,11 @@ describe('pruneChatContainer', () => {
     expect(state.chatContainer.children[70]).toBe(keptTool);
     expect(state.chatContainer.children[80]).toBe(keptSlash);
     expect(state.chatContainer.children[90]).toBe(keptReminder);
+    expect(state.chatContainer.children[95]).toBe(keptShell);
     expect(state.allToolComponents).toEqual([keptTool]);
     expect(state.allSlashCommandComponents).toEqual([keptSlash]);
     expect(state.allSystemReminderComponents).toEqual([keptReminder]);
+    expect(state.allShellComponents).toEqual([keptShell]);
   });
 
   it('does nothing when the container is already within the limit', () => {

--- a/mastracode/src/tui/__tests__/prune-chat.test.ts
+++ b/mastracode/src/tui/__tests__/prune-chat.test.ts
@@ -18,6 +18,7 @@ function createState(childrenCount: number): TUIState {
     allToolComponents: [],
     allSlashCommandComponents: [],
     allSystemReminderComponents: [],
+    allShellComponents: [],
   } as unknown as TUIState;
 }
 

--- a/mastracode/src/tui/commands/clone.ts
+++ b/mastracode/src/tui/commands/clone.ts
@@ -90,6 +90,7 @@ export async function resetUIAfterClone(ctx: CloneResetContext, clonedTitle: str
   state.pendingTools.clear();
   state.allToolComponents = [];
   state.allSystemReminderComponents = [];
+  state.allShellComponents = [];
   state.harness.getDisplayState().modifiedFiles.clear();
   if (state.taskProgress) {
     state.taskProgress.updateTasks([]);

--- a/mastracode/src/tui/commands/new.ts
+++ b/mastracode/src/tui/commands/new.ts
@@ -7,6 +7,7 @@ export function handleNewCommand(ctx: SlashCommandContext): void {
   state.chatContainer.clear();
   state.pendingTools.clear();
   state.allToolComponents = [];
+  state.allSlashCommandComponents = [];
   state.allSystemReminderComponents = [];
   state.allShellComponents = [];
   // Clear file tracking in display state (thread_created will also reset this)

--- a/mastracode/src/tui/commands/new.ts
+++ b/mastracode/src/tui/commands/new.ts
@@ -8,6 +8,7 @@ export function handleNewCommand(ctx: SlashCommandContext): void {
   state.pendingTools.clear();
   state.allToolComponents = [];
   state.allSystemReminderComponents = [];
+  state.allShellComponents = [];
   // Clear file tracking in display state (thread_created will also reset this)
   state.harness.getDisplayState().modifiedFiles.clear();
   if (state.taskProgress) {

--- a/mastracode/src/tui/commands/resource.ts
+++ b/mastracode/src/tui/commands/resource.ts
@@ -43,6 +43,7 @@ export async function handleResourceCommand(ctx: SlashCommandContext, args: stri
     state.pendingTools.clear();
     state.allToolComponents = [];
     state.allSystemReminderComponents = [];
+    state.allShellComponents = [];
     state.pendingNewThread = false;
     await ctx.renderExistingMessages();
     ctx.showInfo(
@@ -55,6 +56,7 @@ export async function handleResourceCommand(ctx: SlashCommandContext, args: stri
     state.pendingTools.clear();
     state.allToolComponents = [];
     state.allSystemReminderComponents = [];
+    state.allShellComponents = [];
     state.pendingNewThread = true;
     ctx.showInfo(
       sub === 'reset'

--- a/mastracode/src/tui/commands/threads.ts
+++ b/mastracode/src/tui/commands/threads.ts
@@ -146,6 +146,7 @@ export async function handleThreadsCommand(ctx: SlashCommandContext): Promise<vo
         state.chatContainer.clear();
         state.allToolComponents = [];
         state.allSystemReminderComponents = [];
+        state.allShellComponents = [];
         state.pendingTools.clear();
         await ctx.renderExistingMessages();
 

--- a/mastracode/src/tui/components/shell-output.ts
+++ b/mastracode/src/tui/components/shell-output.ts
@@ -140,7 +140,7 @@ export class ShellStreamComponent extends Container {
     if (displayLines.length > 0) {
       const maxVisible = this.expanded ? MAX_LINES : COLLAPSED_LINES;
       const truncated = displayLines.length > maxVisible;
-      const visibleLines = truncated ? displayLines.slice(0, maxVisible) : displayLines;
+      const visibleLines = truncated ? displayLines.slice(-maxVisible) : displayLines;
 
       const borderedLines = visibleLines.map(line => {
         const truncatedLine = truncateAnsi(line, maxLineWidth);

--- a/mastracode/src/tui/components/shell-output.ts
+++ b/mastracode/src/tui/components/shell-output.ts
@@ -8,6 +8,7 @@ import stripAnsi from 'strip-ansi';
 import { getTermWidth, theme } from '../theme.js';
 
 const MAX_LINES = 200;
+const COLLAPSED_LINES = 20;
 
 /** Truncate a string with ANSI codes to a visible width.
  *  Handles both SGR sequences (\x1b[...m) and OSC 8 hyperlinks (\x1b]8;...;\x07).
@@ -64,6 +65,7 @@ export class ShellStreamComponent extends Container {
   private trailingPartial = '';
   private exitCode?: number;
   private startTime = Date.now();
+  private expanded = false;
 
   constructor(command: string) {
     super();
@@ -81,6 +83,15 @@ export class ShellStreamComponent extends Container {
       this.lines = this.lines.slice(-MAX_LINES);
     }
     this.rebuild();
+  }
+
+  setExpanded(expanded: boolean): void {
+    this.expanded = expanded;
+    this.rebuild();
+  }
+
+  isExpanded(): boolean {
+    return this.expanded;
   }
 
   finish(exitCode: number): void {
@@ -127,10 +138,21 @@ export class ShellStreamComponent extends Container {
     while (displayLines.length > 0 && displayLines[0] === '') displayLines.shift();
 
     if (displayLines.length > 0) {
-      const borderedLines = displayLines.map(line => {
-        const truncated = truncateAnsi(line, maxLineWidth);
-        return border('│') + ' ' + truncated;
+      const maxVisible = this.expanded ? MAX_LINES : COLLAPSED_LINES;
+      const truncated = displayLines.length > maxVisible;
+      const visibleLines = truncated ? displayLines.slice(0, maxVisible) : displayLines;
+
+      const borderedLines = visibleLines.map(line => {
+        const truncatedLine = truncateAnsi(line, maxLineWidth);
+        return border('│') + ' ' + truncatedLine;
       });
+
+      if (truncated) {
+        const remaining = displayLines.length - maxVisible;
+        const action = this.expanded ? 'collapse' : 'expand';
+        borderedLines.push(border('│') + ' ' + theme.fg('muted', `... ${remaining} more lines (Ctrl+E to ${action})`));
+      }
+
       const displayOutput = borderedLines.join('\n');
       if (displayOutput.trim()) {
         this.addChild(new Text(displayOutput, 0, 0));

--- a/mastracode/src/tui/prune-chat.ts
+++ b/mastracode/src/tui/prune-chat.ts
@@ -22,4 +22,7 @@ export function pruneChatContainer(state: TUIState): void {
   );
   state.allSlashCommandComponents = state.allSlashCommandComponents.filter(component => !removed.has(component));
   state.allSystemReminderComponents = state.allSystemReminderComponents.filter(component => !removed.has(component));
+  state.allShellComponents = state.allShellComponents.filter(
+    component => !removed.has(component as unknown as Component),
+  );
 }

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -192,6 +192,7 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
   state.allToolComponents = [];
   state.allSlashCommandComponents = [];
   state.allSystemReminderComponents = [];
+  state.allShellComponents = [];
 
   // Local accumulator for detecting task clears during history reconstruction
   let previousTasksAcc: TaskItem[] = [];

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -121,6 +121,9 @@ export function setupKeyboardShortcuts(
     for (const reminder of state.allSystemReminderComponents) {
       reminder.setExpanded(state.toolOutputExpanded);
     }
+    for (const shell of state.allShellComponents) {
+      shell.setExpanded(state.toolOutputExpanded);
+    }
     state.ui.requestRender();
   });
 

--- a/mastracode/src/tui/shell.ts
+++ b/mastracode/src/tui/shell.ts
@@ -13,6 +13,10 @@ export async function handleShellPassthrough(state: TUIState, command: string): 
   }
 
   const component = new ShellStreamComponent(command);
+  if (state.toolOutputExpanded) {
+    component.setExpanded(true);
+  }
+  state.allShellComponents.push(component);
   state.chatContainer.addChild(component);
   state.ui.requestRender();
 

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -23,6 +23,7 @@ import type { GradientAnimator } from './components/obi-loader.js';
 import type { OMMarkerComponent } from './components/om-marker.js';
 import type { OMProgressComponent } from './components/om-progress.js';
 import type { PlanApprovalInlineComponent } from './components/plan-approval-inline.js';
+import type { ShellStreamComponent } from './components/shell-output.js';
 import type { SlashCommandComponent } from './components/slash-command.js';
 import type { SubagentExecutionComponent } from './components/subagent-execution.js';
 import type { SystemReminderComponent } from './components/system-reminder.js';
@@ -111,6 +112,8 @@ export interface TUIState {
   allSlashCommandComponents: SlashCommandComponent[];
   /** Track inline system reminders for expand/collapse */
   allSystemReminderComponents: SystemReminderComponent[];
+  /** Track shell passthrough components for expand/collapse */
+  allShellComponents: ShellStreamComponent[];
   /** Track active subagent tasks */
   pendingSubagents: Map<string, SubagentExecutionComponent>;
   toolOutputExpanded: boolean;
@@ -232,6 +235,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
     allToolComponents: [],
     allSlashCommandComponents: [],
     allSystemReminderComponents: [],
+    allShellComponents: [],
     pendingSubagents: new Map(),
     toolOutputExpanded: false,
     hideThinkingBlock: true,


### PR DESCRIPTION
Shell output now defaults to 20 lines collapsed with Ctrl+E to expand/collapse, matching the existing tool call output behavior.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

When you run shell commands in the chat (starting with `!`), they can produce lots of output. This PR makes that output "collapsible" — it now shows only the last 20 lines by default, but you can press Ctrl+E to expand it and see everything, just like how tool outputs already work.

## Overview

This PR implements collapsible output functionality for shell passthrough commands (`!` commands), matching the existing behavior for tool call outputs. Shell output now defaults to displaying the last 20 lines in a collapsed state, with the ability to expand/collapse using Ctrl+E.

## Key Changes

### State Management
- Added `allShellComponents: ShellStreamComponent[]` array to `TUIState` to track all shell components across the application, enabling centralized expand/collapse control
- Updated state initialization in `createTUIState()` to include the new array

### Component-Level Expansion
- Enhanced `ShellStreamComponent` with:
  - `expanded` state property
  - `setExpanded(expanded: boolean)` method to control visibility mode
  - `isExpanded()` method to query current state
  - Conditional rendering: shows last 20 lines when collapsed, up to 200 lines when expanded
  - Visual indicator showing number of hidden lines and "Ctrl+E to expand/collapse" hint when collapsed

### Command Handlers Integration
- `handleShellPassthrough()`: Now tracks created shell components in `state.allShellComponents` and applies `state.toolOutputExpanded` setting to new components
- `setupKeyboardShortcuts()`: Updated Ctrl+E handler (`expandTools`) to toggle `expanded` state on all shell components alongside existing tool components
- `handleNewCommand()`, `handleResourceCommand()`, `handleThreadsCommand()`, `resetUIAfterClone()`: Now clear `allShellComponents` during UI resets to prevent stale component references

### Pruning and Rendering
- `pruneChatContainer()`: Prunes shell components from `allShellComponents` using the same removal set applied to other component types
- `renderExistingMessages()`: Clears `allShellComponents` during history re-rendering

### Testing
- Updated test helper to initialize and validate pruning behavior for shell components

## Documentation
Updated changeset documentation to specify that shell output is now collapsible with 20-line default display and Ctrl+E toggle functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->