### PR TITLE
fix: propagate resourceId to nested workflow runs

### DIFF
--- a/.changeset/fix-nested-workflow-resource-id.md
+++ b/.changeset/fix-nested-workflow-resource-id.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed nested workflow runs not inheriting `resourceId` from the parent workflow. When a workflow is invoked as a step inside a parent workflow that was created with a `resourceId`, child workflow snapshots are now correctly persisted with the parent's `resourceId`, maintaining tenant/resource association across nested workflows.

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2193,6 +2193,7 @@ export class Workflow<
   // To run a workflow use `.createRun` and then `.start` or `.resume`
   async execute({
     runId,
+    resourceId,
     inputData,
     resumeData,
     state,
@@ -2215,6 +2216,7 @@ export class Workflow<
     ...rest
   }: {
     runId?: string;
+    resourceId?: string;
     inputData: TInput;
     resumeData?: unknown;
     state: TState;
@@ -2274,7 +2276,9 @@ export class Workflow<
 
     const isTimeTravel = !!(timeTravel && timeTravel.steps.length > 0);
 
-    const run = isResume ? await this.createRun({ runId: resume.runId }) : await this.createRun({ runId });
+    const run = isResume
+      ? await this.createRun({ runId: resume.runId, resourceId })
+      : await this.createRun({ runId, resourceId });
     const nestedAbortCb = () => {
       abort();
     };


### PR DESCRIPTION
Fixes #15246

## Problem

When a parent workflow is started with a resourceId and contains nested child workflows as steps, the child workflows do not inherit the parent's resourceId when persisting their snapshots.

**Root cause:** The execute() method on Workflow did not destructure resourceId from its parameters — it fell into ...rest and was never passed to createRun().

## Solution

Added resourceId to the destructured parameter list of Workflow.execute() and passed it to createRun() in both the resume and fresh start paths.

## Testing

Traced the data flow: handlers/step.ts already passes resourceId to runStep (line 317). The nested workflow's execute() now correctly receives and uses it when creating the run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you start a workflow with a tracking ID (resourceId), any child workflows running inside it weren't getting that same ID, losing the connection to their parent. This PR fixes that by passing the ID down to all nested workflows so everything stays properly linked.

## Problem

When a parent workflow was initiated with a `resourceId` parameter (used for tenant/resource association), nested child workflows executed within that parent did not inherit or propagate the parent's `resourceId`. This caused the child workflow snapshots to be persisted without the correct resource identifier, breaking tenant isolation and resource tracking.

## Solution

Modified `Workflow.execute()` to accept and pass through the `resourceId` parameter:
- Added optional `resourceId?: string` parameter to the method's destructured inputs
- When creating a run via `createRun()`, both for resumed workflows and newly-started workflows, the `resourceId` is now passed along with the `runId`
- This ensures that nested workflow executions preserve their parent's resource association through the entire execution chain

## Changes

- **packages/core/src/workflows/workflow.ts**: Updated the `Workflow.execute()` method signature to include `resourceId` in its destructured parameters, and ensured it's passed to `createRun()` in both the resume and fresh-start code paths
- **.changeset/fix-nested-workflow-resource-id.md**: Added changeset documentation for the patch release

## Impact

- Nested workflows now correctly inherit and persist the `resourceId` from their parent workflows
- Resource tracking and tenant isolation is properly maintained across nested workflow hierarchies
- The fix integrates seamlessly with existing code where `handlers/step.ts` already passes `resourceId` to `runStep()`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->