### PR TITLE
Playground UI / DS - DataPanel

### DIFF
--- a/.changeset/tasty-bobcats-marry.md
+++ b/.changeset/tasty-bobcats-marry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added DataPanel compound component — a container for detail panels with header, navigation, close button, loading, and empty states

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-close-button.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-close-button.tsx
@@ -7,11 +7,7 @@ export interface DataPanelCloseButtonProps {
   className?: string;
 }
 
-export function DataPanelCloseButton({
-  onClick,
-  tooltip = 'Close panel',
-  className,
-}: DataPanelCloseButtonProps) {
+export function DataPanelCloseButton({ onClick, tooltip = 'Close panel', className }: DataPanelCloseButtonProps) {
   return (
     <ButtonWithTooltip
       size="md"

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-close-button.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-close-button.tsx
@@ -1,0 +1,26 @@
+import { XIcon } from 'lucide-react';
+import { ButtonWithTooltip } from '@/ds/components/Button/ButtonWithTooltip';
+
+export interface DataPanelCloseButtonProps {
+  onClick: () => void;
+  tooltip?: string;
+  className?: string;
+}
+
+export function DataPanelCloseButton({
+  onClick,
+  tooltip = 'Close panel',
+  className,
+}: DataPanelCloseButtonProps) {
+  return (
+    <ButtonWithTooltip
+      size="md"
+      onClick={onClick}
+      aria-label="Close Panel"
+      tooltipContent={tooltip}
+      className={className}
+    >
+      <XIcon />
+    </ButtonWithTooltip>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-content.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-content.tsx
@@ -1,0 +1,14 @@
+import { type ReactNode, type Ref } from 'react';
+
+export interface DataPanelContentProps {
+  children: ReactNode;
+  ref?: Ref<HTMLDivElement>;
+}
+
+export function DataPanelContent({ children, ref }: DataPanelContentProps) {
+  return (
+    <div ref={ref} className="flex-1 p-4 overflow-y-auto">
+      {children}
+    </div>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-content.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-content.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type Ref } from 'react';
+import type { ReactNode, Ref } from 'react';
 
 export interface DataPanelContentProps {
   children: ReactNode;

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-header.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-header.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/lib/utils';
+
+export interface DataPanelHeaderProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function DataPanelHeader({ className, children }: DataPanelHeaderProps) {
+  return (
+    <div className={cn('flex items-center justify-between gap-2 border-b border-border1 mx-4 py-3', className)}>
+      {children}
+    </div>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-heading.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-heading.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/lib/utils';
+
+export interface DataPanelHeadingProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function DataPanelHeading({ className, children }: DataPanelHeadingProps) {
+  return (
+    <h3 className={cn('flex gap-2 text-ui-md text-neutral3 [&>b]:text-neutral2 [&>b]:font-normal', className)}>
+      {children}
+    </h3>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-loading-data.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-loading-data.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+import { Spinner } from '@/ds/components/Spinner';
+
+export interface DataPanelLoadingDataProps {
+  children?: ReactNode;
+}
+
+export function DataPanelLoadingData({ children }: DataPanelLoadingDataProps) {
+  return (
+    <div className="flex items-center justify-center gap-2 px-4 py-6 text-ui-sm text-neutral3">
+      <Spinner /> {children ?? 'Loading...'}
+    </div>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-next-prev-nav.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-next-prev-nav.tsx
@@ -1,0 +1,28 @@
+import { ArrowDownIcon, ArrowUpIcon } from 'lucide-react';
+import { ButtonWithTooltip } from '@/ds/components/Button/ButtonWithTooltip';
+import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
+
+export interface DataPanelNextPrevNavProps {
+  onPrevious?: () => void;
+  onNext?: () => void;
+  previousLabel?: string;
+  nextLabel?: string;
+}
+
+export function DataPanelNextPrevNav({
+  onPrevious,
+  onNext,
+  previousLabel = 'Previous',
+  nextLabel = 'Next',
+}: DataPanelNextPrevNavProps) {
+  return (
+    <ButtonsGroup spacing="close">
+      <ButtonWithTooltip size="md" tooltipContent={previousLabel} onClick={onPrevious} disabled={!onPrevious}>
+        <ArrowUpIcon />
+      </ButtonWithTooltip>
+      <ButtonWithTooltip size="md" tooltipContent={nextLabel} onClick={onNext} disabled={!onNext}>
+        <ArrowDownIcon />
+      </ButtonWithTooltip>
+    </ButtonsGroup>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-no-data.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-no-data.tsx
@@ -1,0 +1,7 @@
+export interface DataPanelNoDataProps {
+  children?: React.ReactNode;
+}
+
+export function DataPanelNoData({ children }: DataPanelNoDataProps) {
+  return <p className="px-4 py-6 text-ui-sm text-neutral2">{children ?? 'No data found.'}</p>;
+}

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-root.tsx
@@ -1,0 +1,19 @@
+import { cn } from '@/lib/utils';
+
+export interface DataPanelProps {
+  collapsed?: boolean;
+  children: React.ReactNode;
+}
+
+export function DataPanelRoot({ collapsed, children }: DataPanelProps) {
+  return (
+    <section
+      className={cn(
+        'flex flex-col bg-surface2 border border-border1 rounded-xl overflow-hidden',
+        collapsed ? 'h-auto' : 'h-full',
+      )}
+    >
+      {children}
+    </section>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DataPanel } from './data-panel';
+import { TooltipProvider } from '../Tooltip';
+import type { DataPanelProps } from './data-panel-root';
+
+const meta: Meta<typeof DataPanel> = {
+  title: 'Composite/DataPanel',
+  component: DataPanel,
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <div className="h-[500px] w-[400px]">
+          <Story />
+        </div>
+      </TooltipProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<DataPanelProps>;
+
+export const Default: Story = {
+  render: () => (
+    <DataPanel>
+      <DataPanel.Header>
+        <DataPanel.Heading>Span Details</DataPanel.Heading>
+        <DataPanel.CloseButton onClick={() => {}} />
+      </DataPanel.Header>
+      <DataPanel.Content>
+        <p className="text-ui-sm text-neutral3">Panel content goes here.</p>
+      </DataPanel.Content>
+    </DataPanel>
+  ),
+};
+
+export const WithNavigation: Story = {
+  render: () => (
+    <DataPanel>
+      <DataPanel.Header>
+        <DataPanel.Heading>
+          <b>Trace</b> abc123
+        </DataPanel.Heading>
+        <div className="flex items-center gap-2">
+          <DataPanel.NextPrevNav onPrevious={() => {}} onNext={() => {}} />
+          <DataPanel.CloseButton onClick={() => {}} />
+        </div>
+      </DataPanel.Header>
+      <DataPanel.Content>
+        <p className="text-ui-sm text-neutral3">Navigate between items with the arrows.</p>
+      </DataPanel.Content>
+    </DataPanel>
+  ),
+};
+
+export const NoData: Story = {
+  render: () => (
+    <DataPanel>
+      <DataPanel.Header>
+        <DataPanel.Heading>Empty Panel</DataPanel.Heading>
+        <DataPanel.CloseButton onClick={() => {}} />
+      </DataPanel.Header>
+      <DataPanel.NoData />
+    </DataPanel>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <DataPanel>
+      <DataPanel.Header>
+        <DataPanel.Heading>Loading Panel</DataPanel.Heading>
+        <DataPanel.CloseButton onClick={() => {}} />
+      </DataPanel.Header>
+      <DataPanel.LoadingData>Fetching trace data...</DataPanel.LoadingData>
+    </DataPanel>
+  ),
+};
+
+export const Collapsed: Story = {
+  render: () => (
+    <DataPanel collapsed>
+      <DataPanel.Header>
+        <DataPanel.Heading>Collapsed Panel</DataPanel.Heading>
+        <DataPanel.CloseButton onClick={() => {}} />
+      </DataPanel.Header>
+      <DataPanel.Content>
+        <p className="text-ui-sm text-neutral3">This panel uses h-auto instead of h-full.</p>
+      </DataPanel.Content>
+    </DataPanel>
+  ),
+};
+
+export const DisabledNav: Story = {
+  render: () => (
+    <DataPanel>
+      <DataPanel.Header>
+        <DataPanel.Heading>
+          <b>First Item</b> (no previous)
+        </DataPanel.Heading>
+        <div className="flex items-center gap-2">
+          <DataPanel.NextPrevNav onNext={() => {}} />
+          <DataPanel.CloseButton onClick={() => {}} />
+        </div>
+      </DataPanel.Header>
+      <DataPanel.Content>
+        <p className="text-ui-sm text-neutral3">Previous button is disabled because onPrevious is undefined.</p>
+      </DataPanel.Content>
+    </DataPanel>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel.tsx
@@ -1,0 +1,18 @@
+import { DataPanelCloseButton } from './data-panel-close-button';
+import { DataPanelContent } from './data-panel-content';
+import { DataPanelHeader } from './data-panel-header';
+import { DataPanelHeading } from './data-panel-heading';
+import { DataPanelLoadingData } from './data-panel-loading-data';
+import { DataPanelNextPrevNav } from './data-panel-next-prev-nav';
+import { DataPanelNoData } from './data-panel-no-data';
+import { DataPanelRoot } from './data-panel-root';
+
+export const DataPanel = Object.assign(DataPanelRoot, {
+  Header: DataPanelHeader,
+  Heading: DataPanelHeading,
+  CloseButton: DataPanelCloseButton,
+  NextPrevNav: DataPanelNextPrevNav,
+  LoadingData: DataPanelLoadingData,
+  NoData: DataPanelNoData,
+  Content: DataPanelContent,
+});

--- a/packages/playground-ui/src/ds/components/DataPanel/index.ts
+++ b/packages/playground-ui/src/ds/components/DataPanel/index.ts
@@ -1,0 +1,9 @@
+export { DataPanel } from './data-panel';
+export type { DataPanelProps } from './data-panel-root';
+export type { DataPanelHeaderProps } from './data-panel-header';
+export type { DataPanelHeadingProps } from './data-panel-heading';
+export type { DataPanelCloseButtonProps } from './data-panel-close-button';
+export type { DataPanelNextPrevNavProps } from './data-panel-next-prev-nav';
+export type { DataPanelLoadingDataProps } from './data-panel-loading-data';
+export type { DataPanelNoDataProps } from './data-panel-no-data';
+export type { DataPanelContentProps } from './data-panel-content';


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

<img width="1435" height="885" alt="CleanShot 2026-04-07 at 11 36 21" src="https://github.com/user-attachments/assets/73715c1a-bfb0-45a4-bad7-3d912013a358" />

## Related Issue(s)



<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a reusable DataPanel "box" UI component to the playground design system so developers can consistently show item details with a title, scrollable content, loading indicator, empty state, navigation arrows, and a close button.

## Overview

Adds a compound DataPanel component to @mastra/playground-ui composed from focused subcomponents so consumers can assemble consistent detail panels with header, content area, navigation, close action, loading UI, and no-data UI.

## Changes

### Component Architecture
DataPanel is implemented as a compound component (Object.assign on a root component) with these parts:
- DataPanelRoot — section container with layout/border and optional collapsed prop
- DataPanelHeader — header wrapper with border/styling
- DataPanelHeading — title typography (h3)
- DataPanelContent — scrollable content wrapper (flex + overflow), accepts a ref
- DataPanelCloseButton — X icon button with tooltip and aria-label, accepts onClick
- DataPanelNextPrevNav — previous/next navigation buttons (arrow icons), optional handlers and labels, buttons disabled when handlers absent
- DataPanelLoadingData — centered spinner with optional children or "Loading..." fallback
- DataPanelNoData — empty state message or custom content

### Exports
- packages/playground-ui/src/ds/components/DataPanel/index.ts re-exports the composed DataPanel and prop types:
  - DataPanel
  - Types: DataPanelProps, DataPanelHeaderProps, DataPanelHeadingProps, DataPanelCloseButtonProps, DataPanelNextPrevNavProps, DataPanelLoadingDataProps, DataPanelNoDataProps, DataPanelContentProps

### Documentation / Stories
- packages/playground-ui/src/ds/components/DataPanel/data-panel.stories.tsx — Storybook stories demonstrating six configurations: Default, WithNavigation, NoData, Loading, Collapsed, DisabledNav. Stories wrap content in TooltipProvider and a constrained container; handlers are stubbed.

### Release
- .changeset/tasty-bobcats-marry.md — Adds a changeset declaring a minor version bump for @mastra/playground-ui, noting the new DataPanel compound component and its loading/empty/nav/close states.

## Files Added
- .changeset/tasty-bobcats-marry.md
- packages/playground-ui/src/ds/components/DataPanel/data-panel-root.tsx
- packages/playground-ui/src/ds/components/DataPanel/data-panel-header.tsx
- packages/playground-ui/src/ds/components/DataPanel/data-panel-heading.tsx
- packages/playground-ui/src/ds/components/DataPanel/data-panel-content.tsx
- packages/playground-ui/src/ds/components/DataPanel/data-panel-close-button.tsx
- packages/playground-ui/src/ds/components/DataPanel/data-panel-next-prev-nav.tsx
- packages/playground-ui/src/ds/components/DataPanel/data-panel-loading-data.tsx
- packages/playground-ui/src/ds/components/DataPanel/data-panel-no-data.tsx
- packages/playground-ui/src/ds/components/DataPanel/data-panel.tsx
- packages/playground-ui/src/ds/components/DataPanel/index.ts
- packages/playground-ui/src/ds/components/DataPanel/data-panel.stories.tsx
<!-- end of auto-generated comment: release notes by coderabbit.ai -->