### PR TITLE
feat(core): add MASTRA_OFFLINE env var to disable provider network fetches

### DIFF
--- a/.changeset/three-poets-beam.md
+++ b/.changeset/three-poets-beam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added MASTRA_OFFLINE environment variable to disable network fetches for provider data in offline/air-gapped environments. When set to 'true' or '1', all provider sync and auto-refresh operations are skipped while the static provider registry remains fully functional.

--- a/packages/core/src/llm/model/provider-registry.test.ts
+++ b/packages/core/src/llm/model/provider-registry.test.ts
@@ -616,6 +616,57 @@ describe('GatewayRegistry Auto-Refresh', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it('should skip syncGateways when MASTRA_OFFLINE is set to true', async () => {
+    process.env.MASTRA_OFFLINE = 'true';
+
+    const registry = GatewayRegistry.getInstance({ useDynamicLoading: true });
+
+    // Mock fetchProviders to detect if network calls are attempted
+    const fetchSpy = vi.spyOn(ModelsDevGateway.prototype, 'fetchProviders');
+
+    await registry.syncGateways(true);
+
+    // fetchProviders should never be called — syncGateways bails out early
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should skip syncGateways when MASTRA_OFFLINE is set to 1', async () => {
+    process.env.MASTRA_OFFLINE = '1';
+
+    const registry = GatewayRegistry.getInstance({ useDynamicLoading: true });
+
+    const fetchSpy = vi.spyOn(ModelsDevGateway.prototype, 'fetchProviders');
+
+    await registry.syncGateways(true);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not skip syncGateways when MASTRA_OFFLINE is set to false', async () => {
+    process.env.MASTRA_OFFLINE = 'false';
+
+    const registry = GatewayRegistry.getInstance({ useDynamicLoading: true });
+
+    // Mock fetchProviders to avoid actual network calls but verify it's called
+    const fetchSpy = vi.spyOn(ModelsDevGateway.prototype, 'fetchProviders').mockResolvedValue({});
+    vi.spyOn(NetlifyGateway.prototype, 'fetchProviders').mockResolvedValue({});
+
+    await registry.syncGateways(true);
+
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it('should skip startAutoRefresh when MASTRA_OFFLINE is set', () => {
+    process.env.MASTRA_OFFLINE = 'true';
+
+    const registry = GatewayRegistry.getInstance({ useDynamicLoading: true });
+
+    registry.startAutoRefresh(100);
+
+    // @ts-expect-error - accessing private property for testing
+    expect(registry.refreshInterval).toBeNull();
+  });
+
   it('should write .d.ts file to correct dist subdirectory path', async () => {
     const tmpDir = path.join(os.tmpdir(), `mastra-test-${Date.now()}`);
     fs.mkdirSync(tmpDir, { recursive: true });

--- a/packages/core/src/llm/model/provider-registry.ts
+++ b/packages/core/src/llm/model/provider-registry.ts
@@ -23,6 +23,15 @@ interface RegistryData {
   version: string;
 }
 
+/**
+ * Check if running in offline/air-gapped mode.
+ * When MASTRA_OFFLINE is set to 'true' or '1', all network fetches for provider data are skipped.
+ */
+export function isOfflineMode(): boolean {
+  const value = process.env.MASTRA_OFFLINE;
+  return value === 'true' || value === '1';
+}
+
 function getEnabledGatewayIds(gateways: MastraModelGateway[]): Set<string> {
   const enabledGatewayIds = new Set<string>();
 
@@ -496,6 +505,11 @@ export class GatewayRegistry {
       return;
     }
 
+    // Skip all network fetches when running in offline/air-gapped mode
+    if (isOfflineMode()) {
+      return;
+    }
+
     if (this.isRefreshing && !forceRefresh) {
       // console.debug('[GatewayRegistry] Sync already in progress, skipping...');
       return;
@@ -591,6 +605,11 @@ export class GatewayRegistry {
       return;
     }
 
+    // Skip auto-refresh when running in offline/air-gapped mode
+    if (isOfflineMode()) {
+      return;
+    }
+
     if (this.refreshInterval) {
       // console.debug('[GatewayRegistry] Auto-refresh already running');
       return;
@@ -677,10 +696,12 @@ export class GatewayRegistry {
 
 // Auto-start refresh if enabled
 // Defaults to enabled when MASTRA_DEV=true (which enables dynamic loading by default)
+// Disabled entirely when MASTRA_OFFLINE is set (air-gapped/offline environments)
 const isDev = process.env.MASTRA_DEV === 'true' || process.env.MASTRA_DEV === '1';
 const autoRefreshEnabled =
-  process.env.MASTRA_AUTO_REFRESH_PROVIDERS === 'true' ||
-  (process.env.MASTRA_AUTO_REFRESH_PROVIDERS !== 'false' && isDev);
+  !isOfflineMode() &&
+  (process.env.MASTRA_AUTO_REFRESH_PROVIDERS === 'true' ||
+    (process.env.MASTRA_AUTO_REFRESH_PROVIDERS !== 'false' && isDev));
 
 if (autoRefreshEnabled) {
   // console.debug('[GatewayRegistry] Auto-refresh enabled');


### PR DESCRIPTION
## Description

Adds support for a `MASTRA_OFFLINE` environment variable (`true` or `1`) that disables all network fetches for provider data from models.dev. When set, `syncGateways()` and `startAutoRefresh()` bail out early, and the auto-refresh interval is never created. The static provider registry remains fully functional, so providers with configured API keys continue to work in offline/air-gapped environments.

## Related Issue(s)

Fixes #15095

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `MASTRA_OFFLINE` environment variable: when set to `'true'` or `'1'`, network fetches and auto-refresh for provider data are disabled, while the static provider registry remains fully operational for offline and air-gapped environments.

* **Tests**
  * Added comprehensive test coverage to validate offline mode behavior and early bailout mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->