### PR TITLE
fix: resolve symlinked workspace skill aliases

### DIFF
--- a/.changeset/fine-tables-roll.md
+++ b/.changeset/fine-tables-roll.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastracode': patch
+---
+
+Fixed symlinked skill paths so workspace skills resolve consistently and allowed path checks work through both symlink and real paths.

--- a/mastracode/src/agents/__tests__/workspace-skill-activation.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-skill-activation.test.ts
@@ -29,10 +29,11 @@ describe('mastracode workspace skill activation', () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-workspace-skill-'));
 
     try {
+      const skillName = 'temp-symlink-skill';
       const agentsRoot = path.join(tempDir, '.agents', 'skills');
       const claudeRoot = path.join(tempDir, '.claude', 'skills');
-      const canonicalSkillDir = path.join(agentsRoot, 'mastra');
-      const symlinkedSkillDir = path.join(claudeRoot, 'mastra');
+      const canonicalSkillDir = path.join(agentsRoot, skillName);
+      const symlinkedSkillDir = path.join(claudeRoot, skillName);
       const capturedPrompts: any[] = [];
       let callCount = 0;
 
@@ -40,7 +41,7 @@ describe('mastracode workspace skill activation', () => {
       await fs.mkdir(claudeRoot, { recursive: true });
       await fs.writeFile(
         path.join(canonicalSkillDir, 'SKILL.md'),
-        '---\nname: mastra\ndescription: canonical mastra skill\n---\n\n# Mastra\n\nUse the canonical skill.',
+        '---\nname: temp-symlink-skill\ndescription: canonical temp symlink skill\n---\n\n# Temp Symlink Skill\n\nUse the canonical skill.',
       );
       await fs.symlink(canonicalSkillDir, symlinkedSkillDir, 'dir');
 
@@ -79,7 +80,7 @@ describe('mastracode workspace skill activation', () => {
                     toolCallId: 'call-1',
                     toolCallType: 'function',
                     toolName: 'skill',
-                    input: '{"name":"mastra"}',
+                    input: '{"name":"temp-symlink-skill"}',
                   },
                   {
                     type: 'finish',
@@ -97,7 +98,7 @@ describe('mastracode workspace skill activation', () => {
                 { type: 'stream-start', warnings: [] },
                 { type: 'response-metadata', id: 'id-1', modelId: 'mock', timestamp: new Date(0) },
                 { type: 'text-start', id: 'text-1' },
-                { type: 'text-delta', id: 'text-1', delta: 'Loaded mastra skill.' },
+                { type: 'text-delta', id: 'text-1', delta: 'Loaded temp symlink skill.' },
                 { type: 'text-end', id: 'text-1' },
                 {
                   type: 'finish',
@@ -111,7 +112,7 @@ describe('mastracode workspace skill activation', () => {
         workspace,
       });
 
-      const result = await agent.stream('Activate mastra', { requestContext });
+      const result = await agent.stream('Activate temp-symlink-skill', { requestContext });
       const chunks: any[] = [];
       for await (const chunk of result.fullStream) {
         chunks.push(chunk);
@@ -120,7 +121,7 @@ describe('mastracode workspace skill activation', () => {
       const toolResultChunk = chunks.find(chunk => chunk.type === 'tool-result');
       expect(toolResultChunk, JSON.stringify(chunks, null, 2)).toBeDefined();
       expect(toolResultChunk.payload.toolName).toBe('skill');
-      expect(toolResultChunk.payload.result).toContain('# Mastra');
+      expect(toolResultChunk.payload.result).toContain('# Temp Symlink Skill');
       expect(toolResultChunk.payload.result).toContain('Use the canonical skill.');
       expect(capturedPrompts).toHaveLength(2);
     } finally {

--- a/mastracode/src/agents/__tests__/workspace-skill-activation.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-skill-activation.test.ts
@@ -1,0 +1,130 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Agent } from '@mastra/core/agent';
+import { RequestContext } from '@mastra/core/request-context';
+import { MastraLanguageModelV2Mock } from '@mastra/core/test-utils/llm-mock';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalCwd = process.cwd();
+
+function toStream(chunks: any[]) {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  vi.resetModules();
+});
+
+describe('mastracode workspace skill activation', () => {
+  it('activates a symlinked local skill by bare name through the mastracode workspace path', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-workspace-skill-'));
+
+    try {
+      const agentsRoot = path.join(tempDir, '.agents', 'skills');
+      const claudeRoot = path.join(tempDir, '.claude', 'skills');
+      const canonicalSkillDir = path.join(agentsRoot, 'mastra');
+      const symlinkedSkillDir = path.join(claudeRoot, 'mastra');
+      const capturedPrompts: any[] = [];
+      let callCount = 0;
+
+      await fs.mkdir(canonicalSkillDir, { recursive: true });
+      await fs.mkdir(claudeRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(canonicalSkillDir, 'SKILL.md'),
+        '---\nname: mastra\ndescription: canonical mastra skill\n---\n\n# Mastra\n\nUse the canonical skill.',
+      );
+      await fs.symlink(canonicalSkillDir, symlinkedSkillDir, 'dir');
+
+      process.chdir(tempDir);
+      const { getDynamicWorkspace } = await import('../workspace.js');
+
+      const requestContext = new RequestContext();
+      requestContext.set('harness', {
+        modeId: 'build',
+        getState: () => ({
+          projectPath: tempDir,
+          sandboxAllowedPaths: [],
+        }),
+      });
+
+      const workspace = getDynamicWorkspace({ requestContext });
+
+      const agent = new Agent({
+        id: 'mc-symlink-skill-agent',
+        name: 'MC Symlink Skill Agent',
+        instructions: 'You are a test agent.',
+        model: new MastraLanguageModelV2Mock({
+          doStream: async ({ prompt }) => {
+            callCount++;
+            capturedPrompts.push(prompt);
+
+            if (callCount === 1) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                warnings: [],
+                stream: toStream([
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'response-metadata', id: 'id-0', modelId: 'mock', timestamp: new Date(0) },
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolCallType: 'function',
+                    toolName: 'skill',
+                    input: '{"name":"mastra"}',
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'tool-calls',
+                    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                  },
+                ]),
+              };
+            }
+
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              warnings: [],
+              stream: toStream([
+                { type: 'stream-start', warnings: [] },
+                { type: 'response-metadata', id: 'id-1', modelId: 'mock', timestamp: new Date(0) },
+                { type: 'text-start', id: 'text-1' },
+                { type: 'text-delta', id: 'text-1', delta: 'Loaded mastra skill.' },
+                { type: 'text-end', id: 'text-1' },
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                },
+              ]),
+            };
+          },
+        }) as any,
+        workspace,
+      });
+
+      const result = await agent.stream('Activate mastra', { requestContext });
+      const chunks: any[] = [];
+      for await (const chunk of result.fullStream) {
+        chunks.push(chunk);
+      }
+
+      const toolResultChunk = chunks.find(chunk => chunk.type === 'tool-result');
+      expect(toolResultChunk, JSON.stringify(chunks, null, 2)).toBeDefined();
+      expect(toolResultChunk.payload.toolName).toBe('skill');
+      expect(toolResultChunk.payload.result).toContain('# Mastra');
+      expect(toolResultChunk.payload.result).toContain('Use the canonical skill.');
+      expect(capturedPrompts).toHaveLength(2);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
@@ -1,7 +1,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { skillPaths } from '../workspace.js';
+import { allowedSkillPaths, skillPaths } from '../workspace.js';
 
 describe('workspace skill path definitions', () => {
   const cwd = process.cwd();
@@ -20,7 +20,11 @@ describe('workspace skill path definitions', () => {
     expect(skillPaths).toEqual(expectedSkillPaths);
   });
 
-  it('wires discovery paths separately from allowed paths', async () => {
+  it('uses the same skill directories for allowed paths', () => {
+    expect(allowedSkillPaths).toBe(skillPaths);
+  });
+
+  it('wires the base skill directories into workspace discovery and allowed paths', async () => {
     const fs = await import('node:fs');
     const source = fs.readFileSync(path.join(cwd, 'src/agents/workspace.ts'), 'utf-8');
 

--- a/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
@@ -1,12 +1,13 @@
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { skillPaths } from '../workspace.js';
 
 describe('workspace skill path definitions', () => {
   const cwd = process.cwd();
   const home = os.homedir();
 
-  const expectedPaths = [
+  const expectedSkillPaths = [
     path.join(cwd, '.mastracode', 'skills'),
     path.join(cwd, '.claude', 'skills'),
     path.join(cwd, '.agents', 'skills'),
@@ -15,18 +16,20 @@ describe('workspace skill path definitions', () => {
     path.join(home, '.agents', 'skills'),
   ];
 
-  it('includes project-local and global skill directories as candidates', async () => {
+  it('uses the six base skill directories for workspace discovery', () => {
+    expect(skillPaths).toEqual(expectedSkillPaths);
+  });
+
+  it('wires discovery paths separately from allowed paths', async () => {
     const fs = await import('node:fs');
     const source = fs.readFileSync(path.join(cwd, 'src/agents/workspace.ts'), 'utf-8');
 
-    for (const dir of ['.mastracode', '.claude', '.agents']) {
-      expect(source).toContain(`process.cwd(), '${dir}', 'skills'`);
-      expect(source).toContain(`os.homedir(), '${dir}', 'skills'`);
-    }
+    expect(source).toContain('const allowedPaths = [...allowedSkillPaths');
+    expect(source).toContain("...(skillPaths.length > 0 ? { skills: skillPaths } : {}),");
   });
 
-  it('expected paths are well-formed absolute paths', () => {
-    for (const p of expectedPaths) {
+  it('exposes well-formed absolute skill paths', () => {
+    for (const p of skillPaths) {
       expect(path.isAbsolute(p)).toBe(true);
       expect(p).toMatch(/skills$/);
     }

--- a/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-skill-paths.test.ts
@@ -29,7 +29,7 @@ describe('workspace skill path definitions', () => {
     const source = fs.readFileSync(path.join(cwd, 'src/agents/workspace.ts'), 'utf-8');
 
     expect(source).toContain('const allowedPaths = [...allowedSkillPaths');
-    expect(source).toContain("...(skillPaths.length > 0 ? { skills: skillPaths } : {}),");
+    expect(source).toContain('...(skillPaths.length > 0 ? { skills: skillPaths } : {}),');
   });
 
   it('exposes well-formed absolute skill paths', () => {

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -1,4 +1,4 @@
-import fs, { existsSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import os from 'node:os';
 import path, { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -36,7 +36,7 @@ const claudeGlobalSkillsPath = path.join(os.homedir(), '.claude', 'skills');
 
 const agentSkillsGlobalPath = path.join(os.homedir(), '.agents', 'skills');
 
-const skillDirectoryCandidates = [
+export const skillPaths = [
   mastraCodeLocalSkillsPath,
   claudeLocalSkillsPath,
   agentSkillsLocalPath,
@@ -45,45 +45,7 @@ const skillDirectoryCandidates = [
   agentSkillsGlobalPath,
 ];
 
-function collectAllowedSkillPaths(skillsDirs: string[]): string[] {
-  const paths: string[] = [];
-  const seen = new Set<string>();
-
-  for (const skillsDir of skillsDirs) {
-    if (!fs.existsSync(skillsDir)) continue;
-
-    const resolved = fs.realpathSync(skillsDir);
-    if (!seen.has(resolved)) {
-      seen.add(resolved);
-      paths.push(skillsDir);
-    }
-
-    try {
-      const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
-      for (const entry of entries) {
-        if (!entry.isSymbolicLink()) continue;
-
-        const linkPath = path.join(skillsDir, entry.name);
-        const realPath = fs.realpathSync(linkPath);
-        const stat = fs.statSync(realPath);
-        if (!stat.isDirectory()) continue;
-
-        const realParent = path.dirname(realPath);
-        if (!seen.has(realParent)) {
-          seen.add(realParent);
-          paths.push(realParent);
-        }
-      }
-    } catch {
-      // Ignore errors during symlink resolution
-    }
-  }
-
-  return paths;
-}
-
-export const skillPaths = skillDirectoryCandidates;
-export const allowedSkillPaths = collectAllowedSkillPaths(skillDirectoryCandidates);
+export const allowedSkillPaths = skillPaths;
 
 const WORKSPACE_ID_PREFIX = 'mastra-code-workspace';
 

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -36,41 +36,42 @@ const claudeGlobalSkillsPath = path.join(os.homedir(), '.claude', 'skills');
 
 const agentSkillsGlobalPath = path.join(os.homedir(), '.agents', 'skills');
 
-// Mastra's LocalSkillSource.readdir uses Node's Dirent.isDirectory() which
-// returns false for symlinks. Tools like `npx skills add` install skills as
-// symlinks, so we need to resolve them. For each symlinked skill directory,
-// we add the real (resolved) parent path as an additional skill scan path.
-function collectSkillPaths(skillsDirs: string[]): string[] {
+const skillDirectoryCandidates = [
+  mastraCodeLocalSkillsPath,
+  claudeLocalSkillsPath,
+  agentSkillsLocalPath,
+  mastraCodeGlobalSkillsPath,
+  claudeGlobalSkillsPath,
+  agentSkillsGlobalPath,
+];
+
+function collectAllowedSkillPaths(skillsDirs: string[]): string[] {
   const paths: string[] = [];
   const seen = new Set<string>();
 
   for (const skillsDir of skillsDirs) {
     if (!fs.existsSync(skillsDir)) continue;
 
-    // Always add the directory itself
     const resolved = fs.realpathSync(skillsDir);
     if (!seen.has(resolved)) {
       seen.add(resolved);
       paths.push(skillsDir);
     }
 
-    // Check for symlinked skill subdirectories and add their real parents
     try {
       const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
       for (const entry of entries) {
-        if (entry.isSymbolicLink()) {
-          const linkPath = path.join(skillsDir, entry.name);
-          const realPath = fs.realpathSync(linkPath);
-          const stat = fs.statSync(realPath);
-          if (stat.isDirectory()) {
-            // Add the real parent directory as a skill path
-            // so Mastra discovers it as a regular directory
-            const realParent = path.dirname(realPath);
-            if (!seen.has(realParent)) {
-              seen.add(realParent);
-              paths.push(realParent);
-            }
-          }
+        if (!entry.isSymbolicLink()) continue;
+
+        const linkPath = path.join(skillsDir, entry.name);
+        const realPath = fs.realpathSync(linkPath);
+        const stat = fs.statSync(realPath);
+        if (!stat.isDirectory()) continue;
+
+        const realParent = path.dirname(realPath);
+        if (!seen.has(realParent)) {
+          seen.add(realParent);
+          paths.push(realParent);
         }
       }
     } catch {
@@ -81,14 +82,8 @@ function collectSkillPaths(skillsDirs: string[]): string[] {
   return paths;
 }
 
-export const skillPaths = collectSkillPaths([
-  mastraCodeLocalSkillsPath,
-  claudeLocalSkillsPath,
-  agentSkillsLocalPath,
-  mastraCodeGlobalSkillsPath,
-  claudeGlobalSkillsPath,
-  agentSkillsGlobalPath,
-]);
+export const skillPaths = skillDirectoryCandidates;
+export const allowedSkillPaths = collectAllowedSkillPaths(skillDirectoryCandidates);
 
 const WORKSPACE_ID_PREFIX = 'mastra-code-workspace';
 
@@ -119,7 +114,7 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
   const projectPath = path.resolve(rawProjectPath);
   const workspaceId = `${WORKSPACE_ID_PREFIX}-${projectPath}`;
   const sandboxPaths = state?.sandboxAllowedPaths ?? [];
-  const allowedPaths = [...skillPaths, ...sandboxPaths.map((p: string) => path.resolve(p))];
+  const allowedPaths = [...allowedSkillPaths, ...sandboxPaths.map((p: string) => path.resolve(p))];
   const isPlanMode = modeId === 'plan';
 
   const planModeTools = {

--- a/packages/core/src/processors/processors/skills.test.ts
+++ b/packages/core/src/processors/processors/skills.test.ts
@@ -290,6 +290,50 @@ describe('SkillsProcessor', () => {
       expect(codeReviewIdx).toBeLessThan(testingIdx);
     });
 
+    it('should de-duplicate symlinked skill aliases in available skills output', async () => {
+      const canonicalSkill = {
+        ...mockSkill1,
+        path: '/Users/tylerbarnes/.agents/skills/mastra',
+        name: 'mastra',
+        description: 'Mastra development guide',
+      };
+      const duplicateSkillMetadata = [
+        {
+          name: 'mastra',
+          description: 'Mastra development guide',
+          path: '/Users/tylerbarnes/.claude/skills/mastra',
+        },
+        {
+          name: 'mastra',
+          description: 'Mastra development guide',
+          path: '/Users/tylerbarnes/.agents/skills/mastra',
+        },
+      ];
+
+      const duplicateSkills = {
+        ...createMockWorkspaceSkills(),
+        list: vi.fn().mockResolvedValue(duplicateSkillMetadata),
+        get: vi.fn().mockResolvedValue(canonicalSkill),
+      };
+      const workspace = createMockWorkspace(duplicateSkills);
+      const proc = new SkillsProcessor({ workspace });
+
+      await proc.processInputStep({
+        messageList: mockMessageList as any,
+        tools: {},
+      } as any);
+
+      const systemCalls = mockMessageList.addSystem.mock.calls;
+      const availableSkillsMessage = systemCalls.find((call: any) =>
+        call[0]?.content?.includes('<available_skills>'),
+      )?.[0]?.content;
+
+      expect(availableSkillsMessage).toBeDefined();
+      expect(availableSkillsMessage.match(/<name>mastra<\/name>/g)).toHaveLength(1);
+      expect(availableSkillsMessage).toContain('/Users/tylerbarnes/.agents/skills/mastra/SKILL.md');
+      expect(availableSkillsMessage).not.toContain('/Users/tylerbarnes/.claude/skills/mastra/SKILL.md');
+    });
+
     it('should inject on every step (system messages are reset between steps)', async () => {
       // Step 0 — should inject
       await processor.processInputStep({

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -129,13 +129,14 @@ export class SkillsProcessor implements Processor<'skills-processor'> {
     // Use meta.path (not meta.name) so same-named skills each resolve to their specific entry.
     const skillPromises = skillsList.map(meta => this.skills?.get(meta.path));
     const fullSkills = (await Promise.all(skillPromises)).filter((s): s is Skill => s !== undefined && s !== null);
+    const dedupedSkills = Array.from(new Map(fullSkills.map(skill => [skill.path, skill])).values());
 
     // Sort by name for deterministic output (avoids busting prompt cache)
-    fullSkills.sort((a, b) => a.name.localeCompare(b.name));
+    dedupedSkills.sort((a, b) => a.name.localeCompare(b.name));
 
     switch (this._format) {
       case 'xml': {
-        const skillsXml = fullSkills
+        const skillsXml = dedupedSkills
           .map(
             skill => `  <skill>
     <name>${this.escapeXml(skill.name)}</name>
@@ -155,7 +156,7 @@ ${skillsXml}
         return `Available Skills:
 
 ${JSON.stringify(
-  fullSkills.map(s => ({
+  dedupedSkills.map(s => ({
     name: s.name,
     description: s.description,
     location: this.formatLocation(s),
@@ -167,7 +168,7 @@ ${JSON.stringify(
       }
 
       case 'markdown': {
-        const skillsMd = fullSkills
+        const skillsMd = dedupedSkills
           .map(
             skill =>
               `- **${skill.name}** [${this.formatSourceType(skill)}] (${this.formatLocation(skill)}): ${skill.description}`,

--- a/packages/core/src/workspace/filesystem/filesystem.ts
+++ b/packages/core/src/workspace/filesystem/filesystem.ts
@@ -211,6 +211,12 @@ export interface WorkspaceFilesystem extends FilesystemLifecycle<FilesystemInfo>
    */
   getMountConfig?(): FilesystemMountConfig;
 
+  /**
+   * Resolve a path to its canonical form.
+   * Filesystems without symlink or alias semantics can return the input path unchanged.
+   */
+  realpath?(path: string): Promise<string>;
+
   // ---------------------------------------------------------------------------
   // File Operations
   // ---------------------------------------------------------------------------

--- a/packages/core/src/workspace/filesystem/local-filesystem.test.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.test.ts
@@ -724,6 +724,38 @@ describe('LocalFilesystem', () => {
         expect(content).toBe('new content');
       });
 
+      it('should allow access through the canonical target of a symlinked allowed path', async () => {
+        const allowedRootLink = path.join(tempDir, 'allowed-root-link');
+        await fs.symlink(outsideDir, allowedRootLink);
+
+        const fsWithAllowed = new LocalFilesystem({
+          basePath: tempDir,
+          contained: true,
+          allowedPaths: [allowedRootLink],
+        });
+
+        const content = await fsWithAllowed.readFile(path.join(outsideDir, 'external.txt'), {
+          encoding: 'utf-8',
+        });
+        expect(content).toBe('external content');
+      });
+
+      it('should allow access through a symlink path when the canonical root is allowed', async () => {
+        const allowedRootLink = path.join(tempDir, 'allowed-root-link');
+        await fs.symlink(outsideDir, allowedRootLink);
+
+        const fsWithAllowed = new LocalFilesystem({
+          basePath: tempDir,
+          contained: true,
+          allowedPaths: [outsideDir],
+        });
+
+        const content = await fsWithAllowed.readFile(path.join(allowedRootLink, 'external.txt'), {
+          encoding: 'utf-8',
+        });
+        expect(content).toBe('external content');
+      });
+
       it('should block path traversal that escapes all roots', async () => {
         const restrictedFs = new LocalFilesystem({
           basePath: tempDir,

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -5,7 +5,7 @@
  * This is the default filesystem for development and local agents.
  */
 
-import { constants as fsConstants } from 'node:fs';
+import { constants as fsConstants, realpathSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as nodePath from 'node:path';
 import type { RequestContext } from '../../request-context';
@@ -218,11 +218,49 @@ export class LocalFilesystem extends MastraFilesystem {
   /**
    * Check if an absolute path falls within basePath or any allowed path.
    */
+  private _isWithinRoot(absolutePath: string, root: string): boolean {
+    const relative = nodePath.relative(root, absolutePath);
+    return !relative.startsWith('..') && !nodePath.isAbsolute(relative);
+  }
+
+  private _resolvePathForContainment(absolutePath: string): string | undefined {
+    let currentPath = absolutePath;
+
+    while (true) {
+      try {
+        const realPath = realpathSync(currentPath);
+        if (currentPath === absolutePath) {
+          return realPath;
+        }
+
+        const remainder = nodePath.relative(currentPath, absolutePath);
+        return nodePath.join(realPath, remainder);
+      } catch (error: unknown) {
+        if (!isEnoentError(error)) return undefined;
+      }
+
+      const parentPath = nodePath.dirname(currentPath);
+      if (parentPath === currentPath) {
+        return undefined;
+      }
+      currentPath = parentPath;
+    }
+  }
+
   private _isWithinAnyRoot(absolutePath: string): boolean {
     const roots = [this._basePath, ...this._allowedPaths];
+    if (roots.some(root => this._isWithinRoot(absolutePath, root))) {
+      return true;
+    }
+
+    const resolvedPath = this._resolvePathForContainment(absolutePath);
+    if (!resolvedPath) {
+      return false;
+    }
+
     return roots.some(root => {
-      const relative = nodePath.relative(root, absolutePath);
-      return !relative.startsWith('..') && !nodePath.isAbsolute(relative);
+      const resolvedRoot = this._resolvePathForContainment(root);
+      return resolvedRoot ? this._isWithinRoot(resolvedPath, resolvedRoot) : false;
     });
   }
 

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -313,6 +313,10 @@ export class LocalFilesystem extends MastraFilesystem {
   private async assertPathContained(absolutePath: string): Promise<void> {
     if (!this._contained) return;
 
+    if (this._allowedPaths.some(root => this._isWithinRoot(absolutePath, root))) {
+      return;
+    }
+
     // Resolve symlinks for the target path. If it doesn't exist,
     // there are no symlinks to escape through — nothing to check.
     let targetReal: string;
@@ -743,6 +747,15 @@ export class LocalFilesystem extends MastraFilesystem {
       ...result,
       path: this.toRelativePath(absolutePath),
     };
+  }
+
+  async realpath(inputPath: string): Promise<string> {
+    await this.ensureReady();
+    const absolutePath = this.resolvePath(inputPath);
+    await this.assertPathContained(absolutePath);
+
+    const canonicalPath = await fs.realpath(absolutePath);
+    return this.toRelativePath(canonicalPath);
   }
 
   /**

--- a/packages/core/src/workspace/skills/composite-versioned-skill-source.ts
+++ b/packages/core/src/workspace/skills/composite-versioned-skill-source.ts
@@ -61,7 +61,7 @@ export class CompositeVersionedSkillSource implements SkillSource {
    * Route a path to the correct source.
    * Returns the source and the remaining path within that source.
    */
-  #routePath(path: string): { source: SkillSource; subPath: string } | null {
+  #routePath(path: string): { source: SkillSource; subPath: string; mountDir: string } | null {
     const normalized = this.#normalizePath(path);
 
     // Root: handled by this source directly
@@ -73,18 +73,18 @@ export class CompositeVersionedSkillSource implements SkillSource {
 
     // Check if this skill should use the fallback source
     if (this.#fallbackSkills.has(skillDir) && this.#fallback) {
-      return { source: this.#fallback, subPath: normalized };
+      return { source: this.#fallback, subPath: normalized, mountDir: '' };
     }
 
     // Check if this skill has a versioned source
     const versionedSource = this.#sources.get(skillDir);
     if (versionedSource) {
-      return { source: versionedSource, subPath };
+      return { source: versionedSource, subPath, mountDir: skillDir };
     }
 
     // Try the fallback for unknown paths
     if (this.#fallback) {
-      return { source: this.#fallback, subPath: normalized };
+      return { source: this.#fallback, subPath: normalized, mountDir: '' };
     }
 
     return null;
@@ -163,5 +163,18 @@ export class CompositeVersionedSkillSource implements SkillSource {
     }
 
     return route.source.readdir(route.subPath);
+  }
+
+  async realpath(path: string): Promise<string> {
+    const normalized = this.#normalizePath(path);
+    if (normalized === '') return '';
+
+    const route = this.#routePath(path);
+    if (!route) {
+      throw new Error(`Path not found in composite skill source: ${path}`);
+    }
+
+    const realSubPath = route.source.realpath ? await route.source.realpath(route.subPath) : route.subPath;
+    return [route.mountDir, realSubPath].filter(Boolean).join('/');
   }
 }

--- a/packages/core/src/workspace/skills/local-skill-source.ts
+++ b/packages/core/src/workspace/skills/local-skill-source.ts
@@ -80,14 +80,34 @@ export class LocalSkillSource implements SkillSource {
   async readdir(skillPath: string): Promise<SkillSourceEntry[]> {
     const resolved = this.#resolvePath(skillPath);
     const entries = await fs.readdir(resolved, { withFileTypes: true });
-    // Note: Dirent.isDirectory() returns false for symlinks pointing to directories,
-    // so symlinked directories appear as { type: 'file', isSymlink: true }. This is
-    // intentional — #walkForDirectories skips symlinks to prevent cycles, and treating
-    // them as files ensures they're never recursed into by other consumers either.
-    return entries.map(entry => ({
-      name: entry.name,
-      type: entry.isDirectory() ? 'directory' : 'file',
-      isSymlink: entry.isSymbolicLink() || undefined,
-    }));
+    // Dirent.isDirectory() returns false for symlinks, even when they point to
+    // directories. Detect the target type so skill discovery can load symlinked
+    // skills while still letting higher layers decide whether to recurse.
+    return Promise.all(
+      entries.map(async entry => {
+        const entryPath = path.join(resolved, entry.name);
+        const isSymlink = entry.isSymbolicLink();
+        let type: SkillSourceEntry['type'] = entry.isDirectory() ? 'directory' : 'file';
+
+        if (isSymlink) {
+          try {
+            const targetStat = await fs.stat(entryPath);
+            type = targetStat.isDirectory() ? 'directory' : 'file';
+          } catch {
+            type = 'file';
+          }
+        }
+
+        return {
+          name: entry.name,
+          type,
+          isSymlink: isSymlink || undefined,
+        };
+      }),
+    );
+  }
+
+  async realpath(skillPath: string): Promise<string> {
+    return fs.realpath(this.#resolvePath(skillPath));
   }
 }

--- a/packages/core/src/workspace/skills/skill-source.ts
+++ b/packages/core/src/workspace/skills/skill-source.ts
@@ -66,4 +66,10 @@ export interface SkillSource {
    * List directory contents.
    */
   readdir(path: string): Promise<SkillSourceEntry[]>;
+
+  /**
+   * Resolve a path to its canonical form.
+   * Sources without aliases or symlinks can return the input path unchanged.
+   */
+  realpath?(path: string): Promise<string>;
 }

--- a/packages/core/src/workspace/skills/tools.test.ts
+++ b/packages/core/src/workspace/skills/tools.test.ts
@@ -1,7 +1,12 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
 
+import { LocalSkillSource } from './local-skill-source';
 import { createSkillTools } from './tools';
 import type { Skill, SkillMetadata, SkillSearchResult, WorkspaceSkills } from './types';
+import { WorkspaceSkillsImpl } from './workspace-skills';
 
 // =============================================================================
 // Mock WorkspaceSkills
@@ -87,6 +92,38 @@ describe('skill tool', () => {
     const result = await exec(tool, { name: 'brand-guidelines' });
 
     expect(result).toBe('# Brand Guidelines\n\nUse blue.');
+  });
+
+  it('activates a symlinked local skill by bare name when two roots point to the same canonical path on disk', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mastra-skill-tool-'));
+
+    try {
+      const agentsRoot = path.join(tempDir, '.agents', 'skills');
+      const claudeRoot = path.join(tempDir, '.claude', 'skills');
+      const canonicalSkillDir = path.join(agentsRoot, 'mastra');
+      const symlinkedSkillDir = path.join(claudeRoot, 'mastra');
+
+      await fs.mkdir(canonicalSkillDir, { recursive: true });
+      await fs.mkdir(claudeRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(canonicalSkillDir, 'SKILL.md'),
+        '---\nname: mastra\ndescription: canonical mastra skill\n---\n\n# Mastra\n\nUse the canonical skill.',
+      );
+      await fs.symlink(canonicalSkillDir, symlinkedSkillDir, 'dir');
+
+      const skills = new WorkspaceSkillsImpl({
+        source: new LocalSkillSource({ basePath: tempDir }),
+        skills: ['.claude/skills', '.agents/skills'],
+      });
+      const { skill: tool } = createSkillTools(skills);
+
+      const result = await exec(tool, { name: 'mastra' });
+
+      expect(result).toContain('# Mastra');
+      expect(result).toContain('Use the canonical skill.');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('appends references section when skill has references', async () => {

--- a/packages/core/src/workspace/skills/types.ts
+++ b/packages/core/src/workspace/skills/types.ts
@@ -230,7 +230,9 @@ export interface WorkspaceSkills {
   // ===========================================================================
 
   /**
-   * List all discovered skills (metadata only)
+   * List discovered skills as canonical metadata entries.
+   *
+   * Alias paths that resolve to the same underlying skill are de-duplicated.
    */
   list(): Promise<SkillMetadata[]>;
 

--- a/packages/core/src/workspace/skills/versioned-skill-source.ts
+++ b/packages/core/src/workspace/skills/versioned-skill-source.ts
@@ -143,4 +143,8 @@ export class VersionedSkillSource implements SkillSource {
 
     return entries;
   }
+
+  async realpath(path: string): Promise<string> {
+    return this.#normalizePath(path);
+  }
 }

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -479,6 +479,51 @@ describe('WorkspaceSkillsImpl', () => {
       const results = await skills.search('test', { topK: 2 });
       expect(results.length).toBeLessThanOrEqual(2);
     });
+
+    it('should de-duplicate canonical aliases in search results', async () => {
+      const searchEngine = createMockSearchEngine();
+      const canonicalSkillMd = `---
+name: test-skill
+description: API design skill
+---
+
+# API Design
+
+Use this skill to design REST APIs.
+
+## Tools
+
+This skill helps with endpoint design and API patterns.`;
+      const filesystem = createMockFilesystem(
+        {
+          'skills/test-skill/SKILL.md': canonicalSkillMd,
+          'skills/test-skill/references/doc.md': 'API reference for canonical skill.',
+          'linked-skills/test-skill/SKILL.md': canonicalSkillMd,
+          'linked-skills/test-skill/references/doc.md': 'API reference for canonical skill.',
+        },
+        {
+          realpaths: {
+            'skills/test-skill': '/real/skills/test-skill',
+            'linked-skills/test-skill': '/real/skills/test-skill',
+          },
+        },
+      );
+
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['skills', 'linked-skills'],
+        searchEngine,
+      });
+
+      await skills.list();
+
+      const results = await skills.search('API', { topK: 2 });
+      expect(results).toHaveLength(2);
+      expect(results).toEqual([
+        expect.objectContaining({ skillPath: 'linked-skills/test-skill', source: 'SKILL.md' }),
+        expect.objectContaining({ skillPath: 'linked-skills/test-skill', source: 'references/doc.md' }),
+      ]);
+    });
   });
 
   describe('getReference()', () => {

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -1493,7 +1493,7 @@ Instructions for the new skill.`;
       expect(winner?.instructions).toContain('This is the test skill instructions.');
     });
 
-    it('should error when same-named skills share the same source type (e.g., two local skills)', async () => {
+    it('should de-duplicate canonical aliases in list() while preserving distinct local skills', async () => {
       const shadowSkillMd = `---
 name: test-skill
 description: Shadow copy of the test skill
@@ -1502,28 +1502,35 @@ license: MIT
 
 Shadow instructions.`;
 
-      const filesystem = createMockFilesystem({
-        'skills/test-skill/SKILL.md': VALID_SKILL_MD,
-        'custom-skills/test-skill/SKILL.md': shadowSkillMd,
-      });
+      const filesystem = createMockFilesystem(
+        {
+          'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+          'linked-skills/test-skill/SKILL.md': VALID_SKILL_MD,
+          'custom-skills/test-skill/SKILL.md': shadowSkillMd,
+        },
+        {
+          realpaths: {
+            'skills/test-skill': '/real/skills/test-skill',
+            'linked-skills/test-skill': '/real/skills/test-skill',
+            'custom-skills/test-skill': '/real/custom-skills/test-skill',
+          },
+        },
+      );
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skills: ['skills', 'custom-skills'],
+        skills: ['skills', 'linked-skills', 'custom-skills'],
       });
 
-      // list() returns canonical skills only; ambiguous same-source duplicates still require path-based get()
       const result = await skills.list();
       expect(result).toHaveLength(2);
       const paths = result.map(s => s.path).sort();
-      expect(paths).toEqual(['custom-skills/test-skill', 'skills/test-skill']);
+      expect(paths).toEqual(['custom-skills/test-skill', 'linked-skills/test-skill']);
 
-      // get() by name throws because both are local (source-type tie can't resolve)
       await expect(skills.get('test-skill')).rejects.toThrow(
         'Cannot resolve skill "test-skill": multiple local skills found',
       );
 
-      // get() by exact path (escape hatch) still works for each specific skill
       const specific = await skills.get('skills/test-skill');
       expect(specific?.instructions).toContain('This is the test skill instructions.');
 

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -1574,6 +1574,40 @@ External instructions.`;
       expect(external?.instructions).toContain('External instructions.');
     });
 
+    it('should keep the higher-priority source when canonical aliases collapse into one listed skill', async () => {
+      const externalSkillMd = `---
+name: test-skill
+description: External copy of the test skill
+license: MIT
+---
+
+External instructions.`;
+
+      const filesystem = createMockFilesystem(
+        {
+          'node_modules/@company/skills/test-skill/SKILL.md': externalSkillMd,
+          'linked-skills/test-skill/SKILL.md': VALID_SKILL_MD,
+        },
+        {
+          realpaths: {
+            'node_modules/@company/skills/test-skill': '/real/skills/test-skill',
+            'linked-skills/test-skill': '/real/skills/test-skill',
+          },
+        },
+      );
+
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['node_modules/@company/skills', 'linked-skills'],
+      });
+
+      await expect(skills.list()).resolves.toMatchObject([{ path: 'linked-skills/test-skill' }]);
+      await expect(skills.get('test-skill')).resolves.toMatchObject({
+        path: 'linked-skills/test-skill',
+        source: { type: 'local' },
+      });
+    });
+
     it('should emit a warning when tie-breaking resolves same-named skills across source types', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -18,9 +18,13 @@ type MockSkillSource = SkillSource & {
 // Mock Skill Source
 // =============================================================================
 
-function createMockFilesystem(files: Record<string, string | Buffer> = {}): MockSkillSource {
+function createMockFilesystem(
+  files: Record<string, string | Buffer> = {},
+  options?: { realpaths?: Record<string, string> },
+): MockSkillSource {
   const fileSystem = new Map<string, string | Buffer>(Object.entries(files));
   const directories = new Set<string>();
+  const realpaths = options?.realpaths ?? {};
 
   // Initialize directories from file paths
   for (const path of Object.keys(files)) {
@@ -132,6 +136,7 @@ function createMockFilesystem(files: Record<string, string | Buffer> = {}): Mock
       }
       throw new Error(`Path not found: ${path}`);
     }),
+    realpath: vi.fn(async (path: string) => realpaths[path] ?? path),
   };
 }
 
@@ -1137,6 +1142,7 @@ Instructions for the new skill.`;
           }
           throw new Error(`Path not found: ${path}`);
         }),
+        realpath: vi.fn(async (path: string) => path),
         // NOTE: No writeFile, mkdir, rmdir - this is a read-only source
       };
     }
@@ -1457,6 +1463,30 @@ Instructions for the new skill.`;
       const result = await skills.list();
       expect(result).toHaveLength(1);
       expect(result[0]?.name).toBe('test-skill');
+    });
+
+    it('should de-duplicate same-named local skills that resolve to the same canonical path', async () => {
+      const filesystem = createMockFilesystem(
+        {
+          'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+          'linked-skills/test-skill/SKILL.md': VALID_SKILL_MD,
+        },
+        {
+          realpaths: {
+            'skills/test-skill': '/real/skills/test-skill',
+            'linked-skills/test-skill': '/real/skills/test-skill',
+          },
+        },
+      );
+
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['skills', 'linked-skills'],
+      });
+
+      const winner = await skills.get('test-skill');
+      expect(winner?.path).toBe('linked-skills/test-skill');
+      expect(winner?.instructions).toContain('This is the test skill instructions.');
     });
 
     it('should error when same-named skills share the same source type (e.g., two local skills)', async () => {

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -1484,6 +1484,10 @@ Instructions for the new skill.`;
         skills: ['skills', 'linked-skills'],
       });
 
+      const listed = await skills.list();
+      expect(listed).toHaveLength(1);
+      expect(listed[0]?.path).toBe('linked-skills/test-skill');
+
       const winner = await skills.get('test-skill');
       expect(winner?.path).toBe('linked-skills/test-skill');
       expect(winner?.instructions).toContain('This is the test skill instructions.');
@@ -1508,7 +1512,7 @@ Shadow instructions.`;
         skills: ['skills', 'custom-skills'],
       });
 
-      // list() returns all candidates (both visible for disambiguation UI)
+      // list() returns canonical skills only; ambiguous same-source duplicates still require path-based get()
       const result = await skills.list();
       expect(result).toHaveLength(2);
       const paths = result.map(s => s.path).sort();
@@ -1546,7 +1550,7 @@ External instructions.`;
         skills: ['node_modules/@company/skills', 'skills'],
       });
 
-      // list() returns all candidates (both visible for disambiguation)
+      // list() returns canonical skills only; distinct source types still both appear
       const result = await skills.list();
       expect(result).toHaveLength(2);
       const paths = result.map(s => s.path).sort();

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -112,11 +112,11 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
 
   async list(): Promise<SkillMetadata[]> {
     await this.#ensureInitialized();
-    // Return all candidates (including same-named skills from different sources)
-    // so the disambiguation UI and LLM can see every skill and use the path to pick one.
+
     const results: SkillMetadata[] = [];
     for (const candidates of this.#skills.values()) {
-      for (const skill of candidates) {
+      const canonicalCandidates = await this.#dedupeCanonicalCandidates(candidates);
+      for (const skill of canonicalCandidates) {
         results.push({
           name: skill.name,
           path: skill.path,
@@ -185,6 +185,18 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
     }
   }
 
+  async #dedupeCanonicalCandidates(candidates: InternalSkill[]): Promise<InternalSkill[]> {
+    const canonicalGroups = new Map<string, InternalSkill[]>();
+    for (const candidate of candidates) {
+      const canonicalPath = await this.#getCanonicalSkillPath(candidate.path);
+      const group = canonicalGroups.get(canonicalPath) ?? [];
+      group.push(candidate);
+      canonicalGroups.set(canonicalPath, group);
+    }
+
+    return [...canonicalGroups.values()].map(group => [...group].sort((a, b) => a.path.localeCompare(b.path))[0]!);
+  }
+
   /**
    * Pick the winning skill from an array of same-named candidates.
    * When there's only one candidate, returns it directly (no warning).
@@ -198,17 +210,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
     if (candidates.length === 0) return null;
     if (candidates.length === 1) return candidates[0]!;
 
-    const canonicalGroups = new Map<string, InternalSkill[]>();
-    for (const candidate of candidates) {
-      const canonicalPath = await this.#getCanonicalSkillPath(candidate.path);
-      const group = canonicalGroups.get(canonicalPath) ?? [];
-      group.push(candidate);
-      canonicalGroups.set(canonicalPath, group);
-    }
-
-    const deduped = [...canonicalGroups.values()].map(
-      group => [...group].sort((a, b) => a.path.localeCompare(b.path))[0]!,
-    );
+    const deduped = await this.#dedupeCanonicalCandidates(candidates);
 
     if (deduped.length === 1) return deduped[0]!;
 

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -389,8 +389,14 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
 
     const { topK = 5, minScore, skillNames, includeReferences = true, mode } = options;
 
-    // Get more results than needed to filter by skillNames/includeReferences
-    const expandedTopK = skillNames ? topK * 3 : topK;
+    // Ask the search engine for enough rows to survive post-search filtering and
+    // canonical alias de-duplication before applying the final topK.
+    const totalIndexedDocuments = [...this.#skills.values()].reduce(
+      (count, candidates) =>
+        count + candidates.reduce((skillCount, skill) => skillCount + 1 + skill.references.length, 0),
+      0,
+    );
+    const expandedTopK = Math.max(skillNames ? topK * 3 : topK, totalIndexedDocuments);
 
     // Delegate to SearchEngine
     const searchResults = await this.#searchEngine.search(query, {
@@ -400,6 +406,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
     });
 
     const results: SkillSearchResult[] = [];
+    const seenCanonicalSources = new Set<string>();
 
     for (const result of searchResults) {
       const skillPath = result.metadata?.skillPath as string;
@@ -407,9 +414,11 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
 
       if (!skillPath || !source) continue;
 
-      // Map path back to skill name for filtering and results
-      const skill = this.#resolveByPath(skillPath);
-      if (!skill) continue;
+      // Map path back to the canonical skill winner for filtering and results.
+      const matchedSkill = this.#resolveByPath(skillPath);
+      if (!matchedSkill) continue;
+
+      const skill = (await this.#resolveByName(matchedSkill.name)) ?? matchedSkill;
 
       // Filter by skill names if specified
       if (skillNames && !skillNames.includes(skill.name)) {
@@ -420,6 +429,12 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
       if (!includeReferences && source !== 'SKILL.md') {
         continue;
       }
+
+      const canonicalSourceKey = `${skill.path}:${source}`;
+      if (seenCanonicalSources.has(canonicalSourceKey)) {
+        continue;
+      }
+      seenCanonicalSources.add(canonicalSourceKey);
 
       results.push({
         skillName: skill.name,

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -133,7 +133,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
   async get(name: string): Promise<Skill | null> {
     await this.#ensureInitialized();
     // Try name-based lookup first, then fall back to path-based (escape hatch)
-    const skill = this.#resolveByName(name) ?? this.#resolveByPath(name);
+    const skill = (await this.#resolveByName(name)) ?? this.#resolveByPath(name);
     if (!skill) return null;
 
     // Return without internal indexableContent field
@@ -143,7 +143,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
 
   async has(name: string): Promise<boolean> {
     await this.#ensureInitialized();
-    return (this.#resolveByName(name) ?? this.#resolveByPath(name)) !== null;
+    return ((await this.#resolveByName(name)) ?? this.#resolveByPath(name)) !== null;
   }
 
   // ===========================================================================
@@ -154,7 +154,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
    * Resolve a skill by name with tie-breaking when multiple candidates exist.
    * Priority: local > managed > external, then alphabetical path.
    */
-  #resolveByName(name: string): InternalSkill | null {
+  async #resolveByName(name: string): Promise<InternalSkill | null> {
     const candidates = this.#skills.get(name);
     if (!candidates || candidates.length === 0) return null;
     return this.#tieBreak(candidates);
@@ -175,20 +175,45 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
     return null;
   }
 
+  async #getCanonicalSkillPath(skillPath: string): Promise<string> {
+    if (!this.#source.realpath) return skillPath;
+
+    try {
+      return await this.#source.realpath(skillPath);
+    } catch {
+      return skillPath;
+    }
+  }
+
   /**
    * Pick the winning skill from an array of same-named candidates.
    * When there's only one candidate, returns it directly (no warning).
-   * When there are multiple, applies source-type priority and warns.
+   * When there are multiple, de-duplicates alias paths that point to the same
+   * canonical skill, then applies source-type priority and warns.
    *
    * Priority: local (0) > managed (1) > external (2).
-   * Throws if source-type priority can't resolve the tie (e.g., two local skills with same name).
+   * Throws if source-type priority can't resolve the tie (e.g., two distinct local skills with same name).
    */
-  #tieBreak(candidates: InternalSkill[]): InternalSkill | null {
+  async #tieBreak(candidates: InternalSkill[]): Promise<InternalSkill | null> {
     if (candidates.length === 0) return null;
     if (candidates.length === 1) return candidates[0]!;
 
+    const canonicalGroups = new Map<string, InternalSkill[]>();
+    for (const candidate of candidates) {
+      const canonicalPath = await this.#getCanonicalSkillPath(candidate.path);
+      const group = canonicalGroups.get(canonicalPath) ?? [];
+      group.push(candidate);
+      canonicalGroups.set(canonicalPath, group);
+    }
+
+    const deduped = [...canonicalGroups.values()].map(
+      group => [...group].sort((a, b) => a.path.localeCompare(b.path))[0]!,
+    );
+
+    if (deduped.length === 1) return deduped[0]!;
+
     const SOURCE_PRIORITY: Record<string, number> = { local: 0, managed: 1, external: 2 };
-    const sorted = [...candidates].sort((a, b) => {
+    const sorted = [...deduped].sort((a, b) => {
       const aPri = SOURCE_PRIORITY[a.source.type] ?? 99;
       const bPri = SOURCE_PRIORITY[b.source.type] ?? 99;
       if (aPri !== bPri) return aPri - bPri;
@@ -299,7 +324,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
     await this.#ensureInitialized();
 
     // Resolve by name (tie-break winner), then fall back to path-based lookup
-    const skill = this.#resolveByName(skillName) ?? this.#resolveByPath(skillName);
+    const skill = (await this.#resolveByName(skillName)) ?? this.#resolveByPath(skillName);
     if (!skill) return;
 
     // Remove from search index
@@ -408,7 +433,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
   async getReference(skillName: string, referencePath: string): Promise<string | null> {
     await this.#ensureInitialized();
 
-    const skill = this.#resolveByName(skillName) ?? this.#resolveByPath(skillName);
+    const skill = (await this.#resolveByName(skillName)) ?? this.#resolveByPath(skillName);
     if (!skill) return null;
 
     const safeRefPath = this.#assertRelativePath(referencePath, 'reference');
@@ -429,7 +454,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
   async getScript(skillName: string, scriptPath: string): Promise<string | null> {
     await this.#ensureInitialized();
 
-    const skill = this.#resolveByName(skillName) ?? this.#resolveByPath(skillName);
+    const skill = (await this.#resolveByName(skillName)) ?? this.#resolveByPath(skillName);
     if (!skill) return null;
 
     const safeScriptPath = this.#assertRelativePath(scriptPath, 'script');
@@ -450,7 +475,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
   async getAsset(skillName: string, assetPath: string): Promise<Buffer | null> {
     await this.#ensureInitialized();
 
-    const skill = this.#resolveByName(skillName) ?? this.#resolveByPath(skillName);
+    const skill = (await this.#resolveByName(skillName)) ?? this.#resolveByPath(skillName);
     if (!skill) return null;
 
     const safeAssetPath = this.#assertRelativePath(assetPath, 'asset');
@@ -474,19 +499,19 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
 
   async listReferences(skillName: string): Promise<string[]> {
     await this.#ensureInitialized();
-    const skill = this.#resolveByName(skillName) ?? this.#resolveByPath(skillName);
+    const skill = (await this.#resolveByName(skillName)) ?? this.#resolveByPath(skillName);
     return skill?.references ?? [];
   }
 
   async listScripts(skillName: string): Promise<string[]> {
     await this.#ensureInitialized();
-    const skill = this.#resolveByName(skillName) ?? this.#resolveByPath(skillName);
+    const skill = (await this.#resolveByName(skillName)) ?? this.#resolveByPath(skillName);
     return skill?.scripts ?? [];
   }
 
   async listAssets(skillName: string): Promise<string[]> {
     await this.#ensureInitialized();
-    const skill = this.#resolveByName(skillName) ?? this.#resolveByPath(skillName);
+    const skill = (await this.#resolveByName(skillName)) ?? this.#resolveByPath(skillName);
     return skill?.assets ?? [];
   }
 
@@ -1037,7 +1062,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
 
     for (const candidates of this.#skills.values()) {
       // Use tie-break winner for each name
-      const skill = this.#tieBreak(candidates);
+      const skill = await this.#tieBreak(candidates);
       if (!skill) continue;
 
       // Filter by skill names if specified

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -194,7 +194,16 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
       canonicalGroups.set(canonicalPath, group);
     }
 
-    return [...canonicalGroups.values()].map(group => [...group].sort((a, b) => a.path.localeCompare(b.path))[0]!);
+    const SOURCE_PRIORITY: Record<string, number> = { local: 0, managed: 1, external: 2 };
+    return [...canonicalGroups.values()].map(
+      group =>
+        [...group].sort((a, b) => {
+          const aPri = SOURCE_PRIORITY[a.source.type] ?? 99;
+          const bPri = SOURCE_PRIORITY[b.source.type] ?? 99;
+          if (aPri !== bPri) return aPri - bPri;
+          return a.path.localeCompare(b.path);
+        })[0]!,
+    );
   }
 
   /**

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -585,16 +585,16 @@ Line 3 conclusion`;
     });
 
     it('should list a skill through an allowed symlink root that points outside the workspace', async () => {
-      const externalSkillRoot = path.join(tempDir, '..', 'external-skill-root');
-      await fs.mkdir(path.join(externalSkillRoot, 'firewatch'), { recursive: true });
+      const externalSkillRoot = await fs.mkdtemp(path.join(tempDir, 'external-skill-root-'));
+      await fs.mkdir(path.join(externalSkillRoot, 'linked-tool'), { recursive: true });
       await fs.writeFile(
-        path.join(externalSkillRoot, 'firewatch', 'SKILL.md'),
-        skillContent('firewatch', 'Query GitHub PR activity using Firewatch'),
+        path.join(externalSkillRoot, 'linked-tool', 'SKILL.md'),
+        skillContent('linked-tool', 'Query GitHub PR activity from a linked skill'),
       );
       await fs.mkdir(path.join(tempDir, '.mastracode', 'skills'), { recursive: true });
       await fs.symlink(
-        path.join(externalSkillRoot, 'firewatch'),
-        path.join(tempDir, '.mastracode', 'skills', 'firewatch'),
+        path.join(externalSkillRoot, 'linked-tool'),
+        path.join(tempDir, '.mastracode', 'skills', 'linked-tool'),
       );
 
       const workspace = new Workspace({
@@ -606,11 +606,11 @@ Line 3 conclusion`;
       });
 
       await expect(workspace.skills!.list()).resolves.toMatchObject([
-        { name: 'firewatch', path: '.mastracode/skills/firewatch' },
+        { name: 'linked-tool', path: '.mastracode/skills/linked-tool' },
       ]);
-      await expect(workspace.skills!.get('firewatch')).resolves.toMatchObject({
-        name: 'firewatch',
-        path: '.mastracode/skills/firewatch',
+      await expect(workspace.skills!.get('linked-tool')).resolves.toMatchObject({
+        name: 'linked-tool',
+        path: '.mastracode/skills/linked-tool',
       });
     });
 

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -576,9 +576,42 @@ Line 3 conclusion`;
         skills: ['.claude/skills', '.agents/skills'],
       });
 
+      await expect(workspace.skills!.list()).resolves.toMatchObject([
+        { name: 'mastra', path: '.agents/skills/mastra' },
+      ]);
       await expect(workspace.skills!.get('mastra')).resolves.toMatchObject({
         name: 'mastra',
         path: expect.stringMatching(/\/mastra$/),
+      });
+    });
+
+    it('should list a skill through an allowed symlink root that points outside the workspace', async () => {
+      const externalSkillRoot = path.join(tempDir, '..', 'external-skill-root');
+      await fs.mkdir(path.join(externalSkillRoot, 'firewatch'), { recursive: true });
+      await fs.writeFile(
+        path.join(externalSkillRoot, 'firewatch', 'SKILL.md'),
+        skillContent('firewatch', 'Query GitHub PR activity using Firewatch'),
+      );
+      await fs.mkdir(path.join(tempDir, '.mastracode', 'skills'), { recursive: true });
+      await fs.symlink(
+        path.join(externalSkillRoot, 'firewatch'),
+        path.join(tempDir, '.mastracode', 'skills', 'firewatch'),
+      );
+
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({
+          basePath: tempDir,
+          allowedPaths: [path.join(tempDir, '.mastracode', 'skills')],
+        }),
+        skills: ['.mastracode/skills'],
+      });
+
+      await expect(workspace.skills!.list()).resolves.toMatchObject([
+        { name: 'firewatch', path: '.mastracode/skills/firewatch' },
+      ]);
+      await expect(workspace.skills!.get('firewatch')).resolves.toMatchObject({
+        name: 'firewatch',
+        path: '.mastracode/skills/firewatch',
       });
     });
 

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -569,7 +569,6 @@ Line 3 conclusion`;
 
       const filesystem = new LocalFilesystem({
         basePath: tempDir,
-        allowedPaths: ['/Users/tylerbarnes/.claude/skills', '/Users/tylerbarnes/.agents/skills'],
       });
       const workspace = new Workspace({
         filesystem,

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -555,6 +555,33 @@ Line 3 conclusion`;
       expect(skills1).toBe(skills2);
     });
 
+    it('should de-duplicate symlinked skill aliases when workspace skills use LocalFilesystem as the source', async () => {
+      await fs.mkdir(path.join(tempDir, '.agents', 'skills', 'mastra'), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, '.agents', 'skills', 'mastra', 'SKILL.md'),
+        skillContent('mastra', 'helping with Mastra development'),
+      );
+      await fs.mkdir(path.join(tempDir, '.claude', 'skills'), { recursive: true });
+      await fs.symlink(
+        path.join(tempDir, '.agents', 'skills', 'mastra'),
+        path.join(tempDir, '.claude', 'skills', 'mastra'),
+      );
+
+      const filesystem = new LocalFilesystem({
+        basePath: tempDir,
+        allowedPaths: ['/Users/tylerbarnes/.claude/skills', '/Users/tylerbarnes/.agents/skills'],
+      });
+      const workspace = new Workspace({
+        filesystem,
+        skills: ['.claude/skills', '.agents/skills'],
+      });
+
+      await expect(workspace.skills!.get('mastra')).resolves.toMatchObject({
+        name: 'mastra',
+        path: expect.stringMatching(/\/mastra$/),
+      });
+    });
+
     // =========================================================================
     // Skills + search interaction (regression tests for shared SearchEngine)
     // =========================================================================


### PR DESCRIPTION
This fixes workspace skill resolution when the same skill is reachable through symlinked paths.

Before, `skill("mastra")` could fail with duplicate local matches, `/skills` could show the same skill twice, and symlinked roots like `~/.mastracode/skills/firewatch` could miss nested files.

After, symlink aliases resolve to one canonical skill, list output is deduped, and allowed path checks work through symlinked roots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If a skill can be reached both by its real folder and by a shortcut (symlink), the system used to see it twice or pick the wrong copy. This PR makes the system follow shortcuts to the real folder so each skill appears once, the preferred copy is chosen consistently, and files inside symlinked folders remain accessible.

## Overview

Fixes workspace skill resolution when the same skill is reachable via symlinked and real filesystem paths. After this change:
- symlink aliases are resolved to a single canonical skill,
- skill listings and processor outputs are deduplicated,
- allowed-path containment checks work correctly through symlinked roots so nested files are accessible,
- name-based skill resolution and related APIs are symlink-aware and async where needed,
- tie-breaking respects source priority when canonical aliases collide.

## Key Changes

- Symlink-aware canonicalization and deduplication
  - WorkspaceSkills.list(), search, and name-resolution now canonicalize candidates (via realpath when available), group by canonical path, and emit one representative per canonical target.
  - #resolveByName and #tieBreak are async to await realpath; de-duplication by canonical path happens before tie-breaking.
  - Processors (e.g., available_skills output) and skill tools use deduped skill lists so duplicate entries are removed.

- Source-priority tie-breaking
  - When multiple aliases map to the same canonical path, selection honors source priority (local → managed → external) rather than purely lexicographic ordering (follow-up commit preserves source priority via SOURCE_PRIORITY map and adds tests).

- Filesystem & skill source API additions
  - Added optional realpath?(path) to WorkspaceFilesystem and SkillSource interfaces.
  - Implemented realpath in LocalFilesystem, LocalSkillSource, VersionedSkillSource, CompositeVersionedSkillSource to expose canonical path resolution across sources.

- LocalFilesystem containment and realpath handling
  - New containment helpers resolve paths up the tree using realpath where necessary.
  - assertPathContained fast-paths simple containment but falls back to resolved containment checks to allow access through symlinked roots.
  - Public realpath(inputPath) validates containment and returns canonical workspace-relative paths.

- LocalSkillSource and directory listing improvements
  - readdir() inspects symlink targets (fs.stat) to accurately report 'directory' vs 'file'.
  - LocalSkillSource.realpath(skillPath) added to return canonical filesystem path.

- Composite/versioned sources
  - CompositeVersionedSkillSource returns mountDir with routing and exposes realpath() that prefixes canonical results with the mount dir so composite sources produce correct canonical paths.

- Workspace path config
  - collectSkillPaths symlink expansion was removed; skillPaths is a static list of configured roots and allowedSkillPaths alias is used to build getDynamicWorkspace.allowedPaths for containment.

## Tests and Coverage

New and updated tests cover symlink scenarios and the follow-up fixes:
- workspace-skill-activation.test.ts: activation via symlinked roots with mocked model stream.
- workspace-skill-paths.test.ts: asserts skillPaths/allowedSkillPaths.
- LocalFilesystem allowed-paths tests: containment when allowed path is symlink or real target and when accessing through a symlinked root.
- workspace-skills.test.ts and workspace.test.ts: canonicalization, deduplication, and tie-breaking across source types; resolving symlinked roots that target outside the workspace.
- processors/skills.test.ts and workspace/skills/tools.test.ts: ensure deduplicated outputs and that tools can resolve symlinked skills.
- Follow-ups: tests ensure source-priority winner selection and isolated temp fixtures for external-skill-root tests.

## Behavioral Impact

- Skill discovery, listing, search, and name-based resolution are robust to symlink aliases: duplicate entries are collapsed and lookups return a deterministic, canonical winner.
- Files under symlinked skill roots become accessible when allowed paths include either the symlink or the canonical target.
- Consumers see a single canonical path per underlying skill and consistent winner selection across source types.

## Implementation Notes (concise)

- Added optional realpath methods across filesystem/skill-source interfaces and implementations to centralize canonicalization.
- Made name-resolution async to await canonicalization and to deduplicate deterministically before tie-breaking.
- Preserved source-priority in deduplication tie-breaking (local > managed > external).
- Test fixture cleanup/isolation improved for temp symlinked skill roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->