### PR TITLE
Upload studio assets to R2 for all publish types

### DIFF
--- a/.changeset/upload-studio-assets-r2.md
+++ b/.changeset/upload-studio-assets-r2.md
@@ -1,0 +1,5 @@
+---
+mastra: patch
+---
+
+Upload Studio assets to R2 during snapshot, prerelease, and stable publishes so each published CLI version has matching hosted Studio files.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -82,6 +82,23 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
           REQUIRE_PACKAGE_DOCS: 'true'
 
+      - name: Get CLI version
+        id: cli-version
+        run: |
+          version=$(node -p 'require("./packages/cli/package.json").version')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Upload studio assets to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          STUDIO_BUCKET_NAME: ${{ secrets.STUDIO_BUCKET_NAME }}
+          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
+        run: |
+          aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
   # ===========================================
   # STABLE RELEASE: Manual trigger only
   # ===========================================
@@ -363,3 +380,20 @@ jobs:
         run: pnpm publish -r --no-git-checks --tag ${{ env.FINAL_TAG }} --access public
         env:
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Get CLI version
+        id: cli-version
+        run: |
+          version=$(node -p 'require("./packages/cli/package.json").version')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Upload studio assets to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          STUDIO_BUCKET_NAME: ${{ secrets.STUDIO_BUCKET_NAME }}
+          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
+        run: |
+          aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete


### PR DESCRIPTION
## Summary
- upload Studio assets to R2 during prerelease publishes
- upload Studio assets to R2 during snapshot publishes
- keep the workflow changes documented with a changeset

## Test Plan
- parse `.github/workflows/npm-publish.yml` with `node` + `yaml`
- inspect `git diff` for the workflow and changeset updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

When the CLI tool is published, the studio files that go with it are now automatically copied to cloud storage (R2) so they're always available with the right version. This happens for all types of releases—snapshot, test releases, and official releases.

## Changes

### Changeset Documentation
- Added `.changeset/upload-studio-assets-r2.md` to document the feature with a patch-level release note

### Workflow Updates
Modified `.github/workflows/npm-publish.yml` with two new workflow steps:

1. **Get CLI version**: Extracts the version number from `packages/cli/package.json` using `node -p` and outputs it for use in subsequent steps
2. **Upload studio assets to R2**: Syncs the compiled studio assets from `packages/cli/dist/studio` to R2 object storage using `aws s3 sync`, with the upload path scoped by the published CLI version (`s3://$STUDIO_BUCKET_NAME/<cli-version>/studio/`)

These steps are added to the `snapshot`, `prerelease`, and `stable` publish jobs, with appropriate dry-run guards. The upload uses the `--endpoint-url` flag for R2 and `--delete` to clean up removed files.

### Summary of Changes
- **Files changed**: 2
- **Lines added**: +39
- **Lines removed**: 0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->