### PR TITLE
feat: Add SessionExpired component for 401 error handling

### DIFF
--- a/.changeset/bold-carrots-count.md
+++ b/.changeset/bold-carrots-count.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added SessionExpired component and is401UnauthorizedError utility to handle 401 Unauthorized errors gracefully. When a user's token expires and refresh fails, they now see a clear 'Session Expired' message with a 'Log In' button instead of a broken/empty UI state.

--- a/.changeset/modern-streets-warn.md
+++ b/.changeset/modern-streets-warn.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Updated all pages to display SessionExpired component when 401 Unauthorized errors occur after token refresh failure.

--- a/packages/playground-ui/src/ds/components/SessionExpired/SessionExpired.tsx
+++ b/packages/playground-ui/src/ds/components/SessionExpired/SessionExpired.tsx
@@ -1,10 +1,10 @@
 import { LogIn } from 'lucide-react';
 
-import { useSSOLogin } from '@/domains/auth/hooks/use-auth-actions';
-
+import { Icon } from '../../icons/Icon';
 import { Button } from '../Button';
 import { EmptyState } from '../EmptyState';
-import { Icon } from '../../icons/Icon';
+
+import { useSSOLogin } from '@/domains/auth/hooks/use-auth-actions';
 
 export interface SessionExpiredProps {
   /** Custom title override */

--- a/packages/playground-ui/src/ds/components/SessionExpired/SessionExpired.tsx
+++ b/packages/playground-ui/src/ds/components/SessionExpired/SessionExpired.tsx
@@ -1,0 +1,49 @@
+import { LogIn } from 'lucide-react';
+
+import { useSSOLogin } from '@/domains/auth/hooks/use-auth-actions';
+
+import { Button } from '../Button';
+import { EmptyState } from '../EmptyState';
+import { Icon } from '../../icons/Icon';
+
+export interface SessionExpiredProps {
+  /** Custom title override */
+  title?: string;
+  /** Custom description override */
+  description?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+export function SessionExpired({ title, description, className }: SessionExpiredProps) {
+  const { mutate: login, isPending } = useSSOLogin();
+
+  const handleLogin = () => {
+    login(
+      { redirectUri: window.location.href },
+      {
+        onSuccess: data => {
+          window.location.href = data.url;
+        },
+      },
+    );
+  };
+
+  return (
+    <EmptyState
+      className={className}
+      iconSlot={
+        <Icon size="lg" className="text-neutral3">
+          <LogIn />
+        </Icon>
+      }
+      titleSlot={title ?? 'Session Expired'}
+      descriptionSlot={description ?? 'Your session has expired. Please log in again to continue.'}
+      actionSlot={
+        <Button variant="default" onClick={handleLogin} disabled={isPending}>
+          {isPending ? 'Redirecting...' : 'Log in'}
+        </Button>
+      }
+    />
+  );
+}

--- a/packages/playground-ui/src/ds/components/SessionExpired/index.ts
+++ b/packages/playground-ui/src/ds/components/SessionExpired/index.ts
@@ -1,0 +1,2 @@
+export { SessionExpired } from './SessionExpired';
+export type { SessionExpiredProps } from './SessionExpired';

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -26,6 +26,7 @@ export * from './ds/components/CodeEditor/index';
 export * from './ds/components/EmptyState/index';
 export * from './ds/components/Entity/index';
 export * from './ds/components/PermissionDenied';
+export * from './ds/components/SessionExpired';
 export * from './ds/components/Header/index';
 export * from './ds/components/Logo/index';
 export * from './ds/components/Table/index';

--- a/packages/playground-ui/src/lib/query-utils.ts
+++ b/packages/playground-ui/src/lib/query-utils.ts
@@ -27,8 +27,10 @@ export function is401UnauthorizedError(error: unknown): boolean {
 
   // Check error message for client-js pattern: "HTTP error! status: 401"
   if ('message' in error) {
-    const message = (error as { message: string }).message;
-    return message.includes('status: 401');
+    const message = (error as { message: unknown }).message;
+    if (typeof message === 'string') {
+      return /\bstatus:\s*401\b/.test(message);
+    }
   }
 
   return false;
@@ -53,8 +55,10 @@ export function is403ForbiddenError(error: unknown): boolean {
 
   // Check error message for client-js pattern: "HTTP error! status: 403"
   if ('message' in error) {
-    const message = (error as { message: string }).message;
-    return message.includes('status: 403');
+    const message = (error as { message: unknown }).message;
+    if (typeof message === 'string') {
+      return /\bstatus:\s*403\b/.test(message);
+    }
   }
 
   return false;
@@ -81,8 +85,10 @@ export function isNonRetryableError(error: unknown): boolean {
 
   // Check error message for client-js pattern
   if ('message' in error) {
-    const message = (error as { message: string }).message;
-    return HTTP_NO_RETRY_STATUSES.some(code => message.includes(`status: ${code}`));
+    const message = (error as { message: unknown }).message;
+    if (typeof message === 'string') {
+      return HTTP_NO_RETRY_STATUSES.some(code => new RegExp(`\\bstatus:\\s*${code}\\b`).test(message));
+    }
   }
 
   return false;

--- a/packages/playground-ui/src/lib/query-utils.ts
+++ b/packages/playground-ui/src/lib/query-utils.ts
@@ -8,6 +8,33 @@
 const HTTP_NO_RETRY_STATUSES = [400, 401, 403, 404];
 
 /**
+ * Check if error is a 401 Unauthorized response.
+ * Indicates the user's session has expired or token is invalid.
+ * Handles both direct status property and client-js error message format.
+ */
+export function is401UnauthorizedError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  // Check for status property (direct response or wrapped)
+  if ('status' in error && (error as { status: number }).status === 401) {
+    return true;
+  }
+
+  // Check for statusCode property (some HTTP clients)
+  if ('statusCode' in error && (error as { statusCode: number }).statusCode === 401) {
+    return true;
+  }
+
+  // Check error message for client-js pattern: "HTTP error! status: 401"
+  if ('message' in error) {
+    const message = (error as { message: string }).message;
+    return message.includes('status: 401');
+  }
+
+  return false;
+}
+
+/**
  * Check if error is a 403 Forbidden response.
  * Handles both direct status property and client-js error message format.
  */

--- a/packages/playground/src/pages/agents/agent-evaluate/index.tsx
+++ b/packages/playground/src/pages/agents/agent-evaluate/index.tsx
@@ -6,7 +6,9 @@ import {
   useAgentCmsForm,
   Spinner,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
   mapAgentResponseToDataSource,
   useLinkComponent,
 } from '@mastra/playground-ui';
@@ -54,6 +56,14 @@ function AgentEvaluate() {
       return null;
     },
   );
+
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <SessionExpired />
+      </div>
+    );
+  }
 
   if (error && is403ForbiddenError(error)) {
     return (

--- a/packages/playground/src/pages/agents/agent-playground/index.tsx
+++ b/packages/playground/src/pages/agents/agent-playground/index.tsx
@@ -10,7 +10,9 @@ import {
   mapAgentResponseToDataSource,
   Spinner,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import type { AgentDataSource } from '@mastra/playground-ui';
 import { useCallback, useMemo, useState } from 'react';
@@ -75,6 +77,14 @@ function AgentPlayground() {
     },
     [latestVersion?.id],
   );
+
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <SessionExpired />
+      </div>
+    );
+  }
 
   if (error && is403ForbiddenError(error)) {
     return (

--- a/packages/playground/src/pages/agents/agent-review/index.tsx
+++ b/packages/playground/src/pages/agents/agent-review/index.tsx
@@ -2,7 +2,9 @@ import {
   AgentPlaygroundReview,
   Spinner,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
   useLinkComponent,
   useAgent,
 } from '@mastra/playground-ui';
@@ -13,6 +15,14 @@ function AgentReview() {
   const { navigate } = useLinkComponent();
 
   const { data: codeAgent, isLoading, error } = useAgent(agentId!);
+
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <SessionExpired />
+      </div>
+    );
+  }
 
   if (error && is403ForbiddenError(error)) {
     return (

--- a/packages/playground/src/pages/agents/agent/index.tsx
+++ b/packages/playground/src/pages/agents/agent/index.tsx
@@ -17,7 +17,9 @@ import {
   ActivatedSkillsProvider,
   SchemaRequestContextProvider,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import type { AgentSettingsType } from '@mastra/playground-ui';
 import { useEffect, useMemo } from 'react';
@@ -86,6 +88,15 @@ function Agent() {
       },
     };
   }, [agent]);
+
+  // 401 check - session expired, needs re-authentication
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <SessionExpired />
+      </div>
+    );
+  }
 
   // 403 check - permission denied for agents
   if (error && is403ForbiddenError(error)) {

--- a/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
@@ -11,7 +11,9 @@ import {
   ExperimentPageContent,
   ExperimentPageHeader,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import { Database } from 'lucide-react';
 import { useParams, Link } from 'react-router';
@@ -48,6 +50,16 @@ function DatasetExperimentPage() {
       <MainContentLayout>
         <div className="flex items-center justify-center h-full">
           <Spinner />
+        </div>
+      </MainContentLayout>
+    );
+  }
+
+  if (experimentError && is401UnauthorizedError(experimentError)) {
+    return (
+      <MainContentLayout>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
         </div>
       </MainContentLayout>
     );

--- a/packages/playground/src/pages/datasets/dataset/experiments/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/experiments/index.tsx
@@ -10,7 +10,9 @@ import {
   DatasetExperimentsComparison,
   useDataset,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import { Database, GitCompare, ArrowLeft } from 'lucide-react';
 import { useParams, useSearchParams, Link } from 'react-router';
@@ -21,6 +23,16 @@ function CompareDatasetExperimentsPage() {
   const { data: dataset, error } = useDataset(datasetId ?? '');
   const experimentIdA = searchParams.get('baseline') ?? '';
   const experimentIdB = searchParams.get('contender') ?? '';
+
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <MainContentLayout>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
+      </MainContentLayout>
+    );
+  }
 
   if (error && is403ForbiddenError(error)) {
     return (

--- a/packages/playground/src/pages/datasets/dataset/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/index.tsx
@@ -14,7 +14,9 @@ import {
   Icon,
   DatasetCombobox,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import type { DatasetVersion } from '@mastra/playground-ui';
 import { Database, Play } from 'lucide-react';
@@ -53,6 +55,16 @@ function DatasetPage() {
         <MainContentContent>
           <div className="text-neutral3 p-4">Dataset not found</div>
         </MainContentContent>
+      </MainContentLayout>
+    );
+  }
+
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <MainContentLayout>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
       </MainContentLayout>
     );
   }

--- a/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
@@ -22,7 +22,9 @@ import {
   Column,
   ButtonsGroup,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import { Database, ArrowLeft, GitCompareIcon, History, ArrowLeftIcon, DiffIcon, ColumnsIcon } from 'lucide-react';
 import { Fragment, useState } from 'react';
@@ -51,6 +53,16 @@ function DatasetItemsComparePage() {
 
   const { data: itemA } = useDatasetItem(datasetId ?? '', itemIds[0] ?? '');
   const { data: itemB } = useDatasetItem(datasetId ?? '', itemIds[1] ?? '');
+
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <MainContentLayout>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
+      </MainContentLayout>
+    );
+  }
 
   if (error && is403ForbiddenError(error)) {
     return (

--- a/packages/playground/src/pages/datasets/dataset/item/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/index.tsx
@@ -23,7 +23,9 @@ import {
   Column,
   Notice,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import type { DatasetItemVersion } from '@mastra/playground-ui';
 import { format } from 'date-fns';
@@ -204,6 +206,16 @@ function DatasetItemPage() {
         updatedAt: versionToDisplay.updatedAt,
       }
     : null;
+
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <MainContentLayout>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
+      </MainContentLayout>
+    );
+  }
 
   if (error && is403ForbiddenError(error)) {
     return (

--- a/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
@@ -21,7 +21,9 @@ import {
   ButtonsGroup,
   Chip,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import type { DatasetItemVersion } from '@mastra/playground-ui';
 import { format } from 'date-fns';
@@ -79,6 +81,16 @@ function DatasetItemVersionsComparePage() {
     versionNumbers[1] ?? 0,
     dataset?.version,
   );
+
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <MainContentLayout>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
+      </MainContentLayout>
+    );
+  }
 
   if (error && is403ForbiddenError(error)) {
     return (

--- a/packages/playground/src/pages/datasets/dataset/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/versions/index.tsx
@@ -15,7 +15,9 @@ import {
   DatasetCompareVersionToolbar,
   DatasetCompareVersionsList,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import { ArrowLeft, Database, ScaleIcon, HistoryIcon } from 'lucide-react';
 import { useMemo } from 'react';
@@ -53,6 +55,16 @@ function DatasetCompareVersionsPage() {
   // Lookup maps to resolve each item's version in A and B
   const itemsAMap = useMemo(() => new Map(itemsA.map(i => [i.id, i])), [itemsA]);
   const itemsBMap = useMemo(() => new Map(itemsB.map(i => [i.id, i])), [itemsB]);
+
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <MainContentLayout>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
+      </MainContentLayout>
+    );
+  }
 
   if (error && is403ForbiddenError(error)) {
     return (

--- a/packages/playground/src/pages/experiments/experiment/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/index.tsx
@@ -11,7 +11,9 @@ import {
   ExperimentPageContent,
   ExperimentPageHeader,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import { FlaskConical } from 'lucide-react';
 import { useParams, Link } from 'react-router';
@@ -51,6 +53,16 @@ function ExperimentPage() {
       <MainContentLayout>
         <div className="flex items-center justify-center h-full">
           <Spinner />
+        </div>
+      </MainContentLayout>
+    );
+  }
+
+  if (experimentError && is401UnauthorizedError(experimentError)) {
+    return (
+      <MainContentLayout>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
         </div>
       </MainContentLayout>
     );

--- a/packages/playground/src/pages/observability/index.tsx
+++ b/packages/playground/src/pages/observability/index.tsx
@@ -21,7 +21,9 @@ import {
   useEnvironments,
   useServiceNames,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 
 import { BookIcon, EyeIcon } from 'lucide-react';
@@ -311,6 +313,39 @@ export default function Observability() {
     }
     return ordered;
   }, [traces, groupByThread]);
+
+  // 401 check - session expired, needs re-authentication
+  if (TracesError && is401UnauthorizedError(TracesError)) {
+    return (
+      <EntityListPageLayout>
+        <EntityListPageLayout.Top>
+          <MainHeader withMargins={false}>
+            <MainHeader.Column>
+              <MainHeader.Title>
+                <EyeIcon /> Observability
+              </MainHeader.Title>
+              <MainHeader.Description>Explore observability traces for your entities</MainHeader.Description>
+            </MainHeader.Column>
+            <MainHeader.Column className="flex justify-end gap-2">
+              <ButtonWithTooltip
+                as="a"
+                href="https://mastra.ai/en/docs/observability/tracing/overview"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Observability documentation"
+                tooltipContent="Go to Observability documentation"
+              >
+                <BookIcon />
+              </ButtonWithTooltip>
+            </MainHeader.Column>
+          </MainHeader>
+        </EntityListPageLayout.Top>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
+      </EntityListPageLayout>
+    );
+  }
 
   // 403 check - permission denied for traces
   if (TracesError && is403ForbiddenError(TracesError)) {

--- a/packages/playground/src/pages/processors/processor/index.tsx
+++ b/packages/playground/src/pages/processors/processor/index.tsx
@@ -12,13 +12,39 @@ import {
   useProcessor,
   Skeleton,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import { Link, useParams, Navigate } from 'react-router';
 
 export function Processor() {
   const { processorId } = useParams();
   const { data: processor, isLoading, error } = useProcessor(processorId!);
+
+  // 401 check - session expired
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <div className="h-full w-full overflow-y-hidden">
+        <Header>
+          <Breadcrumb>
+            <Crumb as={Link} to={`/processors`}>
+              <Icon>
+                <ProcessorIcon />
+              </Icon>
+              Processors
+            </Crumb>
+            <Crumb as="span" to="" isCurrent>
+              {processorId}
+            </Crumb>
+          </Breadcrumb>
+        </Header>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
+      </div>
+    );
+  }
 
   // 403 check - permission denied for processors
   if (error && is403ForbiddenError(error)) {

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -24,7 +24,9 @@ import {
   toast,
   Spinner,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import type { ScoreEntityOption as EntityOptions } from '@mastra/playground-ui';
 import { GaugeIcon, PencilIcon } from 'lucide-react';
@@ -176,6 +178,30 @@ export default function Scorer() {
     setDialogIsOpen(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, scores]);
+
+  if (scorerError && is401UnauthorizedError(scorerError)) {
+    return (
+      <MainContentLayout>
+        <Header>
+          <Breadcrumb>
+            <Crumb as={Link} to={`/evaluation?tab=scorers`}>
+              <Icon>
+                <GaugeIcon />
+              </Icon>
+              Scorers
+            </Crumb>
+            <Crumb as="span" to="" isCurrent>
+              {scorerId}
+            </Crumb>
+          </Breadcrumb>
+        </Header>
+
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
+      </MainContentLayout>
+    );
+  }
 
   if (scorerError && is403ForbiddenError(scorerError)) {
     return (

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -179,7 +179,11 @@ export default function Scorer() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, scores]);
 
-  if (scorerError && is401UnauthorizedError(scorerError)) {
+  if (
+    is401UnauthorizedError(scorerError) ||
+    is401UnauthorizedError(agentsError) ||
+    is401UnauthorizedError(workflowsError)
+  ) {
     return (
       <MainContentLayout>
         <Header>

--- a/packages/playground/src/pages/workflows/workflow/index.tsx
+++ b/packages/playground/src/pages/workflows/workflow/index.tsx
@@ -1,9 +1,25 @@
-import { WorkflowGraph, useWorkflow, PermissionDenied, is403ForbiddenError } from '@mastra/playground-ui';
+import {
+  WorkflowGraph,
+  useWorkflow,
+  PermissionDenied,
+  SessionExpired,
+  is403ForbiddenError,
+  is401UnauthorizedError,
+} from '@mastra/playground-ui';
 import { useParams } from 'react-router';
 
 export const Workflow = () => {
   const { workflowId } = useParams();
   const { data: workflow, isLoading, error } = useWorkflow(workflowId!);
+
+  // 401 check - session expired, needs re-authentication
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <SessionExpired />
+      </div>
+    );
+  }
 
   // 403 check - permission denied for workflows
   if (error && is403ForbiddenError(error)) {

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -25,7 +25,9 @@ import {
   useWorkspaceFile,
   isWorkspaceNotSupportedError,
   is403ForbiddenError,
+  is401UnauthorizedError,
   PermissionDenied,
+  SessionExpired,
   // Skills.sh
   AddSkillDialog,
   useInstallSkill,
@@ -70,6 +72,9 @@ export default function Workspace() {
     isLoading: isLoadingInfo,
     error: workspaceInfoError,
   } = useWorkspaceInfo(effectiveWorkspaceId);
+
+  // Check if 401 unauthorized (session expired)
+  const isSessionExpired = is401UnauthorizedError(workspacesError) || is401UnauthorizedError(workspaceInfoError);
 
   // Check if 403 forbidden (permission denied)
   const isPermissionDenied = is403ForbiddenError(workspacesError) || is403ForbiddenError(workspaceInfoError);
@@ -296,6 +301,39 @@ export default function Workspace() {
   const canSearchFiles = hasFilesystem && (canBM25 || canVector);
   const canSearchSkills = hasSkills && isSkillsConfigured && skills.length > 0;
   const hasSearchCapability = canSearchFiles || canSearchSkills;
+
+  // If session expired (401 error)
+  if (isSessionExpired) {
+    return (
+      <MainContentLayout>
+        <Header>
+          <HeaderTitle>
+            <Icon>
+              <Folder className="h-4 w-4" />
+            </Icon>
+            Workspace
+          </HeaderTitle>
+
+          <HeaderAction>
+            <Button
+              as={Link}
+              to="https://mastra.ai/en/docs/workspace/overview"
+              target="_blank"
+              variant="ghost"
+              size="md"
+            >
+              <DocsIcon />
+              Workspaces documentation
+            </Button>
+          </HeaderAction>
+        </Header>
+
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
+      </MainContentLayout>
+    );
+  }
 
   // If permission denied (403 error)
   if (isPermissionDenied) {

--- a/packages/playground/src/pages/workspace/skills/[skillName]/index.tsx
+++ b/packages/playground/src/pages/workspace/skills/[skillName]/index.tsx
@@ -13,7 +13,9 @@ import {
   useWorkspaceSkillReference,
   useWorkspaceFile,
   PermissionDenied,
+  SessionExpired,
   is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { Bot, Folder, Wand2 } from 'lucide-react';
@@ -124,6 +126,18 @@ export default function WorkspaceSkillDetailPage() {
         <Header>{renderBreadcrumb('Loading...')}</Header>
         <div className="grid place-items-center h-full">
           <div className="h-8 w-8 border-2 border-accent1 border-t-transparent rounded-full animate-spin" />
+        </div>
+      </MainContentLayout>
+    );
+  }
+
+  // 401 check - session expired
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <MainContentLayout>
+        <Header>{renderBreadcrumb('Session Expired')}</Header>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
         </div>
       </MainContentLayout>
     );


### PR DESCRIPTION
## Summary

When a user's token expires and the refresh fails, they previously saw a broken/empty UI. This PR adds graceful error handling that displays a "Session Expired" message with a "Log In" button.

## Changes

### @mastra/playground-ui
- Added `is401UnauthorizedError()` utility function to `query-utils.ts` (mirrors existing `is403ForbiddenError()` pattern)
- Created `SessionExpired` component that displays:
  - "Session Expired" title
  - "Your session has expired. Please log in again to continue." message
  - "Log In" button that logs out and redirects to login

### @mastra/playground
- Updated all 18 pages that handle 403 errors to also handle 401 errors
- Pages now check for 401 before 403 and render `SessionExpired` component

## Affected Pages
- Agents (4 pages): agent, agent-evaluate, agent-playground, agent-review
- Datasets (7 pages): dataset, experiments, experiment, item, item/compare, item/versions, versions
- Experiments (1 page)
- Observability (1 page)
- Processors (1 page)
- Scorers (1 page)
- Workflows (1 page)
- Workspace (2 pages): index, skills/[skillName]

## Test Plan
1. Start the playground with auth enabled
2. Log in successfully
3. Invalidate the token (e.g., clear the session on the server)
4. Navigate to any page that fetches protected data
5. Verify the "Session Expired" UI appears instead of a broken state
6. Click "Log In" and verify redirect to login page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session expiration handling across the app. When authentication fails, users now see a clear "Session Expired" message with a login option instead of broken or empty UI states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->