### PR TITLE
fix: capture stream errors via onError callback instead of onFinish payload

### DIFF
--- a/.changeset/four-poems-jump.md
+++ b/.changeset/four-poems-jump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent streaming errors to log upstream provider details correctly and end agent traces when the stream fails.

--- a/.changeset/four-poems-jump.md
+++ b/.changeset/four-poems-jump.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed agent streaming errors to log upstream provider details correctly and end agent traces when the stream fails.
+Fixed agent streaming errors to use `onError` for logging, preserve resolved model metadata, and end agent traces when the stream fails.

--- a/packages/core/src/agent/__tests__/save-and-errors.test.ts
+++ b/packages/core/src/agent/__tests__/save-and-errors.test.ts
@@ -1286,7 +1286,7 @@ function saveAndErrorTests(version: 'v1' | 'v2') {
         expect(caughtError.message).toMatch(/Simulated stream error/);
       });
 
-      it('should log upstream stream errors with provider and model metadata from APICallError.data', async () => {
+      it('should pass resolved model metadata through onError for stream failures', async () => {
         if (version === 'v1') return;
 
         const upstreamError = new APICallError({
@@ -1294,13 +1294,11 @@ function saveAndErrorTests(version: 'v1' | 'v2') {
           url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent',
           requestBodyValues: {},
           statusCode: 504,
-          data: {
-            provider: 'google.vertex',
-            modelId: 'gemini-2.5-pro',
-          },
         });
 
         const errorModel = new MockLanguageModelV2({
+          provider: 'google-vertex',
+          modelId: 'gemini-2.5-pro',
           doGenerate() {
             throw upstreamError;
           },
@@ -1323,10 +1321,14 @@ function saveAndErrorTests(version: 'v1' | 'v2') {
         agent.__setLogger(logger);
 
         let caughtError: Error | string | null = null;
+        let caughtProvider: string | undefined;
+        let caughtModelId: string | undefined;
 
         const stream = await agent.stream('Hello', {
-          onError: ({ error }) => {
+          onError: ({ error, provider, modelId }) => {
             caughtError = error;
+            caughtProvider = provider;
+            caughtModelId = modelId;
           },
           modelSettings: {
             maxRetries: 0,
@@ -1338,12 +1340,14 @@ function saveAndErrorTests(version: 'v1' | 'v2') {
         } catch {}
 
         expect(caughtError).toBe(upstreamError);
+        expect(caughtProvider).toBe('google-vertex');
+        expect(caughtModelId).toBe('gemini-2.5-pro');
         expect(logger.error).toHaveBeenCalledWith(
-          'Upstream LLM API error from google.vertex (model: gemini-2.5-pro)',
+          'Upstream LLM API error from google-vertex (model: gemini-2.5-pro)',
           expect.objectContaining({
             error: upstreamError,
             runId: expect.any(String),
-            provider: 'google.vertex',
+            provider: 'google-vertex',
             modelId: 'gemini-2.5-pro',
           }),
         );

--- a/packages/core/src/agent/__tests__/save-and-errors.test.ts
+++ b/packages/core/src/agent/__tests__/save-and-errors.test.ts
@@ -3,6 +3,7 @@ import { APICallError } from '@internal/ai-sdk-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
+import { noopLogger } from '../../logger';
 import { MockMemory } from '../../memory/mock';
 import { createTool } from '../../tools';
 import { Agent } from '../agent';
@@ -1283,6 +1284,69 @@ function saveAndErrorTests(version: 'v1' | 'v2') {
         expect(errorCaught).toBe(true);
         expect(caughtError).toBeDefined();
         expect(caughtError.message).toMatch(/Simulated stream error/);
+      });
+
+      it('should log upstream stream errors with provider and model metadata from APICallError.data', async () => {
+        if (version === 'v1') return;
+
+        const upstreamError = new APICallError({
+          message: 'Google Vertex request timed out',
+          url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent',
+          requestBodyValues: {},
+          statusCode: 504,
+          data: {
+            provider: 'google.vertex',
+            modelId: 'gemini-2.5-pro',
+          },
+        });
+
+        const errorModel = new MockLanguageModelV2({
+          doGenerate() {
+            throw upstreamError;
+          },
+          doStream() {
+            throw upstreamError;
+          },
+        });
+
+        const agent = new Agent({
+          id: 'test-options-onerror-upstream-metadata',
+          name: 'Test Options OnError Upstream Metadata',
+          model: errorModel,
+          instructions: 'You are a helpful assistant.',
+        });
+
+        const logger = {
+          ...noopLogger,
+          error: vi.fn(),
+        };
+        agent.__setLogger(logger);
+
+        let caughtError: Error | string | null = null;
+
+        const stream = await agent.stream('Hello', {
+          onError: ({ error }) => {
+            caughtError = error;
+          },
+          modelSettings: {
+            maxRetries: 0,
+          },
+        });
+
+        try {
+          await stream.consumeStream();
+        } catch {}
+
+        expect(caughtError).toBe(upstreamError);
+        expect(logger.error).toHaveBeenCalledWith(
+          'Upstream LLM API error from google.vertex (model: gemini-2.5-pro)',
+          expect.objectContaining({
+            error: upstreamError,
+            runId: expect.any(String),
+            provider: 'google.vertex',
+            modelId: 'gemini-2.5-pro',
+          }),
+        );
       });
 
       it('should call options.onChunk when streaming in stream', async () => {

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -310,6 +310,8 @@ export function createMapResultsStep<OUTPUT = undefined>({
             capabilities.logger.error(`Upstream LLM API error${providerInfo}${modelInfo}`, {
               error: streamError,
               runId,
+              ...(provider && { provider }),
+              ...(modelId && { modelId }),
             });
           } else {
             capabilities.logger.error('Error in agent stream', {

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -310,8 +310,6 @@ export function createMapResultsStep<OUTPUT = undefined>({
             capabilities.logger.error(`Upstream LLM API error${providerInfo}${modelInfo}`, {
               error: streamError,
               runId,
-              ...(provider && { provider }),
-              ...(modelId && { modelId }),
             });
           } else {
             capabilities.logger.error('Error in agent stream', {

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -17,19 +17,6 @@ import type { AgentMethodType } from '../../types';
 import { isSupportedLanguageModel } from '../../utils';
 import type { AgentCapabilities, PrepareMemoryStepOutput, PrepareToolsStepOutput } from './schema';
 
-function getUpstreamErrorMetadata(error: APICallError): { provider?: string; modelId?: string } {
-  const { data } = error;
-
-  if (!data || typeof data !== 'object') {
-    return {};
-  }
-
-  const provider = 'provider' in data && typeof data.provider === 'string' ? data.provider : undefined;
-  const modelId = 'modelId' in data && typeof data.modelId === 'string' ? data.modelId : undefined;
-
-  return { provider, modelId };
-}
-
 interface MapResultsStepOptions<OUTPUT = undefined> {
   capabilities: AgentCapabilities;
   options: InnerAgentExecutionOptions<OUTPUT>;
@@ -299,9 +286,8 @@ export function createMapResultsStep<OUTPUT = undefined>({
         onStepFinish: result.onStepFinish,
         onChunk: options.onChunk,
         onError: async (errorInfo: Parameters<NonNullable<InnerAgentExecutionOptions<OUTPUT>['onError']>>[0]) => {
-          const { error } = errorInfo;
+          const { error, provider, modelId } = errorInfo;
           const isUpstreamError = APICallError.isInstance(error);
-          const { provider, modelId } = isUpstreamError ? getUpstreamErrorMetadata(error) : {};
           const streamError = getErrorFromUnknown(error, { supportSerialization: false });
 
           if (isUpstreamError) {

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -1,5 +1,6 @@
 import { APICallError } from '@internal/ai-sdk-v5';
 import { MastraError, ErrorDomain, ErrorCategory } from '../../../error';
+import { getErrorFromUnknown } from '../../../error/utils.js';
 import { getModelMethodFromAgentMethod } from '../../../llm/model/model-method-from-agent';
 import type { ModelLoopStreamArgs, ModelMethodType } from '../../../llm/model/model.loop.types';
 import type { MastraMemory } from '../../../memory/memory';
@@ -15,6 +16,19 @@ import { getModelOutputForTripwire } from '../../trip-wire';
 import type { AgentMethodType } from '../../types';
 import { isSupportedLanguageModel } from '../../utils';
 import type { AgentCapabilities, PrepareMemoryStepOutput, PrepareToolsStepOutput } from './schema';
+
+function getUpstreamErrorMetadata(error: APICallError): { provider?: string; modelId?: string } {
+  const { data } = error;
+
+  if (!data || typeof data !== 'object') {
+    return {};
+  }
+
+  const provider = 'provider' in data && typeof data.provider === 'string' ? data.provider : undefined;
+  const modelId = 'modelId' in data && typeof data.modelId === 'string' ? data.modelId : undefined;
+
+  return { provider, modelId };
+}
 
 interface MapResultsStepOptions<OUTPUT = undefined> {
   capabilities: AgentCapabilities;
@@ -219,45 +233,8 @@ export function createMapResultsStep<OUTPUT = undefined>({
         ...(options.prepareStep && { prepareStep: options.prepareStep }),
         onFinish: async (payload: any) => {
           if (payload.finishReason === 'error') {
-            const provider = payload.model?.provider;
-            const modelId = payload.model?.modelId;
-            const isUpstreamError = APICallError.isInstance(payload.error);
-
-            if (isUpstreamError) {
-              capabilities.logger.error('Upstream LLM API error', {
-                error: payload.error,
-                runId,
-                ...(provider && { provider }),
-                ...(modelId && { modelId }),
-              });
-            } else {
-              capabilities.logger.error('Error in agent stream', {
-                error: payload.error,
-                runId,
-                ...(provider && { provider }),
-                ...(modelId && { modelId }),
-              });
-            }
-
-            const error =
-              payload.error instanceof Error
-                ? payload.error
-                : new MastraError(
-                    {
-                      id: 'AGENT_STREAM_ERROR',
-                      domain: ErrorDomain.AGENT,
-                      category: ErrorCategory.SYSTEM,
-                      details: { runId },
-                    },
-                    payload.error,
-                  );
-            // End the AGENT_RUN span so the trace is exported.
-            // Without this, the span is orphaned and exporters that wait
-            // for the root span to end (e.g. Datadog) never emit the trace.
-            agentSpan?.error({ error, endSpan: true });
             return;
           }
-
           // Skip memory persistence when the abort signal has fired.
           // The LLM response may have continued after the caller disconnected,
           // and we should not persist a partial or full response for an aborted request.
@@ -321,7 +298,32 @@ export function createMapResultsStep<OUTPUT = undefined>({
         },
         onStepFinish: result.onStepFinish,
         onChunk: options.onChunk,
-        onError: options.onError,
+        onError: async (errorInfo: Parameters<NonNullable<InnerAgentExecutionOptions<OUTPUT>['onError']>>[0]) => {
+          const { error } = errorInfo;
+          const isUpstreamError = APICallError.isInstance(error);
+          const { provider, modelId } = isUpstreamError ? getUpstreamErrorMetadata(error) : {};
+          const streamError = getErrorFromUnknown(error, { supportSerialization: false });
+
+          if (isUpstreamError) {
+            const providerInfo = provider ? ` from ${provider}` : '';
+            const modelInfo = modelId ? ` (model: ${modelId})` : '';
+            capabilities.logger.error(`Upstream LLM API error${providerInfo}${modelInfo}`, {
+              error: streamError,
+              runId,
+              ...(provider && { provider }),
+              ...(modelId && { modelId }),
+            });
+          } else {
+            capabilities.logger.error('Error in agent stream', {
+              error: streamError,
+              runId,
+            });
+          }
+
+          agentSpan?.error({ error: streamError, endSpan: true });
+
+          await options.onError?.(errorInfo);
+        },
         onAbort: options.onAbort,
         abortSignal: options.abortSignal,
       },

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -496,7 +496,15 @@ export async function createNetworkLoop({
     verboseIntrospection?: boolean;
   };
   onStepFinish?: (event: any) => Promise<void> | void;
-  onError?: ({ error }: { error: Error | string }) => Promise<void> | void;
+  onError?: ({
+    error,
+    provider,
+    modelId,
+  }: {
+    error: Error | string;
+    provider?: string;
+    modelId?: string;
+  }) => Promise<void> | void;
   onAbort?: (event: any) => Promise<void> | void;
   abortSignal?: AbortSignal;
 }) {

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -82,9 +82,15 @@ export type PrepareStepFunction = (
   args: ProcessInputStepArgs,
 ) => Promise<ProcessInputStepResult | undefined | void> | ProcessInputStepResult | undefined | void;
 
+export type LoopErrorInfo = {
+  error: Error | string;
+  provider?: string;
+  modelId?: string;
+};
+
 export type LoopConfig<OUTPUT = undefined> = {
   onChunk?: (chunk: ChunkType<OUTPUT>) => Promise<void> | void;
-  onError?: ({ error }: { error: Error | string }) => Promise<void> | void;
+  onError?: (errorInfo: LoopErrorInfo) => Promise<void> | void;
   onFinish?: MastraOnFinishCallback<OUTPUT>;
   onStepFinish?: MastraOnStepFinishCallback<OUTPUT>;
   onAbort?: (event: any) => Promise<void> | void;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -45,6 +45,8 @@ type ProcessOutputStreamOptions<OUTPUT = undefined> = {
   tools?: ToolSet;
   messageId: string;
   includeRawChunks?: boolean;
+  provider?: string;
+  modelId?: string;
   messageList: MessageList;
   outputStream: MastraModelOutput<OUTPUT>;
   runState: AgenticRunState;
@@ -107,6 +109,8 @@ async function processOutputStream<OUTPUT = undefined>({
   controller,
   responseFromModel,
   includeRawChunks,
+  provider,
+  modelId,
   logger,
   transportRef,
   transportResolver,
@@ -508,7 +512,11 @@ async function processOutputStream<OUTPUT = undefined>({
           fallbackMessage: 'Unknown error in agent stream',
         });
         safeEnqueue(controller, { ...chunk, payload: { ...chunk.payload, error } });
-        await options?.onError?.({ error });
+        await options?.onError?.({
+          error,
+          ...(provider && { provider }),
+          ...(modelId && { modelId }),
+        });
         break;
 
       // Provider-executed tool results (e.g. web_search). Client tool results
@@ -1105,6 +1113,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             messageList,
             runState,
             options,
+            provider: model?.provider,
+            modelId: model?.modelId,
             controller,
             responseFromModel: {
               warnings,


### PR DESCRIPTION
## Summary
- move stream error capture to `onError`, which is where the loop delivers the real error object
- preserve upstream provider and model metadata from `APICallError.data` in logs when available
- keep `onFinish` focused on finalization while still avoiding finish-time persistence on failed streams
- add regression coverage for upstream stream-error logging and keep AGENT_RUN span-ending coverage intact
- add the missing `@mastra/core` patch changeset

## Testing
- `pnpm vitest run src/agent/__tests__/save-and-errors.test.ts`
- `pnpm check`

## Supersedes
- Supersedes #14576
- Fixes #14575


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes a bug so Mastra captures real streaming errors from AI providers by listening to the stream's onError callback (where the SDK delivers the actual error) instead of reading an absent error from the finish event. That lets Mastra log the true error and which provider/model caused it.

## Overview

Move upstream stream-error capture from onFinish to the onError callback so the loop receives the actual error object and preserved provider/model metadata. End agent spans on stream failure in the onError path and avoid persisting or treating finish-time payloads as the source of upstream errors.

## Key changes

- map-results-step.ts
  - Added normalized error conversion via getErrorFromUnknown and moved upstream error handling into the stream onError wrapper.
  - Extracts provider/modelId from APICallError.data and logs upstream LLM errors with provider/model context.
  - Records error on agentSpan with endSpan: true inside onError, then forwards to downstream options.onError.
  - Removed the previous onFinish-based error-logging/persistence for finishReason === 'error'.

- Loop types & network loop
  - Added LoopErrorInfo type: { error: Error | string; provider?: string; modelId?: string }.
  - Updated LoopConfig.onError signature and createNetworkLoop onError callback to accept provider/modelId alongside error.

- llm-execution-step.ts / processOutputStream
  - Threaded provider and modelId into processOutputStream and enriched error callbacks so onError receives { error, provider?, modelId? } when a stream error occurs.

- Tests
  - Added regression test (packages/core/src/agent/__tests__/save-and-errors.test.ts) verifying:
    - onError receives the original APICallError instance for v2 streams,
    - resolved provider (`google-vertex`) and modelId (`gemini-2.5-pro`) are passed through,
    - agent logger.error is called with an object containing error, runId, provider, and modelId.
  - Test is v2-only (returns early for v1).

- Changeset
  - .changeset/four-poems-jump.md: patch for @mastra/core documenting the fix and trace behavior.

## Rationale / linked issue

Fixes issue where Vercel AI SDK does not include errors in OnFinishEvent; the SDK delivers actual upstream errors via onError. This PR ensures Mastra logs the real error object and preserves upstream provider/model metadata when available. Supersedes #14576 and fixes #14575.

## Testing

- New unit test added: pnpm vitest run src/agent/__tests__/save-and-errors.test.ts
- pnpm check (CI expectations)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->