### PR TITLE
fix(mcp): retry tool discovery after connection drops

### DIFF
--- a/.changeset/steady-dingos-repair.md
+++ b/.changeset/steady-dingos-repair.md
@@ -1,0 +1,7 @@
+---
+"@mastra/mcp": patch
+---
+
+Improved MCP tool discovery to retry once after reconnectable connection errors like `Connection closed` during `tools/list`.
+
+`MCPClient.listToolsets()`, `listToolsetsWithErrors()`, and `listTools()` now attempt a reconnect before treating transient discovery failures as missing tools.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,7 +26,7 @@
     "build:lib": "tsup --silent --config tsup.config.ts",
     "prepack": "pnpx tsx ../../scripts/generate-package-docs.ts",
     "build:watch": "pnpm build:lib --watch",
-    "test:client": "vitest run ./src/client/client.test.ts",
+    "test:client": "vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts",
     "test:server": "vitest run ./src/server/server.test.ts",
     "test:integration": "cd integration-tests && pnpm test:mcp",
     "test": "pnpm test:server && pnpm test:client && pnpm test:integration",

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -45,6 +45,7 @@ import { ElicitationClientActions } from './actions/elicitation';
 import { ProgressClientActions } from './actions/progress';
 import { PromptClientActions } from './actions/prompt';
 import { ResourceClientActions } from './actions/resource';
