### PR TITLE
fix(ai-sdk): populate response.messages in data-tool-agent events for nested agents

### DIFF
--- a/.changeset/fix-nested-agent-response-messages.md
+++ b/.changeset/fix-nested-agent-response-messages.md
@@ -1,0 +1,20 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+fix(ai-sdk): populate response.messages in data-tool-agent events for nested agents
+
+In nested agent setups, `part.data.response.messages` (and per-step
+`steps[i].response.messages`) was always empty in `data-tool-agent` events.
+
+The `finish` and `step-finish` payloads originate from `LLMIterationData`,
+which has no `response` field. `transformAgent` tried to read
+`payload.payload.response?.messages` — always `undefined` — and fell back to
+the initial `[]` set in the `start` case.
+
+The fix falls back to `payload.payload.messages?.nonUser`, which IS present in
+`LLMIterationData` and carries the accumulated model-format response messages
+from the sub-agent run. When `response.messages` is explicitly provided it
+still takes priority.
+
+Fixes #15051.

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-response-messages.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-response-messages.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformAgent } from '../transformers';
+
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/15051
+ *
+ * In nested agent setups, the `data-tool-agent` event had empty
+ * `response.messages` (and per-step `steps[i].response.messages`).
+ *
+ * Root cause: the `finish` and `step-finish` payloads originate from
+ * `LLMIterationData`, which has no `response` field. `transformAgent` tried
+ * to read `payload.payload.response?.messages` — always `undefined` — and
+ * fell back to the initial `[]` set in the `start` case.
+ *
+ * Fix: fall back to `payload.payload.messages?.nonUser`, which IS present in
+ * `LLMIterationData` and carries the accumulated model-format response
+ * messages from the sub-agent run.
+ */
+describe('transformAgent response.messages (issue #15051)', () => {
+  function makePayload(type: string, runId: string, payload: any) {
+    return { type, runId, payload } as any;
+  }
+
+  const mockAssistantMessage = {
+    role: 'assistant',
+    content: [
+      { type: 'text', text: 'Hello from sub-agent' },
+      { type: 'tool-call', toolCallId: 'call-1', toolName: 'search', args: { q: 'test' } },
+    ],
+  };
+
+  it('finish event should populate response.messages from messages.nonUser when response field is absent', () => {
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'sub-agent-run';
+
+    transformAgent(makePayload('start', runId, { id: 'sub-agent' }), bufferedSteps);
+
+    // Simulate a finish payload from LLMIterationData (no `response` field,
+    // but has `messages.nonUser` with accumulated model-format messages).
+    const finishResult = transformAgent(
+      makePayload('finish', runId, {
+        stepResult: { reason: 'stop', warnings: [] },
+        output: { usage: { inputTokens: 50, outputTokens: 20, totalTokens: 70 } },
+        metadata: { modelId: 'gpt-4o', timestamp: new Date() },
+        messages: {
+          all: [{ role: 'user', content: 'hi' }, mockAssistantMessage],
+          user: [{ role: 'user', content: 'hi' }],
+          nonUser: [mockAssistantMessage],
+        },
+        // No `response` field — mirrors the actual LLMIterationData structure
+      }),
+      bufferedSteps,
+    );
+
+    expect(finishResult).not.toBeNull();
+    expect(finishResult!.data.response.messages).toHaveLength(1);
+    expect(finishResult!.data.response.messages[0]).toEqual(mockAssistantMessage);
+  });
+
+  it('finish event with explicit response.messages should use those over messages.nonUser', () => {
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'sub-agent-run-2';
+
+    transformAgent(makePayload('start', runId, { id: 'sub-agent' }), bufferedSteps);
+
+    const explicitMessage = { role: 'assistant', content: [{ type: 'text', text: 'Explicit' }] };
+
+    const finishResult = transformAgent(
+      makePayload('finish', runId, {
+        stepResult: { reason: 'stop', warnings: [] },
+        output: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+        metadata: {},
+        // Both `response.messages` and `messages.nonUser` present — `response.messages` wins
+        response: { messages: [explicitMessage] },
+        messages: {
+          all: [mockAssistantMessage],
+          user: [],
+          nonUser: [mockAssistantMessage],
+        },
+      }),
+      bufferedSteps,
+    );
+
+    expect(finishResult!.data.response.messages).toHaveLength(1);
+    expect(finishResult!.data.response.messages[0]).toEqual(explicitMessage);
+  });
+
+  it('step-finish event should populate response.messages from messages.nonUser when response field is absent', () => {
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'sub-agent-run-3';
+
+    transformAgent(makePayload('start', runId, { id: 'sub-agent' }), bufferedSteps);
+    transformAgent(makePayload('text-delta', runId, { text: 'thinking...' }), bufferedSteps);
+
+    const stepFinishResult = transformAgent(
+      makePayload('step-finish', runId, {
+        id: 'step-0',
+        stepResult: { reason: 'stop', warnings: [] },
+        output: { usage: { inputTokens: 30, outputTokens: 10, totalTokens: 40 } },
+        metadata: { timestamp: new Date(), modelId: 'gpt-4o' },
+        // `messages.nonUser` present but no `response` field (LLMIterationData shape)
+        messages: {
+          all: [{ role: 'user', content: 'q' }, mockAssistantMessage],
+          user: [{ role: 'user', content: 'q' }],
+          nonUser: [mockAssistantMessage],
+        },
+      }),
+      bufferedSteps,
+    );
+
+    expect(stepFinishResult).not.toBeNull();
+    const step = stepFinishResult!.data.steps[0];
+    expect(step.response.messages).toHaveLength(1);
+    expect(step.response.messages[0]).toEqual(mockAssistantMessage);
+  });
+
+  it('finish event should have empty response.messages when neither response nor messages.nonUser is present', () => {
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'sub-agent-run-4';
+
+    transformAgent(makePayload('start', runId, { id: 'sub-agent' }), bufferedSteps);
+
+    const finishResult = transformAgent(
+      makePayload('finish', runId, {
+        stepResult: { reason: 'stop', warnings: [] },
+        output: { usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+        metadata: {},
+      }),
+      bufferedSteps,
+    );
+
+    expect(finishResult!.data.response.messages).toEqual([]);
+  });
+});

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -442,21 +442,32 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
       });
       hasChanged = true;
       break;
