### PR TITLE
fix(browser): browser init with default thread scope

### DIFF
--- a/.changeset/major-steaks-wear.md
+++ b/.changeset/major-steaks-wear.md
@@ -1,0 +1,7 @@
+---
+'@mastra/agent-browser': patch
+'@mastra/stagehand': patch
+'@mastra/core': patch
+---
+
+Fixed AgentBrowser and StagehandBrowser failing to open a browser when used with the default configuration. Previously, using `new AgentBrowser()` without passing a specific thread ID would result in a "Browser not initialized" error. The browser now launches correctly out of the box without needing to set `scope: 'shared'` as a workaround. (Fixes #15283)

--- a/browser/agent-browser/src/__tests__/agent-browser.test.ts
+++ b/browser/agent-browser/src/__tests__/agent-browser.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_THREAD_ID } from '@mastra/core/browser';
 import type { BrowserConfig } from '@mastra/core/browser';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -270,6 +271,18 @@ describe('AgentBrowser', () => {
       await browser.ensureReady();
       // Should have re-launched
       expect(mockManager.launch).toHaveBeenCalledTimes(2);
+    });
+
+    it('supports the default thread after launch in thread scope', async () => {
+      browser = new AgentBrowser({ scope: 'thread' });
+
+      await browser.launch();
+
+      const result = await browser.tabs({ action: 'list' });
+
+      expect(result.success).toBe(true);
+      expect(browser['threadManager'].hasSession(DEFAULT_THREAD_ID)).toBe(true);
+      expect(mockManager.launch).toHaveBeenCalledOnce();
     });
   });
 

--- a/browser/agent-browser/src/agent-browser.ts
+++ b/browser/agent-browser/src/agent-browser.ts
@@ -100,14 +100,14 @@ export class AgentBrowser extends MastraBrowser {
 
     // For 'thread' scope, create the thread session first
     // This ensures checkBrowserAlive() has a browser to check
-    if (scope === 'thread' && threadId !== DEFAULT_THREAD_ID && !existingSession) {
+    if (scope === 'thread' && !existingSession) {
       await this.getManagerForThread(threadId);
     }
 
     await super.ensureReady();
 
     // For 'thread' scope with existing session, just verify it's accessible
-    if (scope === 'thread' && threadId !== DEFAULT_THREAD_ID && existingSession) {
+    if (scope === 'thread' && existingSession) {
       await this.getManagerForThread(threadId);
     }
   }
@@ -118,18 +118,6 @@ export class AgentBrowser extends MastraBrowser {
    */
   async getManagerForThread(threadId?: string): Promise<BrowserManager> {
     const effectiveThreadId = threadId ?? this.getCurrentThread();
-    const scope = this.threadManager.getScope();
-
-    // In 'thread' scope with no specific threadId, check for an existing manager first
-    // to avoid creating a new session unnecessarily
-    if (scope === 'thread' && (!effectiveThreadId || effectiveThreadId === DEFAULT_THREAD_ID)) {
-      const existingManager = this.threadManager.getExistingManagerForThread(effectiveThreadId);
-      if (existingManager) {
-        return existingManager;
-      }
-      // Fall through to create a session for DEFAULT_THREAD_ID
-    }
-
     return this.threadManager.getManagerForThread(effectiveThreadId);
   }
 

--- a/browser/stagehand/src/__tests__/stagehand-browser.test.ts
+++ b/browser/stagehand/src/__tests__/stagehand-browser.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_THREAD_ID } from '@mastra/core/browser';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Create mocks BEFORE vi.mock using vi.hoisted so they're available in the mock
@@ -217,6 +218,16 @@ describe('StagehandBrowser', () => {
       await browser.ensureReady();
       // Should have re-launched
       expect(mockStagehand.init).toHaveBeenCalledTimes(2);
+    });
+
+    it('supports the default thread after launch in thread scope', async () => {
+      browser = new StagehandBrowser({ scope: 'thread' });
+
+      await browser.launch();
+      // Tools call ensureReady() before act/extract/observe, which creates the session
+      await browser.ensureReady();
+
+      expect(browser['threadManager'].hasSession(DEFAULT_THREAD_ID)).toBe(true);
     });
   });
 

