### PR TITLE
fix(voice-sarvam): support current bulbul and saaras v3 models

### DIFF
--- a/.changeset/few-windows-tell.md
+++ b/.changeset/few-windows-tell.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/voice-sarvam': minor
+'@mastra/voice-sarvam': major
 ---
 
 Added support for Sarvam's current TTS and STT models. Previously the package only supported the now-deprecated bulbul:v1 and saarika:v1/v2/flash models, which Sarvam has retired.

--- a/.changeset/few-windows-tell.md
+++ b/.changeset/few-windows-tell.md
@@ -1,0 +1,46 @@
+---
+'@mastra/voice-sarvam': minor
+---
+
+Added support for Sarvam's current TTS and STT models. Previously the package only supported the now-deprecated bulbul:v1 and saarika:v1/v2/flash models, which Sarvam has retired.
+
+**What's new:**
+
+- TTS models: `bulbul:v2`, `bulbul:v3` (default), and `bulbul:v3-beta`. `bulbul:v3` and `bulbul:v3-beta` support 39 speakers; `bulbul:v2` supports 7 speakers.
+- STT models: `saarika:v2.5` (default) and `saaras:v3`. `saaras:v3` is a multi-mode model that supports `transcribe`, `translate`, `verbatim`, `translit`, and `codemix` via a new `mode` option.
+- New bulbul:v3 parameters: `temperature`, `dict_id`, `output_audio_codec`.
+- Expanded `speech_sample_rate` options: 8000, 16000, 22050, 24000, 32000, 44100, 48000.
+
+**Breaking changes:**
+
+- Removed the deprecated `bulbul:v1` TTS model and its speakers (`meera`, `pavithra`, `maitreyi`, `arvind`, `amol`, `amartya`, `diya`, `neel`, `misha`, `vian`, `arjun`, `maya`). Sarvam has retired the underlying API.
+- Removed the deprecated `saarika:v1`, `saarika:v2`, and `saarika:flash` STT models.
+- The default TTS model is now `bulbul:v3` and the default speaker is `shubh`. Speakers are not interchangeable between bulbul versions — each has its own catalog.
+- The TTS request body now sends `text` (single string) instead of `inputs` (array), matching Sarvam's current API.
+
+**Migration:**
+
+Before:
+
+```typescript
+const voice = new SarvamVoice({
+  speechModel: { model: 'bulbul:v1', language: 'en-IN' },
+  speaker: 'meera',
+  listeningModel: { model: 'saarika:v2' },
+});
+```
+
+After:
+
+```typescript
+const voice = new SarvamVoice({
+  speechModel: { model: 'bulbul:v3', language: 'en-IN' },
+  speaker: 'shubh',
+  listeningModel: { model: 'saarika:v2.5' },
+});
+
+// Or use saaras:v3 for speech translation:
+await voice.listen(audio, { model: 'saaras:v3', mode: 'translate' });
+```
+
+Resolves #15188.

