### PR TITLE
fix(core): pass usage data to processOutputStep in output processors

### DIFF
--- a/.changeset/polite-kiwis-lie.md
+++ b/.changeset/polite-kiwis-lie.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed processOutputStep not receiving token usage data. Output processors now receive usage (inputTokens, outputTokens, totalTokens) for the current LLM step, enabling per-step cost tracking and token budget enforcement.

--- a/examples/agent/src/process-output-step-usage.ts
+++ b/examples/agent/src/process-output-step-usage.ts
@@ -1,0 +1,67 @@
+import { Agent, MastraDBMessage, MessageList } from '@mastra/core/agent';
+import { Processor, ProcessorMessageResult, ProcessOutputStepArgs } from '@mastra/core/processors';
+import { createTool } from '@mastra/core/tools';
+import z from 'zod';
+
+class OutputStepUsageLogger implements Processor {
+  readonly id = 'OutputStepUsageLogger';
+  readonly name = 'OutputStepUsageLogger';
+
+  async processOutputStep({
+    messageList,
+    usage,
+    stepNumber,
+  }: ProcessOutputStepArgs<unknown>): Promise<MessageList | MastraDBMessage[]> {
+    console.log('step ', stepNumber, 'usage', usage);
+    return messageList;
+  }
+}
+
+async function main() {
+  console.log('running main');
+
+  const weatherTool = createTool({
+    id: 'weather',
+    description: 'Get the weather for a city',
+    inputSchema: z.object({
+      city: z.string(),
+    }),
+    execute: async () => {
+      const randomm = Math.floor(Math.random() * 100);
+      return 'The weather is ' + randomm;
+    },
+  });
+
+  const simpleAgent = new Agent({
+    id: 'simple-agent',
+    name: 'Simple Agent',
+    instructions: `You are a coding assistant.`,
+    model: 'vercel/google/gemini-3-flash-preview',
+    outputProcessors: [new OutputStepUsageLogger()],
+    tools: { weather: weatherTool },
+  });
+
+  const stream = await simpleAgent.stream({
+    id: 'msg-123',
+    role: 'user',
+    parts: [{ type: 'text', text: 'whats the weather in nyc and washington?' }],
+  });
+
+  for await (const chunk of stream.fullStream) {
+    if (chunk.type === 'tripwire') {
+      console.log('🚫 Tripwire detected during streaming!');
+      console.log('  Reason:', chunk.payload?.reason);
+      console.log('  Retry allowed:', chunk.payload?.retry);
+      console.log('  Metadata:', JSON.stringify(chunk.payload?.metadata, null, 2));
+      console.log('  Processor ID:', chunk.payload?.processorId);
+      break;
+    } else if (chunk.type === 'text-delta') {
+      // Normal text streaming
+      process.stdout.write(chunk.payload?.text || '');
+    } else {
+      console.log(JSON.stringify(chunk));
+    }
+  }
+}
+
+main();

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1261,6 +1261,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             finishReason: immediateFinishReason,
             toolCalls: toolCallInfos.length > 0 ? toolCallInfos : undefined,
             text: immediateText,
+            usage: outputStream._getImmediateUsage(),
             ...createObservabilityContext(outputStepTracingContext),
             requestContext,
             retryCount: currentRetryCount,

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -251,6 +251,8 @@ export interface ProcessOutputStepArgs<TTripwireMetadata = unknown> extends Proc
   toolCalls?: ToolCallInfo[];
   /** Generated text from this step */
   text?: string;
+  /** Token usage for the current step (input tokens, output tokens, etc.) */
+  usage: LanguageModelUsage;
   /** All system messages */
   systemMessages: CoreMessageV4[];
   /** All completed steps so far (including the current step) */

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -1809,6 +1809,83 @@ describe('ProcessorRunner', () => {
       expect(allMessages).toHaveLength(2);
       expect(allMessages[1].role).toBe('assistant');
     });
