### PR TITLE
feat: support S3 prefix mounting in sandboxes

### DIFF
--- a/.changeset/true-snails-watch.md
+++ b/.changeset/true-snails-watch.md
@@ -1,0 +1,24 @@
+---
+'@mastra/s3': minor
+'@mastra/daytona': minor
+'@mastra/e2b': minor
+'@mastra/blaxel': minor
+---
+
+Added S3 prefix (subdirectory) mount support. You can now mount a specific folder within an S3 bucket instead of the entire bucket by setting the `prefix` option on your S3 filesystem.
+
+**Example:**
+
+```typescript
+const fs = new S3Filesystem({
+  bucket: 'my-bucket',
+  region: 'us-east-1',
+  prefix: 'workspace/data',
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+});
+```
+
+When mounted in a sandbox, only the contents under `workspace/data/` in the bucket will be visible at the mount path. This uses the s3fs `bucket:/path` syntax under the hood.
+
+Closes #15147.

--- a/workspaces/_test-utils/src/integration/types.ts
+++ b/workspaces/_test-utils/src/integration/types.ts
@@ -32,8 +32,8 @@ export interface WorkspaceIntegrationTestConfig {
    * When true: sandbox commands like `cat /mount1/file.txt` see the same files
    * as `fs1.readFile('/file.txt')`. Required for sandbox-dependent multi-mount tests.
    *
-   * When false: only API-level isolation tests run (e.g. prefix-based S3 on same bucket
-   * where s3fs mounts the full bucket, not the prefix).
+   * When false: only API-level isolation tests run for providers/configurations
+   * where sandbox-visible paths do not match filesystem API paths.
    *
    * @default true
    */

--- a/workspaces/blaxel/src/sandbox/index.integration.test.ts
+++ b/workspaces/blaxel/src/sandbox/index.integration.test.ts
@@ -608,19 +608,18 @@ if (canRunSharedIntegration && hasGCSCredentials) {
 /**
  * S3+S3 Multi-Mount Integration Tests
  *
- * Same bucket with different prefixes. s3fs FUSE mounts the full bucket,
- * so sandbox paths don't align with prefix-scoped API paths.
- * Only the API-level isolation test runs; sandbox-dependent tests are skipped.
+ * Same bucket with different prefixes. With prefix-aware s3fs mounts,
+ * sandbox paths should align with prefix-scoped API paths so the full
+ * multi-mount scenario suite can run.
  */
 if (canRunSharedIntegration) {
   createWorkspaceIntegrationTests({
     suiteName: 'Blaxel + S3+S3 Multi-Mount Integration',
     testTimeout: 120000,
-    sandboxPathsAligned: false,
     testScenarios: {
       fileSync: false,
       multiMount: true,
-      crossMountCopy: false,
+      crossMountCopy: true,
     },
     createWorkspace: () => {
       const s3Config = getS3TestConfig();

--- a/workspaces/blaxel/src/sandbox/index.test.ts
+++ b/workspaces/blaxel/src/sandbox/index.test.ts
@@ -729,6 +729,7 @@ describe('BlaxelSandbox Mount Configuration', () => {
     expect(s3fsMountCall).toBeDefined();
     if (s3fsMountCall) {
       expect(s3fsMountCall[0].command).toContain('test-bucket:/workspace/data');
+      expect(s3fsMountCall[0].command).not.toContain('test-bucket:/workspace/data/');
     }
   });
 });

--- a/workspaces/blaxel/src/sandbox/index.test.ts
+++ b/workspaces/blaxel/src/sandbox/index.test.ts
@@ -698,6 +698,39 @@ describe('BlaxelSandbox Mount Configuration', () => {
       expect(s3fsMountCall[0].command).toMatch(/\bro\b/);
     }
   });
+
+  it('S3 prefix mount uses bucket:/prefix syntax in mount command', async () => {
+    const sandbox = new BlaxelSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-s3-prefix',
+      name: 'S3Filesystem',
+      provider: 's3',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 's3',
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        accessKeyId: 'key',
+        secretAccessKey: 'secret',
+        prefix: 'workspace/data/',
+      }),
+    } as any;
+
+    await sandbox.mount(mockFilesystem, '/data/s3-prefix');
+
+    const calls = mockSandbox.process.exec.mock.calls;
+    const s3fsMountCall = calls.find((call: any[]) => {
+      const cmd = call[0]?.command || '';
+      return cmd.includes('s3fs') && cmd.includes('/data/s3-prefix') && !cmd.includes('which');
+    });
+
+    expect(s3fsMountCall).toBeDefined();
+    if (s3fsMountCall) {
+      expect(s3fsMountCall[0].command).toContain('test-bucket:/workspace/data');
+    }
+  });
 });
 
 /**

--- a/workspaces/blaxel/src/sandbox/mounts/s3.ts
+++ b/workspaces/blaxel/src/sandbox/mounts/s3.ts
@@ -177,7 +177,7 @@ export async function mountS3(mountPath: string, config: BlaxelS3MountConfig, ct
   }
 
   const quotedMountPath = shellQuote(mountPath);
-  const mountCmd = `s3fs ${bucketArg} ${quotedMountPath} -o ${mountOptions.join(' -o ')}`;
+  const mountCmd = `s3fs ${shellQuote(bucketArg)} ${quotedMountPath} -o ${mountOptions.join(' -o ')}`;
   logger.debug(`${LOG_PREFIX} Mounting S3:`, hasCredentials ? mountCmd.replace(credentialsPath, '***') : mountCmd);
 
   const result = await runCommand(sandbox, mountCmd, { timeout: 60_000 });

--- a/workspaces/blaxel/src/sandbox/mounts/s3.ts
+++ b/workspaces/blaxel/src/sandbox/mounts/s3.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
-import { LOG_PREFIX, validateBucketName, validateEndpoint, runCommand, detectPackageManager } from './types';
+import { LOG_PREFIX, validateBucketName, validateEndpoint, validatePrefix, runCommand, detectPackageManager } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -26,6 +26,11 @@ export interface BlaxelS3MountConfig extends FilesystemMountConfig {
   accessKeyId?: string;
   /** AWS secret access key (optional - omit for public buckets) */
   secretAccessKey?: string;
