### PR TITLE
DataKeysAndValues update - add  variants of value component

### DIFF
--- a/.changeset/stale-worlds-happen.md
+++ b/.changeset/stale-worlds-happen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added ValueLink, ValueWithTooltip, and ValueWithCopyBtn variants to DataKeysAndValues component

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-link.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-link.tsx
@@ -1,0 +1,44 @@
+import { ExternalLinkIcon, Link2Icon } from 'lucide-react';
+import { dataKeysAndValuesValueStyles } from './shared';
+import { useLinkComponent } from '@/lib/framework';
+import { cn } from '@/lib/utils';
+
+export interface DataKeysAndValuesValueLinkProps {
+  className?: string;
+  children: React.ReactNode;
+  href: string;
+}
+
+function isExternalUrl(href: string) {
+  return /^https?:\/\//.test(href);
+}
+
+export function DataKeysAndValuesValueLink({ className, children, href }: DataKeysAndValuesValueLinkProps) {
+  const { Link } = useLinkComponent();
+  const isExternal = isExternalUrl(href);
+
+  const linkClassName = cn(
+    'truncate flex items-center gap-2 hover:text-neutral4 transition-colors',
+    '[&>svg]:w-4 [&>svg]:h-4 [&>svg]:shrink-0 [&>svg]:opacity-70 [&:hover>svg]:opacity-100',
+  );
+
+  if (isExternal) {
+    return (
+      <dd className={cn(dataKeysAndValuesValueStyles, className)}>
+        <a href={href} target="_blank" rel="noopener noreferrer" className={linkClassName}>
+          <span>{children}</span>
+          <ExternalLinkIcon />
+        </a>
+      </dd>
+    );
+  }
+
+  return (
+    <dd className={cn(dataKeysAndValuesValueStyles, className)}>
+      <Link href={href} className={linkClassName}>
+        <span>{children}</span>
+        <Link2Icon />
+      </Link>
+    </dd>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-copy-btn.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-copy-btn.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, CopyIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { dataKeysAndValuesValueStyles } from './shared';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
@@ -17,6 +17,7 @@ export function DataKeysAndValuesValueWithCopyBtn({
   copyValue,
 }: DataKeysAndValuesValueWithCopyBtnProps) {
   const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const { handleCopy: originalHandleCopy } = useCopyToClipboard({
     text: copyValue,
     copyMessage: 'Copied!',
@@ -25,8 +26,11 @@ export function DataKeysAndValuesValueWithCopyBtn({
   const handleCopy = () => {
     originalHandleCopy();
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    clearTimeout(copyTimeoutRef.current);
+    copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
   };
+
+  useEffect(() => () => clearTimeout(copyTimeoutRef.current), []);
 
   return (
     <dd className={cn(dataKeysAndValuesValueStyles, className)}>

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-copy-btn.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-copy-btn.tsx
@@ -1,5 +1,4 @@
 import { CheckIcon, CopyIcon } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
 import { dataKeysAndValuesValueStyles } from './shared';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
@@ -9,32 +8,23 @@ export interface DataKeysAndValuesValueWithCopyBtnProps {
   className?: string;
   children: React.ReactNode;
   copyValue: string;
+  copyTooltip?: string;
 }
 
 export function DataKeysAndValuesValueWithCopyBtn({
   className,
   children,
   copyValue,
+  copyTooltip = 'Copy to clipboard',
 }: DataKeysAndValuesValueWithCopyBtnProps) {
-  const [copied, setCopied] = useState(false);
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const { handleCopy: originalHandleCopy } = useCopyToClipboard({
+  const { isCopied, handleCopy } = useCopyToClipboard({
     text: copyValue,
     copyMessage: 'Copied!',
   });
 
-  const handleCopy = () => {
-    originalHandleCopy();
-    setCopied(true);
-    clearTimeout(copyTimeoutRef.current);
-    copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
-  };
-
-  useEffect(() => () => clearTimeout(copyTimeoutRef.current), []);
-
   return (
     <dd className={cn(dataKeysAndValuesValueStyles, className)}>
-      <Tooltip open={copied || undefined}>
+      <Tooltip open={isCopied || undefined}>
         <TooltipTrigger asChild>
           <button
             onClick={handleCopy}
@@ -42,16 +32,15 @@ export function DataKeysAndValuesValueWithCopyBtn({
             className={cn(
               'flex gap-2 items-center',
               '[&>svg]:w-3 [&>svg]:h-3 [&>svg]:shrink-0 [&>svg]:opacity-70 [&:hover>svg]:opacity-100',
-              { '[&>svg]:w-4 [&>svg]:h-4 [&>svg]:text-accent1': copied },
-              className,
+              { '[&>svg]:w-4 [&>svg]:h-4 [&>svg]:text-accent1': isCopied },
             )}
-            aria-label={copied ? 'Copied!' : 'Copy to clipboard'}
+            aria-label={isCopied ? 'Copied!' : copyTooltip}
           >
             <span>{children}</span>
-            {copied ? <CheckIcon /> : <CopyIcon />}
+            {isCopied ? <CheckIcon /> : <CopyIcon />}
           </button>
         </TooltipTrigger>
-        <TooltipContent>{copied ? 'Copied!' : 'Copy to clipboard'}</TooltipContent>
+        <TooltipContent>{isCopied ? 'Copied!' : copyTooltip}</TooltipContent>
       </Tooltip>
     </dd>
   );

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-copy-btn.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-copy-btn.tsx
@@ -1,0 +1,54 @@
+import { CheckIcon, CopyIcon } from 'lucide-react';
+import { useState } from 'react';
+import { dataKeysAndValuesValueStyles } from './shared';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
+import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
+import { cn } from '@/lib/utils';
+
+export interface DataKeysAndValuesValueWithCopyBtnProps {
+  className?: string;
+  children: React.ReactNode;
+  copyValue: string;
+}
+
+export function DataKeysAndValuesValueWithCopyBtn({
+  className,
+  children,
+  copyValue,
+}: DataKeysAndValuesValueWithCopyBtnProps) {
+  const [copied, setCopied] = useState(false);
+  const { handleCopy: originalHandleCopy } = useCopyToClipboard({
+    text: copyValue,
+    copyMessage: 'Copied!',
+  });
+
+  const handleCopy = () => {
+    originalHandleCopy();
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <dd className={cn(dataKeysAndValuesValueStyles, className)}>
+      <Tooltip open={copied || undefined}>
+        <TooltipTrigger asChild>
+          <button
+            onClick={handleCopy}
+            type="button"
+            className={cn(
+              'flex gap-2 items-center',
+              '[&>svg]:w-3 [&>svg]:h-3 [&>svg]:shrink-0 [&>svg]:opacity-70 [&:hover>svg]:opacity-100',
+              { '[&>svg]:w-4 [&>svg]:h-4 [&>svg]:text-accent1': copied },
+              className,
+            )}
+            aria-label={copied ? 'Copied!' : 'Copy to clipboard'}
+          >
+            <span>{children}</span>
+            {copied ? <CheckIcon /> : <CopyIcon />}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{copied ? 'Copied!' : 'Copy to clipboard'}</TooltipContent>
+      </Tooltip>
+    </dd>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-tooltip.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-tooltip.tsx
@@ -17,7 +17,9 @@ export function DataKeysAndValuesValueWithTooltip({
     <dd className={cn(dataKeysAndValuesValueStyles, className)}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="truncate cursor-help hover:text-neutral4 ">{children}</span>
+          <div tabIndex={0} className="truncate cursor-help hover:text-neutral4 inline">
+            {children}
+          </div>
         </TooltipTrigger>
         <TooltipContent>{tooltip}</TooltipContent>
       </Tooltip>

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-tooltip.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-tooltip.tsx
@@ -1,0 +1,26 @@
+import { dataKeysAndValuesValueStyles } from './shared';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
+import { cn } from '@/lib/utils';
+
+export interface DataKeysAndValuesValueWithTooltipProps {
+  className?: string;
+  children: React.ReactNode;
+  tooltip: string;
+}
+
+export function DataKeysAndValuesValueWithTooltip({
+  className,
+  children,
+  tooltip,
+}: DataKeysAndValuesValueWithTooltipProps) {
+  return (
+    <dd className={cn(dataKeysAndValuesValueStyles, className)}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="truncate cursor-help hover:text-neutral4 ">{children}</span>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </dd>
+  );
+}

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value.tsx
@@ -1,3 +1,4 @@
+import { dataKeysAndValuesValueStyles } from './shared';
 import { cn } from '@/lib/utils';
 
 export interface DataKeysAndValuesValueProps {
@@ -6,5 +7,7 @@ export interface DataKeysAndValuesValueProps {
 }
 
 export function DataKeysAndValuesValue({ className, children }: DataKeysAndValuesValueProps) {
-  return <dd className={cn('text-ui-smd text-neutral3 truncate min-w-0 py-0.5', className)}>{children}</dd>;
+  return (
+    <dd className={cn(dataKeysAndValuesValueStyles, 'truncate', className)}>{children}</dd>
+  );
 }

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value.tsx
@@ -7,7 +7,5 @@ export interface DataKeysAndValuesValueProps {
 }
 
 export function DataKeysAndValuesValue({ className, children }: DataKeysAndValuesValueProps) {
-  return (
-    <dd className={cn(dataKeysAndValuesValueStyles, 'truncate', className)}>{children}</dd>
-  );
+  return <dd className={cn(dataKeysAndValuesValueStyles, 'truncate', className)}>{children}</dd>;
 }

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { DataKeysAndValues } from './data-keys-and-values';
 import type { DataKeysAndValuesProps } from './data-keys-and-values-root';
+import { forwardRef } from 'react';
+import { TooltipProvider } from '@/ds/components/Tooltip';
+import { LinkComponentProvider } from '@/lib/framework';
+import type { LinkComponentProps } from '@/lib/framework';
 
 const meta: Meta<typeof DataKeysAndValues> = {
   title: 'Elements/DataKeysAndValues',
@@ -114,6 +118,98 @@ export const TruncatedValues: Story = {
       <DataKeysAndValues.Value>abc123def456ghi789jkl012mno345pqr678stu901vwx234</DataKeysAndValues.Value>
       <DataKeysAndValues.Key>Span ID</DataKeysAndValues.Key>
       <DataKeysAndValues.Value>span-001-very-long-identifier-that-should-truncate</DataKeysAndValues.Value>
+    </DataKeysAndValues>
+  ),
+};
+
+const StoryLink = forwardRef<HTMLAnchorElement, LinkComponentProps>(({ href, children, ...props }, ref) => (
+  <a ref={ref} href={href} {...props}>
+    {children}
+  </a>
+));
+
+export const ValueLink: Story = {
+  decorators: [
+    Story => (
+      <LinkComponentProvider Link={StoryLink} navigate={() => {}} paths={{} as never}>
+        <Story />
+      </LinkComponentProvider>
+    ),
+  ],
+  render: () => (
+    <DataKeysAndValues>
+      <DataKeysAndValues.Key>Agent</DataKeysAndValues.Key>
+      <DataKeysAndValues.ValueLink href="/agents/my-agent">my-agent</DataKeysAndValues.ValueLink>
+      <DataKeysAndValues.Key>Workflow</DataKeysAndValues.Key>
+      <DataKeysAndValues.ValueLink href="/workflows/data-pipeline">data-pipeline</DataKeysAndValues.ValueLink>
+    </DataKeysAndValues>
+  ),
+};
+
+export const ValueWithTooltip: Story = {
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <div>
+          <Story />
+        </div>
+      </TooltipProvider>
+    ),
+  ],
+  render: () => (
+    <DataKeysAndValues>
+      <DataKeysAndValues.Key>Trace ID</DataKeysAndValues.Key>
+      <DataKeysAndValues.ValueWithTooltip tooltip="abc123def456ghi789jkl012mno345pqr678stu901vwx234">
+        abc123def456ghi7...
+      </DataKeysAndValues.ValueWithTooltip>
+      <DataKeysAndValues.Key>Status</DataKeysAndValues.Key>
+      <DataKeysAndValues.ValueWithTooltip tooltip="Completed successfully with no errors">
+        Completed
+      </DataKeysAndValues.ValueWithTooltip>
+    </DataKeysAndValues>
+  ),
+};
+
+export const ValueWithCopyBtn: Story = {
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+  render: () => (
+    <DataKeysAndValues>
+      <DataKeysAndValues.Key>Trace ID</DataKeysAndValues.Key>
+      <DataKeysAndValues.ValueWithCopyBtn copyValue="abc123def456">abc123def456</DataKeysAndValues.ValueWithCopyBtn>
+      <DataKeysAndValues.Key>Span ID</DataKeysAndValues.Key>
+      <DataKeysAndValues.ValueWithCopyBtn copyValue="span-001-xyz">span-001-xyz</DataKeysAndValues.ValueWithCopyBtn>
+    </DataKeysAndValues>
+  ),
+};
+
+export const MixedValueTypes: Story = {
+  decorators: [
+    Story => (
+      <LinkComponentProvider Link={StoryLink} navigate={() => {}} paths={{} as never}>
+        <TooltipProvider>
+          <Story />
+        </TooltipProvider>
+      </LinkComponentProvider>
+    ),
+  ],
+  render: () => (
+    <DataKeysAndValues>
+      <DataKeysAndValues.Key>Status</DataKeysAndValues.Key>
+      <DataKeysAndValues.Value>Running</DataKeysAndValues.Value>
+      <DataKeysAndValues.Key>Agent</DataKeysAndValues.Key>
+      <DataKeysAndValues.ValueLink href="/agents/my-agent">my-agent</DataKeysAndValues.ValueLink>
+      <DataKeysAndValues.Key>Trace ID</DataKeysAndValues.Key>
+      <DataKeysAndValues.ValueWithCopyBtn copyValue="abc123def456">abc123def456</DataKeysAndValues.ValueWithCopyBtn>
+      <DataKeysAndValues.Key>Description</DataKeysAndValues.Key>
+      <DataKeysAndValues.ValueWithTooltip tooltip="A very long description that gets truncated in the UI">
+        A very long description that gets truncated in the UI
+      </DataKeysAndValues.ValueWithTooltip>
     </DataKeysAndValues>
   ),
 };

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
@@ -184,6 +184,10 @@ export const ValueWithCopyBtn: Story = {
       <DataKeysAndValues.ValueWithCopyBtn copyValue="abc123def456">abc123def456</DataKeysAndValues.ValueWithCopyBtn>
       <DataKeysAndValues.Key>Span ID</DataKeysAndValues.Key>
       <DataKeysAndValues.ValueWithCopyBtn copyValue="span-001-xyz">span-001-xyz</DataKeysAndValues.ValueWithCopyBtn>
+      <DataKeysAndValues.Key>API Key</DataKeysAndValues.Key>
+      <DataKeysAndValues.ValueWithCopyBtn copyValue="sk-1234" copyTooltip="Copy API key">
+        sk-1234
+      </DataKeysAndValues.ValueWithCopyBtn>
     </DataKeysAndValues>
   ),
 };

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.tsx
@@ -2,9 +2,15 @@ import { DataKeysAndValuesHeader } from './data-keys-and-values-header';
 import { DataKeysAndValuesKey } from './data-keys-and-values-key';
 import { DataKeysAndValuesRoot } from './data-keys-and-values-root';
 import { DataKeysAndValuesValue } from './data-keys-and-values-value';
+import { DataKeysAndValuesValueLink } from './data-keys-and-values-value-link';
+import { DataKeysAndValuesValueWithCopyBtn } from './data-keys-and-values-value-with-copy-btn';
+import { DataKeysAndValuesValueWithTooltip } from './data-keys-and-values-value-with-tooltip';
 
 export const DataKeysAndValues = Object.assign(DataKeysAndValuesRoot, {
   Key: DataKeysAndValuesKey,
   Value: DataKeysAndValuesValue,
+  ValueLink: DataKeysAndValuesValueLink,
+  ValueWithTooltip: DataKeysAndValuesValueWithTooltip,
+  ValueWithCopyBtn: DataKeysAndValuesValueWithCopyBtn,
   Header: DataKeysAndValuesHeader,
 });

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/shared.ts
@@ -1,0 +1,1 @@
+export const dataKeysAndValuesValueStyles = 'text-ui-smd text-neutral3 min-w-0 py-0.5';


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

add three value type components
- value link
- value with copy button
- value with tooltip

<img width="1424" height="1024" alt="CleanShot 2026-04-09 at 13 46 19" src="https://github.com/user-attachments/assets/faee93c1-7348-4222-a687-1557c718f9b8" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds three simple ways to display values in the DataKeysAndValues component: make values clickable links, show extra info on hover via tooltips, and add a copy-to-clipboard button so users can open links, view details, or copy values quickly.

## Changes

### New Components
- DataKeysAndValues.ValueLink
  - File: packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-link.tsx
  - Renders a value as a link; detects external URLs (http/https) and uses a native <a> with target="_blank" and ExternalLinkIcon, otherwise uses the framework Link with Link2Icon. Applies truncation, consistent icon sizing, and hover styles.

- DataKeysAndValues.ValueWithTooltip
  - File: packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-tooltip.tsx
  - Wraps the truncated value in TooltipTrigger/TooltipContent to show the provided tooltip string on hover/focus.

- DataKeysAndValues.ValueWithCopyBtn
  - File: packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-value-with-copy-btn.tsx
  - Renders a value with an inline copy button using useCopyToClipboard; reflects copy state via icon/tooltip/aria-label and manages copied state for feedback.

### Shared styles & minor refactor
- Added shared style constant:
  - packages/playground-ui/src/ds/components/DataKeysAndValues/shared.ts
  - export const dataKeysAndValuesValueStyles = 'text-ui-smd text-neutral3 min-w-0 py-0.5'
- Updated DataKeysAndValues.Value to use the shared `dataKeysAndValuesValueStyles`.

### Public API Expansion
- Extended the DataKeysAndValues composite to expose the new variants:
  - DataKeysAndValues.ValueLink → DataKeysAndValuesValueLink
  - DataKeysAndValues.ValueWithTooltip → DataKeysAndValuesValueWithTooltip
  - DataKeysAndValues.ValueWithCopyBtn → DataKeysAndValuesValueWithCopyBtn
  - File modified: packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.tsx

### Documentation / Stories
- Added Storybook stories demonstrating the new variants and a mixed example:
  - packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
  - Stories: ValueLink, ValueWithTooltip, ValueWithCopyBtn, MixedValueTypes
  - Stories include TooltipProvider and LinkComponentProvider setup where needed.

### Changeset
- Added .changeset/stale-worlds-happen.md declaring a patch release for @mastra/playground-ui documenting the new variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->