+
+    it('should receive usage data in processOutputStep', async () => {
+      let receivedUsage: unknown = undefined;
+
+      const outputProcessors: Processor[] = [
+        {
+          id: 'usage-processor',
+          name: 'Usage Processor',
+          processOutputStep: async ({ messages, usage }) => {
+            receivedUsage = usage;
+            return messages;
+          },
+        },
+      ];
+
+      runner = new ProcessorRunner({
+        inputProcessors: [],
+        outputProcessors,
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      messageList.add([createMessage('user message', 'user')], 'user');
+
+      const usage = {
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      };
+
+      await runner.runProcessOutputStep({
+        steps: [],
+        messages: messageList.get.all.db(),
+        messageList,
+        stepNumber: 0,
+        usage,
+      });
+
+      expect(receivedUsage).toEqual(usage);
+    });
+
+    it('should provide default usage when not supplied', async () => {
+      let receivedUsage: unknown = 'NOT_CALLED';
+
+      const outputProcessors: Processor[] = [
+        {
+          id: 'usage-default-processor',
+          name: 'Usage Default Processor',
+          processOutputStep: async ({ messages, usage }) => {
+            receivedUsage = usage;
+            return messages;
+          },
+        },
+      ];
+
+      runner = new ProcessorRunner({
+        inputProcessors: [],
+        outputProcessors,
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      messageList.add([createMessage('user message', 'user')], 'user');
+
+      await runner.runProcessOutputStep({
+        steps: [],
+        messages: messageList.get.all.db(),
+        messageList,
+        stepNumber: 0,
+      });
+
+      expect(receivedUsage).toEqual({
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      });
+    });
   });
 
   describe('writer availability in output processors', () => {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -12,6 +12,7 @@ import type { ObservabilityContext, Span } from '../observability';
 import type { RequestContext } from '../request-context';
 import type { ChunkType } from '../stream';
 import type { MastraModelOutput } from '../stream/base/output';
+import type { LanguageModelUsage } from '../stream/types';
 import type { ProcessorStepOutput } from './step-schema';
 import { isMaybeClaude46, TrailingAssistantGuard } from './trailing-assistant-guard';
 import { isProcessorWorkflow } from './index';
@@ -1110,6 +1111,7 @@ export class ProcessorRunner {
       finishReason?: string;
       toolCalls?: ToolCallInfo[];
       text?: string;
+      usage?: LanguageModelUsage;
       requestContext?: RequestContext;
       retryCount?: number;
       writer?: ProcessorStreamWriter;
@@ -1122,6 +1124,7 @@ export class ProcessorRunner {
       finishReason,
       toolCalls,
       text,
+      usage,
       requestContext,
       retryCount = 0,
       writer,
@@ -1147,6 +1150,7 @@ export class ProcessorRunner {
             finishReason,
             toolCalls,
             text,
+            usage,
             systemMessages: currentSystemMessages,
             steps,
             retryCount,
@@ -1196,6 +1200,11 @@ export class ProcessorRunner {
       const processorState = this.getProcessorState(processor.id);
 
       try {
+        const defaultUsage: LanguageModelUsage = {
+          inputTokens: undefined,
+          outputTokens: undefined,
+          totalTokens: undefined,
+        };
         const result = await processMethod({
           messages: processableMessages,
           messageList,
@@ -1203,6 +1212,7 @@ export class ProcessorRunner {
           finishReason,
           toolCalls,
           text,
+          usage: usage ?? defaultUsage,
           systemMessages: currentSystemMessages,
           steps,
           state: processorState.customState,

--- a/packages/core/src/processors/step-schema.ts
+++ b/packages/core/src/processors/step-schema.ts
@@ -166,6 +166,7 @@ export type ProcessorOutputStepPhaseType = {
   finishReason?: string;
   toolCalls?: Array<{ toolName: string; toolCallId: string; args?: unknown }>;
   text?: string;
+  usage?: Record<string, unknown>;
   systemMessages?: CoreMessageType[];
   retryCount?: number;
 };
@@ -190,6 +191,7 @@ export type ProcessorStepOutputType = {
   finishReason?: string;
   toolCalls?: Array<{ toolName: string; toolCallId: string; args?: unknown }>;
   text?: string;
+  usage?: Record<string, unknown>;
   retryCount?: number;
   model?: MastraLanguageModel;
   tools?: ProcessorStepToolsConfig;
@@ -593,6 +595,10 @@ export const ProcessorOutputStepPhaseSchema = z.object({
   finishReason: z.string().optional().describe('The finish reason from the LLM (stop, tool-use, length, etc.)'),
   toolCalls: z.array(toolCallSchema).optional().describe('Tool calls made in this step (if any)'),
   text: z.string().optional().describe('Generated text from this step'),
+  usage: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Token usage for the current step (inputTokens, outputTokens, totalTokens, etc.)'),
   systemMessages: systemMessagesSchema.optional(),
   retryCount: retryCountSchema,
 });
@@ -651,6 +657,7 @@ export const ProcessorStepOutputSchema: z.ZodType<ProcessorStepOutputType> = z.o
   finishReason: z.string().optional(),
   toolCalls: z.array(toolCallSchema).optional(),
   text: z.string().optional(),
+  usage: z.record(z.string(), z.unknown()).optional(),
 
   // Retry count
   retryCount: z.number().optional(),

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -22,7 +22,7 @@ import { toStandardSchema } from '../../schema';
 import type { InferPublicSchema, InferStandardSchemaOutput, PublicSchema, StandardSchemaWithJSON } from '../../schema';
 
 import { WorkflowRunOutput } from '../../stream/RunOutput';
-import type { ChunkType } from '../../stream/types';
+import type { ChunkType, LanguageModelUsage } from '../../stream/types';
 import { ChunkFrom } from '../../stream/types';
 import { Tool } from '../../tools';
 import type { ToolExecutionContext } from '../../tools/types';
@@ -751,6 +751,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         modelSettings,
         structuredOutput,
         steps,
+        usage,
         messageId,
         rotateResponseMessageId,
         // Shared processor states map for accessing persisted state
@@ -1200,6 +1201,11 @@ function createStepFromProcessor<TProcessorId extends string>(
               const idsBeforeProcessing = (messages as MastraDBMessage[]).map(m => m.id);
               const check = passThrough.messageList.makeMessageSourceChecker();
 
+              const defaultUsage: LanguageModelUsage = {
+                inputTokens: undefined,
+                outputTokens: undefined,
+                totalTokens: undefined,
+              };
               const result = await processor.processOutputStep({
                 ...baseContext,
                 messages: messages as MastraDBMessage[],
@@ -1208,6 +1214,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                 finishReason,
                 toolCalls: toolCalls as any,
                 text,
+                usage: (usage as LanguageModelUsage) ?? defaultUsage,
                 systemMessages: (systemMessages ?? []) as CoreMessage[],
                 steps: steps ?? [],
               });

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -873,6 +873,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         modelSettings,
         structuredOutput,
         steps,
+        usage,
         messageId: currentMessageId,
         rotateResponseMessageId: rotateCurrentResponseMessageId,
       };

--- a/packages/core/src/workflows/processor-step.test.ts
+++ b/packages/core/src/workflows/processor-step.test.ts
@@ -363,6 +363,35 @@ describe('createStep with Processor', () => {
       );
     });
 
+    it('should pass usage to processOutputStep in workflow path', async () => {
+      let receivedUsage: any = undefined;
+
+      const processor: Processor = {
+        id: 'usage-step-processor',
+        processOutputStep: async ({ messages, usage }) => {
+          receivedUsage = usage;
+          return messages;
+        },
+      };
+
+      const step = createStep(processor);
+      const messageList = createMockMessageList();
+      const inputData = {
+        phase: 'outputStep' as const,
+        messages: [{ id: '1', role: 'assistant', content: 'response' }],
+        messageList,
+        stepNumber: 0,
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      };
+
+      await step.execute({ inputData } as any);
+
+      expect(receivedUsage).toBeDefined();
+      expect(receivedUsage.inputTokens).toBe(100);
+      expect(receivedUsage.outputTokens).toBe(50);
+      expect(receivedUsage.totalTokens).toBe(150);
+    });
+
     it('should return original messages when processor method not implemented', async () => {
       const processor: Processor = {
         id: 'partial-processor',

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -34,7 +34,7 @@ import { toStandardSchema } from '../schema';
 import type { InferPublicSchema, InferStandardSchemaOutput, PublicSchema, StandardSchemaWithJSON } from '../schema';
 import type { StorageListWorkflowRunsInput } from '../storage';
 import { WorkflowRunOutput } from '../stream/RunOutput';
-import type { ChunkType } from '../stream/types';
+import type { ChunkType, LanguageModelUsage } from '../stream/types';
 import { ChunkFrom } from '../stream/types';
 import { Tool } from '../tools';
 import type { ToolExecutionContext } from '../tools';
@@ -711,6 +711,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         modelSettings,
         structuredOutput,
         steps,
+        usage,
         messageId,
         rotateResponseMessageId,
         // Shared processor states map for accessing persisted state
@@ -1186,6 +1187,11 @@ function createStepFromProcessor<TProcessorId extends string>(
               const idsBeforeProcessing = (messages as MastraDBMessage[]).map(m => m.id);
               const check = checkedMessageList.makeMessageSourceChecker();
 
+              const defaultUsage: LanguageModelUsage = {
+                inputTokens: undefined,
+                outputTokens: undefined,
+                totalTokens: undefined,
+              };
               const result = await processor.processOutputStep({
                 ...baseContext,
                 messages: messages as MastraDBMessage[],
@@ -1194,6 +1200,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                 finishReason,
                 toolCalls: toolCalls as any,
                 text,
+                usage: (usage as LanguageModelUsage) ?? defaultUsage,
                 systemMessages: (systemMessages ?? []) as CoreMessage[],
                 steps: steps ?? [],
               });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -846,6 +846,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         modelSettings,
         structuredOutput,
         steps,
+        usage,
         messageId: currentMessageId,
         rotateResponseMessageId: rotateCurrentResponseMessageId,
       };

--- a/packages/server/src/server/handlers/processors.ts
+++ b/packages/server/src/server/handlers/processors.ts
@@ -445,6 +445,7 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
               finishReason: 'stop',
               toolCalls: [],
               text: extractTextFromMessages(messages),
+              usage: { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined },
             });
             break;
 

--- a/workflows/inngest/src/index.ts
+++ b/workflows/inngest/src/index.ts
@@ -10,7 +10,7 @@ import type { Processor, ProcessorStepOutput, ProcessorStepInputSchema, OutputRe
 import { ProcessorRunner, ProcessorStepOutputSchema, ProcessorStepSchema } from '@mastra/core/processors';
 import type { InferPublicSchema, PublicSchema, StandardSchemaWithJSON } from '@mastra/core/schema';
 import { toStandardSchema } from '@mastra/core/schema';
-import type { ChunkType } from '@mastra/core/stream';
+import type { ChunkType, LanguageModelUsage } from '@mastra/core/stream';
 import type { ToolExecutionContext } from '@mastra/core/tools';
 import { Tool, createTool } from '@mastra/core/tools';
 import type { DynamicArgument } from '@mastra/core/types';
@@ -581,6 +581,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         modelSettings,
         structuredOutput,
         steps,
+        usage,
       } = input;
 
       // Create a minimal abort function that throws TripWire
@@ -669,6 +670,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         modelSettings,
         structuredOutput,
         steps,
+        usage,
       };
 
       // Helper to execute phase with proper span lifecycle management
@@ -987,6 +989,11 @@ function createStepFromProcessor<TProcessorId extends string>(
               const idsBeforeProcessing = (messages as MastraDBMessage[]).map(m => m.id);
               const check = passThrough.messageList.makeMessageSourceChecker();
 
+              const defaultUsage: LanguageModelUsage = {
+                inputTokens: undefined,
+                outputTokens: undefined,
+                totalTokens: undefined,
+              };
               const result = await processor.processOutputStep({
                 ...baseContext,
                 messages: messages as MastraDBMessage[],
@@ -995,6 +1002,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                 finishReason,
                 toolCalls: toolCalls as any,
                 text,
+                usage: (usage as LanguageModelUsage) ?? defaultUsage,
                 systemMessages: (systemMessages ?? []) as CoreMessage[],
                 steps: steps ?? [],
                 state: {},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes sure that when your AI processes output from language models, it now tells processors exactly how many tokens (small pieces of text) were used in each step. Before, processors were flying blind and couldn't track costs or manage how many tokens they were using. Now they can see the numbers and make smarter decisions.

## Overview

This PR adds token usage data (`inputTokens`, `outputTokens`, `totalTokens`) to the `ProcessOutputStepArgs` interface, enabling output processors to receive per-step LLM usage metrics. This supports cost tracking and token budget enforcement at the processor level.

## Changes

**Type Definitions & Interfaces**
- Updated `ProcessOutputStepArgs<TTripwireMetadata>` in `packages/core/src/processors/index.ts` to include a required `usage: LanguageModelUsage` field
- Extended `ProcessorOutputStepPhaseType` and `ProcessorStepOutputType` in `packages/core/src/processors/step-schema.ts` with optional `usage?: Record<string, unknown>` fields and corresponding Zod validation schemas

**Processor Execution**
- Modified `ProcessorRunner.runProcessOutputStep()` in `packages/core/src/processors/runner.ts` to accept an optional `usage?: LanguageModelUsage` parameter and pass it to processors, with a fallback to a default usage object when not provided
- Updated `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts` to explicitly pass `outputStream._getImmediateUsage()` as the `usage` field to `processorRunner.runProcessOutputStep()`

**Workflow Integration**
- Extended processor execution contexts in `packages/core/src/workflows/workflow.ts` and `packages/core/src/workflows/evented/workflow.ts` to thread `usage` through processor callbacks and pass it to `processOutputStep` invocations
- Updated `workflows/inngest/src/index.ts` to include `usage` in the pass-through object and ensure `processOutputStep` receives usage data
- Modified `packages/server/src/server/handlers/processors.ts` to include a `usage` field in the `outputStep` phase result

**Testing & Examples**
- Added test coverage in `packages/core/src/processors/runner.test.ts` verifying that `processOutputStep` receives passed `usage` data or defaults to undefined values when not provided
- Added test in `packages/core/src/workflows/processor-step.test.ts` confirming `usage` propagates from input data through to the processor
- Created `examples/agent/src/process-output-step-usage.ts` demonstrating a custom `OutputStepUsageLogger` processor that logs token usage metrics

**Documentation**
- Updated changelog in `.changeset/polite-kiwis-lie.md` documenting the fix that enables output processors to receive token-usage data for per-step cost tracking and token budget enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->