### PR TITLE
docs: add CI/CD deployment section to Mastra platform guide

### DIFF
--- a/docs/src/content/en/guides/deployment/mastra-platform.mdx
+++ b/docs/src/content/en/guides/deployment/mastra-platform.mdx
@@ -44,7 +44,7 @@ npm install -g mastra
     mastra server deploy
     ```
 
-    If you're not already authenticated, the CLI will prompt you to log in. It'll store your credentials locally and any subsequent CLI commands will use these credentials.
+    If you're not already authenticated, the CLI prompts you to log in. It stores your credentials locally and any subsequent CLI commands use these credentials.
 
     The command runs `mastra build`, uploads the artifact, builds a Docker image, and deploys it to Railway. On first deploy, the CLI creates a `.mastra-project.json` file linking your local project to the platform. Commit this file so subsequent deploys and CI/CD target the same project.
 
@@ -53,7 +53,7 @@ npm install -g mastra
     Review and sanitize these files before first deploy to avoid uploading development-only or personal secrets.
     :::
 
-    See the [CLI reference](/reference/cli/mastra#mastra-server-deploy) for the full list of flags and CI/CD usage.
+    See the [CLI reference](/reference/cli/mastra#mastra-server-deploy) for the full list of flags.
   </StepItem>
 
   <StepItem>
@@ -69,9 +69,154 @@ npm install -g mastra
 
 A deploy transitions through **queued → uploading → building → deploying → running** (or **failed**, **cancelled**, **crashed**, or **stopped**). Only one build runs per project at a time. If multiple deploys queue up, only the latest proceeds and the rest are cancelled. Builds running longer than 15 minutes are automatically failed. The first deploy provisions Railway infrastructure and seeds environment variables from your local `.env`. Your server URL remains stable across deploys.
 
+## CI/CD
+
+Automate deployments from GitHub Actions, GitLab CI, or any CI provider. After your first interactive deploy, CI/CD needs just two things: an API token and the `.mastra-project.json` file committed to your repository.
+
+### Create an API token
+
+<Steps>
+  <StepItem>
+    Run the following command locally:
+
+    ```bash
+    mastra auth tokens create ci-deploy
+    ```
+
+    The CLI prints the token once. Copy it immediately — it cannot be retrieved again.
+  </StepItem>
+
+  <StepItem>
+    Add the token as a secret in your CI provider. In GitHub Actions, go to **Settings → Secrets and variables → Actions** and create a secret named `MASTRA_API_TOKEN`.
+  </StepItem>
+
+  <StepItem>
+    Ensure your `.mastra-project.json` file is committed to the repository. The CLI reads the `organizationId` and `projectId` from this file to target the correct project during CI deploys.
+  </StepItem>
+</Steps>
+
+### The `--yes` flag
+
+Pass `--yes` (or `-y`) to skip all confirmation prompts. Without it, the CLI waits for interactive input and your CI job hangs.
+
+```bash
+mastra server deploy --yes
+```
+
+### GitHub Actions
+
+The following workflow deploys on every push to `main`:
+
+```yaml title=".github/workflows/deploy-mastra.yml"
+name: Deploy to Mastra platform
+
+on:
+  push:
+    branches: [main]
+    paths: ['src/mastra/**']
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy to Mastra platform
+        run: pnpm mastra server deploy --yes
+        env:
+          MASTRA_API_TOKEN: ${{ secrets.MASTRA_API_TOKEN }}
+```
+
+Adjust the `paths` filter and `working-directory` if your Mastra project is in a subdirectory (e.g. a monorepo).
+
+:::note
+
+For Studio deploys, replace `mastra server deploy` with `mastra studio deploy`. The flags and environment variables are the same.
+
+:::
+
+### GitLab CI
+
+The following pipeline deploys on pushes to `main`:
+
+```yaml title=".gitlab-ci.yml"
+deploy:
+  image: node:22
+  stage: deploy
+  only:
+    - main
+  before_script:
+    - corepack enable
+    - pnpm install --frozen-lockfile
+  script:
+    - pnpm mastra server deploy --yes
+  variables:
+    MASTRA_API_TOKEN: $MASTRA_API_TOKEN
+```
+
+Add `MASTRA_API_TOKEN` as a CI/CD variable in **Settings → CI/CD → Variables**.
+
+### Other CI providers
+
+Any CI system that runs Node.js and shell commands works with Mastra:
+
+1. Install dependencies.
+1. Set `MASTRA_API_TOKEN` as an environment variable.
+1. Run `mastra server deploy --yes` (or `mastra studio deploy --yes`).
+
+### Verify the deploy
+
+After the workflow completes, verify the deployment by hitting the health endpoint:
+
+```bash
+curl -f https://<your-project>.server.mastra.cloud/health
+```
+
+Or check the agents endpoint, which returns a JSON list of your agents:
+
+```bash
+curl -f https://<your-project>.server.mastra.cloud/api/agents
+```
+
+The following example adds a verification step to a GitHub Actions workflow:
+
+```yaml
+- name: Verify deployment
+  run: |
+    sleep 30
+    curl -f https://<your-project>.server.mastra.cloud/health
+```
+
+### Override project config with environment variables
+
+The CLI reads `organizationId` and `projectId` from `.mastra-project.json` by default. To override these values (e.g. deploying to a different project from the same repository), set the following environment variables:
+
+| Variable | Description |
+| - | - |
+| `MASTRA_ORG_ID` | Overrides the organization ID from `.mastra-project.json`. |
+| `MASTRA_PROJECT_ID` | Overrides the project ID from `.mastra-project.json`. |
+
+### CI/CD troubleshooting
+
+**"No organizations found"**: The CLI cannot resolve the organization. Ensure your `.mastra-project.json` file is committed and contains a valid `organizationId`, or set `MASTRA_ORG_ID` as an environment variable.
+
+**CI job hangs**: The CLI is waiting for interactive input. Ensure you pass the `--yes` flag and that `MASTRA_API_TOKEN` is set.
+
 ## Related
 
-- [CLI reference](/reference/cli/mastra#mastra-server-deploy)
+- [CLI reference: `mastra server deploy`](/reference/cli/mastra#mastra-server-deploy)
+- [CLI reference: `mastra studio deploy`](/reference/cli/mastra#mastra-studio-deploy)
+- [CLI reference: `mastra auth tokens`](/reference/cli/mastra#mastra-auth-tokens)
 - [Mastra platform overview](/docs/mastra-platform/overview)
 - [Studio deployment](/docs/studio/deployment#mastra-platform)
 - [Deployment overview](/docs/deployment/overview)

--- a/docs/src/content/en/guides/deployment/mastra-platform.mdx
+++ b/docs/src/content/en/guides/deployment/mastra-platform.mdx
@@ -120,19 +120,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'pnpm'
-
+          cache: 'npm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
+        run: npm install
       - name: Deploy to Mastra platform
-        run: pnpm mastra server deploy --yes
+        run: npx mastra server deploy --yes
         env:
           MASTRA_API_TOKEN: ${{ secrets.MASTRA_API_TOKEN }}
 ```
@@ -156,12 +151,9 @@ deploy:
   only:
     - main
   before_script:
-    - corepack enable
-    - pnpm install --frozen-lockfile
+    - npm install
   script:
-    - pnpm mastra server deploy --yes
-  variables:
-    MASTRA_API_TOKEN: $MASTRA_API_TOKEN
+    - npx mastra server deploy --yes
 ```
 
 Add `MASTRA_API_TOKEN` as a CI/CD variable in **Settings → CI/CD → Variables**.
@@ -205,12 +197,6 @@ The CLI reads `organizationId` and `projectId` from `.mastra-project.json` by de
 | - | - |
 | `MASTRA_ORG_ID` | Overrides the organization ID from `.mastra-project.json`. |
 | `MASTRA_PROJECT_ID` | Overrides the project ID from `.mastra-project.json`. |
-
-### CI/CD troubleshooting
-
-**"No organizations found"**: The CLI cannot resolve the organization. Ensure your `.mastra-project.json` file is committed and contains a valid `organizationId`, or set `MASTRA_ORG_ID` as an environment variable.
-
-**CI job hangs**: The CLI is waiting for interactive input. Ensure you pass the `--yes` flag and that `MASTRA_API_TOKEN` is set.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Extends the Mastra platform deployment guide with a comprehensive CI/CD section so users can automate deploys from any CI provider.

### What's added

The new `## CI/CD` section in `mastra-platform.mdx` covers:

