### PR TITLE
fix: import composio example

### DIFF
--- a/docs/src/content/en/docs/editor/tools.mdx
+++ b/docs/src/content/en/docs/editor/tools.mdx
@@ -65,7 +65,7 @@ Integration providers connect external tool platforms to the editor. Once regist
    ```typescript title="src/mastra/index.ts"
    import { Mastra } from '@mastra/core'
    import { MastraEditor } from '@mastra/editor'
-   import { ComposioToolProvider } from '@mastra/editor/providers/composio'
+   import { ComposioToolProvider } from '@mastra/editor/composio'
 
    export const mastra = new Mastra({
      agents: {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR fixes a broken example in the documentation. Someone copying the code from the Composio tools example would have gotten an error because the import statement was pointing to the wrong location. The fix updates the import path so the code example actually works.

## Changes

This PR updates the documentation example for integrating the Composio tool provider with the Mastra editor. The import statement for `ComposioToolProvider` has been corrected to import from `@mastra/editor/composio` instead of the incorrect path, ensuring the code example matches the actual library structure.

**File modified:**
- `docs/src/content/en/docs/editor/tools.mdx`

The change ensures that developers following the documentation will have a working code example when setting up Composio integration with their Mastra editor configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->