### PR TITLE
fix(agent-browser): initialize browser for default thread ID in thread scope

### DIFF
--- a/.changeset/fix-agent-browser-default-thread-scope.md
+++ b/.changeset/fix-agent-browser-default-thread-scope.md
@@ -3,4 +3,4 @@
 "@mastra/core": patch
 ---
 
-Fixed AgentBrowser failing to initialize when using default thread scope. Browser now correctly creates a dedicated session for the default thread ID instead of falling back to an uninitialized shared manager.
+AgentBrowser with default thread scope now initializes correctly. Previously, calling launch() followed by getPage() would throw "Browser not launched" when no explicit thread ID was provided.

--- a/.changeset/fix-agent-browser-default-thread-scope.md
+++ b/.changeset/fix-agent-browser-default-thread-scope.md
@@ -1,0 +1,6 @@
+---
+"@mastra/agent-browser": patch
+"@mastra/core": patch
+---
+
+Fixed AgentBrowser failing to initialize when using default thread scope. Browser now correctly creates a dedicated session for the default thread ID instead of falling back to an uninitialized shared manager.

--- a/browser/agent-browser/src/__tests__/thread-manager.test.ts
+++ b/browser/agent-browser/src/__tests__/thread-manager.test.ts
@@ -229,6 +229,32 @@ describe('AgentBrowserThreadManager', () => {
       expect(threadManager.hasActiveThreadManagers()).toBe(false);
     });
 
+    it('creates dedicated session for DEFAULT_THREAD_ID in thread scope', async () => {
+      const threadManager = new AgentBrowserThreadManager({
+        scope: 'thread',
+        browserConfig: { headless: true },
+      });
+
+      // Should create a session for DEFAULT_THREAD_ID without throwing
+      await threadManager.getManagerForThread();
+
+      expect(mockManager.launch).toHaveBeenCalledTimes(1);
+      expect(threadManager.hasActiveThreadManagers()).toBe(true);
+    });
+
+    it('getPageForThread works with DEFAULT_THREAD_ID in thread scope', async () => {
+      const threadManager = new AgentBrowserThreadManager({
+        scope: 'thread',
+        browserConfig: { headless: true },
+      });
+
+      // Should not throw "Browser not launched"
+      const page = await threadManager.getPageForThread();
+
+      expect(page).toBeDefined();
+      expect(mockManager.launch).toHaveBeenCalledTimes(1);
+    });
+
     it('onBrowserCreated callback is called', async () => {
       const onBrowserCreated = vi.fn();
       const threadManager = new AgentBrowserThreadManager({

--- a/browser/agent-browser/src/agent-browser.ts
+++ b/browser/agent-browser/src/agent-browser.ts
@@ -100,14 +100,14 @@ export class AgentBrowser extends MastraBrowser {
 
     // For 'thread' scope, create the thread session first
     // This ensures checkBrowserAlive() has a browser to check
-    if (scope === 'thread' && threadId !== DEFAULT_THREAD_ID && !existingSession) {
+    if (scope === 'thread' && !existingSession) {
       await this.getManagerForThread(threadId);
     }
 
     await super.ensureReady();
 
     // For 'thread' scope with existing session, just verify it's accessible
-    if (scope === 'thread' && threadId !== DEFAULT_THREAD_ID && existingSession) {
+    if (scope === 'thread' && existingSession) {
       await this.getManagerForThread(threadId);
     }
   }

--- a/packages/core/src/browser/thread-manager.ts
+++ b/packages/core/src/browser/thread-manager.ts
@@ -192,7 +192,8 @@ export abstract class ThreadManager<TManager = unknown> {
     const effectiveThreadId = threadId ?? DEFAULT_THREAD_ID;
 
     // Shared scope - always use shared manager
-    if (this.scope === 'shared' || effectiveThreadId === DEFAULT_THREAD_ID) {
+    // For thread scope, always create/use a dedicated session (even for DEFAULT_THREAD_ID)
+    if (this.scope === 'shared') {
       return this.getSharedManager();
     }
 


### PR DESCRIPTION
## Summary
Fixes #15283

## Problem
When `AgentBrowser` is used with default `scope: 'thread'` config, 
`launch()` succeeds but `getPage()` throws "Browser not launched".

Two root causes:

1. In `ThreadManager.getManagerForThread()`, `DEFAULT_THREAD_ID` was 
treated the same as `shared` scope — falling back to `getSharedManager()` 
which is just an uninitialized placeholder in thread scope.

2. In `AgentBrowser.ensureReady()`, the session creation guard 
`threadId !== DEFAULT_THREAD_ID` prevented a browser from ever being 
launched for the default thread.

## Fix
**`packages/core/src/browser/thread-manager.ts`** — Remove 
`DEFAULT_THREAD_ID` from the shared scope condition so thread scope 
always creates a dedicated session, even for the default thread.

**`browser/agent-browser/src/agent-browser.ts`** — Remove 
`threadId !== DEFAULT_THREAD_ID` guard so `ensureReady()` correctly 
creates a session for the default thread.

## Changes
- `packages/core/src/browser/thread-manager.ts` — 1 line fix
- `browser/agent-browser/src/agent-browser.ts` — 2 line fix  
- `.changeset/fix-agent-browser-default-thread-scope.md` — patch changeset

## Notes
Existing `scope: 'shared'` behavior is completely unchanged.