### PR TITLE
feat(memory): per-record config overrides for observation & reflection thresholds

### DIFF
--- a/.changeset/rare-pears-joke.md
+++ b/.changeset/rare-pears-joke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': minor
+---
+
+Added per-record config overrides for observation and reflection thresholds in Observational Memory. Each thread can now have its own `messageTokens` and `observationTokens` thresholds that override the instance-level defaults, without requiring a process restart or cache invalidation. If no per-record override is set, the instance-level config is used as before.

--- a/packages/core/src/storage/domains/memory/base.ts
+++ b/packages/core/src/storage/domains/memory/base.ts
@@ -22,8 +22,13 @@ import type {
   SwapBufferedToActiveResult,
   SwapBufferedReflectionToActiveInput,
   CreateReflectionGenerationInput,
+  UpdateObservationalMemoryConfigInput,
 } from '../../types';
 import { StorageDomain } from '../base';
+
+function isPlainObj(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 // Constants for metadata key validation
 const SAFE_METADATA_KEY_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
@@ -318,6 +323,32 @@ export abstract class MemoryStorage extends StorageDomain {
    */
   async setPendingMessageTokens(_id: string, _tokenCount: number): Promise<void> {
     throw new Error(`Observational memory is not implemented by this storage adapter (${this.constructor.name}).`);
+  }
+
+  /**
+   * Update the config of an existing observational memory record.
+   * The provided config is deep-merged into the record's existing config.
+   */
+  async updateObservationalMemoryConfig(_input: UpdateObservationalMemoryConfigInput): Promise<void> {
+    throw new Error(`Observational memory is not implemented by this storage adapter (${this.constructor.name}).`);
+  }
+
+  /**
+   * Deep-merge two plain objects. Available for subclasses to merge
+   * partial config overrides into existing record configs.
+   */
+  protected deepMergeConfig(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {
+    const output: Record<string, unknown> = { ...target };
+    for (const key of Object.keys(source)) {
+      const tVal = target[key];
+      const sVal = source[key];
+      if (isPlainObj(tVal) && isPlainObj(sVal)) {
+        output[key] = this.deepMergeConfig(tVal, sVal);
+      } else if (sVal !== undefined) {
+        output[key] = sVal;
+      }
+    }
+    return output;
   }
 
   /**

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -25,6 +25,7 @@ import type {
   SwapBufferedToActiveResult,
   SwapBufferedReflectionToActiveInput,
   CreateReflectionGenerationInput,
+  UpdateObservationalMemoryConfigInput,
 } from '../../types';
 import { filterByDateRange, jsonValueEquals, safelyParseJSON } from '../../utils';
 import type { InMemoryDB } from '../inmemory-db';
@@ -1220,6 +1221,16 @@ export class InMemoryMemory extends MemoryStorage {
     }
 
     record.pendingMessageTokens = tokenCount;
+    record.updatedAt = new Date();
+  }
+
+  async updateObservationalMemoryConfig(input: UpdateObservationalMemoryConfigInput): Promise<void> {
+    const record = this.findObservationalMemoryRecordById(input.id);
+    if (!record) {
+      throw new Error(`Observational memory record not found: ${input.id}`);
+    }
+
+    record.config = this.deepMergeConfig(record.config as Record<string, unknown>, input.config);
     record.updatedAt = new Date();
   }
 

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1322,6 +1322,15 @@ export interface CreateReflectionGenerationInput {
   tokenCount: number;
 }
 
+/**
+ * Input for updating the config of an existing observational memory record.
+ * The provided config is deep-merged into the record's existing config.
+ */
+export interface UpdateObservationalMemoryConfigInput {
+  id: string;
+  config: Record<string, unknown>;
+}
+
 // ============================================
 // MCP Client Storage Types
 // ============================================

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1774,6 +1774,37 @@ Notes:
   }
 
   /**
+   * Update per-record observational memory config overrides for a thread.
+   * The provided config is deep-merged, so you only need to specify fields you want to change.
+   *
+   * @example
+   * ```ts
+   * await memory.updateObservationalMemoryConfig({
+   *   threadId: 'thread-1',
+   *   config: {
+   *     observation: { messageTokens: 2000 },
+   *     reflection: { observationTokens: 8000 },
+   *   },
+   * });
+   * ```
+   */
+  public async updateObservationalMemoryConfig({
+    threadId,
+    resourceId,
+    config,
+  }: {
+    threadId: string;
+    resourceId?: string;
+    config: Record<string, unknown>;
+  }): Promise<void> {
+    const omEngine = await this.omEngine;
+    if (!omEngine) {
+      throw new Error('Observational memory is not enabled');
+    }
+    await omEngine.updateRecordConfig(threadId, resourceId, config);
+  }
+
+  /**
    * Index a list of messages directly (without querying storage).
    * Used by observe-time indexing to vectorize newly-observed messages.
    */

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
@@ -2119,3 +2119,192 @@ describe('setPendingMessageTokens (via storage)', () => {
     expect(updated.pendingMessageTokens).toBe(7000);
   });
 });
