### PR TITLE
fix(memory): respect per-record reflection threshold overrides in maybeReflect()

### DIFF
--- a/.changeset/bold-ants-cheer.md
+++ b/.changeset/bold-ants-cheer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed reflection threshold not respecting per-record overrides set via the PATCH API. Previously, lowering the reflection threshold for a specific record had no effect on the actual reflection trigger — only the default 40k threshold was used. Now per-record overrides are correctly applied in both sync and async reflection paths.

--- a/packages/memory/src/processors/observational-memory/reflector-runner.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-runner.ts
@@ -36,6 +36,7 @@ import type {
   ObserveHooks,
   ResolvedObservationConfig,
   ResolvedReflectionConfig,
+  ThresholdRange,
 } from './types';
 
 type ConcreteReflectionModel = Exclude<ResolvedReflectionConfig['model'], ModelByInputTokens>;
@@ -393,7 +394,11 @@ export class ReflectorRunner {
     const freshRecord = await this.storage.getObservationalMemory(record.threadId, record.resourceId);
     const currentRecord = freshRecord ?? record;
     const observationTokens = currentRecord.observationTokenCount ?? 0;
-    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
+    const bufOverrides = (
+      currentRecord.config as { _overrides?: { reflection?: { observationTokens?: number | ThresholdRange } } }
+    )?._overrides;
+    const bufEffectiveTokens = bufOverrides?.reflection?.observationTokens ?? this.reflectionConfig.observationTokens;
+    const reflectThreshold = getMaxThreshold(bufEffectiveTokens);
     const bufferActivation = this.reflectionConfig.bufferActivation ?? 0.5;
     const startedAt = new Date().toISOString();
     const cycleId = `reflect-buf-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
@@ -605,7 +610,12 @@ export class ReflectorRunner {
       observabilityContext,
     } = opts;
     const lockKey = this.buffering.getLockKey(record.threadId, record.resourceId);
-    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
+    const overrides = (
+      record.config as { _overrides?: { reflection?: { observationTokens?: number | ThresholdRange } } }
+    )?._overrides;
+    const effectiveObservationTokens =
+      overrides?.reflection?.observationTokens ?? this.reflectionConfig.observationTokens;
+    const reflectThreshold = getMaxThreshold(effectiveObservationTokens);
 
     // ════════════════════════════════════════════════════════════════════════
     // ASYNC BUFFERING: Trigger background reflection at bufferActivation ratio

--- a/packages/memory/src/processors/observational-memory/reflector-runner.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-runner.ts
@@ -126,12 +126,31 @@ export class ReflectorRunner {
     });
   }
 
-  private getObservationMarkerConfig(): ObservationMarkerConfig {
+  private getObservationMarkerConfig(record?: ObservationalMemoryRecord): ObservationMarkerConfig {
     return {
       messageTokens: getMaxThreshold(this.observationConfig.messageTokens),
-      observationTokens: getMaxThreshold(this.reflectionConfig.observationTokens),
+      observationTokens: getMaxThreshold(
+        record ? this.getEffectiveReflectionTokens(record) : this.reflectionConfig.observationTokens,
+      ),
       scope: this.scope,
     };
+  }
+
+  /**
+   * Resolve the effective reflection observationTokens for a record.
+   * Only explicit per-record overrides (stored under `_overrides`) win;
+   * the initial config snapshot is ignored so instance-level changes
+   * still take effect for existing records.
+   */
+  private getEffectiveReflectionTokens(record: ObservationalMemoryRecord): number | ThresholdRange {
+    const overrides = (
+      record.config as { _overrides?: { reflection?: { observationTokens?: number | ThresholdRange } } }
+    )?._overrides;
+    const recordTokens = overrides?.reflection?.observationTokens;
+    if (recordTokens) {
+      return recordTokens;
+    }
+    return this.reflectionConfig.observationTokens;
   }
 
   /**
@@ -394,11 +413,7 @@ export class ReflectorRunner {
     const freshRecord = await this.storage.getObservationalMemory(record.threadId, record.resourceId);
     const currentRecord = freshRecord ?? record;
     const observationTokens = currentRecord.observationTokenCount ?? 0;
-    const bufOverrides = (
-      currentRecord.config as { _overrides?: { reflection?: { observationTokens?: number | ThresholdRange } } }
-    )?._overrides;
-    const bufEffectiveTokens = bufOverrides?.reflection?.observationTokens ?? this.reflectionConfig.observationTokens;
-    const reflectThreshold = getMaxThreshold(bufEffectiveTokens);
+    const reflectThreshold = getMaxThreshold(this.getEffectiveReflectionTokens(currentRecord));
     const bufferActivation = this.reflectionConfig.bufferActivation ?? 0.5;
     const startedAt = new Date().toISOString();
     const cycleId = `reflect-buf-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
@@ -435,7 +450,7 @@ export class ReflectorRunner {
         recordId: record.id,
         threadId: record.threadId ?? '',
         threadIds: record.threadId ? [record.threadId] : [],
-        config: this.getObservationMarkerConfig(),
+        config: this.getObservationMarkerConfig(currentRecord),
       });
       void writer.custom(startMarker).catch(() => {});
     }
