### PR TITLE
Add 401 and 403 error handling in Logs page

### DIFF
--- a/.changeset/logs-error-handling.md
+++ b/.changeset/logs-error-handling.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Added 401 and 403 error handling to the Logs page for session expired and permission denied states

--- a/packages/playground/src/pages/logs/index.tsx
+++ b/packages/playground/src/pages/logs/index.tsx
@@ -6,6 +6,10 @@ import {
   isValidLogsDatePreset,
   useLogsFilters,
   EntityListPageLayout,
+  PermissionDenied,
+  SessionExpired,
+  is403ForbiddenError,
+  is401UnauthorizedError,
 } from '@mastra/playground-ui';
 import { LogsIcon } from 'lucide-react';
 import { useMemo, useCallback } from 'react';
@@ -100,6 +104,44 @@ export default function Logs() {
     updateFilterGroups,
     filteredLogs,
   } = useLogsFilters(logs as LogRecord[]);
+
+  if (logsError && is401UnauthorizedError(logsError)) {
+    return (
+      <EntityListPageLayout>
+        <EntityListPageLayout.Top>
+          <MainHeader withMargins={false}>
+            <MainHeader.Column>
+              <MainHeader.Title>
+                <LogsIcon /> Logs
+              </MainHeader.Title>
+            </MainHeader.Column>
+          </MainHeader>
+        </EntityListPageLayout.Top>
+        <div className="flex h-full items-center justify-center">
+          <SessionExpired />
+        </div>
+      </EntityListPageLayout>
+    );
+  }
+
+  if (logsError && is403ForbiddenError(logsError)) {
+    return (
+      <EntityListPageLayout>
+        <EntityListPageLayout.Top>
+          <MainHeader withMargins={false}>
+            <MainHeader.Column>
+              <MainHeader.Title>
+                <LogsIcon /> Logs
+              </MainHeader.Title>
+            </MainHeader.Column>
+          </MainHeader>
+        </EntityListPageLayout.Top>
+        <div className="flex h-full items-center justify-center">
+          <PermissionDenied resource="logs" />
+        </div>
+      </EntityListPageLayout>
+    );
+  }
 
   return (
     <EntityListPageLayout className="max-w-none">


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Added 401 and 403 error handling to the Logs page for session expired and permission denied states

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When you try to view the Logs page but your session has expired or you don't have permission to view logs, the page now shows a helpful error message instead of breaking or showing nothing.

---

## Changes

### Changesets
- Added `.changeset/logs-error-handling.md`: A patch release entry documenting the addition of 401 and 403 error handling to the Logs page.

### Logs Page Error Handling
Updated `packages/playground/src/pages/logs/index.tsx` to display user-friendly error states:
- **401 Unauthorized**: Renders a "SessionExpired" message when the user's session has expired
- **403 Forbidden**: Renders a "PermissionDenied" message with `resource="logs"` when the user lacks permission to access logs

These error-specific UI states are rendered early in the component lifecycle, preventing the normal log list interface from appearing when authorization checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->