### PR TITLE
feat: support Agent Skills spec skill directories

### DIFF
--- a/.changeset/whole-nails-go.md
+++ b/.changeset/whole-nails-go.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Added support for Agent Skills spec directories (.agents/skills/) for skill discovery, both project-local and global (~/.agents/skills/)

--- a/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
@@ -1,0 +1,37 @@
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('workspace skill path definitions', () => {
+  const cwd = process.cwd();
+  const home = os.homedir();
+
+  const expectedPaths = [
+    path.join(cwd, '.mastracode', 'skills'),
+    path.join(cwd, '.claude', 'skills'),
+    path.join(cwd, '.agents', 'skills'),
+    path.join(home, '.mastracode', 'skills'),
+    path.join(home, '.claude', 'skills'),
+    path.join(home, '.agents', 'skills'),
+  ];
+
+  it('includes all expected skill directories as candidates', async () => {
+    // We cannot import the module directly because collectSkillPaths filters
+    // out directories that do not exist on disk. Instead, verify that the
+    // source file declares the expected path variables so the discovery
+    // list stays in sync with the spec.
+    const fs = await import('node:fs');
+    const source = fs.readFileSync(path.join(cwd, 'src/agents/workspace.ts'), 'utf-8');
+
+    for (const dir of ['.mastracode', '.claude', '.agents']) {
+      expect(source).toContain(`'${dir}', 'skills'`);
+    }
+  });
+
+  it('expected paths are well-formed absolute paths', () => {
+    for (const p of expectedPaths) {
+      expect(path.isAbsolute(p)).toBe(true);
+      expect(p).toMatch(/skills$/);
+    }
+  });
+});

