### PR TITLE
fix(cli): defer project creation until after user confirmation

### DIFF
--- a/.changeset/fix-cli-project-creation-timing.md
+++ b/.changeset/fix-cli-project-creation-timing.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed `mastra studio deploy` creating orphan projects when user cancels. Project creation is now deferred until after the user confirms the deploy settings.

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -220,7 +220,7 @@ async function resolveProject(
     if (match) {
       return { existing: true, projectId: match.id, projectName: match.name, projectSlug: match.slug ?? match.name };
     }
-    return { existing: true, projectId: flagProject, projectName: flagProject, projectSlug: flagProject };
+    return { existing: false, projectName: flagProject };
   }
 
   // 2. project.json (only if same org)
@@ -288,39 +288,31 @@ export async function deployAction(
 
     const isAlreadyLinked = projectConfig?.projectId === projectId && projectConfig?.organizationId === orgId;
 
-    if (!isAlreadyLinked) {
-      // Show confirmation for linking to existing project
-      p.note(
-        [
-          `Organization:  ${orgName}`,
-          `Project:       ${projectName}`,
-          `Directory:     ${targetDir}`,
-          ...(gitBranch ? [`Git branch:    ${gitBranch}`] : []),
-          ...(mastraVersion ? [`Mastra:        ${mastraVersion}`] : []),
-        ].join('\n'),
-        'Deploy settings',
-      );
+    p.note(
+      [
+        `Organization:  ${orgName}`,
+        `Project:       ${projectName}`,
+        `Directory:     ${targetDir}`,
+        ...(gitBranch ? [`Git branch:    ${gitBranch}`] : []),
+        ...(mastraVersion ? [`Mastra:        ${mastraVersion}`] : []),
+      ].join('\n'),
+      'Deploy settings',
+    );
 
-      if (!autoAccept) {
-        const confirmed = await p.confirm({
-          message: 'Deploy with these settings?',
-        });
+    if (!autoAccept) {
+      const confirmed = await p.confirm({
+        message: 'Deploy with these settings?',
+      });
 
-        if (p.isCancel(confirmed) || !confirmed) {
-          p.cancel('Deploy cancelled.');
-          process.exit(0);
-        }
+      if (p.isCancel(confirmed) || !confirmed) {
+        p.cancel('Deploy cancelled.');
+        process.exit(0);
       }
+    }
 
-      // Save the project link
+    if (!isAlreadyLinked) {
       await saveProjectConfig(targetDir, { projectId, projectName, projectSlug, organizationId: orgId }, opts.config);
       p.log.success(`Saved ${opts.config || '.mastra-project.json'}`);
-    } else {
-      // Already linked — just show a summary line
-      p.log.info(`Organization: ${orgName} (${orgId})`);
-      p.log.info(`Project: ${projectName} (${projectId})`);
-      if (gitBranch) p.log.info(`Git branch: ${gitBranch}`);
-      if (mastraVersion) p.log.info(`Mastra: ${mastraVersion}`);
     }
   } else {
     // New project — show confirmation BEFORE creating

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -191,17 +191,26 @@ async function resolveOrg(
 /*  Resolve project                                                   */
 /* ------------------------------------------------------------------ */
 
+type ProjectResolution =
+  | { existing: true; projectId: string; projectName: string; projectSlug: string }
+  | { existing: false; projectName: string };
+
+/**
+ * Attempts to resolve an existing project without creating one.
+ * Returns { existing: true, ... } if found, or { existing: false, projectName } if a new project should be created.
+ * This allows the caller to show a confirmation prompt before actually creating the project.
+ */
 async function resolveProject(
   token: string,
   orgId: string,
   projectConfig: { projectId?: string; projectName?: string; projectSlug?: string; organizationId?: string } | null,
   flagProject?: string,
   defaultName?: string | null,
-): Promise<{ projectId: string; projectName: string; projectSlug: string }> {
+): Promise<ProjectResolution> {
   // 0. MASTRA_PROJECT_ID env var (CI/CD headless path)
   const envProjectId = process.env.MASTRA_PROJECT_ID;
   if (envProjectId) {
-    return { projectId: envProjectId, projectName: envProjectId, projectSlug: envProjectId };
+    return { existing: true, projectId: envProjectId, projectName: envProjectId, projectSlug: envProjectId };
   }
 
   // 1. CLI flag — match by slug first, then id
@@ -209,28 +218,28 @@ async function resolveProject(
     const projects = await fetchProjects(token, orgId);
     const match = projects.find(proj => proj.slug === flagProject || proj.id === flagProject);
     if (match) {
-      return { projectId: match.id, projectName: match.name, projectSlug: match.slug ?? match.name };
+      return { existing: true, projectId: match.id, projectName: match.name, projectSlug: match.slug ?? match.name };
     }
-    return { projectId: flagProject, projectName: flagProject, projectSlug: flagProject };
+    return { existing: true, projectId: flagProject, projectName: flagProject, projectSlug: flagProject };
   }
 
   // 2. project.json (only if same org)
   if (projectConfig?.projectId && projectConfig.organizationId === orgId) {
     return {
+      existing: true,
       projectId: projectConfig.projectId,
       projectName: projectConfig.projectName ?? projectConfig.projectId,
       projectSlug: projectConfig.projectSlug ?? projectConfig.projectName ?? projectConfig.projectId,
     };
   }
 
-  // 3. Auto-create from package name
+  // 3. No existing project — return the name so caller can create after confirmation
   const name = defaultName;
   if (!name) {
     throw new Error('Could not determine project name from package.json. Use --project to specify one.');
   }
 
-  const project = await createProject(token, orgId, name);
-  return { projectId: project.id, projectName: project.name, projectSlug: project.slug ?? project.name };
+  return { existing: false, projectName: name };
 }
 
 /* ------------------------------------------------------------------ */
@@ -264,23 +273,63 @@ export async function deployAction(
   // Step 3: Resolve org
   const { orgId, orgName } = await resolveOrg(token, projectConfig, opts.org);
 
-  // Step 4: Resolve project (pass packageName as default for new project creation)
-  const { projectId, projectName, projectSlug } = await resolveProject(
-    token,
-    orgId,
-    projectConfig,
-    opts.project,
-    packageName,
-  );
+  // Step 4: Resolve project (does NOT create yet — waits for confirmation)
+  const resolution = await resolveProject(token, orgId, projectConfig, opts.project, packageName);
 
-  // Step 5: Confirmation — show settings and let user verify (skipped with -y or if already linked)
-  const isAlreadyLinked = projectConfig?.projectId === projectId && projectConfig?.organizationId === orgId;
+  let projectId: string;
+  let projectName: string;
+  let projectSlug: string;
 
-  if (!isAlreadyLinked) {
+  if (resolution.existing) {
+    // Existing project found
+    projectId = resolution.projectId;
+    projectName = resolution.projectName;
+    projectSlug = resolution.projectSlug;
+
+    const isAlreadyLinked = projectConfig?.projectId === projectId && projectConfig?.organizationId === orgId;
+
+    if (!isAlreadyLinked) {
+      // Show confirmation for linking to existing project
+      p.note(
+        [
+          `Organization:  ${orgName}`,
+          `Project:       ${projectName}`,
+          `Directory:     ${targetDir}`,
+          ...(gitBranch ? [`Git branch:    ${gitBranch}`] : []),
+          ...(mastraVersion ? [`Mastra:        ${mastraVersion}`] : []),
+        ].join('\n'),
+        'Deploy settings',
+      );
+
+      if (!autoAccept) {
+        const confirmed = await p.confirm({
+          message: 'Deploy with these settings?',
+        });
+
+        if (p.isCancel(confirmed) || !confirmed) {
+          p.cancel('Deploy cancelled.');
+          process.exit(0);
+        }
+      }
+
+      // Save the project link
+      await saveProjectConfig(targetDir, { projectId, projectName, projectSlug, organizationId: orgId }, opts.config);
+      p.log.success(`Saved ${opts.config || '.mastra-project.json'}`);
+    } else {
+      // Already linked — just show a summary line
+      p.log.info(`Organization: ${orgName} (${orgId})`);
+      p.log.info(`Project: ${projectName} (${projectId})`);
+      if (gitBranch) p.log.info(`Git branch: ${gitBranch}`);
+      if (mastraVersion) p.log.info(`Mastra: ${mastraVersion}`);
+    }
+  } else {
+    // New project — show confirmation BEFORE creating
+    projectName = resolution.projectName;
+
     p.note(
       [
         `Organization:  ${orgName}`,
-        `Project:       ${projectName}`,
+        `Project:       ${projectName} (new)`,
         `Directory:     ${targetDir}`,
         ...(gitBranch ? [`Git branch:    ${gitBranch}`] : []),
         ...(mastraVersion ? [`Mastra:        ${mastraVersion}`] : []),
@@ -290,7 +339,7 @@ export async function deployAction(
 
     if (!autoAccept) {
       const confirmed = await p.confirm({
-        message: 'Deploy with these settings?',
+        message: 'Create project and deploy?',
       });
 
       if (p.isCancel(confirmed) || !confirmed) {
@@ -299,24 +348,15 @@ export async function deployAction(
       }
     }
 
+    // NOW create the project (after user confirmed)
+    const project = await createProject(token, orgId, projectName);
+    projectId = project.id;
+    projectSlug = project.slug ?? project.name;
+    p.log.success(`Created project "${projectName}"`);
+
     // Save the project link
-    await saveProjectConfig(
-      targetDir,
-      {
-        projectId,
-        projectName,
-        projectSlug,
-        organizationId: orgId,
-      },
-      opts.config,
-    );
+    await saveProjectConfig(targetDir, { projectId, projectName, projectSlug, organizationId: orgId }, opts.config);
     p.log.success(`Saved ${opts.config || '.mastra-project.json'}`);
-  } else {
-    // Already linked — just show a summary line
-    p.log.info(`Organization: ${orgName} (${orgId})`);
-    p.log.info(`Project: ${projectName} (${projectId})`);
-    if (gitBranch) p.log.info(`Git branch: ${gitBranch}`);
-    if (mastraVersion) p.log.info(`Mastra: ${mastraVersion}`);
   }
 
   // Step 6: Build + Zip + Upload + Poll


### PR DESCRIPTION
## Problem

When running `mastra studio deploy`, the CLI would immediately create a new project **before** showing the confirmation prompt. If the user cancelled the deploy (e.g., Ctrl+C or answering 'no'), the project was already created in the database but `.mastra-project.json` was never saved locally.

Running the command again would create another orphan project, leading to multiple duplicate projects in the dashboard.

Reported by Ward in Slack.

## Solution

Refactored `resolveProject()` to return a discriminated union:
- `{ existing: true, projectId, projectName, projectSlug }` — for existing projects
- `{ existing: false, projectName }` — signals a new project should be created

The `deployAction()` function now:
1. Checks for existing project (env var, CLI flag, or config file)
2. If no existing project, shows confirmation with `(new)` indicator
3. Only creates the project **after** user confirms
4. Saves `.mastra-project.json`

## Changes

- `packages/cli/src/commands/studio/deploy.ts`:
  - Changed `resolveProject()` return type to `ProjectResolution` union
  - Moved `createProject()` call to after confirmation in `deployAction()`
  - Updated confirmation message for new projects: "Create project and deploy?"
  - Added "(new)" indicator in deploy settings note

## Testing

Manual testing:
1. Run `mastra studio deploy` in a directory without `.mastra-project.json`
2. Cancel at the confirmation prompt
3. Verify no project was created in the dashboard
4. Run again and confirm — project should now be created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where orphan projects could be created in Mastra Studio Deploy if deployment was cancelled. Project creation now occurs only after confirming deploy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->