### PR TITLE
docs: fix "agent" → "IDE" wording in README and add Anthropic/Google keys to .env template

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -154,6 +154,8 @@ Create a `.env` file in the root directory with the following content:
 
 ```text
 OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_GENERATIVE_AI_API_KEY=
 COHERE_API_KEY=
 PINECONE_API_KEY=
 CLOUDFLARE_ACCOUNT_ID=

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Visit our [official documentation](https://mastra.ai/docs).
 
 ## Build with AI
 
-Learn how to make your agent a Mastra expert by following the [Build with AI guide](https://mastra.ai/docs/getting-started/build-with-ai).
+Learn how to make your IDE a Mastra expert by following the [Build with AI guide](https://mastra.ai/docs/getting-started/build-with-ai).
 
 ## Contributing
 


### PR DESCRIPTION
 ## What

     Two small documentation fixes:

     1. **README.md** — The "MCP Servers" section says "make your agent a 
     Mastra expert" but the MCP docs server is installed into your **IDE** 
     (Cursor, Windsurf, etc.), not an agent. Fixed wording to "IDE".

     2. **DEVELOPMENT.md** — The sample `.env` template was missing 
     `ANTHROPIC_API_KEY` and `GOOGLE_GENERATIVE_AI_API_KEY`. Mastra supports 
     Anthropic and Google as first-class providers, so contributors using 
     those providers hit confusing test failures with no hint of what to set.

     No code changes. No changeset needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes two small documentation mistakes: it clarifies that an AI documentation tool (MCP) works with your IDE (the code editor you use), not with an AI agent, and it adds missing instructions so developers know which extra passwords/keys they need to set up if they want to use Anthropic or Google's AI tools.

## Changes

### DEVELOPMENT.md
Added missing API key environment variable entries to the `.env` file template:
- `ANTHROPIC_API_KEY`
- `GOOGLE_GENERATIVE_AI_API_KEY`

This ensures developers using Anthropic or Google AI providers won't encounter unclear test failures due to missing configuration.

### README.md
Updated the "MCP Servers" section wording to clarify that the MCP documentation server is installed into the **IDE** (Cursor, Windsurf, etc.), not into an **agent**.

## Impact
- **Scope**: Documentation only; no code changes
- **Risk**: Minimal
- **Changeset**: Not required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->