### PR TITLE
fix: prefix gateway provider IDs to prevent duplicate entries

### DIFF
--- a/.changeset/old-views-shop.md
+++ b/.changeset/old-views-shop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed duplicate provider entries when fetching providers from gateways by applying consistent ID prefixing

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -179,7 +179,7 @@ describe('getProvidersHandler', () => {
       name: 'Test Gateway',
       getId: () => 'test-gateway',
       fetchProviders: vi.fn().mockResolvedValue({
-        'test-gateway/custom-llm': {
+        'custom-llm': {
           name: 'Custom LLM',
           models: ['custom-model-1', 'custom-model-2'],
           apiKeyEnvVar: 'CUSTOM_LLM_API_KEY',

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -1247,7 +1247,12 @@ export const GET_PROVIDERS_ROUTE = createRoute({
             try {
               const gatewayProviders = await gateway.fetchProviders();
               for (const [providerId, config] of Object.entries(gatewayProviders)) {
-                allProviders[providerId] = config;
+                // Apply the same prefixing logic as registry-generator to avoid
+                // creating duplicate entries alongside PROVIDER_REGISTRY data.
+                // If providerId matches gateway.id, it's a unified gateway — use just the gateway ID.
+                // Otherwise, prefix with gateway.id (e.g., "netlify/anthropic").
+                const prefixedId = providerId === gateway.id ? gateway.id : `${gateway.id}/${providerId}`;
+                allProviders[prefixedId] = config;
               }
             } catch (error) {
               console.warn(`Failed to fetch providers from gateway "${gateway.id}":`, error);


### PR DESCRIPTION
## Description

When fetching providers from gateways, provider IDs were stored as-is, which could create duplicate entries alongside data from `PROVIDER_REGISTRY`. This fix applies the same prefixing logic used by `registry-generator` — if the provider ID matches the gateway ID, it uses just the gateway ID; otherwise, it prefixes with `gateway.id/providerId` (e.g., `netlify/anthropic`).

## Related Issue(s)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where duplicate provider entries appeared when fetching providers from gateways. Provider IDs are now consistently prefixed to ensure unique identification across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->