### PR TITLE
fix: inherit gateway config for structured output models

### DIFF
--- a/.changeset/good-donuts-accept.md
+++ b/.changeset/good-donuts-accept.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed custom gateway model IDs passed to structuredOutput.model so the structuring pass uses the same Mastra gateway configuration as the parent agent.
+Fixed `structuredOutput.model` custom gateway resolution by registering the internal structuring agent with the parent Mastra instance.

--- a/.changeset/good-donuts-accept.md
+++ b/.changeset/good-donuts-accept.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed custom gateway model IDs passed to structuredOutput.model so the structuring pass uses the same Mastra gateway configuration as the parent agent.

--- a/packages/core/src/agent/__tests__/structured-output.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output.test.ts
@@ -1,3 +1,5 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5';
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import {
@@ -6,8 +8,56 @@ import {
 } from '@internal/ai-v6/test';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
+import { MastraModelGateway } from '../../llm/model/gateways/base';
+import type { ProviderConfig } from '../../llm/model/gateways/base';
 import { Mastra } from '../../mastra';
 import { Agent } from '../agent';
+
+class StructuredOutputTestGateway extends MastraModelGateway {
+  readonly id = 'structured-test';
+  readonly name = 'structured-output-test-gateway';
+  readonly prefix = 'structured-test';
+
+  async fetchProviders(): Promise<Record<string, ProviderConfig>> {
+    return {
+      'test-provider': {
+        name: 'Test Provider',
+        models: ['structuring-model'],
+        apiKeyEnvVar: 'TEST_API_KEY',
+        gateway: 'structured-output-test-gateway',
+        url: 'https://api.test.com/v1',
+      },
+    };
+  }
+
+  buildUrl(_modelId: string): string {
+    return 'https://api.test.com/v1';
+  }
+
+  async getApiKey(_modelId: string): Promise<string> {
+    return process.env.TEST_API_KEY || 'test-key';
+  }
+
+  async resolveLanguageModel({
+    modelId,
+    providerId,
+    apiKey,
+    headers,
+  }: {
+    modelId: string;
+    providerId: string;
+    apiKey: string;
+    headers?: Record<string, string>;
+  }): Promise<LanguageModelV2> {
+    return createOpenAICompatible({
+      name: providerId,
+      apiKey,
+      baseURL: this.buildUrl(`${providerId}/${modelId}`),
+      headers,
+      supportsStructuredOutputs: true,
+    }).chatModel(modelId);
+  }
+}
 
 function structuredOutputTests({ version }: { version: 'v1' | 'v2' | 'v3' }) {
   let zodSchemaModel: MockLanguageModelV1 | MockLanguageModelV2 | MockLanguageModelV3;
@@ -399,6 +449,95 @@ function structuredOutputTests({ version }: { version: 'v1' | 'v2' | 'v3' }) {
     });
 
     if (version === 'v2' || version === 'v3') {
+      it('should use Mastra custom gateways for a separate structuring model', async () => {
+        process.env.TEST_API_KEY = 'test-api-key-123';
+
+        const primaryModel =
+          version === 'v2'
+            ? new MockLanguageModelV2({
+                doGenerate: async () => ({
+                  rawCall: { rawPrompt: null, rawSettings: {} },
+                  finishReason: 'stop',
+                  usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                  content: [{ type: 'text', text: 'There are 3 files in the directory.' }],
+                  warnings: [],
+                }),
+                doStream: async () => ({
+                  rawCall: { rawPrompt: null, rawSettings: {} },
+                  warnings: [],
+                  stream: convertArrayToReadableStream([
+                    { type: 'stream-start', warnings: [] },
+                    { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+                    { type: 'text-start', id: 'text-1' },
+                    { type: 'text-delta', id: 'text-1', delta: 'There are 3 files in the directory.' },
+                    { type: 'text-end', id: 'text-1' },
+                    {
+                      type: 'finish',
+                      finishReason: 'stop',
+                      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                    },
+                  ]),
+                }),
+              })
+            : new MockLanguageModelV3({
+                doGenerate: async () => ({
+                  finishReason: 'stop' as const,
+                  usage: {
+                    inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+                    outputTokens: { total: 20, text: 20, reasoning: undefined },
+                  },
+                  content: [{ type: 'text', text: 'There are 3 files in the directory.' }],
+                  warnings: [],
+                }),
+                doStream: async () => ({
+                  stream: convertArrayToReadableStreamV3([
+                    { type: 'stream-start', warnings: [] },
+                    { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+                    { type: 'text-start', id: 'text-1' },
+                    { type: 'text-delta', id: 'text-1', delta: 'There are 3 files in the directory.' },
+                    { type: 'text-end', id: 'text-1' },
+                    {
+                      type: 'finish',
+                      finishReason: 'stop',
+                      usage: {
+                        inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+                        outputTokens: { total: 20, text: 20, reasoning: undefined },
+                      },
+                    },
+                  ]),
+                }),
+              });
+
+        const agent = new Agent({
+          id: `structured-output-custom-gateway-${version}`,
+          name: 'Structured Output Custom Gateway',
+          instructions: 'You are a helpful assistant.',
+          model: primaryModel,
+        });
+
+        const mastra = new Mastra({
+          agents: { agent },
+          gateways: {
+            structuredTest: new StructuredOutputTestGateway(),
+          },
+          logger: false,
+        });
+
+        const registeredAgent = mastra.getAgent('agent');
+
+        const result = await registeredAgent.generate('Summarize: there are 3 files in the directory.', {
+          structuredOutput: {
+            schema: z.object({
+              summary: z.string(),
+              filesFound: z.number(),
+            }),
+            model: 'structured-test/test-provider/structuring-model',
+          },
+        });
+
+        expect(result.tripwire?.reason).not.toContain('Could not find config for provider structured-test');
+      });
+
       it('should surface separate structuring model errors from the processor', async () => {
         const primaryModel =
           version === 'v2'

--- a/packages/core/src/agent/__tests__/structured-output.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output.test.ts
@@ -1,5 +1,3 @@
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5';
-import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import {
@@ -38,24 +36,43 @@ class StructuredOutputTestGateway extends MastraModelGateway {
     return process.env.TEST_API_KEY || 'test-key';
   }
 
-  async resolveLanguageModel({
-    modelId,
-    providerId,
-    apiKey,
-    headers,
-  }: {
+  async resolveLanguageModel(_args: {
     modelId: string;
     providerId: string;
     apiKey: string;
     headers?: Record<string, string>;
-  }): Promise<LanguageModelV2> {
-    return createOpenAICompatible({
-      name: providerId,
-      apiKey,
-      baseURL: this.buildUrl(`${providerId}/${modelId}`),
-      headers,
-      supportsStructuredOutputs: true,
-    }).chatModel(modelId);
+  }): Promise<MockLanguageModelV2> {
+    return new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        content: [
+          { type: 'text', text: JSON.stringify({ summary: 'There are 3 files in the directory.', filesFound: 3 }) },
+        ],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'structuring-model', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          {
+            type: 'text-delta',
+            id: 'text-1',
+            delta: JSON.stringify({ summary: 'There are 3 files in the directory.', filesFound: 3 }),
+          },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+      }),
+    });
   }
 }
 
@@ -535,7 +552,11 @@ function structuredOutputTests({ version }: { version: 'v1' | 'v2' | 'v3' }) {
           },
         });
 
-        expect(result.tripwire?.reason).not.toContain('Could not find config for provider structured-test');
+        expect(result.tripwire).toBeUndefined();
+        expect(result.object).toEqual({
+          summary: 'There are 3 files in the directory.',
+          filesFound: 3,
+        });
       });
 
       it('should surface separate structuring model errors from the processor', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4579,6 +4579,7 @@ export class Agent<
       getMemory: this.getMemory.bind(this),
       getModel: this.getModel.bind(this),
       generateMessageId: this.#mastra?.generateId?.bind(this.#mastra) || (() => randomUUID()),
+      mastra: this.#mastra,
       _agentNetworkAppend:
         '_agentNetworkAppend' in this
           ? Boolean((this as unknown as { _agentNetworkAppend: unknown })._agentNetworkAppend)

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -179,6 +179,9 @@ export function createMapResultsStep<OUTPUT = undefined>({
         ...options.structuredOutput,
         logger: capabilities.logger,
       });
+      if (capabilities.mastra) {
+        structuredProcessor.__registerMastra(capabilities.mastra);
+      }
       effectiveOutputProcessors = effectiveOutputProcessors
         ? [...effectiveOutputProcessors, structuredProcessor]
         : [structuredProcessor];

--- a/packages/core/src/agent/workflows/prepare-stream/schema.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/schema.ts
@@ -14,6 +14,7 @@ export type AgentCapabilities = {
   getMemory: Agent['getMemory'];
   getModel: Agent['getModel'];
   generateMessageId: Mastra['generateId'];
+  mastra?: Mastra;
   _agentNetworkAppend?: boolean;
   saveStepMessages: Agent['saveStepMessages'];
   convertTools: Agent['convertTools'];

--- a/packages/core/src/processors/processors/structured-output.test.ts
+++ b/packages/core/src/processors/processors/structured-output.test.ts
@@ -3,6 +3,7 @@ import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { z } from 'zod/v4';
 import type { Agent } from '../../agent';
+import { Mastra } from '../../mastra';
 import type { ChunkType } from '../../stream/types';
 import { ChunkFrom } from '../../stream/types';
 import { StructuredOutputProcessor } from './structured-output';
@@ -57,6 +58,18 @@ describe('StructuredOutputProcessor', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('__registerMastra', () => {
+    it('should propagate mastra registration to the internal structuring agent', () => {
+      const mastra = new Mastra({ logger: false });
+
+      expect((processor as any).structuringAgent.getMastraInstance()).toBeUndefined();
+
+      (processor as any).__registerMastra(mastra);
+
+      expect((processor as any).structuringAgent.getMastraInstance()).toBe(mastra);
+    });
   });
 
   describe('processOutputStream', () => {

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -4,6 +4,7 @@ import type { StructuredOutputOptions } from '../../agent/types';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { IMastraLogger } from '../../logger';
+import type { Mastra } from '../../mastra';
 import type { ObservabilityContext } from '../../observability';
 import { resolveObservabilityContext } from '../../observability';
 import type { StandardSchemaWithJSON } from '../../schema';
@@ -72,6 +73,10 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
       instructions: options.instructions || this.generateInstructions(),
       model: options.model,
     });
+  }
+
+  __registerMastra(mastra: Mastra) {
+    this.structuringAgent.__registerMastra(mastra);
   }
 
   async processOutputStream(


### PR DESCRIPTION
The structured output processor now registers its internal structuring agent with the parent Mastra instance, so `structuredOutput.model` can resolve custom gateway models the same way the parent agent does.

Before, a separate structuring model like `structured-test/test-provider/structuring-model` could fail inside the nested agent with `Could not find config for provider ...` even though the parent agent was already running with the right gateway setup.

After this change, the nested structuring pass inherits the same Mastra gateway configuration and the regression tests cover both the processor registration path and a successful custom gateway structured output flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When using custom AI model providers for structured outputs, the internal structuring agent couldn't find the parent's model configuration. This PR fixes it by passing the parent Mastra instance's configuration to the nested agent so it can properly resolve custom model providers.

## Overview
This PR fixes a regression where `StructuredOutputProcessor` failed to resolve custom gateway model IDs (e.g., `structured-test/test-provider/structuring-model`) because its internal structuring agent didn't have access to the parent Mastra instance's gateway configuration.

## Changes Made

### Core Fix
- **Agent capabilities exposure**: Modified `Agent#execute()` to expose the underlying Mastra instance via `capabilities.mastra`, allowing child components to access parent configuration.
- **Structured output processor registration**: Added `__registerMastra(mastra: Mastra)` method to `StructuredOutputProcessor` to propagate the parent Mastra instance to the internal structuring agent.
- **Capability registration**: Updated `prepare-stream/map-results-step.ts` to conditionally call `structuredProcessor.__registerMastra(capabilities.mastra)` when a custom structured output model is configured.
- **Type updates**: Extended `AgentCapabilities` interface to include an optional `mastra?: Mastra` property.

### Testing & Documentation
- Added regression test with a custom `StructuredOutputTestGateway` demonstrating successful resolution of custom gateway models in structured output flows.
- Added unit test verifying `__registerMastra()` correctly propagates the Mastra instance to the internal structuring agent.
- Added changeset documenting the fix with `patch` version bump for `@mastra/core`.

## Result
Nested agents now inherit the parent Mastra gateway configuration, enabling structured output processors to successfully resolve custom gateway model IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->