--- a/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
@@ -15,12 +15,13 @@ describe('workspace skill path definitions', () => {
     path.join(home, '.agents', 'skills'),
   ];
 
-  it('includes all expected skill directories as candidates', async () => {
+  it('includes project-local and global skill directories as candidates', async () => {
     const fs = await import('node:fs');
     const source = fs.readFileSync(path.join(cwd, 'src/agents/workspace.ts'), 'utf-8');
 
     for (const dir of ['.mastracode', '.claude', '.agents']) {
-      expect(source).toContain(`'${dir}', 'skills'`);
+      expect(source).toContain(`process.cwd(), '${dir}', 'skills'`);
+      expect(source).toContain(`os.homedir(), '${dir}', 'skills'`);
     }
   });
 

--- a/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
@@ -16,10 +16,6 @@ describe('workspace skill path definitions', () => {
   ];
 
   it('includes all expected skill directories as candidates', async () => {
-    // We cannot import the module directly because collectSkillPaths filters
-    // out directories that do not exist on disk. Instead, verify that the
-    // source file declares the expected path variables so the discovery
-    // list stays in sync with the spec.
     const fs = await import('node:fs');
     const source = fs.readFileSync(path.join(cwd, 'src/agents/workspace.ts'), 'utf-8');
 

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -19,16 +19,22 @@ import { TOOL_NAME_OVERRIDES } from '../tool-names.js';
 // We support multiple skill locations for compatibility:
 // 1. Project-local: .mastracode/skills (project-specific mastracode skills)
 // 2. Project-local: .claude/skills (Claude Code compatible skills)
-// 3. Global: ~/.mastracode/skills (user-wide mastracode skills)
-// 4. Global: ~/.claude/skills (user-wide Claude Code skills)
+// 3. Project-local: .agents/skills (Agent Skills spec compatible)
+// 4. Global: ~/.mastracode/skills (user-wide mastracode skills)
+// 5. Global: ~/.claude/skills (user-wide Claude Code skills)
+// 6. Global: ~/.agents/skills (user-wide Agent Skills spec compatible)
 
 const mastraCodeLocalSkillsPath = path.join(process.cwd(), '.mastracode', 'skills');
 
 const claudeLocalSkillsPath = path.join(process.cwd(), '.claude', 'skills');
 
+const agentSkillsLocalPath = path.join(process.cwd(), '.agents', 'skills');
+
 const mastraCodeGlobalSkillsPath = path.join(os.homedir(), '.mastracode', 'skills');
 
 const claudeGlobalSkillsPath = path.join(os.homedir(), '.claude', 'skills');
+
+const agentSkillsGlobalPath = path.join(os.homedir(), '.agents', 'skills');
 
 // Mastra's LocalSkillSource.readdir uses Node's Dirent.isDirectory() which
 // returns false for symlinks. Tools like `npx skills add` install skills as
@@ -78,8 +84,10 @@ function collectSkillPaths(skillsDirs: string[]): string[] {
 export const skillPaths = collectSkillPaths([
   mastraCodeLocalSkillsPath,
   claudeLocalSkillsPath,
+  agentSkillsLocalPath,
   mastraCodeGlobalSkillsPath,
   claudeGlobalSkillsPath,
+  agentSkillsGlobalPath,
 ]);
 
 const WORKSPACE_ID_PREFIX = 'mastra-code-workspace';

--- a/mastracode/src/tui/commands/skills.ts
+++ b/mastracode/src/tui/commands/skills.ts
@@ -17,8 +17,10 @@ export async function handleSkillsCommand(ctx: SlashCommandContext): Promise<voi
         'Add skills to any of these locations:\n' +
         '  .mastracode/skills/   (project-local)\n' +
         '  .claude/skills/       (project-local)\n' +
+        '  .agents/skills/       (project-local)\n' +
         '  ~/.mastracode/skills/ (global)\n' +
-        '  ~/.claude/skills/     (global)\n\n' +
+        '  ~/.claude/skills/     (global)\n' +
+        '  ~/.agents/skills/     (global)\n\n' +
         'Each skill is a folder with a SKILL.md file.\n' +
         'Install skills: npx add-skill <github-url>',
     );


### PR DESCRIPTION
## Description

Adds support for the Agent Skills spec directories (`.agents/skills/`) as skill discovery paths in MastraCode. Skills placed in:

- `.agents/skills/` (project-local)
- `~/.agents/skills/` (global)

are now discovered alongside the existing:

- `.mastracode/skills/`
- `.claude/skills/`

paths.

## Related Issue(s)

Fixes #15145

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
MastraCode now looks for AI skills in two additional folders used by the Agent Skills spec — a project folder (.agents/skills/) and a global folder (~/.agents/skills/) — so skills organized per that spec will be discovered automatically.

## Changes
- Add support for discovering skills from Agent Skills spec directories:
  - Project-local: ./.agents/skills/
  - Global: ~/.agents/skills/
- These are discovered alongside the existing:
  - .mastracode/skills/ and ~/.mastracode/skills/
  - .claude/skills/ and ~/.claude/skills/

## Files Modified
- mastracode/src/agents/workspace.ts
  - Introduced constants for agentSkillsLocalPath and agentSkillsGlobalPath.
  - Included those paths in the collectSkillPaths([...]) input so the workspace can discover skills from .agents/skills (local and global).
  - Kept existing symlink-resolution behavior (collectSkillPaths adds resolved parent directories for symlinked skills).
  - skillPaths are appended to allowedPaths and to the workspace's skills configuration when present.
- mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
  - New Vitest tests that assert the source includes path construction for .mastracode, .claude, and .agents under both process.cwd() and os.homedir().
  - Tests also validate the expected candidate paths are absolute and end with "skills".
- mastracode/src/tui/commands/skills.ts
  - Updated the "no skills configured" help text to list the new .agents/skills/ and ~/.agents/skills/ locations.
- .changeset/whole-nails-go.md
  - Added a changeset documenting the patch-level release for mastracode with Agent Skills directory support.

## Implementation Notes
- Backward compatible: existing discovery and symlink-resolution behavior unchanged; this PR only broadens the set of scanned directories.
- When skill paths are present, the workspace logs loaded skill paths and adds them to allowedPaths and the workspace skills config.
- A new test suite asserts the presence and well-formedness of the candidate skill paths.

## Related
- Implements the Agent Skills layout discovery requested in the linked issue to recognize skills under ~/.agents and ./.agents (Agent Skills spec).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->