### PR TITLE
fix: detect Gemini models through gateway providers in schema compat layer

### DIFF
--- a/.changeset/light-rings-poke.md
+++ b/.changeset/light-rings-poke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed Google Gemini tool schemas failing when using gateway providers like OpenRouter. The schema compatibility layer now correctly detects Gemini models regardless of the provider, so sub-agent tools work across all supported gateways.

--- a/packages/schema-compat/src/provider-compats/google.test.ts
+++ b/packages/schema-compat/src/provider-compats/google.test.ts
@@ -38,6 +38,28 @@ describe('GoogleSchemaCompatLayer', () => {
       expect(layer.shouldApply()).toBe(true);
     });
 
+    it('should apply for gemini models via gateway providers like OpenRouter', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'openrouter',
+        modelId: 'google/gemini-3-flash-preview',
+        supportsStructuredOutputs: false,
+      };
+
+      const layer = new GoogleSchemaCompatLayer(modelInfo);
+      expect(layer.shouldApply()).toBe(true);
+    });
+
+    it('should apply for gemini models via gateway with no google prefix', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'some-gateway',
+        modelId: 'gemini-2.5-flash',
+        supportsStructuredOutputs: false,
+      };
+
+      const layer = new GoogleSchemaCompatLayer(modelInfo);
+      expect(layer.shouldApply()).toBe(true);
+    });
+
     it('should not apply for non-Google models', () => {
       const modelInfo: ModelInformation = {
         provider: 'openai',

--- a/packages/schema-compat/src/provider-compats/google.ts
+++ b/packages/schema-compat/src/provider-compats/google.ts
@@ -106,7 +106,8 @@ export class GoogleSchemaCompatLayer extends SchemaCompatLayer {
   }
 
   shouldApply(): boolean {
-    return this.getModel().provider.includes('google') || this.getModel().modelId.includes('google');
+    const model = this.getModel();
+    return model.provider.includes('google') || model.modelId.includes('google') || model.modelId.includes('gemini');
   }
   processZodType(value: ZodTypeV3): ZodTypeV3;
   processZodType(value: ZodTypeV4): ZodTypeV4;


### PR DESCRIPTION
## Description

The GoogleSchemaCompatLayer wasn't activating for Gemini models accessed through gateway providers like OpenRouter. The `shouldApply()` check only matched "google" in the provider or modelId, but gateway providers set the provider to their own name (e.g., "openrouter") and may use modelIds like "gemini-3-flash-preview" without a "google" prefix. This caused
`.nullish()` schemas to produce `anyOf` constructs that Gemini rejects, breaking all sub-agent tool calls.

This change adds "gemini" to the modelId detection — consistent with how other compat layers match on model family names:
- Anthropic matches "claude"
- Meta matches "meta"
- DeepSeek matches "deepseek"

This ensures Gemini models accessed via gateway providers correctly activate the GoogleSchemaCompatLayer.

## Related Issue(s)

Fixes #15076

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you want to use Google's Gemini AI through a different service (like OpenRouter) that acts as a middleman. The code wasn't recognizing that the AI model being used was Gemini, so it wasn't applying special formatting rules that Gemini needs. This PR fixes that by teaching the code to look for "gemini" in the model name, not just the provider name, so it works correctly no matter which service you access Gemini through.

## Changes

### Files Modified

**packages/schema-compat/src/provider-compats/google.ts**
- Updated `GoogleSchemaCompatLayer.shouldApply()` to detect Gemini models by checking if `"gemini"` is present in the `modelId`, in addition to existing provider checks
- Refactored to cache `this.getModel()` in a local variable for cleaner code

**packages/schema-compat/src/provider-compats/google.test.ts**
- Added two new test cases validating that `GoogleSchemaCompatLayer.shouldApply()` returns `true` for:
  - Gemini models from gateway providers with `google/`-prefixed modelIds (e.g., OpenRouter)
  - Gemini models from gateway providers without the `google/` prefix (e.g., `gemini-3-flash-preview`)

**.changeset/light-rings-poke.md**
- New changeset entry documenting the patch-level fix for `@mastra/schema-compat`

## Problem Being Fixed

Gemini models accessed through gateway providers (like OpenRouter) were not recognized by the GoogleSchemaCompatLayer because the provider name was set to the gateway name (e.g., `"openrouter"`) rather than `"google"`. This caused the compat layer to not apply necessary schema transformations. Specifically, `.nullish()` schemas were generating `anyOf` constructs that Gemini's function-calling API does not support, resulting in errors for sub-agent tool declarations.

## Solution

Added `"gemini"` to the modelId detection pattern in `GoogleSchemaCompatLayer.shouldApply()`, aligning with how other compat layers detect models by family name (e.g., Anthropic detects `"claude"`). This ensures the compatibility layer activates for all Gemini models regardless of whether they come through the direct Google provider or a gateway provider.

## Related Issue

Fixes #15076

<!-- end of auto-generated comment: release notes by coderabbit.ai -->