--- a/browser/stagehand/src/stagehand-browser.ts
+++ b/browser/stagehand/src/stagehand-browser.ts
@@ -93,7 +93,7 @@ export class StagehandBrowser extends MastraBrowser {
     // For 'thread' scope, ensure thread session exists after browser is ready
     const scope = this.getScope();
     const threadId = this.getCurrentThread();
-    if (scope === 'thread' && threadId && threadId !== DEFAULT_THREAD_ID) {
+    if (scope === 'thread') {
       // This will create the Stagehand instance for this thread if needed
       await this.getManagerForThread(threadId);
     }
@@ -404,10 +404,6 @@ export class StagehandBrowser extends MastraBrowser {
       return this.sharedManager;
     }
 
-    if (!threadId || threadId === DEFAULT_THREAD_ID) {
-      return this.sharedManager;
-    }
-
     // For 'thread' scope, get or create the thread's Stagehand instance
     let stagehand = this.threadManager.getExistingManagerForThread(threadId);
     if (!stagehand) {
@@ -446,7 +442,7 @@ export class StagehandBrowser extends MastraBrowser {
     const threadId = explicitThreadId ?? this.getCurrentThread();
 
     // For 'thread' scope, get the thread's Stagehand's active page
-    if (scope === 'thread' && threadId && threadId !== DEFAULT_THREAD_ID) {
+    if (scope === 'thread' && threadId) {
       const stagehand = this.threadManager.getExistingManagerForThread(threadId);
       if (stagehand?.context) {
         return stagehand.context.activePage() as V3Page | null;

--- a/packages/core/src/browser/browser.ts
+++ b/packages/core/src/browser/browser.ts
@@ -711,7 +711,7 @@ export abstract class MastraBrowser extends MastraBase {
     const scope = this.threadManager?.getScope();
     const threadId = this.getCurrentThread();
 
-    if (scope === 'thread' && threadId !== DEFAULT_THREAD_ID) {
+    if (scope === 'thread' && this.threadManager?.hasSession(threadId)) {
       // Only clear the specific thread's session - other threads have independent browsers
       this.threadManager!.clearSession(threadId);
       this.logger.debug?.(`Cleared browser session for thread: ${threadId}`);
@@ -719,7 +719,7 @@ export abstract class MastraBrowser extends MastraBase {
       // since other threads may still have active browsers
       this.notifyBrowserClosed(threadId);
     } else {
-      // For 'shared' scope or default thread, the shared browser is gone
+      // For 'shared' scope, the shared browser is gone
       this.sharedManager = null;
       // Also clear the shared manager in the thread manager so getManagerForThread
       // doesn't return the dead manager

--- a/packages/core/src/browser/thread-manager.ts
+++ b/packages/core/src/browser/thread-manager.ts
@@ -192,7 +192,7 @@ export abstract class ThreadManager<TManager = unknown> {
     const effectiveThreadId = threadId ?? DEFAULT_THREAD_ID;
 
     // Shared scope - always use shared manager
-    if (this.scope === 'shared' || effectiveThreadId === DEFAULT_THREAD_ID) {
+    if (this.scope === 'shared') {
       return this.getSharedManager();
     }
 


### PR DESCRIPTION
## Description

Fixes a bug where `@mastra/agent-browser` (and `@mastra/stagehand`) failed to initialize a browser when using the default `scope: 'thread'` configuration without an explicit thread ID.
The root cause was that `DEFAULT_THREAD_ID` was short-circuited to return the shared manager (an unlaunched placeholder) instead of creating a real dedicated session.

## Related Issue(s)

Fixes #15283

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

The browser can give each user their own copy (thread scope) or everyone a shared copy. When you didn't say who you were, the code gave you a placeholder shared copy that wasn't opened. This PR makes it open a real personal copy even when you don't provide a thread ID.

---

## Overview

Fixes a bug where AgentBrowser and StagehandBrowser failed to initialize in thread scope when using the default thread ID (DEFAULT_THREAD_ID) without an explicit thread ID, causing "Browser not initialized" errors. The root cause was special-case logic that redirected DEFAULT_THREAD_ID to a shared, unlaunched manager; the PR removes that special case so thread scope always creates/uses a real session. Fixes #15283.

## Changes Made

- Removed DEFAULT_THREAD_ID short-circuiting across thread-scoped code paths so the default thread gets a real session instead of the shared placeholder.
- Files updated:
  - packages/core/src/browser/thread-manager.ts — allow thread-session creation/lookup for DEFAULT_THREAD_ID unless scope === 'shared'.
  - browser/agent-browser/src/agent-browser.ts — ensureReady() and getManagerForThread() now create/verify thread managers for thread scope regardless of DEFAULT_THREAD_ID.
  - browser/stagehand/src/stagehand-browser.ts — thread-scoped initialization, getManagerForThread(), getPage(), and active-page checks no longer exclude DEFAULT_THREAD_ID.
  - packages/core/src/browser/browser.ts — handleBrowserDisconnected() uses threadManager?.hasSession(threadId) to decide per-thread cleanup rather than comparing against DEFAULT_THREAD_ID.
  - .changeset/major-steaks-wear.md — bump patch versions for @mastra/agent-browser, @mastra/stagehand, and @mastra/core and record the fix.
- Tests added:
  - browser/agent-browser/src/__tests__/agent-browser.test.ts — verifies thread-scoped AgentBrowser launches and creates a session for DEFAULT_THREAD_ID.
  - browser/stagehand/src/__tests__/stagehand-browser.test.ts — verifies StagehandBrowser with scope: 'thread' creates a session for DEFAULT_THREAD_ID.

## Impact

- User-facing: Constructing a browser with default config now initializes correctly in thread scope without requiring scope: 'shared' or an explicit thread ID.
- API: No public API/signature changes.
- Scope: Localized bug fix to thread-scoped manager/session handling; shared-scope behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->