### PR TITLE
Add support for API key endpoints in CloudExporter

### DIFF
--- a/.changeset/witty-jokes-design.md
+++ b/.changeset/witty-jokes-design.md
@@ -1,0 +1,17 @@
+---
+'@mastra/observability': minor
+---
+
+Added support for project-scoped CloudExporter collector routes for organization API keys.
+
+**What changed**
+CloudExporter now accepts a `projectId` option and reads `MASTRA_PROJECT_ID` so remote writes can target project-scoped collector URLs when you authenticate with an organization API key.
+
+```ts
+new CloudExporter({
+  accessToken: process.env.MASTRA_CLOUD_ACCESS_TOKEN,
+  projectId: process.env.MASTRA_PROJECT_ID,
+});
+```
+
+When `projectId` is set, base endpoints resolve to `/projects/:projectId/ai/{signal}/publish`. Without it, existing JWT-style `/ai/{signal}/publish` routes still work as before.

--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -15,14 +15,23 @@ The `CloudExporter` sends traces to Mastra Cloud for centralized monitoring and 
 
 1. **Mastra Cloud Account**: Sign up at [cloud.mastra.ai](https://cloud.mastra.ai)
 1. **Mastra Cloud Project**: Create a project in Mastra Cloud. Traces are scoped per project, so even if you only want observability, you need a project to act as the destination for your traces.
-1. **Access Token**: Generate in your project's sidebar under **Project Settings → Access Tokens**
+1. **Authentication**: Use either a project-scoped access token or an organization API key. Generate both from Mastra Cloud.
 1. **Environment Variables**: Set your credentials:
 
 ```bash title=".env"
 MASTRA_CLOUD_ACCESS_TOKEN=mst_xxxxxxxxxxxxxxxx
 ```
 
+If you authenticate with an organization API key, also set the destination project ID:
+
+```bash title=".env"
+MASTRA_CLOUD_ACCESS_TOKEN=sk_xxxxxxxxxxxxxxxx
+MASTRA_PROJECT_ID=project_123
+```
+
 ### Basic Setup
+
+Project-scoped access tokens work without any extra routing configuration:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -41,6 +50,19 @@ export const mastra = new Mastra({
   }),
 })
 ```
+
+### Organization API keys
+
+Organization API keys are scoped to the whole org, so the exporter needs a project ID (letters, numbers, hyphens, underscores only) to generate project-scoped collector routes.
+
+```typescript title="src/mastra/index.ts"
+new CloudExporter({
+  accessToken: process.env.MASTRA_CLOUD_ACCESS_TOKEN,
+  projectId: process.env.MASTRA_PROJECT_ID,
+})
+```
+
+When `projectId` is set, base endpoints resolve to `/projects/:projectId/ai/{signal}/publish`. Without it, the exporter keeps using `/ai/{signal}/publish`.
 
 ### Recommended Configuration
 
@@ -78,6 +100,10 @@ new CloudExporter({
   // Optional - defaults to env var
   accessToken: process.env.MASTRA_CLOUD_ACCESS_TOKEN,
 
+  // Optional - required for organization API keys or any project-scoped collector route
+  // Letters, numbers, hyphens, and underscores only
+  projectId: process.env.MASTRA_PROJECT_ID,
+
   // Optional - for self-hosted Mastra Cloud
   endpoint: 'https://cloud.your-domain.com',
 
@@ -104,7 +130,7 @@ new CloudExporter({
    - Error status
 
 :::note
-Traces are scoped to the project that issued the access token. To view traces, make sure you're viewing the same project you generated the token from.
+If you use a project-scoped token, view the project that issued the token. If you use an organization API key, view the project named in `MASTRA_PROJECT_ID` or `projectId`.
 :::
 
 ### Features

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -44,11 +44,26 @@ interface CloudExporterConfig extends BaseExporterConfig {
   /** Cloud access token (from env or config) */
   accessToken?: string
 
+  /** Project ID for project-scoped collector routes (letters, numbers, hyphens, underscores) */
+  projectId?: string
+
   /** Base cloud observability endpoint */
   endpoint?: string
 
   /** Explicit cloud traces endpoint override */
   tracesEndpoint?: string
+
+  /** Explicit cloud logs endpoint override */
+  logsEndpoint?: string
+
+  /** Explicit cloud metrics endpoint override */
+  metricsEndpoint?: string
+
+  /** Explicit cloud scores endpoint override */
+  scoresEndpoint?: string
+
+  /** Explicit cloud feedback endpoint override */
+  feedbackEndpoint?: string
 }
 ```
 
