### PR TITLE
ObservabilityBus honors serializationOptions for payload sanitization

### DIFF
--- a/.changeset/bus-honors-serialization-options.md
+++ b/.changeset/bus-honors-serialization-options.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+ObservabilityBus now honors per-instance `serializationOptions` (maxStringLength, maxDepth, maxArrayLength, maxObjectKeys) when deep-cleaning log/metric/score/feedback payloads, matching the behavior of tracing spans. Previously these signals always used the built-in defaults regardless of user configuration.

--- a/observability/mastra/src/bus/observability-bus.test.ts
+++ b/observability/mastra/src/bus/observability-bus.test.ts
@@ -949,4 +949,192 @@ describe('ObservabilityBus', () => {
       await bus.flush(); // should not throw
     });
   });
+
+  describe('deepClean payload sanitization', () => {
+    it('should deepClean log events before delivering to handlers (defaults)', () => {
+      const onLogEvent = vi.fn();
+      bus.registerExporter(createMockExporter({ onLogEvent }));
+
+      // Circular ref + function should be stripped by deepClean defaults.
+      const circular: any = { name: 'circ' };
+      circular.self = circular;
+      const event: LogEvent = {
+        type: 'log',
+        log: {
+          timestamp: new Date(),
+          level: 'info',
+          message: 'hello',
+          data: { circular, fn: () => 'nope', ok: 'value' },
+        } as any,
+      };
+
+      bus.emit(event);
+
+      expect(onLogEvent).toHaveBeenCalledTimes(1);
+      const delivered = onLogEvent.mock.calls[0]![0] as LogEvent;
+      // Cleaning replaces the payload object with a sanitized clone.
+      expect(delivered.log).not.toBe(event.log);
+      // JSON-safe (no circular refs, no functions).
+      expect(() => JSON.stringify(delivered)).not.toThrow();
+      const data = (delivered.log as any).data;
+      expect(data.ok).toBe('value');
+      expect(typeof data.fn).not.toBe('function');
+    });
+
+    it('should deepClean metric / score / feedback payloads before delivery', () => {
+      const onMetricEvent = vi.fn();
+      const onScoreEvent = vi.fn();
+      const onFeedbackEvent = vi.fn();
+      bus.registerExporter(createMockExporter({ onMetricEvent, onScoreEvent, onFeedbackEvent }));
+
+      const circular: any = { x: 1 };
+      circular.self = circular;
+
+      bus.emit({
+        type: 'metric',
+        metric: {
+          timestamp: new Date(),
+          name: 'mastra_test_counter',
+          value: 1,
+          labels: { env: 'test' },
+          metadata: { circular },
+        } as any,
+      });
+      bus.emit({
+        type: 'score',
+        score: {
+          timestamp: new Date(),
+          traceId: 'trace-1',
+          scorerId: 'rel',
+          score: 0.5,
+          metadata: { circular },
+        } as any,
+      });
+      bus.emit({
+        type: 'feedback',
+        feedback: {
+          timestamp: new Date(),
+          traceId: 'trace-1',
+          source: 'user',
+          feedbackType: 'thumbs',
+          value: 1,
+          metadata: { circular },
+        } as any,
+      });
+
+      expect(() => JSON.stringify(onMetricEvent.mock.calls[0]![0])).not.toThrow();
+      expect(() => JSON.stringify(onScoreEvent.mock.calls[0]![0])).not.toThrow();
+      expect(() => JSON.stringify(onFeedbackEvent.mock.calls[0]![0])).not.toThrow();
+    });
+
+    it('should pass cleaned events to bridges as well as exporters', () => {
+      const onLogEvent = vi.fn();
+      const bridgeOnLog = vi.fn();
+      bus.registerExporter(createMockExporter({ onLogEvent }));
+      bus.registerBridge(createMockBridge({ onLogEvent: bridgeOnLog } as any));
+
+      const circular: any = {};
+      circular.self = circular;
+
+      bus.emit({
+        type: 'log',
+        log: {
+          timestamp: new Date(),
+          level: 'info',
+          message: 'hi',
+          data: { circular },
+        } as any,
+      });
+
+      expect(() => JSON.stringify(onLogEvent.mock.calls[0]![0])).not.toThrow();
+      expect(() => JSON.stringify(bridgeOnLog.mock.calls[0]![0])).not.toThrow();
+    });
+
+    it('should honor custom serializationOptions for non-tracing signals', async () => {
+      const customBus = new ObservabilityBus({
+        serializationOptions: {
+          maxStringLength: 10,
+          maxArrayLength: 2,
+        },
+      });
+      const onLogEvent = vi.fn();
+      const onMetricEvent = vi.fn();
+      const onScoreEvent = vi.fn();
+      const onFeedbackEvent = vi.fn();
+      customBus.registerExporter(createMockExporter({ onLogEvent, onMetricEvent, onScoreEvent, onFeedbackEvent }));
+
+      const longStr = 'x'.repeat(500);
+
+      customBus.emit({
+        type: 'log',
+        log: {
+          timestamp: new Date(),
+          level: 'info',
+          message: longStr,
+          data: { arr: [1, 2, 3, 4, 5] },
+        } as any,
+      });
+      customBus.emit({
+        type: 'metric',
+        metric: {
+          timestamp: new Date(),
+          name: 'mastra_test_counter',
+          value: 1,
+          labels: { env: 'test' },
+          metadata: { note: longStr },
+        } as any,
+      });
+      customBus.emit({
+        type: 'score',
+        score: {
+          timestamp: new Date(),
+          traceId: 't',
+          scorerId: 's',
+          score: 0.5,
+          reason: longStr,
+        } as any,
+      });
+      customBus.emit({
+        type: 'feedback',
+        feedback: {
+          timestamp: new Date(),
+          traceId: 't',
+          source: 'user',
+          feedbackType: 'comment',
+          value: 1,
+          comment: longStr,
+        } as any,
+      });
+
+      const log = onLogEvent.mock.calls[0]![0] as LogEvent;
+      // Custom maxStringLength applied (longStr is 500 chars, capped to 10
+      // plus a truncation marker — must be drastically shorter than original).
+      expect((log.log as any).message.length).toBeLessThan(longStr.length);
+      // Custom maxArrayLength applied.
+      expect((log.log as any).data.arr.length).toBeLessThanOrEqual(3); // 2 + truncation marker tolerance
+
+      const metric = onMetricEvent.mock.calls[0]![0] as MetricEvent;
+      expect((metric.metric as any).metadata.note.length).toBeLessThan(longStr.length);
+
+      const score = onScoreEvent.mock.calls[0]![0] as ScoreEvent;
+      expect((score.score as any).reason.length).toBeLessThan(longStr.length);
+
+      const feedback = onFeedbackEvent.mock.calls[0]![0] as FeedbackEvent;
+      expect((feedback.feedback as any).comment.length).toBeLessThan(longStr.length);
+
+      await customBus.shutdown();
+    });
+
+    it('should leave tracing events unchanged (already cleaned at span construction)', () => {
+      const onTracingEvent = vi.fn();
+      bus.registerExporter(createMockExporter({ onTracingEvent }));
+
+      const event = createTracingEvent();
+      bus.emit(event);
+
+      // Same reference passes through — bus does not re-clean tracing events.
+      expect(onTracingEvent).toHaveBeenCalledTimes(1);
+      expect(onTracingEvent.mock.calls[0]![0]).toBe(event);
+    });
+  });
 });

