### PR TITLE
Update Evaluation page headers

### DIFF
--- a/.changeset/evaluation-header-docs.md
+++ b/.changeset/evaluation-header-docs.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Added documentation links to Evaluation page header for datasets, scorers, and experiments tabs. Moved Create Dataset button to header and simplified toolbar layout.

--- a/packages/playground/src/pages/evaluation/index.tsx
+++ b/packages/playground/src/pages/evaluation/index.tsx
@@ -99,6 +99,7 @@ export default function Evaluation() {
                   href="https://mastra.ai/en/docs/evals/datasets/overview"
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="Datasets documentation"
                   tooltipContent="Go to Datasets documentation"
                 >
                   <BookIcon />
@@ -114,6 +115,7 @@ export default function Evaluation() {
                 href="https://mastra.ai/en/docs/evals/overview"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Scorers documentation"
                 tooltipContent="Go to Scorers documentation"
               >
                 <BookIcon />
@@ -125,6 +127,7 @@ export default function Evaluation() {
                 href="https://mastra.ai/en/docs/evals/datasets/running-experiments"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Experiments documentation"
                 tooltipContent="Go to Experiments documentation"
               >
                 <BookIcon />

--- a/packages/playground/src/pages/evaluation/index.tsx
+++ b/packages/playground/src/pages/evaluation/index.tsx
@@ -14,9 +14,10 @@ import {
   MainHeader,
   SelectFieldBlock,
   useEvaluationDatasets,
+  ButtonWithTooltip,
 } from '@mastra/playground-ui';
 import type { EvaluationTab } from '@mastra/playground-ui';
-import { BeakerIcon, DatabaseIcon, FlaskConicalIcon, Plus, TestTubeDiagonalIcon, XIcon } from 'lucide-react';
+import { BeakerIcon, BookIcon, DatabaseIcon, FlaskConicalIcon, Plus, TestTubeDiagonalIcon, XIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
@@ -90,6 +91,46 @@ export default function Evaluation() {
               {headerIcon} {headerLabel}
             </MainHeader.Title>
           </MainHeader.Column>
+          <MainHeader.Column>
+            {activeTab === 'datasets' && (
+              <ButtonsGroup>
+                <ButtonWithTooltip
+                  as="a"
+                  href="https://mastra.ai/en/docs/evals/datasets/overview"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  tooltipContent="Go to Datasets documentation"
+                >
+                  <BookIcon />
+                </ButtonWithTooltip>
+                <Button onClick={() => setIsCreateDialogOpen(true)}>
+                  <Plus className="size-4" /> Create Dataset
+                </Button>
+              </ButtonsGroup>
+            )}
+            {activeTab === 'scorers' && (
+              <ButtonWithTooltip
+                as="a"
+                href="https://mastra.ai/en/docs/evals/overview"
+                target="_blank"
+                rel="noopener noreferrer"
+                tooltipContent="Go to Scorers documentation"
+              >
+                <BookIcon />
+              </ButtonWithTooltip>
+            )}
+            {activeTab === 'experiments' && (
+              <ButtonWithTooltip
+                as="a"
+                href="https://mastra.ai/en/docs/evals/datasets/running-experiments"
+                target="_blank"
+                rel="noopener noreferrer"
+                tooltipContent="Go to Experiments documentation"
+              >
+                <BookIcon />
+              </ButtonWithTooltip>
+            )}
+          </MainHeader.Column>
         </MainHeader>
 
         {activeTab === 'scorers' && (
@@ -115,49 +156,44 @@ export default function Evaluation() {
         )}
 
         {activeTab === 'datasets' && (
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="flex flex-wrap items-center gap-2">
-              <ListSearch label="Search datasets" placeholder="Filter by dataset name" onSearch={setDatasetsSearch} />
-              <ButtonsGroup>
+          <div className="flex flex-wrap items-center  gap-2">
+            <ListSearch label="Search datasets" placeholder="Filter by dataset name" onSearch={setDatasetsSearch} />
+            <ButtonsGroup>
+              <SelectFieldBlock
+                label="Target"
+                labelIsHidden
+                name="filter-target"
+                options={[...EVALUATION_DATASET_TARGET_OPTIONS]}
+                value={datasetsTargetFilter}
+                onValueChange={setDatasetsTargetFilter}
+                className="whitespace-nowrap"
+              />
+              <SelectFieldBlock
+                label="Experiments"
+                labelIsHidden
+                name="filter-experiments"
+                options={[...EVALUATION_DATASET_EXPERIMENT_OPTIONS]}
+                value={datasetsExperimentFilter}
+                onValueChange={setDatasetsExperimentFilter}
+                className="whitespace-nowrap"
+              />
+              {datasetTagOptions.length > 1 && (
                 <SelectFieldBlock
-                  label="Target"
+                  label="Tags"
                   labelIsHidden
-                  name="filter-target"
-                  options={[...EVALUATION_DATASET_TARGET_OPTIONS]}
-                  value={datasetsTargetFilter}
-                  onValueChange={setDatasetsTargetFilter}
+                  name="filter-tags"
+                  options={datasetTagOptions}
+                  value={datasetsTagFilter}
+                  onValueChange={setDatasetsTagFilter}
                   className="whitespace-nowrap"
                 />
-                <SelectFieldBlock
-                  label="Experiments"
-                  labelIsHidden
-                  name="filter-experiments"
-                  options={[...EVALUATION_DATASET_EXPERIMENT_OPTIONS]}
-                  value={datasetsExperimentFilter}
-                  onValueChange={setDatasetsExperimentFilter}
-                  className="whitespace-nowrap"
-                />
-                {datasetTagOptions.length > 1 && (
-                  <SelectFieldBlock
-                    label="Tags"
-                    labelIsHidden
-                    name="filter-tags"
-                    options={datasetTagOptions}
-                    value={datasetsTagFilter}
-                    onValueChange={setDatasetsTagFilter}
-                    className="whitespace-nowrap"
-                  />
-                )}
-                {hasDatasetFilters && (
-                  <Button onClick={resetDatasetFilters} size="sm" variant="light">
-                    <XIcon className="size-3" /> Reset
-                  </Button>
-                )}
-              </ButtonsGroup>
-            </div>
-            <Button variant="primary" size="sm" onClick={() => setIsCreateDialogOpen(true)}>
-              <Plus className="size-4" /> Create Dataset
-            </Button>
+              )}
+              {hasDatasetFilters && (
+                <Button onClick={resetDatasetFilters} size="sm" variant="light">
+                  <XIcon className="size-3" /> Reset
+                </Button>
+              )}
+            </ButtonsGroup>
           </div>
         )}
 
@@ -197,7 +233,7 @@ export default function Evaluation() {
         )}
       </EntityListPageLayout.Top>
 
-      <div className="overflow-y-auto px-4 pt-2">
+      <div className="overflow-y-auto pt-2">
         <EvaluationDashboard
           activeTab={activeTab}
           scorerSearch={scorersSearch}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

- add links to docs
- move Create Dataset to header

<img width="1209" height="191" alt="CleanShot 2026-04-08 at 15 32 36" src="https://github.com/user-attachments/assets/f5806d42-70ea-4ae5-a2fd-6d28918cc214" />

<img width="1213" height="179" alt="CleanShot 2026-04-08 at 15 32 24" src="https://github.com/user-attachments/assets/06fe1d5f-c53b-417f-a10c-472b91bf71cf" />

<img width="1215" height="194" alt="CleanShot 2026-04-08 at 15 32 46" src="https://github.com/user-attachments/assets/154a4a1f-c499-4d7d-bc56-e452014f7934" />

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR cleans up the Evaluation pages by adding quick documentation links in the header for each tab and moving the "Create Dataset" button into the main header so it's easier to find; it also streamlines the filter toolbar layout.

## Changes

### `.changeset/evaluation-header-docs.md`
- Added a changeset entry (patch) documenting:
  - Documentation links added to the Evaluation page header (datasets, scorers, experiments).
  - "Create Dataset" button moved into the header and toolbar layout simplified.

### `packages/playground/src/pages/evaluation/index.tsx`
- Header:
  - Added tab-specific documentation links (ButtonWithTooltip wrapping BookIcon) for datasets, scorers, and experiments.
  - Moved the "Create Dataset" action (Button + Plus) into the main header column when the datasets tab is active.
- Filters / Toolbar:
  - Removed the separate two-column justify-between layout in favor of a grouped row for filter controls.
  - Added an "Experiments" SelectFieldBlock (datasetsExperimentFilter) to the datasets filter row alongside Target and conditional Tags.
  - Kept conditional Reset buttons per tab (scorers, datasets, experiments) based on active filters.
- Layout:
  - Removed horizontal padding from the scrollable dashboard container (now div with class "overflow-y-auto pt-2").
- State / Utilities:
  - Introduced datasetsExperimentFilter state and related reset/hasFilters logic.
  - Added memoized dataset/experiment options and tag options usage.

These changes make the header more consistent across tabs, surface documentation links, and simplify dataset toolbar controls while keeping existing filtering capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->