@@ -61,8 +76,9 @@ Extends `BaseExporterConfig`, which includes:
 
 The exporter reads these environment variables if not provided in config:
 
-- `MASTRA_CLOUD_ACCESS_TOKEN` - Project-scoped access token for authentication (generate in your Mastra Cloud project under **Project Settings → Access Tokens**)
-- `MASTRA_CLOUD_TRACES_ENDPOINT` - Base cloud endpoint (defaults to `https://api.mastra.ai`)
+- `MASTRA_CLOUD_ACCESS_TOKEN` - Authentication token. Project-scoped tokens work with the default `/ai/{signal}/publish` routes. Organization API keys require `projectId` or `MASTRA_PROJECT_ID`.
+- `MASTRA_PROJECT_ID` - Project ID to use when deriving project-scoped collector routes such as `/projects/:projectId/ai/spans/publish`
+- `MASTRA_CLOUD_TRACES_ENDPOINT` - Traces endpoint override. Pass either a base origin or a full traces publish URL. Defaults to `https://api.mastra.ai`
 
 ## Properties
 
@@ -226,6 +242,13 @@ The exporter batches tracing spans, logs, metrics, scores, and feedback for effi
 - Drops batches after all retries fail
 - Logs errors but continues processing new events
 
+### Endpoint routing
+
+- Base origins derive signal endpoints automatically
+- Without `projectId`, derived routes use `/ai/{signal}/publish`
+- With `projectId` or `MASTRA_PROJECT_ID`, derived routes use `/projects/:projectId/ai/{signal}/publish`
+- Explicit full publish URLs are used as-is, even when `projectId` is configured
+
 ### Signal Processing
 
 - `exportTracingEvent()` only exports `SPAN_ENDED` tracing events
