### PR TITLE
ci: use prod CF R2 secrets for studio production upload, allow failure

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -100,13 +100,15 @@ jobs:
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \
             --delete
 
+      # TODO: Remove continue-on-error once production CF R2 credentials are configured.
       - name: Upload studio assets to R2 (production)
         if: ${{ !inputs.dry_run }}
+        continue-on-error: true
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_PROD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_PROD_SECRET_ACCESS_KEY }}
           STUDIO_BUCKET_NAME: studio-assets
-          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
+          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_PROD_ENDPOINT_URL }}
         run: |
           aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \
@@ -220,13 +222,15 @@ jobs:
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \
             --delete
 
+      # TODO: Remove continue-on-error once production CF R2 credentials are configured.
       - name: Upload studio assets to R2 (production)
         if: ${{ !inputs.dry_run }}
+        continue-on-error: true
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_PROD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_PROD_SECRET_ACCESS_KEY }}
           STUDIO_BUCKET_NAME: studio-assets
-          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
+          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_PROD_ENDPOINT_URL }}
         run: |
           aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \
@@ -424,13 +428,15 @@ jobs:
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \
             --delete
 
+      # TODO: Remove continue-on-error once production CF R2 credentials are configured.
       - name: Upload studio assets to R2 (production)
         if: ${{ !inputs.dry_run }}
+        continue-on-error: true
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_PROD_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_PROD_SECRET_ACCESS_KEY }}
           STUDIO_BUCKET_NAME: studio-assets
-          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_ENDPOINT_URL }}
+          STUDIO_ENDPOINT_URL: ${{ secrets.STUDIO_PROD_ENDPOINT_URL }}
         run: |
           aws s3 sync packages/cli/dist/studio "s3://${STUDIO_BUCKET_NAME}/${{ steps.cli-version.outputs.version }}/studio/" \
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \


### PR DESCRIPTION
## Summary

The publish workflow's `Upload studio assets to R2 (production)` step has been failing with `AccessDenied` (see [run 24108791701](https://github.com/mastra-ai/mastra/actions/runs/24108791701/job/70338402912)) and breaking the publish pipeline.

The production step was reusing the staging `CF_R2_ACCESS_KEY_ID` / `CF_R2_SECRET_ACCESS_KEY` / `STUDIO_ENDPOINT_URL` secrets but targeting the `studio-assets` production bucket. Those credentials don't have access to the prod bucket, so the step failed and stopped the rest of the workflow.

This PR makes two changes to the production upload step in all three jobs (`prerelease`, `stable`, `snapshot`) in `.github/workflows/npm-publish.yml`:

1. Switches the production upload to use prod-specific secrets:
   - `CF_R2_PROD_ACCESS_KEY_ID`
   - `CF_R2_PROD_SECRET_ACCESS_KEY`
   - `STUDIO_PROD_ENDPOINT_URL`
2. Marks the production step as `continue-on-error: true` so any failure (e.g. while the prod secrets are still being set up) doesn't block the rest of the workflow.

Each step has a `TODO` to remove `continue-on-error` once the prod CF R2 secrets are configured. Staging uploads are unchanged.

## Follow-up

- Configure the three new secrets at the org/repo level: `CF_R2_PROD_ACCESS_KEY_ID`, `CF_R2_PROD_SECRET_ACCESS_KEY`, `STUDIO_PROD_ENDPOINT_URL`.
- Once the next publish run uploads to prod successfully, remove `continue-on-error: true` from the three production steps.

## Test plan

- [x] YAML is valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Next prerelease run completes successfully past the studio upload steps (production step may still show as failed but won't block)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the team publishes npm packages, the workflow tries to upload files to a cloud storage bucket. It was using the wrong credentials for the production storage bucket, causing failures that stopped the entire publishing process. This PR tells the workflow "try to upload to production storage, but if it fails, keep going anyway" and switches to use production-specific credentials. Once the production credentials are properly set up, the workflow will succeed and the "keep going anyway" setting can be removed.

## Changes

Updated `.github/workflows/npm-publish.yml` to modify the "Upload studio assets to R2 (production)" step in three jobs:

- **prerelease** job (line 104)
- **stable** job (line 226)  
- **snapshot** job (line 432)

### Modifications to each production upload step:

1. **Added `continue-on-error: true`** — Allows the workflow to continue past this step even if the upload fails, preventing failures from blocking the rest of the publish pipeline.

2. **Updated secrets to production-specific credentials:**
   - `CF_R2_ACCESS_KEY_ID` → `CF_R2_PROD_ACCESS_KEY_ID`
   - `CF_R2_SECRET_ACCESS_KEY` → `CF_R2_PROD_SECRET_ACCESS_KEY`
   - `STUDIO_ENDPOINT_URL` → `STUDIO_PROD_ENDPOINT_URL`

3. **Changed bucket reference** — Updated `STUDIO_BUCKET_NAME` from a secret variable to a hardcoded value `studio-assets`.

4. **Added TODO comment** — Each modified step includes "TODO: Remove continue-on-error once production CF R2 credentials are configured" to remind the team to remove the error suppression once production secrets are in place.

Staging uploads remain unchanged and continue to use existing staging credentials.

## Rationale

Previously, the production upload step was reusing staging credentials (`CF_R2_ACCESS_KEY_ID`/`CF_R2_SECRET_ACCESS_KEY`) while targeting the production bucket, causing AccessDenied failures that blocked the entire publish workflow. The step now references production-specific secrets that will properly authenticate with the production bucket once those secrets are configured in the repository. Until then, the `continue-on-error` flag ensures the workflow can complete, with failures reported in the job summary for visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->