### PR TITLE
fix(observability): MODEL_STEP span input shows raw HTTP request instead of messages

### DIFF
--- a/.changeset/icy-sides-act.md
+++ b/.changeset/icy-sides-act.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': patch
+---
+
+Added support for Gemini content format in Datadog input formatting. Gemini messages with {role, parts} are now normalized to {role, content} instead of being stringified.

--- a/.changeset/plenty-masks-obey.md
+++ b/.changeset/plenty-masks-obey.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed MODEL_STEP span input containing the entire raw HTTP request body instead of just the messages. Observability exporters (Datadog, Langfuse, etc.) now receive clean message arrays as MODEL_STEP span input.

--- a/observability/datadog/src/utils.test.ts
+++ b/observability/datadog/src/utils.test.ts
@@ -145,6 +145,18 @@ describe('formatInput', () => {
       const result = formatInput({ query: 'search term', filters: { date: '2024' } }, SpanType.MODEL_GENERATION);
       expect(result).toEqual([{ role: 'user', content: '{"query":"search term","filters":{"date":"2024"}}' }]);
     });
+
+    it('normalizes Gemini content array to message format', () => {
+      const contents = [
+        { role: 'user', parts: [{ text: 'Hello' }] },
+        { role: 'model', parts: [{ text: 'Hi ' }, { text: 'there!' }] },
+      ];
+      const result = formatInput(contents, SpanType.MODEL_GENERATION);
+      expect(result).toEqual([
+        { role: 'user', content: 'Hello' },
+        { role: 'model', content: 'Hi there!' },
+      ]);
+    });
   });
 
   describe('non-LLM spans (TOOL_CALL)', () => {

--- a/observability/datadog/src/utils.test.ts
+++ b/observability/datadog/src/utils.test.ts
@@ -157,6 +157,27 @@ describe('formatInput', () => {
         { role: 'model', content: 'Hi there!' },
       ]);
     });
+
+    it('redacts binary data and summarizes tool calls in Gemini parts', () => {
+      const contents = [
+        {
+          role: 'user',
+          parts: [
+            { text: 'Describe this image: ' },
+            { inlineData: { mimeType: 'image/png', data: 'iVBORw0KGgo...base64...' } },
+          ],
+        },
+        {
+          role: 'model',
+          parts: [{ functionCall: { name: 'analyze_image', args: { format: 'png' } } }],
+        },
+      ];
+      const result = formatInput(contents, SpanType.MODEL_GENERATION);
+      expect(result).toEqual([
+        { role: 'user', content: 'Describe this image: [image/png]' },
+        { role: 'model', content: '[tool: analyze_image]' },
+      ]);
+    });
   });
 
   describe('non-LLM spans (TOOL_CALL)', () => {

--- a/observability/datadog/src/utils.ts
+++ b/observability/datadog/src/utils.ts
@@ -119,10 +119,18 @@ function isGeminiContentArray(data: any): data is Array<{ role: string; parts: a
 
 /**
  * Converts a Gemini content item to Datadog message format.
- * Joins text parts into a single content string.
+ * Extracts text from parts, skips binary data to avoid bloating traces.
  */
 function geminiContentToMessage(item: { role: string; parts: any[] }): { role: string; content: string } {
-  const text = item.parts.map(p => (typeof p === 'string' ? p : (p?.text ?? safeStringify(p)))).join('');
+  const text = item.parts
+    .map(p => {
+      if (typeof p === 'string') return p;
+      if (p?.text) return p.text;
+      if (p?.inlineData) return `[${p.inlineData.mimeType ?? 'binary'}]`;
+      if (p?.functionCall) return `[tool: ${p.functionCall.name ?? 'unknown'}]`;
+      return safeStringify(p);
+    })
+    .join('');
   return { role: item.role, content: text };
 }
 

--- a/observability/datadog/src/utils.ts
+++ b/observability/datadog/src/utils.ts
@@ -111,6 +111,22 @@ function isMessageArray(data: any): data is Array<{ role: string; content: any }
 }
 
 /**
+ * Checks if data is in Gemini content array format ({role, parts}[]).
+ */
+function isGeminiContentArray(data: any): data is Array<{ role: string; parts: any[] }> {
+  return Array.isArray(data) && data.every(m => m?.role && Array.isArray(m?.parts));
+}
+
+/**
+ * Converts a Gemini content item to Datadog message format.
+ * Joins text parts into a single content string.
+ */
+function geminiContentToMessage(item: { role: string; parts: any[] }): { role: string; content: string } {
+  const text = item.parts.map(p => (typeof p === 'string' ? p : (p?.text ?? safeStringify(p)))).join('');
+  return { role: item.role, content: text };
+}
+
+/**
  * Formats input data for Datadog annotations.
  * LLM spans use message array format; others use raw or stringified data.
  */
@@ -123,6 +139,10 @@ export function formatInput(input: any, spanType: SpanType): any {
         role: m.role,
         content: typeof m.content === 'string' ? m.content : safeStringify(m.content),
       }));
