### PR TITLE
fix(core): add zai/glm-5.1 to vercel provider types

### DIFF
--- a/packages/core/src/llm/model/provider-registry.json
+++ b/packages/core/src/llm/model/provider-registry.json
@@ -2895,6 +2895,7 @@
         "zai/glm-4.7-flash",
         "zai/glm-4.7-flashx",
         "zai/glm-5",
+        "zai/glm-5.1",
         "zai/glm-5-turbo",
         "zai/glm-5v-turbo"
       ],

--- a/packages/core/src/llm/model/provider-registry.json
+++ b/packages/core/src/llm/model/provider-registry.json
@@ -6855,6 +6855,7 @@
       "zai/glm-4.7-flash",
       "zai/glm-4.7-flashx",
       "zai/glm-5",
+      "zai/glm-5.1",
       "zai/glm-5-turbo",
       "zai/glm-5v-turbo"
     ],

--- a/packages/core/src/llm/model/provider-types.generated.d.ts
+++ b/packages/core/src/llm/model/provider-types.generated.d.ts
@@ -2397,6 +2397,7 @@ export type ProviderModelsMap = {
     'zai/glm-4.7-flash',
     'zai/glm-4.7-flashx',
     'zai/glm-5',
+    'zai/glm-5.1',
     'zai/glm-5-turbo',
     'zai/glm-5v-turbo',
   ];


### PR DESCRIPTION
## Summary
- add missing `zai/glm-5.1` to the vendored Vercel provider registry
- add the same missing model to the generated provider types

Fixes #15236

## Why
Vercel AI Gateway currently exposes `zai/glm-5.1`, but Mastra's vendored `vercel` model list omits it. That causes `ModelForProvider<"vercel">` to reject a valid Vercel model ID even though the live catalog supports it.

## Notes
- this is a minimal data fix only
- the generator already emits the correct type once the registry source includes the model
- the underlying source data may also need an upstream update if this registry is periodically refreshed from an external catalog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra keeps a list of AI models available through different providers. Vercel added a new model called "zai/glm-5.1", but Mastra's internal list didn't include it, so the system rejected it even though it was actually available. This PR adds that model to Mastra's lists so it's now accepted.

## Changes

This PR adds the model identifier `zai/glm-5.1` to Mastra's vendored Vercel provider registry:

- **provider-registry.json**: Added `"zai/glm-5.1"` to both the `vercel` provider's models list and the aggregated `vercel` model list (+2 lines)
- **provider-types.generated.d.ts**: The auto-generated TypeScript definitions were updated to reflect the new model in the `ProviderModelsMap` type (+1 line)

This ensures that `ModelForProvider<"vercel">` now accepts `zai/glm-5.1` as a valid Vercel model ID, aligning Mastra's type system with what Vercel AI Gateway actually exposes.

## Related Issue

Fixes #15236 — ModelForProvider<"vercel"> is missing zai/glm-5.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->