### PR TITLE
Playground UI/DS - minimized shape of SearchFieldBlock

### DIFF
--- a/.changeset/clever-paths-love.md
+++ b/.changeset/clever-paths-love.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': minor
 ---
 
-Added isMinimized and onMinimizedChange props to SearchFieldBlock — allows collapsing the search input into a compact icon button with tooltip, auto-focusing on expand
+Search input can now be collapsed into a compact icon button with tooltip and auto-focuses when expanded

--- a/.changeset/clever-paths-love.md
+++ b/.changeset/clever-paths-love.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added isMinimized and onMinimizedChange props to SearchFieldBlock — allows collapsing the search input into a compact icon button with tooltip, auto-focusing on expand

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.stories.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.stories.tsx
@@ -1,11 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { SearchFieldBlock, type SearchFieldBlockProps } from './search-field-block';
+import { TooltipProvider } from '../../Tooltip';
 
 function SearchFieldBlockControlled(props: SearchFieldBlockProps) {
   const [value, setValue] = useState(props.value ?? '');
+  const [isMinimized, setIsMinimized] = useState(props.isMinimized ?? false);
   return (
-    <SearchFieldBlock {...props} value={value} onChange={e => setValue(e.target.value)} onReset={() => setValue('')} />
+    <SearchFieldBlock
+      {...props}
+      value={value}
+      onChange={e => setValue(e.target.value)}
+      onReset={() => setValue('')}
+      isMinimized={props.isMinimized !== undefined ? isMinimized : undefined}
+      onMinimizedChange={props.isMinimized !== undefined ? setIsMinimized : undefined}
+    />
   );
 }
 
@@ -40,9 +49,11 @@ const meta: Meta<typeof SearchFieldBlock> = {
   },
   decorators: [
     Story => (
-      <div style={{ width: 320 }}>
-        <Story />
-      </div>
+      <TooltipProvider>
+        <div style={{ width: 320 }}>
+          <Story />
+        </div>
+      </TooltipProvider>
     ),
   ],
   render: args => <SearchFieldBlockControlled {...args} />,
@@ -113,6 +124,16 @@ export const HorizontalLayout: Story = {
     name: 'search',
     label: 'Search',
     layout: 'horizontal',
+  },
+};
+
+export const Minimized: Story = {
+  args: {
+    name: 'search',
+    label: 'Search',
+    labelIsHidden: true,
+    isMinimized: true,
+    size: 'sm',
   },
 };
 

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
@@ -1,9 +1,11 @@
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { SearchIcon, XIcon } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { Button } from '../../Button';
 import { Input } from '../../Input';
 import type { InputProps } from '../../Input';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../Tooltip';
 import { FieldBlock } from '../block/field-block';