+  /**
+   * Optional prefix (subdirectory) to mount instead of the entire bucket.
+   * Uses s3fs `bucket:/prefix` syntax. Leading/trailing slashes are normalized.
+   */
+  prefix?: string;
   /** Mount as read-only (even if credentials have write access) */
   readOnly?: boolean;
 }
@@ -157,8 +162,15 @@ export async function mountS3(mountPath: string, config: BlaxelS3MountConfig, ct
     logger.debug(`${LOG_PREFIX} Mounting as read-only`);
   }
 
+  // Build the s3fs bucket argument — supports optional prefix via `bucket:/path` syntax
+  let bucketArg = config.bucket;
+  if (config.prefix) {
+    const normalizedPrefix = validatePrefix(config.prefix);
+    bucketArg = `${config.bucket}:/${normalizedPrefix}`;
+  }
+
   const quotedMountPath = shellQuote(mountPath);
-  const mountCmd = `s3fs ${config.bucket} ${quotedMountPath} -o ${mountOptions.join(' -o ')}`;
+  const mountCmd = `s3fs ${bucketArg} ${quotedMountPath} -o ${mountOptions.join(' -o ')}`;
   logger.debug(`${LOG_PREFIX} Mounting S3:`, hasCredentials ? mountCmd.replace(credentialsPath, '***') : mountCmd);
 
   const result = await runCommand(sandbox, mountCmd, { timeout: 60_000 });

--- a/workspaces/blaxel/src/sandbox/mounts/s3.ts
+++ b/workspaces/blaxel/src/sandbox/mounts/s3.ts
@@ -3,7 +3,14 @@ import crypto from 'node:crypto';
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
-import { LOG_PREFIX, validateBucketName, validateEndpoint, validatePrefix, runCommand, detectPackageManager } from './types';
+import {
+  LOG_PREFIX,
+  validateBucketName,
+  validateEndpoint,
+  validatePrefix,
+  runCommand,
+  detectPackageManager,
+} from './types';
 import type { MountContext } from './types';
 
 /**

--- a/workspaces/blaxel/src/sandbox/mounts/types.ts
+++ b/workspaces/blaxel/src/sandbox/mounts/types.ts
@@ -60,9 +60,10 @@ export function validateEndpoint(endpoint: string): void {
 /**
  * Validate and normalize a mount prefix before interpolating into shell commands.
  * Returns the normalized prefix (no leading/trailing slashes).
+ *
+ * Shell safety is handled by shellQuote() at the call site, so this function
+ * only enforces path-level rules (no traversal, no empty result, no control chars).
  */
