### PR TITLE
feat: generate playground route roots manifest

### DIFF
--- a/.changeset/playground-route-roots.md
+++ b/.changeset/playground-route-roots.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Added a routes manifest file to the playground build that lists the top-level route names.

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,7 +1,9 @@
+import fs from 'node:fs/promises';
 import { builtinModules } from 'node:module';
 import path from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
+import ts from 'typescript';
 import type { Plugin, PluginOption, UserConfig } from 'vite';
 import { defineConfig } from 'vite';
 
@@ -52,9 +54,164 @@ const stubNodeBuiltinsPlugin: Plugin = {
   },
 };
 
+const routesManifestPlugin = (): Plugin => {
+  const getPropertyName = (name: ts.PropertyName) => {
+    if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+      return name.text;
+    }
+
+    return undefined;
+  };
+
+  const collectRouteRoots = async (sourcePath: string) => {
+    const sourceText = await fs.readFile(sourcePath, 'utf8');
+    const sourceFile = ts.createSourceFile(sourcePath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+    const arraysByName = new Map<string, ts.Expression>();
+
+    const visit = (node: ts.Node) => {
+      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+        arraysByName.set(node.name.text, node.initializer);
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+
+    const collectedRoots = new Set<string>();
+    const visitedArrayExpressions = new Set<ts.ArrayLiteralExpression>();
+
+    const getRootSegment = (routePath: string) => {
+      if (!routePath.startsWith('/')) {
+        return undefined;
+      }
+
+      const normalizedPath = routePath.slice(1);
+      const [rootSegment] = normalizedPath.split('/');
+      return rootSegment || undefined;
+    };
+
+    const collectFromExpression = (expression: ts.Expression | undefined, inheritedRoot?: string) => {
+      if (!expression) {
+        return;
+      }
+
+      if (ts.isArrayLiteralExpression(expression)) {
+        if (visitedArrayExpressions.has(expression)) {
+          return;
+        }
+
+        visitedArrayExpressions.add(expression);
+
+        for (const element of expression.elements) {
+          collectFromArrayElement(element, inheritedRoot);
+        }
+
+        return;
+      }
+
+      if (ts.isIdentifier(expression)) {
+        collectFromExpression(arraysByName.get(expression.text), inheritedRoot);
+        return;
+      }
+
+      if (ts.isParenthesizedExpression(expression)) {
+        collectFromExpression(expression.expression, inheritedRoot);
+        return;
+      }
+
+      if (ts.isConditionalExpression(expression)) {
+        collectFromExpression(expression.whenTrue, inheritedRoot);
+        collectFromExpression(expression.whenFalse, inheritedRoot);
+        return;
+      }
+
+      if (ts.isSpreadElement(expression)) {
+        collectFromExpression(expression.expression, inheritedRoot);
+      }
+    };
+
+    const collectFromArrayElement = (element: ts.Expression | ts.SpreadElement, inheritedRoot?: string) => {
+      if (ts.isObjectLiteralExpression(element)) {
+        collectFromObjectLiteral(element, inheritedRoot);
+        return;
+      }
+
+      if (ts.isSpreadElement(element)) {
+        collectFromExpression(element.expression, inheritedRoot);
+        return;
+      }
+
+      if (ts.isConditionalExpression(element)) {
+        collectFromExpression(element.whenTrue, inheritedRoot);
+        collectFromExpression(element.whenFalse, inheritedRoot);
+        return;
+      }
+
+      if (ts.isParenthesizedExpression(element)) {
+        collectFromExpression(element.expression, inheritedRoot);
+      }
+    };
+
+    const collectFromObjectLiteral = (objectLiteral: ts.ObjectLiteralExpression, inheritedRoot?: string) => {
+      let routeRoot = inheritedRoot;
+
+      for (const property of objectLiteral.properties) {
+        if (!ts.isPropertyAssignment(property)) {
+          continue;
+        }
+
+        const propertyName = getPropertyName(property.name);
+
+        if (propertyName === 'path' && ts.isStringLiteralLike(property.initializer)) {
+          routeRoot = getRootSegment(property.initializer.text) ?? inheritedRoot;
+
+          if (routeRoot) {
+            collectedRoots.add(routeRoot);
+          }
+        }
+      }
+
+      for (const property of objectLiteral.properties) {
+        if (!ts.isPropertyAssignment(property)) {
+          continue;
+        }
+
+        if (getPropertyName(property.name) === 'children') {
+          collectFromExpression(property.initializer, routeRoot);
+        }
+      }
+    };
+
+    collectFromExpression(arraysByName.get('routes'));
+
+    return [...collectedRoots].sort();
+  };
+
+  let resolvedConfig: { root: string; build: { outDir: string } } | undefined;
+
+  return {
+    name: 'routes-manifest',
+    apply: 'build',
+    configResolved(config) {
+      resolvedConfig = config;
+    },
+    async writeBundle() {
+      const root = resolvedConfig?.root ?? __dirname;
+      const outDir = path.resolve(root, resolvedConfig?.build?.outDir ?? 'dist');
+      const sourcePath = path.resolve(root, 'src', 'App.tsx');
+      const outputPath = path.join(outDir, 'routes-manifest.json');
+      const manifest = JSON.stringify(await collectRouteRoots(sourcePath), null, 2) + '\n';
+
+      await fs.mkdir(outDir, { recursive: true });
+      await fs.writeFile(outputPath, manifest, 'utf8');
+    },
+  };
+};
+
 export default defineConfig(({ mode }) => {
   const commonConfig: UserConfig = {
-    plugins: [stubNodeBuiltinsPlugin, tailwindcss(), react()],
+    plugins: [stubNodeBuiltinsPlugin, tailwindcss(), react(), routesManifestPlugin()],
     base: './',
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- add a Vite build plugin in playground that writes a routes-manifest.json file
- emit only the root segment for absolute route paths
- add a changeset for @internal/playground

## Test Plan
- pnpm --filter ./packages/playground build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes the playground build automatically produce a small JSON file that lists the app's top-level route names so tools or developers can know the main entry routes without scanning code.

## Changes

### Changeset
- Added `.changeset/playground-route-roots.md` declaring a patch release for `@internal/playground` describing the new routes manifest.

### Vite plugin: routes-manifest
- Added a new build-only Vite plugin in `packages/playground/vite.config.ts` named `routes-manifest`.
- The plugin parses `src/App.tsx` at build time using the TypeScript compiler API to find a variable named `routes` and recursively traverses arrays, objects, spreads, conditional and parenthesized expressions.
- It extracts `path` string literals and records only the first segment of absolute paths (those starting with `/`), collecting unique root segments.
- On writeBundle, it writes a sorted array of those root route segments to `routes-manifest.json` in the build output directory (resolved from Vite config.build.outDir, default `dist`), creating the directory if needed.
- The plugin is included in the `plugins` array for non-development builds (the dev config still pushes the studio standalone plugin).

## Testing
- Build the playground package to verify output: pnpm --filter ./packages/playground build
- Confirm `routes-manifest.json` appears in the build output directory and contains the expected top-level route segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->