@@ -267,6 +290,7 @@ const exporter = new CloudExporter()
 // Explicit configuration
 const customExporter = new CloudExporter({
   accessToken: 'your-token',
+  projectId: 'project_123',
   maxBatchSize: 500,
   maxBatchWaitMs: 2000,
   logLevel: 'debug',

--- a/observability/mastra/src/exporters/cloud.test.ts
+++ b/observability/mastra/src/exporters/cloud.test.ts
@@ -978,6 +978,28 @@ describe('CloudExporter', () => {
       await derivedExporter.shutdown();
     });
 
+    it('should derive project-scoped signal endpoints from a base endpoint when projectId is configured', async () => {
+      const derivedExporter = new CloudExporter({
+        accessToken: 'sk_org_api_key',
+        endpoint: 'https://collector.example.com',
+        projectId: 'project-workos',
+      });
+
+      await derivedExporter.onMetricEvent(getMockMetricEvent());
+      await derivedExporter.flush();
+
+      expect(mockFetchWithRetry).toHaveBeenCalledWith(
+        'https://collector.example.com/projects/project-workos/ai/metrics/publish',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(String),
+        }),
+        3,
+      );
+
+      await derivedExporter.shutdown();
+    });
+
     it('should derive sibling signal endpoints from an explicit traces endpoint override', async () => {
       const derivedExporter = new CloudExporter({
         accessToken: testJWT,
@@ -1012,6 +1034,41 @@ describe('CloudExporter', () => {
       await derivedExporter.shutdown();
     });
 
+    it('should derive project-scoped sibling signal endpoints from an origin-only traces endpoint override', async () => {
+      const derivedExporter = new CloudExporter({
+        accessToken: 'sk_org_api_key',
+        endpoint: 'https://fallback.example.com',
+        tracesEndpoint: 'https://collector.example.com',
+        projectId: 'project-workos',
+      });
+
+      await derivedExporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: mockSpan,
+      });
+      await derivedExporter.onMetricEvent(getMockMetricEvent());
+      await derivedExporter.flush();
+
+      expect(mockFetchWithRetry).toHaveBeenCalledWith(
+        'https://collector.example.com/projects/project-workos/ai/spans/publish',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(String),
+        }),
+        3,
+      );
+      expect(mockFetchWithRetry).toHaveBeenCalledWith(
+        'https://collector.example.com/projects/project-workos/ai/metrics/publish',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(String),
+        }),
+        3,
+      );
+
+      await derivedExporter.shutdown();
+    });
+
     it('should prefer explicit per-signal endpoint overrides over derived traces siblings', async () => {
       const derivedExporter = new CloudExporter({
         accessToken: testJWT,
@@ -1022,6 +1079,41 @@ describe('CloudExporter', () => {
       await derivedExporter.onLogEvent(getMockLogEvent());
       await derivedExporter.flush();
 
+      expect(mockFetchWithRetry).toHaveBeenCalledWith(
+        'https://logs.example.com/custom/logs/publish',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(String),
+        }),
+        3,
+      );
+
+      await derivedExporter.shutdown();
+    });
+
+    it('should leave explicit full publish URLs unchanged when projectId is configured', async () => {
+      const derivedExporter = new CloudExporter({
+        accessToken: 'sk_org_api_key',
+        projectId: 'project-workos',
+        tracesEndpoint: 'https://collector.example.com/custom/spans/publish',
+        logsEndpoint: 'https://logs.example.com/custom/logs/publish',
+      });
+
+      await derivedExporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: mockSpan,
+      });
+      await derivedExporter.onLogEvent(getMockLogEvent());
+      await derivedExporter.flush();
+
+      expect(mockFetchWithRetry).toHaveBeenCalledWith(
+        'https://collector.example.com/custom/spans/publish',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(String),
+        }),
+        3,
+      );
       expect(mockFetchWithRetry).toHaveBeenCalledWith(
         'https://logs.example.com/custom/logs/publish',
         expect.objectContaining({
@@ -1047,6 +1139,144 @@ describe('CloudExporter', () => {
 
         expect(mockFetchWithRetry).toHaveBeenCalledWith(
           'https://collector.example.com/env/scores/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+        );
+      } finally {
+        await derivedExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should derive project-scoped signal endpoints from MASTRA_PROJECT_ID', async () => {
+      vi.stubEnv('MASTRA_PROJECT_ID', 'project-from-env');
+
+      const derivedExporter = new CloudExporter({
+        accessToken: 'sk_org_api_key',
+        endpoint: 'https://collector.example.com',
+      });
+
+      try {
+        await derivedExporter.onScoreEvent(getMockScoreEvent());
+        await derivedExporter.flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'https://collector.example.com/projects/project-from-env/ai/scores/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+        );
+      } finally {
+        await derivedExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should prefer config projectId over MASTRA_PROJECT_ID', async () => {
+      vi.stubEnv('MASTRA_PROJECT_ID', 'project-from-env');
+
+      const derivedExporter = new CloudExporter({
+        accessToken: 'sk_org_api_key',
+        endpoint: 'https://collector.example.com',
+        projectId: 'project-from-config',
+      });
+
+      try {
+        await derivedExporter.onFeedbackEvent(getMockFeedbackEvent());
+        await derivedExporter.flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'https://collector.example.com/projects/project-from-config/ai/feedback/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+        );
+      } finally {
+        await derivedExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should treat an empty MASTRA_PROJECT_ID as unset', async () => {
+      vi.stubEnv('MASTRA_PROJECT_ID', '');
+
+      const derivedExporter = new CloudExporter({
+        accessToken: 'sk_org_api_key',
+        endpoint: 'https://collector.example.com',
+      });
+
+      try {
+        await derivedExporter.onMetricEvent(getMockMetricEvent());
+        await derivedExporter.flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'https://collector.example.com/ai/metrics/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+        );
+      } finally {
+        await derivedExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should reject an empty config projectId', () => {
+      expect(
+        () =>
+          new CloudExporter({
+            accessToken: 'sk_org_api_key',
+            endpoint: 'https://collector.example.com',
+            projectId: '',
+          }),
+      ).toThrowError('CloudExporter projectId must only contain letters, numbers, hyphens, and underscores.');
+    });
+
+    it('should reject a config projectId that contains whitespace', () => {
+      expect(
+        () =>
+          new CloudExporter({
+            accessToken: 'sk_org_api_key',
+            endpoint: 'https://collector.example.com',
+            projectId: 'project 123',
+          }),
+      ).toThrowError('CloudExporter projectId must only contain letters, numbers, hyphens, and underscores.');
+    });
+
+    it('should reject a config projectId with special characters', () => {
+      expect(
+        () =>
+          new CloudExporter({
+            accessToken: 'sk_org_api_key',
+            endpoint: 'https://collector.example.com',
+            projectId: 'project/123',
+          }),
+      ).toThrowError('CloudExporter projectId must only contain letters, numbers, hyphens, and underscores.');
+    });
+
+    it('should treat an invalid MASTRA_PROJECT_ID as unset', async () => {
+      vi.stubEnv('MASTRA_PROJECT_ID', 'has spaces');
+
+      const derivedExporter = new CloudExporter({
+        accessToken: 'sk_org_api_key',
+        endpoint: 'https://collector.example.com',
+      });
+
+      try {
+        await derivedExporter.onMetricEvent(getMockMetricEvent());
+        await derivedExporter.flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'https://collector.example.com/ai/metrics/publish',
           expect.objectContaining({
             method: 'POST',
             body: expect.any(String),

--- a/observability/mastra/src/exporters/cloud.ts
+++ b/observability/mastra/src/exporters/cloud.ts
@@ -20,6 +20,7 @@ export interface CloudExporterConfig extends BaseExporterConfig {
 
   // Cloud-specific configuration
   accessToken?: string; // Cloud access token (from env or config)
+  projectId?: string; // Project ID for project-scoped collector routes
   endpoint?: string; // Base cloud endpoint
   tracesEndpoint?: string; // Explicit cloud traces endpoint override
   logsEndpoint?: string; // Explicit cloud logs endpoint override
@@ -38,15 +39,7 @@ const SIGNAL_PUBLISH_SUFFIXES: Record<CloudSignal, string> = {
   feedback: '/feedback/publish',
 };
 
-const SIGNAL_PUBLISH_PATHS: Record<CloudSignal, string> = {
-  traces: '/ai/spans/publish',
-  logs: '/ai/logs/publish',
-  metrics: '/ai/metrics/publish',
-  scores: '/ai/scores/publish',
-  feedback: '/ai/feedback/publish',
-};
-
-const SIGNAL_PAYLOAD_KEYS: Record<CloudSignal, string> = {
+const SIGNAL_PUBLISH_SEGMENTS: Record<CloudSignal, string> = {
   traces: 'spans',
   logs: 'logs',
   metrics: 'metrics',
@@ -79,6 +72,20 @@ function createInvalidEndpointError(endpoint: string, text: string, cause?: unkn
   );
 }
 
+const VALID_PROJECT_ID = /^[a-zA-Z0-9_-]+$/;
+
+function createInvalidProjectIdError(projectId: string): MastraError {
+  return new MastraError({
+    id: `CLOUD_EXPORTER_INVALID_PROJECT_ID`,
+    text: 'CloudExporter projectId must only contain letters, numbers, hyphens, and underscores.',
+    domain: ErrorDomain.MASTRA_OBSERVABILITY,
+    category: ErrorCategory.USER,
+    details: {
+      projectId,
+    },
+  });
+}
+
 function resolveBaseEndpoint(baseEndpoint: string): string {
   const normalizedEndpoint = trimTrailingSlashes(baseEndpoint);
   const invalidText =
@@ -99,11 +106,20 @@ function resolveBaseEndpoint(baseEndpoint: string): string {
   }
 }
 
-function buildSignalEndpoint(baseEndpoint: string, signal: CloudSignal): string {
-  return `${baseEndpoint}${SIGNAL_PUBLISH_PATHS[signal]}`;
+function buildSignalPath(signal: CloudSignal, projectId?: string): string {
+  const signalSegment = SIGNAL_PUBLISH_SEGMENTS[signal];
+  if (!projectId) {
+    return `/ai/${signalSegment}/publish`;
+  }
+
+  return `/projects/${projectId}/ai/${signalSegment}/publish`;
 }
 
-function resolveExplicitSignalEndpoint(signal: CloudSignal, endpoint: string): string {
+function buildSignalEndpoint(baseEndpoint: string, signal: CloudSignal, projectId?: string): string {
+  return `${baseEndpoint}${buildSignalPath(signal, projectId)}`;
+}
+
+function resolveExplicitSignalEndpoint(signal: CloudSignal, endpoint: string, projectId?: string): string {
   const normalizedEndpoint = trimTrailingSlashes(endpoint);
   const invalidText = `CloudExporter ${signal}Endpoint must be a base origin like "https://collector.example.com" or a full ${signal} publish URL ending in "${SIGNAL_PUBLISH_SUFFIXES[signal]}".`;
 
@@ -117,7 +133,7 @@ function resolveExplicitSignalEndpoint(signal: CloudSignal, endpoint: string): s
     const normalizedPathname = trimTrailingSlashes(parsedEndpoint.pathname);
 
     if (!normalizedPathname || normalizedPathname === '/') {
-      return buildSignalEndpoint(normalizedOrigin, signal);
+      return buildSignalEndpoint(normalizedOrigin, signal, projectId);
     }
 
     if (normalizedPathname.endsWith(SIGNAL_PUBLISH_SUFFIXES[signal])) {
@@ -205,7 +221,7 @@ type ResolvedCloudConfig = {
 export class CloudExporter extends BaseExporter {
   name = 'mastra-cloud-observability-exporter';
 
-  private cloudConfig: ResolvedCloudConfig;
+  private readonly cloudConfig: Readonly<ResolvedCloudConfig>;
   private buffer: MastraCloudBuffer;
   private flushTimer: NodeJS.Timeout | null = null;
   private inFlightFlushes = new Set<Promise<void>>();
@@ -213,7 +229,13 @@ export class CloudExporter extends BaseExporter {
   constructor(config: CloudExporterConfig = {}) {
     super(config);
 
+    if (config.projectId !== undefined && !VALID_PROJECT_ID.test(config.projectId)) {
+      throw createInvalidProjectIdError(config.projectId);
+    }
+
     const accessToken = config.accessToken ?? process.env.MASTRA_CLOUD_ACCESS_TOKEN;
+    const rawProjectId = config.projectId ?? process.env.MASTRA_PROJECT_ID;
+    const projectId = rawProjectId && VALID_PROJECT_ID.test(rawProjectId) ? rawProjectId : undefined;
     if (!accessToken) {
       this.setDisabled('MASTRA_CLOUD_ACCESS_TOKEN environment variable not set.');
     }
@@ -223,10 +245,10 @@ export class CloudExporter extends BaseExporter {
     let tracesEndpoint: string;
 
     if (tracesEndpointOverride) {
-      tracesEndpoint = resolveExplicitSignalEndpoint('traces', tracesEndpointOverride);
+      tracesEndpoint = resolveExplicitSignalEndpoint('traces', tracesEndpointOverride, projectId);
     } else {
       baseEndpoint = resolveBaseEndpoint(config.endpoint ?? DEFAULT_CLOUD_ENDPOINT);
-      tracesEndpoint = buildSignalEndpoint(baseEndpoint, 'traces');
+      tracesEndpoint = buildSignalEndpoint(baseEndpoint, 'traces', projectId);
     }
 
     const resolveConfiguredSignalEndpoint = (
@@ -234,14 +256,14 @@ export class CloudExporter extends BaseExporter {
       explicitEndpoint?: string,
     ): string => {
       if (explicitEndpoint) {
-        return resolveExplicitSignalEndpoint(signal, explicitEndpoint);
+        return resolveExplicitSignalEndpoint(signal, explicitEndpoint, projectId);
       }
 
       if (tracesEndpointOverride) {
         return deriveSignalEndpointFromTracesEndpoint(signal, tracesEndpoint);
       }
 
-      return buildSignalEndpoint(baseEndpoint!, signal);
+      return buildSignalEndpoint(baseEndpoint!, signal, projectId);
     };
 
     this.cloudConfig = {
@@ -517,7 +539,7 @@ export class CloudExporter extends BaseExporter {
     const options: RequestInit = {
       method: 'POST',
       headers,
-      body: JSON.stringify({ [SIGNAL_PAYLOAD_KEYS[signal]]: records }),
+      body: JSON.stringify({ [SIGNAL_PUBLISH_SEGMENTS[signal]]: records }),
     };
 
     await fetchWithRetry(endpointMap[signal], options, this.cloudConfig.maxRetries);


### PR DESCRIPTION
## Description

Add `projectId` support to `CloudExporter` so organization-scoped API keys can route telemetry to the correct project.
- **New `projectId` option**: Accepts a config value or reads `MASTRA_PROJECT_ID` from the environment. When set, derived endpoints use `/projects/:projectId/ai/{signal}/publish` instead of `/ai/{signal}/publish`.
- **Strict validation**: Config `projectId` must match `[a-zA-Z0-9_-]+` or the constructor throws. Invalid env var values are silently treated as unset for graceful degradation.
- **Explicit URL escape hatch**: Full publish URLs (e.g. `tracesEndpoint: 'https://collector.example.com/custom/spans/publish'`) are used as-is even when `projectId` is configured.
- **Internal cleanup**: Consolidated duplicate `SIGNAL_PAYLOAD_KEYS` / `SIGNAL_PUBLISH_PATHS` maps into a single `SIGNAL_PUBLISH_SEGMENTS` map. Made `cloudConfig` `readonly`.
Backward-compatible — without `projectId`, all behavior is unchanged.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a "project ID" feature to CloudExporter so that when you have an organization-level API key, you can tell it which specific project the tracing data belongs to. Instead of sending everything to a generic endpoint, it now sends it to a project-specific endpoint (like `/projects/my-project-id/...` instead of just `/...`). If you don't set a project ID, it works exactly like before.

## Overview

This pull request introduces `projectId` support to `CloudExporter`, enabling organization API key authentication to route telemetry data to project-scoped collector endpoints. The changes are fully backward compatible—existing configurations without `projectId` continue to work unchanged.

## Key Changes

**CloudExporter Configuration**
- Added optional `projectId?: string` field to `CloudExporterConfig`
- `projectId` can be supplied directly in config or via the `MASTRA_PROJECT_ID` environment variable
- Config values are strictly validated against the regex `[a-zA-Z0-9_-]+`; invalid config values throw a `CLOUD_EXPORTER_INVALID_PROJECT_ID` error
- Invalid environment variable values are treated as unset (graceful degradation with no error)

**Endpoint Routing**
- When `projectId` is set, derived publish endpoints change from `/ai/{signal}/publish` to `/projects/:projectId/ai/{signal}/publish`
- Applies to all signal types: spans, logs, metrics, scores, and feedback
- Explicitly provided full publish URLs (e.g., `tracesEndpoint: 'https://collector.example.com/custom/spans/publish'`) are respected verbatim and unaffected by `projectId`

**Internal Refactoring**
- Consolidated duplicate `SIGNAL_PAYLOAD_KEYS` and `SIGNAL_PUBLISH_PATHS` into a single `SIGNAL_PUBLISH_SEGMENTS` map
- Made `cloudConfig` property `private readonly` to prevent reassignment
- Added new per-signal endpoint config options: `logsEndpoint`, `metricsEndpoint`, `scoresEndpoint`, `feedbackEndpoint`

## Testing & Documentation

- Extended test suite with comprehensive coverage for `projectId` behavior, including validation, environment variable handling, endpoint derivation, and override scenarios
- Updated user documentation with authentication guidance for both project-scoped tokens and organization API keys
- Added reference documentation for new configuration options and environment variables
- Included changeset documenting the new feature

## Impact

- **Backward Compatible**: Existing configurations without `projectId` are unaffected
- **Config Priority**: Config `projectId` takes precedence over `MASTRA_PROJECT_ID` environment variable
- **Error Handling**: Config-level validation errors are reported immediately; environment variable errors degrade gracefully

<!-- end of auto-generated comment: release notes by coderabbit.ai -->