### PR TITLE
fix(mastracode): clear task list on thread switch instead of reading stale global state

### DIFF
--- a/.changeset/slimy-states-flow.md
+++ b/.changeset/slimy-states-flow.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed task list leaking across threads when switching conversations. Tasks from the previous thread no longer appear in the new thread.

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -135,14 +135,13 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       if (currentThread) {
         state.currentThreadTitle = currentThread.title;
       }
-      // Restore tasks from thread state
-      const threadState = state.harness.getState() as {
-        tasks?: TaskItem[];
-      };
+      // Clear tasks — they are ephemeral per-thread and should not leak
+      // from the previous thread's global harness state.
       if (state.taskProgress) {
-        state.taskProgress.updateTasks(threadState.tasks ?? []);
+        state.taskProgress.updateTasks([]);
         state.ui.requestRender();
       }
+      state.taskWriteInsertIndex = -1;
       break;
     }
 


### PR DESCRIPTION
## Problem

When switching threads, the task list from the previous thread would persist in the UI. Tasks from thread A would appear in thread B.

## Root Cause

The `thread_changed` handler in `event-dispatch.ts` was reading tasks from `state.harness.getState().tasks` — the **global** harness state — which still held the previous thread's tasks.

The flow was:
1. Thread A: `task_write` → sets `harness.state.tasks = [task1, task2, ...]`
2. Switch to thread B
3. `resetThreadDisplayState()` correctly clears `displayState.tasks = []`
4. TUI reads `harness.getState().tasks` → gets thread A's stale tasks from global state
5. TUI calls `updateTasks(staleTasksFromA)` → tasks leak into thread B

## Fix

Replace the stale global state read with a simple `updateTasks([])` call, matching the existing `thread_created` behavior. Also resets `taskWriteInsertIndex` for consistency.

Tasks are ephemeral (scoped to the current agent turn) and should not persist across thread switches.

## Test Plan

- All 158 harness tests pass
- No new type errors introduced (pre-existing type error in `headless.ts:290` is unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're keeping a to-do list for different conversation threads. When you switched to a new conversation, the old conversation's to-do items were still showing up on the screen. This PR fixes that by making sure to clear out the old to-do list completely whenever you switch to a different conversation, instead of trying to reuse leftover items from before.

## Changes

### Task List Persistence Fix

**File: `mastracode/src/tui/event-dispatch.ts`**

Modified the `thread_changed` event handler to properly clear the task list when switching threads. The previous implementation read stale task data from the global harness state, allowing tasks from the previous thread to persist in the UI.

- Replaced `updateTasks(threadState.tasks ?? [])` with unconditional `updateTasks([])` call to clear tasks
- Added `taskWriteInsertIndex` reset to `-1` for consistency
- Removed unused `TaskItem` type reference from the handler

This ensures tasks, which are scoped to the current agent turn, do not leak across thread switches.

### Release Notes

**File: `.changeset/slimy-states-flow.md`**

Declared a `patch` release for the `mastracode` package documenting the fix for task list leakage across threads.

## Testing

All 158 harness tests pass with no new type errors introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->