### PR TITLE
fix: preserve system reminders and filter them at query time

### DIFF
--- a/.changeset/flat-boxes-thank.md
+++ b/.changeset/flat-boxes-thank.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed AGENTS.md reminder persistence and deduplication across turns by storing reminder metadata on injected user messages.

--- a/.changeset/fuzzy-rivers-listen.md
+++ b/.changeset/fuzzy-rivers-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Added an `includeSystemReminders` option to `listThreadMessages()` and memory thread message listing so clients can opt into raw system reminder history when needed.

--- a/.changeset/some-mirrors-cross.md
+++ b/.changeset/some-mirrors-cross.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed recall() to hide dynamic system reminder messages by default, with includeSystemReminders available when callers need raw reminder history.

--- a/.changeset/thick-jobs-play.md
+++ b/.changeset/thick-jobs-play.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved chat rendering for system reminder messages by showing a collapsible reminder badge instead of raw XML text.

--- a/client-sdks/client-js/src/client.test.ts
+++ b/client-sdks/client-js/src/client.test.ts
@@ -652,6 +652,51 @@ describe('MastraClient', () => {
         expect(result).toEqual(mockMessages);
       });
 
+      it('should not include system reminders by default', async () => {
+        const mockMessages = {
+          messages: [{ id: 'msg-1', content: 'Hello' }],
+        };
+        (global.fetch as any).mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: { get: () => 'application/json' },
+          json: async () => mockMessages,
+        });
+
+        const result = await client.listThreadMessages('thread-1', {
+          agentId: 'agent-1',
+        });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'http://localhost:4111/api/memory/threads/thread-1/messages?agentId=agent-1',
+          expect.any(Object),
+        );
+        expect(result).toEqual(mockMessages);
+      });
+
+      it('should include system reminders when requested', async () => {
+        const mockMessages = {
+          messages: [{ id: 'msg-1', content: 'Hello' }],
+        };
+        (global.fetch as any).mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: { get: () => 'application/json' },
+          json: async () => mockMessages,
+        });
+
+        const result = await client.listThreadMessages('thread-1', {
+          agentId: 'agent-1',
+          includeSystemReminders: true,
+        });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'http://localhost:4111/api/memory/threads/thread-1/messages?agentId=agent-1&includeSystemReminders=true',
+          expect.any(Object),
+        );
+        expect(result).toEqual(mockMessages);
+      });
+
       it('should list messages without agentId (storage fallback)', async () => {
         const mockMessages = {
           messages: [{ id: 'msg-1', content: 'Hello' }],

--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -308,15 +308,23 @@ export class MastraClient extends BaseResource {
    */
   public listThreadMessages(
     threadId: string,
-    opts: { agentId?: string; networkId?: string; requestContext?: RequestContext | Record<string, any> } = {},
+    opts: {
+      agentId?: string;
+      networkId?: string;
+      requestContext?: RequestContext | Record<string, any>;
+      includeSystemReminders?: boolean;
+    } = {},
   ): Promise<ListMemoryThreadMessagesResponse> {
     let url = '';
+    const includeSystemRemindersQuery =
+      opts.includeSystemReminders === undefined ? '' : `includeSystemReminders=${opts.includeSystemReminders}`;
+
     if (opts.networkId) {
-      url = `/memory/network/threads/${threadId}/messages?networkId=${opts.networkId}${requestContextQueryString(opts.requestContext, '&')}`;
+      url = `/memory/network/threads/${threadId}/messages?networkId=${opts.networkId}${includeSystemRemindersQuery ? `&${includeSystemRemindersQuery}` : ''}${requestContextQueryString(opts.requestContext, includeSystemRemindersQuery ? '&' : '&')}`;
     } else if (opts.agentId) {
-      url = `/memory/threads/${threadId}/messages?agentId=${opts.agentId}${requestContextQueryString(opts.requestContext, '&')}`;
+      url = `/memory/threads/${threadId}/messages?agentId=${opts.agentId}${includeSystemRemindersQuery ? `&${includeSystemRemindersQuery}` : ''}${requestContextQueryString(opts.requestContext, '&')}`;
     } else {
-      url = `/memory/threads/${threadId}/messages${requestContextQueryString(opts.requestContext, '?')}`;
+      url = `/memory/threads/${threadId}/messages${includeSystemRemindersQuery ? `?${includeSystemRemindersQuery}` : ''}${requestContextQueryString(opts.requestContext, includeSystemRemindersQuery ? '&' : '?')}`;
     }
     return this.request(url);
   }

--- a/client-sdks/client-js/src/resources/memory-thread.ts
+++ b/client-sdks/client-js/src/resources/memory-thread.ts
@@ -82,7 +82,7 @@ export class MemoryThread extends BaseResource {
       requestContext?: RequestContext | Record<string, any>;
     } = {},
   ): Promise<ListMemoryThreadMessagesResponse> {
-    const { page, perPage, orderBy, filter, include, resourceId, requestContext } = params;
+    const { page, perPage, orderBy, filter, include, resourceId, requestContext, includeSystemReminders } = params;
     const queryParams: Record<string, string> = {};
 
     if (this.agentId) queryParams.agentId = this.agentId;
@@ -92,6 +92,7 @@ export class MemoryThread extends BaseResource {
     if (orderBy) queryParams.orderBy = JSON.stringify(orderBy);
     if (filter) queryParams.filter = JSON.stringify(filter);
     if (include) queryParams.include = JSON.stringify(include);
+    if (includeSystemReminders !== undefined) queryParams.includeSystemReminders = String(includeSystemReminders);
 
     const query = new URLSearchParams(queryParams);
     const queryString = query.toString();

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -617,7 +617,9 @@ export interface UpdateMemoryThreadParams {
   requestContext?: RequestContext | Record<string, any>;
 }
 
-export type ListMemoryThreadMessagesParams = Omit<StorageListMessagesInput, 'threadId'>;
+export type ListMemoryThreadMessagesParams = Omit<StorageListMessagesInput, 'threadId'> & {
+  includeSystemReminders?: boolean;
+};
 
 export type ListMemoryThreadMessagesResponse = {
   messages: MastraDBMessage[];

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -97,6 +97,48 @@ export const memoryDefaultOptions = {
   },
 } satisfies MemoryConfigInternal;
 
+const SYSTEM_REMINDER_METADATA_KEY = 'dynamicAgentsMdReminder';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function hasSystemReminderText(message: MastraDBMessage): boolean {
+  const parts = isRecord(message.content) ? message.content.parts : undefined;
+  if (!Array.isArray(parts)) {
+    return false;
+  }
+
+  return parts.some(
+    part =>
+      isRecord(part) && part.type === 'text' && typeof part.text === 'string' && part.text.includes('<system-reminder'),
+  );
+}
+
+export function isSystemReminderMessage(message: MastraDBMessage): boolean {
+  if (message.role !== 'user' || !isRecord(message.content)) {
+    return false;
+  }
+
+  const metadata = message.content.metadata;
+  if (isRecord(metadata) && SYSTEM_REMINDER_METADATA_KEY in metadata) {
+    return true;
+  }
+
+  return hasSystemReminderText(message);
+}
+
+export function filterSystemReminderMessages(
+  messages: MastraDBMessage[],
+  includeSystemReminders?: boolean,
+): MastraDBMessage[] {
+  if (includeSystemReminders) {
+    return messages;
+  }
+
+  return messages.filter(message => !isSystemReminderMessage(message));
+}
+
 /**
  * Abstract base class for implementing conversation memory systems.
  *
@@ -467,6 +509,7 @@ https://mastra.ai/en/docs/memory/overview`,
     args: StorageListMessagesInput & {
       threadConfig?: MemoryConfigInternal;
       vectorSearchString?: string;
+      includeSystemReminders?: boolean;
     },
   ): Promise<{
     messages: MastraDBMessage[];

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -14,7 +14,7 @@ import type {
 import { InMemoryStore } from '../storage';
 import { createTool } from '../tools';
 import type { ToolAction } from '../tools';
-import { MastraMemory } from './memory';
+import { filterSystemReminderMessages, MastraMemory } from './memory';
 import type {
   StorageThreadType,
   MemoryConfigInternal,
@@ -96,7 +96,11 @@ export class MockMemory extends MastraMemory {
   }
 
   async recall(
-    args: StorageListMessagesInput & { threadConfig?: MemoryConfigInternal; vectorSearchString?: string },
+    args: StorageListMessagesInput & {
+      threadConfig?: MemoryConfigInternal;
+      vectorSearchString?: string;
+      includeSystemReminders?: boolean;
+    },
   ): Promise<{
     messages: MastraDBMessage[];
     usage?: { tokens: number };
@@ -107,10 +111,18 @@ export class MockMemory extends MastraMemory {
   }> {
     const memoryStorage = await this.getMemoryStore();
     // Extract only the StorageListMessagesInput properties, excluding threadConfig and vectorSearchString
-    const { threadConfig: _threadConfig, vectorSearchString: _vectorSearchString, ...listMessagesArgs } = args;
+    const {
+      threadConfig: _threadConfig,
+      vectorSearchString: _vectorSearchString,
+      includeSystemReminders,
+      ...listMessagesArgs
+    } = args;
     const result = await memoryStorage.listMessages(listMessagesArgs);
 
-    return result;
+    return {
+      ...result,
+      messages: filterSystemReminderMessages(result.messages, includeSystemReminders),
+    };
   }
 
   async deleteThread(threadId: string) {

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -603,6 +603,49 @@ describe('MessageHistory', () => {
       expect(savedMessages.every((m: any) => m.role !== 'system')).toBe(true);
     });
 
+    it('should preserve system-reminder text when persisting non-system user messages', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+
+      const processor = new MessageHistory({
+        storage: mockStorage,
+      });
+
+      const reminderMarkup =
+        '<system-reminder type="dynamic-agents-md" path="/repo/packages/core/AGENTS.md">Core guidance</system-reminder>';
+
+      const messages: MastraDBMessage[] = [
+        {
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: reminderMarkup }] },
+          id: 'msg-reminder',
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList().add(messages, `input`);
+      await processor.processOutputResult({
+        messageList,
+        messages,
+        abort: ((reason?: string) => {
+          throw new Error(reason || 'Aborted');
+        }) as (reason?: string) => never,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedMessages = (mockStorage.saveMessages as any).mock.calls[0][0].messages as MastraDBMessage[];
+      expect(savedMessages).toHaveLength(1);
+      expect(savedMessages[0]?.content.parts).toEqual([{ type: 'text', text: reminderMarkup }]);
+    });
+
     it('should update thread metadata', async () => {
       const mockStorage = {
         saveMessages: vi.fn().mockResolvedValue(undefined),

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -603,7 +603,7 @@ describe('MessageHistory', () => {
       expect(savedMessages.every((m: any) => m.role !== 'system')).toBe(true);
     });
 
-    it('should preserve system-reminder text when persisting non-system user messages', async () => {
+    it('should preserve dynamic system reminders in persisted non-system messages to avoid cache invalidation and re-injection', async () => {
       const mockStorage = {
         saveMessages: vi.fn().mockResolvedValue(undefined),
         getThreadById: vi.fn().mockResolvedValue({
@@ -643,7 +643,14 @@ describe('MessageHistory', () => {
 
       const savedMessages = (mockStorage.saveMessages as any).mock.calls[0][0].messages as MastraDBMessage[];
       expect(savedMessages).toHaveLength(1);
-      expect(savedMessages[0]?.content.parts).toEqual([{ type: 'text', text: reminderMarkup }]);
+      expect(savedMessages[0]).toEqual(
+        expect.objectContaining({
+          role: 'user',
+          content: expect.objectContaining({
+            parts: [{ type: 'text', text: reminderMarkup }],
+          }),
+        }),
+      );
     });
 
     it('should update thread metadata', async () => {

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -1,7 +1,7 @@
 import type { Processor } from '..';
 import type { MastraDBMessage, MessageList } from '../../agent';
 import { parseMemoryRequestContext } from '../../memory';
-import { removeWorkingMemoryTags, removeSystemReminderTags } from '../../memory/working-memory-utils';
+import { removeWorkingMemoryTags } from '../../memory/working-memory-utils';
 import type { ObservabilityContext } from '../../observability';
 import type { RequestContext } from '../../request-context';
 import type { MemoryStorage } from '../../storage';
@@ -138,11 +138,9 @@ export class MessageHistory implements Processor {
           newMessage.content = { ...m.content };
         }
 
-        // Strip working memory and system-reminder tags from string content
+        // Strip working memory tags from string content
         if (typeof newMessage.content?.content === 'string' && newMessage.content.content.length > 0) {
-          newMessage.content.content = removeSystemReminderTags(
-            removeWorkingMemoryTags(newMessage.content.content),
-          ).trim();
+          newMessage.content.content = removeWorkingMemoryTags(newMessage.content.content).trim();
         }
 
         if (Array.isArray(newMessage.content?.parts)) {
@@ -156,12 +154,12 @@ export class MessageHistory implements Processor {
               if (p.type === `tool-invocation` && p.toolInvocation.toolName === `updateWorkingMemory`) {
                 return null;
               }
-              // Strip working memory and system-reminder tags from text parts
+              // Strip working memory tags from text parts
               if (p.type === `text`) {
                 const text = typeof p.text === 'string' ? p.text : '';
                 return {
                   ...p,
-                  text: removeSystemReminderTags(removeWorkingMemoryTags(text)).trim(),
+                  text: removeWorkingMemoryTags(text).trim(),
                 };
               }
               return p;

--- a/packages/core/src/processors/tool-result-reminder.test.ts
+++ b/packages/core/src/processors/tool-result-reminder.test.ts
@@ -386,6 +386,34 @@ describe('AgentsMDInjector', () => {
     ]);
   });
 
+  it('does not inject duplicate reminder when a prior reminder for the same path has different content', async () => {
+    const messageList = new TestMessageList();
+    const toolCallId = 'call-duplicate-path';
+    messageList.push(
+      createUserMessage(
+        `<system-reminder type="dynamic-agents-md" path="/repo/AGENTS.md">[truncated older content]</system-reminder>`,
+      ),
+      createAssistantMessage({
+        format: 2,
+        parts: [createToolInvocationPart(toolCallId, { path: '/repo/src/index.ts' }, 'result', { ok: true })],
+      }),
+    );
+
+    const testProcessor = new AgentsMDInjector({
+      pathExists: path => String(path) === '/repo/AGENTS.md',
+      isDirectory: path => String(path) !== '/repo/src/index.ts',
+      readFile: () => 'Project guidance from AGENTS',
+    });
+
+    await testProcessor.processInputStep(
+      createProcessInputStepArgs(messageList, [createToolCall({ path: '/repo/src/index.ts' }, 'view', toolCallId)]),
+    );
+
+    expect(extractReminderMarkup(messageList)).toEqual([
+      `<system-reminder type="dynamic-agents-md" path="/repo/AGENTS.md">[truncated older content]</system-reminder>`,
+    ]);
+  });
+
   it('injects a new reminder when the path differs', async () => {
     const messageList = new TestMessageList();
     const toolCallId = 'call-different-path';

--- a/packages/core/src/processors/tool-result-reminder.test.ts
+++ b/packages/core/src/processors/tool-result-reminder.test.ts
@@ -30,6 +30,7 @@ type TestMessageContent = {
   format: 2;
   parts: Array<TestTextPart | TestToolInvocationPart>;
   toolInvocations?: TestToolInvocation[];
+  metadata?: Record<string, unknown>;
 };
 
 class TestMessageList {
@@ -43,8 +44,8 @@ class TestMessageList {
     };
   }
 
-  add(message: string, _source: 'user' | 'response' | 'input') {
-    this.messages.push(createUserMessage(message));
+  add(message: string | MastraDBMessage, _source: 'user' | 'response' | 'input') {
+    this.messages.push(typeof message === 'string' ? createUserMessage(message) : message);
     return this;
   }
 
@@ -53,13 +54,14 @@ class TestMessageList {
   }
 }
 
-function createUserMessage(text: string): MastraDBMessage {
+function createUserMessage(text: string, metadata?: Record<string, unknown>): MastraDBMessage {
   return {
     id: `msg-${Math.random().toString(36).slice(2, 8)}`,
     role: 'user',
     content: {
       format: 2,
       parts: [{ type: 'text', text }],
+      ...(metadata ? { metadata } : {}),
     } as MastraDBMessage['content'],
     createdAt: new Date(),
     threadId: 'test-thread',
@@ -188,6 +190,13 @@ describe('AgentsMDInjector', () => {
     expect(extractReminderMarkup(messageList)).toEqual([
       `<system-reminder type="dynamic-agents-md" path="/repo/src/agents/nested/AGENTS.md"># Nested AGENTS\n\nUse the nested instructions when replying.</system-reminder>`,
     ]);
+    const injectedReminder = messageList.get.all.db().at(-1);
+    expect(injectedReminder?.content.metadata).toEqual({
+      dynamicAgentsMdReminder: {
+        path: '/repo/src/agents/nested/AGENTS.md',
+        type: 'dynamic-agents-md',
+      },
+    });
   });
 
   it('injects reminder for tool calls array format', async () => {

--- a/packages/core/src/processors/tool-result-reminder.ts
+++ b/packages/core/src/processors/tool-result-reminder.ts
@@ -2,12 +2,21 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, normalize, resolve } from 'node:path';
 import { estimateTokenCount } from 'tokenx';
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
+import type { MastraMessageContentV2 } from '../agent/message-list/state/types';
 import type { DataChunkType } from '../stream/types';
 import type { ProcessInputStepArgs, Processor, ToolCallInfo } from './index';
 
 const INSTRUCTION_FILE_NAMES = ['AGENTS.md', 'CLAUDE.md', 'CONTEXT.md'] as const;
 const PATH_FIELDS = ['path', 'file', 'filePath', 'target', 'targetPath', 'dest', 'destination'] as const;
 const REMINDER_TYPE = 'dynamic-agents-md';
+const REMINDER_METADATA_KEY = 'dynamicAgentsMdReminder';
+
+type ReminderMessageMetadata = {
+  [REMINDER_METADATA_KEY]?: {
+    path?: string;
+    type?: string;
+  };
+};
 
 type SystemReminderChunk = DataChunkType & {
   type: 'data-system-reminder';
@@ -129,6 +138,44 @@ function extractReminderPath(messageText: string): string | undefined {
   }
 
   return decodeXmlEntities(pathMatch[1]);
+}
+
+function getReminderMetadata(instructionPath: string): ReminderMessageMetadata {
+  return {
+    [REMINDER_METADATA_KEY]: {
+      path: instructionPath,
+      type: REMINDER_TYPE,
+    },
+  };
+}
+
+function extractReminderPathFromMetadata(message: MastraDBMessage): string | undefined {
+  const metadata = message.content.metadata;
+  if (!isRecord(metadata)) {
+    return undefined;
+  }
+
+  const reminderMetadata = metadata[REMINDER_METADATA_KEY];
+  if (!isRecord(reminderMetadata)) {
+    return undefined;
+  }
+
+  return typeof reminderMetadata.path === 'string' ? reminderMetadata.path : undefined;
+}
+
+function createReminderMessage(reminderMarkup: string, instructionPath: string): MastraDBMessage {
+  const content: MastraMessageContentV2 = {
+    format: 2,
+    parts: [{ type: 'text', text: reminderMarkup }],
+    metadata: getReminderMetadata(instructionPath),
+  };
+
+  return {
+    id: crypto.randomUUID(),
+    role: 'user',
+    content,
+    createdAt: new Date(),
+  };
 }
 
 function getReminderMarkup(reminderText: string, instructionPath: string): string {
@@ -265,7 +312,7 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
       await args.writer.custom(chunk);
     }
 
-    messageList.add(reminderMarkup, 'user');
+    messageList.add(createReminderMessage(reminderMarkup, instructionPath), 'user');
     rotateResponseMessageId?.();
     return messageList;
   }
@@ -335,6 +382,10 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
     return messages.some(message => {
       if (message.role !== 'user') {
         return false;
+      }
+
+      if (reminderPath && extractReminderPathFromMetadata(message) === reminderPath) {
+        return true;
       }
 
       const messageText = getMessageText(message);

--- a/packages/core/src/processors/tool-result-reminder.ts
+++ b/packages/core/src/processors/tool-result-reminder.ts
@@ -107,6 +107,30 @@ function getMessageText(message: MastraDBMessage): string {
     .join('\n');
 }
 
+function decodeXmlEntities(value: string): string {
+  return value.replaceAll('&quot;', '"').replaceAll('&gt;', '>').replaceAll('&lt;', '<').replaceAll('&amp;', '&');
+}
+
+function extractReminderPath(messageText: string): string | undefined {
+  const startTagIndex = messageText.indexOf('<system-reminder');
+  if (startTagIndex === -1) {
+    return undefined;
+  }
+
+  const startTagEndIndex = messageText.indexOf('>', startTagIndex);
+  if (startTagEndIndex === -1) {
+    return undefined;
+  }
+
+  const startTag = messageText.slice(startTagIndex, startTagEndIndex + 1);
+  const pathMatch = startTag.match(/\bpath="([^"]+)"/);
+  if (!pathMatch?.[1]) {
+    return undefined;
+  }
+
+  return decodeXmlEntities(pathMatch[1]);
+}
+
 function getReminderMarkup(reminderText: string, instructionPath: string): string {
   return `<system-reminder type="${REMINDER_TYPE}" path="${escapeXmlAttribute(instructionPath)}">${escapeXml(reminderText)}</system-reminder>`;
 }
@@ -306,6 +330,23 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
   }
 
   private hasReminderAlready(messages: MastraDBMessage[], reminderMarkup: string): boolean {
-    return messages.some(message => message.role === 'user' && getMessageText(message).includes(reminderMarkup));
+    const reminderPath = extractReminderPath(reminderMarkup);
+
+    return messages.some(message => {
+      if (message.role !== 'user') {
+        return false;
+      }
+
+      const messageText = getMessageText(message);
+      if (messageText.includes(reminderMarkup)) {
+        return true;
+      }
+
+      if (!reminderPath) {
+        return false;
+      }
+
+      return extractReminderPath(messageText) === reminderPath;
+    });
   }
 }

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -29,6 +29,11 @@ class TestableMemory extends Memory {
   }
 }
 
+function getTextParts(message: MastraDBMessage): string[] {
+  const parts = Array.isArray(message.content.parts) ? message.content.parts : [];
+  return parts.filter(part => part.type === 'text').map(part => part.text);
+}
+
 describe('Memory', () => {
   describe('updateMessageToHideWorkingMemoryV2', () => {
     const memory = new TestableMemory();
@@ -1836,6 +1841,92 @@ describe('Memory', () => {
         });
       }
       await memory.saveMessages({ messages });
+    });
+
+    it('filters system reminder user messages from recall() by default', async () => {
+      const reminderMarkup =
+        '<system-reminder type="dynamic-agents-md" path="/repo/packages/memory/AGENTS.md">Memory guidance</system-reminder>';
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-reminder-metadata',
+            threadId,
+            resourceId,
+            role: 'user',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: reminderMarkup }],
+              metadata: {
+                dynamicAgentsMdReminder: {
+                  path: '/repo/packages/memory/AGENTS.md',
+                  type: 'dynamic-agents-md',
+                },
+              },
+            },
+            createdAt: new Date('2024-01-01T10:06:00Z'),
+          },
+          {
+            id: 'msg-reminder-legacy',
+            threadId,
+            resourceId,
+            role: 'user',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: reminderMarkup }],
+            },
+            createdAt: new Date('2024-01-01T10:07:00Z'),
+          },
+        ],
+      });
+
+      const result = await memory.recall({
+        threadId,
+        resourceId,
+        perPage: false,
+      });
+
+      expect(result.messages.map(message => message.id)).not.toContain('msg-reminder-metadata');
+      expect(result.messages.map(message => message.id)).not.toContain('msg-reminder-legacy');
+    });
+
+    it('includes system reminder user messages when includeSystemReminders is true', async () => {
+      const reminderMarkup =
+        '<system-reminder type="dynamic-agents-md" path="/repo/packages/memory/AGENTS.md">Memory guidance</system-reminder>';
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-reminder-visible',
+            threadId,
+            resourceId,
+            role: 'user',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: reminderMarkup }],
+              metadata: {
+                dynamicAgentsMdReminder: {
+                  path: '/repo/packages/memory/AGENTS.md',
+                  type: 'dynamic-agents-md',
+                },
+              },
+            },
+            createdAt: new Date('2024-01-01T10:06:00Z'),
+          },
+        ],
+      });
+
+      const result = await memory.recall({
+        threadId,
+        resourceId,
+        perPage: false,
+        includeSystemReminders: true,
+      });
+
+      expect(result.messages.map(message => message.id)).toContain('msg-reminder-visible');
+      expect(getTextParts(result.messages.find(message => message.id === 'msg-reminder-visible')!)).toContain(
+        reminderMarkup,
+      );
     });
 
     it('should return pagination metadata from recall()', async () => {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -6,7 +6,12 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/agent';
 
 import { coreFeatures } from '@mastra/core/features';
-import { MastraMemory, extractWorkingMemoryContent, removeWorkingMemoryTags } from '@mastra/core/memory';
+import {
+  MastraMemory,
+  extractWorkingMemoryContent,
+  filterSystemReminderMessages,
+  removeWorkingMemoryTags,
+} from '@mastra/core/memory';
 import type {
   MemoryConfigInternal,
   SharedMemoryConfig,
@@ -207,6 +212,7 @@ export class Memory extends MastraMemory {
     args: StorageListMessagesInput & {
       threadConfig?: MemoryConfigInternal;
       vectorSearchString?: string;
+      includeSystemReminders?: boolean;
       threadId: string;
     },
   ): Promise<{
@@ -217,7 +223,17 @@ export class Memory extends MastraMemory {
     perPage: number | false;
     hasMore: boolean;
   }> {
-    const { threadId, resourceId, perPage: perPageArg, page, orderBy, threadConfig, vectorSearchString, filter } = args;
+    const {
+      threadId,
+      resourceId,
+      perPage: perPageArg,
+      page,
+      orderBy,
+      threadConfig,
+      vectorSearchString,
+      includeSystemReminders,
+      filter,
+    } = args;
     const config = this.getMergedThreadConfig(threadConfig || {});
     if (resourceId) await this.validateThreadIsOwnedByResource(threadId, resourceId, config);
 
@@ -360,7 +376,7 @@ export class Memory extends MastraMemory {
     const list = new MessageList({ threadId, resourceId }).add(rawMessages, 'memory');
 
     // Always return mastra-db format (V2)
-    const messages = list.get.all.db();
+    const messages = filterSystemReminderMessages(list.get.all.db(), includeSystemReminders);
 
     const { total, page: resultPage, perPage: resultPerPage, hasMore } = paginatedResult;
     return { messages, usage, total, page: resultPage, perPage: resultPerPage, hasMore };

--- a/packages/playground-ui/src/hooks/use-agent-messages.ts
+++ b/packages/playground-ui/src/hooks/use-agent-messages.ts
@@ -15,7 +15,11 @@ export const useAgentMessages = ({ threadId, agentId, memory }: UseAgentMessages
     queryKey: ['memory', 'messages', threadId, agentId, 'requestContext'],
     queryFn: async () => {
       if (!threadId) return null;
-      const result = await client.listThreadMessages(threadId, { agentId, requestContext });
+      const result = await client.listThreadMessages(threadId, {
+        agentId,
+        requestContext,
+        includeSystemReminders: true,
+      });
       return result;
     },
     enabled: memory && Boolean(threadId),

--- a/packages/playground-ui/src/lib/ai-ui/messages/system-reminder-badge.test.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/messages/system-reminder-badge.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SystemReminderBadge } from './system-reminder-badge';
+import { parseSystemReminder } from './system-reminder-utils';
+
+describe('parseSystemReminder', () => {
+  it('parses reminder path, type, and decoded body', () => {
+    const reminder = parseSystemReminder(
+      '<system-reminder type="dynamic-agents-md" path="/repo/packages/core/AGENTS.md">Use &lt;tags&gt; &amp; keep quotes &quot;safe&quot;</system-reminder>',
+    );
+
+    expect(reminder).toEqual({
+      type: 'dynamic-agents-md',
+      path: '/repo/packages/core/AGENTS.md',
+      body: 'Use <tags> & keep quotes "safe"',
+    });
+  });
+
+  it('parses reminders without attributes', () => {
+    expect(parseSystemReminder('<system-reminder>plain reminder body</system-reminder>')).toEqual({
+      type: undefined,
+      path: undefined,
+      body: 'plain reminder body',
+    });
+  });
+
+  it('returns null for non-reminder text', () => {
+    expect(parseSystemReminder('plain user text')).toBeNull();
+  });
+});
+
+describe('SystemReminderBadge', () => {
+  it('falls back to plain text when the content is not a system reminder', () => {
+    render(<SystemReminderBadge text="plain user text" />);
+
+    expect(screen.getByText('plain user text')).toBeTruthy();
+  });
+
+  it('shows reminder details when expanded', () => {
+    render(
+      <SystemReminderBadge text='<system-reminder type="dynamic-agents-md" path="/repo/packages/core/AGENTS.md">Remember nested instructions</system-reminder>' />,
+    );
+
+    expect(screen.getByText('System reminder')).toBeTruthy();
+    expect(screen.getByText('/repo/packages/core/AGENTS.md')).toBeTruthy();
+    expect(screen.queryByText('Remember nested instructions')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /system reminder/i }));
+
+    expect(screen.getByText('Remember nested instructions')).toBeTruthy();
+  });
+});

--- a/packages/playground-ui/src/lib/ai-ui/messages/system-reminder-badge.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/messages/system-reminder-badge.tsx
@@ -1,0 +1,47 @@
+import { ChevronDown, ChevronRight, FileText } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { parseSystemReminder } from './system-reminder-utils';
+
+export interface SystemReminderBadgeProps {
+  text: string;
+}
+
+export const SystemReminderBadge = ({ text }: SystemReminderBadgeProps) => {
+  const reminder = useMemo(() => parseSystemReminder(text), [text]);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!reminder) {
+    return text;
+  }
+
+  const title = reminder.path || reminder.type || 'System reminder';
+
+  return (
+    <div className="rounded-lg border border-border1 bg-surface2 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsExpanded(value => !value)}
+        className="w-full flex items-start gap-3 px-4 py-3 text-left hover:bg-surface3 transition-colors"
+      >
+        <FileText className="w-4 h-4 text-icon3 mt-0.5 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <p className="text-ui-sm leading-ui-sm font-medium text-neutral6">System reminder</p>
+          <p className="text-ui-xs leading-ui-xs text-neutral4 break-all mt-1">{title}</p>
+        </div>
+        {isExpanded ? (
+          <ChevronDown className="w-4 h-4 text-icon3 shrink-0" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-icon3 shrink-0" />
+        )}
+      </button>
+
+      {isExpanded && reminder.body && (
+        <div className="border-t border-border1 px-4 py-3 bg-surface1">
+          <pre className="whitespace-pre-wrap break-words text-ui-xs leading-ui-md text-neutral5 font-mono">
+            {reminder.body}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/playground-ui/src/lib/ai-ui/messages/system-reminder-utils.ts
+++ b/packages/playground-ui/src/lib/ai-ui/messages/system-reminder-utils.ts
@@ -1,0 +1,27 @@
+const SYSTEM_REMINDER_REGEX = /<system-reminder(?:\s+([^>]*?))?>([\s\S]*?)<\/system-reminder>/i;
+
+function decodeXmlEntities(value: string): string {
+  return value.replaceAll('&quot;', '"').replaceAll('&gt;', '>').replaceAll('&lt;', '<').replaceAll('&amp;', '&');
+}
+
+function parseAttributes(rawAttributes: string): Record<string, string> {
+  return Object.fromEntries(
+    [...rawAttributes.matchAll(/(\w+)="([^"]*)"/g)].map(([, key, value]) => [key, decodeXmlEntities(value)]),
+  );
+}
+
+export function parseSystemReminder(text: string): { path?: string; type?: string; body: string } | null {
+  const match = text.match(SYSTEM_REMINDER_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const [, rawAttributes = '', rawBody = ''] = match;
+  const attributes = parseAttributes(rawAttributes);
+
+  return {
+    path: attributes.path,
+    type: attributes.type,
+    body: decodeXmlEntities(rawBody).trim(),
+  };
+}

--- a/packages/playground-ui/src/lib/ai-ui/messages/user-messages.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/messages/user-messages.tsx
@@ -2,6 +2,7 @@ import { MessagePrimitive, useMessage } from '@assistant-ui/react';
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { ImageEntry, PdfEntry, TxtEntry } from '../attachments/attachment-preview-dialog';
 import { DatasetSaveAction } from './dataset-save-action';
+import { SystemReminderBadge } from './system-reminder-badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 export interface InMessageAttachmentProps {
   type: string;
@@ -65,6 +66,10 @@ export const UserMessage = () => {
               return <InMessageAttachment type="image" nameSlot="Unknown filename" src={p.image} />;
             },
             Text: p => {
+              if (p.text.trimStart().startsWith('<system-reminder')) {
+                return <SystemReminderBadge text={p.text} />;
+              }
+
               if (p.text.includes('<attachment name=')) {
                 return (
                   <InMessageAttachment

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -871,6 +871,7 @@ export const LIST_MESSAGES_ROUTE = createRoute({
     orderBy,
     include,
     filter,
+    includeSystemReminders,
     requestContext,
   }: any) => {
     try {
@@ -928,6 +929,7 @@ export const LIST_MESSAGES_ROUTE = createRoute({
           orderBy,
           include,
           filter,
+          includeSystemReminders,
         });
         return result;
       }

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -226,6 +226,11 @@ export const listMessagesQuerySchema = createPagePaginationSchema(40).extend({
   orderBy: messageOrderBySchema,
   include: includeSchema,
   filter: filterSchema,
+  includeSystemReminders: z.preprocess(val => {
+    if (val === 'true') return true;
+    if (val === 'false') return false;
+    return val;
+  }, z.boolean().optional()),
 });
 
 /**


### PR DESCRIPTION
This fixes the regression from https://github.com/mastra-ai/mastra/pull/14938 where dynamic system reminders were being stripped before persistence.

That stripping broke prompt caching and let the same reminders get re-injected on later turns because the original reminder was no longer present in stored history.

Now reminder messages are preserved in storage and tagged with metadata so de-dupe works reliably across turns and reloads.

To solve the UI problem that the regression was trying to address, reminders are now filtered at query time by default instead of being removed from storage.

```ts
await client.listThreadMessages(threadId)
// reminders hidden by default

await client.listThreadMessages(threadId, { includeSystemReminders: true })
// reminders included when a client wants them
```

playground-ui also renders reminder messages with a dedicated collapsible component instead of showing raw XML.

<img width="1105" height="803" alt="Screenshot 2026-04-06 at 12 15 06 PM" src="https://github.com/user-attachments/assets/a17d8718-2899-4f4c-a03f-7680cd7a71d6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `includeSystemReminders` option to memory recall and list thread messages APIs for controlling system reminder visibility
  * System reminders are hidden by default with opt-in retrieval capability
  * Playground chat now renders system reminders as collapsible badges instead of raw text

* **Bug Fixes**
  * Fixed system reminder persistence and deduplication across conversation turns

* **Tests**
  * Added test coverage for system reminder filtering and badge rendering behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->