### PR TITLE
Fix OpenAI reasoning stripping for current-step prompts

### DIFF
--- a/.changeset/fix-message-list-prettier-check.md
+++ b/.changeset/fix-message-list-prettier-check.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed MessageList formatting so Prettier checks pass in `packages/core`

--- a/.changeset/sharp-rivers-frame.md
+++ b/.changeset/sharp-rivers-frame.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed OpenAI reasoning stripping so replayed memory is sanitized without dropping reasoning from the current agent run. Multi-step loops now keep step-to-step reasoning continuity while remembered history still avoids OpenAI item pairing errors.

--- a/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
@@ -209,6 +209,65 @@ describe('sanitizeV5UIMessages — provider-executed tool handling', () => {
   });
 });
 
+describe('sanitizeV5UIMessages — OpenAI reasoning scope', () => {
+  const makeMessage = (id: string): AIV5Type.UIMessage => ({
+    id,
+    role: 'assistant',
+    parts: [
+      {
+        type: 'reasoning',
+        text: `reasoning-${id}`,
+        state: 'done',
+        providerMetadata: {
+          openai: {
+            itemId: `rs_${id}`,
+            reasoningEncryptedContent: null,
+          },
+        },
+      },
+      {
+        type: 'text',
+        text: `text-${id}`,
+        providerMetadata: {
+          openai: {
+            itemId: `msg_${id}`,
+          },
+        },
+      },
+    ],
+  });
+
+  it('should keep current-run OpenAI reasoning when the caller opts out of stripping', () => {
+    const msg = makeMessage('current');
+
+    const result = sanitizeV5UIMessages([msg], true, () => false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.parts.find(part => part.type === 'reasoning')).toBeDefined();
+
+    const textPart = result[0]!.parts.find(part => part.type === 'text') as Extract<
+      AIV5Type.UIMessage['parts'][number],
+      { type: 'text' }
+    >;
+    expect(textPart.providerMetadata?.openai?.itemId).toBe('msg_current');
+  });
+
+  it('should still strip remembered OpenAI reasoning when the caller marks the message for stripping', () => {
+    const msg = makeMessage('memory');
+
+    const result = sanitizeV5UIMessages([msg], true, () => true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.parts.find(part => part.type === 'reasoning')).toBeUndefined();
+
+    const textPart = result[0]!.parts.find(part => part.type === 'text') as Extract<
+      AIV5Type.UIMessage['parts'][number],
+      { type: 'text' }
+    >;
+    expect(textPart.providerMetadata?.openai).toBeUndefined();
+  });
+});
+
 describe('addStartStepPartsForAIV5 — client/provider tool splitting', () => {
   const makeToolPart = (
     overrides: Partial<AIV5Type.ToolUIPart> & { type: string; toolCallId: string },

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -107,6 +107,7 @@ export function sanitizeAIV4UIMessages(messages: UIMessageV4[]): UIMessageV4[] {
 export function sanitizeV5UIMessages(
   messages: AIV5Type.UIMessage[],
   filterIncompleteToolCalls = false,
+  shouldStripReasoning: (message: AIV5Type.UIMessage) => boolean = () => true,
 ): AIV5Type.UIMessage[] {
   const msgs = messages
     .map(m => {
@@ -118,6 +119,7 @@ export function sanitizeV5UIMessages(
       // parts to prevent item_reference linking to the stripped reasoning items.
       const hasOpenAIReasoning =
         filterIncompleteToolCalls &&
+        shouldStripReasoning(m) &&
         m.parts.some(
           p =>
             p.type === 'reasoning' &&
@@ -351,8 +353,9 @@ export function aiV5UIMessagesToAIV5ModelMessages(
   messages: AIV5Type.UIMessage[],
   dbMessages: MastraDBMessage[],
   filterIncompleteToolCalls = false,
+  shouldStripReasoning?: (message: AIV5Type.UIMessage) => boolean,
 ): AIV5Type.ModelMessage[] {
-  const sanitized = sanitizeV5UIMessages(messages, filterIncompleteToolCalls);
+  const sanitized = sanitizeV5UIMessages(messages, filterIncompleteToolCalls, shouldStripReasoning);
   const preprocessed = addStartStepPartsForAIV5(sanitized);
 
   const result = restoreAssistantFileProviderMetadata(AIV5.convertToModelMessages(preprocessed), preprocessed);

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -361,8 +361,14 @@ export class MessageList {
           this.createAdapterContext(),
           this.messages,
         );
+        const rememberedMessageIds = new Set(this.remembered.db().map(message => message.id));
         // Filter incomplete tool calls when sending messages TO the LLM
-        const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true);
+        const modelMessages = convertAIV5UIToModelMessages(
+          this.all.aiV5.ui(),
+          this.messages,
+          true,
+          message => rememberedMessageIds.has(message.id),
+        );
 
         const messages = [...systemMessages, ...modelMessages];
 
@@ -380,8 +386,14 @@ export class MessageList {
           downloadRetries: 3,
         },
       ): Promise<LanguageModelV2Prompt> => {
+        const rememberedMessageIds = new Set(this.remembered.db().map(message => message.id));
         // Filter incomplete tool calls when sending messages TO the LLM
-        const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true);
+        const modelMessages = convertAIV5UIToModelMessages(
+          this.all.aiV5.ui(),
+          this.messages,
+          true,
+          message => rememberedMessageIds.has(message.id),
+        );
 
         const storedModelOutputs = new Map<string, unknown>();
         for (const dbMsg of this.messages) {

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -363,11 +363,8 @@ export class MessageList {
         );
         const rememberedMessageIds = new Set(this.remembered.db().map(message => message.id));
         // Filter incomplete tool calls when sending messages TO the LLM
-        const modelMessages = convertAIV5UIToModelMessages(
-          this.all.aiV5.ui(),
-          this.messages,
-          true,
-          message => rememberedMessageIds.has(message.id),
+        const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true, message =>
+          rememberedMessageIds.has(message.id),
         );
 
         const messages = [...systemMessages, ...modelMessages];
@@ -388,11 +385,8 @@ export class MessageList {
       ): Promise<LanguageModelV2Prompt> => {
         const rememberedMessageIds = new Set(this.remembered.db().map(message => message.id));
         // Filter incomplete tool calls when sending messages TO the LLM
-        const modelMessages = convertAIV5UIToModelMessages(
-          this.all.aiV5.ui(),
-          this.messages,
-          true,
-          message => rememberedMessageIds.has(message.id),
+        const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true, message =>
+          rememberedMessageIds.has(message.id),
         );
 
         const storedModelOutputs = new Map<string, unknown>();

--- a/packages/core/src/agent/message-list/tests/openai-reasoning-prompt.test.ts
+++ b/packages/core/src/agent/message-list/tests/openai-reasoning-prompt.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { MessageList } from '../message-list';
+import type { MastraDBMessage } from '../state';
+
+function makeAssistantMessage(id: string, reasoningText: string, text: string, suffix: string): MastraDBMessage {
+  return {
+    id,
+    role: 'assistant',
+    createdAt: new Date(),
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+    content: {
+      format: 2,
+      parts: [
+        {
+          type: 'reasoning',
+          reasoning: reasoningText,
+          providerMetadata: {
+            openai: {
+              itemId: `rs_${suffix}`,
+              reasoningEncryptedContent: null,
+            },
+          },
+        },
+        {
+          type: 'text',
+          text,
+          providerMetadata: {
+            openai: {
+              itemId: `msg_${suffix}`,
+            },
+          },
+        },
+      ],
+    },
+  };
+}
+
+function getAssistantParts(messages: Array<{ role: string; content: unknown }>) {
+  return messages
+    .filter(message => message.role === 'assistant' && Array.isArray(message.content))
+    .flatMap(message => message.content as Array<Record<string, any>>);
+}
+
+function assertReasoningScope(messages: Array<{ role: string; content: unknown }>) {
+  const assistantParts = getAssistantParts(messages);
+
+  expect(
+    assistantParts.find(part => part.type === 'reasoning' && (part.text ?? part.reasoning) === 'remembered reasoning'),
+  ).toBeUndefined();
+
+  const rememberedText = assistantParts.find(part => part.type === 'text' && part.text === 'remembered answer');
+  expect(rememberedText).toBeDefined();
+  expect(rememberedText.providerOptions?.openai).toBeUndefined();
+
+  const currentReasoning = assistantParts.find(
+    part => part.type === 'reasoning' && (part.text ?? part.reasoning) === 'current reasoning',
+  );
+  expect(currentReasoning).toBeDefined();
+  expect(currentReasoning.providerOptions?.openai?.itemId).toBe('rs_current');
+
+  const currentText = assistantParts.find(part => part.type === 'text' && part.text === 'current answer');
+  expect(currentText).toBeDefined();
+  expect(currentText.providerOptions?.openai?.itemId).toBe('msg_current');
+}
+
+describe('MessageList OpenAI reasoning prompt handling', () => {
+  it('should strip remembered reasoning but preserve current-run reasoning in aiV5.prompt()', () => {
+    const list = new MessageList({ threadId: 'thread-1', resourceId: 'resource-1' });
+
+    list.add({ role: 'user', content: 'Earlier question' }, 'memory');
+    list.add(makeAssistantMessage('assistant-memory', 'remembered reasoning', 'remembered answer', 'memory'), 'memory');
+    list.add({ role: 'user', content: 'Continue the current task' }, 'input');
+    list.add(makeAssistantMessage('assistant-current', 'current reasoning', 'current answer', 'current'), 'response');
+
+    assertReasoningScope(list.get.all.aiV5.prompt());
+  });
+
+  it('should strip remembered reasoning but preserve current-run reasoning in aiV5.llmPrompt()', async () => {
+    const list = new MessageList({ threadId: 'thread-1', resourceId: 'resource-1' });
+
+    list.add({ role: 'user', content: 'Earlier question' }, 'memory');
+    list.add(makeAssistantMessage('assistant-memory', 'remembered reasoning', 'remembered answer', 'memory'), 'memory');
+    list.add({ role: 'user', content: 'Continue the current task' }, 'input');
+    list.add(makeAssistantMessage('assistant-current', 'current reasoning', 'current answer', 'current'), 'response');
+
+    assertReasoningScope(await list.get.all.aiV5.llmPrompt());
+  });
+});


### PR DESCRIPTION
## Description

Fixes OpenAI reasoning stripping so only replayed memory messages are sanitized before prompt conversion. Current-run assistant step history now keeps reasoning continuity between tool-calling steps, and the change adds focused sanitizer and prompt-assembly regression coverage.

## Related Issue(s)

Fixes #15118

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper stripping of OpenAI reasoning during agent replay, preventing item-pairing errors while preserving step-to-step reasoning across multi-step runs.

* **Tests**
  * Added tests to verify conditional handling of OpenAI reasoning and ensure remembered vs. current-run reasoning behaves correctly.

* **Chores**
  * Formatting fixes to satisfy code style checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->