### PR TITLE
fix(client-js): correct Vector SDK return types to match server responses

### DIFF
--- a/.changeset/fix-vector-sdk-return-types.md
+++ b/.changeset/fix-vector-sdk-return-types.md
@@ -1,0 +1,13 @@
+---
+'@mastra/client-js': patch
+---
+
+Fixed Vector SDK return types to match actual server responses.
+
+Three methods had incorrect TypeScript return types that caused runtime failures even though TypeScript compilation succeeded:
+
+- `getIndexes()` now returns `Promise<string[]>` instead of `Promise<{ indexes: string[] }>`
+- `upsert()` now returns `Promise<{ ids: string[] }>` instead of `Promise<string[]>`
+- `query()` now returns `Promise<QueryResult[]>` instead of `Promise<QueryVectorResponse>`
+
+The `QueryVectorResponse` interface is now deprecated — use `QueryResult[]` from `@mastra/core/vector` instead.

--- a/client-sdks/client-js/src/resources/vector.ts
+++ b/client-sdks/client-js/src/resources/vector.ts
@@ -1,9 +1,9 @@
+import type { QueryResult } from '@mastra/core/vector';
 import type { RequestContext } from '@mastra/core/request-context';
 import type {
   CreateIndexParams,
   GetVectorIndexResponse,
   QueryVectorParams,
-  QueryVectorResponse,
   ClientOptions,
   UpsertVectorParams,
 } from '../types';
@@ -47,7 +47,7 @@ export class Vector extends BaseResource {
    * @param requestContext - Optional request context to pass as query parameter
    * @returns Promise containing array of index names
    */
-  getIndexes(requestContext?: RequestContext | Record<string, any>): Promise<{ indexes: string[] }> {
+  getIndexes(requestContext?: RequestContext | Record<string, any>): Promise<string[]> {
     return this.request(
       `/vector/${encodeURIComponent(this.vectorName)}/indexes${requestContextQueryString(requestContext)}`,
     );
@@ -68,9 +68,9 @@ export class Vector extends BaseResource {
   /**
    * Upserts vectors into an index
    * @param params - Parameters containing vectors, metadata, and optional IDs
-   * @returns Promise containing array of vector IDs
+   * @returns Promise containing object with array of vector IDs
    */
-  upsert(params: UpsertVectorParams): Promise<string[]> {
+  upsert(params: UpsertVectorParams): Promise<{ ids: string[] }> {
     return this.request(`/vector/${encodeURIComponent(this.vectorName)}/upsert`, {
       method: 'POST',
       body: params,
@@ -80,9 +80,9 @@ export class Vector extends BaseResource {
   /**
    * Queries vectors in an index
    * @param params - Query parameters including query vector and search options
-   * @returns Promise containing query results
+   * @returns Promise containing array of query results
    */
-  query(params: QueryVectorParams): Promise<QueryVectorResponse> {
+  query(params: QueryVectorParams): Promise<QueryResult[]> {
     return this.request(`/vector/${encodeURIComponent(this.vectorName)}/query`, {
       method: 'POST',
       body: params,

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -542,6 +542,10 @@ export interface QueryVectorParams {
   includeVector?: boolean;
 }
 
+/**
+ * @deprecated The server returns `QueryResult[]` directly, not a wrapped object.
+ * Use `QueryResult[]` from `@mastra/core/vector` instead.
+ */
 export interface QueryVectorResponse {
   results: QueryResult[];
 }


### PR DESCRIPTION
Fixes #15089

## Problem

Three methods in `@mastra/client-js` Vector resource had TypeScript return types that didn't match what the server actually returns, causing silent runtime failures:

| Method | SDK declared | Server returns |
|---|---|---|
| `getIndexes()` | `Promise<{ indexes: string[] }>` | `string[]` |
| `upsert()` | `Promise<string[]>` | `{ ids: string[] }` |
| `query()` | `Promise<QueryVectorResponse>` | `QueryResult[]` |

## Solution

Updated return types in `client-sdks/client-js/src/resources/vector.ts` to match the server's Zod response schemas (in `packages/server/src/server/schemas/vectors.ts`):

- `getIndexes()` → `Promise<string[]>`
- `upsert()` → `Promise<{ ids: string[] }>`
- `query()` → `Promise<QueryResult[]>` (using `QueryResult` from `@mastra/core/vector`)

Also marked `QueryVectorResponse` as `@deprecated` in `types.ts` since it describes a shape that never existed in the server response.

## Testing

The fix aligns the SDK types with the existing server Zod schemas (`listIndexesResponseSchema`, `upsertVectorsResponseSchema`, `queryVectorsResponseSchema`) which serve as the source of truth for what the server returns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect TypeScript return types in Vector SDK methods (`getIndexes()`, `upsert()`, `query()`) to match actual server responses.
  * Deprecated `QueryVectorResponse` type; use `QueryResult[]` from `@mastra/core/vector` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->