### PR TITLE
Allow omitting model in Responses API requests

### DIFF
--- a/.changeset/lazy-cooks-shine.md
+++ b/.changeset/lazy-cooks-shine.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed the Responses API to use the agent default model when create requests omit model.

--- a/.changeset/some-worlds-tease.md
+++ b/.changeset/some-worlds-tease.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fixed the client JS Responses types to allow omitting the model override.

--- a/client-sdks/client-js/src/resources/responses.test.ts
+++ b/client-sdks/client-js/src/resources/responses.test.ts
@@ -128,6 +128,47 @@ describe('Responses Resource', () => {
     );
   });
 
+  it('allows create requests without a model override', async () => {
+    mockJsonResponse({
+      id: 'resp_123',
+      object: 'response',
+      created_at: 1234567890,
+      model: 'openai/gpt-5',
+      status: 'completed',
+      output: [
+        {
+          id: 'msg_123',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'Hello from Mastra' }],
+        },
+      ],
+      usage: null,
+      instructions: null,
+      previous_response_id: null,
+      store: false,
+    });
+
+    const response = await client.responses.create({
+      agent_id: 'support-agent',
+      input: 'Summarize this ticket',
+    });
+
+    expect(response.model).toBe('openai/gpt-5');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:4111/api/v1/responses',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining(clientOptions.headers),
+        body: JSON.stringify({
+          agent_id: 'support-agent',
+          input: 'Summarize this ticket',
+        }),
+      }),
+    );
+  });
+
   it('passes providerOptions through in create requests', async () => {
     mockJsonResponse({
       id: 'resp_123',

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -219,8 +219,8 @@ export type ResponsesDeleteResponse = {
 };
 
 export type CreateResponseParams = {
-  /** Target model identifier, such as `openai/gpt-5`. */
-  model: string;
+  /** Optional model override, such as `openai/gpt-5`. When omitted, the agent default model is used. */
+  model?: string;
   /** Mastra agent ID for the request. Required on initial requests; stored follow-ups can omit it when using `previous_response_id`. */
   agent_id?: string;
   /** Input text or message history for the current turn. */

--- a/packages/server/src/server/handlers/responses.test.ts
+++ b/packages/server/src/server/handlers/responses.test.ts
@@ -6,6 +6,7 @@ import { createTool } from '@mastra/core/tools';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { z } from 'zod';
 import { HTTPException } from '../http-exception';
+import { createResponseBodySchema } from '../schemas/responses';
 import { CREATE_RESPONSE_ROUTE, DELETE_RESPONSE_ROUTE, GET_RESPONSE_ROUTE } from './responses';
 import { createTestServerContext } from './test-utils';
 
@@ -180,7 +181,11 @@ async function readSseEvents(response: Response): Promise<SseEventPayload[]> {
 }
 
 function mockAgentSpecVersion(agent: Agent, specificationVersion: 'v1' | 'v2' = 'v2') {
-  vi.spyOn(agent, 'getModel').mockResolvedValue({ specificationVersion } as never);
+  vi.spyOn(agent, 'getModel').mockResolvedValue({
+    specificationVersion,
+    provider: 'openai',
+    modelId: specificationVersion === 'v1' ? 'legacy-model' : 'test-model',
+  } as never);
 }
 
 class RootInjectedMockMemory extends MockMemory {
@@ -377,6 +382,44 @@ describe('Responses Handlers', () => {
     });
 
     expect(retrieved).toEqual(created);
+  });
+
+  it('accepts omitted model in the create response request schema', () => {
+    const result = createResponseBodySchema.safeParse({
+      agent_id: 'test-agent',
+      input: 'Hello',
+      stream: false,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('uses the agent default model when create requests omit model', async () => {
+    vi.spyOn(agent, 'getModel').mockResolvedValue({
+      specificationVersion: 'v2',
+      provider: 'openai.responses',
+      modelId: 'gpt-4o-mini',
+    } as never);
+    const generateSpy = vi
+      .spyOn(agent, 'generate')
+      .mockResolvedValue(createGenerateResult({ text: 'Hello from Mastra' }));
+
+    const response = (await CREATE_RESPONSE_ROUTE.handler({
+      ...createTestServerContext({ mastra }),
+      agent_id: 'test-agent',
+      input: 'Hello',
+      store: false,
+      stream: false,
+    })) as Response;
+
+    const created = await readJson(response);
+
+    expect((generateSpy.mock.calls[0]?.[1] as Record<string, unknown>)?.model).toBeUndefined();
+    expect(created).toMatchObject({
+      object: 'response',
+      model: 'openai/gpt-4o-mini',
+      status: 'completed',
+    });
   });
 
   it('maps text.format json_object to structuredOutput for v2 generate requests', async () => {

--- a/packages/server/src/server/handlers/responses.ts
+++ b/packages/server/src/server/handlers/responses.ts
@@ -45,6 +45,7 @@ import type {
 import { getEffectiveResourceId, getEffectiveThreadId, validateThreadOwnership } from './utils';
 
 type AgentExecutionInput = Parameters<Agent['generate']>[0];
+type ResolvedAgentModel = Awaited<ReturnType<Agent['getModel']>>;
 
 type ResponseExecutionResult = {
   text?: string;
@@ -99,7 +100,9 @@ type PreparedCreateResponseRequest = {
   didStore: boolean;
   executionInput: AgentExecutionInput;
   previousResponseTurnRecord: ResponseTurnRecord | null;
+  resolvedModel: ResolvedAgentModel;
   responseId: string;
+  responseModel: string;
   responseMetadata: Omit<
     ResponseTurnRecordMetadata,
     'completedAt' | 'status' | 'usage' | 'providerOptions' | 'messageIds'
@@ -139,6 +142,33 @@ function createStructuredOutput(text: CreateResponseBody['text']) {
     default:
       return undefined;
   }
+}
+
+function formatResponseModel({
+  requestedModel,
+  resolvedModel,
+}: {
+  requestedModel?: string;
+  resolvedModel: ResolvedAgentModel;
+}) {
+  if (requestedModel) {
+    return requestedModel;
+  }
+
+  if (resolvedModel.provider && resolvedModel.modelId) {
+    const publicProviderId = resolvedModel.provider.includes('.')
+      ? resolvedModel.provider.split('.')[0]!
+      : resolvedModel.provider;
+    return `${publicProviderId}/${resolvedModel.modelId}`;
+  }
+
+  if (resolvedModel.modelId) {
+    return resolvedModel.modelId;
+  }
+
+  throw new HTTPException(500, {
+    message: 'Responses route could not determine the effective model for this request',
+  });
 }
 
 function getStreamedMessageOutputItem(response: ResponseObject, responseId: string) {
@@ -320,7 +350,8 @@ async function resolveAgentMemoryStore({
  */
 async function executeGenerate({
   agent,
-  model,
+  resolvedModel,
+  modelOverride,
   instructions,
   text,
   providerOptions,
@@ -330,7 +361,8 @@ async function executeGenerate({
   threadContext,
 }: {
   agent: Agent;
-  model: string;
+  resolvedModel: ResolvedAgentModel;
+  modelOverride?: string;
   instructions: string | undefined;
   text: CreateResponseBody['text'];
   providerOptions: CreateResponseBody['providerOptions'];
@@ -341,16 +373,16 @@ async function executeGenerate({
 }) {
   const executionMemory = createExecutionMemory(threadContext);
   const structuredOutput = createStructuredOutput(text);
+  const modelOption = modelOverride ? { model: modelOverride } : {};
   const commonOptions = {
     instructions,
     requestContext,
     abortSignal,
-    model,
+    ...modelOption,
     structuredOutput,
     providerOptions,
     ...(executionMemory ?? {}),
   };
-  const resolvedModel = await agent.getModel({ requestContext, modelConfig: model });
 
   if (resolvedModel.specificationVersion === 'v1') {
     if (threadContext) {
@@ -358,7 +390,7 @@ async function executeGenerate({
         instructions,
         requestContext,
         abortSignal,
-        model,
+        ...modelOption,
         output: structuredOutput?.schema,
         providerOptions,
         resourceId: threadContext.resourceId,
@@ -370,7 +402,7 @@ async function executeGenerate({
       instructions,
       requestContext,
       abortSignal,
-      model,
+      ...modelOption,
       output: structuredOutput?.schema,
       providerOptions,
     } as never)) as ResponseExecutionResult;
@@ -384,7 +416,8 @@ async function executeGenerate({
  */
 async function executeStream({
   agent,
-  model,
+  resolvedModel,
+  modelOverride,
   instructions,
   text,
   providerOptions,
@@ -394,7 +427,8 @@ async function executeStream({
   threadContext,
 }: {
   agent: Agent;
-  model: string;
+  resolvedModel: ResolvedAgentModel;
+  modelOverride?: string;
   instructions: string | undefined;
   text: CreateResponseBody['text'];
   providerOptions: CreateResponseBody['providerOptions'];
@@ -405,16 +439,16 @@ async function executeStream({
 }) {
   const executionMemory = createExecutionMemory(threadContext);
   const structuredOutput = createStructuredOutput(text);
+  const modelOption = modelOverride ? { model: modelOverride } : {};
   const commonOptions = {
     instructions,
     requestContext,
     abortSignal,
-    model,
+    ...modelOption,
     structuredOutput,
     providerOptions,
     ...(executionMemory ?? {}),
   };
-  const resolvedModel = await agent.getModel({ requestContext, modelConfig: model });
 
   if (resolvedModel.specificationVersion === 'v1') {
     if (threadContext) {
@@ -422,7 +456,7 @@ async function executeStream({
         instructions,
         requestContext,
         abortSignal,
-        model,
+        ...modelOption,
         output: structuredOutput?.schema,
         providerOptions,
         resourceId: threadContext.resourceId,
@@ -434,7 +468,7 @@ async function executeStream({
       instructions,
       requestContext,
       abortSignal,
-      model,
+      ...modelOption,
       output: structuredOutput?.schema,
       providerOptions,
     } as never)) as ResponseStreamResult;
@@ -615,6 +649,14 @@ async function prepareCreateResponseRequest({
     mastra,
     agentId: body.agent_id,
   });
+  const resolvedModel = await agent.getModel({
+    requestContext,
+    modelConfig: body.model,
+  });
+  const responseModel = formatResponseModel({
+    requestedModel: body.model,
+    resolvedModel,
+  });
   const shouldStore = body.store ?? false;
   const needsMemoryStore = shouldStore || Boolean(body.conversation_id) || Boolean(body.previous_response_id);
   const agentMemoryStore = needsMemoryStore
@@ -666,10 +708,12 @@ async function prepareCreateResponseRequest({
     didStore,
     executionInput,
     previousResponseTurnRecord,
+    resolvedModel,
     responseId,
+    responseModel,
     responseMetadata: {
       agentId: agent.id,
-      model: body.model,
+      model: responseModel,
       createdAt,
       instructions: body.instructions,
       text: body.text,
@@ -693,6 +737,7 @@ function createResponseEventStream({
   didStore,
   previousResponseTurnRecord,
   responseId,
+  responseModel,
   responseMetadata,
   streamResult,
   threadContext,
@@ -704,6 +749,7 @@ function createResponseEventStream({
   didStore: boolean;
   previousResponseTurnRecord: ResponseTurnRecord | null;
   responseId: string;
+  responseModel: string;
   responseMetadata: Omit<
     ResponseTurnRecordMetadata,
     'completedAt' | 'status' | 'usage' | 'providerOptions' | 'messageIds'
@@ -713,7 +759,7 @@ function createResponseEventStream({
 }) {
   const createdResponse = buildInProgressResponse({
     responseId,
-    model: body.model,
+    model: responseModel,
     createdAt,
     instructions: body.instructions,
     textConfig: body.text,
@@ -793,7 +839,7 @@ function createResponseEventStream({
           result: streamResult,
           responseId,
           createdAt,
-          model: body.model,
+          model: responseModel,
           instructions: body.instructions,
           previousResponseId: previousResponseTurnRecord?.message.id ?? body.previous_response_id,
           conversationId: threadContext?.threadId ?? body.conversation_id,
@@ -864,7 +910,9 @@ export const CREATE_RESPONSE_ROUTE = createRoute({
         didStore,
         executionInput,
         previousResponseTurnRecord,
+        resolvedModel,
         responseId,
+        responseModel,
         responseMetadata,
         threadContext,
       } = await prepareCreateResponseRequest({ body, mastra, requestContext });
@@ -872,7 +920,8 @@ export const CREATE_RESPONSE_ROUTE = createRoute({
       if (!body.stream) {
         const result = await executeGenerate({
           agent,
-          model: body.model,
+          resolvedModel,
+          modelOverride: body.model,
           instructions: body.instructions,
           text: body.text,
           providerOptions: body.providerOptions,
@@ -889,7 +938,7 @@ export const CREATE_RESPONSE_ROUTE = createRoute({
           result,
           responseId,
           createdAt,
-          model: body.model,
+          model: responseModel,
           instructions: body.instructions,
           previousResponseId: previousResponseTurnRecord?.message.id ?? body.previous_response_id,
           conversationId: threadContext?.threadId ?? body.conversation_id,
@@ -903,7 +952,8 @@ export const CREATE_RESPONSE_ROUTE = createRoute({
 
       const streamResult = await executeStream({
         agent,
-        model: body.model,
+        resolvedModel,
+        modelOverride: body.model,
         instructions: body.instructions,
         text: body.text,
         providerOptions: body.providerOptions,
@@ -921,6 +971,7 @@ export const CREATE_RESPONSE_ROUTE = createRoute({
         didStore,
         previousResponseTurnRecord,
         responseId,
+        responseModel,
         responseMetadata,
         streamResult,
         threadContext,

--- a/packages/server/src/server/handlers/responses.ts
+++ b/packages/server/src/server/handlers/responses.ts
@@ -144,33 +144,6 @@ function createStructuredOutput(text: CreateResponseBody['text']) {
   }
 }
 
-function formatResponseModel({
-  requestedModel,
-  resolvedModel,
-}: {
-  requestedModel?: string;
-  resolvedModel: ResolvedAgentModel;
-}) {
-  if (requestedModel) {
-    return requestedModel;
-  }
-
-  if (resolvedModel.provider && resolvedModel.modelId) {
-    const publicProviderId = resolvedModel.provider.includes('.')
-      ? resolvedModel.provider.split('.')[0]!
-      : resolvedModel.provider;
-    return `${publicProviderId}/${resolvedModel.modelId}`;
-  }
-
-  if (resolvedModel.modelId) {
-    return resolvedModel.modelId;
-  }
-
-  throw new HTTPException(500, {
-    message: 'Responses route could not determine the effective model for this request',
-  });
-}
-
 function getStreamedMessageOutputItem(response: ResponseObject, responseId: string) {
   return (
     response.output.find(
@@ -653,10 +626,24 @@ async function prepareCreateResponseRequest({
     requestContext,
     modelConfig: body.model,
   });
-  const responseModel = formatResponseModel({
-    requestedModel: body.model,
-    resolvedModel,
-  });
+  const responseModel =
+    body.model ??
+    (() => {
+      if (resolvedModel.provider && resolvedModel.modelId) {
+        const publicProviderId = resolvedModel.provider.includes('.')
+          ? resolvedModel.provider.split('.')[0]!
+          : resolvedModel.provider;
+        return `${publicProviderId}/${resolvedModel.modelId}`;
+      }
+
+      if (resolvedModel.modelId) {
+        return resolvedModel.modelId;
+      }
+
+      throw new HTTPException(500, {
+        message: 'Responses route could not determine the effective model for this request',
+      });
+    })();
   const shouldStore = body.store ?? false;
   const needsMemoryStore = shouldStore || Boolean(body.conversation_id) || Boolean(body.previous_response_id);
   const agentMemoryStore = needsMemoryStore

--- a/packages/server/src/server/schemas/responses.ts
+++ b/packages/server/src/server/schemas/responses.ts
@@ -53,7 +53,12 @@ export type ResponseTextConfig = z.infer<typeof responseTextSchema>;
 
 export const createResponseBodySchema = z
   .object({
-    model: z.string().describe('Model identifier used to generate the response, such as openai/gpt-5'),
+    model: z
+      .string()
+      .optional()
+      .describe(
+        'Optional model identifier override, such as openai/gpt-5. When omitted, the agent default model is used.',
+      ),
     agent_id: z.string().describe('Mastra agent ID for the request'),
     input: z.union([z.string(), z.array(responseInputMessageSchema)]),
     instructions: z.string().optional(),


### PR DESCRIPTION
## Summary
- make the server Responses create schema accept omitted `model` and fall back to the agent default model
- keep the resolved response payload model stable by deriving a public `provider/modelId` string from the resolved agent model
- make `@mastra/client-js` Responses create params allow omitted model overrides and add focused coverage

## Testing
- pnpm test src/server/handlers/responses.test.ts
- pnpm test:unit src/resources/responses.test.ts
- pnpm build:lib (packages/server)
- pnpm build:lib (client-sdks/client-js)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

You can now call the Responses API without specifying a model — the system will automatically use the agent's default model and still report which model was used.

## Overview

Requests to create Responses no longer require a `model` override. If omitted, the agent's configured default model is resolved and a stable public model identifier (provider/modelId) is derived, stored, and returned in response metadata. Server-side request handling, persistence, streaming events, and the client JS types/tests were updated to reflect this behavior.

## Changes

### Server-side Schema and Handling (packages/server)

- Schema update (packages/server/src/server/schemas/responses.ts)
  - `createResponseBodySchema.model` changed from required to optional with docs clarifying omission falls back to the agent default.
- Request handler refactor (packages/server/src/server/handlers/responses.ts)
  - Added a ResolvedAgentModel type and resolve logic: call agent.getModel(...) to determine the effective model when `model` is omitted.
  - Compute a normalized `responseModel` string (prefers explicit body.model; otherwise derives from resolvedModel.provider + resolvedModel.modelId or modelId alone; throws if neither available).
  - Prepared request now includes `resolvedModel` and `responseModel`.
  - Refactored executeGenerate/executeStream to accept resolvedModel + optional modelOverride and to pass modelOverride into execution options.
  - Persisted response turn metadata, built SSE events, and finalized responses now use the normalized `responseModel` so stored and streamed responses consistently reflect the effective model.
- Tests (packages/server/src/server/handlers/responses.test.ts)
  - Enhanced mock agent getModel shape (provider + modelId).
  - Added tests asserting the schema accepts omitted `model`.
  - Added tests verifying the handler uses the agent default model when `model` is omitted and that the returned response includes the normalized model string.

### Client-side SDK (client-sdks/client-js)

- Types (client-sdks/client-js/src/types.ts)
  - `CreateResponseParams.model` is now optional; JSDoc updated to describe fallback to agent default when omitted.
- Tests (client-sdks/client-js/src/resources/responses.test.ts)
  - Added test verifying client.responses.create works without a `model` override, that the server-provided model is returned, and that the outgoing POST body omits `model` when not supplied.

### Changelogs / Changesets

- Added changeset entries:
  - @mastra/server: patch noting Responses API accepts omitted `model` and falls back to agent default.
  - @mastra/client-js: patch noting client types allow omitting model override.

## Testing

Included tests and build steps exercised in the PR:
- pnpm test src/server/handlers/responses.test.ts
- pnpm test:unit src/resources/responses.test.ts
- pnpm build:lib (packages/server)
- pnpm build:lib (client-sdks/client-js)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->