### PR TITLE
fix(core): use .optional() instead of .nullish() in sub-agent tool schemas

### DIFF
--- a/.changeset/fix-agent-schema-optional-gemini.md
+++ b/.changeset/fix-agent-schema-optional-gemini.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed sub-agent tool input schema to use `.optional()` instead of `.nullish()` for optional fields (`threadId`, `resourceId`, `instructions`, `maxSteps`). The previous `.nullish()` produced `anyOf: [T, {type: "null"}]` in JSON Schema, which Google Gemini's function calling API rejects. Using `.optional()` generates clean JSON Schema without `anyOf`, while the execute handler already handles null values via falsy checks so OpenAI compatibility is preserved.

--- a/packages/core/src/agent/__tests__/tools.test.ts
+++ b/packages/core/src/agent/__tests__/tools.test.ts
@@ -1395,10 +1395,10 @@ describe('sub-agent prompt input normalization (GitHub #14154)', () => {
   // by CoreToolBuilder.createExecute) must normalize it before validation fails.
   const agentInputSchema = z.object({
     prompt: z.string().describe('The prompt to send to the agent'),
-    threadId: z.string().nullish().describe('Thread ID'),
-    resourceId: z.string().nullish().describe('Resource ID'),
-    instructions: z.string().nullish().describe('Additional instructions'),
-    maxSteps: z.number().min(3).nullish().describe('Max steps'),
+    threadId: z.string().optional().describe('Thread ID'),
+    resourceId: z.string().optional().describe('Resource ID'),
+    instructions: z.string().optional().describe('Additional instructions'),
+    maxSteps: z.number().min(3).optional().describe('Max steps'),
   });
 
   it('should normalize "query" to "prompt" through validateToolInput', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2926,16 +2926,18 @@ export class Agent<
       for (const [agentName, agent] of Object.entries(agents)) {
         const agentInputSchema = z.object({
           prompt: z.string().describe('The prompt to send to the agent'),
-          // Using .nullish() instead of .optional() because OpenAI sends null for unfilled optional fields
-          threadId: z.string().nullish().describe('Thread ID for conversation continuity for memory messages'),
-          resourceId: z.string().nullish().describe('Resource/user identifier for memory messages'),
+          // Using .optional() (not .nullish()) so the JSON Schema for tool calling avoids anyOf:[T,null]
+          // constructs that break Google Gemini function calling. The execute handler already coerces
+          // null to undefined via falsy checks, so OpenAI sending null for unfilled fields is safe.
+          threadId: z.string().optional().describe('Thread ID for conversation continuity for memory messages'),
+          resourceId: z.string().optional().describe('Resource/user identifier for memory messages'),
           instructions: z
             .string()
-            .nullish()
+            .optional()
             .describe(
               'Additional instructions to append to the agent instructions. Only provide if you have specific guidance beyond what the agent already knows. Leave empty in most cases.',
             ),
-          maxSteps: z.number().min(3).nullish().describe('Maximum number of execution steps for the sub-agent'),
+          maxSteps: z.number().min(3).optional().describe('Maximum number of execution steps for the sub-agent'),
           // using minimum of 3 to ensure if the agent has a tool call, the llm gets executed again after the tool call step, using the tool call result
           // to return a proper llm response
         });


### PR DESCRIPTION
Fixes #15076

## Problem

Agent network sub-agent tool declarations are rejected by Google Gemini's function-calling API with `property is not defined`. Root cause: `agentInputSchema` uses `.nullish()` which generates `anyOf:[{type:"string"},{type:"null"}]` JSON Schema that Gemini rejects.

## Solution

Changed `.nullish()` to `.optional()` for `threadId`, `resourceId`, `instructions`, `maxSteps`. OpenAI null values are already handled by `validateToolInput` Step 5 (GitHub #12362).

## Testing

Updated `tools.test.ts` schema copy to match. Existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR fixes a compatibility problem where Google Gemini can't handle the way optional fields were being described in sub-agent tool schemas. The fix changes how optional fields are marked (using `.optional()` instead of `.nullish()`), which makes the schema descriptions simpler and compatible with Gemini's requirements, while still working properly with other AI providers like OpenAI.

## Summary

This PR resolves issue #15076 by updating sub-agent tool input schemas to use `.optional()` instead of `.nullish()` for optional fields, ensuring compatibility with Google Gemini's function-calling API.

### Problem
Agent network sub-agent tool declarations were being rejected by Google Gemini's function-calling API with errors indicating that properties were not defined. The root cause was that the `agentInputSchema` used Zod's `.nullish()` method, which generates JSON Schema containing `anyOf` constructs (e.g., `anyOf: [{type: "string"}, {type: "null"}]`). Gemini's function-calling API does not support `anyOf` in parameter schema definitions.

### Solution
Replaced `.nullish()` with `.optional()` for optional input fields (`threadId`, `resourceId`, `instructions`, `maxSteps`) while keeping `prompt` as a required field. This change eliminates the `anyOf` construct from the generated JSON Schema, producing simpler schema definitions that Gemini can process.

The solution maintains compatibility with OpenAI by relying on existing runtime validation and coercion through the `validateToolInput` step (referenced in PR #12362), which already handles transformation of null values to undefined at execution time. The execute handler implements falsy checks that safely coerce null to undefined for non-required fields, so OpenAI sending null for unfilled fields remains safe.

### Changes
- **packages/core/src/agent/agent.ts**: Updated the dynamically constructed sub-agent tool input Zod schema to use `.optional()` instead of `.nullish()` for `threadId`, `resourceId`, `instructions`, and `maxSteps` fields. Added clarifying comments explaining that `.optional()` avoids `anyOf` constructs that break Gemini function calling, and that the execute handler already handles null coercion via falsy checks for OpenAI compatibility.
- **packages/core/src/agent/__tests__/tools.test.ts**: Updated the test-local `agentInputSchema` in the "sub-agent prompt input normalization (GitHub #14154)" test to match the schema changes, changing the same four fields from `.nullish()` to `.optional()`.
- **.changeset/fix-agent-schema-optional-gemini.md**: Added a changeset entry documenting the patch-level update to `@mastra/core`.

### Impact
- Fixes Gemini function-calling compatibility without breaking existing OpenAI integration
- Simplifies generated JSON schemas by removing `anyOf` constructs that some providers cannot process
- Existing validation and coercion logic continue to handle null/undefined values appropriately at runtime
- Tests continue to pass with the updated schema definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->