--- a/docs/src/content/en/docs/voice/overview.mdx
+++ b/docs/src/content/en/docs/voice/overview.mdx
@@ -290,7 +290,7 @@ For detailed configuration options and advanced features, check out our [Text-to
 
     // Convert text to speech to an Audio Stream
     const audioStream = await voiceAgent.voice.speak(text, {
-      speaker: 'default', // Optional: specify a speaker
+      speaker: 'shubh', // Optional: specify a bulbul:v3 speaker
     })
 
     playAudio(audioStream)
@@ -794,12 +794,15 @@ Each voice provider can be configured with different models and options. Below a
     // Sarvam Voice Configuration
     const voice = new SarvamVoice({
       speechModel: {
-        name: 'sarvam-voice', // Example model name
+        model: 'bulbul:v3', // TTS model (bulbul:v2 or bulbul:v3)
         apiKey: process.env.SARVAM_API_KEY,
-        language: 'en-IN', // Language code
-        style: 'conversational', // Style setting
+        language: 'en-IN', // BCP-47 language code
       },
-      // Sarvam may not have a separate listening model
+      listeningModel: {
+        model: 'saarika:v2.5', // STT model (saarika:v2.5 or saaras:v3)
+        apiKey: process.env.SARVAM_API_KEY,
+      },
+      speaker: 'shubh', // Default bulbul:v3 speaker
     })
     ```
 

--- a/docs/src/content/en/reference/voice/sarvam.mdx
+++ b/docs/src/content/en/reference/voice/sarvam.mdx
@@ -20,25 +20,23 @@ const voice = new SarvamVoice()
 // Or initialize with specific configuration
 const voiceWithConfig = new SarvamVoice({
   speechModel: {
-    model: 'bulbul:v1',
+    model: 'bulbul:v3',
     apiKey: process.env.SARVAM_API_KEY!,
     language: 'en-IN',
     properties: {
-      pitch: 0,
-      pace: 1.65,
-      loudness: 1.5,
-      speech_sample_rate: 8000,
-      enable_preprocessing: false,
-      eng_interpolation_wt: 123,
+      pace: 1.0,
+      temperature: 0.6,
+      speech_sample_rate: 24000,
+      output_audio_codec: 'wav',
     },
   },
   listeningModel: {
-    model: 'saarika:v2',
+    model: 'saarika:v2.5',
     apiKey: process.env.SARVAM_API_KEY!,
     languageCode: 'en-IN',
     filetype: 'wav',
   },
-  speaker: 'meera', // Default voice
+  speaker: 'shubh', // Default voice for bulbul:v3
 })
 
 // Convert text to speech
@@ -52,7 +50,7 @@ const text = await voice.listen(audioStream, {
 
 ### Sarvam API Docs -
 
-[https://docs.sarvam.ai/api-reference-docs/endpoints/text-to-speech](https://docs.sarvam.ai/api-reference-docs/endpoints/text-to-speech)
+[https://docs.sarvam.ai/api-reference-docs/text-to-speech/convert](https://docs.sarvam.ai/api-reference-docs/text-to-speech/convert)
 
 ## Configuration
 
@@ -65,7 +63,7 @@ const text = await voice.listen(audioStream, {
     type: 'SarvamVoiceConfig',
     description: 'Configuration for text-to-speech synthesis.',
     isOptional: true,
-    defaultValue: "{ model: 'bulbul:v1', language: 'en-IN' }",
+    defaultValue: "{ model: 'bulbul:v3', language: 'en-IN' }",
     properties: [
       {
         type: 'SarvamVoiceConfig',
@@ -79,9 +77,10 @@ const text = await voice.listen(audioStream, {
           {
             name: 'model',
             type: 'SarvamTTSModel',
-            description: 'Specifies the model to use for text-to-speech conversion.',
+            description:
+              'Specifies the model to use for text-to-speech conversion. Available options: bulbul:v2, bulbul:v3, bulbul:v3-beta. bulbul:v3-beta is a beta variant of bulbul:v3 that shares the same speaker catalog. Note: bulbul:v1 has been deprecated by Sarvam and is no longer supported.',
             isOptional: true,
-            defaultValue: "'bulbul:v1'",
+            defaultValue: "'bulbul:v3'",
           },
           {
             name: 'language',
@@ -98,43 +97,55 @@ const text = await voice.listen(audioStream, {
             isOptional: true,
           },
           {
-            name: 'properties.pitch',
-            type: 'number',
-            description:
-              'Controls the pitch of the audio. Lower values result in a deeper voice, while higher values make it sharper. The suitable range is between -0.75 and 0.75.',
-            isOptional: true,
-          },
-          {
             name: 'properties.pace',
             type: 'number',
             description:
-              'Controls the speed of the audio. Lower values result in slower speech, while higher values make it faster. The suitable range is between 0.5 and 2.0. Default is 1.0. Required range: 0.3 <= x <= 3',
+              'Controls the speed of the audio. Supported by both bulbul:v2 (range 0.3–3.0) and bulbul:v3 (range 0.5–2.0).',
+            isOptional: true,
+          },
+          {
+            name: 'properties.temperature',
+            type: 'number',
+            description:
+              'Sampling temperature that controls the randomness of the generated voice. bulbul:v3 only. Range: 0.01–2.0. Default: 0.6.',
+            isOptional: true,
+          },
+          {
+            name: 'properties.dict_id',
+            type: 'string',
+            description: 'Pronunciation dictionary ID. bulbul:v3 only.',
+            isOptional: true,
+          },
+          {
+            name: 'properties.pitch',
+            type: 'number',
+            description:
+              'Controls the pitch of the audio. Lower values result in a deeper voice, while higher values make it sharper. bulbul:v2 only. Range: -0.75 to 0.75.',
             isOptional: true,
           },
           {
             name: 'properties.loudness',
             type: 'number',
-            description:
-              'Controls the loudness of the audio. Lower values result in quieter audio, while higher values make it louder. The suitable range is between 0.3 and 3.0. Required range: 0 <= x <= 3',
-            isOptional: true,
-          },
-          {
-            name: 'properties.speech_sample_rate',
-            type: '8000 | 16000 | 22050',
-            description: 'Audio sample rate in Hz.',
+            description: 'Controls the loudness of the audio. bulbul:v2 only. Range: 0.3 to 3.0.',
             isOptional: true,
           },
           {
             name: 'properties.enable_preprocessing',
             type: 'boolean',
             description:
-              'Controls whether normalization of English words and numeric entities (e.g., numbers, dates) is performed. Set to true for better handling of mixed-language text. Default is false.',
+              'Enables normalization of English words and numeric entities (numbers, dates, etc.). bulbul:v2 only. Default is false.',
             isOptional: true,
           },
           {
-            name: 'properties.eng_interpolation_wt',
-            type: 'number',
-            description: 'Weight for interpolating with English speaker at encoder.',
+            name: 'properties.speech_sample_rate',
+            type: '8000 | 16000 | 22050 | 24000 | 32000 | 44100 | 48000',
+            description: 'Audio sample rate in Hz.',
+            isOptional: true,
+          },
+          {
+            name: 'properties.output_audio_codec',
+            type: "'mp3' | 'wav' | 'linear16' | 'mulaw' | 'alaw' | 'opus' | 'flac' | 'aac'",
+            description: 'Output audio codec.',
             isOptional: true,
           },
         ],
@@ -145,16 +156,16 @@ const text = await voice.listen(audioStream, {
     name: 'speaker',
     type: 'SarvamVoiceId',
     description:
-      'The speaker to be used for the output audio. If not provided, Meera will be used as default. AvailableOptions - meera, pavithra, maitreyi, arvind, amol, amartya, diya, neel, misha, vian, arjun, maya',
+      "The speaker to be used for the output audio. Defaults to 'shubh'. bulbul:v3 supports 39 voices (shubh, aditya, ritu, priya, neha, rahul, pooja, rohan, simran, kavya, amit, dev, ishita, shreya, ratan, varun, manan, sumit, roopa, kabir, aayan, ashutosh, advait, amelia, sophia, anand, tanya, tarun, sunny, mani, gokul, vijay, shruti, suhani, mohit, kavitha, rehan, soham, rupali). bulbul:v2 supports 7 voices (anushka, manisha, vidya, arya, abhilash, karun, hitesh). Speakers are not interchangeable between model versions.",
     isOptional: true,
-    defaultValue: "'meera'",
+    defaultValue: "'shubh'",
   },
   {
     name: 'listeningModel',
     type: 'SarvamListenOptions',
     description: 'Configuration for speech-to-text recognition.',
     isOptional: true,
-    defaultValue: "{ model: 'saarika:v2', language_code: 'unknown' }",
+    defaultValue: "{ model: 'saarika:v2.5', languageCode: 'unknown' }",
     properties: [
       {
         type: 'SarvamListenOptions',
@@ -169,15 +180,15 @@ const text = await voice.listen(audioStream, {
             name: 'model',
             type: 'SarvamSTTModel',
             description:
-              'Specifies the model to use for speech-to-text conversion. Note:- Default model is saarika:v2 . Available options: saarika:v1, saarika:v2, saarika:flash',
+              'Specifies the model to use for speech-to-text conversion. Available options: saarika:v2.5 (transcription), saaras:v3 (multi-mode: transcribe/translate/verbatim/translit/codemix). Note: saarika:v1, saarika:v2, and saarika:flash have been deprecated by Sarvam.',
             isOptional: true,
-            defaultValue: "'saarika:v2'",
+            defaultValue: "'saarika:v2.5'",
           },
           {
             name: 'languageCode',
             type: 'SarvamSTTLanguage',
             description:
-              'Specifies the language of the input audio. This parameter is required to ensure accurate transcription. For the saarika:v1 model, this parameter is mandatory. For the saarika:v2 model, it is optional. unknown: Use this when the language is not known; the API will detect it automatically. Note:- that the saarika:v1 model does not support unknown language code. Available options: unknown, hi-IN, bn-IN, kn-IN, ml-IN, mr-IN, od-IN, pa-IN, ta-IN, te-IN, en-IN, gu-IN',
+              "BCP-47 language code of the input audio. Optional for saarika:v2.5 and saaras:v3 (the API will detect the language automatically when 'unknown' is passed). Available options: unknown, hi-IN, bn-IN, kn-IN, ml-IN, mr-IN, od-IN, pa-IN, ta-IN, te-IN, en-IN, gu-IN.",
             isOptional: true,
             defaultValue: "'unknown'",
           },
@@ -185,6 +196,13 @@ const text = await voice.listen(audioStream, {
             name: 'filetype',
             type: "'mp3' | 'wav'",
             description: 'Audio format of the input stream.',
+            isOptional: true,
+          },
+          {
+            name: 'mode',
+            type: 'SarvamSTTMode',
+            description:
+              "Operation mode. Only valid when using the saaras:v3 model; ignored by saarika:v2.5. Available options: 'transcribe', 'translate', 'verbatim', 'translit', 'codemix'.",
             isOptional: true,
           },
         ],
@@ -269,3 +287,5 @@ Returns: `Promise<Array<{voiceId: SarvamVoiceId}>>`
 - The service communicates with the Sarvam AI API at `https://api.sarvam.ai`
 - Audio is returned as a stream containing binary audio data
 - Speech recognition supports mp3 and wav audio formats
+- `bulbul:v1`, `saarika:v1`, `saarika:v2`, and `saarika:flash` have been deprecated by Sarvam and are no longer supported. Use `bulbul:v3` (or `bulbul:v2`) for TTS and `saarika:v2.5` (or `saaras:v3`) for STT.
+- Speaker names are not interchangeable between `bulbul:v2` and `bulbul:v3` — each model version has its own speaker catalog.

--- a/voice/sarvam/README.md
+++ b/voice/sarvam/README.md
@@ -23,16 +23,16 @@ import { SarvamVoice } from '@mastra/voice-sarvam';
 
 const voice = new SarvamVoice({
   speechModel: {
-    model: 'bulbul:v1',
+    model: 'bulbul:v3',
     apiKey: process.env.SARVAM_API_KEY!,
     language: 'en-IN',
   },
   listeningModel: {
     apiKey: process.env.SARVAM_API_KEY!,
-    model: 'saarika:v2',
-    languageCode: 'unknown', // By default only works with saarika:v2
+    model: 'saarika:v2.5',
+    languageCode: 'unknown',
   },
-  speaker: 'meera',
+  speaker: 'shubh',
 });
 
 // Create an agent with voice capabilities

--- a/voice/sarvam/README.md
+++ b/voice/sarvam/README.md
@@ -78,26 +78,21 @@ const text = await voice.listen(audioStream);
 ## Features
 
 - High-quality Text-to-Speech and Speech-to-Text synthesis
-- Support for 10+ Indian languages
-- Choice of 10+ diverse speakers
-- Advanced voice customization options
+- Support for 11 Indian languages
+- 46 speakers across `bulbul:v2` and `bulbul:v3`
+- Multi-mode Speech-to-Text via `saaras:v3` (transcribe, translate, verbatim, translit, codemix)
 
 ## Available Voices
 
-### Speakers
+Speaker catalogs are not interchangeable between `bulbul:v2` and `bulbul:v3` — pick a speaker compatible with your selected TTS model.
 
-- `meera` (default)
-- `pavithra`
-- `maitreyi`
-- `arvind`
-- `amol`
-- `amartya`
-- `diya`
-- `neel`
-- `misha`
-- `vian`
-- `arjun`
-- `maya`
+### Speakers for `bulbul:v3` and `bulbul:v3-beta` (39 voices)
+
+`shubh` (default), `aditya`, `ritu`, `priya`, `neha`, `rahul`, `pooja`, `rohan`, `simran`, `kavya`, `amit`, `dev`, `ishita`, `shreya`, `ratan`, `varun`, `manan`, `sumit`, `roopa`, `kabir`, `aayan`, `ashutosh`, `advait`, `amelia`, `sophia`, `anand`, `tanya`, `tarun`, `sunny`, `mani`, `gokul`, `vijay`, `shruti`, `suhani`, `mohit`, `kavitha`, `rehan`, `soham`, `rupali`
+
+### Speakers for `bulbul:v2` (7 voices)
+
+`anushka` (default), `manisha`, `vidya`, `arya`, `abhilash`, `karun`, `hitesh`
 
 ### Languages
 

--- a/voice/sarvam/src/index.test.ts
+++ b/voice/sarvam/src/index.test.ts
@@ -10,7 +10,7 @@ import { SarvamVoice } from './index';
 describe('Sarvam AI Voice Integration Tests', () => {
   const voice = new SarvamVoice({
     speechModel: {
-      model: 'bulbul:v1',
+      model: 'bulbul:v3',
       apiKey: process.env.SARVAM_API_KEY!,
       language: 'en-IN',
     },
@@ -28,7 +28,7 @@ describe('Sarvam AI Voice Integration Tests', () => {
     }
 
     const speakers = await voice.getSpeakers();
-    voiceId = speakers.find(v => v.voiceId === 'meera')!.voiceId as SarvamVoiceId;
+    voiceId = speakers.find(v => v.voiceId === 'shubh')!.voiceId as SarvamVoiceId;
     expect(voiceId).toBeDefined();
   });
 

--- a/voice/sarvam/src/index.ts
+++ b/voice/sarvam/src/index.ts
@@ -85,14 +85,17 @@ export class SarvamVoice extends MastraVoice {
       speaker,
     });
 
-    this.apiKey = speechModel?.apiKey || defaultSpeechModel.apiKey;
+    this.apiKey = speechModel?.apiKey || listeningModel?.apiKey || defaultSpeechModel.apiKey;
     if (!this.apiKey) {
       throw new Error('SARVAM_API_KEY must be set');
     }
     this.model = speechModel?.model || defaultSpeechModel.model;
     this.language = speechModel?.language || defaultSpeechModel.language;
     this.properties = speechModel?.properties || {};
-    this.speaker = speaker || 'shubh';
+    // bulbul:v2 and bulbul:v3 have non-overlapping speaker catalogs, so the
+    // default speaker depends on the selected TTS model.
+    const defaultSpeaker: SarvamVoiceId = this.model === 'bulbul:v2' ? 'anushka' : 'shubh';
+    this.speaker = speaker || defaultSpeaker;
   }
 
   private async makeRequest(endpoint: string, payload: any) {

--- a/voice/sarvam/src/index.ts
+++ b/voice/sarvam/src/index.ts
@@ -2,19 +2,36 @@ import { PassThrough } from 'node:stream';
 
 import { MastraVoice } from '@mastra/core/voice';
 import { SARVAM_VOICES } from './voices';
-import type { SarvamTTSLanguage, SarvamSTTLanguage, SarvamSTTModel, SarvamTTSModel, SarvamVoiceId } from './voices';
+import type {
+  SarvamTTSLanguage,
+  SarvamSTTLanguage,
+  SarvamSTTModel,
+  SarvamTTSModel,
+  SarvamVoiceId,
+  SarvamSTTMode,
+} from './voices';
 
 interface SarvamVoiceConfig {
   apiKey?: string;
   model?: SarvamTTSModel;
   language?: SarvamTTSLanguage;
   properties?: {
-    pitch?: number;
+    /** Controls the speed of the audio. Supported by bulbul:v2 (0.3–3.0) and bulbul:v3 (0.5–2.0). */
     pace?: number;
+    /** Sampling temperature. bulbul:v3 only. Range: 0.01–2.0. Default: 0.6. */
+    temperature?: number;
+    /** Pronunciation dictionary ID. bulbul:v3 only. */
+    dict_id?: string;
+    /** Controls the pitch of the audio. bulbul:v2 only. Range: -0.75–0.75. */
+    pitch?: number;
+    /** Controls the loudness of the audio. bulbul:v2 only. Range: 0.3–3.0. */
     loudness?: number;
-    speech_sample_rate?: 8000 | 16000 | 22050;
+    /** Enables normalization of English words and numeric entities. bulbul:v2 only. */
     enable_preprocessing?: boolean;
-    eng_interpolation_wt?: number;
+    /** Audio sample rate in Hz. */
+    speech_sample_rate?: 8000 | 16000 | 22050 | 24000 | 32000 | 44100 | 48000;
+    /** Output audio codec. */
+    output_audio_codec?: 'mp3' | 'wav' | 'linear16' | 'mulaw' | 'alaw' | 'opus' | 'flac' | 'aac';
   };
 }
 
@@ -23,26 +40,28 @@ interface SarvamListenOptions {
   model?: SarvamSTTModel;
   languageCode?: SarvamSTTLanguage;
   filetype?: 'mp3' | 'wav';
+  /** Operation mode for saaras:v3. Ignored by other models. */
+  mode?: SarvamSTTMode;
 }
 
 const defaultSpeechModel = {
-  model: 'bulbul:v1' as const,
+  model: 'bulbul:v3' as const,
   apiKey: process.env.SARVAM_API_KEY,
   language: 'en-IN' as const,
 };
 
 const defaultListeningModel = {
-  model: 'saarika:v2' as const,
+  model: 'saarika:v2.5' as const,
   apiKey: process.env.SARVAM_API_KEY,
   language_code: 'unknown' as const,
 };
 
 export class SarvamVoice extends MastraVoice {
   private apiKey?: string;
-  private model: SarvamTTSModel = 'bulbul:v1';
+  private model: SarvamTTSModel = 'bulbul:v3';
   private language: SarvamTTSLanguage = 'en-IN';
   private properties: Record<string, any> = {};
-  speaker: SarvamVoiceId = 'meera';
+  speaker: SarvamVoiceId = 'shubh';
   private baseUrl = 'https://api.sarvam.ai';
 
   constructor({
@@ -61,7 +80,7 @@ export class SarvamVoice extends MastraVoice {
       },
       listeningModel: {
         name: listeningModel?.model ?? defaultListeningModel.model,
-        apiKey: listeningModel?.model ?? defaultListeningModel.apiKey,
+        apiKey: listeningModel?.apiKey ?? defaultListeningModel.apiKey,
       },
       speaker,
     });
@@ -73,7 +92,7 @@ export class SarvamVoice extends MastraVoice {
     this.model = speechModel?.model || defaultSpeechModel.model;
     this.language = speechModel?.language || defaultSpeechModel.language;
     this.properties = speechModel?.properties || {};
-    this.speaker = speaker || 'meera';
+    this.speaker = speaker || 'shubh';
   }
 
   private async makeRequest(endpoint: string, payload: any) {
@@ -117,7 +136,7 @@ export class SarvamVoice extends MastraVoice {
     const text = typeof input === 'string' ? input : await this.streamToString(input);
 
     const payload = {
-      inputs: [text],
+      text,
       target_language_code: this.language,
       speaker: options?.speaker || this.speaker,
       model: this.model,
@@ -175,8 +194,12 @@ export class SarvamVoice extends MastraVoice {
     const blob = new Blob([audioBuffer], { type: mimeType });
 
     form.append('file', blob);
-    form.append('model', options?.model || 'saarika:v2');
+    form.append('model', options?.model || 'saarika:v2.5');
     form.append('language_code', options?.languageCode || 'unknown');
+    // `mode` is only meaningful for saaras:v3 — Sarvam ignores it for saarika models.
+    if (options?.mode) {
+      form.append('mode', options.mode);
+    }
     const requestOptions = {
       method: 'POST',
       headers: {
@@ -188,7 +211,6 @@ export class SarvamVoice extends MastraVoice {
     try {
       const response = await fetch(`${this.baseUrl}/speech-to-text`, requestOptions);
       const result = (await response.json()) as any;
-      //console.log(result);
       return result.transcript;
     } catch (error) {
       console.error('Error during speech-to-text request:', error);

--- a/voice/sarvam/src/voices.ts
+++ b/voice/sarvam/src/voices.ts
@@ -1,17 +1,61 @@
-export const SARVAM_VOICES = [
-  'meera',
-  'pavithra',
-  'maitreyi',
-  'arvind',
-  'amol',
-  'amartya',
-  'diya',
-  'neel',
-  'misha',
-  'vian',
-  'arjun',
-  'maya',
+// Speakers available for bulbul:v3 (39 voices)
+export const SARVAM_BULBUL_V3_SPEAKERS = [
+  'shubh',
+  'aditya',
+  'ritu',
+  'priya',
+  'neha',
+  'rahul',
+  'pooja',
+  'rohan',
+  'simran',
+  'kavya',
+  'amit',
+  'dev',
+  'ishita',
+  'shreya',
+  'ratan',
+  'varun',
+  'manan',
+  'sumit',
+  'roopa',
+  'kabir',
+  'aayan',
+  'ashutosh',
+  'advait',
+  'amelia',
+  'sophia',
+  'anand',
+  'tanya',
+  'tarun',
+  'sunny',
+  'mani',
+  'gokul',
+  'vijay',
+  'shruti',
+  'suhani',
+  'mohit',
+  'kavitha',
+  'rehan',
+  'soham',
+  'rupali',
 ] as const;
+
+// Speakers available for bulbul:v2 (7 voices, no overlap with v3)
+export const SARVAM_BULBUL_V2_SPEAKERS = [
+  'anushka',
+  'manisha',
+  'vidya',
+  'arya',
+  'abhilash',
+  'karun',
+  'hitesh',
+] as const;
+
+// Combined list of all Sarvam speakers across supported bulbul models.
+// bulbul:v1 speakers (meera, pavithra, …) have been removed as Sarvam
+// deprecated bulbul:v1 — use bulbul:v2 or bulbul:v3 instead.
+export const SARVAM_VOICES = [...SARVAM_BULBUL_V3_SPEAKERS, ...SARVAM_BULBUL_V2_SPEAKERS] as const;
 
 export const SARVAM_TTS_LANGUAGES = [
   'hi-IN',
@@ -29,8 +73,17 @@ export const SARVAM_TTS_LANGUAGES = [
 
 export const SARVAM_STT_LANGUAGES = [...SARVAM_TTS_LANGUAGES, 'unknown'] as const;
 
-export const SARVAM_TTS_MODELS = ['bulbul:v1'] as const;
-export const SARVAM_STT_MODELS = ['saarika:v1', 'saarika:v2', 'saarika:flash'] as const;
+// Current TTS models. bulbul:v1 was deprecated and removed by Sarvam.
+// bulbul:v3-beta is a beta variant of bulbul:v3 that shares the same speaker catalog.
+export const SARVAM_TTS_MODELS = ['bulbul:v2', 'bulbul:v3', 'bulbul:v3-beta'] as const;
+
+// Current STT models. saarika:v1, saarika:v2, and saarika:flash were deprecated.
+// saaras:v3 is a multi-mode model that supports transcribe/translate/verbatim/translit/codemix
+// via the `mode` option and is served from the same POST /speech-to-text endpoint.
+export const SARVAM_STT_MODELS = ['saarika:v2.5', 'saaras:v3'] as const;
+
+// Operation modes supported by saaras:v3 only.
+export const SARVAM_STT_MODES = ['transcribe', 'translate', 'verbatim', 'translit', 'codemix'] as const;
 
 export type SarvamVoiceId = (typeof SARVAM_VOICES)[number];
 
@@ -39,3 +92,4 @@ export type SarvamSTTLanguage = (typeof SARVAM_STT_LANGUAGES)[number];
 
 export type SarvamTTSModel = (typeof SARVAM_TTS_MODELS)[number];
 export type SarvamSTTModel = (typeof SARVAM_STT_MODELS)[number];
+export type SarvamSTTMode = (typeof SARVAM_STT_MODES)[number];


### PR DESCRIPTION
## Description

Upgrades `@mastra/voice-sarvam` to support Sarvam's current TTS and STT model lineup, replacing the now-deprecated `bulbul:v1` and `saarika:v1`/`v2`/`flash` models that Sarvam has retired (leaving the package broken for new users).

**TTS:** Adds `bulbul:v2`, `bulbul:v3` (new default), and `bulbul:v3-beta`. `bulbul:v3`/`v3-beta` expose 39 speakers; `bulbul:v2` exposes 7. Default speaker changed from `meera` (v1, dead) to `shubh`. Adds v3-only parameters `temperature`, `dict_id`, `output_audio_codec`, plus widens `speech_sample_rate` to Sarvam's current options (8000–48000 Hz). Switches the TTS request body from the legacy `inputs: [text]` array to `text: string`, matching Sarvam's documented canonical form.

**STT:** Adds `saarika:v2.5` (new default) and `saaras:v3`. Exposes `saaras:v3`'s multi-mode operation via a new `mode` option (`transcribe`, `translate`, `verbatim`, `translit`, `codemix`) — both models continue to use the same `POST /speech-to-text` endpoint.

**Bug fix:** Corrects a latent constructor typo where `listeningModel.apiKey` was being sourced from `listeningModel.model`.

**Docs:** Full refresh of `reference/voice/sarvam.mdx` with per-version parameter annotations and the 39/7 speaker catalogs. Also fixes two broken Sarvam examples in `docs/voice/overview.mdx` — one used the invalid `speaker: 'default'`, and one had a fabricated `style:` property and falsely claimed Sarvam has no listening model.

Every decision was empirically verified against the live Sarvam API. Ten targeted probes confirmed each model/speaker/parameter combination; the full 8-test integration suite passes against `https://api.sarvam.ai`. Removal of legacy models was confirmed by the API returning explicit deprecation errors (e.g., `"Model 'saarika:v2' has been deprecated. Please use 'saarika:v2.5' instead."`), and the `bulbul:v3-beta` addition came directly from the API's own validator error listing valid model strings.

## Related Issue(s)

Fixes #15188

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR updates the Sarvam voice integration to use Sarvam's current text-to-speech and speech-to-text models (newer ones that work), fixes a constructor typo that broke API key selection, and refreshes docs and tests to match the new models.

## Overview

Upgrades @mastra/voice-sarvam to support Sarvam’s current TTS and STT lineup, removes deprecated models, updates request contracts and runtime defaults, fixes a bug in the constructor that mis-sourced the listening API key, refreshes documentation with per-version parameter notes and speaker catalogs, and updates tests and examples.

## Key Changes

### Text-to-Speech (TTS)
- Added models: bulbul:v2, bulbul:v3 (new default), bulbul:v3-beta.
- Removed: bulbul:v1 (deprecated).
- Speaker catalogs: bulbul:v3/v3-beta expose 39 speakers; bulbul:v2 exposes 7 speakers. Speaker IDs are not interchangeable across versions.
- Default speaker: changed from meera → shubh (conditional default: bulbul:v2 → anushka, otherwise shubh).
- New bulbul:v3-only params: temperature, dict_id, output_audio_codec.
- Expanded speech_sample_rate range to 8000–48000 Hz.
- TTS request payload changed from legacy { inputs: [text] } to { text }.

### Speech-to-Text (STT)
- Added models: saarika:v2.5 (new default), saaras:v3.
- Removed: saarika:v1, saarika:v2, saarika:flash (deprecated).
- saaras:v3 supports multi-mode via new mode option: transcribe, translate, verbatim, translit, codemix.
- STT continues to use POST /speech-to-text; multipart form now conditionally appends mode when provided.

### API / Runtime Behavior
- Default TTS model changed bulbul:v1 → bulbul:v3.
- Default STT model changed saarika:v2 → saarika:v2.5.
- Constructor API key fallback fixed to prefer listeningModel?.apiKey correctly (previously sourced from listeningModel.model).
- listen() options now accept mode?: SarvamSTTMode.

### Public API Changes
- Added exported constants: SARVAM_BULBUL_V3_SPEAKERS (39), SARVAM_BULBUL_V2_SPEAKERS (7), SARVAM_STT_MODES.
- Added exported type: SarvamSTTMode.
- Modified exports: SARVAM_VOICES (now v3 + v2 lists), SARVAM_TTS_MODELS → ['bulbul:v2','bulbul:v3','bulbul:v3-beta'], SARVAM_STT_MODELS → ['saarika:v2.5','saaras:v3'].
- SarvamListenOptions now includes optional mode?: SarvamSTTMode.

### Tests & Docs
- Updated integration test to use bulbul:v3 and speaker shubh.
- Full refresh of docs/reference/voice/sarvam.mdx with per-version parameter annotations and speaker catalogs.
- Fixed two broken Sarvam examples in docs/voice/overview.mdx (removed invalid speaker 'default' and fabricated style property; corrected listening model claim).
- README and examples updated to reflect new defaults and speaker catalogs.

### Validation / Empirics
- Empirical verification: targeted probes and an integration suite ran against https://api.sarvam.ai; legacy models returned deprecation errors and bulbul:v3-beta was validated via API feedback.

## Breaking Changes
- Removal of bulbul:v1 and its speakers.
- Removal of deprecated STT models: saarika:v1, saarika:v2, saarika:flash.
- TTS payload format changed from inputs: [text] → text.
- Default model/speaker changes: TTS default → bulbul:v3; STT default → saarika:v2.5; speaker default → shubh.
- Speakers are no longer interchangeable across bulbul versions.

## Files Changed (high level)
- .changeset/few-windows-tell.md
- voice/sarvam/src/index.ts (defaults, request format, STT mode)
- voice/sarvam/src/voices.ts (speaker & model catalogs, STT modes)
- voice/sarvam/src/index.test.ts (tests)
- voice/sarvam/README.md
- docs/src/content/en/docs/voice/overview.mdx
- docs/src/content/en/reference/voice/sarvam.mdx
<!-- end of auto-generated comment: release notes by coderabbit.ai -->