--- a/observability/mastra/src/bus/observability-bus.ts
+++ b/observability/mastra/src/bus/observability-bus.ts
@@ -12,9 +12,22 @@
 
 import type { ObservabilityExporter, ObservabilityBridge, ObservabilityEvent } from '@mastra/core/observability';
 
-import { deepClean } from '../spans/serialization';
+import type { DeepCleanOptions } from '../spans/serialization';
+import { deepClean, mergeSerializationOptions } from '../spans/serialization';
 import { BaseObservabilityEventBus } from './base';
 import { routeToHandler } from './route-event';
+
+/**
+ * User-supplied serialization options forwarded to deepClean. Mirrors the
+ * shape accepted by spans (see `mergeSerializationOptions`) so logs/metrics/
+ * scores/feedback honor the same per-instance limits as tracing spans.
+ */
+export interface ObservabilityBusSerializationOptions {
+  maxStringLength?: number;
+  maxDepth?: number;
+  maxArrayLength?: number;
+  maxObjectKeys?: number;
+}
 
 /**
  * Apply deepClean() to non-tracing observability events. Tracing events are
@@ -32,16 +45,16 @@ import { routeToHandler } from './route-event';
  * by deepClean unchanged, so the cleaned object is structurally identical to
  * the input for well-formed events.
  */