@@ -567,7 +582,7 @@ export class ReflectorRunner {
         threadId: freshRecord.threadId ?? '',
         generationCount: afterRecord?.generationCount ?? freshRecord.generationCount ?? 0,
         observations: afterRecord?.activeObservations,
-        config: this.getObservationMarkerConfig(),
+        config: this.getObservationMarkerConfig(freshRecord),
       });
       void writer.custom(activationMarker).catch(() => {});
       await this.persistMarkerToMessage(
@@ -610,12 +625,7 @@ export class ReflectorRunner {
       observabilityContext,
     } = opts;
     const lockKey = this.buffering.getLockKey(record.threadId, record.resourceId);
-    const overrides = (
-      record.config as { _overrides?: { reflection?: { observationTokens?: number | ThresholdRange } } }
-    )?._overrides;
-    const effectiveObservationTokens =
-      overrides?.reflection?.observationTokens ?? this.reflectionConfig.observationTokens;
-    const reflectThreshold = getMaxThreshold(effectiveObservationTokens);
+    const reflectThreshold = getMaxThreshold(this.getEffectiveReflectionTokens(record));
 
     // ════════════════════════════════════════════════════════════════════════
     // ASYNC BUFFERING: Trigger background reflection at bufferActivation ratio
@@ -712,7 +722,7 @@ export class ReflectorRunner {
         recordId: record.id,
         threadId,
         threadIds: [threadId],
-        config: this.getObservationMarkerConfig(),
+        config: this.getObservationMarkerConfig(record),
       });
       await writer.custom(startMarker).catch(() => {});
     }


### PR DESCRIPTION
## Summary

`maybeReflect()` and `doAsyncBufferedReflection()` in `reflector-runner.ts` were computing the reflection threshold from `this.reflectionConfig.observationTokens` (the constructor-level default of 40k) and ignoring per-record `_overrides` set via the PATCH API.

This meant `getStatus()` correctly reported `shouldReflect=true` when a per-record override lowered the threshold, but the actual reflection trigger inside `observe() → SyncObservationStrategy.run() → maybeReflect()` never fired.

## Fix

Both methods now resolve the effective threshold from the record's `_overrides` before falling back to the default, matching the existing `ObservationalMemory.getEffectiveReflectionTokens()` logic.

**`maybeReflect()`** — affects all 3 downstream uses of `reflectThreshold`:
1. Async buffering check (`observationTokens < reflectThreshold`)
2. Activation point calculation (`reflectThreshold * bufferActivation`)
3. Sync reflection gate (`observationTokens < reflectThreshold`)

**`doAsyncBufferedReflection()`** — same fix for the async buffered reflection path.

## Test Plan

- `pnpm --filter ./packages/memory check` — typecheck passes
- `pnpm --filter ./packages/memory test:unit` — all 966 tests pass
- `pnpm build:memory` — build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The memory system sometimes reviews past events based on a token threshold. If someone set a custom, per-record threshold, the system ignored it and used the global default—this PR makes the system actually honor per-record overrides when deciding to reflect.

---

## Summary

This PR fixes a bug where per-record reflection threshold overrides (set via the PATCH API and stored under record.config._overrides) were ignored at runtime. maybeReflect() and doAsyncBufferedReflection() previously used the constructor-level default observationTokens (40,000) instead of the per-record override, causing getStatus() to indicate a record should reflect while the runtime trigger never fired. The runtime now resolves per-record overrides before falling back to the default, matching ObservationalMemory.getEffectiveReflectionTokens() behavior.

### Changes Made

- Introduced ReflectorRunner.getEffectiveReflectionTokens(record) to centralize resolution of effective reflection observationTokens (prefer explicit per-record _overrides.reflection.observationTokens, otherwise use instance default).
- Updated getObservationMarkerConfig(record?) to accept an optional record and derive observationTokens from getEffectiveReflectionTokens(record) when provided.
- Replaced usages of this.reflectionConfig.observationTokens in maybeReflect() and doAsyncBufferedReflection() with the per-record-effective threshold:
  - Async buffering gating (observationTokens < reflectThreshold)
  - Activation calculation (reflectThreshold * bufferActivation)
  - Sync reflection gate (observationTokens < reflectThreshold)
- Passed record into marker creation (createObservationStartMarker, createActivationMarker, etc.) so persisted/emitted marker metadata reflects the runtime threshold source.
- Added ThresholdRange import and small code cleanup to remove duplication.

### Impact

- Runtime reflection decision-making now respects per-record reflection threshold overrides for both synchronous and asynchronous reflection paths.
- Aligns observe()/maybeReflect()/doAsyncBufferedReflection() behavior with ObservationalMemory.getEffectiveReflectionTokens() and with what getStatus() reports.
- No public API or exported type changes.

### Tests

- Typecheck: pnpm --filter ./packages/memory check — passes  
- Unit tests: pnpm --filter ./packages/memory test:unit — all 966 tests pass  
- Build: pnpm build:memory — build succeeds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->