### PR TITLE
fix(memory): accept best non-degenerate result when all reflector retries are exhausted

### DIFF
--- a/.changeset/fix-reflector-accept-best-on-exhausted-retries.md
+++ b/.changeset/fix-reflector-accept-best-on-exhausted-retries.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+fix(memory): reflector now returns best non-degenerate result instead of empty string when all compression attempts produce degenerate output, preventing silent memory wipe

--- a/packages/memory/src/processors/observational-memory/reflector-runner.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-runner.ts
@@ -192,6 +192,11 @@ export class ReflectorRunner {
     let reflectedTokens = 0;
     let attemptNumber = 0;
 
+    // Track the best (smallest) non-degenerate result seen across all attempts.
+    // Used as fallback when all attempts fail or produce degenerate output.
+    let bestNonDegenerateObservations: string | null = null;
+    let bestNonDegenerateTokenCount = Infinity;
+
     while (currentLevel <= maxLevel) {
       attemptNumber++;
       const isRetry = attemptNumber > 1;
@@ -282,6 +287,11 @@ export class ReflectorRunner {
         reflectedTokens = originalTokens;
       } else {
         reflectedTokens = this.tokenCounter.countObservations(parsed.observations);
+        // Track the best (smallest) non-degenerate result for fallback.
+        if (reflectedTokens < bestNonDegenerateTokenCount) {
+          bestNonDegenerateTokenCount = reflectedTokens;
+          bestNonDegenerateObservations = parsed.observations;
+        }
       }
       omDebug(
         `[OM:callReflector] attempt #${attemptNumber} parsed: reflectedTokens=${reflectedTokens}, targetThreshold=${targetThreshold}, compressionValid=${validateCompression(reflectedTokens, targetThreshold)}, parsedObsLen=${parsed.observations?.length}, degenerate=${parsed.degenerate ?? false}`,
@@ -328,8 +338,22 @@ export class ReflectorRunner {
       currentLevel = Math.min(currentLevel + 1, maxLevel) as CompressionLevel;
     }
 
+    // If the final parsed output is degenerate (empty), fall back to the best non-degenerate
+    // result seen during the retry loop. If no non-degenerate result was ever obtained, fall
+    // back to the original observations to avoid silently wiping out memory.
+    const finalObservations =
+      parsed.degenerate || !parsed.observations
+        ? (bestNonDegenerateObservations ?? observations)
+        : parsed.observations;
+
+    if (parsed.degenerate || !parsed.observations) {
+      omDebug(
+        `[OM:callReflector] all attempts resulted in degenerate output; using ${bestNonDegenerateObservations ? `best non-degenerate result (${bestNonDegenerateTokenCount} tokens)` : 'original observations as fallback'}`,
+      );
+    }
+
     return {
-      observations: parsed.observations,
+      observations: finalObservations,
       suggestedContinuation: parsed.suggestedContinuation,
       usage: totalUsage.totalTokens > 0 ? totalUsage : undefined,
     };


### PR DESCRIPTION
Fixes #15062

## Problem

When all reflector compression attempts produce degenerate output (detected repetition loops), the `ReflectorRunner.call()` method was returning `parsed.observations = ''` (empty string). This caused `createReflectionGeneration` to store empty observations, silently wiping out the agent's entire observational memory.

The flow:
1. Observations grow beyond the reflection threshold
2. Reflector is called at increasing compression levels (0 → maxLevel)
3. All attempts return degenerate repetition output
4. At maxLevel the loop breaks with `parsed.observations = ''`
5. Empty observations are stored as the new reflection → memory is lost

## Solution

Track the best (smallest token count) non-degenerate result seen across all retry attempts. After the loop exits:
- If the final result is degenerate or empty, return the best non-degenerate result seen during retries
- If no non-degenerate result was ever produced, fall back to the original observations unchanged

This ensures the reflector never silently discards valid memory, even when extreme compression fails.

## Testing

Manual code review — the fix is confined to the retry loop exit logic in `ReflectorRunner.call()`. The existing test suite covers degenerate detection (`parseReflectorOutput` returns `{observations: '', degenerate: true}`) and retry behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're trying to shrink a really big notebook (observations) to fit in a small box (compression limit). If every way you try to shrink it either fails or makes it unreadable, this PR makes sure you keep the best "shrunk but still readable" version instead of throwing everything away and losing all your notes.

## Overview

This PR fixes issue #15062, where the reflector would discard all observational memory when compression attempts repeatedly failed. When observations exceeded the reflection threshold and all retry attempts with increasing compression levels produced degenerate (repetitive/corrupted) output, `ReflectorRunner.call()` would return empty observations, silently wiping out the agent's memory.

## Changes

**Changeset Entry** (`fix-reflector-accept-best-on-exhausted-retries.md`)
- Added a new changeset declaring a patch-level release for `@mastra/memory` package

**Core Fix** (`reflector-runner.ts`)
- Modified `ReflectorRunner.call()` to track the best non-degenerate result (minimum token count) across all retry attempts
- During the retry/compression loop, when a result is not marked degenerate, the method now records the token count and observations as potential fallback values
- After the loop completes, if the final result is degenerate or empty, the method returns the best non-degenerate observations found
- If no non-degenerate result was ever produced, falls back to returning the original observations unchanged
- Added debug logging to indicate when all attempts produce degenerate output

This prevents silent deletion of observational memory when extreme compression fails, ensuring that at least some valid observational data is retained rather than an empty string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->