### PR TITLE
fix(cli): fix deploy command issues (subdirectory builds, error output, --skip-build)

### DIFF
--- a/.changeset/loud-maps-lick.md
+++ b/.changeset/loud-maps-lick.md
@@ -2,4 +2,6 @@
 'mastra': patch
 ---
 
-Fixed deploy commands failing with 'No such file or directory' when the mastra source directory is a subdirectory (e.g. `mastra server deploy src`). The build step now runs in-process instead of shelling out to a binary, so it works regardless of where `node_modules` lives. Also added `--debug` flag to both `mastra server deploy` and `mastra studio deploy` for verbose build output.
+Fixed `mastra server deploy` and `mastra studio deploy` failing when deploying from a subdirectory (e.g. `mastra server deploy src`).
+Added `--debug` flag to both deploy commands for verbose build logs.
+Fixed build errors displaying as `error: {}` instead of the actual error message.

--- a/.changeset/loud-maps-lick.md
+++ b/.changeset/loud-maps-lick.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed deploy commands failing with 'No such file or directory' when the mastra source directory is a subdirectory (e.g. `mastra server deploy src`). The build step now runs in-process instead of shelling out to a binary, so it works regardless of where `node_modules` lives. Also added `--debug` flag to both `mastra server deploy` and `mastra studio deploy` for verbose build output.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -243,6 +243,10 @@ Path to the project config file. Defaults to `.mastra-project.json`.
 
 Skip the build step and deploy the existing `.mastra/output` directory.
 
+#### `--debug`
+
+Enable debug logs during the build step.
+
 ### CI/CD usage
 
 Set `MASTRA_API_TOKEN`, `MASTRA_ORG_ID`, and `MASTRA_PROJECT_ID` as environment variables for headless deploys. Interactive prompts are skipped automatically when `MASTRA_API_TOKEN` is set.

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -79,11 +79,11 @@ export async function build({
         const { message, ...details } = error.toJSONDetails();
         logger.error(message, details);
       } else if (error instanceof Error) {
-        logger.error('Mastra Build failed', { error });
+        logger.error(`Mastra Build failed: ${error.message}`, { stack: error.stack });
       }
     } catch {
       if (error instanceof Error) {
-        logger.error('Mastra Build failed', { error });
+        logger.error(`Mastra Build failed: ${error.message}`, { stack: error.stack });
       }
     }
     process.exit(1);

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('node:child_process', () => ({
-  execSync: vi.fn().mockReturnValue('my-app'),
-}));
+vi.mock('node:child_process', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    execSync: vi.fn().mockReturnValue('my-app'),
+  };
+});
 
 let closeHandler: (() => void) | undefined;
 
