### PR TITLE
fix(posthog): extract structured messages from generation spans

### DIFF
--- a/.changeset/tall-trams-see.md
+++ b/.changeset/tall-trams-see.md
@@ -1,0 +1,5 @@
+---
+'@mastra/posthog': patch
+---
+
+Fixed generation traces producing stringified JSON in messages instead of structured content. Input messages wrapped as `{messages: [...]}` and output objects with `text` are now properly extracted and formatted.

--- a/observability/posthog/src/tracing.test.ts
+++ b/observability/posthog/src/tracing.test.ts
@@ -733,6 +733,58 @@ describe('PosthogExporter', () => {
         },
       ]);
     });
+
+    it('should unwrap {messages: [...]} wrapper from generation input', async () => {
+      const generation = createSpan({
+        type: SpanType.MODEL_GENERATION,
+        parentSpanId: 'parent-1',
+        input: {
+          messages: [
+            { role: 'system', content: 'You are a helpful assistant.' },
+            { role: 'user', content: 'What is the weather?' },
+          ],
+        },
+      });
+
+      await exportSpanLifecycle(exporter, generation);
+
+      const capturedInput = mockCapture.mock.calls[0][0].properties.$ai_input;
+      expect(capturedInput).toEqual([
+        {
+          role: 'system',
+          content: [{ type: 'text', text: 'You are a helpful assistant.' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What is the weather?' }],
+        },
+      ]);
+    });
+
+    it('should extract text from generation output object without tool calls', async () => {
+      const generation = createSpan({
+        type: SpanType.MODEL_GENERATION,
+        parentSpanId: 'parent-1',
+        output: {
+          text: 'The weather is sunny.',
+          files: [],
+          reasoning: [],
+          reasoningText: '',
+          sources: [],
+          warnings: [],
+        },
+      });
+
+      await exportSpanLifecycle(exporter, generation);
+
+      const capturedOutput = mockCapture.mock.calls[0][0].properties.$ai_output_choices;
+      expect(capturedOutput).toEqual([
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'The weather is sunny.' }],
+        },
+      ]);
+    });
   });
 
   // --- Priority 4: Integration Scenarios ---

--- a/observability/posthog/src/tracing.test.ts
+++ b/observability/posthog/src/tracing.test.ts
@@ -785,6 +785,19 @@ describe('PosthogExporter', () => {
         },
       ]);
     });
+
+    it('should handle empty messages array without stringifying', async () => {
+      const generation = createSpan({
+        type: SpanType.MODEL_GENERATION,
+        parentSpanId: 'parent-1',
+        input: { messages: [] },
+      });
+
+      await exportSpanLifecycle(exporter, generation);
+
+      const capturedInput = mockCapture.mock.calls[0][0].properties.$ai_input;
+      expect(capturedInput).toEqual([]);
+    });
   });
 
   // --- Priority 4: Integration Scenarios ---

--- a/observability/posthog/src/tracing.ts
+++ b/observability/posthog/src/tracing.ts
@@ -534,7 +534,7 @@ export class PosthogExporter extends TrackingExporter<
   }
 
   private isMessageArray(data: unknown): data is MastraMessage[] {
-    if (!Array.isArray(data) || data.length === 0) {
+    if (!Array.isArray(data)) {
       return false;
     }
 

--- a/observability/posthog/src/tracing.ts
+++ b/observability/posthog/src/tracing.ts
@@ -483,6 +483,14 @@ export class PosthogExporter extends TrackingExporter<
   }
 
   private formatMessages(data: SpanData, defaultRole: 'user' | 'assistant' = 'user'): PostHogMessage[] {
+    // Unwrap {messages: [...]} wrapper produced by generation span inputs
+    if (typeof data === 'object' && data !== null && !Array.isArray(data) && 'messages' in data) {
+      const wrapped = (data as Record<string, unknown>).messages;
+      if (this.isMessageArray(wrapped)) {
+        return wrapped.map(msg => this.normalizeMessage(msg));
+      }
+    }
+
     if (this.isMessageArray(data)) {
       return data.map(msg => this.normalizeMessage(msg));
     }
@@ -504,6 +512,14 @@ export class PosthogExporter extends TrackingExporter<
         });
       }
       return [{ role: 'assistant', content }];
+    }
+
+    // Extract text from output objects (e.g. generation outputs with text but no tool calls)
+    if (typeof data === 'object' && data !== null && !Array.isArray(data) && 'text' in data) {
+      const text = (data as Record<string, unknown>).text;
+      if (typeof text === 'string') {
+        return [{ role: defaultRole, content: [{ type: 'text', text }] }];
+      }
     }
 
     return [{ role: defaultRole, content: [{ type: 'text', text: this.safeStringify(data) }] }];


### PR DESCRIPTION
Fixes #15333

## Description

Generation span inputs are wrapped as `{messages: [...]}` and outputs as `{text: "...", files: [], ...}`. The `formatMessages()` method didn't handle these shapes and fell through to `JSON.stringify()`, producing stringified JSON blobs in trace messages instead of proper structured content.

**Before:** PostHog traces show `{"messages":[{"role":"system","content":"..."},...]}` as a single text blob in the generation's input/output messages.

**After:** Messages are properly unwrapped and formatted as structured `role`/`content` pairs that PostHog's LLM observability UI can render correctly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR