### PR TITLE
Playground UI / DS -  DataKeysAndValues

### DIFF
--- a/.changeset/cold-ideas-grab.md
+++ b/.changeset/cold-ideas-grab.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added DataKeysAndValues component — a compound component for displaying key-value pairs in a grid layout with support for single or two-column modes and section headers

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-header.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-header.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/lib/utils';
+
+export interface DataKeysAndValuesHeaderProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function DataKeysAndValuesHeader({ className, children }: DataKeysAndValuesHeaderProps) {
+  return (
+    <dt className={cn('col-span-full text-ui-sm uppercase tracking-widest text-neutral2 py-3', className)}>
+      {children}
+    </dt>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-key.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-key.tsx
@@ -1,0 +1,10 @@
+import { cn } from '@/lib/utils';
+
+export interface DataKeysAndValuesKeyProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function DataKeysAndValuesKey({ className, children }: DataKeysAndValuesKeyProps) {
+  return <dt className={cn('text-ui-smd  text-neutral2 shrink-0 py-0.5', className)}>{children}</dt>;
+}

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-root.tsx
@@ -1,0 +1,18 @@
+import { cn } from '@/lib/utils';
+
+export interface DataKeysAndValuesProps {
+  className?: string;
+  children: React.ReactNode;
+  numOfCol?: 1 | 2;
+}
+
+export function DataKeysAndValuesRoot({ className, children, numOfCol = 1 }: DataKeysAndValuesProps) {
+  return (
+    <dl
+      className={cn('grid gap-x-4 gap-y-1.5 grid-cols-[auto_1fr]', className)}
+      style={numOfCol === 2 ? { gridTemplateColumns: 'auto 1fr auto 1fr' } : undefined}
+    >
+      {children}
+    </dl>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value.tsx
@@ -1,0 +1,10 @@
+import { cn } from '@/lib/utils';
+
+export interface DataKeysAndValuesValueProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function DataKeysAndValuesValue({ className, children }: DataKeysAndValuesValueProps) {
+  return <dd className={cn('text-ui-smd text-neutral3 truncate min-w-0 py-0.5', className)}>{children}</dd>;
+}

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DataKeysAndValues } from './data-keys-and-values';
+import type { DataKeysAndValuesProps } from './data-keys-and-values-root';
+
+const meta: Meta<typeof DataKeysAndValues> = {
+  title: 'Elements/DataKeysAndValues',
+  component: DataKeysAndValues,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    numOfCol: {
+      control: { type: 'inline-radio' },
+      options: [1, 2],
+    },
+  },
+  decorators: [
+    Story => (
+      <div className="w-[480px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<DataKeysAndValuesProps>;
+
+export const Default: Story = {
+  args: {
+    numOfCol: 1,
+  },
+  render: args => (
+    <DataKeysAndValues {...args}>
+      <DataKeysAndValues.Key>Status</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>Running</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Duration</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>1.23s</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Model</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>gpt-4o</DataKeysAndValues.Value>
+    </DataKeysAndValues>
+  ),
+};
+
+export const TwoColumns: Story = {
+  args: {
+    numOfCol: 2,
+  },
+  render: args => (
+    <DataKeysAndValues {...args}>
+      <DataKeysAndValues.Key>Status</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>Running</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Duration</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>1.23s</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Model</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>gpt-4o</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Tokens</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>2,451</DataKeysAndValues.Value>
+    </DataKeysAndValues>
+  ),
+};
+
+export const WithHeader: Story = {
+  args: {
+    numOfCol: 1,
+  },
+  render: args => (
+    <DataKeysAndValues {...args}>
+      <DataKeysAndValues.Header>General</DataKeysAndValues.Header>
+      <DataKeysAndValues.Key>Status</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>Running</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Duration</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>1.23s</DataKeysAndValues.Value>
+      <DataKeysAndValues.Header>Model</DataKeysAndValues.Header>
+      <DataKeysAndValues.Key>Name</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>gpt-4o</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Tokens</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>2,451</DataKeysAndValues.Value>
+    </DataKeysAndValues>
+  ),
+};
+
+export const WithHeaderTwoColumns: Story = {
+  args: {
+    numOfCol: 2,
+  },
+  render: args => (
+    <DataKeysAndValues {...args}>
+      <DataKeysAndValues.Header>Span Details</DataKeysAndValues.Header>
+      <DataKeysAndValues.Key>Status</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>Running</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Duration</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>1.23s</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Model</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>gpt-4o</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Tokens</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>2,451</DataKeysAndValues.Value>
+    </DataKeysAndValues>
+  ),
+};
+
+export const TruncatedValues: Story = {
+  decorators: [
+    Story => (
+      <div className="w-[200px]">
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <DataKeysAndValues>
+      <DataKeysAndValues.Key>Trace ID</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>abc123def456ghi789jkl012mno345pqr678stu901vwx234</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Span ID</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>span-001-very-long-identifier-that-should-truncate</DataKeysAndValues.Value>
+    </DataKeysAndValues>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.tsx
@@ -1,0 +1,10 @@
+import { DataKeysAndValuesHeader } from './data-keys-and-values-header';
+import { DataKeysAndValuesKey } from './data-keys-and-values-key';
+import { DataKeysAndValuesRoot } from './data-keys-and-values-root';
+import { DataKeysAndValuesValue } from './data-keys-and-values-value';
+
+export const DataKeysAndValues = Object.assign(DataKeysAndValuesRoot, {
+  Key: DataKeysAndValuesKey,
+  Value: DataKeysAndValuesValue,
+  Header: DataKeysAndValuesHeader,
+});

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/index.ts
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/index.ts
@@ -1,0 +1,5 @@
+export { DataKeysAndValues } from './data-keys-and-values';
+export type { DataKeysAndValuesProps } from './data-keys-and-values-root';
+export type { DataKeysAndValuesKeyProps } from './data-keys-and-values-key';
+export type { DataKeysAndValuesValueProps } from './data-keys-and-values-value';
+export type { DataKeysAndValuesHeaderProps } from './data-keys-and-values-header';


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

<img width="1437" height="1143" alt="CleanShot 2026-04-07 at 11 08 50" src="https://github.com/user-attachments/assets/4c987f77-59fa-4852-ab08-90f23f6173b1" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a new component called `DataKeysAndValues` to the Mastra playground UI library. It's like a table that displays pairs of information (like a key and its value) and can show them in one or two columns, kind of like how you might organize a list of facts on a page.

## Changes

### New Component: DataKeysAndValues

A compound component for displaying key-value pairs in a grid layout, supporting:
- Single-column (default) and two-column modes
- Optional section headers
- Text truncation for long values

### Component Structure

The implementation uses a compound component pattern with the following subcomponents:

- **`DataKeysAndValuesRoot`** – The main container that renders a `<dl>` element with configurable grid layout. Accepts `numOfCol` prop (`1` or `2`) to control columns and optional `className` for styling.
- **`DataKeysAndValuesKey`** – Renders key elements as `<dt>` with semantic styling (`text-ui-smd text-neutral2 shrink-0 py-0.5`).
- **`DataKeysAndValuesValue`** – Renders values as `<dd>` with truncation support (`text-ui-smd text-neutral3 truncate min-w-0 py-0.5`).
- **`DataKeysAndValuesHeader`** – Optional header elements rendered as `<dt>` for section labeling.

The components are composed together via `Object.assign` in `data-keys-and-values.tsx`, making them accessible as static properties on the main component (e.g., `DataKeysAndValues.Key`, `DataKeysAndValues.Value`, `DataKeysAndValues.Header`).

### Storybook Documentation

Added comprehensive Storybook stories demonstrating:
- Default one-column layout
- Two-column layout
- Layout with header support
- Two-column layout with headers
- Value truncation behavior with fixed-width container

### Version & Exports

- Recorded as a minor version bump in changeset for `@mastra/playground-ui`
- Barrel export (`index.ts`) exposes the component and all prop type definitions for public consumption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->