### PR TITLE
fix(auth-studio): check memberOrgIds for cross-org access

### DIFF
--- a/auth/studio/src/index.test.ts
+++ b/auth/studio/src/index.test.ts
@@ -37,6 +37,7 @@ const mockMeResponse = {
   organizationId: 'org-1',
   role: 'admin',
   permissions: ['projects:read', 'projects:write'],
+  memberOrgIds: ['org-1'],
 };
 
 const mockVerifyResponse = {
@@ -48,6 +49,7 @@ const mockVerifyResponse = {
   },
   organizationId: 'org-2',
   role: 'member',
+  memberOrgIds: ['org-2'],
 };
 
 // ---------------------------------------------------------------------------
@@ -125,6 +127,7 @@ describe('MastraAuthStudio', () => {
         organizationId: 'org-1',
         role: 'admin',
         permissions: ['projects:read', 'projects:write'],
+        memberOrgIds: ['org-1'],
       });
 
       // Should have called /auth/me with the cookie
@@ -150,6 +153,7 @@ describe('MastraAuthStudio', () => {
         name: 'Bob',
         organizationId: 'org-2',
         role: 'member',
+        memberOrgIds: ['org-2'],
       });
 
       // Should have called /auth/verify with the bearer token
@@ -178,6 +182,7 @@ describe('MastraAuthStudio', () => {
         name: 'Bob',
         organizationId: 'org-2',
         role: 'member',
+        memberOrgIds: ['org-2'],
       });
 
       expect(fetchSpy).toHaveBeenCalledTimes(2);
@@ -337,6 +342,7 @@ describe('MastraAuthStudio', () => {
         organizationId: 'org-1',
         role: 'admin',
         permissions: ['projects:read', 'projects:write'],
+        memberOrgIds: ['org-1'],
       });
       expect(result.tokens.accessToken).toBe('sealed-session-token');
       // cookies should NOT be returned — the Mastra server fallback path

--- a/auth/studio/src/index.test.ts
+++ b/auth/studio/src/index.test.ts
@@ -869,6 +869,27 @@ describe('MastraAuthStudio org-scoping', () => {
     const user = await auth.authenticateToken('', req);
     expect(user).toBeNull();
   });
+
+  it('should allow user when current org differs but memberOrgIds includes instance org (cross-org access)', async () => {
+    // This is the core fix: user's "current" org is org-1, but they're also a member of org-owner
+    // The deployed studio belongs to org-owner, so access should be allowed
+    const auth = new MastraAuthStudio({ sharedApiUrl: SHARED_API, organizationId: 'org-owner' });
+
+    const multiOrgResponse = {
+      ...mockMeResponse,
+      organizationId: 'org-1', // user's current org
+      memberOrgIds: ['org-1', 'org-owner'], // user is member of both orgs
+    };
+
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(multiOrgResponse), { status: 200 }));
+
+    const req = mockRequest({ cookie: 'wos-session=sealed-token' });
+    const user = await auth.authenticateToken('', req);
+
+    expect(user).not.toBeNull();
+    expect(user!.organizationId).toBe('org-1'); // current org unchanged
+    expect(user!.memberOrgIds).toContain('org-owner'); // but they're a member of instance org
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/auth/studio/src/index.ts
+++ b/auth/studio/src/index.ts
@@ -19,6 +19,8 @@ export interface StudioUser extends EEUser {
   organizationId?: string;
   role?: string;
   permissions?: string[];
+  /** All organization IDs the user is a member of (for cross-org access checks) */
+  memberOrgIds?: string[];
 }
 
 export interface MastraAuthStudioOptions extends MastraAuthProviderOptions<StudioUser> {
@@ -121,8 +123,9 @@ export class MastraAuthStudio
 
     if (!user) return null;
 
-    // Org-scoping: if this instance belongs to a specific org, reject users not in that org
-    if (this.organizationId && user.organizationId !== this.organizationId) {
+    // Org-scoping: if this instance belongs to a specific org, reject users not a member of that org
+    // Check memberOrgIds (all orgs user belongs to) rather than organizationId (current org)
+    if (this.organizationId && !user.memberOrgIds?.includes(this.organizationId)) {
       return null;
     }
 
@@ -385,6 +388,7 @@ export class MastraAuthStudio
         organizationId: string;
         role?: string;
         permissions?: string[];
+        memberOrgIds?: string[];
       };
 
       return {
@@ -395,6 +399,7 @@ export class MastraAuthStudio
         organizationId: data.organizationId,
         role: data.role,
         permissions: data.permissions,
+        memberOrgIds: data.memberOrgIds,
       };
     } catch {
       return null;
@@ -424,6 +429,7 @@ export class MastraAuthStudio
         };
         organizationId: string;
         role?: string;
+        memberOrgIds?: string[];
       };
 
       return {
@@ -432,6 +438,7 @@ export class MastraAuthStudio
         name: [data.user.firstName, data.user.lastName].filter(Boolean).join(' ') || undefined,
         organizationId: data.organizationId,
         role: data.role,
+        memberOrgIds: data.memberOrgIds,
       };
     } catch {
       return null;


### PR DESCRIPTION
## Problem

Users with memberships in multiple orgs couldn't access deployed studios belonging to a different org than their 'current' org.

The issue was in `MastraAuthStudio.authenticateToken()`:
```typescript
if (this.organizationId && user.organizationId !== this.organizationId) {
  return null;
}
```

This compared the user's **current** org against the deployed instance's org, blocking access even when the user is a member of both orgs.

## Solution

Check `memberOrgIds` (all orgs user belongs to) instead of `organizationId` (current org):
```typescript
if (this.organizationId && !user.memberOrgIds?.includes(this.organizationId)) {
  return null;
}
```

### Changes

- **`verifySessionCookie()`**: Parse `memberOrgIds` from `/auth/me` response
- **`verifyBearerToken()`**: Parse `memberOrgIds` from `/auth/verify` response  
- **`StudioUser` interface**: Add `memberOrgIds?: string[]`
- **Org-scoping check**: Use `memberOrgIds.includes()` instead of direct comparison
- **Tests**: Updated fixtures and expectations

## Related PR

Companion PR in platform repo: mastra-ai/platform#455 (adds `memberOrgIds` to session and auth responses)

## Testing

```bash
cd auth/studio && pnpm vitest run
# 81 tests pass
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication now recognizes users as members of multiple organizations, allowing access when the instance organization appears in a user's membership list while preserving the user's reported primary organization.
* **Tests**
  * Added a cross-organization test verifying access when instance org differs from the user's primary org but is included in their memberships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->