### PR TITLE
Apply deepClean to all observability signals before export

### DIFF
--- a/.changeset/deepclean-all-signals.md
+++ b/.changeset/deepclean-all-signals.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Apply `deepClean()` to all observability signals (logs, metrics, scores, feedback) before fanning out to exporters and bridges. Previously only tracing spans were deep-cleaned at construction time, leaving free-form payload fields on other signals (e.g. `log.data`, `log.metadata`, `metric.metadata`, `metric.costContext.costMetadata`, `score.metadata`, `feedback.metadata`) susceptible to circular references, oversized strings, and other non-serializable values. Sanitization now happens centrally in `ObservabilityBus.emit()` so every signal leaving the bus is bounded and JSON-safe.

--- a/observability/mastra/src/bus/observability-bus.ts
+++ b/observability/mastra/src/bus/observability-bus.ts
@@ -17,62 +17,31 @@ import { BaseObservabilityEventBus } from './base';
 import { routeToHandler } from './route-event';
 
 /**
- * Apply deepClean() to free-form payload fields on non-tracing observability
- * events. Tracing events are already deep-cleaned at span construction time
- * (see spans/base.ts and spans/default.ts), so they pass through unchanged.
+ * Apply deepClean() to non-tracing observability events. Tracing events are
+ * already deep-cleaned at span construction time (see spans/base.ts and
+ * spans/default.ts), so they pass through unchanged.
  *
- * This guarantees every signal leaving the bus has been sanitized for
- * circular references, oversized strings, functions, and other non-
- * serializable values before being handed to exporters/bridges.
+ * For log/metric/score/feedback we clean the entire exported payload object
+ * (not just the freeform sub-fields) so every user-supplied field — top-level
+ * strings like `message`/`reason`/`comment`, arrays like `tags`, nested
+ * `metadata`/`data`/`costMetadata`, and any future fields — is bounded,
+ * stripped of circular refs/functions/symbols, and safe for JSON.stringify
+ * before exporters or bridges see it.
+ *
+ * Identity scalars (timestamps, numeric score/value, IDs) are passed through
+ * by deepClean unchanged, so the cleaned object is structurally identical to
+ * the input for well-formed events.
  */
 function cleanEvent(event: ObservabilityEvent): ObservabilityEvent {
   switch (event.type) {
-    case 'log': {
-      const log = event.log;
-      return {
-        type: 'log',
-        log: {
-          ...log,
-          data: log.data ? deepClean(log.data) : log.data,
-          metadata: log.metadata ? deepClean(log.metadata) : log.metadata,
-        },
-      };
-    }
-    case 'metric': {
-      const metric = event.metric;
-      const costContext = metric.costContext;
-      return {
-        type: 'metric',
-        metric: {
-          ...metric,
-          metadata: metric.metadata ? deepClean(metric.metadata) : metric.metadata,
-          costContext:
-            costContext && costContext.costMetadata
-              ? { ...costContext, costMetadata: deepClean(costContext.costMetadata) }
-              : costContext,
-        },
-      };
-    }
-    case 'score': {
-      const score = event.score;
-      return {
-        type: 'score',
-        score: {
-          ...score,
-          metadata: score.metadata ? deepClean(score.metadata) : score.metadata,
-        },
-      };
-    }
-    case 'feedback': {
-      const feedback = event.feedback;
-      return {
-        type: 'feedback',
-        feedback: {
-          ...feedback,
-          metadata: feedback.metadata ? deepClean(feedback.metadata) : feedback.metadata,
-        },
-      };
-    }
+    case 'log':
+      return { type: 'log', log: deepClean(event.log) };
+    case 'metric':
+      return { type: 'metric', metric: deepClean(event.metric) };
+    case 'score':
+      return { type: 'score', score: deepClean(event.score) };
+    case 'feedback':
+      return { type: 'feedback', feedback: deepClean(event.feedback) };
     default:
       // Tracing events are already cleaned at span construction.
       return event;

--- a/observability/mastra/src/bus/observability-bus.ts
+++ b/observability/mastra/src/bus/observability-bus.ts
@@ -12,8 +12,72 @@
 
 import type { ObservabilityExporter, ObservabilityBridge, ObservabilityEvent } from '@mastra/core/observability';
 
+import { deepClean } from '../spans/serialization';
 import { BaseObservabilityEventBus } from './base';
 import { routeToHandler } from './route-event';
+
+/**
+ * Apply deepClean() to free-form payload fields on non-tracing observability
+ * events. Tracing events are already deep-cleaned at span construction time
+ * (see spans/base.ts and spans/default.ts), so they pass through unchanged.
+ *
+ * This guarantees every signal leaving the bus has been sanitized for
+ * circular references, oversized strings, functions, and other non-
+ * serializable values before being handed to exporters/bridges.
+ */
+function cleanEvent(event: ObservabilityEvent): ObservabilityEvent {
+  switch (event.type) {
+    case 'log': {
+      const log = event.log;
+      return {
+        type: 'log',
+        log: {
+          ...log,
+          data: log.data ? deepClean(log.data) : log.data,
+          metadata: log.metadata ? deepClean(log.metadata) : log.metadata,
+        },
+      };
+    }
+    case 'metric': {
+      const metric = event.metric;
+      const costContext = metric.costContext;
+      return {
+        type: 'metric',
+        metric: {
+          ...metric,
+          metadata: metric.metadata ? deepClean(metric.metadata) : metric.metadata,
+          costContext:
+            costContext && costContext.costMetadata
+              ? { ...costContext, costMetadata: deepClean(costContext.costMetadata) }
+              : costContext,
+        },
+      };
+    }
+    case 'score': {
+      const score = event.score;
+      return {
+        type: 'score',
+        score: {
+          ...score,
+          metadata: score.metadata ? deepClean(score.metadata) : score.metadata,
+        },
+      };
+    }
+    case 'feedback': {
+      const feedback = event.feedback;
+      return {
+        type: 'feedback',
+        feedback: {
+          ...feedback,
+          metadata: feedback.metadata ? deepClean(feedback.metadata) : feedback.metadata,
+        },
+      };
+    }
+    default:
+      // Tracing events are already cleaned at span construction.
+      return event;
+  }
+}
 
 /** Max flush drain iterations before bailing — prevents infinite loops when handlers re-emit. */
 const MAX_FLUSH_ITERATIONS = 3;
@@ -110,18 +174,23 @@ export class ObservabilityBus extends BaseObservabilityEventBus<ObservabilityEve
    * and can be drained via flush().
    */
   emit(event: ObservabilityEvent): void {
+    // Sanitize free-form payload fields on non-tracing signals before
+    // fanning out. Tracing events are already deep-cleaned at span
+    // construction, so cleanEvent() returns them unchanged.
+    const cleaned = cleanEvent(event);
+
     // Route to appropriate handler on each registered exporter
     for (const exporter of this.exporters) {
-      this.trackPromise(routeToHandler(exporter, event, this.logger));
+      this.trackPromise(routeToHandler(exporter, cleaned, this.logger));
     }
 
     // Route to bridge (same routing logic as exporters)
     if (this.bridge) {
-      this.trackPromise(routeToHandler(this.bridge, event, this.logger));
+      this.trackPromise(routeToHandler(this.bridge, cleaned, this.logger));
     }
 
     // Deliver to subscribers (base class tracks its own pending promises)
-    super.emit(event);
+    super.emit(cleaned);
   }
 
   /**


### PR DESCRIPTION
## Description

This PR extends payload sanitization to all observability signals (logs, metrics, scores, feedback) by applying `deepClean()` centrally in `ObservabilityBus.emit()` before fanning out to exporters and bridges.

Previously, only tracing spans were deep-cleaned at construction time. Other signals left free-form payload fields (e.g., `log.data`, `log.metadata`, `metric.metadata`, `score.metadata`, `feedback.metadata`) unsanitized, making them susceptible to circular references, oversized strings, functions, symbols, and other non-serializable values that could break downstream exporters or bridges.

The new `cleanEvent()` function routes each signal type to `deepClean()` on its payload object, ensuring every user-supplied field is bounded and JSON-safe before leaving the bus. Tracing events pass through unchanged since they're already cleaned at span construction.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

https://claude.ai/code/session_01NRNpyJwaMKk9XtwFMiAdxJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

Think of the observability system as a postal worker that handles different types of mail (logs, metrics, scores, feedback). Before, the worker only checked trace mail to make sure it was properly wrapped and safe. Now, the worker checks **all** types of mail before sending them out. This prevents problems when the mail gets damaged or contains messy stuff that could break the recipient's mailbox.

## Overview

This PR extends payload sanitization across all observability signals by applying `deepClean()` centrally in `ObservabilityBus.emit()` before fanning out to exporters and bridges. Previously, only tracing spans were deep-cleaned at construction time. Other signals (logs, metrics, scores, feedback) allowed free-form payload fields—such as `log.data`, `log.metadata`, `metric.metadata`, `score.metadata`, and `feedback.metadata`—to remain unsanitized. Those fields could contain circular references, oversized strings, functions, symbols, bigints, or other non-serializable values that might break downstream exporters or bridges.

## Changes

**observability/mastra/src/bus/observability-bus.ts**
- Added a `cleanEvent()` helper function that applies `deepClean()` to non-tracing observability payloads (log, metric, score, feedback) while leaving other event types unchanged
- Updated `ObservabilityBus.emit()` to apply the cleaning function to each event and route the cleaned event to exporters, the bridge, and the base bus for subscriber delivery
- Introduced `deepClean` import from `../spans/serialization`

**.changeset/deepclean-all-signals.md**
- Documented a patch-level version bump for `@mastra/observability` indicating that `deepClean()` is now applied to all observability signals before export
- Notes the shift from per-signal cleaning at construction time to centralized cleaning in the emit pipeline

## Result

All observability signals emitted from the bus are now bounded, stripped of circular references, functions, symbols, and bigints, and safe for JSON serialization before reaching exporters and bridges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->