### PR TITLE
feat(auth): add @mastra/auth-agentlair provider

### DIFF
--- a/.changeset/add-auth-agentlair.md
+++ b/.changeset/add-auth-agentlair.md
@@ -1,0 +1,7 @@
+---
+'@mastra/auth-agentlair': minor
+---
+
+Add AgentLair auth provider for AI agent identity verification and behavioral trust scoring.
+
+`MastraAgentLairAuth` extends `MastraAuthProvider` to verify EdDSA-signed Agent Authentication Tokens (AATs) against AgentLair's JWKS endpoint. Supports trust-based authorization via behavioral trust scores (0-1000) and trust tiers, along with scope-based access control. Implements `IUserProvider` for Mastra Studio integration.

--- a/packages/auth-agentlair/.gitignore
+++ b/packages/auth-agentlair/.gitignore
@@ -1,0 +1,1 @@
+.env.mastra

--- a/packages/auth-agentlair/CHANGELOG.md
+++ b/packages/auth-agentlair/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @mastra/auth-agentlair

--- a/packages/auth-agentlair/README.md
+++ b/packages/auth-agentlair/README.md
@@ -1,0 +1,55 @@
+# @mastra/auth-agentlair
+
+AgentLair auth provider for Mastra — EdDSA JWT verification and behavioral trust scoring for AI agents.
+
+## Installation
+
+```bash
+pnpm add @mastra/auth-agentlair
+```
+
+## Usage
+
+```typescript
+import { MastraAgentLairAuth } from '@mastra/auth-agentlair';
+import { Mastra } from '@mastra/core';
+
+const auth = new MastraAgentLairAuth({
+  audience: 'https://my-service.com',
+  apiKey: process.env.AGENTLAIR_API_KEY,
+  fetchTrustScore: true,
+  minimumTrustScore: 500,
+});
+
+const mastra = new Mastra({
+  server: {
+    authProvider: auth,
+  },
+});
+```
+
+## How It Works
+
+[AgentLair](https://agentlair.dev) provides verifiable identity and behavioral trust scoring for AI agents. Agents authenticate using EdDSA-signed JWTs (Agent Authentication Tokens) that are verified against AgentLair's JWKS endpoint.
+
+This provider extends Mastra's `MastraAuthProvider` to:
+
+1. **Verify agent identity** — EdDSA/Ed25519 JWT signature verification via JWKS
+2. **Enforce trust-based authorization** — Behavioral trust scores (0-1000) as a permission layer
+3. **Integrate with Mastra Studio** — Implements `IUserProvider` for agent awareness in the Studio UI
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `apiKey` | `string` | — | AgentLair API key for trust score lookups |
+| `audience` | `string` | — | Expected JWT audience claim |
+| `issuer` | `string` | `https://agentlair.dev` | Expected JWT issuer |
+| `fetchTrustScore` | `boolean` | `false` | Fetch trust scores during authentication |
+| `minimumTrustScore` | `number` | `0` | Minimum score required for authorization |
+| `requiredTier` | `string` | — | Required trust tier (`untrusted`, `provisional`, `trusted`, `verified`) |
+| `requiredScopes` | `string[]` | — | Required agent scopes (all must match) |
+
+## License
+
+Apache-2.0

--- a/packages/auth-agentlair/eslint.config.js
+++ b/packages/auth-agentlair/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/packages/auth-agentlair/lint-staged.config.js
+++ b/packages/auth-agentlair/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['eslint --fix', 'prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/packages/auth-agentlair/package.json
+++ b/packages/auth-agentlair/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@mastra/auth-agentlair",
+  "version": "0.1.0",
+  "description": "AgentLair auth provider for Mastra — EdDSA JWT verification and behavioral trust scoring for AI agents.",
+  "type": "module",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "prepack": "pnpx tsx ../../scripts/generate-package-docs.ts",
+    "build:watch": "tsup --watch --silent --config tsup.config.ts",
+    "test": "vitest run",
+    "lint": "eslint ."
+  },
+  "keywords": [
+    "mastra",
+    "agentlair",
+    "auth",
+    "agent-identity",
+    "eddsa",
+    "jwt",
+    "trust-scoring",
+    "ai-agent"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "jose": "^6.0.11"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.19.15",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "eslint": "^9.39.4",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "packages/auth-agentlair"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/packages/auth-agentlair/src/index.ts
+++ b/packages/auth-agentlair/src/index.ts
@@ -1,0 +1,8 @@
+export { MastraAgentLairAuth } from './provider';
+export type {
+  AATClaims,
+  MastraAgentLairAuthOptions,
+  TrustBreakdown,
+  TrustScore,
+  VerifiedAgent,
+} from './types';

--- a/packages/auth-agentlair/src/provider.test.ts
+++ b/packages/auth-agentlair/src/provider.test.ts
@@ -56,6 +56,9 @@ function mockTrustScore(overrides: Partial<TrustScore> = {}): TrustScore {
   };
 }
 
+// Shared test audience — always provided to satisfy the required audience check
+const TEST_AUDIENCE = 'https://test.example.com';
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('MastraAgentLairAuth', () => {
@@ -71,8 +74,13 @@ describe('MastraAgentLairAuth', () => {
   });
 
   describe('constructor', () => {
-    it('constructs with default options', () => {
-      const auth = new MastraAgentLairAuth();
+    it('throws when audience is not provided', () => {
+      expect(() => new MastraAgentLairAuth()).toThrow('audience');
+      expect(() => new MastraAgentLairAuth({ baseUrl: 'https://agentlair.dev' })).toThrow('audience');
+    });
+
+    it('constructs with required audience', () => {
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       expect(auth).toBeInstanceOf(MastraAgentLairAuth);
     });
 
@@ -90,14 +98,14 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('creates JWKS client with correct URL', () => {
-      new MastraAgentLairAuth({ baseUrl: 'https://custom.example.com' });
+      new MastraAgentLairAuth({ baseUrl: 'https://custom.example.com', audience: TEST_AUDIENCE });
       expect(mockCreateRemoteJWKSet).toHaveBeenCalledWith(
         new URL('https://custom.example.com/.well-known/jwks.json'),
       );
     });
 
     it('accepts custom JWKS URL', () => {
-      new MastraAgentLairAuth({ jwksUrl: 'https://keys.example.com/jwks' });
+      new MastraAgentLairAuth({ jwksUrl: 'https://keys.example.com/jwks', audience: TEST_AUDIENCE });
       expect(mockCreateRemoteJWKSet).toHaveBeenCalledWith(new URL('https://keys.example.com/jwks'));
     });
   });
@@ -137,7 +145,7 @@ describe('MastraAgentLairAuth', () => {
     it('returns null for invalid token', async () => {
       mockJwtVerify.mockRejectedValue(new Error('Invalid signature'));
 
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const agent = await auth.authenticateToken('invalid.token', mockHonoRequest() as any);
 
       expect(agent).toBeNull();
@@ -156,6 +164,7 @@ describe('MastraAgentLairAuth', () => {
       const auth = new MastraAgentLairAuth({
         apiKey: 'al_live_test',
         fetchTrustScore: true,
+        audience: TEST_AUDIENCE,
       });
       const agent = await auth.authenticateToken('valid.token', mockHonoRequest() as any);
 
@@ -172,7 +181,7 @@ describe('MastraAgentLairAuth', () => {
       mockJwtVerify.mockResolvedValue({ payload: validClaims() });
       (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
 
-      const auth = new MastraAgentLairAuth({ apiKey: 'key', fetchTrustScore: true });
+      const auth = new MastraAgentLairAuth({ apiKey: 'key', fetchTrustScore: true, audience: TEST_AUDIENCE });
       const agent = await auth.authenticateToken('valid.token', mockHonoRequest() as any);
 
       expect(agent).not.toBeNull();
@@ -182,7 +191,7 @@ describe('MastraAgentLairAuth', () => {
 
   describe('authorizeUser', () => {
     it('authorizes agent with no trust requirements', async () => {
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: [],
@@ -195,7 +204,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('rejects agent missing required scope', async () => {
-      const auth = new MastraAgentLairAuth({ requiredScopes: ['admin'] });
+      const auth = new MastraAgentLairAuth({ requiredScopes: ['admin'], audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: ['read', 'write'],
@@ -208,7 +217,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('allows wildcard scope to satisfy any requirement', async () => {
-      const auth = new MastraAgentLairAuth({ requiredScopes: ['admin', 'superuser'] });
+      const auth = new MastraAgentLairAuth({ requiredScopes: ['admin', 'superuser'], audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: ['*'],
@@ -221,7 +230,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('rejects agent below minimum trust score', async () => {
-      const auth = new MastraAgentLairAuth({ minimumTrustScore: 800 });
+      const auth = new MastraAgentLairAuth({ minimumTrustScore: 800, audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: [],
@@ -235,7 +244,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('allows agent meeting minimum trust score', async () => {
-      const auth = new MastraAgentLairAuth({ minimumTrustScore: 500 });
+      const auth = new MastraAgentLairAuth({ minimumTrustScore: 500, audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: [],
@@ -249,7 +258,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('rejects agent below required tier', async () => {
-      const auth = new MastraAgentLairAuth({ requiredTier: 'verified' });
+      const auth = new MastraAgentLairAuth({ requiredTier: 'verified', audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: [],
@@ -263,7 +272,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('allows agent meeting required tier', async () => {
-      const auth = new MastraAgentLairAuth({ requiredTier: 'trusted' });
+      const auth = new MastraAgentLairAuth({ requiredTier: 'trusted', audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: [],
@@ -286,6 +295,7 @@ describe('MastraAgentLairAuth', () => {
       const auth = new MastraAgentLairAuth({
         apiKey: 'al_live_test',
         minimumTrustScore: 500,
+        audience: TEST_AUDIENCE,
       });
       const agent: VerifiedAgent = {
         accountId: 'test',
@@ -301,7 +311,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('rejects when trust score needed but no API key', async () => {
-      const auth = new MastraAgentLairAuth({ minimumTrustScore: 500 });
+      const auth = new MastraAgentLairAuth({ minimumTrustScore: 500, audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: [],
@@ -318,7 +328,7 @@ describe('MastraAgentLairAuth', () => {
     it('returns user from valid Bearer token', async () => {
       mockJwtVerify.mockResolvedValue({ payload: validClaims() });
 
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const request = mockRequest({ Authorization: 'Bearer valid.token' });
       const user = await auth.getCurrentUser(request);
 
@@ -331,7 +341,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('returns null when no Authorization header', async () => {
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const user = await auth.getCurrentUser(mockRequest());
       expect(user).toBeNull();
     });
@@ -339,7 +349,7 @@ describe('MastraAgentLairAuth', () => {
     it('returns null for invalid token', async () => {
       mockJwtVerify.mockRejectedValue(new Error('Invalid'));
 
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const user = await auth.getCurrentUser(mockRequest({ Authorization: 'Bearer bad' }));
       expect(user).toBeNull();
     });
@@ -347,7 +357,7 @@ describe('MastraAgentLairAuth', () => {
     it('accepts case-insensitive Bearer scheme', async () => {
       mockJwtVerify.mockResolvedValue({ payload: validClaims() });
 
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const user = await auth.getCurrentUser(mockRequest({ Authorization: 'BEARER valid.token' }));
       expect(user).not.toBeNull();
     });
@@ -355,7 +365,7 @@ describe('MastraAgentLairAuth', () => {
     it('returns null when authorization fails', async () => {
       mockJwtVerify.mockResolvedValue({ payload: validClaims() });
 
-      const auth = new MastraAgentLairAuth({ requiredScopes: ['admin'] });
+      const auth = new MastraAgentLairAuth({ requiredScopes: ['admin'], audience: TEST_AUDIENCE });
       const user = await auth.getCurrentUser(mockRequest({ Authorization: 'Bearer valid.token' }));
       expect(user).toBeNull();
     });
@@ -363,7 +373,7 @@ describe('MastraAgentLairAuth', () => {
 
   describe('getUser', () => {
     it('returns null (JWT is stateless)', async () => {
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const user = await auth.getUser('agent_123');
       expect(user).toBeNull();
     });
@@ -371,7 +381,7 @@ describe('MastraAgentLairAuth', () => {
 
   describe('convenience methods', () => {
     it('hasScope returns true for matching scope', () => {
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: ['read', 'write'],
@@ -383,7 +393,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('hasScope returns true for wildcard', () => {
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: ['*'],
@@ -394,7 +404,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('meetsTrustTier compares tiers correctly', () => {
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: [],
@@ -409,7 +419,7 @@ describe('MastraAgentLairAuth', () => {
     });
 
     it('meetsTrustTier returns false without trust score', () => {
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       const agent: VerifiedAgent = {
         accountId: 'test',
         scopes: [],
@@ -419,16 +429,27 @@ describe('MastraAgentLairAuth', () => {
       expect(auth.meetsTrustTier(agent, 'provisional')).toBe(false);
     });
 
-    it('getUserProfileUrl returns correct URL', () => {
-      const auth = new MastraAgentLairAuth();
-      const url = auth.getUserProfileUrl({ id: 'agent_123', name: 'Test' });
-      expect(url).toBe('https://agentlair.dev/agents/agent_123');
+    it('getUserProfileUrl returns correct URL using configured baseUrl', () => {
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
+      expect(auth.getUserProfileUrl({ id: 'agent_123', name: 'Test' })).toBe(
+        'https://agentlair.dev/agents/agent_123',
+      );
+    });
+
+    it('getUserProfileUrl uses custom baseUrl', () => {
+      const auth = new MastraAgentLairAuth({
+        audience: TEST_AUDIENCE,
+        baseUrl: 'https://self-hosted.example.com',
+      });
+      expect(auth.getUserProfileUrl({ id: 'agent_123', name: 'Test' })).toBe(
+        'https://self-hosted.example.com/agents/agent_123',
+      );
     });
   });
 
   describe('fetchTrustScore', () => {
     it('requires API key', async () => {
-      const auth = new MastraAgentLairAuth();
+      const auth = new MastraAgentLairAuth({ audience: TEST_AUDIENCE });
       await expect(auth.fetchTrustScore('agent_123')).rejects.toThrow('API key required');
     });
 
@@ -439,7 +460,7 @@ describe('MastraAgentLairAuth', () => {
         json: () => Promise.resolve(score),
       });
 
-      const auth = new MastraAgentLairAuth({ apiKey: 'al_live_test' });
+      const auth = new MastraAgentLairAuth({ apiKey: 'al_live_test', audience: TEST_AUDIENCE });
       const result = await auth.fetchTrustScore('agent_123');
 
       expect(result).toEqual(score);
@@ -454,8 +475,29 @@ describe('MastraAgentLairAuth', () => {
     it('throws on API error', async () => {
       (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false, status: 404 });
 
-      const auth = new MastraAgentLairAuth({ apiKey: 'al_live_test' });
+      const auth = new MastraAgentLairAuth({ apiKey: 'al_live_test', audience: TEST_AUDIENCE });
       await expect(auth.fetchTrustScore('agent_404')).rejects.toThrow('HTTP 404');
+    });
+
+    it('throws a timeout error when fetch exceeds trustScoreTimeoutMs', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+        (_url: string, opts: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            opts.signal?.addEventListener('abort', () => {
+              const err = new Error('The operation was aborted');
+              (err as Error & { name: string }).name = 'AbortError';
+              reject(err);
+            });
+          }),
+      );
+
+      const auth = new MastraAgentLairAuth({
+        apiKey: 'al_live_test',
+        audience: TEST_AUDIENCE,
+        trustScoreTimeoutMs: 50,
+      });
+
+      await expect(auth.fetchTrustScore('agent_slow')).rejects.toThrow('timed out');
     });
   });
 });

--- a/packages/auth-agentlair/src/provider.test.ts
+++ b/packages/auth-agentlair/src/provider.test.ts
@@ -1,0 +1,461 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { MastraAgentLairAuth } from './provider';
+import type { VerifiedAgent, TrustScore } from './types';
+
+// ── Mock jose ───────────────────────────────────────────────────────────────
+
+const mockJwtVerify = vi.fn();
+const mockCreateRemoteJWKSet = vi.fn().mockReturnValue('mock-jwks');
+
+vi.mock('jose', () => ({
+  jwtVerify: (...args: unknown[]) => mockJwtVerify(...args),
+  createRemoteJWKSet: (...args: unknown[]) => mockCreateRemoteJWKSet(...args),
+}));
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function validClaims() {
+  return {
+    iss: 'https://agentlair.dev',
+    sub: 'agent_test_123',
+    aud: 'https://my-service.com',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    iat: Math.floor(Date.now() / 1000),
+    jti: 'jti_abc',
+    al_name: 'Test Agent',
+    al_email: 'test@agentlair.dev',
+    al_scopes: ['read', 'write'],
+    al_audit_url: 'https://agentlair.dev/audit/agent_test_123',
+  };
+}
+
+function mockRequest(headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/api/test', { headers });
+}
+
+function mockHonoRequest(headers: Record<string, string> = {}) {
+  const req = mockRequest(headers);
+  return {
+    header: (name: string) => req.headers.get(name),
+    url: 'http://localhost/api/test',
+    method: 'GET',
+    raw: req,
+  };
+}
+
+function mockTrustScore(overrides: Partial<TrustScore> = {}): TrustScore {
+  return {
+    agentId: 'agent_test_123',
+    score: 750,
+    tier: 'trusted',
+    breakdown: { behavioral: 200, consistency: 200, reputation: 200, transparency: 150 },
+    computedAt: '2026-04-12T00:00:00Z',
+    observationCount: 42,
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('MastraAgentLairAuth', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('constructor', () => {
+    it('constructs with default options', () => {
+      const auth = new MastraAgentLairAuth();
+      expect(auth).toBeInstanceOf(MastraAgentLairAuth);
+    });
+
+    it('constructs with custom options', () => {
+      const auth = new MastraAgentLairAuth({
+        baseUrl: 'https://custom.agentlair.dev',
+        apiKey: 'al_live_test',
+        audience: 'https://my-service.com',
+        fetchTrustScore: true,
+        minimumTrustScore: 500,
+        requiredTier: 'trusted',
+        requiredScopes: ['admin'],
+      });
+      expect(auth).toBeInstanceOf(MastraAgentLairAuth);
+    });
+
+    it('creates JWKS client with correct URL', () => {
+      new MastraAgentLairAuth({ baseUrl: 'https://custom.example.com' });
+      expect(mockCreateRemoteJWKSet).toHaveBeenCalledWith(
+        new URL('https://custom.example.com/.well-known/jwks.json'),
+      );
+    });
+
+    it('accepts custom JWKS URL', () => {
+      new MastraAgentLairAuth({ jwksUrl: 'https://keys.example.com/jwks' });
+      expect(mockCreateRemoteJWKSet).toHaveBeenCalledWith(new URL('https://keys.example.com/jwks'));
+    });
+  });
+
+  describe('authenticateToken', () => {
+    it('verifies valid EdDSA token', async () => {
+      const claims = validClaims();
+      mockJwtVerify.mockResolvedValue({ payload: claims, protectedHeader: { alg: 'EdDSA' } });
+
+      const auth = new MastraAgentLairAuth({ audience: 'https://my-service.com' });
+      const agent = await auth.authenticateToken('valid.jwt.token', mockHonoRequest() as any);
+
+      expect(agent).not.toBeNull();
+      expect(agent!.accountId).toBe('agent_test_123');
+      expect(agent!.name).toBe('Test Agent');
+      expect(agent!.email).toBe('test@agentlair.dev');
+      expect(agent!.scopes).toEqual(['read', 'write']);
+      expect(agent!.auditUrl).toBe('https://agentlair.dev/audit/agent_test_123');
+    });
+
+    it('passes correct verification options to jose', async () => {
+      mockJwtVerify.mockResolvedValue({ payload: validClaims() });
+
+      const auth = new MastraAgentLairAuth({
+        audience: 'https://my-service.com',
+        issuer: 'https://custom-issuer.dev',
+      });
+      await auth.authenticateToken('test.token', mockHonoRequest() as any);
+
+      expect(mockJwtVerify).toHaveBeenCalledWith('test.token', 'mock-jwks', {
+        issuer: 'https://custom-issuer.dev',
+        audience: 'https://my-service.com',
+        algorithms: ['EdDSA'],
+      });
+    });
+
+    it('returns null for invalid token', async () => {
+      mockJwtVerify.mockRejectedValue(new Error('Invalid signature'));
+
+      const auth = new MastraAgentLairAuth();
+      const agent = await auth.authenticateToken('invalid.token', mockHonoRequest() as any);
+
+      expect(agent).toBeNull();
+    });
+
+    it('fetches trust score when configured', async () => {
+      const claims = validClaims();
+      mockJwtVerify.mockResolvedValue({ payload: claims });
+
+      const score = mockTrustScore();
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(score),
+      });
+
+      const auth = new MastraAgentLairAuth({
+        apiKey: 'al_live_test',
+        fetchTrustScore: true,
+      });
+      const agent = await auth.authenticateToken('valid.token', mockHonoRequest() as any);
+
+      expect(agent!.trustScore).toEqual(score);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://agentlair.dev/v1/trust/agent_test_123',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer al_live_test' }),
+        }),
+      );
+    });
+
+    it('succeeds even when trust score fetch fails', async () => {
+      mockJwtVerify.mockResolvedValue({ payload: validClaims() });
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+
+      const auth = new MastraAgentLairAuth({ apiKey: 'key', fetchTrustScore: true });
+      const agent = await auth.authenticateToken('valid.token', mockHonoRequest() as any);
+
+      expect(agent).not.toBeNull();
+      expect(agent!.trustScore).toBeUndefined();
+    });
+  });
+
+  describe('authorizeUser', () => {
+    it('authorizes agent with no trust requirements', async () => {
+      const auth = new MastraAgentLairAuth();
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: [],
+        auditUrl: '',
+        claims: validClaims(),
+      };
+
+      const result = await auth.authorizeUser(agent, mockHonoRequest() as any);
+      expect(result).toBe(true);
+    });
+
+    it('rejects agent missing required scope', async () => {
+      const auth = new MastraAgentLairAuth({ requiredScopes: ['admin'] });
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: ['read', 'write'],
+        auditUrl: '',
+        claims: validClaims(),
+      };
+
+      const result = await auth.authorizeUser(agent, mockHonoRequest() as any);
+      expect(result).toBe(false);
+    });
+
+    it('allows wildcard scope to satisfy any requirement', async () => {
+      const auth = new MastraAgentLairAuth({ requiredScopes: ['admin', 'superuser'] });
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: ['*'],
+        auditUrl: '',
+        claims: validClaims(),
+      };
+
+      const result = await auth.authorizeUser(agent, mockHonoRequest() as any);
+      expect(result).toBe(true);
+    });
+
+    it('rejects agent below minimum trust score', async () => {
+      const auth = new MastraAgentLairAuth({ minimumTrustScore: 800 });
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: [],
+        auditUrl: '',
+        claims: validClaims(),
+        trustScore: mockTrustScore({ score: 400 }),
+      };
+
+      const result = await auth.authorizeUser(agent, mockHonoRequest() as any);
+      expect(result).toBe(false);
+    });
+
+    it('allows agent meeting minimum trust score', async () => {
+      const auth = new MastraAgentLairAuth({ minimumTrustScore: 500 });
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: [],
+        auditUrl: '',
+        claims: validClaims(),
+        trustScore: mockTrustScore({ score: 750 }),
+      };
+
+      const result = await auth.authorizeUser(agent, mockHonoRequest() as any);
+      expect(result).toBe(true);
+    });
+
+    it('rejects agent below required tier', async () => {
+      const auth = new MastraAgentLairAuth({ requiredTier: 'verified' });
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: [],
+        auditUrl: '',
+        claims: validClaims(),
+        trustScore: mockTrustScore({ tier: 'trusted' }),
+      };
+
+      const result = await auth.authorizeUser(agent, mockHonoRequest() as any);
+      expect(result).toBe(false);
+    });
+
+    it('allows agent meeting required tier', async () => {
+      const auth = new MastraAgentLairAuth({ requiredTier: 'trusted' });
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: [],
+        auditUrl: '',
+        claims: validClaims(),
+        trustScore: mockTrustScore({ tier: 'trusted' }),
+      };
+
+      const result = await auth.authorizeUser(agent, mockHonoRequest() as any);
+      expect(result).toBe(true);
+    });
+
+    it('fetches trust score on demand when needed for authorization', async () => {
+      const score = mockTrustScore({ score: 800 });
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(score),
+      });
+
+      const auth = new MastraAgentLairAuth({
+        apiKey: 'al_live_test',
+        minimumTrustScore: 500,
+      });
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: [],
+        auditUrl: '',
+        claims: validClaims(),
+        // No trustScore — should be fetched on demand
+      };
+
+      const result = await auth.authorizeUser(agent, mockHonoRequest() as any);
+      expect(result).toBe(true);
+      expect(agent.trustScore).toEqual(score);
+    });
+
+    it('rejects when trust score needed but no API key', async () => {
+      const auth = new MastraAgentLairAuth({ minimumTrustScore: 500 });
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: [],
+        auditUrl: '',
+        claims: validClaims(),
+      };
+
+      const result = await auth.authorizeUser(agent, mockHonoRequest() as any);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getCurrentUser (IUserProvider)', () => {
+    it('returns user from valid Bearer token', async () => {
+      mockJwtVerify.mockResolvedValue({ payload: validClaims() });
+
+      const auth = new MastraAgentLairAuth();
+      const request = mockRequest({ Authorization: 'Bearer valid.token' });
+      const user = await auth.getCurrentUser(request);
+
+      expect(user).toEqual({
+        id: 'agent_test_123',
+        email: 'test@agentlair.dev',
+        name: 'Test Agent',
+        avatarUrl: undefined,
+      });
+    });
+
+    it('returns null when no Authorization header', async () => {
+      const auth = new MastraAgentLairAuth();
+      const user = await auth.getCurrentUser(mockRequest());
+      expect(user).toBeNull();
+    });
+
+    it('returns null for invalid token', async () => {
+      mockJwtVerify.mockRejectedValue(new Error('Invalid'));
+
+      const auth = new MastraAgentLairAuth();
+      const user = await auth.getCurrentUser(mockRequest({ Authorization: 'Bearer bad' }));
+      expect(user).toBeNull();
+    });
+
+    it('accepts case-insensitive Bearer scheme', async () => {
+      mockJwtVerify.mockResolvedValue({ payload: validClaims() });
+
+      const auth = new MastraAgentLairAuth();
+      const user = await auth.getCurrentUser(mockRequest({ Authorization: 'BEARER valid.token' }));
+      expect(user).not.toBeNull();
+    });
+
+    it('returns null when authorization fails', async () => {
+      mockJwtVerify.mockResolvedValue({ payload: validClaims() });
+
+      const auth = new MastraAgentLairAuth({ requiredScopes: ['admin'] });
+      const user = await auth.getCurrentUser(mockRequest({ Authorization: 'Bearer valid.token' }));
+      expect(user).toBeNull();
+    });
+  });
+
+  describe('getUser', () => {
+    it('returns null (JWT is stateless)', async () => {
+      const auth = new MastraAgentLairAuth();
+      const user = await auth.getUser('agent_123');
+      expect(user).toBeNull();
+    });
+  });
+
+  describe('convenience methods', () => {
+    it('hasScope returns true for matching scope', () => {
+      const auth = new MastraAgentLairAuth();
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: ['read', 'write'],
+        auditUrl: '',
+        claims: validClaims(),
+      };
+      expect(auth.hasScope(agent, 'read')).toBe(true);
+      expect(auth.hasScope(agent, 'admin')).toBe(false);
+    });
+
+    it('hasScope returns true for wildcard', () => {
+      const auth = new MastraAgentLairAuth();
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: ['*'],
+        auditUrl: '',
+        claims: validClaims(),
+      };
+      expect(auth.hasScope(agent, 'anything')).toBe(true);
+    });
+
+    it('meetsTrustTier compares tiers correctly', () => {
+      const auth = new MastraAgentLairAuth();
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: [],
+        auditUrl: '',
+        claims: validClaims(),
+        trustScore: mockTrustScore({ tier: 'trusted' }),
+      };
+
+      expect(auth.meetsTrustTier(agent, 'provisional')).toBe(true);
+      expect(auth.meetsTrustTier(agent, 'trusted')).toBe(true);
+      expect(auth.meetsTrustTier(agent, 'verified')).toBe(false);
+    });
+
+    it('meetsTrustTier returns false without trust score', () => {
+      const auth = new MastraAgentLairAuth();
+      const agent: VerifiedAgent = {
+        accountId: 'test',
+        scopes: [],
+        auditUrl: '',
+        claims: validClaims(),
+      };
+      expect(auth.meetsTrustTier(agent, 'provisional')).toBe(false);
+    });
+
+    it('getUserProfileUrl returns correct URL', () => {
+      const auth = new MastraAgentLairAuth();
+      const url = auth.getUserProfileUrl({ id: 'agent_123', name: 'Test' });
+      expect(url).toBe('https://agentlair.dev/agents/agent_123');
+    });
+  });
+
+  describe('fetchTrustScore', () => {
+    it('requires API key', async () => {
+      const auth = new MastraAgentLairAuth();
+      await expect(auth.fetchTrustScore('agent_123')).rejects.toThrow('API key required');
+    });
+
+    it('calls trust API correctly', async () => {
+      const score = mockTrustScore();
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(score),
+      });
+
+      const auth = new MastraAgentLairAuth({ apiKey: 'al_live_test' });
+      const result = await auth.fetchTrustScore('agent_123');
+
+      expect(result).toEqual(score);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://agentlair.dev/v1/trust/agent_123',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer al_live_test' }),
+        }),
+      );
+    });
+
+    it('throws on API error', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false, status: 404 });
+
+      const auth = new MastraAgentLairAuth({ apiKey: 'al_live_test' });
+      await expect(auth.fetchTrustScore('agent_404')).rejects.toThrow('HTTP 404');
+    });
+  });
+});

--- a/packages/auth-agentlair/src/provider.ts
+++ b/packages/auth-agentlair/src/provider.ts
@@ -38,26 +38,36 @@ export class MastraAgentLairAuth extends MastraAuthProvider<VerifiedAgent> imple
   private readonly baseUrl: string;
   private readonly jwks: ReturnType<typeof createRemoteJWKSet>;
   private readonly apiKey?: string;
-  private readonly audience?: string;
+  private readonly audience: string;
   private readonly issuer: string;
   private readonly fetchTrustScoreOnAuth: boolean;
   private readonly minimumTrustScore: number;
   private readonly requiredTier?: TrustScore['tier'];
   private readonly requiredScopes?: string[];
+  private readonly trustScoreTimeoutMs: number;
 
   constructor(options?: MastraAgentLairAuthOptions) {
     super({ name: options?.name ?? 'agentlair', ...options });
+
+    if (!options?.audience) {
+      throw new Error(
+        'AgentLair auth requires a configured `audience`. ' +
+          'Set it to your service URL (e.g. "https://my-service.com") to enable JWT aud claim ' +
+          'validation and prevent token reuse across services.',
+      );
+    }
 
     this.baseUrl = (options?.baseUrl ?? 'https://agentlair.dev').replace(/\/$/, '');
     const jwksUrl = options?.jwksUrl ?? `${this.baseUrl}/.well-known/jwks.json`;
     this.jwks = createRemoteJWKSet(new URL(jwksUrl));
     this.apiKey = options?.apiKey;
-    this.audience = options?.audience;
+    this.audience = options.audience;
     this.issuer = options?.issuer ?? 'https://agentlair.dev';
     this.fetchTrustScoreOnAuth = options?.fetchTrustScore ?? false;
     this.minimumTrustScore = options?.minimumTrustScore ?? 0;
     this.requiredTier = options?.requiredTier;
     this.requiredScopes = options?.requiredScopes;
+    this.trustScoreTimeoutMs = options?.trustScoreTimeoutMs ?? 5000;
 
     this.registerOptions(options);
   }
@@ -68,7 +78,7 @@ export class MastraAgentLairAuth extends MastraAuthProvider<VerifiedAgent> imple
    * Uses `jose` to fetch the signing key from AgentLair's JWKS endpoint
    * and verify the JWT signature. Returns a VerifiedAgent on success.
    */
-  async authenticateToken(token: string, _request: HonoRequest): Promise<VerifiedAgent | null> {
+  async authenticateToken(token: string, _request: HonoRequest | Request): Promise<VerifiedAgent | null> {
     try {
       const { payload } = await jwtVerify(token, this.jwks, {
         issuer: this.issuer,
@@ -129,7 +139,7 @@ export class MastraAgentLairAuth extends MastraAuthProvider<VerifiedAgent> imple
    * 2. Minimum trust score
    * 3. Required trust tier
    */
-  async authorizeUser(agent: VerifiedAgent, _request: HonoRequest): Promise<boolean> {
+  async authorizeUser(agent: VerifiedAgent, _request: HonoRequest | Request): Promise<boolean> {
     // Check required scopes
     if (this.requiredScopes?.length) {
       const agentScopes = new Set(agent.scopes);
@@ -172,10 +182,10 @@ export class MastraAgentLairAuth extends MastraAuthProvider<VerifiedAgent> imple
     if (!token) return null;
 
     try {
-      const agent = await this.authenticateToken(token, request as unknown as HonoRequest);
+      const agent = await this.authenticateToken(token, request);
       if (!agent) return null;
 
-      const allowed = await this.authorizeUser(agent, request as unknown as HonoRequest);
+      const allowed = await this.authorizeUser(agent, request);
       if (!allowed) return null;
 
       return {
@@ -200,29 +210,45 @@ export class MastraAgentLairAuth extends MastraAuthProvider<VerifiedAgent> imple
    * Get the agent's audit trail URL as their profile URL.
    */
   getUserProfileUrl(user: User): string {
-    return `https://agentlair.dev/agents/${user.id}`;
+    return `${this.baseUrl}/agents/${user.id}`;
   }
 
   /**
    * Fetch the behavioral trust score for an agent.
+   *
+   * Enforces a configurable timeout (default 5 s) so `authorizeUser` never
+   * blocks indefinitely when the trust API is slow or unreachable.
    */
   async fetchTrustScore(agentId: string): Promise<TrustScore> {
     if (!this.apiKey) {
       throw new Error('API key required for trust score lookups');
     }
 
-    const response = await fetch(`${this.baseUrl}/v1/trust/${encodeURIComponent(agentId)}`, {
-      headers: {
-        Authorization: `Bearer ${this.apiKey}`,
-        'Content-Type': 'application/json',
-      },
-    });
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.trustScoreTimeoutMs);
 
-    if (!response.ok) {
-      throw new Error(`Trust score lookup failed: HTTP ${response.status}`);
+    try {
+      const response = await fetch(`${this.baseUrl}/v1/trust/${encodeURIComponent(agentId)}`, {
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Trust score lookup failed: HTTP ${response.status}`);
+      }
+
+      return response.json() as Promise<TrustScore>;
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new Error(`Trust score lookup timed out after ${this.trustScoreTimeoutMs}ms`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
     }
-
-    return response.json() as Promise<TrustScore>;
   }
 
   // ── Convenience methods ───────────────────────────────────────────────────

--- a/packages/auth-agentlair/src/provider.ts
+++ b/packages/auth-agentlair/src/provider.ts
@@ -1,0 +1,249 @@
+import type { User, IUserProvider } from '@mastra/core/auth';
+import { MastraAuthProvider } from '@mastra/core/server';
+import type { HonoRequest } from 'hono';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+import type { AATClaims, MastraAgentLairAuthOptions, TrustScore, VerifiedAgent } from './types';
+
+const TIER_ORDER: TrustScore['tier'][] = ['untrusted', 'provisional', 'trusted', 'verified'];
+
+/**
+ * AgentLair auth provider for Mastra.
+ *
+ * Verifies agent identity using EdDSA-signed JWTs (Agent Authentication Tokens)
+ * against AgentLair's JWKS endpoint. Optionally enriches authentication with
+ * behavioral trust scores and enforces trust-based authorization.
+ *
+ * @example Basic setup
+ * ```typescript
+ * import { MastraAgentLairAuth } from '@mastra/auth-agentlair';
+ *
+ * const auth = new MastraAgentLairAuth({
+ *   audience: 'https://my-service.com',
+ * });
+ * ```
+ *
+ * @example With trust-based authorization
+ * ```typescript
+ * const auth = new MastraAgentLairAuth({
+ *   apiKey: process.env.AGENTLAIR_API_KEY,
+ *   fetchTrustScore: true,
+ *   minimumTrustScore: 500,
+ *   requiredTier: 'trusted',
+ *   requiredScopes: ['write:data'],
+ * });
+ * ```
+ */
+export class MastraAgentLairAuth extends MastraAuthProvider<VerifiedAgent> implements IUserProvider {
+  private readonly baseUrl: string;
+  private readonly jwks: ReturnType<typeof createRemoteJWKSet>;
+  private readonly apiKey?: string;
+  private readonly audience?: string;
+  private readonly issuer: string;
+  private readonly fetchTrustScoreOnAuth: boolean;
+  private readonly minimumTrustScore: number;
+  private readonly requiredTier?: TrustScore['tier'];
+  private readonly requiredScopes?: string[];
+
+  constructor(options?: MastraAgentLairAuthOptions) {
+    super({ name: options?.name ?? 'agentlair', ...options });
+
+    this.baseUrl = (options?.baseUrl ?? 'https://agentlair.dev').replace(/\/$/, '');
+    const jwksUrl = options?.jwksUrl ?? `${this.baseUrl}/.well-known/jwks.json`;
+    this.jwks = createRemoteJWKSet(new URL(jwksUrl));
+    this.apiKey = options?.apiKey;
+    this.audience = options?.audience;
+    this.issuer = options?.issuer ?? 'https://agentlair.dev';
+    this.fetchTrustScoreOnAuth = options?.fetchTrustScore ?? false;
+    this.minimumTrustScore = options?.minimumTrustScore ?? 0;
+    this.requiredTier = options?.requiredTier;
+    this.requiredScopes = options?.requiredScopes;
+
+    this.registerOptions(options);
+  }
+
+  /**
+   * Verify an EdDSA-signed Agent Authentication Token.
+   *
+   * Uses `jose` to fetch the signing key from AgentLair's JWKS endpoint
+   * and verify the JWT signature. Returns a VerifiedAgent on success.
+   */
+  async authenticateToken(token: string, _request: HonoRequest): Promise<VerifiedAgent | null> {
+    try {
+      const { payload } = await jwtVerify(token, this.jwks, {
+        issuer: this.issuer,
+        audience: this.audience,
+        algorithms: ['EdDSA'],
+      });
+
+      const claims = payload as unknown as AATClaims;
+
+      const agent: VerifiedAgent = {
+        accountId: claims.sub,
+        name: claims.al_name,
+        email: claims.al_email,
+        scopes: claims.al_scopes ?? [],
+        auditUrl: claims.al_audit_url,
+        claims,
+      };
+
+      // Optionally enrich with trust score
+      if (this.fetchTrustScoreOnAuth && this.apiKey) {
+        try {
+          agent.trustScore = await this.fetchTrustScore(claims.sub);
+        } catch {
+          // Trust score fetch failure is non-fatal
+        }
+      }
+
+      return agent;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Authorize a verified agent based on trust score, tier, and scopes.
+   *
+   * When no trust requirements are configured, all verified agents pass.
+   * Otherwise checks (in order):
+   * 1. Required scopes (agent must have all, or wildcard "*")
+   * 2. Minimum trust score
+   * 3. Required trust tier
+   */
+  async authorizeUser(agent: VerifiedAgent, _request: HonoRequest): Promise<boolean> {
+    // Check required scopes
+    if (this.requiredScopes?.length) {
+      const agentScopes = new Set(agent.scopes);
+      const hasWildcard = agentScopes.has('*');
+      for (const scope of this.requiredScopes) {
+        if (!hasWildcard && !agentScopes.has(scope)) {
+          return false;
+        }
+      }
+    }
+
+    // Check minimum trust score
+    if (this.minimumTrustScore > 0) {
+      if (!agent.trustScore) {
+        // Try to fetch if we have an API key
+        if (this.apiKey) {
+          try {
+            agent.trustScore = await this.fetchTrustScore(agent.accountId);
+          } catch {
+            return false;
+          }
+        } else {
+          return false;
+        }
+      }
+      if (agent.trustScore.score < this.minimumTrustScore) {
+        return false;
+      }
+    }
+
+    // Check required tier
+    if (this.requiredTier) {
+      if (!agent.trustScore) {
+        if (this.apiKey) {
+          try {
+            agent.trustScore = await this.fetchTrustScore(agent.accountId);
+          } catch {
+            return false;
+          }
+        } else {
+          return false;
+        }
+      }
+      const agentTierIdx = TIER_ORDER.indexOf(agent.trustScore.tier);
+      const requiredTierIdx = TIER_ORDER.indexOf(this.requiredTier);
+      if (agentTierIdx < requiredTierIdx) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Get the current user (agent) from a request.
+   * Implements IUserProvider for Mastra Studio integration.
+   */
+  async getCurrentUser(request: Request): Promise<User | null> {
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.toLowerCase().startsWith('bearer ') ? authHeader.slice(7).trim() : null;
+    if (!token) return null;
+
+    try {
+      const agent = await this.authenticateToken(token, request as unknown as HonoRequest);
+      if (!agent) return null;
+
+      const allowed = await this.authorizeUser(agent, request as unknown as HonoRequest);
+      if (!allowed) return null;
+
+      return {
+        id: agent.accountId,
+        email: agent.email,
+        name: agent.name,
+        avatarUrl: undefined,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Get user by ID. Returns null because agent identity is stateless (JWT-based).
+   */
+  async getUser(_userId: string): Promise<User | null> {
+    return null;
+  }
+
+  /**
+   * Get the agent's audit trail URL as their profile URL.
+   */
+  getUserProfileUrl(user: User): string {
+    return `https://agentlair.dev/agents/${user.id}`;
+  }
+
+  /**
+   * Fetch the behavioral trust score for an agent.
+   */
+  async fetchTrustScore(agentId: string): Promise<TrustScore> {
+    if (!this.apiKey) {
+      throw new Error('API key required for trust score lookups');
+    }
+
+    const response = await fetch(`${this.baseUrl}/v1/trust/${encodeURIComponent(agentId)}`, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Trust score lookup failed: HTTP ${response.status}`);
+    }
+
+    return response.json() as Promise<TrustScore>;
+  }
+
+  // ── Convenience methods ───────────────────────────────────────────────────
+
+  /**
+   * Check if an agent has a specific scope.
+   */
+  hasScope(agent: VerifiedAgent, scope: string): boolean {
+    return agent.scopes.includes(scope) || agent.scopes.includes('*');
+  }
+
+  /**
+   * Check if an agent meets a minimum trust tier.
+   */
+  meetsTrustTier(agent: VerifiedAgent, requiredTier: TrustScore['tier']): boolean {
+    if (!agent.trustScore) return false;
+    const agentTierIdx = TIER_ORDER.indexOf(agent.trustScore.tier);
+    const requiredTierIdx = TIER_ORDER.indexOf(requiredTier);
+    return agentTierIdx >= requiredTierIdx;
+  }
+}

--- a/packages/auth-agentlair/src/provider.ts
+++ b/packages/auth-agentlair/src/provider.ts
@@ -210,7 +210,7 @@ export class MastraAgentLairAuth extends MastraAuthProvider<VerifiedAgent> imple
    * Get the agent's audit trail URL as their profile URL.
    */
   getUserProfileUrl(user: User): string {
-    return `${this.baseUrl}/agents/${user.id}`;
+    return `${this.baseUrl}/agents/${encodeURIComponent(user.id)}`;
   }
 
   /**
@@ -231,7 +231,7 @@ export class MastraAgentLairAuth extends MastraAuthProvider<VerifiedAgent> imple
       const response = await fetch(`${this.baseUrl}/v1/trust/${encodeURIComponent(agentId)}`, {
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
+          Accept: 'application/json',
         },
         signal: controller.signal,
       });

--- a/packages/auth-agentlair/src/provider.ts
+++ b/packages/auth-agentlair/src/provider.ts
@@ -103,6 +103,24 @@ export class MastraAgentLairAuth extends MastraAuthProvider<VerifiedAgent> imple
   }
 
   /**
+   * Ensure the agent has a trust score, fetching it on-demand if needed.
+   *
+   * Returns true if the agent already has a trust score or one was
+   * successfully fetched. Returns false if no API key is configured or
+   * the fetch fails.
+   */
+  private async ensureTrustScore(agent: VerifiedAgent): Promise<boolean> {
+    if (agent.trustScore) return true;
+    if (!this.apiKey) return false;
+    try {
+      agent.trustScore = await this.fetchTrustScore(agent.accountId);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Authorize a verified agent based on trust score, tier, and scopes.
    *
    * When no trust requirements are configured, all verified agents pass.
@@ -125,37 +143,16 @@ export class MastraAgentLairAuth extends MastraAuthProvider<VerifiedAgent> imple
 
     // Check minimum trust score
     if (this.minimumTrustScore > 0) {
-      if (!agent.trustScore) {
-        // Try to fetch if we have an API key
-        if (this.apiKey) {
-          try {
-            agent.trustScore = await this.fetchTrustScore(agent.accountId);
-          } catch {
-            return false;
-          }
-        } else {
-          return false;
-        }
-      }
-      if (agent.trustScore.score < this.minimumTrustScore) {
+      if (!(await this.ensureTrustScore(agent))) return false;
+      if (agent.trustScore!.score < this.minimumTrustScore) {
         return false;
       }
     }
 
     // Check required tier
     if (this.requiredTier) {
-      if (!agent.trustScore) {
-        if (this.apiKey) {
-          try {
-            agent.trustScore = await this.fetchTrustScore(agent.accountId);
-          } catch {
-            return false;
-          }
-        } else {
-          return false;
-        }
-      }
-      const agentTierIdx = TIER_ORDER.indexOf(agent.trustScore.tier);
+      if (!(await this.ensureTrustScore(agent))) return false;
+      const agentTierIdx = TIER_ORDER.indexOf(agent.trustScore!.tier);
       const requiredTierIdx = TIER_ORDER.indexOf(this.requiredTier);
       if (agentTierIdx < requiredTierIdx) {
         return false;

--- a/packages/auth-agentlair/src/types.ts
+++ b/packages/auth-agentlair/src/types.ts
@@ -92,9 +92,17 @@ export interface MastraAgentLairAuthOptions extends MastraAuthProviderOptions<Ve
   jwksUrl?: string;
 
   /**
-   * Expected JWT audience. If set, tokens with a different `aud` are rejected.
+   * Expected JWT audience. Tokens with a different `aud` are rejected.
+   * Required — omitting this disables `aud` validation and allows tokens
+   * issued for any service to authenticate against yours.
    */
   audience?: string;
+
+  /**
+   * Timeout in milliseconds for trust score API requests.
+   * @default 5000
+   */
+  trustScoreTimeoutMs?: number;
 
   /**
    * Expected JWT issuer.

--- a/packages/auth-agentlair/src/types.ts
+++ b/packages/auth-agentlair/src/types.ts
@@ -1,0 +1,130 @@
+import type { MastraAuthProviderOptions } from '@mastra/core/server';
+
+/**
+ * AgentLair Agent Authentication Token (AAT) claims.
+ * Decoded from an EdDSA-signed JWT, verifiable via JWKS at agentlair.dev.
+ */
+export interface AATClaims {
+  /** Issuer — always "https://agentlair.dev" */
+  iss: string;
+  /** Subject — AgentLair account ID */
+  sub: string;
+  /** Audience — target service URL */
+  aud: string;
+  /** Expiration time (Unix seconds) */
+  exp: number;
+  /** Issued at (Unix seconds) */
+  iat: number;
+  /** Unique token ID */
+  jti: string;
+  /** Agent display name */
+  al_name?: string;
+  /** Agent @agentlair.dev email address */
+  al_email?: string;
+  /** Granted scopes */
+  al_scopes: string[];
+  /** Audit trail URL */
+  al_audit_url: string;
+}
+
+/**
+ * Behavioral trust score for an agent (0-1000).
+ */
+export interface TrustScore {
+  agentId: string;
+  score: number;
+  tier: 'untrusted' | 'provisional' | 'trusted' | 'verified';
+  breakdown: TrustBreakdown;
+  computedAt: string;
+  observationCount: number;
+}
+
+export interface TrustBreakdown {
+  /** Adherence to declared behavior patterns (0-250) */
+  behavioral: number;
+  /** Consistency of actions over time (0-250) */
+  consistency: number;
+  /** Quality of interactions with other agents (0-250) */
+  reputation: number;
+  /** Audit trail completeness and transparency (0-250) */
+  transparency: number;
+}
+
+/**
+ * Verified agent identity — the TUser type for the auth provider.
+ */
+export interface VerifiedAgent {
+  /** AgentLair account ID */
+  accountId: string;
+  /** Agent display name */
+  name?: string;
+  /** Agent email address */
+  email?: string;
+  /** Granted scopes */
+  scopes: string[];
+  /** Audit trail URL */
+  auditUrl: string;
+  /** Trust score (populated when fetchTrustScore is enabled) */
+  trustScore?: TrustScore;
+  /** Decoded JWT claims */
+  claims: AATClaims;
+}
+
+/**
+ * Configuration options for MastraAgentLairAuth.
+ */
+export interface MastraAgentLairAuthOptions extends MastraAuthProviderOptions<VerifiedAgent> {
+  /**
+   * AgentLair API base URL.
+   * @default "https://agentlair.dev"
+   */
+  baseUrl?: string;
+
+  /**
+   * AgentLair API key for trust score lookups (al_live_...).
+   */
+  apiKey?: string;
+
+  /**
+   * JWKS endpoint URL for fetching signing keys.
+   * @default "{baseUrl}/.well-known/jwks.json"
+   */
+  jwksUrl?: string;
+
+  /**
+   * Expected JWT audience. If set, tokens with a different `aud` are rejected.
+   */
+  audience?: string;
+
+  /**
+   * Expected JWT issuer.
+   * @default "https://agentlair.dev"
+   */
+  issuer?: string;
+
+  /**
+   * Whether to fetch trust scores during authentication.
+   * Requires `apiKey`.
+   * @default false
+   */
+  fetchTrustScore?: boolean;
+
+  /**
+   * Minimum trust score required for authorization.
+   * Set to 0 to allow all verified agents.
+   * @default 0
+   */
+  minimumTrustScore?: number;
+
+  /**
+   * Required trust tier for authorization.
+   * If set alongside minimumTrustScore, both must pass.
+   */
+  requiredTier?: TrustScore['tier'];
+
+  /**
+   * Required scopes. The agent must have ALL listed scopes
+   * (or the wildcard scope "*").
+   */
+  requiredScopes?: string[];
+}

--- a/packages/auth-agentlair/tsconfig.build.json
+++ b/packages/auth-agentlair/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+}

--- a/packages/auth-agentlair/tsconfig.json
+++ b/packages/auth-agentlair/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["./global.d.ts", "src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/__fixtures__/"]
+}

--- a/packages/auth-agentlair/tsup.config.ts
+++ b/packages/auth-agentlair/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/packages/auth-agentlair/turbo.json
+++ b/packages/auth-agentlair/turbo.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**", "!dist/docs/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "tsconfig.json", "package.json", "vitest.config.*", "!**/*.md"],
+      "outputs": []
+    }
+  }
+}

--- a/packages/auth-agentlair/vitest.config.ts
+++ b/packages/auth-agentlair/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:packages/auth-agentlair',
+    isolate: false,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

Adds `@mastra/auth-agentlair` — an auth provider for AI agent identity verification and behavioral trust scoring via [AgentLair](https://agentlair.dev).

- **Extends `MastraAuthProvider`** with EdDSA/Ed25519 JWT verification against AgentLair's JWKS endpoint (using `jose`)
- **Trust-based authorization** — behavioral trust scores (0–1000) and trust tiers (`untrusted` → `provisional` → `trusted` → `verified`) as a permission layer, alongside scope-based access control
- **Implements `IUserProvider`** for Mastra Studio integration (agent awareness in the Studio UI)
- **Full test suite** with 25+ test cases covering authentication, authorization, trust scoring, and Studio integration

### Why

AI agents need verifiable identity beyond API keys. AgentLair provides EdDSA-signed Agent Authentication Tokens (AATs) with behavioral trust scoring — enabling Mastra users to authenticate agents and gate sensitive operations by trust level, not just credentials.

This is the auth provider counterpart to the feature request in #15270.

### Package structure

Follows monorepo conventions exactly: `tsup.config.ts`, `vitest.config.ts`, `turbo.json`, `tsconfig.json`, `tsconfig.build.json`, `eslint.config.js`, `lint-staged.config.js`, changeset included.

```
packages/auth-agentlair/
├── src/
│   ├── index.ts           # Public exports
│   ├── provider.ts        # MastraAgentLairAuth (extends MastraAuthProvider)
│   ├── types.ts           # AAT claims, trust score, verified agent types
│   └── provider.test.ts   # Test suite
├── package.json           # @mastra/auth-agentlair
└── [config files]         # Matching @mastra/auth conventions
```

### Usage

```typescript
import { MastraAgentLairAuth } from '@mastra/auth-agentlair';
import { Mastra } from '@mastra/core';

const auth = new MastraAgentLairAuth({
  audience: 'https://my-service.com',
  apiKey: process.env.AGENTLAIR_API_KEY,
  fetchTrustScore: true,
  minimumTrustScore: 500,
  requiredTier: 'trusted',
});

const mastra = new Mastra({
  server: { authProvider: auth },
});
```

## Test plan

- [x] Unit tests for `authenticateToken` (valid token, invalid token, trust score fetch)
- [x] Unit tests for `authorizeUser` (scopes, trust score, trust tier, wildcard)
- [x] Unit tests for `getCurrentUser` (IUserProvider / Studio integration)
- [x] Unit tests for convenience methods (`hasScope`, `meetsTrustTier`, `fetchTrustScore`)
- [ ] Verify `pnpm --filter @mastra/auth-agentlair build:lib` succeeds in CI
- [ ] Verify `pnpm --filter @mastra/auth-agentlair test` passes in CI

Closes #15270

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR adds a new plugin that lets AI agents prove who they are using signed tokens and optionally checks a behavioral "trust" score before allowing actions. It makes agents visible in Mastra Studio and lets the server gate access by scopes and trust levels.

---

## Overview

Adds @mastra/auth-agentlair — an AgentLair-based Mastra auth provider that verifies EdDSA/Ed25519 Agent Authentication Tokens (AATs) via JWKS (using jose) and provides trust-score–based authorization alongside scope checks. Implements IUserProvider for Mastra Studio integration and follows monorepo package conventions.

### Key changes & fixes
- New exported class MastraAgentLairAuth (extends MastraAuthProvider<VerifiedAgent>, implements IUserProvider).
- Verifies AATs with jose.createRemoteJWKSet + jwtVerify (issuer/audience validation; audience is now required).
- Maps claims to VerifiedAgent (accountId/sub, name, email, scopes, auditUrl, raw claims).
- Optional trust-score enrichment via GET {baseUrl}/v1/trust/{agentId} with Bearer apiKey; TrustScore: 0–1000, tier in ['untrusted','provisional','trusted','verified'], TrustBreakdown components included.
- Authorization order: requiredScopes (supports '*') → minimumTrustScore → requiredTier (uses internal TIER_ORDER). Trust-score lookups are on-demand via ensureTrustScore() helper.
- Implements getCurrentUser (parses case-insensitive Bearer header, authenticate + authorize → Mastra User) and getUser (stateless, returns null).
- Convenience helpers: hasScope(agent, scope), meetsTrustTier(agent, tier), getUserProfileUrl(user) — profile URL now uses configured baseUrl and encodes agent IDs.

### Code review fixes (commits ee751f1 / d0ec237)
- audience is required in constructor (throws if missing) to enforce aud validation.
- fetchTrustScore uses AbortController with configurable timeout (trustScoreTimeoutMs, default 5000ms); timeouts produce clear "timed out after Nms" errors.
- getUserProfileUrl uses configured baseUrl and URL-encodes agent IDs.
- fetchTrustScore uses Accept header for GET (not Content-Type).
- Widened request parameter types (accepts HonoRequest | Request) and removed unsafe casts.
- ensureTrustScore extracted to centralize trust-score fetching and validation.

### Tests & QA
- New Vitest suite (packages/auth-agentlair/src/provider.test.ts) with extensive mocks for jose and fetch; covers constructor validation, JWT verification, JWKS wiring, scope checks (including wildcard), trust-score enrichment and error handling, tier/minimum-score gating, getCurrentUser flows, fetchTrustScore edge cases (timeouts, HTTP errors, missing API key), and convenience helpers.
- Author reports 35/35 tests passing locally; CI build/test verification pending.

### Package & tooling
- New package scaffold and config: package.json (ESM + exports map), tsup, vitest, turbo, tsconfig(s), eslint, lint-staged, changeset, README, CHANGELOG, .gitignore.
- Files added: src/provider.ts, src/types.ts, src/index.ts, src/provider.test.ts, package/tooling configs, README, CHANGELOG, .changeset entry.

### Configurable options
- baseUrl (default: https://agentlair.dev)
- jwksUrl (defaults to `${baseUrl}/.well-known/jwks.json`)
- issuer (default: https://agentlair.dev)
- audience (required)
- apiKey (required for trust-score lookups)
- fetchTrustScore (boolean)
- trustScoreTimeoutMs (default 5000)
- minimumTrustScore (number)
- requiredTier (tier string)
- requiredScopes (string[])

Closes issue #15270.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->