@@ -75,6 +79,10 @@ vi.mock('./platform-api.js', () => ({
     instanceUrl: 'https://example.com',
     error: null,
   }),
+}));
+
+vi.mock('../../utils/run-build.js', () => ({
+  runBuild: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../studio/project-config.js', () => ({

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -201,7 +201,7 @@ async function resolveProject(
 
 export async function serverDeployAction(
   dir: string | undefined,
-  opts: { org?: string; project?: string; yes?: boolean; config?: string; debug?: boolean },
+  opts: { org?: string; project?: string; yes?: boolean; config?: string; skipBuild?: boolean; debug?: boolean },
 ) {
   const targetDir = resolve(dir || process.cwd());
   const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);
@@ -282,7 +282,11 @@ export async function serverDeployAction(
   // Step 6: Build + Zip + Upload + Poll
   const s = p.spinner();
 
-  await runBuild(targetDir, { debug: opts.debug });
+  if (opts.skipBuild) {
+    p.log.step('Skipping build (--skip-build)');
+  } else {
+    await runBuild(targetDir, { debug: opts.debug });
+  }
 
   // Verify build output exists
   const outputEntry = join(targetDir, '.mastra', 'output', 'index.mjs');

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import * as p from '@clack/prompts';
 import archiver from 'archiver';
+import { runBuild } from '../../utils/run-build.js';
 import { fetchOrgs } from '../auth/api.js';
 import { MASTRA_STUDIO_URL } from '../auth/client.js';
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
@@ -26,21 +27,6 @@ function getPackageName(projectDir: string): string | null {
   } catch {
     return null;
   }
-}
-
-function runBuild(projectDir: string): void {
-  const localMastra = join(projectDir, 'node_modules', '.bin', 'mastra');
-  p.log.step('Running mastra build...');
-  try {
-    execSync(`"${localMastra}" build`, {
-      cwd: projectDir,
-      stdio: 'inherit',
-      env: { ...process.env, NODE_ENV: 'production' },
-    });
-  } catch {
-    throw new Error('mastra build failed');
-  }
-  console.info('');
 }
 
 async function zipOutput(projectDir: string): Promise<string> {
@@ -215,7 +201,7 @@ async function resolveProject(
 
 export async function serverDeployAction(
   dir: string | undefined,
-  opts: { org?: string; project?: string; yes?: boolean; config?: string },
+  opts: { org?: string; project?: string; yes?: boolean; config?: string; debug?: boolean },
 ) {
   const targetDir = resolve(dir || process.cwd());
   const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);
@@ -296,7 +282,7 @@ export async function serverDeployAction(
   // Step 6: Build + Zip + Upload + Poll
   const s = p.spinner();
 
-  runBuild(targetDir);
+  await runBuild(targetDir, { debug: opts.debug });
 
   // Verify build output exists
   const outputEntry = join(targetDir, '.mastra', 'output', 'index.mjs');

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import * as p from '@clack/prompts';
 import archiver from 'archiver';
+import { runBuild } from '../../utils/run-build.js';
 import { fetchOrgs } from '../auth/api.js';
 import { MASTRA_STUDIO_URL } from '../auth/client.js';
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
@@ -55,21 +56,6 @@ function getMastraVersion(projectDir: string): string | null {
     return null;
   }
 }
-function runBuild(projectDir: string): void {
-  const localMastra = join(projectDir, 'node_modules', '.bin', 'mastra');
-  p.log.step('Running mastra build...');
-  try {
-    execSync(`"${localMastra}" build`, {
-      cwd: projectDir,
-      stdio: 'inherit',
-      env: { ...process.env, NODE_ENV: 'production' },
-    });
-  } catch {
-    throw new Error('mastra build failed');
-  }
-  console.info('');
-}
-
 async function zipOutput(projectDir: string): Promise<string> {
   const outputDir = join(projectDir, '.mastra', 'output');
   const tmpDir = join(tmpdir(), 'mastra-deploy');
@@ -248,7 +234,7 @@ async function resolveProject(
 
 export async function deployAction(
   dir: string | undefined,
-  opts: { org?: string; project?: string; yes?: boolean; config?: string; skipBuild?: boolean },
+  opts: { org?: string; project?: string; yes?: boolean; config?: string; skipBuild?: boolean; debug?: boolean },
 ) {
   const targetDir = resolve(dir || process.cwd());
   const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);
@@ -361,7 +347,7 @@ export async function deployAction(
     p.log.step('Skipping build (--skip-build)');
   } else {
     t = performance.now();
-    runBuild(targetDir);
+    await runBuild(targetDir, { debug: opts.debug });
     p.log.step(`Build completed (${elapsed(performance.now() - t)})`);
   }
 

--- a/packages/cli/src/commands/utils.test.ts
+++ b/packages/cli/src/commands/utils.test.ts
@@ -17,6 +17,7 @@ vi.mock('node:url', () => ({
 describe('getVersionTag', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.resetModules();
   });
 
   test('returns "beta" when CLI version matches beta dist-tag', async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -269,6 +269,7 @@ serverCommand
   .option('--project <id>', 'Project ID')
   .option('-y, --yes', 'Auto-accept defaults without confirmation')
   .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
+  .option('--skip-build', 'Skip the build step and deploy the existing .mastra/output directory')
   .option('--debug', 'Enable debug logs', false)
   .action(wrapAction(serverDeployAction));
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -193,6 +193,7 @@ const deployCommand = studioCommand
   .option('-y, --yes', 'Auto-accept defaults without confirmation')
   .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
   .option('--skip-build', 'Skip the build step and use existing .mastra/output')
+  .option('--debug', 'Enable debug logs', false)
   .action(wrapAction(deployAction));
 
 deployCommand.command('list').description('List deployed studios').action(wrapAction(deploysAction));
@@ -268,6 +269,7 @@ serverCommand
   .option('--project <id>', 'Project ID')
   .option('-y, --yes', 'Auto-accept defaults without confirmation')
   .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
+  .option('--debug', 'Enable debug logs', false)
   .action(wrapAction(serverDeployAction));
 
 serverCommand

--- a/packages/cli/src/utils/run-build.ts
+++ b/packages/cli/src/utils/run-build.ts
@@ -1,0 +1,11 @@
+import * as p from '@clack/prompts';
+import { build } from '../commands/build/build.js';
+
+export async function runBuild(projectDir: string, opts?: { debug?: boolean }): Promise<void> {
+  p.log.step('Running mastra build...');
+  await build({
+    root: projectDir,
+    debug: opts?.debug ?? false,
+  });
+  console.info('');
+}


### PR DESCRIPTION
## Problems

1. **Deploy fails when mastra source is in a subdirectory** — `mastra server deploy src` shelled out to `node_modules/.bin/mastra` relative to the target directory, but `node_modules` lives in the project root.

2. **Build errors show `error: {}`** — `Error` objects have non-enumerable properties (`message`, `stack`), so passing them as pino detail fields produces empty output.

3. **`--skip-build` missing from `server deploy`** — `studio deploy` had it but `server deploy` didn't, despite the docs saying they share the same flags.

## Fixes

- Call `build()` directly instead of shelling out to a binary. This also deduplicates the `runBuild`/`findMastraBin` helpers into `utils/run-build.ts`.
- Extract `error.message` and `error.stack` explicitly so build failures show actionable output.
- Add `--skip-build` to `mastra server deploy` for custom build pipelines.
- Add `--debug` to both deploy commands for verbose build output.
- Document the new `--debug` flag in the CLI reference.
- Fix flaky `getVersionTag` tests in CI (missing `vi.resetModules()`).
- Fix `server/deploy.test.ts` mocks: spread the real `node:child_process` module so transitive imports work, and mock `run-build` so `serverDeployAction` tests don't run an actual build.