### PR TITLE
docs(editor): document programmatic control and reorder Editor tab

### DIFF
--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -71,9 +71,9 @@ Modify the system prompt and save a new draft version. Afterwards, publish the d
 
 ## Programmatic control
 
-Everything you can do in Studio is also available programmatically through `mastra.getEditor()`. This is useful for scripting bulk updates, seeding stored configurations from code, or building automation that tunes agents based on evaluation results.
+Everything you can do in Studio is also available programmatically through [`mastra.getEditor()`](/reference/core/getEditor). This is useful for scripting bulk updates, seeding stored configurations from code, or building automation that tunes agents based on evaluation results.
 
-Call `mastra.getEditor()` from anywhere you have access to the `Mastra` instance. It returns the `MastraEditor` instance you registered, with namespaces for each resource type:
+Call [`mastra.getEditor()`](/reference/core/getEditor) from anywhere you have access to the `Mastra` instance. It returns the `MastraEditor` instance you registered, with namespaces for each resource type:
 
 ```typescript title="src/scripts/seed-agent.ts"
 import { mastra } from '../mastra'

--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -73,7 +73,7 @@ Modify the system prompt and save a new draft version. Afterwards, publish the d
 
 Everything you can do in Studio is also available programmatically through [`mastra.getEditor()`](/reference/core/getEditor). This is useful for scripting bulk updates, seeding stored configurations from code, or building automation that tunes agents based on evaluation results.
 
-Call [`mastra.getEditor()`](/reference/core/getEditor) from anywhere you have access to the `Mastra` instance. It returns the `MastraEditor` instance you registered, with namespaces for each resource type:
+Call `mastra.getEditor()` from anywhere you have access to the `Mastra` instance. It returns the `MastraEditor` instance you registered, with namespaces for each resource type:
 
 ```typescript title="src/scripts/seed-agent.ts"
 import { mastra } from '../mastra'
@@ -119,7 +119,7 @@ The same operations are available over HTTP through the Mastra server. Use these
 | `PATCH` | `/stored/agents/:storedAgentId` | Update a stored agent. |
 | `DELETE` | `/stored/agents/:storedAgentId` | Delete a stored agent. |
 
