### PR TITLE
fix(mcp): return 404 for stale session IDs per MCP spec

### DIFF
--- a/.changeset/thirty-donuts-kiss.md
+++ b/.changeset/thirty-donuts-kiss.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed MCP server to return HTTP 404 (instead of 400) when a client sends a stale or unknown session ID. Per the MCP spec, this tells clients to re-initialize with a new session, which fixes broken tool calls after server redeploys.

--- a/packages/mcp/src/client/error-utils.ts
+++ b/packages/mcp/src/client/error-utils.ts
@@ -13,6 +13,7 @@ export function isReconnectableMCPError(error: unknown): boolean {
     errorMessage.includes('http 400') ||
     errorMessage.includes('http 401') ||
     errorMessage.includes('http 403') ||
+    errorMessage.includes('http 404') ||
     errorMessage.includes('econnrefused') ||
     errorMessage.includes('fetch failed') ||
     errorMessage.includes('connection refused') ||

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -1437,6 +1437,44 @@ describe('MCPServer', () => {
 
       await client.disconnect();
     });
+
+    it('should return 404 when a stale session ID is provided', async () => {
+      sessionServer = new MCPServer({
+        name: 'StaleSessionServer',
+        version: '1.0.0',
+        tools: minimalTestTool,
+      });
+
+      sessionHttpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        const url = new URL(req.url || '', `http://localhost:${currentTestPort}`);
+        await sessionServer.startHTTP({
+          url,
+          httpPath: '/http',
+          req,
+          res,
+        });
+      });
+
+      await new Promise<void>(resolve => sessionHttpServer.listen(currentTestPort, () => resolve()));
+
+      // Send a POST request with a session ID that doesn't exist on the server
+      const response = await fetch(`http://localhost:${currentTestPort}/http`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'mcp-session-id': 'non-existent-session-id',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'tools/list',
+          id: 1,
+        }),
+      });
+
+      expect(response.status).toBe(404);
+      const body = await response.json();
+      expect(body.error.message).toBe('Session not found');
+    });
   });
 });
 

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1406,9 +1406,24 @@ export class MCPServer extends MCPServerBase {
         const body = req.method === 'POST' ? await this.readJsonBody(req) : undefined;
 
         await transport.handleRequest(req, res, body);
+      } else if (sessionId) {
+        // Session ID provided but not found (e.g. server restarted, session expired).
+        // Per MCP spec: server MUST respond with 404 so the client knows to re-initialize.
+        this.logger.warn('Session ID not found, returning 404', { sessionId, method: req.method });
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            error: {
+              code: -32000,
+              message: 'Session not found',
+            },
+            id: null,
+          }),
+        );
       } else {
-        // No session ID or session ID not found
-        this.logger.debug('No existing session found', { method: req.method });
+        // No session ID provided
+        this.logger.debug('No session ID provided', { method: req.method });
 
         // Only allow new sessions via POST initialize request
         if (req.method === 'POST') {


### PR DESCRIPTION
The MCP server was returning 400 when a client sent a session ID that no longer exists (e.g. after a redeploy). The MCP spec says this should be 404, which tells clients to re-initialize with a fresh session instead of failing permanently.

Before this fix, the `else` branch in `startHTTP` lumped "no session ID" and "stale session ID" together, returning 400 for both. Now they're separate: stale → 404, missing → 400 (unchanged).

Also added `'http 404'` to `isReconnectableMCPError` on the client side so the reconnect logic explicitly catches it (was partially covered by the `'session'` match already, but being explicit is better).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The MCP server was telling clients the wrong thing when they tried to use an old session ID that no longer works (after a redeploy). It was saying "bad request" (400) when it should have been saying "not found" (404), which tells clients to get a fresh session instead of giving up. This PR fixes that and teaches the client to properly recognize the 404 response so it knows to reconnect.

## Changes

**Server-side session handling:** The `MCPServer.startHTTP` method now explicitly returns HTTP 404 with a "Session not found" error when a client provides a stale or non-existent session ID, rather than treating it the same as a missing session ID. Missing session IDs continue to return HTTP 400 as before.

**Client-side reconnect logic:** The `isReconnectableMCPError` function now explicitly recognizes `'http 404'` as a reconnectable error, ensuring clients understand that a 404 response indicates they should reinitialize with a new session.

**Test coverage:** Added a test that verifies stale session IDs correctly return HTTP 404 with the appropriate error message.

**Release notes:** A Changeset file was added marking this as a patch release for `@mastra/mcp`.

## Specification compliance

This change aligns the MCP server implementation with the MCP specification requirement that stale session IDs return 404, allowing clients to properly distinguish between missing session IDs (400) and expired sessions (404) and respond with appropriate recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->