### PR TITLE
feat: improve OM recall tool filtering and pagination

### DIFF
--- a/.changeset/every-colts-reply.md
+++ b/.changeset/every-colts-reply.md
@@ -1,0 +1,7 @@
+---
+'@mastra/memory': minor
+---
+
+Updated the recall tool to support more precise message browsing for agents.
+
+Agents using `recall` can now pass `partType` and `toolName` to narrow message results to specific parts, such as tool calls or tool results for one tool. This change also adds `threadId: "current"` support across recall modes and `anchor: "start" | "end"` for no-cursor message paging, making it easier to inspect recent thread activity and past tool usage.

--- a/packages/memory/src/tools/om-tools.test.ts
+++ b/packages/memory/src/tools/om-tools.test.ts
@@ -1682,7 +1682,7 @@ describe('om-tools', () => {
       expect(page3.hasPrevPage).toBe(true);
     });
 
-    it('should clamp oversized pages to the last available page', async () => {
+    it('should return an explicit empty-page message for oversized pages', async () => {
       const result = await recallThreadFromStart({
         memory: memory as any,
         threadId,
@@ -1691,9 +1691,9 @@ describe('om-tools', () => {
         limit: 2,
       });
 
-      expect(result.page).toBe(3);
-      expect(result.count).toBe(1);
-      expect(result.messages).toContain('Message 5 content');
+      expect(result.page).toBe(50);
+      expect(result.count).toBe(0);
+      expect(result.messages).toBe('(no messages found on page 50 for this thread)');
       expect(result.hasNextPage).toBe(false);
       expect(result.hasPrevPage).toBe(true);
     });

--- a/packages/memory/src/tools/om-tools.test.ts
+++ b/packages/memory/src/tools/om-tools.test.ts
@@ -290,6 +290,36 @@ describe('om-tools', () => {
       expect(result.messages).toContain('[msg-3]');
     });
 
+    it('should return a visible-parts empty message when paged messages have no renderable parts', async () => {
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-empty-text-part',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: '' }],
+            },
+            createdAt: new Date('2024-01-01T10:05:00Z'),
+          },
+        ],
+      });
+
+      const result = await recallMessages({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-5',
+        page: 1,
+        limit: 1,
+      });
+
+      expect(result.count).toBe(1);
+      expect(result.messages).toBe('(no visible message parts found for this page)');
+    });
+
     it('should auto-expand low detail when full text fits in token budget', async () => {
       // 200 chars ≈ 50 tokens — well under default 8000 budget
       const longText = 'A'.repeat(200);

--- a/packages/memory/src/tools/om-tools.test.ts
+++ b/packages/memory/src/tools/om-tools.test.ts
@@ -439,6 +439,204 @@ describe('om-tools', () => {
       expect(highResult.messages).toContain('"query": "test query"');
     });
 
+    it('should filter recallMessages by partType', async () => {
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-filter-parts',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [
+                { type: 'text', text: 'Intro text' },
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    toolCallId: 'tc-filter-call',
+                    toolName: 'readFile',
+                    state: 'call',
+                    args: { path: '/src/index.ts' },
+                  },
+                },
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    toolCallId: 'tc-filter-result',
+                    toolName: 'readFile',
+                    state: 'result',
+                    args: { path: '/src/index.ts' },
+                    result: 'export const value = 1;',
+                  },
+                },
+              ],
+            },
+            createdAt: new Date('2024-01-01T10:06:00Z'),
+          },
+        ],
+      });
+
+      const toolResultOnly = await recallMessages({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-5',
+        limit: 2,
+        partType: 'tool-result',
+      });
+
+      expect(toolResultOnly.messages).toContain('Tool Result: readFile');
+      expect(toolResultOnly.messages).not.toContain('Tool Call: readFile');
+      expect(toolResultOnly.messages).not.toContain('Intro text');
+
+      const textOnly = await recallMessages({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-5',
+        limit: 2,
+        partType: 'text',
+      });
+
+      expect(textOnly.messages).toContain('Intro text');
+      expect(textOnly.messages).not.toContain('Tool Result: readFile');
+      expect(textOnly.messages).not.toContain('Tool Call: readFile');
+    });
+
+    it('should filter recallMessages by toolName and combine with partType', async () => {
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-filter-tools',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    toolCallId: 'tc-web-search',
+                    toolName: 'web_search',
+                    state: 'call',
+                    args: { query: 'mastra recall' },
+                  },
+                },
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    toolCallId: 'tc-read-file-result',
+                    toolName: 'readFile',
+                    state: 'result',
+                    args: { path: '/src/index.ts' },
+                    result: 'export const read = true;',
+                  },
+                },
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    toolCallId: 'tc-web-search-result',
+                    toolName: 'web_search',
+                    state: 'result',
+                    args: { query: 'mastra recall' },
+                    result: { results: ['doc-a', 'doc-b'] },
+                  },
+                },
+              ],
+            },
+            createdAt: new Date('2024-01-01T10:07:00Z'),
+          },
+        ],
+      });
+
+      const toolOnly = await recallMessages({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-5',
+        limit: 3,
+        toolName: 'web_search',
+        detail: 'high',
+      });
+
+      expect(toolOnly.messages).toContain('Tool Call: web_search');
+      expect(toolOnly.messages).toContain('next part: partIndex=2');
+      expect(toolOnly.messages).not.toContain('Tool Result: readFile');
+
+      const toolResultOnly = await recallMessages({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-5',
+        limit: 3,
+        toolName: 'web_search',
+        partType: 'tool-result',
+        detail: 'high',
+      });
+
+      expect(toolResultOnly.messages).toContain('Tool Result: web_search');
+      expect(toolResultOnly.messages).not.toContain('Tool Call: web_search');
+      expect(toolResultOnly.messages).not.toContain('Tool Result: readFile');
+
+      const toolCallOnly = await recallMessages({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-5',
+        limit: 3,
+        toolName: 'web_search',
+        partType: 'tool-call',
+        detail: 'high',
+      });
+
+      expect(toolCallOnly.messages).toContain('Tool Call: web_search');
+      expect(toolCallOnly.messages).toContain('"query": "mastra recall"');
+      expect(toolCallOnly.messages).not.toContain('Tool Result: web_search');
+    });
+
+    it('should return no rendered parts when filters match nothing', async () => {
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-no-filter-match',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    toolCallId: 'tc-no-match',
+                    toolName: 'readFile',
+                    state: 'result',
+                    args: { path: '/src/index.ts' },
+                    result: 'no match expected',
+                  },
+                },
+              ],
+            },
+            createdAt: new Date('2024-01-01T10:08:00Z'),
+          },
+        ],
+      });
+
+      const result = await recallMessages({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        cursor: 'msg-5',
+        limit: 4,
+        toolName: 'web_search',
+      });
+
+      expect(result.messages).toBe('(no message parts matched the current filters)');
+      expect(result.count).toBe(1);
+    });
+
     // ── High-detail clamping ──────────────────────────────────────
 
     it('should clamp high detail to 1 part and include continuation hints', async () => {
@@ -1484,6 +1682,58 @@ describe('om-tools', () => {
       expect(page3.hasPrevPage).toBe(true);
     });
 
+    it('should clamp oversized pages to the last available page', async () => {
+      const result = await recallThreadFromStart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        page: 50,
+        limit: 2,
+      });
+
+      expect(result.page).toBe(3);
+      expect(result.count).toBe(1);
+      expect(result.messages).toContain('Message 5 content');
+      expect(result.hasNextPage).toBe(false);
+      expect(result.hasPrevPage).toBe(true);
+    });
+
+    it('should paginate from the newest messages when anchor is end', async () => {
+      const page1 = await recallThreadFromStart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        page: 1,
+        limit: 2,
+        anchor: 'end',
+      });
+
+      expect(page1.page).toBe(1);
+      expect(page1.count).toBe(2);
+      expect(page1.messages).toContain('Message 4 content');
+      expect(page1.messages).toContain('Message 5 content');
+      expect(page1.messages).not.toContain('Message 1 content');
+      expect(page1.hasNextPage).toBe(false);
+      expect(page1.hasPrevPage).toBe(true);
+
+      const page2 = await recallThreadFromStart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        page: 2,
+        limit: 2,
+        anchor: 'end',
+      });
+
+      expect(page2.page).toBe(2);
+      expect(page2.count).toBe(2);
+      expect(page2.messages).toContain('Message 2 content');
+      expect(page2.messages).toContain('Message 3 content');
+      expect(page2.messages).not.toContain('Message 5 content');
+      expect(page2.hasNextPage).toBe(true);
+      expect(page2.hasPrevPage).toBe(true);
+    });
+
     it('should return empty message for a thread with no messages', async () => {
       await memory.saveThread({
         thread: {
@@ -1503,6 +1753,192 @@ describe('om-tools', () => {
 
       expect(result.count).toBe(0);
       expect(result.messages).toContain('no messages');
+    });
+
+    it('should filter recallThreadFromStart by partType and toolName', async () => {
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'start-msg-tool-filter',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [
+                { type: 'text', text: 'Thread intro' },
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    toolCallId: 'tc-start-read-call',
+                    toolName: 'readFile',
+                    state: 'call',
+                    args: { path: '/src/a.ts' },
+                  },
+                },
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    toolCallId: 'tc-start-read-result',
+                    toolName: 'readFile',
+                    state: 'result',
+                    args: { path: '/src/a.ts' },
+                    result: 'export const a = 1;',
+                  },
+                },
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    toolCallId: 'tc-start-web-result',
+                    toolName: 'web_search',
+                    state: 'result',
+                    args: { query: 'memory' },
+                    result: { results: ['memory docs'] },
+                  },
+                },
+              ],
+            },
+            createdAt: new Date('2024-01-01T10:06:00Z'),
+          },
+        ],
+      });
+
+      const byType = await recallThreadFromStart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        partType: 'tool-result',
+        detail: 'high',
+      });
+
+      expect(byType.messages).toContain('Tool Result: readFile');
+      expect(byType.messages).toContain('Tool Result: web_search');
+      expect(byType.messages).not.toContain('Tool Call: readFile');
+      expect(byType.messages).not.toContain('Thread intro');
+
+      const byTool = await recallThreadFromStart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        toolName: 'readFile',
+        detail: 'high',
+      });
+
+      expect(byTool.messages).toContain('Tool Call: readFile');
+      expect(byTool.messages).toContain('Tool Result: readFile');
+      expect(byTool.messages).not.toContain('Tool Result: web_search');
+      expect(byTool.messages).not.toContain('Thread intro');
+
+      const combined = await recallThreadFromStart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        toolName: 'readFile',
+        partType: 'tool-result',
+        detail: 'high',
+      });
+
+      expect(combined.messages).toContain('Tool Result: readFile');
+      expect(combined.messages).not.toContain('Tool Call: readFile');
+      expect(combined.messages).not.toContain('Tool Result: web_search');
+
+      const toolCalls = await recallThreadFromStart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        toolName: 'readFile',
+        partType: 'tool-call',
+        detail: 'high',
+      });
+
+      expect(toolCalls.messages).toContain('Tool Call: readFile');
+      expect(toolCalls.messages).toContain('"path": "/src/a.ts"');
+      expect(toolCalls.messages).not.toContain('Tool Result: readFile');
+    });
+
+    it('should support array-shaped tool-call and tool-result parts', async () => {
+      const mockMemory = {
+        recall: vi.fn().mockResolvedValue({
+          messages: [
+            {
+              id: 'msg-array-tool-parts',
+              threadId,
+              resourceId,
+              role: 'assistant',
+              content: [
+                { type: 'text', text: 'Array intro' },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-array-1',
+                  toolName: 'execute_command',
+                  args: { command: 'pwd' },
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call-array-1',
+                  toolName: 'execute_command',
+                  result: { stdout: '/tmp' },
+                },
+              ],
+              createdAt: new Date('2024-01-01T10:09:00Z'),
+            },
+          ],
+        }),
+        getThreadById: vi.fn().mockResolvedValue({ threadId, resourceId }),
+      };
+
+      const toolCalls = await recallThreadFromStart({
+        memory: mockMemory as any,
+        threadId,
+        resourceId,
+        partType: 'tool-call',
+        toolName: 'execute_command',
+        detail: 'high',
+      });
+
+      expect(toolCalls.messages).toContain('Tool Call: execute_command');
+      expect(toolCalls.messages).toContain('"command": "pwd"');
+      expect(toolCalls.messages).not.toContain('Array intro');
+
+      const toolResults = await recallThreadFromStart({
+        memory: mockMemory as any,
+        threadId,
+        resourceId,
+        partType: 'tool-result',
+        toolName: 'execute_command',
+        detail: 'high',
+      });
+
+      expect(toolResults.messages).toContain('Tool Result: execute_command');
+      expect(toolResults.messages).toContain('stdout');
+    });
+
+    it('should distinguish filtered-empty results from empty threads', async () => {
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-filtered-empty-state',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: 'Only text here' }],
+            },
+            createdAt: new Date('2024-01-01T10:10:00Z'),
+          },
+        ],
+      });
+
+      const result = await recallThreadFromStart({
+        memory: memory as any,
+        threadId,
+        resourceId,
+        partType: 'tool-call',
+      });
+
+      expect(result.messages).toBe('(no message parts matched the current filters)');
+      expect(result.count).toBeGreaterThan(0);
     });
   });
 
