### PR TITLE
Fix Datadog LLM span kinds and token usage reporting

### DIFF
--- a/.changeset/fix-dd-trace-model-span-mapping.md
+++ b/.changeset/fix-dd-trace-model-span-mapping.md
@@ -1,0 +1,9 @@
+---
+'@mastra/datadog': patch
+---
+
+Fix Datadog LLM Observability span kind mapping for model spans.
+
+`MODEL_STEP` (the actual single LLM API call) is now mapped to Datadog's `llm` kind, and `MODEL_GENERATION` (the wrapper around 1..N steps + tool/reasoning events) is mapped to `workflow`. This restores the expected "Model Calls" count in Datadog (one per API call instead of one per generation) and produces a structured `{role, content}` message array on each step span instead of stringifying the wrapper.
+
+Token usage metrics are now reported only on `MODEL_STEP` spans to avoid double-counting cost across the parent `MODEL_GENERATION` and its child steps. `MODEL_STEP` LLM spans inherit `modelName` / `modelProvider` from their parent `MODEL_GENERATION` so the model is still attached in Datadog.

--- a/.changeset/fix-dd-trace-model-span-mapping.md
+++ b/.changeset/fix-dd-trace-model-span-mapping.md
@@ -2,8 +2,9 @@
 '@mastra/datadog': patch
 ---
 
-Fix Datadog LLM Observability span kind mapping for model spans.
+Fix Datadog LLM Observability span kinds for model spans so traces match Datadog's expected shape.
 