-import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
 export type SearchFieldBlockProps = {
@@ -23,6 +25,8 @@ export type SearchFieldBlockProps = {
   layout?: 'horizontal' | 'vertical';
   className?: string;
   size?: InputProps['size'];
+  isMinimized?: boolean;
+  onMinimizedChange?: (minimized: boolean) => void;
 };
 
 export function SearchFieldBlock({
@@ -40,7 +44,30 @@ export function SearchFieldBlock({
   onReset,
   className,
   size,
+  isMinimized,
+  onMinimizedChange,
 }: SearchFieldBlockProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isMinimized === false) {
+      inputRef.current?.focus();
+    }
+  }, [isMinimized]);
+
+  if (isMinimized) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size={size || 'sm'} aria-label={label || 'Search'} onClick={() => onMinimizedChange?.(false)}>
+            <SearchIcon />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{label || 'Search'}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
   return (
     <FieldBlock.Layout layout={layout} className={className}>
       {layout === 'horizontal' ? (
@@ -58,6 +85,7 @@ export function SearchFieldBlock({
         ) : null}
         <div className="relative group">
           <Input
+            ref={inputRef}
             name={name}
             disabled={disabled}
             value={value}
@@ -65,10 +93,10 @@ export function SearchFieldBlock({
             onChange={onChange}
             size={size}
             className={cn(
-              size === 'sm' && 'pl-8',
-              size === 'md' && 'pl-9',
-              (!size || size === 'default') && 'pl-10',
-              size === 'lg' && 'pl-11',
+              size === 'sm' && 'pl-8 pr-8',
+              size === 'md' && 'pl-9 pr-9',
+              (!size || size === 'default') && 'pl-10 pr-10',
+              size === 'lg' && 'pl-11 pr-11',
             )}
           />
           <SearchIcon
@@ -81,20 +109,21 @@ export function SearchFieldBlock({
               size === 'lg' && 'w-5 h-5',
             )}
           />
-          {onReset && value && (
-            <button
-              type="button"
-              onClick={onReset}
-              className={cn(
-                'absolute top-1/2 right-2 -translate-y-1/2 p-1 rounded',
-                transitions.all,
-                'hover:bg-surface4',
-                '[&>svg]:transition-colors [&>svg]:duration-normal',
-                '[&:hover>svg]:text-neutral5',
-              )}
+          {onReset && (value || isMinimized === false) && (
+            <Button
+              variant="ghost"
+              size={size || 'default'}
+              aria-label="Clear search"
+              onClick={() => {
+                onReset();
+                if (isMinimized === false) {
+                  onMinimizedChange?.(true);
+                }
+              }}
+              className="absolute top-1/2 right-0 -translate-y-1/2"
             >
-              <XIcon className="text-neutral3 w-4 h-4" />
-            </button>
+              <XIcon />
+            </Button>
           )}
         </div>
         {helpText && <FieldBlock.HelpText>{helpText}</FieldBlock.HelpText>}

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
@@ -59,7 +59,7 @@ export function SearchFieldBlock({
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button size={size || 'sm'} aria-label={label || 'Search'} onClick={() => onMinimizedChange?.(false)}>
+          <Button size={size || 'sm'} aria-label={label || 'Search'} disabled={disabled} onClick={() => onMinimizedChange?.(false)}>
             <SearchIcon />
           </Button>
         </TooltipTrigger>
@@ -115,7 +115,9 @@ export function SearchFieldBlock({
               size={size || 'default'}
               aria-label="Clear search"
               onClick={() => {
-                onReset();
+                if (value) {
+                  onReset();
+                }
                 if (isMinimized === false) {
                   onMinimizedChange?.(true);
                 }

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
@@ -59,7 +59,12 @@ export function SearchFieldBlock({
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button size={size || 'sm'} aria-label={label || 'Search'} disabled={disabled} onClick={() => onMinimizedChange?.(false)}>
+          <Button
+            size={size || 'sm'}
+            aria-label={label || 'Search'}
+            disabled={disabled}
+            onClick={() => onMinimizedChange?.(false)}
+          >
             <SearchIcon />
           </Button>
         </TooltipTrigger>


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

![CleanShot 2026-04-07 at 12 39 02](https://github.com/user-attachments/assets/9be935cd-1357-407f-ba1d-3d201438db61)


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a tiny/collapsed version of the SearchFieldBlock: it can hide as a single search icon button (with tooltip) and expand back into the full input, which will auto-focus when opened.

## Changes Overview

- Adds a minimized variant to SearchFieldBlock with two new props:
  - isMinimized?: boolean — controlled collapsed state
  - onMinimizedChange?: (minimized: boolean) => void — callback when toggled
- When isMinimized === true the component renders only a tooltip-wrapped ghost Button with a SearchIcon (no label/help/error/input/reset). Clicking the icon calls onMinimizedChange(false).
- When transitioning from minimized to expanded the input is auto-focused (useRef + useEffect watching isMinimized).
- Clear/reset was changed to use Button variant="ghost" with XIcon; its visibility condition is now onReset && (value || isMinimized === false), and its click handler calls onReset() only when value is truthy and additionally calls onMinimizedChange?.(true) when the field is expanded.

## Key Modified Files

- packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
  - Exported props updated: added isMinimized and onMinimizedChange.
  - Early return rendering for minimized state (Tooltip + Button).
  - Input ref + effect to autofocus on expand.
  - Replaced custom clear button with shared Button; adjusted visibility and click logic.
  - Input padding classNames updated; removed transitions import.
  - Lines changed: +54/-18 (per PR summary).

- packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.stories.tsx
  - Wrapped stories with TooltipProvider via meta.decorators.
  - Controlled story wrapper now manages local isMinimized state (initialized from props) and conditionally passes isMinimized/onMinimizedChange only when the arg is provided.
  - New exported story: Minimized (args: labelIsHidden: true, isMinimized: true, size: 'sm').
  - Lines changed: +25/-4.

- .changeset/clever-paths-love.md
  - New changeset marking @mastra/playground-ui for a minor release; notes collapse-to-icon with tooltip and input autofocus on expand.
  - Lines changed: +5/-0.

## Impact and Review Notes

- API change: SearchFieldBlockProps adds optional isMinimized and onMinimizedChange — review consumers that may need to pass or adapt to these props.
- UX: Minimized mode hides all input affordances and exposes a tooltip-wrapped icon; expanding focuses the input automatically.
- Stories: Storybook includes a Minimized story and TooltipProvider decorator to demonstrate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->