### PR TITLE
chore: add missing changesets for core and store packages from #15102

### DIFF
--- a/.changeset/bright-doors-wave.md
+++ b/.changeset/bright-doors-wave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added `UpdateObservationalMemoryConfigInput` type, `updateObservationalMemoryConfig()` method stub, and `deepMergeConfig()` utility to the `MemoryStorage` base class. These additions support per-record observational memory config overrides introduced in `@mastra/memory`.

--- a/.changeset/calm-wolves-rush.md
+++ b/.changeset/calm-wolves-rush.md
@@ -1,0 +1,7 @@
+---
+'@mastra/pg': minor
+'@mastra/libsql': minor
+'@mastra/mongodb': minor
+---
+
+Implemented `updateObservationalMemoryConfig()` in Postgres, LibSQL, and MongoDB storage adapters. This enables per-record config overrides for observational memory thresholds, supporting the new `memory.updateObservationalMemoryConfig()` API in `@mastra/memory`.

--- a/.changeset/quick-masks-fold.md
+++ b/.changeset/quick-masks-fold.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed observational memory date-range queries to use ISO-string timestamp columns (`createdAtZ`) instead of the raw `createdAt` column, ensuring correct filtering when querying observations by date range.


### PR DESCRIPTION
## Summary

PR #15102 (per-record OM config overrides) shipped changesets for `@mastra/memory` but missed the supporting packages. This adds the missing changesets.

## Changesets added

| File | Packages | Bump | Description |
|------|----------|------|-------------|
| `bright-doors-wave.md` | `@mastra/core` | minor | New `UpdateObservationalMemoryConfigInput` type, `updateObservationalMemoryConfig()` stub, and `deepMergeConfig()` on `MemoryStorage` base |
| `quick-masks-fold.md` | `@mastra/pg` | patch | Bug fix: date-range queries now use `createdAtZ` ISO-string columns |
| `calm-wolves-rush.md` | `@mastra/pg`, `@mastra/libsql`, `@mastra/mongodb` | minor | Implemented `updateObservationalMemoryConfig()` across all three store adapters |

## Test plan

Changeset-only PR — no code changes.