### PR TITLE
fix(core): empty uiMessages in multi-step responses with savePerStep

### DIFF
--- a/.changeset/flat-pianos-behave.md
+++ b/.changeset/flat-pianos-behave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed multi-step agent responses returning empty uiMessages when savePerStep is enabled. Tool call results and intermediate step outputs were being lost because the message tracking set was cleared after each step's persistence flush. The final response now reads from the persisted message set which accumulates across all steps.

--- a/packages/core/src/agent/__tests__/save-and-errors.test.ts
+++ b/packages/core/src/agent/__tests__/save-and-errors.test.ts
@@ -1656,6 +1656,24 @@ describe('savePerStep should persist messages during step execution (issue #1398
     expect(toolResultPart).toBeDefined();
     expect(toolResultPart.toolInvocation.result).toEqual(rawResult);
     expect(toolResultPart.providerMetadata?.mastra?.modelOutput).toEqual(modelOutput);
+
+    // Verify uiMessages in the response include parts from ALL steps,
+    // not just the last one (regression: savePerStep drains newResponseMessages).
+    const response = await result.response;
+    const uiMessages = response?.uiMessages ?? [];
+    expect(uiMessages.length).toBeGreaterThan(0);
+
+    const allParts = uiMessages.flatMap((m: any) => m.parts);
+
+    // Must include a tool part from step 1
+    const hasToolPart = allParts.some((p: any) => typeof p.type === 'string' && p.type.startsWith('tool-'));
+    expect(hasToolPart, 'uiMessages should include tool parts from step 1').toBe(true);
+
+    // Must include text from step 2
+    const hasTextPart = allParts.some(
+      (p: any) => p.type === 'text' && typeof p.text === 'string' && p.text.includes('Response after tool'),
+    );
+    expect(hasTextPart, 'uiMessages should include text parts from step 2').toBe(true);
   });
 
   it('should persist messages from completed steps when stream is aborted', async () => {

--- a/packages/core/src/agent/__tests__/stream-id.test.ts
+++ b/packages/core/src/agent/__tests__/stream-id.test.ts
@@ -526,6 +526,115 @@ describe('Stream ID Consistency', () => {
     }
   });
 
+  it('should return complete uiMessages with tool calls when savePerStep is enabled (V2 model)', async () => {
+    let callCount = 0;
+
+    const model = new MockLanguageModelV2({
+      doStream: (async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start' as const, warnings: [] },
+              { type: 'response-metadata' as const, id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call' as const,
+                toolCallId: 'call-1',
+                toolName: 'test-tool',
+                input: '{"input":"test"}',
+                providerExecuted: false,
+              },
+              {
+                type: 'finish' as const,
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ]),
+          };
+        }
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start' as const, warnings: [] },
+            { type: 'response-metadata' as const, id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start' as const, id: 'text-1' },
+            { type: 'text-delta' as const, id: 'text-1', delta: 'Tool result received.' },
+            { type: 'text-end' as const, id: 'text-1' },
+            {
+              type: 'finish' as const,
+              finishReason: 'stop' as const,
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      }) as any,
+    });
+
+    const testTool = createTool({
+      id: 'test-tool',
+      description: 'A test tool',
+      inputSchema: z.object({ input: z.string() }),
+      execute: async () => ({ result: 'Tool executed' }),
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-tool-ids-save-per-step',
+      name: 'Test Agent Tool IDs SavePerStep',
+      instructions: 'You are a helpful assistant.',
+      model,
+      memory,
+      tools: { 'test-tool': testTool },
+    });
+
+    agent.__registerMastra(mastra);
+
+    const threadId = randomUUID();
+    const resourceId = 'test-resource';
+
+    const streamResult = await agent.stream('Use the test tool', {
+      memory: { thread: threadId, resource: resourceId },
+      savePerStep: true,
+    });
+
+    await streamResult.consumeStream();
+
+    // Verify uiMessages via response promise
+    const response = await streamResult.response;
+    const uiMessages = response?.uiMessages ?? [];
+    expect(uiMessages.length).toBeGreaterThan(0);
+
+    const allParts = uiMessages.flatMap((m: any) => m.parts);
+
+    // Must include tool parts from step 1
+    const hasToolPart = allParts.some((p: any) => typeof p.type === 'string' && p.type.startsWith('tool-'));
+    expect(hasToolPart, 'uiMessages should include tool parts from step 1').toBe(true);
+
+    // Must include text from step 2
+    const hasTextPart = allParts.some((p: any) => p.type === 'text' && typeof p.text === 'string' && p.text.length > 0);
+    expect(hasTextPart, 'uiMessages should include text parts from step 2').toBe(true);
+
+    // Verify uiMessage IDs match what was persisted to memory
+    const uiMessageIds = uiMessages.map((m: any) => m.id);
+    const allRecalled = await memory.recall({ threadId });
+
+    for (const uiMsgId of uiMessageIds) {
+      const matchInMemory = allRecalled.messages.find(m => m.id === uiMsgId);
+      expect(matchInMemory, `uiMessage ID ${uiMsgId} should exist in memory`).toBeDefined();
+    }
+
+    // Verify getFullOutput also has complete uiMessages
+    const fullOutput = await streamResult.getFullOutput();
+    const fullUiMessages = fullOutput.response?.uiMessages ?? [];
+    expect(fullUiMessages.length).toBeGreaterThan(0);
+
+    const fullAllParts = fullUiMessages.flatMap((m: any) => m.parts);
+    const fullHasToolPart = fullAllParts.some((p: any) => typeof p.type === 'string' && p.type.startsWith('tool-'));
+    expect(fullHasToolPart, 'getFullOutput uiMessages should include tool parts from step 1').toBe(true);
+  });
+
   describe('onFinish callback with structured output', () => {
     it('should include object field in onFinish callback when using structured output', async () => {
       const mockModel = new MockLanguageModelV2({

--- a/packages/core/src/agent/message-list/utils/convert-messages.test.ts
+++ b/packages/core/src/agent/message-list/utils/convert-messages.test.ts
@@ -314,4 +314,79 @@ describe('convertMessages', () => {
       expect((uploadPart as any).data.percent).toBe(100);
     });
   });
+
+  describe('tool-only assistant messages', () => {
+    // Regression: MastraDBMessages with only tool-invocation parts (no text)
+    // should still produce valid UIMessages and survive round-trip conversion.
+
+    const toolOnlyMessage: MastraDBMessage = {
+      id: 'tool-only-msg',
+      role: 'assistant',
+      createdAt: new Date(),
+      content: {
+        format: 2,
+        content: undefined,
+        toolInvocations: [
+          {
+            toolCallId: 'call-1',
+            toolName: 'get-weather',
+            args: { city: 'SF' },
+            state: 'result',
+            result: { temp: 72, condition: 'sunny' },
+          },
+        ],
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              toolCallId: 'call-1',
+              toolName: 'get-weather',
+              args: { city: 'SF' },
+              state: 'result',
+              result: { temp: 72, condition: 'sunny' },
+            },
+          },
+        ],
+      },
+    };
+
+    it('should produce valid AIV5.UI parts for tool-only assistant messages', () => {
+      const uiMessages = convertMessages(toolOnlyMessage).to('AIV5.UI');
+      expect(uiMessages).toHaveLength(1);
+
+      const msg = uiMessages[0];
+      expect(msg.parts.length).toBeGreaterThan(0);
+
+      // Tool parts use the `tool-${toolName}` type convention
+      const toolPart = msg.parts.find((p: any) => typeof p.type === 'string' && p.type.startsWith('tool-'));
+      expect(toolPart).toBeDefined();
+    });
+
+    it('should preserve tool invocations in MastraDB → AIV5.UI → MastraDB round-trip', () => {
+      // Step 1: Convert to AIV5.UI
+      const uiMessages = convertMessages(toolOnlyMessage).to('AIV5.UI');
+      expect(uiMessages).toHaveLength(1);
+
+      const toolParts = uiMessages[0].parts.filter(
+        (p: any) => typeof p.type === 'string' && p.type.startsWith('tool-'),
+      );
+      expect(toolParts.length).toBeGreaterThan(0);
+
+      // Step 2: Convert back to MastraDB
+      const roundTripped = convertMessages(uiMessages).to('Mastra.V2');
+      expect(roundTripped).toHaveLength(1);
+
+      const rt = roundTripped[0];
+      expect(rt.content).toBeDefined();
+      expect(rt.content.parts).toBeDefined();
+
+      // Tool invocations should survive the round-trip
+      const rtToolParts = rt.content.parts!.filter((p: any) => p.type === 'tool-invocation');
+      expect(rtToolParts.length).toBeGreaterThan(0);
+
+      expect(rt.content.toolInvocations).toBeDefined();
+      expect(rt.content.toolInvocations!.length).toBeGreaterThan(0);
+      expect(rt.content.toolInvocations![0].toolCallId).toBe('call-1');
+    });
+  });
 });

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -785,7 +785,10 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 response = {
                   ...otherMetadata,
                   messages: messageList.get.response.aiV5.model(),
-                  uiMessages: messageList.get.response.aiV5.ui() as LLMStepResult<OUTPUT>['response']['uiMessages'],
+                  // Use getPersisted so that uiMessages includes all steps,
+                  // even when savePerStep drains newResponseMessages mid-execution.
+                  uiMessages:
+                    messageList.getPersisted.response.aiV5.ui() as LLMStepResult<OUTPUT>['response']['uiMessages'],
                 };
               }
 
