### PR TITLE
Playground UI / DS - DateTimeRangePicker

### DIFF
--- a/.changeset/old-numbers-tap.md
+++ b/.changeset/old-numbers-tap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added DateTimeRangePicker component — a date range selector with preset options (last 24h, 7d, 30d, etc.) and a custom range mode with dual calendar and time pickers

--- a/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { DateTimeRangePicker } from './date-time-range-picker';
+import type { DateRangePreset, DateTimeRangePickerProps } from './date-time-range-picker';
+import { TooltipProvider } from '../Tooltip';
+
+const meta: Meta<typeof DateTimeRangePicker> = {
+  title: 'Composite/DateTimeRangePicker',
+  component: DateTimeRangePicker,
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<DateTimeRangePickerProps>;
+
+function DateTimeRangePickerControlled(props: Partial<DateTimeRangePickerProps>) {
+  const [preset, setPreset] = useState<DateRangePreset>(props.preset ?? 'all');
+  const [dateFrom, setDateFrom] = useState<Date | undefined>(props.dateFrom);
+  const [dateTo, setDateTo] = useState<Date | undefined>(props.dateTo);
+
+  return (
+    <DateTimeRangePicker
+      {...props}
+      preset={preset}
+      onPresetChange={setPreset}
+      dateFrom={dateFrom}
+      dateTo={dateTo}
+      onDateChange={(value, type) => {
+        if (type === 'from') setDateFrom(value);
+        else setDateTo(value);
+      }}
+    />
+  );
+}
+
+export const Default: Story = {
+  render: () => <DateTimeRangePickerControlled />,
+};
+
+export const WithPreset: Story = {
+  render: () => <DateTimeRangePickerControlled preset="last-7d" />,
+};
+
+export const CustomRange: Story = {
+  render: () => (
+    <DateTimeRangePickerControlled preset="custom" dateFrom={new Date(2026, 2, 1)} dateTo={new Date(2026, 3, 1)} />
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => <DateTimeRangePickerControlled disabled />,
+};

--- a/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.tsx
@@ -109,7 +109,9 @@ export function DateTimeRangePicker({
               <TimePicker
                 className="mx-4 mb-3 w-auto"
                 defaultValue={draftTimeFrom}
-                onValueChange={setDraftTimeFrom}
+                onValueChange={v => {
+                  if (!disabled) setDraftTimeFrom(v);
+                }}
               />
             </div>
             <div>
@@ -122,14 +124,24 @@ export function DateTimeRangePicker({
                 disabled={disabled}
                 fromDate={draftDateFrom}
               />
-              <TimePicker className="mx-4 mb-3 w-auto" defaultValue={draftTimeTo} onValueChange={setDraftTimeTo} />
+              <TimePicker
+                className="mx-4 mb-3 w-auto"
+                defaultValue={draftTimeTo}
+                onValueChange={v => {
+                  if (!disabled) setDraftTimeTo(v);
+                }}
+              />
             </div>
           </div>
           {customRangeError && <p className={cn('text-ui-sm text-red-500 px-4 pb-1')}>{customRangeError}</p>}
           <div className={cn('flex justify-between items-center px-4 pb-3')}>
             <button
               type="button"
-              className={cn('text-ui-sm text-neutral3 hover:text-neutral4')}
+              disabled={disabled}
+              className={cn(
+                'text-ui-sm text-neutral3 hover:text-neutral4',
+                disabled && 'opacity-50 pointer-events-none',
+              )}
               onClick={() => {
                 setCustomRangeError(undefined);
                 handlePresetSelect('all');
@@ -137,7 +149,7 @@ export function DateTimeRangePicker({
             >
               &larr; Presets
             </button>
-            <Button variant="primary" size="sm" onClick={applyCustomRange}>
+            <Button variant="primary" size="sm" onClick={applyCustomRange} disabled={disabled}>
               Apply
             </Button>
           </div>

--- a/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.tsx
@@ -1,0 +1,166 @@
+import { isValid, parse } from 'date-fns';
+import { CalendarIcon } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/ds/components/Button/Button';
+import { DatePicker, TimePicker } from '@/ds/components/DateTimePicker';
+import { DropdownMenu } from '@/ds/components/DropdownMenu/dropdown-menu';
+import { Popover, PopoverTrigger, PopoverContent } from '@/ds/components/Popover/popover';
+import { cn } from '@/lib/utils';
+
+export type DateRangePreset = 'all' | 'last-24h' | 'last-3d' | 'last-7d' | 'last-14d' | 'last-30d' | 'custom';
+
+const DATE_PRESETS: { value: DateRangePreset; label: string; ms?: number }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'last-24h', label: 'Last 24 hours', ms: 24 * 60 * 60 * 1000 },
+  { value: 'last-3d', label: 'Last 3 days', ms: 3 * 24 * 60 * 60 * 1000 },
+  { value: 'last-7d', label: 'Last 7 days', ms: 7 * 24 * 60 * 60 * 1000 },
+  { value: 'last-14d', label: 'Last 14 days', ms: 14 * 24 * 60 * 60 * 1000 },
+  { value: 'last-30d', label: 'Last 30 days', ms: 30 * 24 * 60 * 60 * 1000 },
+  { value: 'custom', label: 'Custom range...' },
+];
+
+function buildDateWithTime(date: Date, timeStr: string): Date | null {
+  const dateOnly = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const combined = parse(timeStr, 'h:mm a', dateOnly);
+  return isValid(combined) ? combined : null;
+}
+
+export interface DateTimeRangePickerProps {
+  preset?: DateRangePreset;
+  onPresetChange?: (preset: DateRangePreset) => void;
+  dateFrom?: Date;
+  dateTo?: Date;
+  onDateChange?: (value: Date | undefined, type: 'from' | 'to') => void;
+  disabled?: boolean;
+}
+
+export function DateTimeRangePicker({
+  preset = 'all',
+  onPresetChange,
+  dateFrom,
+  dateTo,
+  onDateChange,
+  disabled,
+}: DateTimeRangePickerProps) {
+  const [customRangeOpen, setCustomRangeOpen] = useState(false);
+  const [draftDateFrom, setDraftDateFrom] = useState<Date | undefined>(dateFrom);
+  const [draftDateTo, setDraftDateTo] = useState<Date | undefined>(dateTo);
+  const [draftTimeFrom, setDraftTimeFrom] = useState('12:00 AM');
+  const [draftTimeTo, setDraftTimeTo] = useState('11:59 PM');
+  const [customRangeError, setCustomRangeError] = useState<string | undefined>();
+
+  const datePresetLabel = DATE_PRESETS.find(p => p.value === preset)?.label ?? 'All';
+
+  const handlePresetSelect = (value: DateRangePreset) => {
+    onPresetChange?.(value);
+    if (value === 'custom') {
+      setDraftDateFrom(dateFrom);
+      setDraftDateTo(dateTo);
+      setDraftTimeFrom('12:00 AM');
+      setDraftTimeTo('11:59 PM');
+      setCustomRangeOpen(true);
+      return;
+    }
+    const entry = DATE_PRESETS.find(p => p.value === value);
+    if (entry?.ms) {
+      onDateChange?.(new Date(Date.now() - entry.ms), 'from');
+      onDateChange?.(undefined, 'to');
+    } else {
+      onDateChange?.(undefined, 'from');
+      onDateChange?.(undefined, 'to');
+    }
+  };
+
+  const applyCustomRange = () => {
+    const fromDate = draftDateFrom ? (buildDateWithTime(draftDateFrom, draftTimeFrom) ?? draftDateFrom) : undefined;
+    const toDate = draftDateTo ? (buildDateWithTime(draftDateTo, draftTimeTo) ?? draftDateTo) : undefined;
+    if (fromDate && toDate && fromDate.getTime() > toDate.getTime()) {
+      setCustomRangeError('Start date/time must be before end date/time');
+      return;
+    }
+    setCustomRangeError(undefined);
+    onDateChange?.(fromDate, 'from');
+    onDateChange?.(toDate, 'to');
+    setCustomRangeOpen(false);
+  };
+
+  if (preset === 'custom') {
+    return (
+      <Popover open={customRangeOpen} onOpenChange={setCustomRangeOpen}>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="md" disabled={disabled}>
+            <CalendarIcon />
+            {dateFrom ? dateFrom.toLocaleDateString() : 'Start'} {' \u2013 '}
+            {dateTo ? dateTo.toLocaleDateString() : 'End'}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className={cn('w-auto p-0')}>
+          <div className={cn('flex')}>
+            <div className={cn('border-r border-border1')}>
+              <span className={cn('text-ui-sm text-neutral3 font-medium px-4 pt-3 block')}>Start</span>
+              <DatePicker
+                mode="single"
+                selected={draftDateFrom}
+                month={draftDateFrom}
+                onSelect={setDraftDateFrom}
+                disabled={disabled}
+                toDate={draftDateTo}
+              />
+              <TimePicker
+                className="mx-4 mb-3 w-auto"
+                defaultValue={draftTimeFrom}
+                onValueChange={setDraftTimeFrom}
+              />
+            </div>
+            <div>
+              <span className={cn('text-ui-sm text-neutral3 font-medium px-4 pt-3 block')}>End</span>
+              <DatePicker
+                mode="single"
+                selected={draftDateTo}
+                month={draftDateTo}
+                onSelect={setDraftDateTo}
+                disabled={disabled}
+                fromDate={draftDateFrom}
+              />
+              <TimePicker className="mx-4 mb-3 w-auto" defaultValue={draftTimeTo} onValueChange={setDraftTimeTo} />
+            </div>
+          </div>
+          {customRangeError && <p className={cn('text-ui-sm text-red-500 px-4 pb-1')}>{customRangeError}</p>}
+          <div className={cn('flex justify-between items-center px-4 pb-3')}>
+            <button
+              type="button"
+              className={cn('text-ui-sm text-neutral3 hover:text-neutral4')}
+              onClick={() => {
+                setCustomRangeError(undefined);
+                handlePresetSelect('all');
+              }}
+            >
+              &larr; Presets
+            </button>
+            <Button variant="primary" size="sm" onClick={applyCustomRange}>
+              Apply
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="outline" size="md" disabled={disabled}>
+          <CalendarIcon />
+          {datePresetLabel}
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content align="start">
+        {DATE_PRESETS.map(p => (
+          <DropdownMenu.Item key={p.value} onSelect={() => handlePresetSelect(p.value)}>
+            {p.label}
+          </DropdownMenu.Item>
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DateTimeRangePicker/index.ts
+++ b/packages/playground-ui/src/ds/components/DateTimeRangePicker/index.ts
@@ -1,0 +1,2 @@
+export { DateTimeRangePicker } from './date-time-range-picker';
+export type { DateTimeRangePickerProps, DateRangePreset } from './date-time-range-picker';


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->


<img width="1436" height="904" alt="CleanShot 2026-04-07 at 11 52 29" src="https://github.com/user-attachments/assets/7961736a-0d81-48d7-9089-5d3f2a37faab" />

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a new DateTimeRangePicker component that lets users quickly pick common relative ranges (like "Last 7 days") or define an exact start and end date/time using calendars and time inputs.

---

## Changes

### New Component: DateTimeRangePicker
- packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.tsx
  - Adds `DateTimeRangePicker` component supporting preset-based selection and a "custom" mode with a popover containing start/end DatePicker and TimePicker controls.
  - Exports new types: `DateRangePreset` ('all' | 'last-24h' | 'last-3d' | 'last-7d' | 'last-14d' | 'last-30d' | 'custom') and `DateTimeRangePickerProps`.
  - Props: `preset?`, `onPresetChange?`, `dateFrom?`, `dateTo?`, `onDateChange?`, `disabled?`.
  - Preset behavior: for relative presets with ms mapping, calls `onDateChange(fromDate, 'from')` with computed Date and `onDateChange(undefined, 'to')`; for 'all' clears both.
  - Custom mode: opens a Popover with draft state for dates/times, combines date + time (fallback to date-only if time parse invalid), validates start <= end, shows error message if invalid, applies changes via `onDateChange` and closes popover.
  - All interactive controls respect `disabled`.

### Exports
- packages/playground-ui/src/ds/components/DateTimeRangePicker/index.ts
  - Re-exports `DateTimeRangePicker` and its types.

### Storybook
- packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.stories.tsx
  - Adds Storybook stories: Default, WithPreset, CustomRange, Disabled.
  - Includes a stateful wrapper used by stories to demonstrate controlled behavior and interactions.
  - Story metadata: title 'Composite/DateTimeRangePicker', TooltipProvider decorator, centered layout, autodocs tag.

### Changelog / Release
- .changeset/old-numbers-tap.md
  - Adds a changeset bumping @mastra/playground-ui (minor) with an entry describing the new DateTimeRangePicker and its capabilities.

---

## Notes for reviewers
- Core logic to review: preset-to-date computation, buildDateWithTime parsing (uses date-fns parse with 'h:mm a'), validation that start <= end, and disabled handling.
- Storybook stories provide interactive coverage for default, preset, custom-range, and disabled states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->