### PR TITLE
fix(inngest): add entityName to workflow span creation

### DIFF
--- a/.changeset/inngest-workflow-entityname.md
+++ b/.changeset/inngest-workflow-entityname.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Add `entityName` to workflow span creation in the Inngest workflow engine, parallel to the core fix in #14949. Without this, workflows created via `init(inngest).createWorkflow({...})` show up as "unknown" in the metrics dashboard's workflow trace volume tab even when they have an explicit `id`.

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -279,6 +279,7 @@ export class InngestWorkflow<
             name: `workflow run: '${this.id}'`,
             entityType: EntityType.WORKFLOW_RUN,
             entityId: this.id,
+            entityName: this.id,
             input: inputData,
             metadata: {
               resourceId,


### PR DESCRIPTION
## Summary

Workflows created via `init(inngest).createWorkflow({...})` were missing `entityName` on their root span. This caused the metrics dashboard's workflow trace volume tab to show "unknown" for every Inngest-orchestrated workflow, even when the workflow had an explicit `id`.

This is the parallel of #14949, which fixed the same omission across the 4 call sites in `packages/core/src/workflows/workflow.ts` but missed the Inngest implementation at `workflows/inngest/src/workflow.ts:277-290`.

## Fix

One-line addition: `entityName: this.id,` on the `observability.startSpan({...})` call, mirroring how core sets `entityName: this.workflowId`.

## Test plan

- [ ] Existing inngest workflow tests pass
- [ ] Manual: an `init(inngest).createWorkflow({ id: 'my-workflow', ... })` run shows up as `my-workflow` instead of `unknown` in the metrics dashboard's workflow trace volume tab

Closes #15181

---

*This PR was authored by Claude (Anthropic's AI assistant) on behalf of @raulpineda.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When you create a workflow using Inngest, the system tracks it for metrics and dashboards. But the tracking was forgetting to include the workflow's name/ID, so dashboards showed "unknown" instead. This PR adds that missing piece so dashboards correctly display the workflow name.

## Changes Made

### Core Fix
Added `entityName: this.id` to the workflow root span creation in `workflows/inngest/src/workflow.ts`. This single-line change ensures that Inngest-orchestrated workflows include the entity name field in their observability span, matching the behavior already implemented in core workflow processing (from #14949).

### Changelog
Added `.changeset/inngest-workflow-entityname.md` documenting the `@mastra/inngest` patch release that introduces `entityName` support for workflow spans.

## Motivation

Workflows created via `init(inngest).createWorkflow({...})` with an explicit `id` were appearing as "unknown" in the metrics dashboard's "workflow trace volume" tab. The root cause was that the Inngest workflow implementation was missing the `entityName` field when starting the root span, even though core workflows had already been fixed for this issue in #14949.

## Impact

- **Metrics dashboards** will now correctly display Inngest workflow IDs instead of "unknown"
- Aligns Inngest implementation with core workflow observability behavior
- No changes to workflow execution logic, error handling, or event publishing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->