+    }
+    // Gemini format: {role, parts} → normalize to {role, content}
+    if (isGeminiContentArray(input)) {
+      return input.map(geminiContentToMessage);
     }
     // String input becomes user message
     if (typeof input === 'string') {

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -833,6 +833,38 @@ describe('ModelSpanTracker', () => {
       expect(stepSpans[0]!.input).toEqual({});
     });
 
+    it('should fall back to original request when body is malformed JSON', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const malformedRequest = { body: '{"incomplete":' };
+
+      const chunks = [
+        {
+          type: 'step-start',
+          payload: {
+            messageId: 'msg-1',
+            request: malformedRequest,
+          },
+        },
+        { type: 'text-delta', payload: { text: 'Hi!' } },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+      modelSpan.end();
+
+      const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      expect(stepSpans).toHaveLength(1);
+      expect(stepSpans[0]!.input).toEqual(malformedRequest);
+    });
+
     it('should handle already-parsed body object', async () => {
       const modelSpan = tracing.startSpan({
         type: SpanType.MODEL_GENERATION,

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -719,4 +719,193 @@ describe('ModelSpanTracker', () => {
       expect(stepSpans).toHaveLength(1);
     });
   });
+
+  describe('MODEL_STEP span input extraction', () => {
+    it('should extract messages array from OpenAI-format request body', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const messages = [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'Hello' },
+      ];
+
+      const chunks = [
+        {
+          type: 'step-start',
+          payload: {
+            messageId: 'msg-1',
+            request: {
+              body: JSON.stringify({
+                model: 'gpt-4o',
+                messages,
+                temperature: 0.7,
+                tools: [{ type: 'function', function: { name: 'search' } }],
+              }),
+            },
+          },
+        },
+        { type: 'text-delta', payload: { text: 'Hi!' } },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+      modelSpan.end();
+
+      const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      expect(stepSpans).toHaveLength(1);
+      // Should contain only the messages array, not the entire request
+      expect(stepSpans[0]!.input).toEqual(messages);
+    });
+
+    it('should extract contents array from Google/Gemini-format request body', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const contents = [{ role: 'user', parts: [{ text: 'Hello' }] }];
+
+      const chunks = [
+        {
+          type: 'step-start',
+          payload: {
+            messageId: 'msg-1',
+            request: {
+              body: JSON.stringify({
+                model: 'gemini-2.0-flash',
+                contents,
+                generationConfig: { temperature: 0.7 },
+              }),
+            },
+          },
+        },
+        { type: 'text-delta', payload: { text: 'Hi!' } },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+      modelSpan.end();
+
+      const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      expect(stepSpans).toHaveLength(1);
+      expect(stepSpans[0]!.input).toEqual(contents);
+    });
+
+    it('should handle undefined request body gracefully', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const chunks = [
+        {
+          type: 'step-start',
+          payload: {
+            messageId: 'msg-1',
+            request: {},
+          },
+        },
+        { type: 'text-delta', payload: { text: 'Hi!' } },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+      modelSpan.end();
+
+      const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      expect(stepSpans).toHaveLength(1);
+      // No body — falls back to the original request object
+      expect(stepSpans[0]!.input).toEqual({});
+    });
+
+    it('should handle already-parsed body object', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const messages = [{ role: 'user', content: 'Hello' }];
+
+      const chunks = [
+        {
+          type: 'step-start',
+          payload: {
+            messageId: 'msg-1',
+            request: {
+              body: {
+                model: 'gpt-4o',
+                messages,
+              },
+            },
+          },
+        },
+        { type: 'text-delta', payload: { text: 'Hi!' } },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+      modelSpan.end();
+
+      const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      expect(stepSpans).toHaveLength(1);
+      expect(stepSpans[0]!.input).toEqual(messages);
+    });
+
+    it('should update step input when step-start arrives after startStep()', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const messages = [{ role: 'user', content: 'Hello' }];
+
+      // Start step early (no payload), then step-start chunk arrives with request data
+      tracker.startStep();
+
+      const chunks = [
+        {
+          type: 'step-start',
+          payload: {
+            messageId: 'msg-1',
+            request: {
+              body: JSON.stringify({ model: 'gpt-4o', messages }),
+            },
+          },
+        },
+        { type: 'text-delta', payload: { text: 'Hi!' } },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+      modelSpan.end();
+
+      const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      expect(stepSpans).toHaveLength(1);
+      // updateStep should also extract messages
+      expect(stepSpans[0]!.input).toEqual(messages);
+    });
+  });
 });

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -22,18 +22,9 @@ import type { ChunkType, StepStartPayload, StepFinishPayload } from '@mastra/cor
 import { extractUsageMetrics } from './usage';
 
 /**
- * Extracts the messages array from a step-start request payload for use as span input.
- *
- * The AI SDK provides the raw HTTP request metadata in `request.body` as a JSON string.
- * This contains the full API request (model, messages, tools, temperature, etc.).
- * For span input, we only want the messages — not the entire request payload.
- *
- * Handles multiple provider formats:
- * - OpenAI/Anthropic: `{ messages: [{role, content}] }`
- * - Google/Gemini: `{ contents: [{role, parts}] }`
- *
- * Falls back to the raw request object if extraction fails (undefined body,
- * invalid JSON, no recognized message field, or body already parsed as object).
+ * Extract messages from the raw AI SDK request metadata for use as span input.
+ * Parses request.body and returns `messages` (OpenAI/Anthropic) or `contents` (Gemini).
+ * Falls back to the original request object when body is missing or unparseable.
  */
 function extractStepInput(request: StepStartPayload['request'] | undefined): unknown {
   if (!request) return undefined;

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -22,6 +22,44 @@ import type { ChunkType, StepStartPayload, StepFinishPayload } from '@mastra/cor
 import { extractUsageMetrics } from './usage';
 
 /**
+ * Extracts the messages array from a step-start request payload for use as span input.
+ *
+ * The AI SDK provides the raw HTTP request metadata in `request.body` as a JSON string.
+ * This contains the full API request (model, messages, tools, temperature, etc.).
+ * For span input, we only want the messages — not the entire request payload.
+ *
+ * Handles multiple provider formats:
+ * - OpenAI/Anthropic: `{ messages: [{role, content}] }`
+ * - Google/Gemini: `{ contents: [{role, parts}] }`
+ *
+ * Falls back to the raw request object if extraction fails (undefined body,
+ * invalid JSON, no recognized message field, or body already parsed as object).
+ */
+function extractStepInput(request: StepStartPayload['request'] | undefined): unknown {
+  if (!request) return undefined;
+
+  const { body } = request;
+  if (body == null) return request;
+
+  try {
+    const parsed = typeof body === 'string' ? JSON.parse(body) : body;
+
+    // OpenAI / Anthropic / most providers
+    if (Array.isArray(parsed?.messages)) return parsed.messages;
+
+    // Google / Gemini
+    if (Array.isArray(parsed?.contents)) return parsed.contents;
+
+    // Unrecognized structure — return the full parsed body so exporters at
+    // least get the object rather than the stringified HTTP request wrapper
+    return parsed;
+  } catch {
+    // body was not valid JSON — return as-is
+    return request;
+  }
+}
+
+/**
  * Manages MODEL_STEP and MODEL_CHUNK span tracking for streaming Model responses.
  *
  * Should be instantiated once per MODEL_GENERATION span and shared across
@@ -109,7 +147,7 @@ export class ModelSpanTracker {
         ...(payload?.messageId ? { messageId: payload.messageId } : {}),
         ...(payload?.warnings?.length ? { warnings: payload.warnings } : {}),
       },
-      input: payload?.request,
+      input: extractStepInput(payload?.request),
     });
     // Reset chunk sequence for new step
     this.#chunkSequence = 0;
@@ -126,7 +164,7 @@ export class ModelSpanTracker {
 
     // Update span with request/warnings from the step-start chunk
     this.#currentStepSpan.update({
-      input: payload.request,
+      input: extractStepInput(payload.request),
       attributes: {
         ...(payload.messageId ? { messageId: payload.messageId } : {}),
         ...(payload.warnings?.length ? { warnings: payload.warnings } : {}),


### PR DESCRIPTION
## Description

MODEL_STEP span input was being set to the raw AI SDK request metadata object (`{body: "<entire HTTP request JSON>"}`), which contains the full HTTP body sent to the provider  (model name, system prompt, all tools, all messages, temperature, etc.).

Observability exporters like Datadog received this raw object and rendered the entire API request as a single stringified user message — breaking customer evaluation pipelines that expect structured `{role, content}` message arrays.

Added `extractStepInput()` in `model-tracing.ts` that parses `request.body` and extracts the actual messages array:
- `messages` for OpenAI/Anthropic providers
- `contents` for Google/Gemini providers
- Falls back to the original request object for unrecognized formats or missing body

Verified with a real Gemini 2.5 Flash API call that before the fix span input was `{"body":"{\"generationConfig\":{...},\"contents\":[...]}"}` and after the fix it is `[{"role":"user","parts":[{"text":"..."}]}]`.

## Related Issue(s)

Customer-reported issue: MODEL_STEP span input in Datadog traces contains the entire raw OpenAI API request JSON instead of clean messages.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MODEL_STEP spans now capture only message arrays (not full request bodies), producing cleaner telemetry.
  * Datadog input formatting normalizes Gemini-style messages into {role, content}, redacts inline binary payloads (placeholder like [image/png]) and represents function/tool calls as tool placeholders.

* **Tests**
  * Added coverage for message extraction, Gemini normalization, redaction behavior, malformed/missing bodies, and out-of-order events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->