+
+// =============================================================================
+// Per-record config overrides (_overrides)
+// =============================================================================
+
+describe('per-record config overrides', () => {
+  let storage: InMemoryMemory;
+  const threadId = 'override-thread';
+
+  beforeEach(() => {
+    storage = createInMemoryStorage();
+  });
+
+  it('uses instance-level messageTokens when record has no _overrides', async () => {
+    const om = createOM(storage, { messageTokens: 500 });
+    await storage.saveMessages({ messages: createBulkMessages(20, threadId) });
+
+    const status = await om.getStatus({ threadId });
+    // threshold should reflect the instance-level 500
+    expect(status.threshold).toBe(500);
+  });
+
+  it('ignores the initial config snapshot (not under _overrides)', async () => {
+    // Instance-level: 500 tokens
+    const om = createOM(storage, { messageTokens: 500 });
+    await storage.saveMessages({ messages: createBulkMessages(20, threadId) });
+
+    // getOrCreateRecord writes observation.messageTokens=500 into record.config
+    const record = await om.getOrCreateRecord(threadId);
+    expect(record.config).toBeTruthy();
+    // The snapshot config should NOT be treated as an override
+    const status = await om.getStatus({ threadId });
+    expect(status.threshold).toBe(500);
+  });
+
+  it('applies _overrides.observation.messageTokens when set', async () => {
+    const om = createOM(storage, { messageTokens: 500 });
+    await storage.saveMessages({ messages: createBulkMessages(20, threadId) });
+
+    // Create the record first
+    const record = await om.getOrCreateRecord(threadId);
+
+    // Manually set _overrides on the record config (simulating what updateObservationalMemoryConfig would do)
+    const existingConfig = record.config as Record<string, unknown>;
+    record.config = {
+      ...existingConfig,
+      _overrides: {
+        observation: { messageTokens: 2000 },
+      },
+    };
+
+    // The record object is shared in InMemory storage, so the mutation above
+    // is visible to getStatus() which re-reads from the same reference.
+    const status = await om.getStatus({ threadId });
+    expect(status.threshold).toBe(2000);
+  });
+
+  it('applies _overrides.reflection.observationTokens when set', async () => {
+    const om = createOM(storage, { messageTokens: 100, observationTokens: 10_000 });
+    await storage.saveMessages({ messages: createBulkMessages(20, threadId) });
+
+    const record = await om.getOrCreateRecord(threadId);
+
+    // Set override to a lower reflection threshold
+    const existingConfig = record.config as Record<string, unknown>;
+    record.config = {
+      ...existingConfig,
+      _overrides: {
+        reflection: { observationTokens: 5_000 },
+      },
+    };
+
+    const status = await om.getStatus({ threadId });
+    // Reflection threshold should now be 5000 instead of 10000
+    // shouldReflect checks: currentObservationTokens >= reflectThreshold
+    // With 0 observation tokens, shouldReflect should be false regardless
+    expect(status.shouldReflect).toBe(false);
+  });
+
+  it('clamps observation override below bufferTokens to instance default', async () => {
+    // bufferTokens=200 means messageTokens override must be > 200
+    const om = createOM(storage, { messageTokens: 500, bufferTokens: 200 });
+    await storage.saveMessages({ messages: createBulkMessages(20, threadId) });
+
+    const record = await om.getOrCreateRecord(threadId);
+
+    // Set override below bufferTokens — should be clamped
+    const existingConfig = record.config as Record<string, unknown>;
+    record.config = {
+      ...existingConfig,
+      _overrides: {
+        observation: { messageTokens: 100 }, // Below bufferTokens of 200
+      },
+    };
+
+    const status = await om.getStatus({ threadId });
+    // Should fall back to instance-level 500, not the 100 override
+    expect(status.threshold).toBe(500);
+  });
+
+  it('falls back to instance-level config when _overrides is empty', async () => {
+    const om = createOM(storage, { messageTokens: 500 });
+    await storage.saveMessages({ messages: createBulkMessages(20, threadId) });
+
+    const record = await om.getOrCreateRecord(threadId);
+
+    // Set empty _overrides
+    const existingConfig = record.config as Record<string, unknown>;
+    record.config = {
+      ...existingConfig,
+      _overrides: {},
+    };
+
+    const status = await om.getStatus({ threadId });
+    expect(status.threshold).toBe(500);
+  });
+});
+
+// =============================================================================
+// updateRecordConfig()
+// =============================================================================
+
+describe('updateRecordConfig()', () => {
+  let storage: InMemoryMemory;
+  let om: ObservationalMemory;
+  const threadId = 'config-update-thread';
+
+  beforeEach(() => {
+    storage = createInMemoryStorage();
+    om = createOM(storage, { messageTokens: 100 });
+  });
+
+  it('should store observation config override under _overrides', async () => {
+    await om.getOrCreateRecord(threadId);
+
+    await om.updateRecordConfig(threadId, undefined, {
+      observation: { messageTokens: 2000 },
+    });
+
+    const record = (await om.getRecord(threadId))!;
+    expect((record.config as any)._overrides.observation.messageTokens).toBe(2000);
+  });
+
+  it('should store reflection config override under _overrides', async () => {
+    await om.getOrCreateRecord(threadId);
+
+    await om.updateRecordConfig(threadId, undefined, {
+      reflection: { observationTokens: 8000 },
+    });
+
+    const record = (await om.getRecord(threadId))!;
+    expect((record.config as any)._overrides.reflection.observationTokens).toBe(8000);
+  });
+
+  it('should merge both observation and reflection overrides at once', async () => {
+    await om.getOrCreateRecord(threadId);
+
+    await om.updateRecordConfig(threadId, undefined, {
+      observation: { messageTokens: 3000 },
+      reflection: { observationTokens: 9000 },
+    });
+
+    const record = (await om.getRecord(threadId))!;
+    expect((record.config as any)._overrides.observation.messageTokens).toBe(3000);
+    expect((record.config as any)._overrides.reflection.observationTokens).toBe(9000);
+  });
+
+  it('should apply successive updates incrementally', async () => {
+    await om.getOrCreateRecord(threadId);
+
+    await om.updateRecordConfig(threadId, undefined, {
+      observation: { messageTokens: 1000 },
+    });
+    await om.updateRecordConfig(threadId, undefined, {
+      reflection: { observationTokens: 5000 },
+    });
+
+    const record = (await om.getRecord(threadId))!;
+    // Both updates should be present under _overrides
+    expect((record.config as any)._overrides.observation.messageTokens).toBe(1000);
+    expect((record.config as any)._overrides.reflection.observationTokens).toBe(5000);
+  });
+
+  it('should throw when no record exists for the thread', async () => {
+    await expect(
+      om.updateRecordConfig('nonexistent-thread', undefined, { observation: { messageTokens: 100 } }),
+    ).rejects.toThrow(/No observational memory record found/);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -800,13 +800,31 @@ export class ObservationalMemory {
 
   /**
    * Resolve the effective messageTokens for a record.
-   * Uses the record's stored config if it has a per-record override,
-   * otherwise falls back to the instance-level config.
+   * Only explicit per-record overrides (stored under `_overrides`) win;
+   * the initial config snapshot written by getOrCreateRecord() is ignored
+   * so that later instance-level changes still take effect.
+   *
+   * Overrides that fall below the instance-level buffering floor
+   * (bufferTokens / absolute bufferActivation) are clamped to the
+   * instance threshold to preserve buffering invariants.
    */
   private getEffectiveMessageTokens(record: ObservationalMemoryRecord): number | ThresholdRange {
-    const recordConfig = record.config as { observation?: { messageTokens?: number | ThresholdRange } } | undefined;
-    const recordTokens = recordConfig?.observation?.messageTokens;
-    if (recordTokens != null) {
+    const overrides = (record.config as { _overrides?: { observation?: { messageTokens?: number | ThresholdRange } } })
+      ?._overrides;
+    const recordTokens = overrides?.observation?.messageTokens;
+    if (recordTokens) {
+      const maxOverride = getMaxThreshold(recordTokens);
+
+      // Clamp: override must not violate instance-level buffering invariants
+      const bufferTokens = this.observationConfig.bufferTokens;
+      if (bufferTokens && maxOverride <= bufferTokens) {
+        return this.observationConfig.messageTokens;
+      }
+      const bufferActivation = this.observationConfig.bufferActivation;
+      if (bufferActivation && bufferActivation >= 1000 && maxOverride <= bufferActivation) {
+        return this.observationConfig.messageTokens;
+      }
+
       return recordTokens;
     }
     return this.observationConfig.messageTokens;
@@ -814,13 +832,16 @@ export class ObservationalMemory {
 
   /**
    * Resolve the effective reflection observationTokens for a record.
-   * Uses the record's stored config if it has a per-record override,
-   * otherwise falls back to the instance-level config.
+   * Only explicit per-record overrides (stored under `_overrides`) win;
+   * the initial config snapshot is ignored so instance-level changes
+   * still take effect for existing records.
    */
   private getEffectiveReflectionTokens(record: ObservationalMemoryRecord): number | ThresholdRange {
-    const recordConfig = record.config as { reflection?: { observationTokens?: number | ThresholdRange } } | undefined;
-    const recordTokens = recordConfig?.reflection?.observationTokens;
-    if (recordTokens != null) {
+    const overrides = (
+      record.config as { _overrides?: { reflection?: { observationTokens?: number | ThresholdRange } } }
+    )?._overrides;
+    const recordTokens = overrides?.reflection?.observationTokens;
+    if (recordTokens) {
       return recordTokens;
     }
     return this.reflectionConfig.observationTokens;
@@ -3246,6 +3267,41 @@ ${formattedMessages}
   async getRecord(threadId: string, resourceId?: string): Promise<ObservationalMemoryRecord | null> {
     const ids = this.getStorageIds(threadId, resourceId);
     return this.storage.getObservationalMemory(ids.threadId, ids.resourceId);
+  }
+
+  /**
+   * Update per-record config overrides for observation and/or reflection thresholds.
+   * The provided config is deep-merged into the record's `_overrides` key,
+   * so you only need to specify the fields you want to change.
+   *
+   * Overrides that violate buffering invariants (e.g. messageTokens below
+   * bufferTokens) are silently ignored at read time — the helpers fall back
+   * to the instance-level config.
+   *
+   * @example
+   * ```ts
+   * await om.updateRecordConfig('thread-1', undefined, {
+   *   observation: { messageTokens: 2000 },
+   *   reflection: { observationTokens: 8000 },
+   * });
+   * ```
+   */
+  async updateRecordConfig(
+    threadId: string,
+    resourceId: string | undefined,
+    config: Record<string, unknown>,
+  ): Promise<void> {
+    const ids = this.getStorageIds(threadId, resourceId);
+    const record = await this.storage.getObservationalMemory(ids.threadId, ids.resourceId);
+    if (!record) {
+      throw new Error(`No observational memory record found for thread ${ids.threadId}`);
+    }
+    // Write under _overrides so getEffectiveMessageTokens / getEffectiveReflectionTokens
+    // pick up the override values, distinct from the initial config snapshot.
+    await this.storage.updateObservationalMemoryConfig({
+      id: record.id,
+      config: { _overrides: config },
+    });
   }
 
   /**

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -799,6 +799,34 @@ export class ObservationalMemory {
   }
 
   /**
+   * Resolve the effective messageTokens for a record.
+   * Uses the record's stored config if it has a per-record override,
+   * otherwise falls back to the instance-level config.
+   */
+  private getEffectiveMessageTokens(record: ObservationalMemoryRecord): number | ThresholdRange {
+    const recordConfig = record.config as { observation?: { messageTokens?: number | ThresholdRange } } | undefined;
+    const recordTokens = recordConfig?.observation?.messageTokens;
+    if (recordTokens != null) {
+      return recordTokens;
+    }
+    return this.observationConfig.messageTokens;
+  }
+
+  /**
+   * Resolve the effective reflection observationTokens for a record.
+   * Uses the record's stored config if it has a per-record override,
+   * otherwise falls back to the instance-level config.
+   */
+  private getEffectiveReflectionTokens(record: ObservationalMemoryRecord): number | ThresholdRange {
+    const recordConfig = record.config as { reflection?: { observationTokens?: number | ThresholdRange } } | undefined;
+    const recordTokens = recordConfig?.reflection?.observationTokens;
+    if (recordTokens != null) {
+      return recordTokens;
+    }
+    return this.reflectionConfig.observationTokens;
+  }
+
+  /**
    * Check whether the unobserved message tokens meet the observation threshold.
    */
   private meetsObservationThreshold(opts: {
@@ -809,7 +837,7 @@ export class ObservationalMemory {
     const { record, unobservedTokens, extraTokens = 0 } = opts;
     const pendingTokens = (record.pendingMessageTokens ?? 0) + unobservedTokens + extraTokens;
     const currentObservationTokens = record.observationTokenCount ?? 0;
-    const threshold = calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
+    const threshold = calculateDynamicThreshold(this.getEffectiveMessageTokens(record), currentObservationTokens);
     return pendingTokens >= threshold;
   }
 
@@ -2376,7 +2404,7 @@ ${formattedMessages}
       const projectedMessageRemoval = calculateProjectedMessageRemoval(
         bufferedChunks,
         this.observationConfig.bufferActivation ?? 1,
-        getMaxThreshold(this.observationConfig.messageTokens),
+        getMaxThreshold(this.getEffectiveMessageTokens(record)),
         pendingTokens,
       );
 
@@ -2488,8 +2516,8 @@ ${formattedMessages}
     }
     const pendingTokens = Math.max(0, contextWindowTokens + otherThreadTokens);
 
-    // Calculate observation threshold
-    const threshold = calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
+    // Calculate observation threshold (use per-record override if set)
+    const threshold = calculateDynamicThreshold(this.getEffectiveMessageTokens(record), currentObservationTokens);
 
     // Buffering status
     const bufferedChunks = getBufferedChunks(record);
@@ -2513,16 +2541,17 @@ ${formattedMessages}
     // Should observe?
     const shouldObserve = pendingTokens >= threshold;
 
-    // Should reflect?
-    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
+    // Should reflect? (use per-record override if set)
+    const reflectThreshold = getMaxThreshold(this.getEffectiveReflectionTokens(record));
     const shouldReflect = currentObservationTokens >= reflectThreshold;
 
     // Can activate?
     const canActivate = bufferedChunkCount > 0;
 
     // Effective observation tokens threshold (for shared budget UI display)
-    const isSharedBudget = typeof this.observationConfig.messageTokens !== 'number';
-    const totalBudget = isSharedBudget ? (this.observationConfig.messageTokens as { min: number; max: number }).max : 0;
+    const effectiveMessageTokens = this.getEffectiveMessageTokens(record);
+    const isSharedBudget = typeof effectiveMessageTokens !== 'number';
+    const totalBudget = isSharedBudget ? (effectiveMessageTokens as { min: number; max: number }).max : 0;
     const effectiveObservationTokensThreshold = isSharedBudget
       ? Math.max(totalBudget - threshold, 1000)
       : reflectThreshold;
@@ -2962,8 +2991,8 @@ ${formattedMessages}
       return { activated: false, record };
     }
 
-    // Calculate activation parameters
-    const messageTokensThreshold = getMaxThreshold(this.observationConfig.messageTokens);
+    // Calculate activation parameters (use per-record override if set)
+    const messageTokensThreshold = getMaxThreshold(this.getEffectiveMessageTokens(freshRecord));
     const bufferActivation = this.observationConfig.bufferActivation ?? 0.7;
     const activationRatio = resolveActivationRatio(bufferActivation, messageTokensThreshold);
 
@@ -3167,7 +3196,7 @@ ${formattedMessages}
     registerOp(record.id, 'reflecting');
 
     try {
-      const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
+      const reflectThreshold = getMaxThreshold(this.getEffectiveReflectionTokens(record));
       const reflectResult = await this.reflector.call(
         record.activeObservations,
         prompt,

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -25,6 +25,7 @@ import type {
   UpdateBufferedReflectionInput,
   SwapBufferedReflectionToActiveInput,
   CreateReflectionGenerationInput,
+  UpdateObservationalMemoryConfigInput,
 } from '@mastra/core/storage';
 import {
   createStorageErrorId,
@@ -2033,6 +2034,48 @@ export class MemoryLibSQL extends MemoryStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: { id, tokenCount },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateObservationalMemoryConfig(input: UpdateObservationalMemoryConfigInput): Promise<void> {
+    try {
+      // Read current config
+      const selectResult = await this.#client.execute({
+        sql: `SELECT config FROM "${OM_TABLE}" WHERE id = ?`,
+        args: [input.id],
+      });
+
+      if (selectResult.rows.length === 0) {
+        throw new MastraError({
+          id: createStorageErrorId('LIBSQL', 'UPDATE_OM_CONFIG', 'NOT_FOUND'),
+          text: `Observational memory record not found: ${input.id}`,
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: input.id },
+        });
+      }
+
+      const row = selectResult.rows[0] as any;
+      const existing: Record<string, unknown> = row.config ? JSON.parse(row.config) : {};
+      const merged = this.deepMergeConfig(existing, input.config);
+
+      await this.#client.execute({
+        sql: `UPDATE "${OM_TABLE}" SET config = ?, "updatedAt" = ? WHERE id = ?`,
+        args: [JSON.stringify(merged), new Date().toISOString(), input.id],
+      });
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'UPDATE_OM_CONFIG', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: input.id },
         },
         error,
       );

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -42,6 +42,7 @@ import type {
   UpdateBufferedReflectionInput,
   SwapBufferedReflectionToActiveInput,
   CreateReflectionGenerationInput,
+  UpdateObservationalMemoryConfigInput,
 } from '@mastra/core/storage';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
@@ -1882,6 +1883,43 @@ export class MemoryStorageMongoDB extends MemoryStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: { id, tokenCount },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateObservationalMemoryConfig(input: UpdateObservationalMemoryConfigInput): Promise<void> {
+    try {
+      const collection = await this.getCollection(OM_TABLE);
+
+      // Read current config
+      const doc = await collection.findOne({ id: input.id }, { projection: { config: 1 } });
+
+      if (!doc) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'UPDATE_OM_CONFIG', 'NOT_FOUND'),
+          text: `Observational memory record not found: ${input.id}`,
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: input.id },
+        });
+      }
+
+      const existing: Record<string, unknown> = (doc.config as Record<string, unknown>) ?? {};
+      const merged = this.deepMergeConfig(existing, input.config);
+
+      await collection.updateOne({ id: input.id }, { $set: { config: merged, updatedAt: new Date() } });
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'UPDATE_OM_CONFIG', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: input.id },
         },
         error,
       );

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -57,6 +57,7 @@ import type {
   UpdateBufferedReflectionInput,
   SwapBufferedReflectionToActiveInput,
   CreateReflectionGenerationInput,
+  UpdateObservationalMemoryConfigInput,
 } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
 import {
@@ -1808,13 +1809,13 @@ export class MemoryPG extends MemoryStorage {
       let paramIndex = 2;
 
       if (options?.from) {
-        conditions.push(`"createdAt" >= $${paramIndex}`);
-        params.push(options.from);
+        conditions.push(`"createdAtZ" >= $${paramIndex}`);
+        params.push(options.from.toISOString());
         paramIndex++;
       }
       if (options?.to) {
-        conditions.push(`"createdAt" <= $${paramIndex}`);
-        params.push(options.to);
+        conditions.push(`"createdAtZ" <= $${paramIndex}`);
+        params.push(options.to.toISOString());
         paramIndex++;
       }
 
@@ -2373,6 +2374,55 @@ export class MemoryPG extends MemoryStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: { id, tokenCount },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateObservationalMemoryConfig(input: UpdateObservationalMemoryConfigInput): Promise<void> {
+    try {
+      const tableName = getTableName({
+        indexName: OM_TABLE,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      // Read current config
+      const selectResult = await this.#db.client.query(`SELECT config FROM ${tableName} WHERE id = $1`, [input.id]);
+
+      if (selectResult.rowCount === 0) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'UPDATE_OM_CONFIG', 'NOT_FOUND'),
+          text: `Observational memory record not found: ${input.id}`,
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: input.id },
+        });
+      }
+
+      const row = selectResult.rows[0];
+      const existing: Record<string, unknown> = row.config
+        ? typeof row.config === 'string'
+          ? JSON.parse(row.config)
+          : row.config
+        : {};
+      const merged = this.deepMergeConfig(existing, input.config);
+      const nowStr = new Date().toISOString();
+
+      await this.#db.client.query(
+        `UPDATE ${tableName} SET config = $1, "updatedAt" = $2, "updatedAtZ" = $3 WHERE id = $4`,
+        [JSON.stringify(merged), nowStr, nowStr, input.id],
+      );
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'UPDATE_OM_CONFIG', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: input.id },
         },
         error,
       );


