### PR TITLE
fix(memory): use duck typing for gateway model detection in OM processor

### DIFF
--- a/.changeset/strong-pillows-admire.md
+++ b/.changeset/strong-pillows-admire.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Fixed gateway model detection to use duck typing instead of instanceof check, preventing potential failures from cross-package module resolution issues. Propagates `gatewayId` through the AISDKV5LanguageModel wrapper so duck-type detection works even when models are re-wrapped.

--- a/packages/core/src/agent/__tests__/memory-gateway-duck-typing.test.ts
+++ b/packages/core/src/agent/__tests__/memory-gateway-duck-typing.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Agent } from '../agent';
+
+describe('memory gateway duck typing', () => {
+  it('does not warn when model exposes a mastra gatewayId without being a ModelRouterLanguageModel instance', async () => {
+    const warn = vi.fn();
+
+    const duckTypedGatewayModel = {
+      specificationVersion: 'v2' as const,
+      provider: 'openrouter',
+      modelId: 'openai/gpt-4o',
+      defaultObjectGenerationMode: 'json' as const,
+      supportsStructuredOutputs: true,
+      supportsImageUrls: true,
+      gatewayId: 'mastra',
+      async doGenerate() {
+        return {
+          content: [{ type: 'text' as const, text: 'ok' }],
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+      async doStream() {
+        return {
+          stream: new ReadableStream({
+            start(controller) {
+              controller.enqueue({ type: 'text-start', id: 'text-1' });
+              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'ok' });
+              controller.enqueue({ type: 'text-end', id: 'text-1' });
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+              controller.close();
+            },
+          }),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    };
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model: duckTypedGatewayModel as any,
+    });
+
+    agent.__setLogger({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+      trace: vi.fn(),
+    } as any);
+
+    const result = await agent.generate('hello', {
+      memory: {
+        thread: { id: 'thread-1' },
+        resource: 'resource-1',
+      },
+    });
+
+    expect(result.text).toBe('ok');
+    expect(warn).not.toHaveBeenCalledWith(
+      'No memory is configured but resourceId and threadId were passed in args',
+      expect.anything(),
+    );
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4492,7 +4492,11 @@ export class Agent<
     })) as MastraLLMVNext;
 
     const resolvedModel = llm.getModel();
-    const isGatewayModel = resolvedModel instanceof ModelRouterLanguageModel && resolvedModel.gatewayId === 'mastra';
+    const isGatewayModel =
+      typeof resolvedModel === 'object' &&
+      resolvedModel !== null &&
+      'gatewayId' in resolvedModel &&
+      resolvedModel.gatewayId === 'mastra';
     if (resourceId && threadFromArgs && !this.hasOwnMemory() && !isGatewayModel) {
       this.logger.warn('No memory is configured but resourceId and threadId were passed in args', { agent: this.name });
     }

--- a/packages/core/src/llm/model/aisdk/v5/model.ts
+++ b/packages/core/src/llm/model/aisdk/v5/model.ts
@@ -21,6 +21,7 @@ export class AISDKV5LanguageModel implements MastraLanguageModelV2 {
    * Provider-specific model ID for logging purposes.
    */
   readonly modelId: string;
+  readonly gatewayId?: string;
   /**
    * Supported URL patterns by media type for the provider.
    *
@@ -38,6 +39,7 @@ export class AISDKV5LanguageModel implements MastraLanguageModelV2 {
     this.#model = config;
     this.provider = this.#model.provider;
     this.modelId = this.#model.modelId;
+    this.gatewayId = (config as { gatewayId?: string }).gatewayId;
     this.supportedUrls = this.#model.supportedUrls;
   }
 

--- a/packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts
@@ -3,12 +3,11 @@
  * agent is using a Mastra gateway model. The gateway handles OM server-side,
  * so running it locally would double-process messages and cause duplication.
  *
- * Detection uses the model argument (instanceof ModelRouterLanguageModel with
- * gatewayId === 'mastra') and stores the result in per-processor state — this
- * avoids leaking flags through RequestContext to child agents.
+ * Detection uses a duck-type check (model has gatewayId === 'mastra') and
+ * stores the result in per-processor state — this avoids leaking flags
+ * through RequestContext to child agents.
  */
 import type { MastraDBMessage } from '@mastra/core/agent';
-import { ModelRouterLanguageModel } from '@mastra/core/llm';
 import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -36,16 +35,16 @@ function createStubMemoryProvider(): MemoryContextProvider {
 }
 
 /**
- * Create a mock that passes `instanceof ModelRouterLanguageModel` and has
- * the given gatewayId.  We use Object.create to inherit the prototype
- * without invoking the real constructor (which needs env vars / gateways).
+ * Create a plain object mock with the given gatewayId.
+ * Detection uses duck typing ('gatewayId' in model), so no real class needed.
  */
 function createMockGatewayModel(gatewayId: string) {
-  const mock = Object.create(ModelRouterLanguageModel.prototype) as InstanceType<typeof ModelRouterLanguageModel>;
-  Object.defineProperty(mock, 'gatewayId', { value: gatewayId, writable: false });
-  Object.defineProperty(mock, 'modelId', { value: 'openai/gpt-4o', writable: false });
-  Object.defineProperty(mock, 'provider', { value: 'mastra', writable: false });
-  return mock;
+  return {
+    gatewayId,
+    modelId: 'openai/gpt-4o',
+    provider: 'mastra',
+    specificationVersion: 'v2' as const,
+  };
 }
 
 describe('ObservationalMemoryProcessor — gateway skip', () => {

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -1,5 +1,4 @@
 import type { MastraDBMessage, MessageList } from '@mastra/core/agent';
-import { ModelRouterLanguageModel } from '@mastra/core/llm';
 import { parseMemoryRequestContext } from '@mastra/core/memory';
 import type { ObservabilityContext } from '@mastra/core/observability';
 import type { Processor, ProcessInputStepArgs, ProcessOutputResultArgs } from '@mastra/core/processors';
@@ -56,9 +55,9 @@ function getOmObservabilityContext(
 /** Key used to store gateway detection result in per-processor state. */
 const GATEWAY_STATE_KEY = '__isGatewayModel';
 
-/** Check if the model is routed through a Mastra gateway. */
+/** Check if the model is routed through a Mastra gateway (duck-type check to avoid cross-package instanceof issues). */
 function isMastraGatewayModel(model: ProcessInputStepArgs['model']): boolean {
-  return model instanceof ModelRouterLanguageModel && model.gatewayId === 'mastra';
+  return typeof model === 'object' && model !== null && 'gatewayId' in model && (model as any).gatewayId === 'mastra';
 }
 
 export class ObservationalMemoryProcessor implements Processor<'observational-memory'> {


### PR DESCRIPTION
## What

Replaces `instanceof ModelRouterLanguageModel` check with a duck-type check (`'gatewayId' in model`) in the Observational Memory processor's gateway skip logic.

## Why

The `instanceof` check can fail when:
- Multiple copies of `@mastra/core` exist (bundler duplication, version mismatches)
- Module resolution differs between ESM/CJS contexts
- The model is a string (causes a runtime error with `in` operator on primitives)

Duck typing is more resilient and doesn't require importing `ModelRouterLanguageModel` into `@mastra/memory` at all.

## Changes

- **`processor.ts`**: Replaced `instanceof` with `typeof model === 'object' && 'gatewayId' in model && model.gatewayId === 'mastra'`
- **`gateway-skip.test.ts`**: Updated mocks to use plain objects instead of `Object.create(ModelRouterLanguageModel.prototype)`
- Removed `ModelRouterLanguageModel` import from both files

## Test plan

- All 4 gateway-skip tests pass
- Full OM test suite (755 tests) passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Instead of checking a model's class (which can break when the same code is loaded multiple ways), this PR simply looks for a property — it treats a model as a Mastra gateway model if it has gatewayId === 'mastra'. That avoids brittle cross-package/class-check failures and runtime errors.

## Changes

- packages/memory/src/processors/observational-memory/processor.ts
  - Removed import/use of ModelRouterLanguageModel.
  - Replaced instanceof guard with a duck-type check:
    - typeof model === 'object' && model !== null && 'gatewayId' in model && model.gatewayId === 'mastra'
  - Preserves prior early-return behavior when a gateway model is detected; stores gateway result in processor state as before.
  - Added comment explaining duck-typing rationale.

- packages/memory/src/processors/observational-memory/__tests__/gateway-skip.test.ts
  - Updated mocks to use plain objects (gatewayId, modelId, provider, specificationVersion) instead of prototype-based mocks.
  - Removed ModelRouterLanguageModel import and updated test comments to reflect duck-typing.
  - Tests still cover: skipping on mastra gateway, skipping on stored gateway flag in state, and not skipping for non-mastra gateway.

- packages/core/src/agent/agent.ts
  - Replaced resolvedModel instanceof ModelRouterLanguageModel check with the same duck-type guard to decide gateway models before emitting memory-related warnings.

- packages/core/src/llm/model/aisdk/v5/model.ts
  - Added optional readonly gatewayId?: string to AISDKV5LanguageModel and set it from the provided config to preserve gatewayId through wrapping.

- packages/core/src/agent/__tests__/memory-gateway-duck-typing.test.ts
  - Added test verifying an Agent using a duck-typed model with gatewayId: 'mastra' suppresses the memory-missing warning and still generates expected output.

- .changeset/strong-pillows-admire.md
  - New changeset recording the patch: Observational Memory now uses duck typing for gateway model detection and propagates gatewayId through AISDKV5 wrapper.

## Rationale

- instanceof checks can fail across duplicate package copies or differing ESM/CJS resolution and can error when model is a primitive (e.g., string). Duck typing (checking gatewayId) is robust across these scenarios and keeps the intended behavior: treat a model as a Mastra gateway model only when gatewayId === 'mastra'.

## Tests

- All 4 gateway-skip tests pass.
- Full Observational Memory test suite (755 tests) passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->