-`MODEL_STEP` (the actual single LLM API call) is now mapped to Datadog's `llm` kind, and `MODEL_GENERATION` (the wrapper around 1..N steps + tool/reasoning events) is mapped to `workflow`. This restores the expected "Model Calls" count in Datadog (one per API call instead of one per generation) and produces a structured `{role, content}` message array on each step span instead of stringifying the wrapper.
-
-Token usage metrics are now reported only on `MODEL_STEP` spans to avoid double-counting cost across the parent `MODEL_GENERATION` and its child steps. `MODEL_STEP` LLM spans inherit `modelName` / `modelProvider` from their parent `MODEL_GENERATION` so the model is still attached in Datadog.
+- Each call to a model now shows up as an `llm` span in Datadog (previously the per-call spans were reported as `task`, so Datadog's "Model Calls" count was wrong and per-call inputs/outputs were not rendered as messages).
+- The wrapper around a generation is now reported as a `workflow` span instead of `llm`, so it no longer looks like an extra LLM call.
+- Token usage and cost are reported only on the per-call `llm` spans, so Datadog no longer double-counts tokens against the wrapper.
+- Per-call `llm` spans inherit `modelName` and `modelProvider` from their parent generation, so the model is still attached in the Datadog UI.

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -214,8 +214,8 @@ describe('DatadogExporter', () => {
   describe('span type mapping', () => {
     it.each([
       [SpanType.AGENT_RUN, 'agent'],
-      [SpanType.MODEL_GENERATION, 'llm'],
-      [SpanType.MODEL_STEP, 'task'],
+      [SpanType.MODEL_GENERATION, 'workflow'],
+      [SpanType.MODEL_STEP, 'llm'],
       [SpanType.MODEL_CHUNK, 'task'],
       [SpanType.TOOL_CALL, 'tool'],
       [SpanType.MCP_TOOL_CALL, 'tool'],
@@ -1087,7 +1087,7 @@ describe('DatadogExporter', () => {
     it('includes modelName and modelProvider for llm spans', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({
-        type: SpanType.MODEL_GENERATION,
+        type: SpanType.MODEL_STEP,
         attributes: {
           model: 'gpt-4',
           provider: 'openai',
@@ -1103,6 +1103,33 @@ describe('DatadogExporter', () => {
           modelProvider: 'openai',
         }),
         expect.any(Function),
+      );
+    });
+
+    it('inherits modelName/modelProvider from parent MODEL_GENERATION onto MODEL_STEP children', async () => {
+      const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+      const generation = createMockSpan({
+        id: 'gen',
+        traceId: 'trace-inherit',
+        isRootSpan: true,
+        type: SpanType.MODEL_GENERATION,
+        attributes: { model: 'gpt-4o', provider: 'openai' },
+      });
+      const step = createMockSpan({
+        id: 'step',
+        traceId: 'trace-inherit',
+        isRootSpan: false,
+        parentSpanId: 'gen',
+        type: SpanType.MODEL_STEP,
+        attributes: {},
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, step));
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, generation));
+
+      const stepCall = mockTrace.mock.calls.find(c => c[0].kind === 'llm');
+      expect(stepCall?.[0]).toEqual(
+        expect.objectContaining({ kind: 'llm', modelName: 'gpt-4o', modelProvider: 'openai' }),
       );
     });
 
@@ -1261,7 +1288,7 @@ describe('DatadogExporter', () => {
     it('excludes known LLM fields from attribute forwarding', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({
-        type: SpanType.MODEL_GENERATION,
+        type: SpanType.MODEL_STEP,
         metadata: { userKey: 'userValue' },
         attributes: {
           model: 'gpt-4', // Should be excluded (used for modelName)

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -302,9 +302,11 @@ export class DatadogExporter extends BaseExporter {
       annotations.outputData = formatOutput(span.output, span.type);
     }
 
-    // Add token usage metrics (only on MODEL_GENERATION or MODEL_STEP spans)
-    if (span.type === SpanType.MODEL_GENERATION || span.type === SpanType.MODEL_STEP) {
-      const usage = (span.attributes as ModelGenerationAttributes | ModelStepAttributes)?.usage;
+    // Add token usage metrics on MODEL_STEP spans only.
+    // MODEL_STEP is the actual LLM API call; MODEL_GENERATION is its parent wrapper.
+    // Reporting on both would double-count cost in Datadog.
+    if (span.type === SpanType.MODEL_STEP) {
+      const usage = (span.attributes as ModelStepAttributes)?.usage;
       const metrics = formatUsageMetrics(usage);
       if (metrics) {
         annotations.metrics = metrics;
@@ -646,14 +648,22 @@ export class DatadogExporter extends BaseExporter {
    * Builds LLMObs span options from a Mastra span.
    * Handles trace context, timestamps, and conditional model information for LLM spans.
    */
-  private buildSpanOptions(span: AnyExportedSpan): { traceOptions: LLMObsSpanOptions; endTimeMs: number } {
+  private buildSpanOptions(
+    span: AnyExportedSpan,
+    inheritedModelAttrs?: { model?: string; provider?: string },
+  ): { traceOptions: LLMObsSpanOptions; endTimeMs: number } {
     const traceCtx = this.traceContext.get(span.traceId) || {
       userId: span.metadata?.userId,
       sessionId: span.metadata?.sessionId,
     };
 
     const kind = kindFor(span.type);
-    const attrs = span.attributes as ModelGenerationAttributes | undefined;
+    // MODEL_GENERATION carries model/provider; MODEL_STEP children inherit it from their parent.
+    const ownAttrs = span.attributes as ModelGenerationAttributes | undefined;
+    const attrs = {
+      model: ownAttrs?.model ?? inheritedModelAttrs?.model,
+      provider: ownAttrs?.provider ?? inheritedModelAttrs?.provider,
+    };
 
     const startTime = toDate(span.startTime);
     // Event spans are point-in-time markers; use startTime for endTime if not set (zero duration)
@@ -681,9 +691,23 @@ export class DatadogExporter extends BaseExporter {
    * This ensures parent-child relationships are properly established in Datadog
    * because child spans are created while their parent span is active in scope.
    */
-  private emitSpanTree(node: SpanNode, state: TraceState): void {
+  private emitSpanTree(
+    node: SpanNode,
+    state: TraceState,
+    inheritedModelAttrs?: { model?: string; provider?: string },
+  ): void {
     const span = node.span;
-    const { traceOptions, endTimeMs } = this.buildSpanOptions(span);
+    const { traceOptions, endTimeMs } = this.buildSpanOptions(span, inheritedModelAttrs);
+
+    // If this is a MODEL_GENERATION, propagate its model/provider to MODEL_STEP descendants
+    // so the LLM-kind step spans in Datadog have a model name attached.
+    const childInheritedModelAttrs =
+      span.type === SpanType.MODEL_GENERATION
+        ? {
+            model: (span.attributes as ModelGenerationAttributes | undefined)?.model,
+            provider: (span.attributes as ModelGenerationAttributes | undefined)?.provider,
+          }
+        : inheritedModelAttrs;
 
     // Use nested llmobs.trace() calls - children are emitted INSIDE the parent's callback
     // This ensures the Datadog SDK automatically establishes parent-child relationships
@@ -706,7 +730,7 @@ export class DatadogExporter extends BaseExporter {
       // Recursively emit children INSIDE this span's callback
       // This is the key to establishing proper parent-child relationships
       for (const child of node.children) {
-        this.emitSpanTree(child, state);
+        this.emitSpanTree(child, state, childInheritedModelAttrs);
       }
 
       // Explicitly finish with the correct end time. dd-trace's llmobs.trace() does not

--- a/observability/datadog/src/utils.test.ts
+++ b/observability/datadog/src/utils.test.ts
@@ -9,8 +9,8 @@ import { formatInput, formatOutput, kindFor, toDate, safeStringify, SPAN_TYPE_TO
 describe('kindFor', () => {
   it.each([
     [SpanType.AGENT_RUN, 'agent'],
-    [SpanType.MODEL_GENERATION, 'llm'],
-    [SpanType.MODEL_STEP, 'task'],
+    [SpanType.MODEL_GENERATION, 'workflow'],
+    [SpanType.MODEL_STEP, 'llm'],
     [SpanType.MODEL_CHUNK, 'task'],
     [SpanType.TOOL_CALL, 'tool'],
     [SpanType.MCP_TOOL_CALL, 'tool'],
@@ -47,7 +47,8 @@ describe('SPAN_TYPE_TO_KIND mapping', () => {
     // Verify that only the expected span types have explicit mappings
     const expectedMappings = {
       [SpanType.AGENT_RUN]: 'agent',
-      [SpanType.MODEL_GENERATION]: 'llm',
+      [SpanType.MODEL_GENERATION]: 'workflow',
+      [SpanType.MODEL_STEP]: 'llm',
       [SpanType.TOOL_CALL]: 'tool',
       [SpanType.MCP_TOOL_CALL]: 'tool',
       [SpanType.WORKFLOW_RUN]: 'workflow',
@@ -63,7 +64,6 @@ describe('SPAN_TYPE_TO_KIND mapping', () => {
   it('defaults unmapped types to task', () => {
     // These should not have explicit mappings and should fall back to 'task'
     const taskTypes = [
-      SpanType.MODEL_STEP,
       SpanType.MODEL_CHUNK,
       SpanType.WORKFLOW_STEP,
       SpanType.WORKFLOW_CONDITIONAL,

--- a/observability/datadog/src/utils.ts
+++ b/observability/datadog/src/utils.ts
@@ -16,7 +16,12 @@ export type DatadogSpanKind = 'llm' | 'agent' | 'workflow' | 'tool' | 'task' | '
  */
 export const SPAN_TYPE_TO_KIND: Partial<Record<SpanType, DatadogSpanKind>> = {
   [SpanType.AGENT_RUN]: 'agent',
-  [SpanType.MODEL_GENERATION]: 'llm',
+  // MODEL_GENERATION is the wrapper around 1..N MODEL_STEPs (the actual API calls).
+  // It maps to 'workflow' so Datadog doesn't double-count it as an LLM call.
+  [SpanType.MODEL_GENERATION]: 'workflow',
+  // MODEL_STEP is "Single model execution step within a generation (one API call)"
+  // per packages/core/src/observability/types/tracing.ts, so it is the real LLM span.
+  [SpanType.MODEL_STEP]: 'llm',
   [SpanType.TOOL_CALL]: 'tool',
   [SpanType.MCP_TOOL_CALL]: 'tool',
   [SpanType.WORKFLOW_RUN]: 'workflow',


### PR DESCRIPTION
## Description

This PR fixes the Datadog LLM Observability integration to correctly map span types and report token usage metrics, ensuring traces match Datadog's expected shape for LLM observability.

### Changes Made

1. **Span Kind Mapping**: Updated span type to Datadog kind mapping:
   - `MODEL_GENERATION` now maps to `workflow` (wrapper span, not an LLM call itself)
   - `MODEL_STEP` now maps to `llm` (the actual per-call LLM span)
   - This fixes Datadog's "Model Calls" count and enables proper message rendering for per-call inputs/outputs

2. **Token Usage Reporting**: Changed token usage metrics to report only on `MODEL_STEP` spans instead of both `MODEL_GENERATION` and `MODEL_STEP`:
   - `MODEL_STEP` is the actual LLM API call
   - `MODEL_GENERATION` is its parent wrapper
   - Reporting on both would double-count cost in Datadog

3. **Model Attribute Inheritance**: Implemented inheritance of `modelName` and `modelProvider` from parent `MODEL_GENERATION` spans to child `MODEL_STEP` spans:
   - `MODEL_GENERATION` carries the model/provider information
   - Child `MODEL_STEP` spans now inherit these attributes when not explicitly set
   - Ensures per-call LLM spans in Datadog UI have the model name attached

### Technical Details

- Modified `buildSpanOptions()` to accept and use inherited model attributes
- Updated `emitSpanTree()` to propagate model attributes from `MODEL_GENERATION` parents to `MODEL_STEP` children
- Updated span kind mapping in `utils.ts` with explanatory comments

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code refactoring

## Testing

- Updated existing unit tests to reflect new span kind mappings
- Added new test case verifying model attribute inheritance from parent `MODEL_GENERATION` to child `MODEL_STEP` spans
- All existing tests pass with the updated mappings

https://claude.ai/code/session_017qe7ism2znuCF1pJtcqDjS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

This PR fixes how Mastra reports AI model calls to Datadog monitoring. Think of it like organizing a restaurant's kitchen: instead of mixing the head chef's entire workflow with each individual dish order, we now separate them. The "workflow" tracks the overall process, while each "model call" tracks individual AI API requests. We also make sure each dish knows which chef made it (model information), and we only count the ingredients (tokens) once, on the actual dish, not twice.

## Overview

This update fixes the Datadog LLM Observability integration to properly report span kinds and token metrics in alignment with Datadog's expected format for LLM observability.

## Key Changes

### Span Kind Mapping
- **MODEL_GENERATION** spans now map to Datadog kind `"workflow"` (was `"llm"`)
  - These represent the overall generation wrapper/orchestration
  - Prevents them from being counted as extra LLM calls in Datadog's "Model Calls" counter
- **MODEL_STEP** spans now map to Datadog kind `"llm"` (was unmapped, defaulting to `"task"`)
  - These represent the actual per-call LLM API invocations
  - Now correctly appear in Datadog's "Model Calls" with proper per-call input/output rendering as messages

### Token Usage Reporting
- Token metrics are now reported only on `MODEL_STEP` spans (the actual API calls)
- Previously reported on both `MODEL_GENERATION` and `MODEL_STEP`, causing double-counting of costs in Datadog
- This ensures accurate cost attribution to individual model calls

### Model Attribute Inheritance
- Child `MODEL_STEP` spans now inherit `modelName` and `modelProvider` from parent `MODEL_GENERATION` spans when not explicitly set
- Ensures per-call spans include model information in the Datadog UI for proper context and filtering

## Implementation Details

**observability/datadog/src/utils.ts**
- Updated `SPAN_TYPE_TO_KIND` constant mapping:
  - `MODEL_GENERATION` → `'workflow'`
  - `MODEL_STEP` → `'llm'` (new mapping)

**observability/datadog/src/tracing.ts**
- Modified `buildSpanOptions()` to accept optional `inheritedModelAttrs` parameter
- Derives `traceOptions.modelName` and `modelProvider` from either the current span's attributes or inherited attributes
- Extended `emitSpanTree()` to propagate model attributes from `MODEL_GENERATION` parents to `MODEL_STEP` children
- Updated token metric emission to only report on `MODEL_STEP` spans

**Tests Updated**
- observability/datadog/src/utils.test.ts: Updated span kind mapping expectations
- observability/datadog/src/tracing.test.ts: 
  - Updated kind mapping test expectations
  - Adjusted model-info tests to use `MODEL_STEP` for llm span assertions
  - Added new test verifying model attribute inheritance from parent generation spans to child step spans

**Changeset**
- Added changeset for `@mastra/datadog` package with patch version bump documenting the span mapping and token reporting fixes

## Impact

- Correct "Model Calls" counts in Datadog dashboards (no duplicate counts from wrapper spans)
- Proper per-call message rendering and filtering in Datadog UI
- Accurate cost tracking with no double-counting of tokens
- Model information available on individual API call spans for better observability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->