### PR TITLE
feat(core): trace embed and upsert steps in RAG ingestion pipeline

### DIFF
--- a/.changeset/slow-teeth-hope.md
+++ b/.changeset/slow-teeth-hope.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added observability tracing for embed and upsert steps during RAG ingestion. New `embedForIngestion()` function emits `RAG_EMBEDDING` spans with `mode: 'ingest'`, and new `upsertWithTracing()` method on `MastraVector` emits `RAG_VECTOR_OPERATION` spans with `operation: 'upsert'`. Both are opt-in via `observabilityContext` — existing callers are unaffected. Follow-up to #15137.

--- a/packages/core/src/observability/rag-ingestion.ts
+++ b/packages/core/src/observability/rag-ingestion.ts
@@ -70,7 +70,7 @@ export interface StartRagIngestionResult {
  *   attributes: { vectorStore: 'pgvector', indexName: 'docs' },
  * });
  * try {
- *   const chunks = await doc.chunk({ observabilityContext });
+ *   const chunks = await doc.chunk({}, { observabilityContext });
  *   // ...
  *   span?.end({ output: { chunkCount: chunks.length } });
  * } catch (err) {
@@ -107,13 +107,16 @@ export function startRagIngestion(options: StartRagIngestionOptions): StartRagIn
  *     attributes: { vectorStore: 'pgvector', indexName: 'docs' },
  *   },
  *   async (observabilityContext) => {
- *     const chunks = await doc.chunk({ observabilityContext });
- *     const { embeddings } = await embed(chunks, { observabilityContext });
- *     await vectorStore.upsert({
- *       indexName: 'docs',
- *       vectors: embeddings,
+ *     const chunks = await doc.chunk({}, { observabilityContext });
+ *     const { embeddings } = await embedForIngestion({
+ *       model,
+ *       values: chunks.map(c => c.getText()),
  *       observabilityContext,
  *     });
+ *     await vectorStore.upsertWithTracing(
+ *       { indexName: 'docs', vectors: embeddings },
+ *       { observabilityContext },
+ *     );
  *     return { chunkCount: chunks.length };
  *   },
  * );

--- a/packages/core/src/vector/embed-instrumented.test.ts
+++ b/packages/core/src/vector/embed-instrumented.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import type { ObservabilityContext } from '../observability';
+
+vi.mock('./embed', () => ({
+  embedV1: vi.fn(),
+  embedV2: vi.fn(),
+  embedV3: vi.fn(),
+}));
+
+import { embedV1, embedV2, embedV3 } from './embed';
+import { embedForIngestion } from './embed-instrumented';
+
+const mockEmbedV1 = vi.mocked(embedV1);
+const mockEmbedV2 = vi.mocked(embedV2);
+const mockEmbedV3 = vi.mocked(embedV3);
+
+function createMockModel(specVersion: string) {
+  return {
+    specificationVersion: specVersion,
+    modelId: 'text-embedding-3-small',
+    provider: 'openai',
+  } as any;
+}
+
+function createMockObservabilityContext() {
+  const endFn = vi.fn();
+  const errorFn = vi.fn();
+  const createChildSpanFn = vi.fn().mockReturnValue({
+    end: endFn,
+    error: errorFn,
+  });
+
+  const ctx: ObservabilityContext = {
+    tracingContext: {
+      currentSpan: {
+        createChildSpan: createChildSpanFn,
+      },
+    },
+  } as any;
+
+  return { ctx, createChildSpanFn, endFn, errorFn };
+}
+
+describe('embedForIngestion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('works without observabilityContext (no-op tracing)', async () => {
+    mockEmbedV3.mockResolvedValueOnce({ embedding: [0.1, 0.2, 0.3] } as any);
+
+    const result = await embedForIngestion({
+      model: createMockModel('v3'),
+      values: ['hello world'],
+    });
+
+    expect(result.embeddings).toEqual([[0.1, 0.2, 0.3]]);
+    expect(mockEmbedV3).toHaveBeenCalledOnce();
+  });
+
+  it('creates a child span with correct attributes when observabilityContext is provided', async () => {
+    mockEmbedV3.mockResolvedValueOnce({ embedding: [0.1, 0.2], usage: { tokens: 5 } } as any);
+    mockEmbedV3.mockResolvedValueOnce({ embedding: [0.3, 0.4], usage: { tokens: 3 } } as any);
+
+    const { ctx, createChildSpanFn, endFn } = createMockObservabilityContext();
+
+    const result = await embedForIngestion({
+      model: createMockModel('v3'),
+      values: ['text one', 'text two'],
+      observabilityContext: ctx,
+    });
+
+    expect(result.embeddings).toEqual([
+      [0.1, 0.2],
+      [0.3, 0.4],
+    ]);
+
+    // Verify child span was created with correct type and attributes
+    expect(createChildSpanFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'rag embed: ingest',
+        input: { count: 2 },
+        attributes: expect.objectContaining({
+          mode: 'ingest',
+          inputCount: 2,
+        }),
+      }),
+    );
+
+    // Verify span was ended with dimensions and usage
+    expect(endFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          dimensions: 2,
+          usage: { inputTokens: 8 },
+        }),
+        output: { vectorCount: 2, dimensions: 2 },
+      }),
+    );
+  });
+
+  it('calls embedV2 for v2 models', async () => {
+    mockEmbedV2.mockResolvedValueOnce({ embedding: [1, 2, 3] } as any);
+
+    await embedForIngestion({
+      model: createMockModel('v2'),
+      values: ['test'],
+    });
+
+    expect(mockEmbedV2).toHaveBeenCalledOnce();
+    expect(mockEmbedV1).not.toHaveBeenCalled();
+    expect(mockEmbedV3).not.toHaveBeenCalled();
+  });
+
+  it('calls embedV1 for v1/legacy models', async () => {
+    mockEmbedV1.mockResolvedValueOnce({ embedding: [1, 2, 3] } as any);
+
+    await embedForIngestion({
+      model: createMockModel('v1'),
+      values: ['test'],
+    });
+
+    expect(mockEmbedV1).toHaveBeenCalledOnce();
+    expect(mockEmbedV2).not.toHaveBeenCalled();
+    expect(mockEmbedV3).not.toHaveBeenCalled();
+  });
+
+  it('records error on span and re-throws when embedding fails', async () => {
+    const error = new Error('embedding failed');
+    mockEmbedV3.mockRejectedValueOnce(error);
+
+    const { ctx, errorFn } = createMockObservabilityContext();
+
+    await expect(
+      embedForIngestion({
+        model: createMockModel('v3'),
+        values: ['test'],
+        observabilityContext: ctx,
+      }),
+    ).rejects.toThrow('embedding failed');
+
+    expect(errorFn).toHaveBeenCalledWith({ error, endSpan: true });
+  });
+});

