### PR TITLE
fix(cli): trust .mastra-project.json orgId when using MASTRA_API_TOKEN

### DIFF
--- a/.changeset/fix-deploy-org-id-api-token.md
+++ b/.changeset/fix-deploy-org-id-api-token.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed `mastra deploy` failing with "No organizations found" when using `MASTRA_API_TOKEN` in headless/CI environments. When `.mastra-project.json` contains an `organizationId` and `MASTRA_API_TOKEN` is set, the CLI now trusts the config directly instead of calling the orgs API (which API tokens lack permission to access).

--- a/.changeset/fix-deploy-org-id-api-token.md
+++ b/.changeset/fix-deploy-org-id-api-token.md
@@ -2,4 +2,4 @@
 'mastra': patch
 ---
 
-Fixed `mastra deploy` failing with "No organizations found" when using `MASTRA_API_TOKEN` in headless/CI environments. When `.mastra-project.json` contains an `organizationId` and `MASTRA_API_TOKEN` is set, the CLI now trusts the config directly instead of calling the orgs API (which API tokens lack permission to access).
+Fixed `mastra deploy` failing with "No organizations found" in headless/CI when `MASTRA_API_TOKEN` is set and `.mastra-project.json` includes `organizationId`. Deploy now uses the configured organization directly.

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../auth/api.js', () => ({
+  fetchOrgs: vi.fn(),
+}));
+
+vi.mock('../auth/credentials.js', () => ({
+  getToken: vi.fn(),
+  getCurrentOrgId: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../auth/client.js', () => ({
+  MASTRA_STUDIO_URL: 'https://studio.example.com',
+}));
+
+import { fetchOrgs } from '../auth/api.js';
+import { resolveOrg } from './deploy.js';
+
+const mockFetchOrgs = vi.mocked(fetchOrgs);
+
+describe('resolveOrg', () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.MASTRA_ORG_ID;
+    delete process.env.MASTRA_API_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it('returns MASTRA_ORG_ID from env without calling fetchOrgs', async () => {
+    process.env.MASTRA_ORG_ID = 'env-org-123';
+
+    const result = await resolveOrg('tok', null);
+
+    expect(result).toEqual({ orgId: 'env-org-123', orgName: 'env-org-123' });
+    expect(mockFetchOrgs).not.toHaveBeenCalled();
+  });
+
+  it('trusts projectConfig.organizationId when MASTRA_API_TOKEN is set (skips fetchOrgs)', async () => {
+    process.env.MASTRA_API_TOKEN = 'api-token-abc';
+
+    const result = await resolveOrg('tok', { organizationId: 'config-org-456' });
+
+    expect(result).toEqual({ orgId: 'config-org-456', orgName: 'config-org-456' });
+    expect(mockFetchOrgs).not.toHaveBeenCalled();
+  });
+
+  it('validates projectConfig.organizationId via fetchOrgs when no MASTRA_API_TOKEN', async () => {
+    mockFetchOrgs.mockResolvedValue([{ id: 'config-org-456', name: 'My Org', role: 'admin', isCurrent: true }]);
+
+    const result = await resolveOrg('tok', { organizationId: 'config-org-456' });
+
+    expect(result).toEqual({ orgId: 'config-org-456', orgName: 'My Org' });
+    expect(mockFetchOrgs).toHaveBeenCalledWith('tok');
+  });
+
+  it('falls through when projectConfig org not found in fetchOrgs (no MASTRA_API_TOKEN)', async () => {
+    mockFetchOrgs.mockResolvedValue([{ id: 'other-org', name: 'Other', role: 'admin', isCurrent: true }]);
+
+    // Should fall through to the single-org auto-select path
+    const result = await resolveOrg('tok', { organizationId: 'missing-org' });
+
+    expect(result).toEqual({ orgId: 'other-org', orgName: 'Other' });
+  });
+
+  it('uses flagOrg and validates via fetchOrgs', async () => {
+    mockFetchOrgs.mockResolvedValue([{ id: 'flag-org', name: 'Flag Org', role: 'member', isCurrent: false }]);
+
+    const result = await resolveOrg('tok', null, 'flag-org');
+
+    expect(result).toEqual({ orgId: 'flag-org', orgName: 'Flag Org' });
+    expect(mockFetchOrgs).toHaveBeenCalledWith('tok');
+  });
+});

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -136,7 +136,8 @@ export async function readEnvVars(
 /*  Resolve org                                                       */
 /* ------------------------------------------------------------------ */
 
-async function resolveOrg(
+/** @internal – exported for testing only */
+export async function resolveOrg(
   token: string,
   projectConfig: { organizationId?: string } | null,
   flagOrg?: string,

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -100,7 +100,8 @@ async function readEnvVars(projectDir: string): Promise<Record<string, string>> 
 /*  Resolve org                                                       */
 /* ------------------------------------------------------------------ */
 
-async function resolveOrg(
+/** @internal – exported for testing only */
+export async function resolveOrg(
   token: string,
   projectConfig: { organizationId?: string } | null,
   flagOrg?: string,

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -117,6 +117,9 @@ async function resolveOrg(
   }
 
   if (projectConfig?.organizationId) {
+    if (process.env.MASTRA_API_TOKEN) {
+      return { orgId: projectConfig.organizationId, orgName: projectConfig.organizationId };
+    }
     const orgs = await fetchOrgs(token);
     const match = orgs.find(o => o.id === projectConfig.organizationId);
     if (match) {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,3 +41,6 @@ trustPolicyExclude:
   # 3.47.4 is published with provenance attestation rather than trusted publisher,
   # but it is the official fix published on the @clerk/shared latest-v5 tag.
   - '@clerk/shared@3.47.4'
+  # 0.7.4 is published with provenance attestation rather than trusted publisher,
+  # but it is the official Tailwind Labs release.
+  - 'prettier-plugin-tailwindcss@0.7.4'


### PR DESCRIPTION
## Description

Rebased on latest `main` and resolved the stale merge conflicts for the CLI deploy org-resolution change.

The original functional behavior is now already present on `main` via merged PR #15299, so the remaining PR diff is intentionally minimal:

- keeps `resolveOrg()` exported for the existing test seam
- keeps the release-note changeset for the original fix

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Validation

- `pnpm build:cli`
- `pnpm --filter ./packages/cli typecheck`
- `pnpm --filter ./packages/cli lint`
- `pnpm --filter ./packages/cli exec vitest run src/commands/server/deploy.test.ts`

Link to Devin session: https://app.devin.ai/sessions/7037abb6db41443a934632d9e2819345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If you deploy from CI using an API token, the CLI now trusts the organization ID stored in .mastra-project.json instead of trying to list organizations (which API tokens can't do), so deployments no longer fail with "No organizations found."

## Changes

### Problem
When `MASTRA_API_TOKEN` was used in headless/CI environments, `resolveOrg()` tried to validate `organizationId` from `.mastra-project.json` by calling `fetchOrgs()`. API tokens typically lack org-listing permissions, causing `fetchOrgs()` to return an empty array and produce a "No organizations found" error.

### Solution
- Add a short-circuit in packages/cli/src/commands/server/deploy.ts: if `process.env.MASTRA_API_TOKEN` is set and `projectConfig?.organizationId` exists, return `{ orgId: projectConfig.organizationId, orgName: projectConfig.organizationId }` immediately and skip `fetchOrgs()`.
- This mirrors existing behavior for `MASTRA_ORG_ID` and prevents failing org-list calls for API-token-based CI usage.

### Implementation details
- Export `resolveOrg` (previously file-private) to keep a test seam; signature unchanged.
- Keep all other resolution paths unchanged: `MASTRA_ORG_ID`, `--org`/flag, and fallback `getCurrentOrgId`/org selection.
- Preserve the release-note changeset from the original fix.

### Tests & Validation
- Tests added/updated to verify deployment succeeds with `MASTRA_API_TOKEN` and a valid `.mastra-project.json` orgId without calling `fetchOrgs()`.
- CI/local validation: build, typecheck, lint for packages/cli, and the relevant vitest deploy test. A Devin session link was provided for reproduction.

### Files changed
- packages/cli/src/commands/server/deploy.ts: short-circuit for API token + project config orgId; `resolveOrg` exported.
- .changeset/fix-deploy-org-id-api-token.md: changeset entry for a patch release.
- pnpm-workspace.yaml: minor trust-policy exclude update (prettier-plugin-tailwindcss).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->