@@ -861,7 +864,10 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                     response = {
                       ...otherMetadata,
                       messages: messageList.get.response.aiV5.model(),
-                      uiMessages: messageList.get.response.aiV5.ui() as LLMStepResult<OUTPUT>['response']['uiMessages'],
+                      // Use getPersisted so that uiMessages includes all steps,
+                      // even when savePerStep drains newResponseMessages mid-execution.
+                      uiMessages:
+                        messageList.getPersisted.response.aiV5.ui() as LLMStepResult<OUTPUT>['response']['uiMessages'],
                     };
                   }
 


### PR DESCRIPTION
When `savePerStep: true`, each step flushes messages to storage via `drainUnsavedMessages()`, which clears the `newResponseMessages` set. By the time the final `finish` handler runs, that set is empty, so `response.uiMessages` comes back as `[]`. This means `useChat` in generate mode shows nothing after the first step — tool results and subsequent text are saved to the DB but never surface in the UI.

The fix switches the `finish` handler from `messageList.get.response.aiV5.ui()` to `messageList.getPersisted.response.aiV5.ui()`. The persisted set accumulates across all steps and is never cleared by drain, so it always has the complete picture. When `savePerStep` is false, both sets are identical so there's no behavioral change.

```ts
// before (empty after drain)
uiMessages: messageList.get.response.aiV5.ui()

// after (survives drain)
uiMessages: messageList.getPersisted.response.aiV5.ui()
```