@@ -1965,6 +2401,100 @@ describe('om-tools', () => {
       expect(recallMock).toHaveBeenCalled();
     });
 
+    it('should resolve threadId="current" for mode="messages" in resource scope', async () => {
+      const tool = recallTool(undefined, { retrievalScope: 'resource' });
+      const getThreadById = vi.fn().mockResolvedValue({
+        id: 'thread-a',
+        resourceId: 'res-a',
+        createdAt: new Date('2024-01-01T09:00:00Z'),
+        updatedAt: new Date('2024-01-01T10:00:00Z'),
+      });
+      const recallMock = vi.fn().mockResolvedValue({ messages: [] });
+
+      await tool.execute?.(
+        { mode: 'messages', threadId: 'current' } as any,
+        {
+          memory: { getThreadById, recall: recallMock },
+          agent: { threadId: 'thread-a', resourceId: 'res-a' },
+        } as any,
+      );
+
+      expect(getThreadById).toHaveBeenCalledWith({ threadId: 'thread-a' });
+      expect(recallMock).toHaveBeenCalledWith(expect.objectContaining({ threadId: 'thread-a', resourceId: 'res-a' }));
+    });
+
+    it('should pass anchor="end" through for mode="messages" without a cursor', async () => {
+      const tool = recallTool(undefined, { retrievalScope: 'resource' });
+      const getThreadById = vi.fn().mockResolvedValue({
+        id: 'thread-a',
+        resourceId: 'res-a',
+        createdAt: new Date('2024-01-01T09:00:00Z'),
+        updatedAt: new Date('2024-01-01T10:00:00Z'),
+      });
+      const recallMock = vi.fn().mockResolvedValue({
+        messages: [
+          {
+            id: 'msg-1',
+            threadId: 'thread-a',
+            resourceId: 'res-a',
+            role: 'user',
+            content: { format: 2, parts: [{ type: 'text', text: 'Message 1' }] },
+            createdAt: new Date('2024-01-01T10:00:00Z'),
+          },
+          {
+            id: 'msg-2',
+            threadId: 'thread-a',
+            resourceId: 'res-a',
+            role: 'assistant',
+            content: { format: 2, parts: [{ type: 'text', text: 'Message 2' }] },
+            createdAt: new Date('2024-01-01T10:01:00Z'),
+          },
+        ],
+      });
+
+      const result = await tool.execute?.(
+        { mode: 'messages', threadId: 'current', anchor: 'end', page: 1, limit: 1 } as any,
+        {
+          memory: { getThreadById, recall: recallMock },
+          agent: { threadId: 'thread-a', resourceId: 'res-a' },
+        } as any,
+      );
+
+      expect((result as any)?.messages).toContain('Message 2');
+      expect((result as any)?.page).toBe(1);
+      expect((result as any)?.hasPrevPage).toBe(true);
+      expect((result as any)?.hasNextPage).toBe(false);
+    });
+
+    it('should reject threadId="current" when there is no current thread in context', async () => {
+      const tool = recallTool(undefined, { retrievalScope: 'resource' });
+
+      await expect(
+        tool.execute?.(
+          { mode: 'messages', threadId: 'current' } as any,
+          { memory: {}, agent: { resourceId: 'res-a' } } as any,
+        ),
+      ).rejects.toThrow('Could not resolve current thread.');
+    });
+
+    it('should resolve threadId="current" for mode="search" in resource scope', async () => {
+      const tool = recallTool(undefined, { retrievalScope: 'resource' });
+      const searchMessages = vi.fn().mockResolvedValue({ results: [] });
+      const listThreads = vi.fn().mockResolvedValue({ threads: [], total: 0, hasMore: false, page: 0 });
+
+      await tool.execute?.(
+        { mode: 'search', query: 'test query', threadId: 'current' } as any,
+        {
+          memory: { searchMessages, listThreads },
+          agent: { threadId: 'thread-a', resourceId: 'res-a' },
+        } as any,
+      );
+
+      expect(searchMessages).toHaveBeenCalledWith(
+        expect.objectContaining({ filter: expect.objectContaining({ threadId: 'thread-a' }) }),
+      );
+    });
+
     it('should resolve a visible cursor from resource recall when direct lookup misses', async () => {
       const tool = recallTool(undefined, { retrievalScope: 'resource' });
       const listThreadsMock = vi.fn().mockResolvedValue({
@@ -2050,6 +2580,51 @@ describe('om-tools', () => {
         tool.execute?.(
           { mode: 'messages', threadId: 'thread-b' } as any,
           { memory, agent: { threadId: 'thread-a', resourceId: 'res-a' } } as any,
+        ),
+      ).rejects.toThrow('Thread does not belong to the active resource');
+    });
+
+    it('should resolve threadId="current" for mode="threads" in resource scope', async () => {
+      const tool = recallTool(undefined, { retrievalScope: 'resource' });
+      const getThreadById = vi.fn().mockResolvedValue({
+        id: 'thread-a',
+        resourceId: 'res-a',
+        title: 'Current Thread',
+        createdAt: new Date('2024-01-01T09:00:00Z'),
+        updatedAt: new Date('2024-01-01T10:00:00Z'),
+      });
+
+      const result = await tool.execute?.(
+        { mode: 'threads', threadId: 'current' } as any,
+        {
+          memory: { getThreadById },
+          agent: { threadId: 'thread-a', resourceId: 'res-a' },
+        } as any,
+      );
+
+      expect(getThreadById).toHaveBeenCalledWith({ threadId: 'thread-a' });
+      expect((result as any)?.count).toBe(1);
+      expect((result as any)?.threads).toContain('Current Thread');
+      expect((result as any)?.threads).toContain('← current');
+    });
+
+    it('should reject threadId="current" for mode="threads" when current thread is outside the active resource', async () => {
+      const tool = recallTool(undefined, { retrievalScope: 'resource' });
+      const getThreadById = vi.fn().mockResolvedValue({
+        id: 'thread-a',
+        resourceId: 'other-resource',
+        title: 'Wrong Thread',
+        createdAt: new Date('2024-01-01T09:00:00Z'),
+        updatedAt: new Date('2024-01-01T10:00:00Z'),
+      });
+
+      await expect(
+        tool.execute?.(
+          { mode: 'threads', threadId: 'current' } as any,
+          {
+            memory: { getThreadById },
+            agent: { threadId: 'thread-a', resourceId: 'res-a' },
+          } as any,
         ),
       ).rejects.toThrow('Thread does not belong to the active resource');
     });

--- a/packages/memory/src/tools/om-tools.ts
+++ b/packages/memory/src/tools/om-tools.ts
@@ -1019,7 +1019,12 @@ export async function recallMessages({
   }
 
   const rendered = renderFormattedParts(allParts, timestamps, { detail, maxTokens });
-  const emptyMessage = partType || toolName ? '(no message parts matched the current filters)' : '(no messages found)';
+  const emptyMessage =
+    allParts.length === 0
+      ? partType || toolName
+        ? '(no message parts matched the current filters)'
+        : '(no visible message parts found for this page)'
+      : '(no messages found)';
 
   return {
     messages: rendered.text || emptyMessage,

--- a/packages/memory/src/tools/om-tools.ts
+++ b/packages/memory/src/tools/om-tools.ts
@@ -1079,11 +1079,8 @@ export async function recallThreadFromStart({
   const MAX_LIMIT = 20;
   const normalizedPage = Math.max(Math.min(page, MAX_PAGE), 1);
   const normalizedLimit = Math.min(Math.max(limit, 1), MAX_LIMIT);
-
-  const estimatedTotalPages = Math.max(1, Math.ceil(1 / normalizedLimit));
-  const initialEffectivePage = Math.min(normalizedPage, Math.max(estimatedTotalPages, normalizedPage));
-  const initialPageIndex = initialEffectivePage - 1;
-  const fetchCount = initialPageIndex * normalizedLimit + normalizedLimit + 1;
+  const pageIndex = normalizedPage - 1;
+  const fetchCount = pageIndex * normalizedLimit + normalizedLimit + 1;
 
   const result = await memory.recall({
     threadId,
@@ -1093,19 +1090,15 @@ export async function recallThreadFromStart({
     orderBy: { field: 'createdAt', direction: anchor === 'end' ? 'DESC' : 'ASC' },
   });
 
-  const total = typeof result.total === 'number' ? result.total : result.messages.length;
-  const totalPages = Math.max(1, Math.ceil(total / normalizedLimit));
-  const effectivePage = Math.min(normalizedPage, totalPages);
-  const pageIndex = effectivePage - 1;
-  const windowSize = pageIndex * normalizedLimit + normalizedLimit + 1;
   const visibleMessages =
     anchor === 'end'
-      ? result.messages.slice(0, windowSize).filter(hasVisibleParts).reverse()
-      : result.messages.slice(0, windowSize).filter(hasVisibleParts);
+      ? result.messages.slice(0, fetchCount).filter(hasVisibleParts).reverse()
+      : result.messages.slice(0, fetchCount).filter(hasVisibleParts);
   const skip = pageIndex * normalizedLimit;
   const messages = visibleMessages.slice(skip, skip + normalizedLimit);
-  const hasNextPage = anchor === 'end' ? pageIndex > 0 : effectivePage < totalPages;
-  const hasPrevPage = anchor === 'end' ? effectivePage < totalPages : pageIndex > 0;
+  const hasExtraMessage = visibleMessages.length > skip + messages.length;
+  const hasNextPage = messages.length > 0 ? (anchor === 'end' ? pageIndex > 0 : hasExtraMessage) : false;
+  const hasPrevPage = messages.length > 0 ? (anchor === 'end' ? hasExtraMessage : pageIndex > 0) : pageIndex > 0;
 
   let allParts: FormattedPart[] = [];
   const timestamps = new Map<string, Date>();
@@ -1125,7 +1118,9 @@ export async function recallThreadFromStart({
   const rendered = renderFormattedParts(allParts, timestamps, { detail, maxTokens });
   const emptyMessage =
     messages.length === 0
-      ? '(no messages in this thread)'
+      ? pageIndex > 0
+        ? `(no messages found on page ${normalizedPage} for this thread)`
+        : '(no messages in this thread)'
       : partType || toolName
         ? '(no message parts matched the current filters)'
         : '(no messages found)';
@@ -1134,7 +1129,7 @@ export async function recallThreadFromStart({
     messages: rendered.text || emptyMessage,
     count: messages.length,
     cursor: messages[0]?.id || '',
-    page: effectivePage,
+    page: normalizedPage,
     limit: normalizedLimit,
     detail,
     hasNextPage,

--- a/packages/memory/src/tools/om-tools.ts
+++ b/packages/memory/src/tools/om-tools.ts
@@ -12,11 +12,18 @@ import {
 
 export type RecallDetail = 'low' | 'high';
 
+function getMessageParts(msg: MastraDBMessage): any[] {
+  if (typeof msg.content === 'string') return [];
+  if (Array.isArray(msg.content)) return msg.content;
+  const parts = msg.content?.parts;
+  return Array.isArray(parts) ? parts : [];
+}
+
 /** Returns true if a message has at least one non-data part with visible content. */
 function hasVisibleParts(msg: MastraDBMessage): boolean {
   if (typeof msg.content === 'string') return (msg.content as string).length > 0;
-  const parts = msg.content?.parts;
-  if (!parts || !Array.isArray(parts)) return false;
+  const parts = getMessageParts(msg);
+  if (parts.length === 0) return Boolean(msg.content?.content);
   return parts.some((p: { type?: string }) => !p.type?.startsWith('data-'));
 }
 
@@ -55,7 +62,13 @@ type RecallMemory = {
         endExclusive?: boolean;
       };
     };
-  }) => Promise<{ messages: MastraDBMessage[] }>;
+  }) => Promise<{
+    messages: MastraDBMessage[];
+    total: number;
+    page: number;
+    perPage: number | false;
+    hasMore: boolean;
+  }>;
   listThreads: (args: {
     perPage?: number | false;
     page?: number;
@@ -434,6 +447,7 @@ interface FormattedPart {
   text: string;
   /** Full untruncated text — used for auto-expand when token budget allows */
   fullText: string;
+  toolName?: string;
 }
 
 function truncateByTokens(text: string, maxTokens: number, hint?: string): { text: string; wasTruncated: boolean } {
@@ -456,13 +470,14 @@ function makePart(
   type: string,
   fullText: string,
   detail: RecallDetail,
+  toolName?: string,
 ): FormattedPart {
   if (detail === 'high') {
-    return { messageId: msg.id, partIndex, role: msg.role, type, text: fullText, fullText };
+    return { messageId: msg.id, partIndex, role: msg.role, type, text: fullText, fullText, toolName };
   }
   const hint = `recall cursor="${msg.id}" partIndex=${partIndex} detail="high"`;
   const { text } = truncateByTokens(fullText, lowDetailPartLimit(type), hint);
-  return { messageId: msg.id, partIndex, role: msg.role, type, text, fullText };
+  return { messageId: msg.id, partIndex, role: msg.role, type, text, fullText, toolName };
 }
 
 function formatMessageParts(msg: MastraDBMessage, detail: RecallDetail): FormattedPart[] {
@@ -473,32 +488,74 @@ function formatMessageParts(msg: MastraDBMessage, detail: RecallDetail): Formatt
     return parts;
   }
 
-  if (msg.content?.parts && Array.isArray(msg.content.parts)) {
-    for (let i = 0; i < msg.content.parts.length; i++) {
-      const part = msg.content.parts[i]!;
+  const messageParts = getMessageParts(msg);
+  if (messageParts.length > 0) {
+    for (let i = 0; i < messageParts.length; i++) {
+      const part = messageParts[i]!;
       const partType = (part as { type?: string }).type;
 
       if (partType === 'text') {
-        const text = (part as { text: string }).text;
-        parts.push(makePart(msg, i, 'text', text, detail));
+        const text = (part as { text?: string }).text;
+        if (text) {
+          parts.push(makePart(msg, i, 'text', text, detail));
+        }
       } else if (partType === 'tool-invocation') {
         const inv = (part as any).toolInvocation;
-        if (inv.state === 'result') {
-          const { value: resultValue } = resolveToolResultValue(
-            part as { providerMetadata?: Record<string, any> },
-            inv.result,
-          );
-          // Serialize at high-detail budget — makePart handles per-part truncation with hint
-          const resultStr = formatToolResultForObserver(resultValue, { maxTokens: HIGH_DETAIL_TOOL_RESULT_TOKENS });
-          const fullText = `[Tool Result: ${inv.toolName}]\n${resultStr}`;
-          parts.push(makePart(msg, i, 'tool-result', fullText, detail));
-        } else {
-          const argsStr = detail === 'low' ? '' : `\n${JSON.stringify(inv.args, null, 2)}`;
-          const fullText = `[Tool Call: ${inv.toolName}]${argsStr}`;
-          parts.push({ messageId: msg.id, partIndex: i, role: msg.role, type: 'tool-call', text: fullText, fullText });
+        if (inv?.toolName) {
+          const hasArgs = inv.args != null;
+          if (inv.state !== 'partial-call' && hasArgs) {
+            const argsStr = detail === 'low' ? '' : `\n${JSON.stringify(inv.args, null, 2)}`;
+            const fullText = `[Tool Call: ${inv.toolName}]${argsStr}`;
+            parts.push({
+              messageId: msg.id,
+              partIndex: i,
+              role: msg.role,
+              type: 'tool-call',
+              text: fullText,
+              fullText,
+              toolName: inv.toolName,
+            });
+          }
+
+          if (inv.state === 'result') {
+            const { value: resultValue } = resolveToolResultValue(
+              part as { providerMetadata?: Record<string, any> },
+              inv.result,
+            );
+            const resultStr = formatToolResultForObserver(resultValue, { maxTokens: HIGH_DETAIL_TOOL_RESULT_TOKENS });
+            const fullText = `[Tool Result: ${inv.toolName}]\n${resultStr}`;
+            parts.push(makePart(msg, i, 'tool-result', fullText, detail, inv.toolName));
+          }
+        }
+      } else if (partType === 'tool-call') {
+        const toolName = (part as any).toolName;
+        if (toolName) {
+          const rawArgs = (part as any).input ?? (part as any).args;
+          const argsStr =
+            detail === 'low' || rawArgs == null
+              ? ''
+              : `\n${typeof rawArgs === 'string' ? rawArgs : JSON.stringify(rawArgs, null, 2)}`;
+          const fullText = `[Tool Call: ${toolName}]${argsStr}`;
+          parts.push({
+            messageId: msg.id,
+            partIndex: i,
+            role: msg.role,
+            type: 'tool-call',
+            text: fullText,
+            fullText,
+            toolName,
+          });
+        }
+      } else if (partType === 'tool-result') {
+        const toolName = (part as any).toolName;
+        if (toolName) {
+          const rawResult = (part as any).output ?? (part as any).result;
+          const resultStr = formatToolResultForObserver(rawResult, { maxTokens: HIGH_DETAIL_TOOL_RESULT_TOKENS });
+          const fullText = `[Tool Result: ${toolName}]\n${resultStr}`;
+          parts.push(makePart(msg, i, 'tool-result', fullText, detail, toolName));
         }
       } else if (partType === 'reasoning') {
-        const reasoning = (part as { reasoning?: string }).reasoning;
+        const reasoning = (part as { reasoning?: string; text?: string }).reasoning ?? (part as { text?: string }).text;
         if (reasoning) {
           parts.push(makePart(msg, i, 'reasoning', reasoning, detail));
         }
@@ -699,7 +756,7 @@ export async function recallPart({
     );
   }
 
-  const target = allParts.find(p => p.partIndex === partIndex);
+  const target = [...allParts].reverse().find(p => p.partIndex === partIndex);
 
   if (!target) {
     const availableIndices = allParts.map(p => p.partIndex).join(', ');
@@ -774,6 +831,8 @@ export async function recallMessages({
   page = 1,
   limit = 20,
   detail = 'low',
+  partType,
+  toolName,
   threadScope,
   maxTokens = DEFAULT_MAX_RESULT_TOKENS,
 }: {
@@ -784,6 +843,8 @@ export async function recallMessages({
   page?: number;
   limit?: number;
   detail?: RecallDetail;
+  partType?: 'text' | 'tool-call' | 'tool-result' | 'reasoning' | 'image' | 'file';
+  toolName?: string;
   threadScope?: string;
   maxTokens?: number;
 }): Promise<RecallResult> {
@@ -901,11 +962,19 @@ export async function recallMessages({
   const hasPrevPage = isForward ? pageIndex > 0 : hasMore;
 
   // Format parts from returned messages
-  const allParts: FormattedPart[] = [];
+  let allParts: FormattedPart[] = [];
   const timestamps = new Map<string, Date>();
   for (const msg of messages) {
     timestamps.set(msg.id, msg.createdAt);
     allParts.push(...formatMessageParts(msg, detail));
+  }
+
+  if (toolName) {
+    allParts = allParts.filter(p => (p.type === 'tool-call' || p.type === 'tool-result') && p.toolName === toolName);
+  }
+
+  if (partType) {
+    allParts = allParts.filter(p => p.type === partType);
   }
 
   // High detail: clamp to 1 message and 1 part to avoid token blowup
@@ -950,9 +1019,10 @@ export async function recallMessages({
   }
 
   const rendered = renderFormattedParts(allParts, timestamps, { detail, maxTokens });
+  const emptyMessage = partType || toolName ? '(no message parts matched the current filters)' : '(no messages found)';
 
   return {
-    messages: rendered.text,
+    messages: rendered.text || emptyMessage,
     count: messages.length,
     cursor,
     page: normalizedPage,
@@ -974,6 +1044,9 @@ export async function recallThreadFromStart({
   page = 1,
   limit = 20,
   detail = 'low',
+  partType,
+  toolName,
+  anchor = 'start',
   maxTokens = DEFAULT_MAX_RESULT_TOKENS,
 }: {
   memory: RecallMemory;
@@ -982,6 +1055,9 @@ export async function recallThreadFromStart({
   page?: number;
   limit?: number;
   detail?: RecallDetail;
+  partType?: 'text' | 'tool-call' | 'tool-result' | 'reasoning' | 'image' | 'file';
+  toolName?: string;
+  anchor?: 'start' | 'end';
   maxTokens?: number;
 }): Promise<RecallResult> {
   if (!memory) {
@@ -1003,43 +1079,66 @@ export async function recallThreadFromStart({
   const MAX_LIMIT = 20;
   const normalizedPage = Math.max(Math.min(page, MAX_PAGE), 1);
   const normalizedLimit = Math.min(Math.max(limit, 1), MAX_LIMIT);
-  const pageIndex = normalizedPage - 1;
 
-  // Fetch one extra to detect hasNextPage
-  const fetchCount = pageIndex * normalizedLimit + normalizedLimit + 1;
+  const estimatedTotalPages = Math.max(1, Math.ceil(1 / normalizedLimit));
+  const initialEffectivePage = Math.min(normalizedPage, Math.max(estimatedTotalPages, normalizedPage));
+  const initialPageIndex = initialEffectivePage - 1;
+  const fetchCount = initialPageIndex * normalizedLimit + normalizedLimit + 1;
 
   const result = await memory.recall({
     threadId,
     resourceId,
     page: 0,
     perPage: fetchCount,
-    orderBy: { field: 'createdAt', direction: 'ASC' },
+    orderBy: { field: 'createdAt', direction: anchor === 'end' ? 'DESC' : 'ASC' },
   });
 
-  const visibleMessages = result.messages.filter(hasVisibleParts);
-  const total = visibleMessages.length;
+  const total = typeof result.total === 'number' ? result.total : result.messages.length;
+  const totalPages = Math.max(1, Math.ceil(total / normalizedLimit));
+  const effectivePage = Math.min(normalizedPage, totalPages);
+  const pageIndex = effectivePage - 1;
+  const windowSize = pageIndex * normalizedLimit + normalizedLimit + 1;
+  const visibleMessages =
+    anchor === 'end'
+      ? result.messages.slice(0, windowSize).filter(hasVisibleParts).reverse()
+      : result.messages.slice(0, windowSize).filter(hasVisibleParts);
   const skip = pageIndex * normalizedLimit;
-  const hasMore = total > skip + normalizedLimit;
   const messages = visibleMessages.slice(skip, skip + normalizedLimit);
+  const hasNextPage = anchor === 'end' ? pageIndex > 0 : effectivePage < totalPages;
+  const hasPrevPage = anchor === 'end' ? effectivePage < totalPages : pageIndex > 0;
 
-  const allParts: FormattedPart[] = [];
+  let allParts: FormattedPart[] = [];
   const timestamps = new Map<string, Date>();
   for (const msg of messages) {
     timestamps.set(msg.id, msg.createdAt);
     allParts.push(...formatMessageParts(msg, detail));
   }
 
+  if (toolName) {
+    allParts = allParts.filter(p => (p.type === 'tool-call' || p.type === 'tool-result') && p.toolName === toolName);
+  }
+
+  if (partType) {
+    allParts = allParts.filter(p => p.type === partType);
+  }
+
   const rendered = renderFormattedParts(allParts, timestamps, { detail, maxTokens });
+  const emptyMessage =
+    messages.length === 0
+      ? '(no messages in this thread)'
+      : partType || toolName
+        ? '(no message parts matched the current filters)'
+        : '(no messages found)';
 
   return {
-    messages: rendered.text || '(no messages in this thread)',
+    messages: rendered.text || emptyMessage,
     count: messages.length,
     cursor: messages[0]?.id || '',
-    page: normalizedPage,
+    page: effectivePage,
     limit: normalizedLimit,
     detail,
-    hasNextPage: hasMore,
-    hasPrevPage: pageIndex > 0,
+    hasNextPage,
+    hasPrevPage,
     truncated: rendered.truncated,
     tokenOffset: rendered.tokenOffset,
   };
@@ -1072,7 +1171,9 @@ export const recallTool = (
               .string()
               .min(1)
               .optional()
-              .describe('Browse a different thread. Use mode="threads" first to discover thread IDs.'),
+              .describe(
+                'Browse a different thread, or use "current" for the active thread. Use mode="threads" first to discover thread IDs.',
+              ),
             before: z
               .string()
               .optional()
@@ -1106,6 +1207,12 @@ export const recallTool = (
         .describe(
           'A message ID to use as the pagination cursor. For mode="messages", provide either cursor or threadId. If only cursor is provided, it must belong to the current thread. Extract it from the start or end of an observation group range.',
         ),
+      anchor: z
+        .enum(['start', 'end'])
+        .optional()
+        .describe(
+          'For mode="messages" without a cursor, page from the start (oldest-first) or end (newest-first) of the thread. Defaults to "start".',
+        ),
       page: z
         .number()
         .int()
@@ -1128,6 +1235,17 @@ export const recallTool = (
         .describe(
           'Detail level for messages. "low" (default) returns truncated text and tool names. "high" returns full content with tool args/results.',
         ),
+      partType: z
+        .enum(['text', 'tool-call', 'tool-result', 'reasoning', 'image', 'file'])
+        .optional()
+        .describe('Filter results to only include parts of this type. Only applies to mode="messages".'),
+      toolName: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          'Filter results to only include tool-call and tool-result parts matching this tool name. Only applies to mode="messages".',
+        ),
       partIndex: z
         .number()
         .int()
@@ -1143,9 +1261,12 @@ export const recallTool = (
         query,
         cursor,
         threadId: explicitThreadId,
+        anchor,
         page,
         limit,
         detail,
+        partType,
+        toolName,
         partIndex,
         before,
         after,
@@ -1154,9 +1275,12 @@ export const recallTool = (
         query?: string;
         cursor?: string;
         threadId?: string;
+        anchor?: 'start' | 'end';
         page?: number;
         limit?: number;
         detail?: RecallDetail;
+        partType?: 'text' | 'tool-call' | 'tool-result' | 'reasoning' | 'image' | 'file';
+        toolName?: string;
         partIndex?: number;
         before?: string;
         after?: string;
@@ -1166,9 +1290,14 @@ export const recallTool = (
       const memory = (context as any)?.memory as RecallMemory | undefined;
       const currentThreadId = context?.agent?.threadId;
       const resourceId = context?.agent?.resourceId;
+      const resolvedExplicitThreadId = explicitThreadId === 'current' ? currentThreadId : explicitThreadId;
 
       if (!memory) {
         throw new Error('Memory instance is required for recall');
+      }
+
+      if (explicitThreadId === 'current' && !currentThreadId) {
+        throw new Error('Could not resolve current thread.');
       }
 
       // Search mode
@@ -1187,20 +1316,25 @@ export const recallTool = (
           topK: limit ?? 10,
           before,
           after,
-          threadScope: !isResourceScope ? currentThreadId || undefined : undefined,
+          threadScope: !isResourceScope ? currentThreadId || undefined : resolvedExplicitThreadId || undefined,
         });
       }
 
       // Thread listing mode
       if (mode === 'threads') {
+        const requestedCurrentThread = explicitThreadId === 'current';
+
         // Thread scope: return current thread info only
-        if (!isResourceScope) {
+        if (!isResourceScope || requestedCurrentThread) {
           if (!currentThreadId || !memory.getThreadById) {
             return { error: 'Could not resolve current thread.' };
           }
           const thread = await memory.getThreadById({ threadId: currentThreadId });
           if (!thread) {
             return { error: 'Could not resolve current thread.' };
+          }
+          if (isResourceScope && resourceId && thread.resourceId !== resourceId) {
+            throw new Error('Thread does not belong to the active resource');
           }
           return {
             threads: `- **${thread.title || '(untitled)'}** ← current\n  id: ${thread.id}\n  updated: ${formatTimestamp(thread.updatedAt)} | created: ${formatTimestamp(thread.createdAt)}`,
@@ -1223,7 +1357,7 @@ export const recallTool = (
         });
       }
 
-      const hasExplicitThreadId = typeof explicitThreadId === 'string' && explicitThreadId.length > 0;
+      const hasExplicitThreadId = typeof resolvedExplicitThreadId === 'string' && resolvedExplicitThreadId.length > 0;
       const hasCursor = typeof cursor === 'string' && cursor.length > 0;
 
       if (!hasExplicitThreadId && !hasCursor) {
@@ -1244,7 +1378,7 @@ export const recallTool = (
           throw new Error('Memory instance cannot verify thread access for recall');
         }
 
-        const thread = await memory.getThreadById({ threadId: explicitThreadId! });
+        const thread = await memory.getThreadById({ threadId: resolvedExplicitThreadId! });
         if (!thread || thread.resourceId !== resourceId) {
           throw new Error('Thread does not belong to the active resource');
         }
@@ -1293,6 +1427,9 @@ export const recallTool = (
           page: page ?? 1,
           limit: limit ?? 20,
           detail: detail ?? 'low',
+          partType,
+          toolName,
+          anchor: anchor ?? 'start',
         });
       }
 
@@ -1316,6 +1453,8 @@ export const recallTool = (
         page,
         limit,
         detail: detail ?? 'low',
+        partType,
+        toolName,
         threadScope,
       });
     },


### PR DESCRIPTION
This updates the recall tool so agents can inspect conversation history more precisely.

Agents using `recall` can now filter message browsing by `partType` and `toolName`, and can page no-cursor message results from either the start or end of a thread.

Before:
```ts
await recall({ mode: 'messages', threadId, cursor: 'msg-123' })
```

After:
```ts
await recall({ mode: 'messages', threadId: 'current', partType: 'tool-call', toolName: 'execute_command' })
await recall({ mode: 'messages', threadId: 'current', anchor: 'end', page: 1, limit: 10 })
```

This also fixes a few live recall issues I hit while testing: stored tool results can now surface matching tool-call views when args are present, array-shaped stored content is handled correctly, filtered empty states are clearer, and oversized no-cursor pages clamp instead of returning empty results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering options to narrow message results by part type (text, tool call, tool result, reasoning, image, file) and tool name.
  * Introduced `anchor` parameter to paginate thread messages from oldest or newest entries.
  * Added support for `threadId: "current"` across recall operations.

* **Tests**
  * Extended test coverage for message filtering, pagination, and thread handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->