### PR TITLE
Fix reasoning stream gating in @mastra/ai-sdk

### DIFF
--- a/.changeset/lovely-moles-camp.md
+++ b/.changeset/lovely-moles-camp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed reasoning streams so reasoning UI parts are only emitted when reasoning content is included.

--- a/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
@@ -741,7 +741,7 @@ describe('WorkflowStreamToAISDKTransformer', () => {
       expect(textDeltaChunks[0].delta).toBe('Here is my answer');
     });
 
-    it('should filter reasoning-delta chunks when sendReasoning is not set', async () => {
+    it('should filter all reasoning chunks when sendReasoning is not set', async () => {
       const mockStream = new ReadableStream<ChunkType>({
         async start(controller) {
           controller.enqueue({
@@ -826,7 +826,7 @@ describe('WorkflowStreamToAISDKTransformer', () => {
         },
       });
 
-      // Default behavior (no sendReasoning) should filter reasoning-delta
+      // Default behavior (no sendReasoning) should filter reasoning chunks
       const transformedStream = mockStream.pipeThrough(
         WorkflowStreamToAISDKTransformer({ includeTextStreamParts: true }),
       );
@@ -836,20 +836,18 @@ describe('WorkflowStreamToAISDKTransformer', () => {
         chunks.push(chunk);
       }
 
-      // reasoning-delta should be filtered out (sendReasoning defaults to false)
+      // reasoning chunks should be filtered out (sendReasoning defaults to false)
       const reasoningDeltaChunks = chunks.filter(chunk => chunk.type === 'reasoning-delta');
       expect(reasoningDeltaChunks.length).toBe(0);
-
-      // reasoning-start and reasoning-end still pass through (matching agent stream behavior)
-      expect(chunks.find(chunk => chunk.type === 'reasoning-start')).toBeDefined();
-      expect(chunks.find(chunk => chunk.type === 'reasoning-end')).toBeDefined();
+      expect(chunks.find(chunk => chunk.type === 'reasoning-start')).toBeUndefined();
+      expect(chunks.find(chunk => chunk.type === 'reasoning-end')).toBeUndefined();
 
       // Text should still come through
       const textDeltaChunks = chunks.filter(chunk => chunk.type === 'text-delta');
       expect(textDeltaChunks.length).toBe(1);
     });
 
-    it('should filter reasoning-delta chunks when sendReasoning is explicitly false', async () => {
+    it('should filter all reasoning chunks when sendReasoning is explicitly false', async () => {
       const mockStream = new ReadableStream<ChunkType>({
         async start(controller) {
           controller.enqueue({

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -453,6 +453,9 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
     }
 
     case 'reasoning-start': {
+      if (!sendReasoning) {
+        return;
+      }
       return {
         type: 'reasoning-start',
         id: part.id,
@@ -473,6 +476,9 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
     }
 
     case 'reasoning-end': {
+      if (!sendReasoning) {
+        return;
+      }
       return {
         type: 'reasoning-end',
         id: part.id,


### PR DESCRIPTION
## Summary
- fix the AI SDK stream transform so `sendReasoning: false` suppresses all reasoning UI stream parts, not just `reasoning-delta`
- gate `reasoning-start`, `reasoning-delta`, and `reasoning-end` consistently to prevent empty reasoning blocks in consumers like ui-dojo
- update transformer tests to assert reasoning chunks are fully filtered when `sendReasoning` is omitted or explicitly `false`

## Testing
- `pnpm vitest run src/__tests__/transformers.test.ts`
- `pnpm build:lib && pnpm build:patch-commonjs`

## Notes
- `pnpm test` has unrelated existing failures in this checkout and was not treated as part of this regression


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When someone says "don't show me reasoning," the app was still showing some reasoning pieces (the start and end markers). This fix makes sure that when reasoning is turned off, ALL reasoning pieces are hidden, not just some of them.

## Overview

This PR fixes a stream gating issue in the AI SDK where `sendReasoning: false` was not fully suppressing reasoning-related UI stream parts. Previously, only `reasoning-delta` chunks were being filtered out, while `reasoning-start` and `reasoning-end` were still being emitted, resulting in empty reasoning blocks in consumers like ui-dojo.

## Changes

### Changeset
- Added `.changeset/lovely-moles-camp.md` to document a patch version bump for `@mastra/ai-sdk` with the fix for reasoning streams

### Test Updates
- Updated test cases in `client-sdks/ai-sdk/src/__tests__/transformers.test.ts` to assert that all three reasoning chunk types (`reasoning-start`, `reasoning-delta`, and `reasoning-end`) are filtered out when `sendReasoning` is unset or explicitly `false`
- Verified that text output (`text-delta`) continues to be emitted as expected

### Core Implementation
- Added conditional guards in `client-sdks/ai-sdk/src/helpers.ts` within the `convertFullStreamChunkToUIMessageStream` function
- Now returns `undefined` for `reasoning-start` and `reasoning-end` parts when `sendReasoning` is falsy/undefined
- Maintains existing behavior for `reasoning-delta`, which already conditioned on `sendReasoning`

## Testing
Unit tests can be validated with: `pnpm vitest run src/__tests__/transformers.test.ts`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->