Tests added to `save-and-errors.test.ts`, `stream-id.test.ts`, and `convert-messages.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an AI agent completes multiple steps and saves progress after each step, the final response was forgetting to show what happened in earlier steps (like tool call results). This PR fixes it by making sure the system remembers all the messages from every step when building the final response, not just the most recent ones.

## Overview

This PR fixes a bug in multi-step agent execution where `savePerStep: true` caused `uiMessages` to be empty in the final response. When intermediate persistence was enabled, the system was correctly saving messages to the database but failing to surface them in the UI because the intermediate message tracking was being cleared.

## Root Cause

During step execution with `savePerStep` enabled, each step calls `drainUnsavedMessages()` which clears the `newResponseMessages` set. By the time the finish handler constructs `response.uiMessages`, this set is empty, even though the messages were successfully persisted to the database. This caused tool call results and intermediate step outputs to be lost in the final response.

## Solution

The fix updates the response object construction in two locations of `packages/core/src/stream/base/output.ts` to use `messageList.getPersisted.response.aiV5.ui()` instead of `messageList.get.response.aiV5.ui()`. The persisted set accumulates messages across all steps and is not cleared by `drainUnsavedMessages()`, ensuring the final response includes all tool results and intermediate step outputs from every step.

**Backward Compatibility**: When `savePerStep` is false, both sets are identical, so there is no change in behavior.

## Testing

Three test files were added/modified to verify the fix:

- **save-and-errors.test.ts**: Added assertions to validate that `result.response.uiMessages` includes parts from all steps, including tool-related parts from step 1 and text parts from step 2
- **stream-id.test.ts**: Added a new test case validating that `uiMessages` contains complete tool calls and text when `savePerStep: true` for V2 models, ensuring all message IDs can be found in persisted memory and that `getFullOutput()` also returns complete response messages
- **convert-messages.test.ts**: Added tests for tool-only assistant messages to verify conversion behavior when messages contain `toolInvocations` without text content, ensuring proper preservation of tool invocation data across format conversions

## Files Changed

- `.changeset/flat-pianos-behave.md`: Changeset documentation (patch bump for `@mastra/core`)
- `packages/core/src/stream/base/output.ts`: Core fix to use persisted messages in response construction (2 locations updated)
- `packages/core/src/agent/__tests__/save-and-errors.test.ts`: Enhanced test coverage (+18 lines)
- `packages/core/src/agent/__tests__/stream-id.test.ts`: New test for V2 model with savePerStep (+109 lines)
- `packages/core/src/agent/message-list/utils/convert-messages.test.ts`: New tests for tool message conversion (+75 lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->