### PR TITLE
Enhance deepClean() to handle Map, Set, and Error objects

### DIFF
--- a/.changeset/deepclean-map-set-error.md
+++ b/.changeset/deepclean-map-set-error.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+`deepClean()` now preserves data for `Map`, `Set`, and richer `Error` objects. Previously Maps and Sets were serialized as empty `{}` (entries silently dropped) and Errors only kept `name`/`message`. Maps are now converted to plain objects of entries, Sets to arrays (both respecting `maxObjectKeys`/`maxArrayLength` and cycle detection), and Errors additionally preserve `stack` and recursively cleaned `cause`.

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { DefaultObservabilityInstance } from '../instances';
 import { getExternalParentId } from './base';
-import { deepClean, DEFAULT_DEEP_CLEAN_OPTIONS } from './serialization';
+import { deepClean, DEFAULT_DEEP_CLEAN_OPTIONS, isSerializedMap, reconstructSerializedMap } from './serialization';
 
 // Simple test exporter for capturing events
 class TestExporter implements ObservabilityExporter {
@@ -864,12 +864,34 @@ describe('Span', () => {
       const result = deepClean({ map });
 
       expect(result.map).toEqual({
-        a: 1,
-        b: { x: 'y' },
-        '42': 'num-key',
-        inner: { k: 'v' },
+        __type: 'Map',
+        __map_entries: [
+          ['string', 'a', 1],
+          ['string', 'b', { x: 'y' }],
+          ['number', 42, 'num-key'],
+          ['string', 'inner', { __type: 'Map', __map_entries: [['string', 'k', 'v']] }],
+        ],
       });
       expect(() => JSON.stringify(result)).not.toThrow();
+    });
+
+    it('should preserve distinct Map key identities and allow reconstruction', () => {
+      const map = new Map<any, any>([
+        [1, 'number-key'],
+        ['1', 'string-key'],
+      ]);
+
+      const result = deepClean({ map });
+
+      expect(isSerializedMap(result.map)).toBe(true);
+      expect(result.map.__map_entries).toEqual([
+        ['number', 1, 'number-key'],
+        ['string', '1', 'string-key'],
+      ]);
+
+      const reconstructed = reconstructSerializedMap(result.map);
+      expect(reconstructed.get(1)).toBe('number-key');
+      expect(reconstructed.get('1')).toBe('string-key');
     });
 
     it('should detect self-referential Maps', () => {
@@ -879,8 +901,10 @@ describe('Span', () => {
 
       const result = deepClean({ map });
 
-      expect(result.map.self).toBe('[Circular]');
-      expect(result.map.ok).toBe(1);
+      expect(result.map.__map_entries).toEqual([
+        ['string', 'self', '[Circular]'],
+        ['string', 'ok', 1],
+      ]);
     });
 
     it('should truncate Maps that exceed maxObjectKeys', () => {
@@ -889,8 +913,23 @@ describe('Span', () => {
 
       const result = deepClean({ map }, { ...DEFAULT_DEEP_CLEAN_OPTIONS, maxObjectKeys: 2 });
 
-      expect(Object.keys(result.map).filter(k => k !== '__truncated').length).toBe(2);
+      expect(result.map.__map_entries).toHaveLength(2);
       expect(result.map.__truncated).toBe('3 more keys omitted');
+    });
+
+    it('should strip matching string Map keys before truncation', () => {
+      const map = new Map<any, any>([
+        ['logger', 'omit'],
+        ['visible', 1],
+        [2, 'keep-number-key'],
+      ]);
+
+      const result = deepClean({ map });
+
+      expect(result.map.__map_entries).toEqual([
+        ['string', 'visible', 1],
+        ['number', 2, 'keep-number-key'],
+      ]);
     });
 
     it('should serialize Sets including nested and object items', () => {
@@ -948,6 +987,43 @@ describe('Span', () => {
       expect(result.err.name).toBe('Error');
       expect(result.err.message).toBe('cyclic');
       expect(result.err.cause).toBe('[Circular]');
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
+
+    it('should guard Error property getters that throw', () => {
+      const err = new Error('outer');
+
+      Object.defineProperty(err, 'name', {
+        configurable: true,
+        get() {
+          throw new Error('name getter failed');
+        },
+      });
+      Object.defineProperty(err, 'message', {
+        configurable: true,
+        get() {
+          throw new Error('message getter failed');
+        },
+      });
+      Object.defineProperty(err, 'stack', {
+        configurable: true,
+        get() {
+          throw new Error('stack getter failed');
+        },
+      });
+      Object.defineProperty(err, 'cause', {
+        configurable: true,
+        get() {
+          throw new Error('cause getter failed');
+        },
+      });
+
+      const result = deepClean({ err });
+
+      expect(result.err.name).toBe('[name getter failed]');
+      expect(result.err.message).toBe('[message getter failed]');
+      expect(result.err.stack).toBe('[stack getter failed]');
+      expect(result.err.cause).toBe('[cause getter failed]');
       expect(() => JSON.stringify(result)).not.toThrow();
     });
   });

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -851,6 +851,105 @@ describe('Span', () => {
       expect(result.properties.safe.type).toBe('string');
       expect(result.$schema).toBe('[schema getter failed]');
     });
+
+    it('should serialize Maps including nested and primitive/object values', () => {
+      const inner = new Map<string, any>([['k', 'v']]);
+      const map = new Map<any, any>([
+        ['a', 1],
+        ['b', { x: 'y' }],
+        [42, 'num-key'],
+        ['inner', inner],
+      ]);
+
+      const result = deepClean({ map });
+
+      expect(result.map).toEqual({
+        a: 1,
+        b: { x: 'y' },
+        '42': 'num-key',
+        inner: { k: 'v' },
+      });
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
+
+    it('should detect self-referential Maps', () => {
+      const map = new Map<string, any>();
+      map.set('self', map);
+      map.set('ok', 1);
+
+      const result = deepClean({ map });
+
+      expect(result.map.self).toBe('[Circular]');
+      expect(result.map.ok).toBe(1);
+    });
+
+    it('should truncate Maps that exceed maxObjectKeys', () => {
+      const map = new Map<string, number>();
+      for (let i = 0; i < 5; i++) map.set(`k${i}`, i);
+
+      const result = deepClean({ map }, { ...DEFAULT_DEEP_CLEAN_OPTIONS, maxObjectKeys: 2 });
+
+      expect(Object.keys(result.map).filter(k => k !== '__truncated').length).toBe(2);
+      expect(result.map.__truncated).toBe('3 more keys omitted');
+    });
+
+    it('should serialize Sets including nested and object items', () => {
+      const inner = new Set([1, 2]);
+      const set = new Set<any>([1, 'two', { a: 1 }, inner]);
+
+      const result = deepClean({ set });
+
+      expect(Array.isArray(result.set)).toBe(true);
+      expect(result.set).toEqual([1, 'two', { a: 1 }, [1, 2]]);
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
+
+    it('should detect self-referential Sets', () => {
+      const set = new Set<any>();
+      set.add(1);
+      set.add(set);
+
+      const result = deepClean({ set });
+
+      expect(result.set[0]).toBe(1);
+      expect(result.set[1]).toBe('[Circular]');
+    });
+
+    it('should truncate Sets that exceed maxArrayLength', () => {
+      const set = new Set([1, 2, 3, 4, 5]);
+
+      const result = deepClean({ set }, { ...DEFAULT_DEEP_CLEAN_OPTIONS, maxArrayLength: 2 });
+
+      expect(result.set.slice(0, 2)).toEqual([1, 2]);
+      expect(result.set[2]).toBe('[…3 more items]');
+    });
+
+    it('should preserve Error stack and cause', () => {
+      const cause = new Error('root cause');
+      const err = new Error('outer', { cause });
+
+      const result = deepClean({ err });
+
+      expect(result.err.name).toBe('Error');
+      expect(result.err.message).toBe('outer');
+      expect(typeof result.err.stack).toBe('string');
+      expect(result.err.cause.name).toBe('Error');
+      expect(result.err.cause.message).toBe('root cause');
+      expect(typeof result.err.cause.stack).toBe('string');
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
+
+    it('should detect Error cause cycles', () => {
+      const err: any = new Error('cyclic');
+      err.cause = err;
+
+      const result = deepClean({ err });
+
+      expect(result.err.name).toBe('Error');
+      expect(result.err.message).toBe('cyclic');
+      expect(result.err.cause).toBe('[Circular]');
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
   });
 
   describe('serializationOptions', () => {

--- a/observability/mastra/src/spans/serialization.ts
+++ b/observability/mastra/src/spans/serialization.ts
@@ -89,6 +89,71 @@ export function truncateString(s: string, maxChars: number): string {
   return s.slice(0, maxChars) + '…[truncated]';
 }
 
+export type SerializedMapEntry = [keyType: string, key: any, value: any];
+
+export interface SerializedMap {
+  __type: 'Map';
+  __map_entries: SerializedMapEntry[];
+  __truncated?: string;
+}
+
+function formatSerializationError(error: unknown): string {
+  return `[${error instanceof Error ? truncateString(error.message, 256) : 'unknown error'}]`;
+}
+
+function getMapKeyType(key: unknown): string {
+  if (key === null) {
+    return 'null';
+  }
+  if (key instanceof Date) {
+    return 'date';
+  }
+  if (Array.isArray(key)) {
+    return 'array';
+  }
+  if (key instanceof Map) {
+    return 'map';
+  }
+  if (key instanceof Set) {
+    return 'set';
+  }
+  if (key instanceof Error) {
+    return 'error';
+  }
+
+  return typeof key;
+}
+
+function restoreSerializedMapKey(keyType: string, key: any): unknown {
+  switch (keyType) {
+    case 'undefined':
+      return undefined;
+    case 'null':
+      return null;
+    case 'bigint':
+      return typeof key === 'string' && key.endsWith('n') ? BigInt(key.slice(0, -1)) : key;
+    case 'date':
+      return typeof key === 'string' ? new Date(key) : key;
+    default:
+      return key;
+  }
+}
+
+export function isSerializedMap(value: unknown): value is SerializedMap {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as SerializedMap).__type === 'Map' &&
+    Array.isArray((value as SerializedMap).__map_entries)
+  );
+}
+
+export function reconstructSerializedMap(value: SerializedMap): Map<unknown, unknown> {
+  return new Map(
+    value.__map_entries.map(([keyType, key, mapValue]) => [restoreSerializedMapKey(keyType, key), mapValue]),
+  );
+}
+
 /**
  * Detect if an object is a JSON Schema.
  * Looks for typical JSON Schema markers like $schema, type with properties, etc.
@@ -273,40 +338,94 @@ export function deepClean(value: any, options: DeepCleanOptions = DEFAULT_DEEP_C
       // Done inside the try so the ancestor set is cleaned up in finally,
       // which also means cycles via `cause` are caught.
       if (val instanceof Error) {
-        const cleanedError: Record<string, any> = {
-          name: val.name,
-          message: val.message ? truncateString(val.message, maxStringLength) : undefined,
-        };
-        if (typeof val.stack === 'string') {
-          cleanedError.stack = truncateString(val.stack, maxStringLength);
+        let errorName: unknown;
+        let errorMessage: unknown;
+        let errorStack: unknown;
+        let rawCause: unknown;
+        let causeReadFailed = false;
+
+        try {
+          errorName = val.name;
+        } catch (error) {
+          errorName = formatSerializationError(error);
         }
-        if ((val as any).cause !== undefined) {
+
+        try {
+          errorMessage = val.message;
+        } catch (error) {
+          errorMessage = formatSerializationError(error);
+        }
+
+        try {
+          errorStack = val.stack;
+        } catch (error) {
+          errorStack = formatSerializationError(error);
+        }
+
+        try {
+          rawCause = (val as any).cause;
+        } catch (error) {
+          causeReadFailed = true;
+          rawCause = formatSerializationError(error);
+        }
+
+        const cleanedError: Record<string, any> = {
+          name: typeof errorName === 'string' ? truncateString(errorName, maxStringLength) : errorName,
+          message: typeof errorMessage === 'string' ? truncateString(errorMessage, maxStringLength) : errorMessage,
+        };
+        if (typeof errorStack === 'string') {
+          cleanedError.stack = truncateString(errorStack, maxStringLength);
+        } else if (errorStack !== undefined) {
+          cleanedError.stack = errorStack;
+        }
+        if (causeReadFailed) {
+          cleanedError.cause = rawCause;
+        } else if (rawCause !== undefined) {
           try {
-            cleanedError.cause = helper((val as any).cause, depth + 1);
+            cleanedError.cause = helper(rawCause, depth + 1);
           } catch (error) {
-            cleanedError.cause = `[${error instanceof Error ? truncateString(error.message, 256) : 'unknown error'}]`;
+            cleanedError.cause = formatSerializationError(error);
           }
         }
         return cleanedError;
       }
 
-      // Handle Map - convert to a plain object of entries.
+      // Handle Map - emit a tagged wrapper so key type/value identity is preserved.
       if (val instanceof Map) {
-        const cleanedMap: Record<string, any> = {};
+        const cleanedMap: SerializedMap = { __type: 'Map', __map_entries: [] };
         let mapKeyCount = 0;
-        const totalMapSize = val.size;
+        let omittedMapEntries = 0;
         for (const [mapKey, mapVal] of val) {
+          if (typeof mapKey === 'string' && stripSet.has(mapKey)) {
+            continue;
+          }
+
           if (mapKeyCount >= maxObjectKeys) {
-            cleanedMap['__truncated'] = `${totalMapSize - mapKeyCount} more keys omitted`;
-            break;
+            omittedMapEntries++;
+            continue;
           }
-          const keyStr = typeof mapKey === 'string' ? mapKey : String(mapKey);
+
+          const mapKeyType = getMapKeyType(mapKey);
+          let cleanedMapKey: any;
+          let cleanedMapValue: any;
+
           try {
-            cleanedMap[keyStr] = helper(mapVal, depth + 1);
+            cleanedMapKey = helper(mapKey, depth + 1);
           } catch (error) {
-            cleanedMap[keyStr] = `[${error instanceof Error ? truncateString(error.message, 256) : 'unknown error'}]`;
+            cleanedMapKey = formatSerializationError(error);
           }
+
+          try {
+            cleanedMapValue = helper(mapVal, depth + 1);
+          } catch (error) {
+            cleanedMapValue = formatSerializationError(error);
+          }
+
+          cleanedMap.__map_entries.push([mapKeyType, cleanedMapKey, cleanedMapValue]);
           mapKeyCount++;
+        }
+        if (omittedMapEntries > 0) {
+          cleanedMap.__truncated = `${omittedMapEntries} more keys omitted`;
         }
         return cleanedMap;
       }
@@ -321,7 +440,7 @@ export function deepClean(value: any, options: DeepCleanOptions = DEFAULT_DEEP_C
           try {
             cleanedSet.push(helper(item, depth + 1));
           } catch (error) {
-            cleanedSet.push(`[${error instanceof Error ? truncateString(error.message, 256) : 'unknown error'}]`);
+            cleanedSet.push(formatSerializationError(error));
           }
           i++;
         }
@@ -339,7 +458,7 @@ export function deepClean(value: any, options: DeepCleanOptions = DEFAULT_DEEP_C
           try {
             cleaned.push(helper(val[i], depth + 1));
           } catch (error) {
-            cleaned.push(`[${error instanceof Error ? truncateString(error.message, 256) : 'unknown error'}]`);
+            cleaned.push(formatSerializationError(error));
           }
         }
 
@@ -413,7 +532,7 @@ export function deepClean(value: any, options: DeepCleanOptions = DEFAULT_DEEP_C
           cleaned[key] = helper((val as Record<string, unknown>)[key], depth + 1);
           keyCount++;
         } catch (error) {
-          cleaned[key] = `[${error instanceof Error ? truncateString(error.message, 256) : 'unknown error'}]`;
+          cleaned[key] = formatSerializationError(error);
           keyCount++;
         }
       }

--- a/observability/mastra/src/spans/serialization.ts
+++ b/observability/mastra/src/spans/serialization.ts
@@ -259,14 +259,6 @@ export function deepClean(value: any, options: DeepCleanOptions = DEFAULT_DEEP_C
       return val;
     }
 
-    // Handle Errors specially - preserve name and message
-    if (val instanceof Error) {
-      return {
-        name: val.name,
-        message: val.message ? truncateString(val.message, maxStringLength) : undefined,
-      };
-    }
-
     // Handle circular references — only flag when the same object is an
     // ancestor of the current node (true cycle), not merely seen elsewhere.
     if (typeof val === 'object') {
@@ -277,6 +269,68 @@ export function deepClean(value: any, options: DeepCleanOptions = DEFAULT_DEEP_C
     }
 
     try {
+      // Handle Errors specially - preserve name, message, stack, and cause.
+      // Done inside the try so the ancestor set is cleaned up in finally,
+      // which also means cycles via `cause` are caught.
+      if (val instanceof Error) {
+        const cleanedError: Record<string, any> = {
+          name: val.name,
+          message: val.message ? truncateString(val.message, maxStringLength) : undefined,
+        };
+        if (typeof val.stack === 'string') {
+          cleanedError.stack = truncateString(val.stack, maxStringLength);
+        }
+        if ((val as any).cause !== undefined) {
+          try {
+            cleanedError.cause = helper((val as any).cause, depth + 1);
+          } catch (error) {
+            cleanedError.cause = `[${error instanceof Error ? truncateString(error.message, 256) : 'unknown error'}]`;
+          }
+        }
+        return cleanedError;
+      }
+
+      // Handle Map - convert to a plain object of entries.
+      if (val instanceof Map) {
+        const cleanedMap: Record<string, any> = {};
+        let mapKeyCount = 0;
+        const totalMapSize = val.size;
+        for (const [mapKey, mapVal] of val) {
+          if (mapKeyCount >= maxObjectKeys) {
+            cleanedMap['__truncated'] = `${totalMapSize - mapKeyCount} more keys omitted`;
+            break;
+          }
+          const keyStr = typeof mapKey === 'string' ? mapKey : String(mapKey);
+          try {
+            cleanedMap[keyStr] = helper(mapVal, depth + 1);
+          } catch (error) {
+            cleanedMap[keyStr] = `[${error instanceof Error ? truncateString(error.message, 256) : 'unknown error'}]`;
+          }
+          mapKeyCount++;
+        }
+        return cleanedMap;
+      }
+
+      // Handle Set - convert to an array.
+      if (val instanceof Set) {
+        const cleanedSet: any[] = [];
+        let i = 0;
+        const totalSetSize = val.size;
+        for (const item of val) {
+          if (i >= maxArrayLength) break;
+          try {
+            cleanedSet.push(helper(item, depth + 1));
+          } catch (error) {
+            cleanedSet.push(`[${error instanceof Error ? truncateString(error.message, 256) : 'unknown error'}]`);
+          }
+          i++;
+        }
+        if (totalSetSize > maxArrayLength) {
+          cleanedSet.push(`[…${totalSetSize - maxArrayLength} more items]`);
+        }
+        return cleanedSet;
+      }
+
       // Handle arrays - enforce length limit
       if (Array.isArray(val)) {
         const cleaned = [];


### PR DESCRIPTION
## Description

Improved the `deepClean()` serialization function to properly handle `Map`, `Set`, and richer `Error` objects:

- **Maps**: Now converted to plain objects with entries, respecting `maxObjectKeys` limit and circular reference detection
- **Sets**: Now converted to arrays, respecting `maxArrayLength` limit and circular reference detection  
- **Errors**: Now preserve `stack` property and recursively clean the `cause` property (with cycle detection), in addition to existing `name` and `message` fields

Previously, Maps and Sets were serialized as empty objects with entries silently dropped, and Errors only retained `name` and `message`. This change ensures these types are properly serialized while maintaining safety guarantees around circular references and size limits.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test update

## Testing

Added comprehensive test coverage including:
- Map serialization with nested and primitive values
- Set serialization with nested and object items
- Self-referential Map and Set detection
- Map/Set truncation respecting size limits
- Error stack and cause preservation
- Error cause cycle detection

All new tests pass and verify JSON stringification succeeds without errors.

## Checklist

- [x] I have added tests that prove my feature works

https://claude.ai/code/session_01S4ZmvRsdVQNVWz9wRBxEZo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR teaches deepClean() to understand three special JavaScript things it used to break: Maps, Sets, and Errors. Instead of losing their contents, it now converts Maps and Sets into safe, limited representations and preserves useful Error details (like stack and cause) while avoiding infinite loops and huge outputs.

## Overview
Enhanced the deepClean() serialization utilities in @mastra/observability to properly serialize Map and Set instances and to preserve richer Error information, with safeguards for circular references, depth, and size limits.

## Changes

### Maps
- Maps are serialized to a tagged plain object: { __type: 'Map', __map_entries: [...] }.
- Each entry records key type, string-coerced key (where needed), and cleaned value (SerializedMapEntry = [keyType, key, value]).
- Respects maxObjectKeys; when exceeded an optional __truncated message is added (e.g., "N more keys omitted").
- Detects self-referential/circular entries and emits "[Circular]" for those values.
- Added helpers: isSerializedMap() guard and reconstructSerializedMap() to rebuild a Map from the serialized form.

### Sets
- Sets are serialized to arrays of cleaned elements.
- Respects maxArrayLength and uses a truncation marker ("[…N more items]") when exceeded.
- Detects self-referential/circular elements and emits "[Circular]".

### Errors
- Removed the previous minimal Error special-case; now deepClean() preserves:
  - name, message, stack (when available and within maxStringLength), and
  - cause (recursively cleaned with cycle detection).
- Cyclic cause chains produce "[Circular]".
- Getter failures on Error properties are guarded and replaced with safe placeholder/error wrappers.
- All Error-cleaning remains JSON-stringifiable.

### Other
- Centralized error fallbacks via formatSerializationError() used during traversal.
- Truncation and strip-key logic applied consistently for Map keys and Set items.
- Added exported types and guards for SerializedMap.

## Testing
Added comprehensive tests covering:
- Map serialization: nested Maps, non-string keys, key/value cleaning, truncation (__truncated), and self-referential/circular Maps ("[Circular]").
- Set serialization: nested Sets, element cleaning, truncation marker, and self-referential/circular Sets.
- Error serialization: preservation of stack and cause, recursive cleaning of cause, cause cycle detection, and guarded behavior when getters throw.
- Assertions that cleaned output is safe to JSON.stringify in all tested scenarios.

## Type of change
Non-breaking feature and tests; adds types/exports for SerializedMap utilities and broadens deepClean() behavior while preserving existing limits and safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->