-The Client SDK wraps these endpoints with `client.listStoredAgents()`, `client.createStoredAgent()`, and `client.getStoredAgent()`. Version management endpoints live under `/stored/agents/:storedAgentId/versions` — see [Version management](/reference/client-js/agents#version-management) for the full list.
+The Client SDK wraps these endpoints with `client.listStoredAgents()`, `client.createStoredAgent()`, and `client.getStoredAgent()`. Version management endpoints live under `/stored/agents/:storedAgentId/versions`, see [version management](/reference/client-js/agents#version-management) for the full list.
 
 ### Automated experimentation
 

--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -107,6 +107,20 @@ await editor.agent.update({
 
 The `editor.agent` namespace also exposes `getById`, `list`, `listResolved`, and `delete`. The `editor.prompt` namespace exposes the same CRUD methods for prompt blocks. See [Prompts](/docs/editor/prompts#programmatic-control) for examples.
 
+### Server endpoints
+
+The same operations are available over HTTP through the Mastra server. Use these when you want to manage stored agents from a separate service or from a non-TypeScript client:
+
+| Method | Path | Description |
+| - | - | - |
+| `GET` | `/stored/agents` | List all stored agents. |
+| `POST` | `/stored/agents` | Create a stored agent. |
+| `GET` | `/stored/agents/:storedAgentId` | Get a stored agent by ID. |
+| `PATCH` | `/stored/agents/:storedAgentId` | Update a stored agent. |
+| `DELETE` | `/stored/agents/:storedAgentId` | Delete a stored agent. |
+
+The Client SDK wraps these endpoints with `client.listStoredAgents()`, `client.createStoredAgent()`, and `client.getStoredAgent()`. Version management endpoints live under `/stored/agents/:storedAgentId/versions` — see [Version management](/reference/client-js/agents#version-management) for the full list.
+
 ### Automated experimentation
 
 Because stored agents are just data, you can build automation loops that tune agents without human involvement. A common pattern is to pair the editor API with [datasets](/docs/evals/datasets/overview) and [experiments](/docs/evals/datasets/running-experiments):

--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -69,6 +69,62 @@ Go to the **Agents** tab in Studio and select an agent to edit. Select the **Edi
 
 Modify the system prompt and save a new draft version. Afterwards, publish the draft to make it the active version.
 
+## Programmatic control
+
+Everything you can do in Studio is also available programmatically through `mastra.getEditor()`. This is useful for scripting bulk updates, seeding stored configurations from code, or building automation that tunes agents based on evaluation results.
+
+Call `mastra.getEditor()` from anywhere you have access to the `Mastra` instance. It returns the `MastraEditor` instance you registered, with namespaces for each resource type:
+
+```typescript title="src/scripts/seed-agent.ts"
+import { mastra } from '../mastra'
+
+const editor = mastra.getEditor()
+if (!editor) throw new Error('Editor is not registered on Mastra')
+
+// Create a stored agent override for an existing code-defined agent
+await editor.agent.create({
+  id: 'support-agent',
+  instructions: 'You are a friendly support agent for Acme Inc.',
+  tools: {
+    search_kb: { description: 'Search the Acme knowledge base' },
+  },
+})
+```
+
+Use `editor.agent.update()` to change an existing stored configuration. Every update creates a new draft version automatically:
+
+```typescript title="src/scripts/update-agent.ts"
+import { mastra } from '../mastra'
+
+const editor = mastra.getEditor()!
+
+await editor.agent.update({
+  id: 'support-agent',
+  instructions:
+    "You are a friendly support agent for Acme Inc. Always respond in the user's language.",
+})
+```
+
+The `editor.agent` namespace also exposes `getById`, `list`, `listResolved`, and `delete`. The `editor.prompt` namespace exposes the same CRUD methods for prompt blocks. See [Prompts](/docs/editor/prompts#programmatic-control) for examples.
+
+### Automated experimentation
+
+Because stored agents are just data, you can build automation loops that tune agents without human involvement. A common pattern is to pair the editor API with [datasets](/docs/evals/datasets/overview) and [experiments](/docs/evals/datasets/running-experiments):
+
+- Run a dataset through the current version of an agent and score the results.
+- Have another agent read the failing cases and propose changes to the instructions or tools.
+- Apply those changes with `editor.agent.update()` to create a new draft.
+- Re-run the experiment against the draft and compare scores to the baseline.
+- Promote the draft to the published version when the scores improve.
+
+This turns agent tuning into a closed feedback loop. One agent owns the production configuration, another agent iterates on it, and every change is versioned so you can roll back if a round of automated edits makes things worse. Combine this with [version targeting](#version-targeting-and-experimentation) to keep production traffic on the published version while the draft is being tested.
+
+:::note
+
+See the [MastraEditor reference](/reference/editor/mastra-editor) for the full namespace API.
+
+:::
+
 ## What can be overridden
 
 When you edit a code-defined agent through the editor, only specific fields can be changed:

--- a/docs/src/content/en/docs/editor/prompts.mdx
+++ b/docs/src/content/en/docs/editor/prompts.mdx
@@ -67,6 +67,63 @@ Rule groups can be nested, so you can combine AND and OR conditions for complex 
 
 In the Studio, open a block's **Display conditions** panel to set up rules visually. You can also configure conditions programmatically through the API. Blocks without conditions are always included.
 
+## Programmatic control
+
+Prompt blocks can be managed from code through `mastra.getEditor().prompt`. This is useful for seeding a set of starter prompts, syncing blocks between environments, or generating prompt variants from a script.
+
+Create a new prompt block with `editor.prompt.create()`:
+
+```typescript title="src/scripts/seed-prompts.ts"
+import { mastra } from '../mastra'
+
+const editor = mastra.getEditor()!
+
+await editor.prompt.create({
+  id: 'brand-voice',
+  name: 'Brand voice',
+  description: 'Acme Inc. tone and style guidelines',
+  content:
+    'You write in a friendly, concise tone. Always address the user as {{userName || "there"}}.',
+})
+```
+
+Update an existing block with `editor.prompt.update()`. Each update creates a new draft version:
+
+```typescript title="src/scripts/update-prompt.ts"
+import { mastra } from '../mastra'
+
+const editor = mastra.getEditor()!
+
+await editor.prompt.update({
+  id: 'brand-voice',
+  content: 'You write in a friendly, concise tone. Always greet the user by name when available.',
+})
+```
+
+Use `editor.prompt.list()` to paginate through stored blocks or `editor.prompt.getById()` to fetch a specific block. To preview an agent's full instructions with a set of prompt blocks applied, call `editor.prompt.preview()` with the draft content.
+
+Once a prompt block is created, reference it from an agent's `instructions` field as a `prompt_block_ref`:
+
+```typescript title="src/scripts/attach-prompt.ts"
+import { mastra } from '../mastra'
+
+const editor = mastra.getEditor()!
+
+await editor.agent.update({
+  id: 'support-agent',
+  instructions: [
+    { type: 'prompt_block_ref', id: 'brand-voice' },
+    { type: 'text', content: 'Answer only questions about Acme products.' },
+  ],
+})
+```
+
+:::note
+
+See the [MastraEditor reference](/reference/editor/mastra-editor) for the full `editor.prompt` API.
+
+:::
+
 ## Versioning
 
 Prompt blocks follow the same [versioning lifecycle](/docs/editor/overview#versioning) as agents. Each prompt block has a draft that you can edit and publish as a versioned snapshot. This means prompt content can be versioned and rolled back independently from the agent that uses it.

--- a/docs/src/content/en/docs/editor/prompts.mdx
+++ b/docs/src/content/en/docs/editor/prompts.mdx
@@ -69,7 +69,7 @@ In the Studio, open a block's **Display conditions** panel to set up rules visua
 
 ## Programmatic control
 
-Prompt blocks can be managed from code through `mastra.getEditor().prompt`. This is useful for seeding a set of starter prompts, syncing blocks between environments, or generating prompt variants from a script.
+Prompt blocks can be managed from code through [`mastra.getEditor()`](/reference/core/getEditor)`.prompt`. This is useful for seeding a set of starter prompts, syncing blocks between environments, or generating prompt variants from a script.
 
 Create a new prompt block with `editor.prompt.create()`:
 

--- a/docs/src/content/en/docs/editor/prompts.mdx
+++ b/docs/src/content/en/docs/editor/prompts.mdx
@@ -69,7 +69,7 @@ In the Studio, open a block's **Display conditions** panel to set up rules visua
 
 ## Programmatic control
 
-Prompt blocks can be managed from code through [`mastra.getEditor()`](/reference/core/getEditor)`.prompt`. This is useful for seeding a set of starter prompts, syncing blocks between environments, or generating prompt variants from a script.
+Prompt blocks can be managed from code through [`mastra.getEditor().prompt`](/reference/editor/mastra-editor#namespaces). This is useful for seeding a set of starter prompts, syncing blocks between environments, or generating prompt variants from a script.
 
 Create a new prompt block with `editor.prompt.create()`:
 
@@ -130,7 +130,7 @@ await editor.agent.update({
 
 :::note
 
-See the [MastraEditor reference](/reference/editor/mastra-editor) for the full `editor.prompt` API.
+See the [MastraEditor reference](/reference/editor/mastra-editor#namespaces) for the full `editor.prompt` API.
 
 :::
 

--- a/docs/src/content/en/docs/editor/prompts.mdx
+++ b/docs/src/content/en/docs/editor/prompts.mdx
@@ -102,6 +102,16 @@ await editor.prompt.update({
 
 Use `editor.prompt.list()` to paginate through stored blocks or `editor.prompt.getById()` to fetch a specific block. To preview an agent's full instructions with a set of prompt blocks applied, call `editor.prompt.preview()` with the draft content.
 
+The same operations are available over HTTP through the Mastra server:
+
+| Method | Path | Description |
+| - | - | - |
+| `GET` | `/stored/prompt-blocks` | List all stored prompt blocks. |
+| `POST` | `/stored/prompt-blocks` | Create a stored prompt block. |
+| `GET` | `/stored/prompt-blocks/:storedPromptBlockId` | Get a stored prompt block by ID. |
+| `PATCH` | `/stored/prompt-blocks/:storedPromptBlockId` | Update a stored prompt block. |
+| `DELETE` | `/stored/prompt-blocks/:storedPromptBlockId` | Delete a stored prompt block. |
+
 Once a prompt block is created, reference it from an agent's `instructions` field as a `prompt_block_ref`:
 
 ```typescript title="src/scripts/attach-prompt.ts"

--- a/docs/src/content/en/docs/editor/tools.mdx
+++ b/docs/src/content/en/docs/editor/tools.mdx
@@ -65,7 +65,7 @@ Integration providers connect external tool platforms to the editor. Once regist
    ```typescript title="src/mastra/index.ts"
    import { Mastra } from '@mastra/core'
    import { MastraEditor } from '@mastra/editor'
-   import { ComposioToolProvider } from '@mastra/editor/providers/composio'
+   import { ComposioToolProvider } from '@mastra/editor/composio'
 
    export const mastra = new Mastra({
      agents: {
@@ -94,7 +94,7 @@ Integration providers connect external tool platforms to the editor. Once regist
    ```typescript title="src/mastra/index.ts"
    import { Mastra } from '@mastra/core'
    import { MastraEditor } from '@mastra/editor'
-   import { ArcadeToolProvider } from '@mastra/editor/providers/arcade'
+   import { ArcadeToolProvider } from '@mastra/editor/arcade'
 
    export const mastra = new Mastra({
      agents: {

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -44,30 +44,6 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Editor',
-      customProps: {
-        tags: ['new'],
-      },
-      items: [
-        {
-          type: 'doc',
-          id: 'editor/overview',
-          label: 'Overview',
-        },
-        {
-          type: 'doc',
-          id: 'editor/tools',
-          label: 'Tools',
-        },
-        {
-          type: 'doc',
-          id: 'editor/prompts',
-          label: 'Prompts',
-        },
-      ],
-    },
-    {
-      type: 'category',
       label: 'Agents',
       items: [
         {
@@ -228,6 +204,30 @@ const sidebars = {
           type: 'doc',
           id: 'workflows/error-handling',
           label: 'Error Handling',
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Editor',
+      customProps: {
+        tags: ['new'],
+      },
+      items: [
+        {
+          type: 'doc',
+          id: 'editor/overview',
+          label: 'Overview',
+        },
+        {
+          type: 'doc',
+          id: 'editor/tools',
+          label: 'Tools',
+        },
+        {
+          type: 'doc',
+          id: 'editor/prompts',
+          label: 'Prompts',
         },
       ],
     },

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -44,6 +44,32 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Studio',
+      items: [
+        {
+          type: 'doc',
+          id: 'studio/overview',
+          label: 'Overview',
+        },
+        {
+          type: 'doc',
+          id: 'studio/deployment',
+          label: 'Deployment',
+        },
+        {
+          type: 'doc',
+          id: 'studio/auth',
+          label: 'Auth',
+        },
+        {
+          type: 'doc',
+          id: 'studio/observability',
+          label: 'Observability',
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Agents',
       items: [
         {
@@ -228,32 +254,6 @@ const sidebars = {
           type: 'doc',
           id: 'editor/prompts',
           label: 'Prompts',
-        },
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Studio',
-      items: [
-        {
-          type: 'doc',
-          id: 'studio/overview',
-          label: 'Overview',
-        },
-        {
-          type: 'doc',
-          id: 'studio/deployment',
-          label: 'Deployment',
-        },
-        {
-          type: 'doc',
-          id: 'studio/auth',
-          label: 'Auth',
-        },
-        {
-          type: 'doc',
-          id: 'studio/observability',
-          label: 'Observability',
         },
       ],
     },

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -44,32 +44,6 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Studio',
-      items: [
-        {
-          type: 'doc',
-          id: 'studio/overview',
-          label: 'Overview',
-        },
-        {
-          type: 'doc',
-          id: 'studio/deployment',
-          label: 'Deployment',
-        },
-        {
-          type: 'doc',
-          id: 'studio/auth',
-          label: 'Auth',
-        },
-        {
-          type: 'doc',
-          id: 'studio/observability',
-          label: 'Observability',
-        },
-      ],
-    },
-    {
-      type: 'category',
       label: 'Editor',
       customProps: {
         tags: ['new'],
@@ -254,6 +228,32 @@ const sidebars = {
           type: 'doc',
           id: 'workflows/error-handling',
           label: 'Error Handling',
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Studio',
+      items: [
+        {
+          type: 'doc',
+          id: 'studio/overview',
+          label: 'Overview',
+        },
+        {
+          type: 'doc',
+          id: 'studio/deployment',
+          label: 'Deployment',
+        },
+        {
+          type: 'doc',
+          id: 'studio/auth',
+          label: 'Auth',
+        },
+        {
+          type: 'doc',
+          id: 'studio/observability',
+          label: 'Observability',
         },
       ],
     },

--- a/docs/src/content/en/reference/core/getEditor.mdx
+++ b/docs/src/content/en/reference/core/getEditor.mdx
@@ -1,0 +1,51 @@
+---
+title: "Reference: Mastra.getEditor() | Core"
+description: "Documentation for the `Mastra.getEditor()` method in Mastra, which retrieves the configured editor instance."
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+---
+
+# Mastra.getEditor()
+
+The `.getEditor()` method is used to retrieve the editor instance that has been configured on the Mastra instance. The editor exposes CRUD namespaces for managing stored agents, prompt blocks, MCP clients, scorers, skills, and workspaces programmatically.
+
+## Usage example
+
+```typescript
+import { Mastra } from '@mastra/core'
+import { MastraEditor } from '@mastra/editor'
+
+const mastra = new Mastra({
+  editor: new MastraEditor(),
+})
+
+const editor = mastra.getEditor()
+
+const agent = await editor?.agent.create({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: 'Help customers with their questions.',
+})
+```
+
+## Parameters
+
+This method doesn't accept any parameters.
+
+## Returns
+
+<PropertiesTable
+  content={[
+  {
+    name: 'editor',
+    type: 'MastraEditor | undefined',
+    description: 'The configured editor instance, or undefined if no editor has been configured.',
+  },
+]}
+/>
+
+## Related
+
+- [Editor overview](/docs/editor/overview)
+- [MastraEditor reference](/reference/editor/mastra-editor)

--- a/docs/src/content/en/reference/editor/mastra-editor.mdx
+++ b/docs/src/content/en/reference/editor/mastra-editor.mdx
@@ -88,7 +88,9 @@ export const mastra = new Mastra({
 
 ## Namespaces
 
-The editor exposes namespaces for managing different entity types. These are used by the Mastra server and Studio — you don't call them directly in application code.
+The editor exposes namespaces for managing different entity types. Access them from any Mastra instance with `mastra.getEditor()` and call the CRUD methods directly in application code, or rely on the Mastra server routes that use them under the hood.
+
+All namespaces extend a shared CRUD base class, so they expose the same `create`, `getById`, `update`, `delete`, `list`, `listResolved`, and `clearCache` methods. The namespace-specific property tables below also document any additional methods.
 
 <PropertiesTable
   content={[
@@ -97,27 +99,262 @@ The editor exposes namespaces for managing different entity types. These are use
     type: 'EditorAgentNamespace',
     description:
       'CRUD operations and version management for stored agents. Handles applying stored overrides to code-defined agents.',
+    properties: [
+      {
+        type: 'EditorAgentNamespace',
+        parameters: [
+          {
+            name: 'create',
+            type: '(input: StorageCreateAgentInput) => Promise<Agent>',
+            description:
+              'Create a new stored agent and return a hydrated Agent instance. Accepts an id, authorId, metadata, and the initial snapshot (name, description, instructions, model, tools, memory, and so on).',
+          },
+          {
+            name: 'getById',
+            type: '(id: string, options?: GetByIdOptions) => Promise<Agent | null>',
+            description:
+              'Return a hydrated Agent instance for a stored agent. Pass options with versionId, versionNumber, or status ("draft" | "published" | "archived") to target a specific version. Default version requests are cached.',
+          },
+          {
+            name: 'update',
+            type: '(input: StorageUpdateAgentInput) => Promise<Agent>',
+            description:
+              'Partially update a stored agent. Creates a new draft version with the provided snapshot fields (instructions, tools, memory, and so on) and invalidates the cache. Set memory to null to disable memory.',
+          },
+          {
+            name: 'delete',
+            type: '(id: string) => Promise<void>',
+            description: 'Delete a stored agent and remove it from the Mastra runtime registry.',
+          },
+          {
+            name: 'list',
+            type: '(args?: StorageListAgentsInput) => Promise<StorageListAgentsOutput>',
+            description:
+              'List stored agents with optional pagination, orderBy, authorId, and metadata filters. Returns raw stored snapshots.',
+          },
+          {
+            name: 'listResolved',
+            type: '(args?: StorageListAgentsInput) => Promise<StorageListAgentsResolvedOutput>',
+            description: 'Same as list, but returns fully resolved configurations with references dereferenced.',
+          },
+          {
+            name: 'applyStoredOverrides',
+            type: '(agent: Agent, options?: { versionId?: string; status?: "draft" | "published" }) => Promise<Agent>',
+            description:
+              'Mutate a code-defined agent in place to apply any stored overrides (instructions, tools, variables). Called internally by mastra.getAgent() — you rarely call it directly.',
+          },
+          {
+            name: 'clone',
+            type: '(agent: Agent, options: { newId: string; newName?: string; metadata?: Record<string, unknown>; authorId?: string; requestContext?: RequestContext; }) => Promise<Agent>',
+            description: 'Create a new stored agent by cloning an existing agent.',
+          },
+          {
+            name: 'clearCache',
+            type: '(agentId?: string) => void',
+            description: 'Clear the in-memory cache for one agent or all agents. Called automatically after mutations.',
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'prompt',
     type: 'EditorPromptNamespace',
     description:
       'CRUD operations for prompt blocks. Includes a preview method for resolving instruction blocks with draft content.',
+    properties: [
+      {
+        type: 'EditorPromptNamespace',
+        parameters: [
+          {
+            name: 'create',
+            type: '(input: StorageCreatePromptBlockInput) => Promise<StorageResolvedPromptBlockType>',
+            description:
+              'Create a new stored prompt block. Accepts an id, authorId, metadata, and the initial snapshot (name, description, content, rules, requestContextSchema).',
+          },
+          {
+            name: 'getById',
+            type: '(id: string, options?: GetByIdOptions) => Promise<StorageResolvedPromptBlockType | null>',
+            description: 'Return a resolved prompt block. Pass options to target a specific version or status.',
+          },
+          {
+            name: 'update',
+            type: '(input: StorageUpdatePromptBlockInput) => Promise<StorageResolvedPromptBlockType>',
+            description:
+              'Partially update a stored prompt block. Creates a new draft version with the provided snapshot fields.',
+          },
+          {
+            name: 'delete',
+            type: '(id: string) => Promise<void>',
+            description: 'Delete a stored prompt block and remove it from the Mastra runtime registry.',
+          },
+          {
+            name: 'list',
+            type: '(args?: StorageListPromptBlocksInput) => Promise<StorageListPromptBlocksOutput>',
+            description:
+              'List stored prompt blocks with optional pagination, orderBy, authorId, metadata, and status filters.',
+          },
+          {
+            name: 'listResolved',
+            type: '(args?: StorageListPromptBlocksInput) => Promise<StorageListPromptBlocksResolvedOutput>',
+            description: 'Same as list, but returns fully resolved prompt block content.',
+          },
+          {
+            name: 'preview',
+            type: '(blocks: AgentInstructionBlock[], context: Record<string, unknown>) => Promise<string>',
+            description:
+              'Resolve an array of instruction blocks against a context, rendering template variables and evaluating display conditions. Includes draft content for referenced prompt blocks.',
+          },
+          {
+            name: 'clearCache',
+            type: '(id?: string) => void',
+            description: 'Clear the in-memory cache for one prompt block or all prompt blocks.',
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'mcp',
     type: 'EditorMCPNamespace',
     description: 'CRUD operations for stored MCP client configurations.',
+    properties: [
+      {
+        type: 'EditorMCPNamespace',
+        parameters: [
+          {
+            name: 'create',
+            type: '(input: StorageCreateMCPClientInput) => Promise<MCPClient>',
+            description:
+              'Create a new stored MCP client. Accepts an id, authorId, metadata, and the initial snapshot (servers, tool filtering).',
+          },
+          {
+            name: 'getById',
+            type: '(id: string, options?: GetByIdOptions) => Promise<MCPClient | null>',
+            description: 'Return a hydrated MCPClient instance for a stored MCP client.',
+          },
+          {
+            name: 'update',
+            type: '(input: StorageUpdateMCPClientInput) => Promise<MCPClient>',
+            description: 'Partially update a stored MCP client and invalidate the cache.',
+          },
+          {
+            name: 'delete',
+            type: '(id: string) => Promise<void>',
+            description: 'Delete a stored MCP client and remove it from the Mastra runtime registry.',
+          },
+          {
+            name: 'list',
+            type: '(args?: StorageListMCPClientsInput) => Promise<StorageListMCPClientsOutput>',
+            description: 'List stored MCP clients with optional pagination and filters.',
+          },
+          {
+            name: 'listResolved',
+            type: '(args?: StorageListMCPClientsInput) => Promise<StorageListMCPClientsResolvedOutput>',
+            description: 'Same as list, but returns fully resolved MCP client configurations.',
+          },
+          {
+            name: 'clearCache',
+            type: '(id?: string) => void',
+            description: 'Clear the in-memory cache for one MCP client or all MCP clients.',
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'mcpServer',
     type: 'EditorMCPServerNamespace',
     description: 'CRUD operations for MCP server configurations.',
+    properties: [
+      {
+        type: 'EditorMCPServerNamespace',
+        parameters: [
+          {
+            name: 'create',
+            type: '(input: StorageCreateMCPServerInput) => Promise<MCPServerBase>',
+            description: 'Create a new stored MCP server configuration and return a hydrated server instance.',
+          },
+          {
+            name: 'getById',
+            type: '(id: string, options?: GetByIdOptions) => Promise<MCPServerBase | null>',
+            description: 'Return a hydrated MCP server for a given id.',
+          },
+          {
+            name: 'update',
+            type: '(input: StorageUpdateMCPServerInput) => Promise<MCPServerBase>',
+            description: 'Partially update a stored MCP server configuration.',
+          },
+          {
+            name: 'delete',
+            type: '(id: string) => Promise<void>',
+            description: 'Delete a stored MCP server configuration.',
+          },
+          {
+            name: 'list',
+            type: '(args?: StorageListMCPServersInput) => Promise<StorageListMCPServersOutput>',
+            description: 'List stored MCP server configurations.',
+          },
+          {
+            name: 'listResolved',
+            type: '(args?: StorageListMCPServersInput) => Promise<StorageListMCPServersResolvedOutput>',
+            description: 'Same as list, but returns fully resolved server configurations.',
+          },
+          {
+            name: 'clearCache',
+            type: '(id?: string) => void',
+            description: 'Clear the in-memory cache for one MCP server or all MCP servers.',
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'scorer',
     type: 'EditorScorerNamespace',
     description: 'CRUD operations for scorer configurations.',
+    properties: [
+      {
+        type: 'EditorScorerNamespace',
+        parameters: [
+          {
+            name: 'create',
+            type: '(input: StorageCreateScorerInput) => Promise<MastraScorer>',
+            description: 'Create a new stored scorer and return a hydrated MastraScorer instance.',
+          },
+          {
+            name: 'getById',
+            type: '(id: string, options?: GetByIdOptions) => Promise<MastraScorer | null>',
+            description: 'Return a hydrated scorer for a given id.',
+          },
+          {
+            name: 'update',
+            type: '(input: StorageUpdateScorerInput) => Promise<MastraScorer>',
+            description: 'Partially update a stored scorer.',
+          },
+          {
+            name: 'delete',
+            type: '(id: string) => Promise<void>',
+            description: 'Delete a stored scorer and remove it from the Mastra runtime registry.',
+          },
+          {
+            name: 'list',
+            type: '(args?: StorageListScorersInput) => Promise<StorageListScorersOutput>',
+            description: 'List stored scorers with optional pagination and filters.',
+          },
+          {
+            name: 'listResolved',
+            type: '(args?: StorageListScorersInput) => Promise<StorageListScorersResolvedOutput>',
+            description: 'Same as list, but returns fully resolved scorer configurations.',
+          },
+          {
+            name: 'clearCache',
+            type: '(id?: string) => void',
+            description: 'Clear the in-memory cache for one scorer or all scorers.',
+          },
+        ],
+      },
+    ],
   },
 ]}
 />

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -137,6 +137,7 @@ const sidebars = {
         { type: 'doc', id: 'core/getAgent', label: '.getAgent()' },
         { type: 'doc', id: 'core/getAgentById', label: '.getAgentById()' },
         { type: 'doc', id: 'core/getDeployer', label: '.getDeployer()' },
+        { type: 'doc', id: 'core/getEditor', label: '.getEditor()' },
         { type: 'doc', id: 'core/getGateway', label: '.getGateway()' },
         { type: 'doc', id: 'core/getGatewayById', label: '.getGatewayById()' },
         { type: 'doc', id: 'core/getLogger', label: '.getLogger()' },


### PR DESCRIPTION
## Summary

- Move the **Studio** category in the docs sidebar to appear below **Workflows**.
- Document how to drive the editor programmatically through `mastra.getEditor()`:
  - `editor.agent.create()` / `update()` examples in the editor overview.
  - `editor.prompt.create()` / `update()` examples in the prompts page, plus how to reference a saved prompt block from an agent's instructions.
- Describe the automated experimentation loop where one agent iterates on another using datasets, scorers, and `editor.agent.update()`. Conceptual only — no code for that loop.
- Fix the `ComposioToolProvider` / `ArcadeToolProvider` import paths in `tools.mdx` to match the actual package exports (`@mastra/editor/composio`, `@mastra/editor/arcade`).

## Test plan

- `npm run format` ✅
- `npm run lint:remark` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR updates the docs so you can control the Mastra editor from code (create/update agents and prompts), explains a conceptual automated tuning loop where one agent iterates on another, moves the Editor/Studio docs group to appear after Workflows, and fixes two example import paths for tool providers.

---

## Changes

### Documentation updates

- Editor Overview (docs/src/content/en/docs/editor/overview.mdx)
  - Added "Programmatic control" documenting mastra.getEditor() and editor namespaces (editor.agent, editor.prompt) with examples for editor.agent.create() and editor.agent.update() (updates create draft versions).
  - Listed editor.agent helper methods (getById, list, listResolved, delete) and referenced prompt APIs and the getEditor reference.
  - Added HTTP server endpoints table for stored agents (/stored/agents and version-management under /stored/agents/:storedAgentId/versions).
  - Added a conceptual "Automated experimentation" workflow describing iterative evaluation, agent-proposed changes, editor.agent.update() to create drafts, re-evaluation, and promotion on improved scores.

- Prompts (docs/src/content/en/docs/editor/prompts.mdx)
  - Added "Programmatic control" for prompt blocks via mastra.getEditor().prompt with examples for editor.prompt.create(), editor.prompt.update() (drafts), editor.prompt.list(), editor.prompt.getById(), and editor.prompt.preview().
  - Documented server routes for stored prompt blocks and showed how to reference a saved prompt block from an agent's instructions using { type: 'prompt_block_ref', id: ... }.

- Tools (docs/src/content/en/docs/editor/tools.mdx)
  - Fixed example import paths for integration providers: ComposioToolProvider now imports from @mastra/editor/composio and ArcadeToolProvider from @mastra/editor/arcade.

- New reference page (docs/src/content/en/reference/core/getEditor.mdx)
  - Added Mastra.getEditor() reference with usage example and return type (MastraEditor | undefined). Linked to related editor docs.

- MastraEditor reference (docs/src/content/en/reference/editor/mastra-editor.mdx)
  - Clarified that namespaces are accessible via mastra.getEditor() and expanded the shared CRUD contract and namespace method signatures (agent, prompt, mcp, mcpServer, scorer, etc.), including agent-specific methods (applyStoredOverrides, clone) and prompt.preview.

- Reference sidebar (docs/src/content/en/reference/sidebars.js)
  - Added .getEditor() entry under Core.

### Sidebar reorganization

- Documentation sidebar (docs/src/content/en/docs/sidebars.js)
  - Moved the Editor/Studio category to appear after the Workflows category while preserving its doc entries.

---

## Other notes

- Documentation-only changes; no runtime or exported API behavior modified.
- Test plan: npm run format and npm run lint:remark completed successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->