+import { isReconnectableMCPError } from './error-utils';
 import type {
   FetchLike,
   LogHandler,
@@ -505,44 +506,6 @@ export class InternalMastraMCPClient extends MastraBase {
   }
 
   /**
-   * Checks if an error indicates a session invalidation that requires reconnection.
-   *
-   * Common session-related errors include:
-   * - "No valid session ID provided" (HTTP 400)
-   * - "Server not initialized" (HTTP 400)
-   * - "Not connected" (protocol state error)
-   * - Connection refused errors
-   *
-   * @param error - The error to check
-   * @returns true if the error indicates a session problem requiring reconnection
-   *
-   * @internal
-   */
-  private isSessionError(error: unknown): boolean {
-    if (!(error instanceof Error)) {
-      return false;
-    }
-
-    const errorMessage = error.message.toLowerCase();
-
-    // Check for session-related error patterns
-    return (
-      errorMessage.includes('no valid session') ||
-      errorMessage.includes('session') ||
-      errorMessage.includes('server not initialized') ||
-      errorMessage.includes('not connected') ||
-      errorMessage.includes('http 400') ||
-      errorMessage.includes('http 401') ||
-      errorMessage.includes('http 403') ||
-      errorMessage.includes('econnrefused') ||
-      errorMessage.includes('fetch failed') ||
-      errorMessage.includes('connection refused') ||
-      errorMessage.includes('sse stream disconnected') ||
-      errorMessage.includes('typeerror: terminated')
-    );
-  }
-
-  /**
    * Forces a reconnection to the MCP server by disconnecting and reconnecting.
    *
    * This is useful when the session becomes invalid (e.g., after server restart)
@@ -774,7 +737,7 @@ export class InternalMastraMCPClient extends MastraBase {
                 return await executeToolCall();
               } catch (e) {
                 // Check if this is a session-related error that requires reconnection
-                if (this.isSessionError(e)) {
+                if (isReconnectableMCPError(e)) {
                   this.log('debug', `Session error detected for tool ${tool.name}, attempting reconnection...`, {
                     error: e instanceof Error ? e.message : String(e),
                   });

--- a/packages/mcp/src/client/configuration.test.ts
+++ b/packages/mcp/src/client/configuration.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MCPClient } from './configuration';
+
+let clientId = 0;
+
+describe('MCPClient tool discovery retries', () => {
+  const clients: MCPClient[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(clients.map(client => client.disconnect().catch(() => {})));
+    clients.length = 0;
+  });
+
+  function createClient() {
+    const client = new MCPClient({
+      id: `configuration-test-${++clientId}`,
+      servers: {
+        weather: {
+          url: new URL('http://localhost:1234/sse'),
+        },
+      },
+    });
+
+    clients.push(client);
+    return client;
+  }
+
+  it('retries listToolsetsWithErrors once after a reconnectable discovery failure', async () => {
+    const client = createClient();
+    const toolset = { getWeather: {} as any };
+    const internalClient = {
+      tools: vi.fn().mockRejectedValueOnce(new Error('Connection closed')).mockResolvedValueOnce(toolset),
+    } as any;
+
+    vi.spyOn(client as any, 'getConnectedClientForServer').mockResolvedValue(internalClient);
+    const reconnectSpy = vi.spyOn(client, 'reconnectServer').mockResolvedValue();
+
+    const result = await client.listToolsetsWithErrors();
+
+    expect(result).toEqual({
+      toolsets: {
+        weather: toolset,
+      },
+      errors: {},
+    });
+    expect(internalClient.tools).toHaveBeenCalledTimes(2);
+    expect(reconnectSpy).toHaveBeenCalledTimes(1);
+    expect(reconnectSpy).toHaveBeenCalledWith('weather');
+  });
+
+  it('does not retry listToolsetsWithErrors for non-reconnectable discovery failures', async () => {
+    const client = createClient();
+    const internalClient = {
+      tools: vi.fn().mockRejectedValue(new Error('Validation failed')),
+    } as any;
+
+    vi.spyOn(client as any, 'getConnectedClientForServer').mockResolvedValue(internalClient);
+    const reconnectSpy = vi.spyOn(client, 'reconnectServer').mockResolvedValue();
+
+    const result = await client.listToolsetsWithErrors();
+
+    expect(result).toEqual({
+      toolsets: {},
+      errors: {
+        weather: 'Validation failed',
+      },
+    });
+    expect(internalClient.tools).toHaveBeenCalledTimes(1);
+    expect(reconnectSpy).not.toHaveBeenCalled();
+  });
+
+  it('retries listTools once and preserves namespaced tool names', async () => {
+    const client = createClient();
+    const toolset = { getWeather: {} as any };
+    const internalClient = {
+      tools: vi.fn().mockRejectedValueOnce(new Error('Not connected')).mockResolvedValueOnce(toolset),
+    } as any;
+
+    vi.spyOn(client as any, 'getConnectedClientForServer').mockResolvedValue(internalClient);
+    const reconnectSpy = vi.spyOn(client, 'reconnectServer').mockResolvedValue();
+
+    const tools = await client.listTools();
+
+    expect(tools).toEqual({
+      weather_getWeather: toolset.getWeather,
+    });
+    expect(internalClient.tools).toHaveBeenCalledTimes(2);
+    expect(reconnectSpy).toHaveBeenCalledTimes(1);
+    expect(reconnectSpy).toHaveBeenCalledWith('weather');
+  });
+});

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -14,8 +14,8 @@ import type {
 import equal from 'fast-deep-equal';
 import { v5 as uuidv5 } from 'uuid';
 import { InternalMastraMCPClient } from './client';
-import { isReconnectableMCPError } from './error-utils';
 import type { MastraMCPServerDefinition } from './client';
+import { isReconnectableMCPError } from './error-utils';
 
 const mcpClientInstances = new Map<string, InstanceType<typeof MCPClient>>();
 const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -14,9 +14,11 @@ import type {
 import equal from 'fast-deep-equal';
 import { v5 as uuidv5 } from 'uuid';
 import { InternalMastraMCPClient } from './client';
+import { isReconnectableMCPError } from './error-utils';
 import type { MastraMCPServerDefinition } from './client';
 
 const mcpClientInstances = new Map<string, InstanceType<typeof MCPClient>>();
+const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;
 
 /**
  * Configuration options for creating an MCPClient instance.
@@ -739,6 +741,7 @@ To fix this you have three different options:
    *
    * @returns Object mapping namespaced tool names to tool implementations.
    * Errors for individual servers are logged but don't throw - failed servers are skipped.
+   * Transient connection failures are retried once after reconnecting the affected server.
    *
    * @example
    * ```typescript
@@ -757,8 +760,7 @@ To fix this you have three different options:
 
     for (const serverName of Object.keys(this.serverConfigs)) {
       try {
-        const client = await this.getConnectedClientForServer(serverName);
-        const tools = await client.tools();
+        const tools = await this.getToolsForServer(serverName);
         for (const [toolName, toolConfig] of Object.entries(tools)) {
           connectedTools[`${serverName}_${toolName}`] = toolConfig;
         }
@@ -817,6 +819,7 @@ To fix this you have three different options:
    * or list tools. This allows callers to report specific failure reasons per server.
    *
    * @returns Object with `toolsets` (successful servers) and `errors` (failed servers with error messages).
+   * Transient connection failures are retried once after reconnecting the affected server.
    *
    * @example
    * ```typescript
@@ -836,8 +839,7 @@ To fix this you have three different options:
 
     for (const serverName of Object.keys(this.serverConfigs)) {
       try {
-        const client = await this.getConnectedClientForServer(serverName);
-        const tools = await client.tools();
+        const tools = await this.getToolsForServer(serverName);
         if (tools) {
           connectedToolsets[serverName] = tools;
         }
@@ -965,5 +967,29 @@ To fix this you have three different options:
       throw new Error(`Server configuration not found for name: ${serverName}`);
     }
     return this.getConnectedClient(serverName, serverConfig);
+  }
+
+  private async getToolsForServer(serverName: string): Promise<Record<string, Tool<any, any, any, any>>> {
+    for (let attempt = 1; attempt <= TOOL_DISCOVERY_MAX_ATTEMPTS; attempt++) {
+      try {
+        const client = await this.getConnectedClientForServer(serverName);
+        return await client.tools();
+      } catch (error) {
+        if (attempt === TOOL_DISCOVERY_MAX_ATTEMPTS || !isReconnectableMCPError(error)) {
+          throw error;
+        }
+
+        this.logger.debug('Retrying MCP tool discovery after reconnect', {
+          serverName,
+          attempt,
+          maxAttempts: TOOL_DISCOVERY_MAX_ATTEMPTS,
+          error: error instanceof Error ? error.message : String(error),
+        });
+
+        await this.reconnectServer(serverName);
+      }
+    }
+
+    return {};
   }
 }

--- a/packages/mcp/src/client/error-utils.ts
+++ b/packages/mcp/src/client/error-utils.ts
@@ -1,0 +1,23 @@
+export function isReconnectableMCPError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const errorMessage = error.message.toLowerCase();
+
+  return (
+    errorMessage.includes('no valid session') ||
+    errorMessage.includes('session') ||
+    errorMessage.includes('server not initialized') ||
+    errorMessage.includes('not connected') ||
+    errorMessage.includes('http 400') ||
+    errorMessage.includes('http 401') ||
+    errorMessage.includes('http 403') ||
+    errorMessage.includes('econnrefused') ||
+    errorMessage.includes('fetch failed') ||
+    errorMessage.includes('connection refused') ||
+    errorMessage.includes('connection closed') ||
+    errorMessage.includes('sse stream disconnected') ||
+    errorMessage.includes('typeerror: terminated')
+  );
+}


### PR DESCRIPTION
## Description

Retry MCP tool discovery once after reconnectable `tools/list` failures like `Connection closed` instead of immediately returning empty toolsets. This also reuses the same reconnectable error detection in the lower-level client path and adds focused client tests for the retry behavior.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool discovery now retries once after a transient reconnectable failure by attempting a reconnect, improving reliability when listing tools and toolsets.

* **Tests**
  * Added tests covering retry-and-reconnect behavior for tool discovery, including reconnectable vs non-reconnectable failure scenarios and result namespacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->