-    case 'finish':
+    case 'finish': {
+      const finishData = bufferedSteps.get(payload.runId!);
+      const finishPayload = payload.payload as any;
       bufferedSteps.set(payload.runId!, {
-        ...bufferedSteps.get(payload.runId!),
+        ...finishData,
         finishReason: payload.payload.stepResult.reason,
         usage: payload.payload?.output?.usage,
         warnings: payload.payload?.stepResult?.warnings,
-        steps: bufferedSteps.get(payload.runId!)!.steps,
+        steps: finishData!.steps,
         status: 'finished',
         response: {
-          ...bufferedSteps.get(payload.runId!).response,
+          ...finishData?.response,
           ...(payload.payload.response || {}),
+          // The finish payload (LLMIterationData) has no `response` field, so
+          // response?.messages is always undefined. Fall back to messages.nonUser
+          // which carries the accumulated model-format response messages.
+          messages:
+            finishPayload.response?.messages ??
+            finishPayload.messages?.nonUser ??
+            finishData?.response?.messages ??
+            [],
         },
       });
       hasChanged = true;
       break;
+    }
     case 'text-delta': {
       const prevData = bufferedSteps.get(payload.runId!)!;
       bufferedSteps.set(payload.runId!, {
@@ -560,6 +571,7 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
           ...((payload.payload as any).response || {}),
           messages:
             ((payload.payload as any).response?.messages as typeof stepRun.response.messages) ??
+            ((payload.payload as any).messages?.nonUser as typeof stepRun.response.messages) ??
             stepRun.response.messages ??
             [],
         },


### PR DESCRIPTION
## Summary

Fixes #15051.

When using nested agents (parent agent calling a sub-agent via `createTool`), the `data-tool-agent` stream event always had empty `response.messages` and `steps[i].response.messages`, making it impossible to reconstruct the sub-agent's ordered sequence of message parts (text → tool call → tool result → text).

### Root Cause

The `finish` and `step-finish` chunks received by `transformAgent` originate from `LLMIterationData`, which has **no `response` field**. The code tried to read `payload.payload.response?.messages` — always `undefined` — and fell back to the initial `[]` set in the `start` case.

The model-format response messages ARE available at `payload.payload.messages?.nonUser` (part of `LLMIterationData.messages`), but this field was never consulted.

### Fix

In both the `finish` and `step-finish` cases of `transformAgent`, add a fallback to `payload.payload.messages?.nonUser` when `payload.payload.response?.messages` is absent:

```ts
messages:
  finishPayload.response?.messages ??   // explicit (future-proof)
  finishPayload.messages?.nonUser ??    // LLMIterationData path (actual fix)
  finishData?.response?.messages ??
  [],
```

Explicit `response.messages` still takes priority, so this is fully backward-compatible.

### Testing

Added regression tests in `transform-agent-response-messages.test.ts` that verify:
- `finish` event populates `response.messages` from `messages.nonUser` when `response` field is absent
- Explicit `response.messages` wins over `messages.nonUser` when both are present
- `step-finish` event populates `steps[i].response.messages` from `messages.nonUser`
- Fallback to empty array when neither field exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you ask your assistant to help with a task, but they ask a smaller helper to do part of it. When the helper finishes, you weren't getting a record of what they did or what they said. This PR fixes that by looking in the right place in the data to find the helper's message history, so now you can see everything they worked on.

## What was changed

**Root cause:** When a parent agent calls a sub-agent via `createTool`, the `data-tool-agent` stream events were not populating `response.messages`. This happened because `finish` and `step-finish` chunks come from `LLMIterationData`, which doesn't include a `response` field—so the code was trying to read from an empty location and always fell back to an empty array.

**Solution:** The fix updates the `transformAgent` handler to check an additional location (`payload.payload.messages?.nonUser`) as a fallback when `response?.messages` is absent. This secondary location contains the accumulated model-format messages from the sub-agent's execution.

## Changes made

1. **client-sdks/ai-sdk/src/transformers.ts** – Updated `transformAgent` handler:
   - For `finish` case: implements fallback chain `response?.messages` → `messages?.nonUser` → empty array
   - For `step-finish` case: added fallback to `messages?.nonUser` when populating per-step response messages
   - Optimized by snapshotting `bufferedSteps` lookup into a variable to avoid repeated map access

2. **client-sdks/ai-sdk/src/__tests__/transform-agent-response-messages.test.ts** – Added comprehensive regression tests covering:
   - `finish` populates `response.messages` from `messages.nonUser` when `response` is absent
   - Explicit `response.messages` takes priority when present
   - `step-finish` correctly populates `steps[i].response.messages` from the fallback
   - Fallback to empty array when neither `response` nor `messages.nonUser` exists

3. **.changeset/fix-nested-agent-response-messages.md** – Changeset documenting patch-level fix for `@mastra/ai-sdk`

## Impact

Nested agents now correctly return their ordered message history (text → tool call → tool result → text) in `data-tool-agent` events, enabling proper reconstruction and UI rendering of sub-agent interactions on the frontend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->