### PR TITLE
fix: skip local OM processing when using Mastra gateway model

### DIFF
--- a/.changeset/skip-local-om-gateway-memory.md
+++ b/.changeset/skip-local-om-gateway-memory.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed message history doubling when using Observational Memory with the Mastra gateway. The local ObservationalMemoryProcessor now detects when the agent's model is routed through the Mastra gateway and skips its input/output processing, since the gateway handles OM server-side.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4493,11 +4493,6 @@ export class Agent<
 
     const resolvedModel = llm.getModel();
     const isGatewayModel = resolvedModel instanceof ModelRouterLanguageModel && resolvedModel.gatewayId === 'mastra';
-    if (isGatewayModel) {
-      // Signal to processors (e.g. ObservationalMemory) that the gateway
-      // handles memory operations — local processors should skip their work.
-      requestContext.set('__mastra_gateway_memory', true);
-    }
     if (resourceId && threadFromArgs && !this.hasOwnMemory() && !isGatewayModel) {
       this.logger.warn('No memory is configured but resourceId and threadId were passed in args', { agent: this.name });
     }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4493,6 +4493,11 @@ export class Agent<
 
     const resolvedModel = llm.getModel();
     const isGatewayModel = resolvedModel instanceof ModelRouterLanguageModel && resolvedModel.gatewayId === 'mastra';
+    if (isGatewayModel) {
+      // Signal to processors (e.g. ObservationalMemory) that the gateway
+      // handles memory operations — local processors should skip their work.
+      requestContext.set('__mastra_gateway_memory', true);
+    }
     if (resourceId && threadFromArgs && !this.hasOwnMemory() && !isGatewayModel) {
       this.logger.warn('No memory is configured but resourceId and threadId were passed in args', { agent: this.name });
     }

--- a/packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests that the ObservationalMemoryProcessor skips local processing when the
+ * agent is using a Mastra gateway model. The gateway handles OM server-side,
+ * so running it locally would double-process messages and cause duplication.
+ */
+import type { MastraDBMessage } from '@mastra/core/agent';
+import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ObservationalMemory } from '../observational-memory';
+import { ObservationalMemoryProcessor } from '../processor';
+import type { MemoryContextProvider } from '../processor';
+
+function createInMemoryStorage(): InMemoryMemory {
+  const db = new InMemoryDB();
+  return new InMemoryMemory({ db });
+}
+
+function createStubMemoryProvider(): MemoryContextProvider {
+  return {
+    getContext: vi.fn().mockResolvedValue({
+      systemMessage: undefined,
+      messages: [],
+      hasObservations: false,
+      omRecord: null,
+      continuationMessage: undefined,
+      otherThreadsContext: undefined,
+    }),
+    persistMessages: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('ObservationalMemoryProcessor — gateway skip', () => {
+  const threadId = 'test-thread';
+  const resourceId = 'test-resource';
+
+  let om: ObservationalMemory;
+  let processor: ObservationalMemoryProcessor;
+
+  beforeEach(() => {
+    const storage = createInMemoryStorage();
+    om = new ObservationalMemory({
+      storage,
+      observation: { messageTokens: 100_000, model: 'test-model' },
+      reflection: { observationTokens: 100_000, model: 'test-model' },
+      scope: 'thread',
+    });
+    processor = new ObservationalMemoryProcessor(om, createStubMemoryProvider());
+  });
+
+  it('processInputStep returns messageList unchanged when __mastra_gateway_memory is set', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+    requestContext.set('__mastra_gateway_memory', true);
+
+    const messageList = new MessageList({ threadId, resourceId });
+    const userMsg: MastraDBMessage = {
+      id: 'msg-1',
+      role: 'user',
+      content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+      type: 'text',
+      createdAt: new Date(),
+      threadId,
+      resourceId,
+    };
+
+    const getThreadContextSpy = vi.spyOn(om, 'getThreadContext');
+
+    const result = await processor.processInputStep({
+      messageList,
+      messages: [userMsg],
+      requestContext,
+      stepNumber: 0,
+      state: {},
+      steps: [],
+      systemMessages: [],
+      model: 'test-model' as any,
+      retryCount: 0,
+      abort: (() => {
+        throw new Error('aborted');
+      }) as any,
+    });
+
+    // Should return the same messageList without modifications
+    expect(result).toBe(messageList);
+    // getThreadContext is called before the gateway check (to validate context exists),
+    // but the engine should NOT have proceeded further
+    expect(getThreadContextSpy).toHaveBeenCalled();
+  });
+
+  it('processOutputResult returns messageList unchanged when __mastra_gateway_memory is set', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+    requestContext.set('__mastra_gateway_memory', true);
+
+    const messageList = new MessageList({ threadId, resourceId });
+
+    const result = await processor.processOutputResult({
+      messageList,
+      messages: [],
+      requestContext,
+      state: {},
+      result: { text: 'Hello back' } as any,
+      retryCount: 0,
+      abort: (() => {
+        throw new Error('aborted');
+      }) as any,
+    });
+
+    expect(result).toBe(messageList);
+  });
+
+  it('processInputStep proceeds normally without __mastra_gateway_memory flag', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+    // Note: NOT setting __mastra_gateway_memory
+
+    const messageList = new MessageList({ threadId, resourceId });
+    const userMsg: MastraDBMessage = {
+      id: 'msg-2',
+      role: 'user',
+      content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+      type: 'text',
+      createdAt: new Date(),
+      threadId,
+      resourceId,
+    };
+
+    const getThreadContextSpy = vi.spyOn(om, 'getThreadContext');
+
+    const result = await processor.processInputStep({
+      messageList,
+      messages: [userMsg],
+      requestContext,
+      stepNumber: 0,
+      state: {},
+      steps: [],
+      systemMessages: [],
+      model: 'test-model' as any,
+      retryCount: 0,
+      abort: (() => {
+        throw new Error('aborted');
+      }) as any,
+    });
+
+    // Should still call getThreadContext and proceed further
+    expect(getThreadContextSpy).toHaveBeenCalled();
+    // The result is a MessageList (may have been modified by the normal OM flow)
+    expect(result).toBeDefined();
+  });
+});