--- a/packages/core/src/vector/embed-instrumented.ts
+++ b/packages/core/src/vector/embed-instrumented.ts
@@ -1,0 +1,114 @@
+/**
+ * Instrumented embedding helpers for RAG ingestion.
+ *
+ * Wraps the raw AI SDK `embed` functions with `RAG_EMBEDDING` child spans
+ * carrying `mode: 'ingest'`. This is the ingestion counterpart of the
+ * query-path embedding instrumented inside `vectorQuerySearch`.
+ *
+ * Accepts an optional `observabilityContext`; no-ops when absent.
+ */
+
+import type { ObservabilityContext } from '../observability';
+import { SpanType } from '../observability';
+import { embedV1, embedV2, embedV3 } from './embed';
+import type { MastraEmbeddingModel, MastraEmbeddingOptions } from './vector';
+
+export interface EmbedForIngestionParams {
+  /** The embedding model to use */
+  model: MastraEmbeddingModel<string>;
+  /** Array of text values to embed */
+  values: string[];
+  /** Optional embedding options (maxRetries, providerOptions, etc.) */
+  options?: MastraEmbeddingOptions;
+  /** Observability context for tracing. When absent, no spans are emitted. */
+  observabilityContext?: ObservabilityContext;
+}
+
+export interface EmbedForIngestionResult {
+  /** The computed embedding vectors, one per input value */
+  embeddings: number[][];
+}
+
+/**
+ * Embed an array of texts for ingestion, optionally emitting a
+ * `RAG_EMBEDDING` span with `mode: 'ingest'`.
+ *
+ * This mirrors the embedding logic in `vectorQuerySearch` but handles
+ * batch inputs and tags spans as ingestion rather than query.
+ */
+export async function embedForIngestion({
+  model,
+  values,
+  options,
+  observabilityContext,
+}: EmbedForIngestionParams): Promise<EmbedForIngestionResult> {
+  const parentSpan = observabilityContext?.tracingContext?.currentSpan;
+
+  const embedSpan = parentSpan?.createChildSpan({
+    type: SpanType.RAG_EMBEDDING,
+    name: 'rag embed: ingest',
+    input: { count: values.length },
+    attributes: {
+      mode: 'ingest',
+      model: (model as any)?.modelId,
+      provider: (model as any)?.provider,
+      inputCount: values.length,
+    },
+  });
+
+  try {
+    const embeddings: number[][] = [];
+    let totalTokens = 0;
+
+    for (const value of values) {
+      let result;
+      if (model.specificationVersion === 'v3') {
+        result = await embedV3({
+          model: model,
+          value,
+          maxRetries: options?.maxRetries,
+          ...(options?.providerOptions && {
+            providerOptions: options.providerOptions as Parameters<typeof embedV3>[0]['providerOptions'],
+          }),
+        });
+      } else if (model.specificationVersion === 'v2') {
+        result = await embedV2({
+          model: model,
+          value,
+          maxRetries: options?.maxRetries,
+          ...(options?.providerOptions && {
+            providerOptions: options.providerOptions as Parameters<typeof embedV2>[0]['providerOptions'],
+          }),
+        });
+      } else {
+        result = await embedV1({
+          value,
+          model: model,
+          maxRetries: options?.maxRetries,
+        });
+      }
+
+      embeddings.push(result.embedding);
+      const usage = (result as any)?.usage;
+      if (usage) {
+        totalTokens += usage.tokens ?? usage.promptTokens ?? usage.inputTokens ?? 0;
+      }
+    }
+
+    const dimensions = embeddings[0]?.length;
+    embedSpan?.end({
+      attributes: {
+        dimensions,
+        ...(totalTokens > 0 && {
+          usage: { inputTokens: totalTokens },
+        }),
+      },
+      output: { vectorCount: embeddings.length, dimensions },
+    });
+
+    return { embeddings };
+  } catch (err) {
+    embedSpan?.error({ error: err as Error, endSpan: true });
+    throw err;
+  }
+}