-function cleanEvent(event: ObservabilityEvent): ObservabilityEvent {
+function cleanEvent(event: ObservabilityEvent, options: DeepCleanOptions): ObservabilityEvent {
   switch (event.type) {
     case 'log':
-      return { type: 'log', log: deepClean(event.log) };
+      return { type: 'log', log: deepClean(event.log, options) };
     case 'metric':
-      return { type: 'metric', metric: deepClean(event.metric) };
+      return { type: 'metric', metric: deepClean(event.metric, options) };
     case 'score':
-      return { type: 'score', score: deepClean(event.score) };
+      return { type: 'score', score: deepClean(event.score, options) };
     case 'feedback':
-      return { type: 'feedback', feedback: deepClean(event.feedback) };
+      return { type: 'feedback', feedback: deepClean(event.feedback, options) };
     default:
       // Tracing events are already cleaned at span construction.
       return event;
@@ -62,8 +75,12 @@ export class ObservabilityBus extends BaseObservabilityEventBus<ObservabilityEve
   /** In-flight handler promises from routeToHandler. Self-cleaning via .finally(). */
   private pendingHandlers: Set<Promise<void>> = new Set();
 
-  constructor() {
+  /** Resolved deepClean options applied to non-tracing events before fan-out. */
+  private deepCleanOptions: DeepCleanOptions;
+
+  constructor(opts?: { serializationOptions?: ObservabilityBusSerializationOptions }) {
     super({ name: 'ObservabilityBus' });
+    this.deepCleanOptions = mergeSerializationOptions(opts?.serializationOptions);
   }
 
   /**
@@ -146,7 +163,7 @@ export class ObservabilityBus extends BaseObservabilityEventBus<ObservabilityEve
     // Sanitize free-form payload fields on non-tracing signals before
     // fanning out. Tracing events are already deep-cleaned at span
     // construction, so cleanEvent() returns them unchanged.
-    const cleaned = cleanEvent(event);
+    const cleaned = cleanEvent(event, this.deepCleanOptions);
 
     // Route to appropriate handler on each registered exporter
     for (const exporter of this.exporters) {

--- a/observability/mastra/src/bus/observability-bus.ts
+++ b/observability/mastra/src/bus/observability-bus.ts
@@ -10,24 +10,17 @@
  * events of that type are silently skipped for that handler.
  */
 
-import type { ObservabilityExporter, ObservabilityBridge, ObservabilityEvent } from '@mastra/core/observability';
+import type {
+  ObservabilityExporter,
+  ObservabilityBridge,
+  ObservabilityEvent,
+  SerializationOptions,
+} from '@mastra/core/observability';
 
 import type { DeepCleanOptions } from '../spans/serialization';
 import { deepClean, mergeSerializationOptions } from '../spans/serialization';
 import { BaseObservabilityEventBus } from './base';
 import { routeToHandler } from './route-event';
-
-/**
- * User-supplied serialization options forwarded to deepClean. Mirrors the
- * shape accepted by spans (see `mergeSerializationOptions`) so logs/metrics/
- * scores/feedback honor the same per-instance limits as tracing spans.
- */
-export interface ObservabilityBusSerializationOptions {
-  maxStringLength?: number;
-  maxDepth?: number;
-  maxArrayLength?: number;
-  maxObjectKeys?: number;
-}
 
 /**
  * Apply deepClean() to non-tracing observability events. Tracing events are
@@ -78,7 +71,7 @@ export class ObservabilityBus extends BaseObservabilityEventBus<ObservabilityEve
   /** Resolved deepClean options applied to non-tracing events before fan-out. */
   private deepCleanOptions: DeepCleanOptions;
 
-  constructor(opts?: { serializationOptions?: ObservabilityBusSerializationOptions }) {
+  constructor(opts?: { serializationOptions?: SerializationOptions }) {
     super({ name: 'ObservabilityBus' });
     this.deepCleanOptions = mergeSerializationOptions(opts?.serializationOptions);
   }

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -81,7 +81,9 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     this.cardinalityFilter = new CardinalityFilter(config.cardinality);
 
     // Initialize the unified ObservabilityBus
-    this.observabilityBus = new ObservabilityBus();
+    this.observabilityBus = new ObservabilityBus({
+      serializationOptions: this.config.serializationOptions,
+    });
 
     for (const exporter of this.exporters) {
       this.observabilityBus.registerExporter(exporter);


### PR DESCRIPTION
## Description

ObservabilityBus now respects per-instance `serializationOptions` (maxStringLength, maxDepth, maxArrayLength, maxObjectKeys) when deep-cleaning log, metric, score, and feedback payloads before delivery to exporters and bridges. Previously, these signals always used built-in defaults regardless of user configuration, while tracing spans honored the options. This change brings consistency across all observability signal types.

### Changes Made

1. **ObservabilityBus constructor** now accepts optional `serializationOptions` and resolves them via `mergeSerializationOptions()` for use during event sanitization
2. **cleanEvent()** function now accepts and applies `DeepCleanOptions` to all non-tracing event types
3. **BaseObservabilityInstance** forwards its configured `serializationOptions` to the ObservabilityBus during initialization
4. Added `ObservabilityBusSerializationOptions` interface to document the accepted configuration shape

### Behavior

- Non-tracing events (log, metric, score, feedback) are deep-cleaned with user-supplied limits before fan-out to exporters and bridges
- Tracing events continue to pass through unchanged (already cleaned at span construction)
- Custom limits now apply consistently across all signal types, matching the behavior of tracing spans

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test Coverage

Added comprehensive test suite covering:
- Default deepClean behavior for log events (circular refs, functions stripped)
- deepClean applied to metric, score, and feedback payloads
- Cleaned events passed to both exporters and bridges
- Custom serializationOptions honored for all non-tracing signal types
- Tracing events left unchanged (pass-through behavior)

All tests verify JSON serializability and proper truncation/sanitization of payloads.

https://claude.ai/code/session_014bQXCQWonjd9YwWCiyp99Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

ObservabilityBus now respects your custom payload size limits when cleaning up observability data (logs, metrics, scores, feedback) before sending it out—just like it always did for tracing spans. Before, non-tracing signals ignored your custom limits and used built-in defaults instead.

---

## Summary

This PR makes `ObservabilityBus` honor per-instance `serializationOptions` (maxStringLength, maxDepth, maxArrayLength, maxObjectKeys) when deep-cleaning payloads for non-tracing observability signals (log, metric, score, feedback). Previously, only tracing spans respected these configuration options; other signal types always used built-in defaults.

### Key Changes

**ObservabilityBus constructor** now accepts an optional `serializationOptions` parameter via `constructor(opts?: { serializationOptions?: SerializationOptions })`, resolving these options via `mergeSerializationOptions` and storing them as `deepCleanOptions` for use during event emission.

**cleanEvent() method** now accepts `DeepCleanOptions` and applies them when deep-cleaning non-tracing event payloads (log, metric, score, feedback). Tracing events continue to pass through unchanged.

**BaseObservabilityInstance** now forwards its configured `serializationOptions` to the `ObservabilityBus` during initialization, ensuring user-provided limits propagate from the instance configuration to payload sanitization.

### Behavioral Outcomes

- Non-tracing events (log, metric, score, feedback) are deep-cleaned using custom user-supplied serialization limits before delivery to exporters and bridges
- Tracing events remain unmodified at the bus level (already cleaned at span construction)
- Custom serialization options now apply consistently across all signal types instead of just tracing

### Testing

Comprehensive test coverage was added to `observability/mastra/src/bus/observability-bus.test.ts` validating:
- Default deep-clean behavior for non-tracing events
- Application of sanitization to metric, score, and feedback payloads
- Delivery of cleaned events to both exporters and bridges
- Custom `serializationOptions` are honored for non-tracing signals with proper truncation
- Tracing events bypass re-cleaning at the bus level (delivered as-is)
- All sanitized payloads remain JSON-serializable

### Public API Changes

- `ObservabilityBus` constructor signature: `constructor()` → `constructor(opts?: { serializationOptions?: SerializationOptions })`
- `cleanEvent()` method signature: `cleanEvent(event)` → `cleanEvent(event, options)`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->