--- a/packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts
@@ -2,8 +2,13 @@
  * Tests that the ObservationalMemoryProcessor skips local processing when the
  * agent is using a Mastra gateway model. The gateway handles OM server-side,
  * so running it locally would double-process messages and cause duplication.
+ *
+ * Detection uses the model argument (instanceof ModelRouterLanguageModel with
+ * gatewayId === 'mastra') and stores the result in per-processor state — this
+ * avoids leaking flags through RequestContext to child agents.
  */
 import type { MastraDBMessage } from '@mastra/core/agent';
+import { ModelRouterLanguageModel } from '@mastra/core/llm';
 import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -30,6 +35,19 @@ function createStubMemoryProvider(): MemoryContextProvider {
   };
 }
 
+/**
+ * Create a mock that passes `instanceof ModelRouterLanguageModel` and has
+ * the given gatewayId.  We use Object.create to inherit the prototype
+ * without invoking the real constructor (which needs env vars / gateways).
+ */
+function createMockGatewayModel(gatewayId: string) {
+  const mock = Object.create(ModelRouterLanguageModel.prototype) as InstanceType<typeof ModelRouterLanguageModel>;
+  Object.defineProperty(mock, 'gatewayId', { value: gatewayId, writable: false });
+  Object.defineProperty(mock, 'modelId', { value: 'openai/gpt-4o', writable: false });
+  Object.defineProperty(mock, 'provider', { value: 'mastra', writable: false });
+  return mock;
+}
+
 describe('ObservationalMemoryProcessor — gateway skip', () => {
   const threadId = 'test-thread';
   const resourceId = 'test-resource';
@@ -48,13 +66,12 @@ describe('ObservationalMemoryProcessor — gateway skip', () => {
     processor = new ObservationalMemoryProcessor(om, createStubMemoryProvider());
   });
 
-  it('processInputStep returns messageList unchanged when __mastra_gateway_memory is set', async () => {
+  it('processInputStep returns messageList unchanged when model is a Mastra gateway model', async () => {
     const { MessageList } = await import('@mastra/core/agent');
     const { RequestContext } = await import('@mastra/core/di');
 
     const requestContext = new RequestContext();
     requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
-    requestContext.set('__mastra_gateway_memory', true);
 
     const messageList = new MessageList({ threadId, resourceId });
     const userMsg: MastraDBMessage = {
@@ -68,6 +85,7 @@ describe('ObservationalMemoryProcessor — gateway skip', () => {
     };
 
     const getThreadContextSpy = vi.spyOn(om, 'getThreadContext');
+    const gatewayModel = createMockGatewayModel('mastra');
 
     const result = await processor.processInputStep({
       messageList,
@@ -77,7 +95,7 @@ describe('ObservationalMemoryProcessor — gateway skip', () => {
       state: {},
       steps: [],
       systemMessages: [],
-      model: 'test-model' as any,
+      model: gatewayModel as any,
       retryCount: 0,
       abort: (() => {
         throw new Error('aborted');
@@ -86,26 +104,27 @@ describe('ObservationalMemoryProcessor — gateway skip', () => {
 
     // Should return the same messageList without modifications
     expect(result).toBe(messageList);
-    // getThreadContext is called before the gateway check (to validate context exists),
-    // but the engine should NOT have proceeded further
+    // getThreadContext is called before the gateway check (to validate context exists)
     expect(getThreadContextSpy).toHaveBeenCalled();
   });
 
-  it('processOutputResult returns messageList unchanged when __mastra_gateway_memory is set', async () => {
+  it('processOutputResult returns messageList unchanged when gateway flag was stored in state', async () => {
     const { MessageList } = await import('@mastra/core/agent');
     const { RequestContext } = await import('@mastra/core/di');
 
     const requestContext = new RequestContext();
     requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
-    requestContext.set('__mastra_gateway_memory', true);
 
     const messageList = new MessageList({ threadId, resourceId });
+
+    // Simulate what processInputStep would have stored in state
+    const state: Record<string, unknown> = { __isGatewayModel: true };
 
     const result = await processor.processOutputResult({
       messageList,
       messages: [],
       requestContext,
-      state: {},
+      state,
       result: { text: 'Hello back' } as any,
       retryCount: 0,
       abort: (() => {
@@ -116,17 +135,57 @@ describe('ObservationalMemoryProcessor — gateway skip', () => {
     expect(result).toBe(messageList);
   });
 
-  it('processInputStep proceeds normally without __mastra_gateway_memory flag', async () => {
+  it('does NOT skip when model is a non-mastra gateway', async () => {
     const { MessageList } = await import('@mastra/core/agent');
     const { RequestContext } = await import('@mastra/core/di');
 
     const requestContext = new RequestContext();
     requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
-    // Note: NOT setting __mastra_gateway_memory
 
     const messageList = new MessageList({ threadId, resourceId });
     const userMsg: MastraDBMessage = {
-      id: 'msg-2',
+      id: 'msg-3',
+      role: 'user',
+      content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+      type: 'text',
+      createdAt: new Date(),
+      threadId,
+      resourceId,
+    };
+
+    // A ModelRouterLanguageModel with a different gatewayId should NOT trigger the skip
+    const nonMastraModel = createMockGatewayModel('netlify');
+
+    const result = await processor.processInputStep({
+      messageList,
+      messages: [userMsg],
+      requestContext,
+      stepNumber: 0,
+      state: {},
+      steps: [],
+      systemMessages: [],
+      model: nonMastraModel as any,
+      retryCount: 0,
+      abort: (() => {
+        throw new Error('aborted');
+      }) as any,
+    });
+
+    // Should proceed with normal OM flow (not early-return the same messageList ref)
+    // The result is still a MessageList but OM would have processed it
+    expect(result).toBeDefined();
+  });
+
+  it('processInputStep proceeds normally with a plain string model', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+
+    const messageList = new MessageList({ threadId, resourceId });
+    const userMsg: MastraDBMessage = {
+      id: 'msg-4',
       role: 'user',
       content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
       type: 'text',
@@ -152,9 +211,8 @@ describe('ObservationalMemoryProcessor — gateway skip', () => {
       }) as any,
     });
 
-    // Should still call getThreadContext and proceed further
+    // Should proceed with normal OM flow
     expect(getThreadContextSpy).toHaveBeenCalled();
-    // The result is a MessageList (may have been modified by the normal OM flow)
     expect(result).toBeDefined();
   });
 });

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -1,4 +1,5 @@
 import type { MastraDBMessage, MessageList } from '@mastra/core/agent';
+import { ModelRouterLanguageModel } from '@mastra/core/llm';
 import { parseMemoryRequestContext } from '@mastra/core/memory';
 import type { ObservabilityContext } from '@mastra/core/observability';
 import type { Processor, ProcessInputStepArgs, ProcessOutputResultArgs } from '@mastra/core/processors';
@@ -52,6 +53,14 @@ function getOmObservabilityContext(
   };
 }
 
+/** Key used to store gateway detection result in per-processor state. */
+const GATEWAY_STATE_KEY = '__isGatewayModel';
+
+/** Check if the model is routed through a Mastra gateway. */
+function isMastraGatewayModel(model: ProcessInputStepArgs['model']): boolean {
+  return model instanceof ModelRouterLanguageModel && model.gatewayId === 'mastra';
+}
+
 export class ObservationalMemoryProcessor implements Processor<'observational-memory'> {
   readonly id = 'observational-memory' as const;
   readonly name = 'Observational Memory';
@@ -99,7 +108,10 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
     // When the agent is using a Mastra gateway model, the gateway handles OM
     // (observation, reflection, context injection) server-side. Running it
     // locally would double-process messages and cause history duplication.
-    if (requestContext?.get('__mastra_gateway_memory')) {
+    // We detect this from the model directly (not requestContext) so that
+    // the flag doesn't leak to child agents in delegation scenarios.
+    if (isMastraGatewayModel(model)) {
+      state[GATEWAY_STATE_KEY] = true;
       omDebug(`[OM:processInputStep:GATEWAY] gateway handles OM — skipping local processing`);
       return messageList;
     }
@@ -265,7 +277,7 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
     if (!context) return messageList;
 
     // Gateway handles OM — skip local output processing (see processInputStep).
-    if (requestContext?.get('__mastra_gateway_memory')) return messageList;
+    if (state[GATEWAY_STATE_KEY]) return messageList;
 
     const observabilityContext = getOmObservabilityContext(args);
     state.__omObservabilityContext = observabilityContext;

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -96,6 +96,14 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
       return messageList;
     }
 
+    // When the agent is using a Mastra gateway model, the gateway handles OM
+    // (observation, reflection, context injection) server-side. Running it
+    // locally would double-process messages and cause history duplication.
+    if (requestContext?.get('__mastra_gateway_memory')) {
+      omDebug(`[OM:processInputStep:GATEWAY] gateway handles OM — skipping local processing`);
+      return messageList;
+    }
+
     const { threadId, resourceId } = context;
     const memoryContext = parseMemoryRequestContext(requestContext);
     const readOnly = memoryContext?.memoryConfig?.readOnly;
@@ -255,6 +263,9 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
 
     const context = this.engine.getThreadContext(requestContext, messageList);
     if (!context) return messageList;
+
+    // Gateway handles OM — skip local output processing (see processInputStep).
+    if (requestContext?.get('__mastra_gateway_memory')) return messageList;
 
     const observabilityContext = getOmObservabilityContext(args);
     state.__omObservabilityContext = observabilityContext;


### PR DESCRIPTION
## Problem

When an agent uses a Mastra gateway model (`isGatewayModel`), the gateway handles Observational Memory (OM) server-side — including observation, reflection, and context injection. Running OM locally as well causes **message history doubling** because both the local processor and the gateway independently modify the message sequence.

## Solution

Set a `__mastra_gateway_memory` flag on `requestContext` when `isGatewayModel` is true, and have the `ObservationalMemoryProcessor` check this flag to skip local processing.

### Changes

- **`packages/core/src/agent/agent.ts`**: Set `__mastra_gateway_memory` flag on `requestContext` when `isGatewayModel` is true
- **`packages/memory/src/processors/observational-memory/processor.ts`**: 
  - `processInputStep` returns early when the flag is set (skips observation injection)
  - `processOutputResult` returns early when the flag is set (skips turn conclusion)
- **`packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts`**: New test file covering the skip behavior

### Design notes

The processor still exists in the processor chain to satisfy the `hasObservationalMemory` check in core, which prevents the standard `MessageHistory` processor from running (since the gateway handles history).

## Test plan

- `gateway-skip.test.ts`: 3 new tests covering input skip, output skip, and normal non-gateway flow
- Existing OM tests (398 tests) all pass with no regressions
- `mock-om-agent.test.ts` integration tests (10 tests) pass
- TypeScript type-checking passes on `@mastra/core`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Imagine you have an assistant that helps you remember conversations. When that assistant is routed through an online service (Mastra gateway), the online service handles memory management for you. If your local assistant also tries to remember the conversation at the same time, you end up with duplicate memories. This fix tells the local assistant to skip its memory processing when the online service is already handling it.

## Overview

This PR fixes message history duplication that occurs when an agent uses a Mastra gateway model. The gateway handles Observational Memory (OM) server-side, including observation injection, reflection, and context injection. Previously, the local `ObservationalMemoryProcessor` would also run, causing both processors to modify the message sequence and create duplicates.

The solution is to detect when a model is routed through the Mastra gateway and skip local OM processing in those cases, while leaving the processor in the chain to prevent the standard `MessageHistory` processor from running (since the gateway handles history management).

## Changes

**packages/memory/src/processors/observational-memory/processor.ts**
- Added detection of Mastra gateway-routed models using `ModelRouterLanguageModel` with `gatewayId === 'mastra'`
- When a gateway model is detected in `processInputStep`, the processor sets a per-instance state flag and returns early without performing local OM handling (turn creation, message injection, progress emission, token persistence)
- Added corresponding early return in `processOutputResult` that skips turn finalization when the gateway flag is set

**packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts** (new)
- Comprehensive test suite with 218 lines verifying skip behavior
- Tests that `processInputStep` returns unchanged `MessageList` when processing a Mastra gateway model
- Tests that `processOutputResult` returns unchanged `MessageList` when state indicates a gateway run
- Tests normal non-gateway flow to ensure regular OM processing still works
- Tests with plain string models to verify backwards compatibility

**.changeset/skip-local-om-gateway-memory.md** (new)
- Changeset documenting the fix as a patch for `@mastra/memory`
- Describes the detection mechanism and skip behavior

## Design Notes

The detection occurs at runtime within the processor rather than via a shared `requestContext` flag, preventing the gateway flag from leaking to child agents during delegation and incorrectly skipping their local OM processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->