### PR TITLE
Fix/handle object tool inputs

### DIFF
--- a/.changeset/bedrock-object-tool-inputs.md
+++ b/.changeset/bedrock-object-tool-inputs.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fix tool call handling for AWS Bedrock Anthropic provider
+
+Some AI SDKs (e.g., AWS Bedrock Anthropic provider) pass tool call arguments as already-parsed objects instead of JSON strings. This caused `JSON.parse` errors in the tool-call handler when using Bedrock.
+
+This fix checks if `value.input` is already an object at the call site. If it is, it bypasses all string sanitization and parsing logic and uses the object directly. If it's a string, it proceeds through the existing sanitization flow.

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -220,20 +220,27 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
       let toolCallInput: Record<string, any> | undefined = undefined;
 
       if (value.input) {
-        const sanitized = sanitizeToolCallInput(value.input);
-        if (sanitized) {
-          try {
-            toolCallInput = JSON.parse(sanitized);
-          } catch {
-            // JSON.parse failed — attempt to repair common LLM JSON errors
-            const repaired = tryRepairJson(sanitized);
-            if (repaired) {
-              toolCallInput = repaired;
-            } else {
-              console.error('Error converting tool call input to JSON', {
-                input: value.input,
-              });
-              toolCallInput = undefined;
+        // Some AI SDKs (e.g., AWS Bedrock) pass tool arguments as already-parsed objects.
+        // If input is already an object, use it directly and bypass all string sanitization.
+        if (typeof value.input === 'object') {
+          toolCallInput = value.input;
+        } else {
+          // Input is a string — sanitize and parse it
+          const sanitized = sanitizeToolCallInput(value.input);
+          if (sanitized) {
+            try {
+              toolCallInput = JSON.parse(sanitized);
+            } catch {
+              // JSON.parse failed — attempt to repair common LLM JSON errors
+              const repaired = tryRepairJson(sanitized);
+              if (repaired) {
+                toolCallInput = repaired;
+              } else {
+                console.error('Error converting tool call input to JSON', {
+                  input: value.input,
+                });
+                toolCallInput = undefined;
+              }
             }
           }
         }


### PR DESCRIPTION
## Description

Fixes tool call validation errors when using AWS Bedrock Anthropic provider.

## Problem

Some AI SDKs (e.g., AWS Bedrock Anthropic provider) pass tool call arguments as already-parsed objects instead of JSON strings. This caused `JSON.parse` errors in the tool-call handler: Error converting tool call input to JSON


## Solution

Check if `value.input` is already an object at the call site. If it is, bypass all string sanitization and parsing logic and use the object directly. If it's a string, proceed through the existing sanitization flow (`sanitizeToolCallInput` → `JSON.parse` → `tryRepairJson`).

## Changes

- Added object type check in tool-call handler before calling `sanitizeToolCallInput`
- Objects bypass all parsing logic and go directly to `toolCallInput`
- `sanitizeToolCallInput` remains focused on string sanitization only (no signature changes)
- Added changeset for version management

## Testing

Tested locally with AWS Bedrock Anthropic provider using Claude models with tools/memory.

Fixes issue with Bedrock provider tool validation.

Fixes #15201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra was trying to convert tool arguments from AWS Bedrock into objects (like unpacking a wrapped gift), but Bedrock was already giving them as ready-to-use objects (an unwrapped gift). Now the code checks if the gift is already unwrapped—if it is, it uses it as-is; if it's still wrapped, it unwraps it like before.

## Overview

This PR fixes tool call validation errors that occurred when using the AWS Bedrock Anthropic provider. The issue arose because Bedrock passes tool call arguments as already-parsed objects, while Mastra's code expected strings and attempted to sanitize and parse them, resulting in JSON parsing failures and validation errors.

## Changes

**Core Logic Update** (`packages/core/src/stream/aisdk/v5/transform.ts`)

The tool call handling in `convertFullStreamChunkToMastra` now implements conditional logic for processing `value.input`:
- When `value.input` is an object, it is used directly without sanitization or parsing, bypassing the `sanitizeToolCallInput`, `JSON.parse`, and `tryRepairJson` steps
- When `value.input` is a string, the existing behavior is preserved: sanitization, `JSON.parse` attempt, and fallback to `tryRepairJson` on parse failure

The `sanitizeToolCallInput` function remains unchanged in its signature and string-focused responsibility.

**Metadata** (`.changeset/bedrock-object-tool-inputs.md`)

A changeset file was added to document a patch version bump for `@mastra/core`, capturing this behavioral fix for release management.

## Impact

- Resolves tool validation failures when using AWS Bedrock Anthropic provider (e.g., the `updateWorkingMemory` tool)
- Maintains backward compatibility with string-based tool inputs
- Extends support to properly handle pre-parsed object inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->