-const SAFE_PREFIX_PATH = /^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*$/;
-
 export function validatePrefix(prefix: string): string {
   // Trim leading/trailing slashes
   let normalized = prefix;
@@ -75,10 +76,9 @@ export function validatePrefix(prefix: string): string {
   if (normalized.includes('//') || normalized.split('/').some(s => s === '.' || s === '..')) {
     throw new Error(`Invalid mount prefix: "${prefix}". Path traversal is not allowed.`);
   }
-  if (!SAFE_PREFIX_PATH.test(normalized)) {
-    throw new Error(
-      `Invalid mount prefix: "${prefix}". Must contain only alphanumeric characters, hyphens, dots, underscores, and forward slashes.`,
-    );
+  // Block control characters (U+0000–U+001F, U+007F) which are invalid in filesystem paths
+  if (/[\x00-\x1f\x7f]/.test(normalized)) {
+    throw new Error(`Invalid mount prefix: "${prefix}". Control characters are not allowed.`);
   }
   return normalized;
 }

--- a/workspaces/blaxel/src/sandbox/mounts/types.ts
+++ b/workspaces/blaxel/src/sandbox/mounts/types.ts
@@ -58,6 +58,32 @@ export function validateEndpoint(endpoint: string): void {
 }
 
 /**
+ * Validate and normalize a mount prefix before interpolating into shell commands.
+ * Returns the normalized prefix (no leading/trailing slashes).
+ */
+const SAFE_PREFIX_PATH = /^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*$/;
+
+export function validatePrefix(prefix: string): string {
+  // Trim leading/trailing slashes
+  let normalized = prefix;
+  while (normalized.startsWith('/')) normalized = normalized.slice(1);
+  while (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
+
+  if (!normalized) {
+    throw new Error('Mount prefix cannot be empty after normalization.');
+  }
+  if (normalized.includes('//') || normalized.split('/').some(s => s === '.' || s === '..')) {
+    throw new Error(`Invalid mount prefix: "${prefix}". Path traversal is not allowed.`);
+  }
+  if (!SAFE_PREFIX_PATH.test(normalized)) {
+    throw new Error(
+      `Invalid mount prefix: "${prefix}". Must contain only alphanumeric characters, hyphens, dots, underscores, and forward slashes.`,
+    );
+  }
+  return normalized;
+}
+
+/**
  * Detected system package manager.
  */
 export type PackageManager = 'apt' | 'apk' | 'unknown';

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -594,6 +594,69 @@ describe('DaytonaSandbox', () => {
     });
   });
 
+  describe('Mount Configuration', () => {
+    it('S3 prefix mount uses bucket:/prefix syntax in mount command', async () => {
+      mockSandbox.process.executeCommand.mockImplementation(async (command: string) => {
+        if (command.includes('mountpoint -q') && command.includes('echo "mounted"')) {
+          return { exitCode: 0, result: 'not mounted' };
+        }
+        if (command.includes('echo "non-empty" || echo "ok"')) {
+          return { exitCode: 0, result: 'ok' };
+        }
+        if (command.includes('sudo mkdir -p')) {
+          return { exitCode: 0, result: '' };
+        }
+        if (command.includes('which s3fs')) {
+          return { exitCode: 0, result: '/usr/bin/s3fs' };
+        }
+        if (command.includes('id -u && id -g')) {
+          return { exitCode: 0, result: '1000\n1000' };
+        }
+        if (command.includes('chmod a+rw /dev/fuse')) {
+          return { exitCode: 0, result: '' };
+        }
+        if (command.includes('s3fs') && command.includes('/data/s3-prefix')) {
+          return { exitCode: 0, result: '' };
+        }
+        if (command.includes('mkdir -p /tmp/.mastra-mounts')) {
+          return { exitCode: 0, result: '' };
+        }
+        return { exitCode: 0, result: '' };
+      });
+
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const mockFilesystem = {
+        id: 'test-s3-prefix',
+        name: 'S3Filesystem',
+        provider: 's3',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 's3',
+          bucket: 'test-bucket',
+          region: 'us-east-1',
+          accessKeyId: 'key',
+          secretAccessKey: 'secret',
+          prefix: 'workspace/data/',
+        }),
+      } as any;
+
+      await sandbox.mount(mockFilesystem, '/data/s3-prefix');
+
+      const mountCall = mockSandbox.process.executeCommand.mock.calls.find((call: any[]) => {
+        const command = call[0] || '';
+        return command.includes('s3fs') && command.includes('/data/s3-prefix') && !command.includes('which s3fs');
+      });
+
+      expect(mountCall).toBeDefined();
+      if (mountCall) {
+        expect(mountCall[0]).toContain('test-bucket:/workspace/data');
+        expect(mountCall[0]).not.toContain('test-bucket:/workspace/data/');
+      }
+    });
+  });
+
   describe('Stop & Destroy', () => {
     it('stop calls daytona.stop()', async () => {
       const sandbox = new DaytonaSandbox();

--- a/workspaces/daytona/src/sandbox/mounts/s3.ts
+++ b/workspaces/daytona/src/sandbox/mounts/s3.ts
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto';
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
-import { LOG_PREFIX, validateBucketName, validateEndpoint } from './types';
+import { LOG_PREFIX, validateBucketName, validateEndpoint, validatePrefix } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -26,6 +26,11 @@ export interface DaytonaS3MountConfig extends FilesystemMountConfig {
   accessKeyId?: string;
   /** AWS secret access key (optional - omit for public buckets) */
   secretAccessKey?: string;
+  /**
+   * Optional prefix (subdirectory) to mount instead of the entire bucket.
+   * Uses s3fs `bucket:/prefix` syntax. Leading/trailing slashes are normalized.
+   */
+  prefix?: string;
   /** Mount as read-only (even if credentials have write access) */
   readOnly?: boolean;
 }
@@ -159,9 +164,16 @@ export async function mountS3(mountPath: string, config: DaytonaS3MountConfig, c
     logger.debug(`${LOG_PREFIX} Mounting as read-only`);
   }
 
+  // Build the s3fs bucket argument — supports optional prefix via `bucket:/path` syntax
+  let bucketArg = config.bucket;
+  if (config.prefix) {
+    const normalizedPrefix = validatePrefix(config.prefix);
+    bucketArg = `${config.bucket}:/${normalizedPrefix}`;
+  }
+
   // Run s3fs as the sandbox user (not root) so the FUSE connection is registered
   // in the container's user namespace — allowing fusermount -u to unmount it later.
-  const mountCmd = `s3fs ${shellQuote(config.bucket)} ${quotedMountPath} -o ${mountOptions.join(' -o ')}`;
+  const mountCmd = `s3fs ${shellQuote(bucketArg)} ${quotedMountPath} -o ${mountOptions.join(' -o ')}`;
   logger.debug(`${LOG_PREFIX} Mounting S3:`, hasCredentials ? mountCmd.replace(credentialsPath, '***') : mountCmd);
 
   const result = await run(mountCmd, 60_000);

--- a/workspaces/daytona/src/sandbox/mounts/types.ts
+++ b/workspaces/daytona/src/sandbox/mounts/types.ts
@@ -62,9 +62,10 @@ export function validateEndpoint(endpoint: string): void {
 /**
  * Validate and normalize a mount prefix before interpolating into shell commands.
  * Returns the normalized prefix (no leading/trailing slashes).
+ *
+ * Shell safety is handled by shellQuote() at the call site, so this function
+ * only enforces path-level rules (no traversal, no empty result, no control chars).
  */
-const SAFE_PREFIX_PATH = /^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*$/;
-
 export function validatePrefix(prefix: string): string {
   // Trim leading/trailing slashes
   let normalized = prefix;
@@ -77,10 +78,9 @@ export function validatePrefix(prefix: string): string {
   if (normalized.includes('//') || normalized.split('/').some(s => s === '.' || s === '..')) {
     throw new Error(`Invalid mount prefix: "${prefix}". Path traversal is not allowed.`);
   }
-  if (!SAFE_PREFIX_PATH.test(normalized)) {
-    throw new Error(
-      `Invalid mount prefix: "${prefix}". Must contain only alphanumeric characters, hyphens, dots, underscores, and forward slashes.`,
-    );
+  // Block control characters (U+0000–U+001F, U+007F) which are invalid in filesystem paths
+  if (/[\x00-\x1f\x7f]/.test(normalized)) {
+    throw new Error(`Invalid mount prefix: "${prefix}". Control characters are not allowed.`);
   }
   return normalized;
 }

--- a/workspaces/daytona/src/sandbox/mounts/types.ts
+++ b/workspaces/daytona/src/sandbox/mounts/types.ts
@@ -60,6 +60,32 @@ export function validateEndpoint(endpoint: string): void {
 }
 
 /**
+ * Validate and normalize a mount prefix before interpolating into shell commands.
+ * Returns the normalized prefix (no leading/trailing slashes).
+ */
+const SAFE_PREFIX_PATH = /^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*$/;
+
+export function validatePrefix(prefix: string): string {
+  // Trim leading/trailing slashes
+  let normalized = prefix;
+  while (normalized.startsWith('/')) normalized = normalized.slice(1);
+  while (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
+
+  if (!normalized) {
+    throw new Error('Mount prefix cannot be empty after normalization.');
+  }
+  if (normalized.includes('//') || normalized.split('/').some(s => s === '.' || s === '..')) {
+    throw new Error(`Invalid mount prefix: "${prefix}". Path traversal is not allowed.`);
+  }
+  if (!SAFE_PREFIX_PATH.test(normalized)) {
+    throw new Error(
+      `Invalid mount prefix: "${prefix}". Must contain only alphanumeric characters, hyphens, dots, underscores, and forward slashes.`,
+    );
+  }
+  return normalized;
+}
+
+/**
  * Result of running a command in the Daytona sandbox.
  *
  * Note: Daytona's `executeCommand` returns a single combined string (stdout + stderr).

--- a/workspaces/e2b/src/sandbox/index.integration.test.ts
+++ b/workspaces/e2b/src/sandbox/index.integration.test.ts
@@ -1034,19 +1034,18 @@ if (canRunSharedIntegration && hasGCSCredentials) {
 /**
  * S3+S3 Multi-Mount Integration Tests
  *
- * Same bucket with different prefixes. s3fs FUSE mounts the full bucket,
- * so sandbox paths don't align with prefix-scoped API paths.
- * Only the API-level isolation test runs; sandbox-dependent tests are skipped.
+ * Same bucket with different prefixes. With prefix-aware s3fs mounts,
+ * sandbox paths should align with prefix-scoped API paths so the full
+ * multi-mount scenario suite can run.
  */
 if (canRunSharedIntegration) {
   createWorkspaceIntegrationTests({
     suiteName: 'E2B + S3+S3 Multi-Mount Integration',
     testTimeout: 120000,
-    sandboxPathsAligned: false,
     testScenarios: {
       fileSync: false,
       multiMount: true,
-      crossMountCopy: false,
+      crossMountCopy: true,
     },
     createWorkspace: () => {
       const s3Config = getS3TestConfig();

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -765,6 +765,38 @@ describe('E2BSandbox Mount Configuration', () => {
       expect(s3fsMountCall[0]).toMatch(/\bro\b/);
     }
   });
+
+  it('S3 prefix mount uses bucket:/prefix syntax in mount command', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-s3-prefix',
+      name: 'S3Filesystem',
+      provider: 's3',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 's3',
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        accessKeyId: 'key',
+        secretAccessKey: 'secret',
+        prefix: 'workspace/data/',
+      }),
+    } as any;
+
+    await sandbox.mount(mockFilesystem, '/data/s3-prefix');
+
+    const calls = mockSandbox.commands.run.mock.calls;
+    const s3fsMountCall = calls.find(
+      (call: any[]) => call[0].includes('s3fs') && call[0].includes('/data/s3-prefix') && !call[0].includes('which'),
+    );
+
+    expect(s3fsMountCall).toBeDefined();
+    if (s3fsMountCall) {
+      expect(s3fsMountCall[0]).toContain('test-bucket:/workspace/data');
+    }
+  });
 });
 
 /**

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -795,6 +795,7 @@ describe('E2BSandbox Mount Configuration', () => {
     expect(s3fsMountCall).toBeDefined();
     if (s3fsMountCall) {
       expect(s3fsMountCall[0]).toContain('test-bucket:/workspace/data');
+      expect(s3fsMountCall[0]).not.toContain('test-bucket:/workspace/data/');
     }
   });
 });

--- a/workspaces/e2b/src/sandbox/mounts/s3.ts
+++ b/workspaces/e2b/src/sandbox/mounts/s3.ts
@@ -1,6 +1,6 @@
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
-import { LOG_PREFIX, validateBucketName, validateEndpoint } from './types';
+import { LOG_PREFIX, validateBucketName, validateEndpoint, validatePrefix } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -23,6 +23,11 @@ export interface E2BS3MountConfig extends FilesystemMountConfig {
   accessKeyId?: string;
   /** AWS secret access key (optional - omit for public buckets) */
   secretAccessKey?: string;
+  /**
+   * Optional prefix (subdirectory) to mount instead of the entire bucket.
+   * Uses s3fs `bucket:/prefix` syntax. Leading/trailing slashes are normalized.
+   */
+  prefix?: string;
   /** Mount as read-only (even if credentials have write access) */
   readOnly?: boolean;
 }
@@ -123,8 +128,15 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
     logger.debug(`${LOG_PREFIX} Mounting as read-only`);
   }
 
+  // Build the s3fs bucket argument — supports optional prefix via `bucket:/path` syntax
+  let bucketArg = config.bucket;
+  if (config.prefix) {
+    const normalizedPrefix = validatePrefix(config.prefix);
+    bucketArg = `${config.bucket}:/${normalizedPrefix}`;
+  }
+
   // Mount with sudo (required for /dev/fuse access)
-  const mountCmd = `sudo s3fs ${config.bucket} ${mountPath} -o ${mountOptions.join(' -o ')}`;
+  const mountCmd = `sudo s3fs ${bucketArg} ${mountPath} -o ${mountOptions.join(' -o ')}`;
   logger.debug(`${LOG_PREFIX} Mounting S3:`, hasCredentials ? mountCmd.replace(credentialsPath, '***') : mountCmd);
 
   try {

--- a/workspaces/e2b/src/sandbox/mounts/s3.ts
+++ b/workspaces/e2b/src/sandbox/mounts/s3.ts
@@ -1,5 +1,6 @@
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
+import { shellQuote } from '../../utils/shell-quote';
 import { LOG_PREFIX, validateBucketName, validateEndpoint, validatePrefix } from './types';
 import type { MountContext } from './types';
 
@@ -136,7 +137,7 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
   }
 
   // Mount with sudo (required for /dev/fuse access)
-  const mountCmd = `sudo s3fs ${bucketArg} ${mountPath} -o ${mountOptions.join(' -o ')}`;
+  const mountCmd = `sudo s3fs ${shellQuote(bucketArg)} ${shellQuote(mountPath)} -o ${mountOptions.join(' -o ')}`;
   logger.debug(`${LOG_PREFIX} Mounting S3:`, hasCredentials ? mountCmd.replace(credentialsPath, '***') : mountCmd);
 
   try {

--- a/workspaces/e2b/src/sandbox/mounts/types.ts
+++ b/workspaces/e2b/src/sandbox/mounts/types.ts
@@ -63,9 +63,10 @@ export function validateEndpoint(endpoint: string): void {
 /**
  * Validate and normalize a mount prefix before interpolating into shell commands.
  * Returns the normalized prefix (no leading/trailing slashes).
+ *
+ * Shell safety is handled by shellQuote() at the call site, so this function
+ * only enforces path-level rules (no traversal, no empty result, no control chars).
  */
-const SAFE_PREFIX_PATH = /^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*$/;
-
 export function validatePrefix(prefix: string): string {
   // Trim leading/trailing slashes
   let normalized = prefix;
@@ -78,10 +79,9 @@ export function validatePrefix(prefix: string): string {
   if (normalized.includes('//') || normalized.split('/').some(s => s === '.' || s === '..')) {
     throw new Error(`Invalid mount prefix: "${prefix}". Path traversal is not allowed.`);
   }
-  if (!SAFE_PREFIX_PATH.test(normalized)) {
-    throw new Error(
-      `Invalid mount prefix: "${prefix}". Must contain only alphanumeric characters, hyphens, dots, underscores, and forward slashes.`,
-    );
+  // Block control characters (U+0000–U+001F, U+007F) which are invalid in filesystem paths
+  if (/[\x00-\x1f\x7f]/.test(normalized)) {
+    throw new Error(`Invalid mount prefix: "${prefix}". Control characters are not allowed.`);
   }
   return normalized;
 }

--- a/workspaces/e2b/src/sandbox/mounts/types.ts
+++ b/workspaces/e2b/src/sandbox/mounts/types.ts
@@ -59,3 +59,29 @@ export function validateEndpoint(endpoint: string): void {
     throw new Error(`Invalid endpoint URL: "${endpoint}"`);
   }
 }
+
+/**
+ * Validate and normalize a mount prefix before interpolating into shell commands.
+ * Returns the normalized prefix (no leading/trailing slashes).
+ */
+const SAFE_PREFIX_PATH = /^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*$/;
+
+export function validatePrefix(prefix: string): string {
+  // Trim leading/trailing slashes
+  let normalized = prefix;
+  while (normalized.startsWith('/')) normalized = normalized.slice(1);
+  while (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
+
+  if (!normalized) {
+    throw new Error('Mount prefix cannot be empty after normalization.');
+  }
+  if (normalized.includes('//') || normalized.split('/').some(s => s === '.' || s === '..')) {
+    throw new Error(`Invalid mount prefix: "${prefix}". Path traversal is not allowed.`);
+  }
+  if (!SAFE_PREFIX_PATH.test(normalized)) {
+    throw new Error(
+      `Invalid mount prefix: "${prefix}". Must contain only alphanumeric characters, hyphens, dots, underscores, and forward slashes.`,
+    );
+  }
+  return normalized;
+}

--- a/workspaces/s3/src/filesystem/index.test.ts
+++ b/workspaces/s3/src/filesystem/index.test.ts
@@ -279,6 +279,38 @@ describe('S3Filesystem', () => {
       expect(config1.readOnly).toBeUndefined();
       expect(config2.readOnly).toBeUndefined();
     });
+
+    it('includes prefix if set', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        prefix: 'workspace/data',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBe('workspace/data/');
+    });
+
+    it('excludes prefix if not set', () => {
+      const fs = new S3Filesystem({ bucket: 'test', region: 'us-east-1' });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBeUndefined();
+    });
+
+    it('normalizes prefix with leading/trailing slashes', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        prefix: '/foo/bar/',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBe('foo/bar/');
+    });
   });
 
   describe('getInfo()', () => {

--- a/workspaces/s3/src/filesystem/index.test.ts
+++ b/workspaces/s3/src/filesystem/index.test.ts
@@ -311,6 +311,30 @@ describe('S3Filesystem', () => {
 
       expect(config.prefix).toBe('foo/bar/');
     });
+
+    it('treats prefix "/" as no prefix (root-equivalent)', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        prefix: '/',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBeUndefined();
+    });
+
+    it('treats empty string prefix as no prefix', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        prefix: '',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBeUndefined();
+    });
   });
 
   describe('getInfo()', () => {

--- a/workspaces/s3/src/filesystem/index.ts
+++ b/workspaces/s3/src/filesystem/index.ts
@@ -257,7 +257,8 @@ export class S3Filesystem extends MastraFilesystem {
     this.endpoint = options.endpoint;
     this.forcePathStyle = options.forcePathStyle ?? !!options.endpoint; // Default true for custom endpoints
     // Trim leading/trailing slashes from prefix using iterative approach (avoids polynomial regex)
-    this.prefix = options.prefix ? trimSlashes(options.prefix) + '/' : '';
+    const trimmedPrefix = options.prefix ? trimSlashes(options.prefix) : '';
+    this.prefix = trimmedPrefix ? trimmedPrefix + '/' : '';
 
     // Display metadata - detect icon first, then derive displayName from it
     this.icon = options.icon ?? this.detectIconFromEndpoint(options.endpoint);

--- a/workspaces/s3/src/filesystem/index.ts
+++ b/workspaces/s3/src/filesystem/index.ts
@@ -45,6 +45,12 @@ export interface S3MountConfig extends FilesystemMountConfig {
   secretAccessKey?: string;
   /** AWS session token for temporary credentials (SSO, AssumeRole, container credentials, etc.) */
   sessionToken?: string;
+  /**
+   * Optional prefix (subdirectory) to mount instead of the entire bucket.
+   * Uses s3fs `bucket:/prefix` syntax to scope the mount to a specific path.
+   * Leading/trailing slashes are normalized automatically.
+   */
+  prefix?: string;
   /** Mount as read-only */
   readOnly?: boolean;
 }
@@ -301,6 +307,10 @@ export class S3Filesystem extends MastraFilesystem {
       if (this.sessionToken) {
         config.sessionToken = this.sessionToken;
       }
+    }
+
+    if (this.prefix) {
+      config.prefix = this.prefix;
     }
 
     if (this.readOnly) {


### PR DESCRIPTION
## Description

Added S3 prefix (subdirectory) mount support for sandboxes. Previously, `S3Filesystem` supported `prefix` for SDK-level operations (read/write via API), but `getMountConfig()` dropped it — so FUSE mounts always exposed the entire bucket. Now the `prefix` is passed through to the mount layer, using s3fs's native `bucket:/path` syntax to scope the mount to
a specific subdirectory.

**Example:**

```ts
const fs = new S3Filesystem({
    bucket: 'my-bucket',
    region: 'us-east-1',
    prefix: 'workspace/data',
    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
});
```

When mounted in a sandbox, only the contents under `workspace/data/` will be visible at the mount path.

**Changes across packages:**
- `@mastra/s3` — Added `prefix` to `S3MountConfig`, passed it through in `getMountConfig()`
- `@mastra/daytona` / `@mastra/e2b` / `@mastra/blaxel` — Added `prefix` to each provider's mount config interface, added `validatePrefix()` for shell-safety, and used `bucket:/prefix` syntax in the s3fs mount command

## Related Issue(s)

Fixes #15147

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

You can now mount just a folder inside an S3 bucket into a sandbox instead of the whole bucket, so the sandbox only sees that folder's contents.

## Overview

Propagates an optional S3 prefix from S3Filesystem.getMountConfig() through provider mount logic and uses s3fs's bucket:/path syntax so FUSE mounts are scoped to the specified prefix (subdirectory) rather than exposing the entire bucket.

## Key Changes

- @mastra/s3
  - Added optional prefix?: string to S3MountConfig and S3Filesystem options.
  - S3Filesystem normalizes non-empty prefixes (trims outer slashes, stores with a trailing '/' for key construction) and includes prefix in getMountConfig() when set.

- @mastra/daytona, @mastra/e2b, @mastra/blaxel
  - Added optional prefix?: string to provider mount config interfaces (DaytonaS3MountConfig, E2BS3MountConfig, BlaxelS3MountConfig).
  - Added validatePrefix(prefix: string): string helpers to normalize and validate prefixes for shell safety (trim slashes, disallow empty result, block '.'/'..' segments and '//' sequences, reject control characters).
  - mountS3 computes a bucketArg as bucket:/<normalizedPrefix> when prefix is provided (otherwise uses bucket) and passes that (shell-quoted) to s3fs, so only the specified prefix's contents are visible. Credential resolution, endpoint checks, mount options, and readOnly behavior are unchanged.

## Testing

- workspaces/s3/src/filesystem/index.test.ts: tests for getMountConfig() covering inclusion/omission and normalization of prefix (ensures trailing '/' for non-empty prefixes; treats '/' and '' as no prefix).
- workspaces/blaxel/src/sandbox/index.test.ts and workspaces/e2b/src/sandbox/index.test.ts: added tests asserting the generated s3fs mount command uses the bucket:/prefix form (e.g., test-bucket:/workspace/data).

## Related Issue

Fixes #15147
<!-- end of auto-generated comment: release notes by coderabbit.ai -->