--- a/packages/core/src/vector/index.ts
+++ b/packages/core/src/vector/index.ts
@@ -1,5 +1,6 @@
 export * from './vector';
 export * from './types';
 export * from './embed';
+export * from './embed-instrumented';
 export * from './filter';
 export * from './validation';

--- a/packages/core/src/vector/upsert-with-tracing.test.ts
+++ b/packages/core/src/vector/upsert-with-tracing.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ObservabilityContext } from '../observability';
+import type { UpsertVectorParams, QueryResult, IndexStats, CreateIndexParams } from './types';
+import { MastraVector } from './vector';
+
+// Concrete subclass for testing
+class TestVector extends MastraVector {
+  upsertMock = vi.fn<(params: UpsertVectorParams) => Promise<string[]>>();
+
+  async query(): Promise<QueryResult[]> {
+    return [];
+  }
+
+  async upsert(params: UpsertVectorParams): Promise<string[]> {
+    return this.upsertMock(params);
+  }
+
+  async createIndex(_params: CreateIndexParams): Promise<void> {}
+  async listIndexes(): Promise<string[]> {
+    return [];
+  }
+  async describeIndex(): Promise<IndexStats> {
+    return { dimension: 3, count: 0 };
+  }
+  async deleteIndex(): Promise<void> {}
+  async updateVector(): Promise<void> {}
+  async deleteVector(): Promise<void> {}
+  async deleteVectors(): Promise<void> {}
+}
+
+function createMockObservabilityContext() {
+  const endFn = vi.fn();
+  const errorFn = vi.fn();
+  const createChildSpanFn = vi.fn().mockReturnValue({
+    end: endFn,
+    error: errorFn,
+  });
+
+  const ctx: ObservabilityContext = {
+    tracingContext: {
+      currentSpan: {
+        createChildSpan: createChildSpanFn,
+      },
+    },
+  } as any;
+
+  return { ctx, createChildSpanFn, endFn, errorFn };
+}
+
+describe('MastraVector.upsertWithTracing', () => {
+  it('delegates to upsert() without observabilityContext', async () => {
+    const vector = new TestVector({ id: 'test-store' });
+    vector.upsertMock.mockResolvedValueOnce(['id-1', 'id-2']);
+
+    const params: UpsertVectorParams = {
+      indexName: 'docs',
+      vectors: [
+        [0.1, 0.2],
+        [0.3, 0.4],
+      ],
+    };
+
+    const ids = await vector.upsertWithTracing(params);
+
+    expect(ids).toEqual(['id-1', 'id-2']);
+    expect(vector.upsertMock).toHaveBeenCalledWith(params);
+  });
+
+  it('creates a child span with correct attributes when observabilityContext is provided', async () => {
+    const vector = new TestVector({ id: 'test-pgvector' });
+    vector.upsertMock.mockResolvedValueOnce(['id-1', 'id-2', 'id-3']);
+
+    const { ctx, createChildSpanFn, endFn } = createMockObservabilityContext();
+
+    const params: UpsertVectorParams = {
+      indexName: 'my-index',
+      vectors: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+    };
+
+    const ids = await vector.upsertWithTracing(params, { observabilityContext: ctx });
+
+    expect(ids).toEqual(['id-1', 'id-2', 'id-3']);
+
+    expect(createChildSpanFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'rag vector: upsert',
+        input: { indexName: 'my-index', vectorCount: 3 },
+        attributes: expect.objectContaining({
+          operation: 'upsert',
+          store: 'test-pgvector',
+          indexName: 'my-index',
+          dimensions: 3,
+        }),
+      }),
+    );
+
+    expect(endFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: { vectorCount: 3 },
+      }),
+    );
+  });
+
+  it('records error on span and re-throws when upsert fails', async () => {
+    const vector = new TestVector({ id: 'test-store' });
+    const error = new Error('upsert failed');
+    vector.upsertMock.mockRejectedValueOnce(error);
+
+    const { ctx, errorFn } = createMockObservabilityContext();
+
+    await expect(
+      vector.upsertWithTracing({ indexName: 'docs', vectors: [[1, 2, 3]] }, { observabilityContext: ctx }),
+    ).rejects.toThrow('upsert failed');
+
+    expect(errorFn).toHaveBeenCalledWith({ error, endSpan: true });
+  });
+});

