### PR TITLE
fix: clean up noisy deploy logs in mastra studio deploy

### DIFF
--- a/.changeset/afraid-clouds-trade.md
+++ b/.changeset/afraid-clouds-trade.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Filtered confusing internal server logs (like 'Mastra API running on http://0.0.0.0:3000') from 'mastra studio deploy' output

--- a/.changeset/plenty-coats-take.md
+++ b/.changeset/plenty-coats-take.md
@@ -1,0 +1,5 @@
+---
+'@mastra/loggers': patch
+---
+
+Removed 'component' field from pino-pretty log output to reduce noise in CLI logs

--- a/packages/cli/src/commands/studio/platform-api.ts
+++ b/packages/cli/src/commands/studio/platform-api.ts
@@ -157,9 +157,16 @@ async function streamDeployLogs(deployId: string, token: string, orgId: string, 
     for (const line of lines) {
       if (line.startsWith('data:')) {
         const data = line.slice(5).trim();
-        if (data) {
-          process.stdout.write(`${data}\n`);
-        }
+        if (!data) continue;
+        // Filter internal server startup logs — the public URL is shown by the CLI after deploy.
+        // The pino-pretty "url:" continuation line is also filtered (follows the filtered log entry).
+        if (
+          data.includes('Mastra API running') ||
+          data.includes('Studio available') ||
+          /^(\x1b\[\d+m)*url(\x1b\[\d+m)*:/.test(data)
+        )
+          continue;
+        process.stdout.write(`${data}\n`);
       }
     }
   }

--- a/packages/cli/src/commands/studio/platform-api.ts
+++ b/packages/cli/src/commands/studio/platform-api.ts
@@ -144,6 +144,7 @@ async function streamDeployLogs(deployId: string, token: string, orgId: string, 
   const reader = resp.body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
+  let skipNextUrlMeta = false;
 
   while (!signal.aborted) {
     const { done, value } = await reader.read();
@@ -158,14 +159,16 @@ async function streamDeployLogs(deployId: string, token: string, orgId: string, 
       if (line.startsWith('data:')) {
         const data = line.slice(5).trim();
         if (!data) continue;
-        // Filter internal server startup logs — the public URL is shown by the CLI after deploy.
-        // The pino-pretty "url:" continuation line is also filtered (follows the filtered log entry).
-        if (
-          data.includes('Mastra API running') ||
-          data.includes('Studio available') ||
-          /^(\x1b\[\d+m)*url(\x1b\[\d+m)*:/.test(data)
-        )
+        // Filter internal server startup logs — the public URL is shown by the CLI after deploy
+        if (data.includes('Mastra API running') || data.includes('Studio available')) {
+          skipNextUrlMeta = true;
           continue;
+        }
+        // Skip the pino-pretty "url:" continuation line that follows a filtered startup log
+        if (skipNextUrlMeta) {
+          skipNextUrlMeta = false;
+          if (/^(\x1b\[\d+m)*url(\x1b\[\d+m)*:/.test(data)) continue;
+        }
         process.stdout.write(`${data}\n`);
       }
     }

--- a/packages/loggers/src/pino.ts
+++ b/packages/loggers/src/pino.ts
@@ -50,7 +50,7 @@ export class PinoLogger<CustomLevels extends string = never> extends MastraLogge
       prettyStream = pretty({
         colorize: true,
         levelFirst: true,
-        ignore: 'pid,hostname',
+        ignore: 'pid,hostname,component',
         colorizeObjects: true,
         translateTime: 'SYS:standard',
         singleLine: false,


### PR DESCRIPTION
Running `mastra studio deploy` showed confusing internal server logs:

```
Health check passed (1.1s)
INFO (Mastra): Mastra API running
    component: "BUNDLER"
    url: "http://0.0.0.0:3000/api"
```

The `component: "BUNDLER"` line appeared on every CLI log entry, and the internal bind address `http://0.0.0.0:3000` is misleading since the actual public URL is already shown by the CLI after deploy.

Two fixes:
- Added `component` to pino-pretty's `ignore` list in `@mastra/loggers` — it was bound by `MastraBase.__setLogger()` as a child logger field but is redundant noise
- Filter `Mastra API running` and `Studio available` log lines from the studio deploy SSE stream in the CLI, along with their pino-pretty `url:` continuation lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you deploy a Mastra studio, the output was showing confusing internal messages (like an internal bind address). This PR hides those internal startup lines so the deploy output is cleaner and only shows the user-facing URLs.

## Changes Overview

This PR reduces noisy internal server logs in `mastra studio deploy` by applying two targeted fixes:

1. **Hide redundant `component` field** — Updated `pino-pretty` config in `@mastra/loggers` to add `component` to the `ignore` list, removing duplicate `component: "BUNDLER"` lines introduced by MastraBase.__setLogger().

2. **Filter internal startup logs from CLI SSE stream** — Enhanced the CLI's studio deploy SSE handler to suppress startup messages (`Mastra API running` and `Studio available`) and the immediate pino-pretty `url:` continuation line that reveals the internal bind address. The filter now uses a scoped `skipNextUrlMeta` flag so only a `url:` line immediately following a filtered startup line is skipped, avoiding overbroad suppression of unrelated `url:` log lines.

## Files Modified

- packages/loggers/src/pino.ts — Add `component` to pino-pretty `ignore` list.
- packages/cli/src/commands/studio/platform-api.ts — Strengthen SSE `data:` handling: skip empty data, filter the two startup messages, and scope skipping of the following `url:` meta line with `skipNextUrlMeta`.
- .changeset/afraid-clouds-trade.md — Changeset for `mastra` package (patch).
- .changeset/plenty-coats-take.md — Changeset for `@mastra/loggers` package (patch).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->