### PR DESCRIPTION
## Summary

OM threshold decisions now check the record's stored config first, falling back to the instance-level config. This enables per-thread (or per-resource) threshold overrides without restarting the process or invalidating the OM instance cache.

## What changed

Added two private helpers to `ObservationalMemory`:
- `getEffectiveMessageTokens(record)` — resolves observation `messageTokens` from `record.config.observation.messageTokens`, falling back to `this.observationConfig.messageTokens`
- `getEffectiveReflectionTokens(record)` — resolves reflection `observationTokens` from `record.config.reflection.observationTokens`, falling back to `this.reflectionConfig.observationTokens`

Patched **6 call sites** across threshold-decision points:

| Method | What changed |
|--------|-------------|
| `meetsObservationThreshold()` | Uses per-record observation threshold |
| `getStatus()` | Observation threshold, reflection threshold, and shared budget UI all use per-record values |
| `reflect()` | Reflection token budget passed to reflector uses per-record value |
| `swapBufferedToActive()` | Buffer activation ratio uses per-record observation threshold |

## Motivation

The gateway needs to expose an API for users to set per-thread OM thresholds (e.g. lower the observation threshold for a specific thread to trigger faster observations). Today the OM instance caches config at creation time, and updating the record's config in MongoDB has no effect because all threshold checks read from instance-level config.

## Backward compatibility

Fully backward-compatible. If a record has no per-record override (the default), the helpers fall back to the instance-level config — identical to previous behavior.

## Test plan

- `pnpm tsc --noEmit` passes
- All existing OM tests pass (404/405, 1 unrelated failure due to missing `OPENROUTER_API_KEY`)
- Verified end-to-end: update a record's `config.observation.messageTokens` in MongoDB → next request respects the override

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gateway observational memory progress monitoring and polling for improved memory status visibility.
  * Enhanced thread cloning with full gateway support for multi-thread operations.

* **Bug Fixes**
  * Fixed task and plan state carryover when switching between threads.

* **Tests**
  * Improved mock harness implementation for better test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->