- **API token creation** — step-by-step with `mastra auth tokens create`
- **The `--yes` flag** — required for non-interactive CI environments
- **GitHub Actions** — complete copy-pasteable workflow
- **GitLab CI** — complete pipeline example
- **Other CI providers** — generic 3-step pattern
- **Deploy verification** — `curl` examples and a GitHub Actions verification step
- **Environment variable overrides** — `MASTRA_ORG_ID` / `MASTRA_PROJECT_ID` as optional overrides
- **Troubleshooting** — common CI/CD errors and fixes

### Design decisions

- CI/CD lives as a section within the existing Mastra platform guide rather than a standalone page — it's part of the same deployment flow
- `.mastra-project.json` is presented as the primary config path; env var overrides are secondary
- Only `MASTRA_API_TOKEN` is required as a CI secret; org/project IDs come from the committed config file
- Follows the deployment guide styleguide and general docs styleguide

### Test plan

- `npm run build` in `docs/` passes with no errors
- Sidebar unchanged (no new entries needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds simple, copy-paste instructions to the Mastra docs so CI systems (like GitHub Actions or GitLab CI) can automatically deploy projects using a short-lived API token and a non-interactive CLI flag—so you don't have to click anything during CI runs.

---

## Overview

Adds a CI/CD section to the Mastra platform deployment guide to document automated deployments from common CI providers using the `mastra` CLI, token-based authentication, and verification steps.

## Changes

**File modified:** docs/src/content/en/guides/deployment/mastra-platform.mdx

### Deployment Guide Edits
- Reworded authentication/credential guidance to concise imperative phrasing.
- Adjusted the CLI reference anchor text and expanded the "Related" section with dedicated links for:
  - `mastra server deploy`
  - `mastra studio deploy`
  - `mastra auth tokens`

### New CI/CD Section (Major Addition)
- API token creation: `mastra auth tokens create ci-deploy` and recommendations for CI-safe tokens.
- CI secret configuration: instructs storing token as `MASTRA_API_TOKEN` (only required CI secret).
- Configuration precedence: treats committed `.mastra-project.json` as primary, with `MASTRA_ORG_ID`/`MASTRA_PROJECT_ID` environment variables as overrides.
- Non-interactive CI runs: document using `mastra server deploy --yes` / `-y` to skip prompts.
- Copyable examples:
  - GitHub Actions workflow (copy-pasteable)
  - GitLab CI pipeline example
  - Generic 3-step pattern for other CI providers
- Post-deploy verification: `curl` examples (e.g., /health, /api/agents) and a GitHub Actions verification step.
- Troubleshooting subsection: common CI/CD errors and fixes.
- Design decisions recorded: CI/CD content added as a section in the existing guide; `.mastra-project.json` primary; minimal required CI secret; docs/style conformity.

## Testing

- Ran `npm run build` in docs/ — build passes with no errors.
- Sidebar remains unchanged.

## Stats

Lines changed: +134/-3  
Estimated review effort: Low
<!-- end of auto-generated comment: release notes by coderabbit.ai -->