--- a/packages/core/src/vector/vector.ts
+++ b/packages/core/src/vector/vector.ts
@@ -17,6 +17,8 @@ import type {
 } from '@internal/ai-v6';
 import { MastraBase } from '../base';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
+import type { ObservabilityContext } from '../observability';
+import { SpanType } from '../observability';
 import type { VectorFilter } from './filter';
 import type {
   CreateIndexParams,
@@ -142,6 +144,41 @@ export abstract class MastraVector<Filter = VectorFilter> extends MastraBase {
    * ```
    */
   abstract deleteVectors(params: DeleteVectorsParams<Filter>): Promise<void>;
+
+  /**
+   * Traced wrapper around `upsert()`. Emits a `RAG_VECTOR_OPERATION` child
+   * span with `operation: 'upsert'` when an `observabilityContext` is provided.
+   * Falls back to a plain `upsert()` call when observability is absent.
+   */
+  async upsertWithTracing(
+    params: UpsertVectorParams,
+    options?: { observabilityContext?: ObservabilityContext },
+  ): Promise<string[]> {
+    const parentSpan = options?.observabilityContext?.tracingContext?.currentSpan;
+
+    const upsertSpan = parentSpan?.createChildSpan({
+      type: SpanType.RAG_VECTOR_OPERATION,
+      name: 'rag vector: upsert',
+      input: { indexName: params.indexName, vectorCount: params.vectors.length },
+      attributes: {
+        operation: 'upsert',
+        store: this.id,
+        indexName: params.indexName,
+        dimensions: params.vectors[0]?.length,
+      },
+    });
+
+    try {
+      const ids = await this.upsert(params);
+      upsertSpan?.end({
+        output: { vectorCount: ids.length },
+      });
+      return ids;
+    } catch (err) {
+      upsertSpan?.error({ error: err as Error, endSpan: true });
+      throw err;
+    }
+  }
 
   protected async validateExistingIndex(indexName: string, dimension: number, metric: string) {
     let info: IndexStats;


### PR DESCRIPTION
## Description

Follow-up to #15137 — adds the missing observability tracing for the **embed** and **upsert** steps during RAG
ingestion. Previously only chunking and the query path were instrumented.

- `embedForIngestion()` — wraps `embedV1`/`embedV2`/`embedV3` with a `RAG_EMBEDDING` span (`mode: 'ingest'`),
accumulates token usage across the batch
- `upsertWithTracing()` on `MastraVector` — wraps `upsert()` with a `RAG_VECTOR_OPERATION` span (`operation: 'upsert'`)
- Fixes `withRagIngestion` / `startRagIngestion` JSDoc examples to reference the actual APIs

Both are opt-in via `observabilityContext`. No breaking changes — existing callers are unaffected.

## Related Issue(s)

Follow-up to #15137 (Fixes #10898)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds the ability to track and observe what's happening when RAG systems embed text and store vectors in a database. Think of it like adding checkpoints in a factory assembly line so you can see how long each step takes and spot problems—it helps developers understand and debug how their RAG-powered agents are performing.

## Overview

This PR adds observability tracing for the embed and upsert steps of the RAG ingestion pipeline, following up on PR #15137. It introduces two new instrumented operations:

1. **`embedForIngestion()`** - Wraps embedding calls with RAG observability spans
2. **`upsertWithTracing()`** - Wraps vector upsert calls with RAG observability spans

Tracing is completely optional and controlled via `observabilityContext`, so existing code is unaffected.

## Key Changes

### Embedding Instrumentation
- New `embedForIngestion()` function in `embed-instrumented.ts` that:
  - Creates a `RAG_EMBEDDING` span with `mode: 'ingest'` when observability is enabled
  - Routes to the appropriate embed function (`embedV1`, `embedV2`, or `embedV3`) based on model specification version
  - Accumulates token usage across the batch and includes `inputTokens` in span metadata
  - Records embedding dimensions and vector count on success
  - Properly handles errors with span recording

### Vector Upsert Instrumentation
- New `upsertWithTracing()` method on `MastraVector` class that:
  - Wraps the existing `upsert()` call with a `RAG_VECTOR_OPERATION` span (`operation: 'upsert'`)
  - Includes index name, vector count, and dimensions in span attributes
  - Records output vector count on success
  - Passes through errors while recording them on the span

### Documentation Updates
- Updated JSDoc examples in `rag-ingestion.ts` to:
  - Correct the `doc.chunk()` API signature to use `doc.chunk({}, { observabilityContext })`
  - Replace raw `embed()` calls with `embedForIngestion()`
  - Replace raw `vectorStore.upsert()` calls with `vectorStore.upsertWithTracing()`

### Public API Exports
- Both new functions are exported from the main vector module index for public use

## Testing

Comprehensive test coverage was added:
- `embed-instrumented.test.ts`: Tests routing logic, span creation, token accumulation, and error handling for `embedForIngestion()`
- `upsert-with-tracing.test.ts`: Tests conditional span creation, attribute recording, and error propagation for `upsertWithTracing()`

## Changeset

Added a minor version bump entry for `@mastra/core` documenting the new opt-in observability features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->