### PR TITLE
fix(core): remove hardcoded temperature=0 default in agent model settings

### DIFF
--- a/.changeset/fix-nested-workflow-resource-id.md
+++ b/.changeset/fix-nested-workflow-resource-id.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed nested workflow runs not inheriting `resourceId` from the parent workflow. When a workflow is invoked as a step inside a parent workflow that was created with a `resourceId`, child workflow snapshots are now correctly persisted with the parent's `resourceId`, maintaining tenant/resource association across nested workflows.

--- a/.changeset/fix-remove-hardcoded-temperature-default.md
+++ b/.changeset/fix-remove-hardcoded-temperature-default.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed agents incorrectly defaulting `temperature` to `0` when no temperature is explicitly set by the user. Previously, `agent.stream()` and `agent.generate()` always sent `temperature: 0` to the model provider, which broke models that only accept specific temperature values (e.g., Kimi K2.5 which requires `temperature: 1`). Now, when temperature is not explicitly set, the model provider's own default is used instead.

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -330,7 +330,6 @@ export function createMapResultsStep<OUTPUT = undefined>({
       inputProcessors: effectiveInputProcessors,
       outputProcessors: effectiveOutputProcessors,
       modelSettings: {
-        temperature: 0,
         ...(options.modelSettings || {}),
       },
       messageList: memoryData.messageList!,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2193,6 +2193,7 @@ export class Workflow<
   // To run a workflow use `.createRun` and then `.start` or `.resume`
   async execute({
     runId,
+    resourceId,
     inputData,
     resumeData,
     state,
@@ -2215,6 +2216,7 @@ export class Workflow<
     ...rest
   }: {
     runId?: string;
+    resourceId?: string;
     inputData: TInput;
     resumeData?: unknown;
     state: TState;
@@ -2274,7 +2276,9 @@ export class Workflow<
 
     const isTimeTravel = !!(timeTravel && timeTravel.steps.length > 0);
 
-    const run = isResume ? await this.createRun({ runId: resume.runId }) : await this.createRun({ runId });
+    const run = isResume
+      ? await this.createRun({ runId: resume.runId, resourceId })
+      : await this.createRun({ runId, resourceId });
     const nestedAbortCb = () => {
       abort();
     };


### PR DESCRIPTION
Fixes #15240

## Problem

In `packages/core/src/agent/workflows/prepare-stream/map-results-step.ts`, the `modelSettings` object was built with a hardcoded `temperature: 0` default:

```typescript
modelSettings: {
  temperature: 0,
  ...(options.modelSettings || {}),
},
```

This meant that every `agent.stream()` / `agent.generate()` call silently forced `temperature: 0` when the user did not explicitly set a temperature. This breaks models that only accept specific temperature values — for example, Moonshot's Kimi K2.5 only accepts `temperature=1` and rejects any other value with a `400 Bad Request`.

## Solution

Removed the `temperature: 0` hardcoded default so that when the user does not explicitly set a temperature, no temperature override is injected into the model settings. The user's explicit temperature (if provided via `options.modelSettings.temperature`) is still passed through correctly via the spread.

```typescript
modelSettings: {
  ...(options.modelSettings || {}),
},
```

## Testing

- No existing tests relied on the `temperature: 0` default behavior.
- Users who explicitly set `temperature` in `modelSettings` are unaffected — their value is still passed through.
- Users who do not set `temperature` will now get the model provider's own default instead of a forced `0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're at a restaurant and always tell the kitchen to cook at zero temperature, even though you never asked for that—it would break everything! This PR fixes that by letting the kitchen (model provider) use its normal cooking temperature when you don't specify one. It also makes sure that when a workflow runs another workflow inside it, both remember which restaurant (tenant) they're working for.

## Overview

This PR addresses two related issues in the core workflow and agent execution logic:

1. **Removes hardcoded temperature default** that was preventing certain models from being used (fixes #15240)
2. **Propagates resourceId to nested workflows** to preserve tenant/resource associations in snapshots (fixes #15246)

## Changes

### Temperature Default Removal

**File: `packages/core/src/agent/workflows/prepare-stream/map-results-step.ts`**

Removed the hardcoded `temperature: 0` injection from `modelSettings`. Previously, the code always added `temperature: 0` to model settings regardless of user input. Now it only includes temperature if explicitly provided by the user:

- **Before:** `modelSettings: { temperature: 0, ...(options.modelSettings || {}) }`
- **After:** `modelSettings: { ...(options.modelSettings || {}) }`

This allows models that restrict acceptable temperature ranges (e.g., Moonshot Kimi K2.5 which only accepts `temperature=1`) to use their own default values when users don't explicitly set temperature. This aligns temperature handling with other parameters like `topP` and `topK` which already follow this pattern.

### ResourceId Propagation for Nested Workflows

**File: `packages/core/src/workflows/workflow.ts`**

Updated `Workflow.execute()` to accept and forward an optional `resourceId` parameter to `createRun`, ensuring nested workflows inherit the parent workflow's `resourceId`. This preserves the tenant/resource association in workflow snapshots across nested workflow boundaries:

- Added optional `resourceId?: string` parameter to `execute()` method
- Forwards `resourceId` to `createRun()` in both resume and non-resume execution paths

### Documentation Files

**Files: `.changeset/fix-nested-workflow-resource-id.md` and `.changeset/fix-remove-hardcoded-temperature-default.md`**

Added changeset entries documenting both patch-level fixes for `@mastra/core`.

## Impact

- **User-provided temperature values** remain unchanged and are still passed through
- **Model provider defaults** now apply when users don't specify temperature, fixing compatibility with models that have restricted temperature ranges
- **Nested workflows** now maintain proper resource context in snapshots

<!-- end of auto-generated comment: release notes by coderabbit.ai -->