### PR TITLE
fix(mcp): preserve url and form elicitation capabilities

### DIFF
--- a/.changeset/swift-llamas-joke.md
+++ b/.changeset/swift-llamas-joke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Preserve forwarded MCP client elicitation capabilities so client-supported URL and form elicitations work correctly.

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1596,6 +1596,58 @@ describe('MastraMCPClient - Roots Capability (Issue #8660)', () => {
     await client.disconnect().catch(() => {});
   });
 
+  it('should preserve custom elicitation capability fields', async () => {
+    const customElicitationCapabilities = {
+      supportedContentTypes: ['text/uri-list', 'application/vnd.mastra.form+json'],
+    } as any;
+
+    const client = new InternalMastraMCPClient({
+      name: 'elicitation-capability-test-client',
+      server: {
+        url: testServer.baseUrl,
+      },
+      capabilities: {
+        elicitation: customElicitationCapabilities,
+      } as any,
+    });
+
+    const internalClient = (client as any).client;
+    const capabilities = internalClient._options?.capabilities;
+
+    expect(capabilities).toMatchObject({
+      elicitation: customElicitationCapabilities,
+    });
+
+    await client.disconnect().catch(() => {});
+  });
+
+  it('should preserve custom elicitation fields while auto-enabling roots capability', async () => {
+    const customElicitationCapabilities = {
+      supportedContentTypes: ['text/uri-list'],
+    } as any;
+
+    const client = new InternalMastraMCPClient({
+      name: 'elicitation-with-roots-test-client',
+      server: {
+        url: testServer.baseUrl,
+        roots: [{ uri: 'file:///tmp', name: 'Temp Directory' }],
+      },
+      capabilities: {
+        elicitation: customElicitationCapabilities,
+      } as any,
+    });
+
+    const internalClient = (client as any).client;
+    const capabilities = internalClient._options?.capabilities;
+
+    expect(capabilities).toMatchObject({
+      roots: { listChanged: true },
+      elicitation: customElicitationCapabilities,
+    });
+
+    await client.disconnect().catch(() => {});
+  });
+
   it('should handle roots/list requests from server per MCP spec', async () => {
     /**
      * Per MCP Roots spec (https://modelcontextprotocol.io/specification/2025-11-25/client/roots):

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -154,7 +154,10 @@ export class InternalMastraMCPClient extends MastraBase {
     const hasRoots = this._roots.length > 0 || !!capabilities.roots;
     const clientCapabilities = {
       ...capabilities,
-      elicitation: {},
+      // Merge elicitation capabilities instead of overwriting
+      elicitation: {
+        ...(capabilities.elicitation ?? {}),
+      },
       // Auto-enable roots capability if roots are provided
       ...(hasRoots ? { roots: { listChanged: true, ...(capabilities.roots ?? {}) } } : {}),
     };

--- a/packages/mcp/src/client/configuration.test.ts
+++ b/packages/mcp/src/client/configuration.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { InternalMastraMCPClient } from './client';
 import { MCPClient } from './configuration';
 
 let clientId = 0;
@@ -88,5 +89,33 @@ describe('MCPClient tool discovery retries', () => {
     expect(internalClient.tools).toHaveBeenCalledTimes(2);
     expect(reconnectSpy).toHaveBeenCalledTimes(1);
     expect(reconnectSpy).toHaveBeenCalledWith('weather');
+  });
+
+  it('forwards per-server capabilities into InternalMastraMCPClient', async () => {
+    const customCapabilities = {
+      elicitation: {
+        supportedContentTypes: ['text/uri-list', 'application/vnd.mastra.form+json'],
+      },
+    } as any;
+
+    const connectSpy = vi.spyOn(InternalMastraMCPClient.prototype, 'connect').mockResolvedValue(true);
+
+    const client = new MCPClient({
+      id: `configuration-test-${++clientId}`,
+      servers: {
+        weather: {
+          url: new URL('http://localhost:1234/sse'),
+          capabilities: customCapabilities,
+        },
+      },
+    });
+
+    clients.push(client);
+
+    const internalClient = await (client as any).getConnectedClientForServer('weather');
+    const capabilities = (internalClient as any).client._options?.capabilities;
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(capabilities).toMatchObject(customCapabilities);
   });
 });

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -931,6 +931,7 @@ To fix this you have three different options:
       name,
       server: config,
       timeout: config.timeout ?? this.defaultTimeout,
+      capabilities: config.capabilities,
     });
 
     mcpClient.__setLogger(this.logger);


### PR DESCRIPTION
## Description

This PR fixes MCP client capability forwarding for elicitation support.

It preserves custom `elicitation` capability fields instead of overwriting them during `InternalMastraMCPClient` initialization, and forwards per-server MCP client capabilities from `MCPClient` into `InternalMastraMCPClient`. Together, these changes ensure client-supported URL and form elicitations are advertised correctly.

The PR also adds focused client test coverage for both capability preservation and capability forwarding, and includes a changeset for `@mastra/mcp`.

Note: `pnpm --filter ./packages/mcp test:client` still reproduces 3 pre-existing timeout failures in the filesystem integration tests in `packages/mcp/src/client/client.test.ts`:
- `WITH roots capability: InternalMastraMCPClient properly sends roots`
- `should work with InternalMastraMCPClient roots option`
- `should allow dynamic root updates`

The new elicitation capability tests pass, and these timeout failures are unrelated to this patch.

## Related Issue(s)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Testing

- `pnpm --filter ./packages/mcp build:lib`
- `pnpm --filter ./packages/mcp test:client` currently hits 3 pre-existing timeouts in the filesystem integration tests in `packages/mcp/src/client/client.test.ts`
- `pnpm --filter ./packages/mcp test:client`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

This PR fixes a bug where the MCP client was accidentally erasing special settings that tell it how to handle certain user interactions (like URL inputs and forms). The fix preserves these settings so they don't get lost, and also makes sure server-specific settings are properly passed through the entire system.

## Changes Overview

This PR addresses capability preservation issues in the MCP client initialization flow. The changes ensure that:
1. Custom `elicitation` capability settings are merged rather than overwritten
2. Per-server capabilities are properly forwarded from `MCPClient` to `InternalMastraMCPClient`
3. The `roots` capability continues to work correctly when local/server-provided roots are present

## Modified Files

**packages/mcp/src/client/client.ts**
- Updated capability construction to merge `elicitation` from existing capabilities instead of unconditionally replacing it with an empty object
- Preserved existing behavior for auto-enabling the `roots` capability when roots are present

**packages/mcp/src/client/configuration.ts**
- Added `capabilities: config.capabilities` to the `InternalMastraMCPClient` constructor options in `getConnectedClient`, ensuring per-server capabilities are forwarded to the internal client

**packages/mcp/src/client/client.test.ts**
- Added two new test cases verifying that custom `capabilities.elicitation` objects are preserved when constructing `InternalMastraMCPClient`
- Second test verifies preservation works alongside server roots configuration

**packages/mcp/src/client/configuration.test.ts**
- Added test case verifying per-server `capabilities` are forwarded into `InternalMastraMCPClient` during initialization

**.changeset/swift-llamas-joke.md**
- Added changeset documenting a patch-level release for `@mastra/mcp` with notes on elicitation capability preservation

## Testing Notes

New tests added verify capability preservation and forwarding. Pre-existing filesystem integration test timeouts in `packages/mcp/src/client/client.test.ts` are unrelated to this patch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->