### PR TITLE
fix: upload studio assets to staging and production buckets

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -88,11 +88,24 @@ jobs:
           version=$(node -p 'require("./packages/cli/package.json").version')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Upload studio assets to R2
+      - name: Upload studio assets to R2 (staging)
+        if: ${{ !inputs.dry_run }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
           STUDIO_BUCKET_NAME: ${{ secrets.STUDIO_BUCKET_NAME }}
+          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
+        run: |
+          aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
+      - name: Upload studio assets to R2 (production)
+        if: ${{ !inputs.dry_run }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          STUDIO_BUCKET_NAME: studio-assets
           STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
         run: |
           aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
@@ -195,12 +208,24 @@ jobs:
           version=$(node -p 'require("./packages/cli/package.json").version')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Upload studio assets to R2
+      - name: Upload studio assets to R2 (staging)
         if: ${{ !inputs.dry_run }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
           STUDIO_BUCKET_NAME: ${{ secrets.STUDIO_BUCKET_NAME }}
+          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
+        run: |
+          aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
+      - name: Upload studio assets to R2 (production)
+        if: ${{ !inputs.dry_run }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          STUDIO_BUCKET_NAME: studio-assets
           STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
         run: |
           aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
@@ -387,11 +412,24 @@ jobs:
           version=$(node -p 'require("./packages/cli/package.json").version')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Upload studio assets to R2
+      - name: Upload studio assets to R2 (staging)
+        if: ${{ !inputs.dry_run }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
           STUDIO_BUCKET_NAME: ${{ secrets.STUDIO_BUCKET_NAME }}
+          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
+        run: |
+          aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
+            --endpoint-url "${STUDIO_ENDPOINT_URL}" \
+            --delete
+
+      - name: Upload studio assets to R2 (production)
+        if: ${{ !inputs.dry_run }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          STUDIO_BUCKET_NAME: studio-assets
           STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
         run: |
           aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \


### PR DESCRIPTION
## Summary
- upload CLI studio assets to the staging bucket only when the publish is not a dry run
- also upload the same versioned studio assets to the production bucket for the publish workflows
- keep the existing versioned path layout for both buckets

## Test Plan
- not run (workflow-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

Think of this like a package delivery service that now sends to two addresses instead of one. The PR makes the publishing workflow upload studio assets (the files that power the studio interface) to both a staging location (for testing) and a production location (for real users) at the same time, but only when it's actually publishing (not just doing a test run).

## Summary

This PR modifies the npm publish workflow (`.github/workflows/npm-publish.yml`) to split the studio assets upload into two separate steps:

1. **Staging upload**: Remains gated by the `!inputs.dry_run` condition, renamed to "Upload studio assets to R2 (staging)"
2. **Production upload**: A new step added that uploads to the `studio-assets` bucket with the same behavior and conditions as staging

Both uploads:
- Use the same `aws s3 sync` command with `--delete` flag
- Target versioned destination paths
- Use the same endpoint secret for authentication
- Are gated by `if: ${{ !inputs.dry_run }}` (only run on actual publishes, not dry runs)

These changes are applied across three job sections: `prerelease`, `stable`, and `snapshot`.

## Changes

- Modified `.github/workflows/npm-publish.yml`: +41/-3
- Split single "Upload studio assets to R2" step into staging and production uploads across multiple job sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->