### PR TITLE
feat: emit structured output as data part in AI SDK UI stream

### DIFF
--- a/.changeset/dirty-points-drive.md
+++ b/.changeset/dirty-points-drive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': minor
+---
+
+Added structured output streaming to the AI SDK UI stream. When an agent produces structured output, the final object is now emitted as a `data-structured-output` data part in the UI message stream, making it available to frontends via AI SDK UI's custom data handling.

--- a/client-sdks/ai-sdk/src/__tests__/custom-data.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/custom-data.test.ts
@@ -4,6 +4,65 @@ import { describe, expect, it } from 'vitest';
 import { toAISdkV5Stream } from '../convert-streams';
 
 describe('Custom Data Handling', () => {
+  describe('agent structured output', () => {
+    it('should emit a custom data event for structured output object chunks', async () => {
+      const mockStream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue({
+            type: 'start',
+            runId: 'structured-output-run-id',
+            payload: { id: 'test-id' },
+          });
+
+          controller.enqueue({
+            type: 'object-result',
+            runId: 'structured-output-run-id',
+            object: {
+              suggestions: ['First idea', 'Second idea'],
+            },
+          });
+
+          controller.enqueue({
+            type: 'finish',
+            runId: 'structured-output-run-id',
+            payload: {
+              stepResult: {
+                reason: 'stop',
+                warnings: [],
+              },
+              output: {
+                usage: {
+                  inputTokens: 10,
+                  outputTokens: 20,
+                  totalTokens: 30,
+                },
+              },
+            },
+          });
+
+          controller.close();
+        },
+      });
+
+      const aiSdkStream = toAISdkV5Stream(mockStream as unknown as MastraModelOutput, { from: 'agent' });
+
+      const chunks: any[] = [];
+      for await (const chunk of aiSdkStream) {
+        chunks.push(chunk);
+      }
+
+      const structuredOutputChunk = chunks.find(chunk => chunk.type === 'data-structured-output');
+
+      expect(structuredOutputChunk).toBeDefined();
+      expect(structuredOutputChunk.data).toEqual({
+        object: {
+          suggestions: ['First idea', 'Second idea'],
+        },
+      });
+      expect(chunks.find(chunk => chunk.type === 'finish')).toBeDefined();
+    });
+  });
+
   describe('workflow tool output with custom data', () => {
     it('should process custom data from workflow tool output', async () => {
       const mockStream = new ReadableStream({

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -276,6 +276,15 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
         finishEventSent = true;
       }
 
+      if (chunk.type === 'object-result') {
+        controller.enqueue({
+          type: 'data-structured-output',
+          data: {
+            object: chunk.object,
+          },
+        });
+      }
+
       const part = convertMastraChunkToAISDK({ chunk, mode: 'stream' });
 
       const transformedChunk = convertFullStreamChunkToUIMessageStream<any>({

--- a/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
@@ -17,6 +17,23 @@ Framework-agnostic handler for streaming agent chat in AI SDK-compatible format.
 
 Use [`chatRoute()`](/reference/ai-sdk/chat-route) if you want to create a chat route inside a Mastra server.
 
+## Structured output in UI streams
+
+When you pass `structuredOutput` to the underlying agent execution, the final structured output object is emitted in the AI SDK-compatible UI stream as a custom data part:
+
+```json
+{
+  "type": "data-structured-output",
+  "data": {
+    "object": {}
+  }
+}
+```
+
+The `object` field contains your full structured output value. Mastra emits this event for the final structured output object only. Partial structured output chunks are not exposed in the UI stream.
+
+Read this event with AI SDK UI's custom data handling, such as `onData`, or render it from message data parts.
+
 ## Usage example
 
 Next.js App Router example:

--- a/docs/src/content/en/reference/ai-sdk/to-ai-sdk-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/to-ai-sdk-stream.mdx
@@ -17,6 +17,21 @@ This is useful when building custom streaming endpoints outside Mastra's provide
 
 `toAISdkStream()` keeps the existing AI SDK v5/default behavior. If your app is typed against AI SDK v6, pass `version: 'v6'` in the options object.
 
+## Structured output in UI streams
+
+When the source agent stream includes a final structured output object, `toAISdkStream()` emits it as a custom AI SDK UI data part:
+
+```json
+{
+  "type": "data-structured-output",
+  "data": {
+    "object": {}
+  }
+}
+```
+
+The `object` field contains your full structured output value. This maps Mastra's final structured output chunk into the AI SDK UI stream. Partial structured output chunks are not emitted.
+
 ## Usage example
 
 Next.js App Router example:


### PR DESCRIPTION
Structured output `object-result` chunks from agent streams were being buffered internally but never emitted to the AI SDK UI message stream. Frontends had no way to access structured output in real time.

Now, when an agent produces a final structured output, it's emitted as a `data-structured-output` data part:

```ts
// In your frontend, access via AI SDK UI's onData or message data parts:
{
  type: 'data-structured-output',
  data: {
    object: {
      suggestions: ['Find jobs by title', 'Compare salaries', 'Help with resumes']
    }
  }
}
```

Only the final object is emitted — partial chunks are not surfaced.

Also updates the `handleChatStream` and `toAISdkStream` reference docs to document this behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

When an AI agent produces structured data (like a list of suggestions), it now gets sent to the frontend UI in real-time instead of being hidden internally. This lets websites and apps display that structured data to users as soon as it's available, rather than waiting or never seeing it at all.

## Overview

This PR enables real-time streaming of structured output from AI agents to frontends consuming the AI SDK UI stream. Previously, when agents generated structured outputs, these were buffered internally and never surfaced to the UI layer. Now, the final structured output object is emitted as a `data-structured-output` custom data part on the AI SDK message stream.

## Changes

**Implementation** (`client-sdks/ai-sdk/src/transformers.ts`)
- Modified `createAgentStreamToAISDKTransformer` to detect `object-result` chunks from agent streams
- When detected, emits a new UI chunk with `type: 'data-structured-output'` containing the final structured object
- Only the final structured output is emitted; partial chunks are not surfaced

**Testing** (`client-sdks/ai-sdk/src/__tests__/custom-data.test.ts`)
- Added test case verifying that agent streams containing structured output correctly emit `data-structured-output` chunks with the object data
- Validates that both the structured output and finish chunks are properly emitted to the UI stream

**Documentation**
- Updated `handleChatStream.mdx` to document how `structuredOutput` passed to agent execution is now surfaced in the UI stream as a `data-structured-output` custom data part
- Updated `toAISdkStream.mdx` to describe the new `data-structured-output` emission behavior and clarify that only final objects (not partial chunks) are emitted

**Metadata** (`.changeset/dirty-points-drive.md`)
- Added changeset entry documenting this as a minor version bump for `@mastra/ai-sdk`

## Impact

Frontends can now access structured output in real-time via AI SDK custom data handling (e.g., `onData` callbacks or message data parts), enabling interactive rendering of structured data without waiting for full agent execution completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->