### PR TITLE
Pin Mastra CLI and packages to create-mastra release version during create

### DIFF
--- a/.changeset/pin-create-mastra-versions.md
+++ b/.changeset/pin-create-mastra-versions.md
@@ -1,0 +1,8 @@
+---
+'create-mastra': patch
+'mastra': patch
+---
+
+create-mastra now tells the scaffolder to use the same version number as the create package you ran, so `npm create mastra@1.2.3` gives you the CLI and matching libraries at 1.2.3.
+
+mastra no longer retries failed installs during `create` by switching to the newest published release; the first error is shown instead.

--- a/packages/cli/src/commands/create/install-pinning.test.ts
+++ b/packages/cli/src/commands/create/install-pinning.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const mockExec = vi.fn();
+  const mockChildProcess = {
+    exec: (cmd: string, opts: unknown, cb: unknown) => {
+      mockExec(cmd);
+      if (cb) (cb as (a: null, b: { stdout: string }) => void)(null, { stdout: '' });
+      return {
+        on: (event: string, callback: (code: number) => void) => {
+          if (event === 'exit') callback(0);
+        },
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+      };
+    },
+  };
+  const mockRm = vi.fn().mockResolvedValue(undefined);
+  const mockExistsSync = vi.fn().mockReturnValue(false);
+
+  return {
+    mockExec,
+    mockChildProcess,
+    mockRm,
+    mockExistsSync,
+  };
+});
+
+vi.mock('node:child_process', () => ({
+  default: mocks.mockChildProcess,
+  ...mocks.mockChildProcess,
+}));
+
+vi.mock('node:util', () => ({
+  default: {
+    promisify: () => mocks.mockExec,
+  },
+  promisify: () => mocks.mockExec,
+}));
+
+vi.mock('fs/promises', () => ({
+  default: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockResolvedValue(JSON.stringify({ scripts: {}, engines: {} })),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    rm: mocks.mockRm,
+  },
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: mocks.mockExistsSync,
+  },
+}));
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  text: vi.fn().mockResolvedValue('test-project'),
+  isCancel: vi.fn().mockReturnValue(false),
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    message: vi.fn(),
+  })),
+  outro: vi.fn(),
+  cancel: vi.fn(),
+}));
+
+vi.mock('../../services/service.deps.js', () => ({
+  DepsService: class {
+    addScriptsToPackageJson = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+describe('create install version pinning', () => {
+  const originalEnv = process.env;
+  const originalChdir = process.chdir;
+  const originalCwd = process.cwd;
+  const originalExit = process.exit;
+  const mockChdir = vi.fn();
+  const mockCwd = vi.fn().mockReturnValue('/tmp');
+  const mockExitFn = vi.fn();
+  const mockExit = mockExitFn as unknown as typeof process.exit;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.chdir = mockChdir;
+    process.cwd = mockCwd;
+    process.exit = mockExit;
+    mockChdir.mockClear();
+    mockCwd.mockClear();
+    mockExitFn.mockClear();
+    mocks.mockExec.mockReset();
+    mocks.mockExec.mockResolvedValue({ stdout: '' });
+    mocks.mockRm.mockClear();
+    mocks.mockExistsSync.mockReturnValue(false);
+    process.env.npm_config_user_agent = 'npm/10.0.0';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    process.chdir = originalChdir;
+    process.cwd = originalCwd;
+    process.exit = originalExit;
+  });
+
+  it('does not retry mastra with @latest when a pinned mastra install fails', async () => {
+    mocks.mockExec.mockImplementation(async (cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('mastra@1.3.14')) {
+        throw new Error('install failed');
+      }
+      return { stdout: '' };
+    });
+
+    const { createMastraProject } = await import('./utils');
+
+    await createMastraProject({
+      projectName: 'pinned-fail-project',
+      needsInteractive: false,
+      createVersionTag: '1.3.14',
+    });
+
+    expect(mockExitFn).toHaveBeenCalledWith(1);
+    const joined = mocks.mockExec.mock.calls.map(c => String(c[0])).join('\n');
+    expect(joined).toContain('mastra@1.3.14');
+    expect(joined).not.toMatch(/mastra@latest/);
+  });
+});

--- a/packages/cli/src/commands/create/install-pinning.test.ts
+++ b/packages/cli/src/commands/create/install-pinning.test.ts
@@ -38,7 +38,7 @@ vi.mock('node:util', () => ({
   promisify: () => mocks.mockExec,
 }));
 
-vi.mock('fs/promises', () => ({
+vi.mock('node:fs/promises', () => ({
   default: {
     mkdir: vi.fn().mockResolvedValue(undefined),
     readFile: vi.fn().mockResolvedValue(JSON.stringify({ scripts: {}, engines: {} })),
@@ -47,7 +47,7 @@ vi.mock('fs/promises', () => ({
   },
 }));
 
-vi.mock('fs', () => ({
+vi.mock('node:fs', () => ({
   default: {
     existsSync: mocks.mockExistsSync,
   },

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -138,18 +138,9 @@ async function installMastraDependency(
   try {
     await execWithTimeout(`${pm} ${installCommand} ${dependency}${versionTag}`, timeout);
   } catch (err) {
-    if (versionTag === '@latest') {
-      throw new Error(
-        `Failed to install ${dependency}@latest: ${err instanceof Error ? err.message : 'Unknown error'}`,
-      );
-    }
-    try {
-      await execWithTimeout(`${pm} ${installCommand} ${dependency}@latest`, timeout);
-    } catch (fallbackErr) {
-      throw new Error(
-        `Failed to install ${dependency} (tried ${versionTag} and @latest): ${fallbackErr instanceof Error ? fallbackErr.message : 'Unknown error'}`,
-      );
-    }
+    throw new Error(
+      `Failed to install ${dependency}${versionTag}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+    );
   }
 }
 

--- a/packages/create-mastra/package.json
+++ b/packages/create-mastra/package.json
@@ -36,7 +36,6 @@
   ],
   "dependencies": {
     "commander": "^14.0.3",
-    "execa": "^9.6.1",
     "fs-extra": "^11.3.4",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",

--- a/packages/create-mastra/rollup.config.js
+++ b/packages/create-mastra/rollup.config.js
@@ -9,7 +9,7 @@ import esbuild from 'rollup-plugin-esbuild';
 import nodeExternals from 'rollup-plugin-node-externals';
 import pkgJson from './package.json' with { type: 'json' };
 
-const external = ['commander', 'fs-extra', 'execa', 'prettier', 'posthog-node', 'pino', 'pino-pretty'];
+const external = ['commander', 'fs-extra', 'prettier', 'posthog-node', 'pino', 'pino-pretty'];
 external.forEach(pkg => {
   if (!pkgJson.dependencies[pkg]) {
     throw new Error(`${pkg} is not in the dependencies of create-mastra`);

--- a/packages/create-mastra/src/index.ts
+++ b/packages/create-mastra/src/index.ts
@@ -4,10 +4,9 @@ import { Command } from 'commander';
 import { PosthogAnalytics } from 'mastra/dist/analytics/index.js';
 import { create } from 'mastra/dist/commands/create/create.js';
 
-import { getPackageVersion, getCreateVersionTag } from './utils.js';
+import { getPackageVersion } from './utils.js';
 
 const version = await getPackageVersion();
-const createVersionTag = await getCreateVersionTag();
 
 const analytics = new PosthogAnalytics({
   apiKey: 'phc_SBLpZVAB6jmHOct9CABq3PF0Yn5FU3G2FgT4xUr2XrT',
@@ -62,7 +61,7 @@ program
         components: ['agents', 'tools', 'workflows', 'scorers'],
         llmProvider: 'openai',
         addExample: true,
-        createVersionTag,
+        createVersionTag: version,
         timeout,
         projectName,
         mcpServer: args.mcp,
@@ -78,7 +77,7 @@ program
       llmProvider: args.llm,
       addExample: args.example,
       llmApiKey: args.llmApiKey,
-      createVersionTag,
+      createVersionTag: version,
       timeout,
       projectName,
       directory: args.dir,

--- a/packages/create-mastra/src/utils.ts
+++ b/packages/create-mastra/src/utils.ts
@@ -1,6 +1,5 @@
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execa } from 'execa';
 import fsExtra from 'fs-extra';
 
 export async function getPackageVersion() {
@@ -10,21 +9,4 @@ export async function getPackageVersion() {
 
   const content = await fsExtra.readJSON(pkgJsonPath);
   return content.version;
-}
-
-export async function getCreateVersionTag(): Promise<string | undefined> {
-  try {
-    const pkgPath = fileURLToPath(import.meta.resolve('create-mastra/package.json'));
-    const json = await fsExtra.readJSON(pkgPath);
-
-    const { stdout } = await execa('npm', ['dist-tag', 'create-mastra']);
-    const tagLine = stdout.split('\n').find(distLine => distLine.endsWith(`: ${json.version}`));
-    const tag = tagLine ? tagLine.split(':')[0].trim() : 'latest';
-
-    return tag;
-  } catch {
-    console.error('We could not resolve the create-mastra version tag, falling back to "latest"');
-  }
-
-  return 'latest';
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2249,7 +2249,7 @@ importers:
     dependencies:
       '@vitest/eslint-plugin':
         specifier: ^1.6.12
-        version: 1.6.12(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.18)
+        version: 1.6.12(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.0)
       eslint-plugin-import-x:
         specifier: ^4.16.2
         version: 4.16.2(@typescript-eslint/utils@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
@@ -2274,10 +2274,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18)
+        version: 4.0.18(vitest@4.1.0)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18)
+        version: 4.0.18(vitest@4.1.0)
 
   packages/_external-types:
     dependencies:
@@ -2439,10 +2439,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18)
+        version: 4.0.18(vitest@4.1.0)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18)
+        version: 4.0.18(vitest@4.1.0)
 
   packages/_vendored/ai_v4:
     dependencies:
@@ -2476,10 +2476,10 @@ importers:
         version: 7.0.15
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18)
+        version: 4.0.18(vitest@4.1.0)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18)
+        version: 4.0.18(vitest@4.1.0)
       ai:
         specifier: ^4.3.19
         version: 4.3.19(react@19.2.5)(zod@3.25.76)
@@ -2533,10 +2533,10 @@ importers:
         version: 7.0.15
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18)
+        version: 4.0.18(vitest@4.1.0)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18)
+        version: 4.0.18(vitest@4.1.0)
       ai:
         specifier: ^5.0.154
         version: 5.0.155(zod@4.3.6)
@@ -2597,10 +2597,10 @@ importers:
         version: 7.0.15
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18)
+        version: 4.0.18(vitest@4.1.0)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18)
+        version: 4.0.18(vitest@4.1.0)
       ai:
         specifier: ^6.0.116
         version: 6.0.116(zod@3.25.76)
@@ -3185,9 +3185,6 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
-      execa:
-        specifier: ^9.6.1
-        version: 9.6.1
       fs-extra:
         specifier: ^11.3.4
         version: 11.3.4
@@ -37051,14 +37048,14 @@ snapshots:
       tinyrainbow: 3.0.3
       vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/ui@4.0.18)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@vitest/eslint-plugin@1.6.12(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.18)':
+  '@vitest/eslint-plugin@1.6.12(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.0)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.1
       '@typescript-eslint/utils': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0))(lightningcss@1.32.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/ui@4.0.18)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Problem

Running `npm create mastra@<version>` (for example an older release) could still install the Mastra CLI and dependencies using npm's `latest` tag. That broke reproducible installs and environments that disallow resolving `latest`. See https://github.com/mastra-ai/mastra/issues/15272.

## Solution

- **create-mastra** passes its own published semver from `package.json` into scaffolding instead of inferring a dist-tag via `npm dist-tag` (which could fall back to `latest`). Drops the unused `execa` dependency used only for that lookup.
- **mastra** (`create` flow): dependency install no longer retries with `@latest` after a failed pinned install.

## Verification

- `pnpm --filter ./packages/cli exec vitest run src/commands/create/install-pinning.test.ts`
- `pnpm --filter ./packages/cli typecheck`
- `pnpm --filter ./packages/create-mastra run build`

Includes a changeset for `create-mastra` and `mastra`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you tell npm to create a Mastra project with a specific version (like `npm create mastra@1.2.3`), it should use that exact version. But the old code could accidentally switch to the "latest" version if something went wrong. This PR fixes that by directly using the version number instead of looking it up, and stops retrying with "latest" when an install fails.

---

## Overview

This PR ensures that when `npm create mastra@<version>` is invoked, the scaffolded project installs the Mastra CLI and dependencies pinned to that exact version, without falling back to the `latest` npm dist-tag. This improves reproducibility and supports environments that restrict resolving the `latest` tag.

## Key Changes

**Simplified version pinning in `create-mastra`:**
- Removed the `getCreateVersionTag()` utility function that previously used `execa` to query npm dist-tags
- The `createVersionTag` is now directly sourced from `create-mastra/package.json`'s `version` field, ensuring consistency with the invoked package version
- Removed the unused `execa` dependency from `packages/create-mastra/package.json` and its Rollup external dependencies configuration

**Eliminated retry fallback in Mastra CLI create flow:**
- `installMastraDependency` in `packages/cli/src/commands/create/utils.ts` no longer retries with `@latest` when a pinned version install fails
- Installation errors now throw immediately with the original dependency and attempted version tag, improving error transparency

**Test coverage:**
- Added `packages/cli/src/commands/create/install-pinning.test.ts` with comprehensive mocking of child processes, filesystem, and prompts to verify that:
  - Installation failures with a pinned version cause the process to exit with status code 1
  - The executed command includes the pinned version (e.g., `mastra@1.3.14`)
  - No fallback commands reference `@latest`

**Release notes:**
- Added changeset documenting patch-level updates for both `create-mastra` and `mastra`

## Technical Details

The refactoring improves the create workflow by:
- Eliminating a dynamic npm query that could resolve to unexpected versions
- Reducing dependencies (removed `execa`)
- Making version pinning explicit and deterministic based on the invoked package version
- Surfacing installation errors immediately rather than masking them with fallback attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->