### PR TITLE
fix(core): resolve usage/token cost on aborted streams

### DIFF
--- a/.changeset/violet-pandas-check.md
+++ b/.changeset/violet-pandas-check.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed usage/token cost data being lost when aborting a stream via AbortSignal. Previously, aborting a stream would cause the usage promise to resolve with undefined values or hang indefinitely. Now, `stream.usage` properly resolves with accumulated partial usage data (defaulting to zeros if no usage was tracked before abort). This fix applies to both direct agent streaming and network-layer (Assistant UI) streaming paths.

--- a/.changeset/violet-pandas-check.md
+++ b/.changeset/violet-pandas-check.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed usage/token cost data being lost when aborting a stream via AbortSignal. Previously, aborting a stream would cause the usage promise to resolve with undefined values or hang indefinitely. Now, `stream.usage` properly resolves with accumulated partial usage data (defaulting to zeros if no usage was tracked before abort). This fix applies to both direct agent streaming and network-layer (Assistant UI) streaming paths.
+Aborting a stream now preserves and returns accurate usage and token-cost data instead of losing it.

--- a/packages/core/src/agent/__tests__/usage-tracking.test.ts
+++ b/packages/core/src/agent/__tests__/usage-tracking.test.ts
@@ -106,6 +106,83 @@ describe('Agent usage tracking', () => {
         expect((usage as any).promptTokens).toBeUndefined();
         expect((usage as any).completionTokens).toBeUndefined();
       });
+
+      it('should expose partial usage when stream is aborted', async () => {
+        const abortController = new AbortController();
+        const totalChunks = 20;
+        const abortAfterChunks = 5;
+
+        const model = new MockLanguageModelV2({
+          doStream: async () => {
+            const allChunks = [
+              { type: 'stream-start' as const, warnings: [] },
+              {
+                type: 'response-metadata' as const,
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start' as const, id: 'text-1' },
+              ...Array.from({ length: totalChunks }, (_, i) => ({
+                type: 'text-delta' as const,
+                id: 'text-1',
+                delta: `chunk-${i + 1} `,
+              })),
+              { type: 'text-end' as const, id: 'text-1' },
+              {
+                type: 'finish' as const,
+                finishReason: 'stop' as const,
+                usage: { inputTokens: 50, outputTokens: 100, totalTokens: 150 },
+              },
+            ];
+
+            let index = 0;
+            return {
+              stream: new ReadableStream({
+                pull(controller) {
+                  if (index < allChunks.length) {
+                    const chunk = allChunks[index++]!;
+                    const textDeltaCount = index - 3;
+                    if (chunk.type === 'text-delta' && textDeltaCount === abortAfterChunks) {
+                      abortController.abort();
+                    }
+                    controller.enqueue(chunk);
+                  } else {
+                    controller.close();
+                  }
+                },
+              }),
+            };
+          },
+        });
+
+        const agent = new Agent({
+          id: 'test-abort-usage',
+          name: 'Test Abort Usage',
+          model,
+          instructions: 'You are a helpful assistant',
+        });
+
+        const stream = await agent.stream('Hello', {
+          abortSignal: abortController.signal,
+        });
+
+        try {
+          await stream.consumeStream();
+        } catch {
+          // Expected - abort may throw
+        }
+
+        const usage = await stream.usage;
+
+        expect(usage).toBeDefined();
+        expect(typeof usage.inputTokens).toBe('number');
+        expect(typeof usage.outputTokens).toBe('number');
+        expect(typeof usage.totalTokens).toBe('number');
+        expect(usage.inputTokens).toBeGreaterThanOrEqual(0);
+        expect(usage.outputTokens).toBeGreaterThanOrEqual(0);
+        expect(usage.totalTokens).toBeGreaterThanOrEqual(0);
+      });
     });
   });
 

--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -5449,6 +5449,17 @@ describe('Agent - network - abort functionality', () => {
     // Abort chunk should be emitted
     const abortEvents = chunks.filter(c => c.type === 'routing-agent-abort');
     expect(abortEvents.length).toBeGreaterThan(0);
+    expect(abortEvents[0].payload.usage).toBeDefined();
+    expect(typeof abortEvents[0].payload.usage.inputTokens).toBe('number');
+    expect(typeof abortEvents[0].payload.usage.outputTokens).toBe('number');
+    expect(typeof abortEvents[0].payload.usage.totalTokens).toBe('number');
+
+    const usage = await anStream.usage;
+    expect(typeof usage.inputTokens).toBe('number');
+    expect(typeof usage.outputTokens).toBe('number');
+    expect(typeof usage.totalTokens).toBe('number');
+    expect(typeof usage.reasoningTokens).toBe('number');
+    expect(typeof usage.cachedInputTokens).toBe('number');
   });
 
   it('should call onAbort and emit abort event when abortSignal is triggered during workflow execution', async () => {
@@ -5558,6 +5569,11 @@ describe('Agent - network - abort functionality', () => {
     expect(abortEvents.length).toBeGreaterThan(0);
     expect(abortEvents[0].payload.primitiveType).toBe('workflow');
     expect(abortEvents[0].payload.primitiveId).toBe('abort-test-workflow');
+    expect(abortEvents[0].payload.usage).toMatchObject({
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    });
   });
 
   it('should pass abortSignal to tool execute function', async () => {

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -511,6 +511,13 @@ export async function createNetworkLoop({
     primitiveId: string;
     iteration: number;
     task: string;
+    usage?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      totalTokens?: number;
+      reasoningTokens?: number;
+      cachedInputTokens?: number;
+    };
   }) {
     await onAbort?.({
       primitiveType: opts.primitiveType,
@@ -524,6 +531,7 @@ export async function createNetworkLoop({
       payload: {
         primitiveType: opts.primitiveType,
         primitiveId: opts.primitiveId,
+        ...(opts.usage && { usage: opts.usage }),
       },
     });
     return {
@@ -716,6 +724,12 @@ export async function createNetworkLoop({
 
       // Check if signal was aborted during routing LLM call
       if (abortSignal?.aborted) {
+        let abortUsage: Awaited<typeof result.usage> | undefined;
+        try {
+          abortUsage = await result.usage;
+        } catch {
+          // Usage promise may reject if stream was interrupted before any usage was tracked
+        }
         const base = await handleAbort({
           writer,
           eventType: 'routing-agent-abort',
@@ -723,6 +737,7 @@ export async function createNetworkLoop({
           primitiveId: 'routing-agent',
           iteration: iterationCount,
           task: inputData.task,
+          usage: abortUsage,
         });
         return {
           ...base,
@@ -972,8 +987,14 @@ export async function createNetworkLoop({
       }
 
       // When the sub-agent was aborted, skip saving partial results to memory
-      // and return immediately with the abort event
+      // and return immediately with the abort event (including partial usage)
       if (agentCallAborted) {
+        let abortUsage: Awaited<typeof result.usage> | undefined;
+        try {
+          abortUsage = await result.usage;
+        } catch {
+          // Usage promise may reject if stream was interrupted before any usage was tracked
+        }
         return handleAbort({
           writer,
           eventType: 'agent-execution-abort',
@@ -981,6 +1002,7 @@ export async function createNetworkLoop({
           primitiveId: inputData.primitiveId,
           iteration: inputData.iteration,
           task: inputData.task,
+          usage: abortUsage,
         });
       }
 
@@ -1299,6 +1321,12 @@ export async function createNetworkLoop({
 
       // When the workflow was cancelled due to abort, skip saving results to memory
       if (workflowCancelled && abortSignal?.aborted) {
+        let abortUsage: Awaited<typeof stream.usage> | undefined;
+        try {
+          abortUsage = await stream.usage;
+        } catch {
+          // Usage promise may reject if the workflow was interrupted before any usage was tracked
+        }
         return handleAbort({
           writer,
           eventType: 'workflow-execution-abort',
@@ -1306,6 +1334,7 @@ export async function createNetworkLoop({
           primitiveId: inputData.primitiveId,
           iteration: inputData.iteration,
           task: inputData.task,
+          usage: abortUsage,
         });
       }
 

--- a/packages/core/src/stream/MastraAgentNetworkStream.ts
+++ b/packages/core/src/stream/MastraAgentNetworkStream.ts
@@ -125,7 +125,10 @@ export class MastraAgentNetworkStream<OUTPUT = undefined> extends ReadableStream
               const innerChunk = getInnerChunk(chunk);
               if (
                 innerChunk.type === 'routing-agent-end' ||
+                innerChunk.type === 'routing-agent-abort' ||
                 innerChunk.type === 'agent-execution-end' ||
+                innerChunk.type === 'agent-execution-abort' ||
+                innerChunk.type === 'workflow-execution-abort' ||
                 innerChunk.type === 'workflow-execution-end'
               ) {
                 if (innerChunk.payload?.usage) {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -992,6 +992,59 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               self.#closeTransportIfNeeded();
               break;
 
+            case 'abort': {
+              self.#finishReason = 'abort';
+              self.#streamFinished = true;
+
+              const abortReasoningText =
+                self.#bufferedReasoning.length > 0
+                  ? self.#bufferedReasoning.map(reasoningPart => reasoningPart.payload.text).join('')
+                  : undefined;
+
+              const abortUsage = {
+                inputTokens: self.#usageCount.inputTokens ?? 0,
+                outputTokens: self.#usageCount.outputTokens ?? 0,
+                totalTokens: self.#usageCount.totalTokens ?? 0,
+                ...(self.#usageCount.reasoningTokens !== undefined && {
+                  reasoningTokens: self.#usageCount.reasoningTokens,
+                }),
+                ...(self.#usageCount.cachedInputTokens !== undefined && {
+                  cachedInputTokens: self.#usageCount.cachedInputTokens,
+                }),
+              };
+
+              self.resolvePromises({
+                text: self.#bufferedText.join(''),
+                finishReason: 'abort',
+                object: undefined,
+                usage: abortUsage,
+                warnings: self.#warnings,
+                providerMetadata: undefined,
+                response: {
+                  dbMessages: self.messageList.get.response.db(),
+                },
+                request: self.#request || {},
+                reasoning: Object.values(self.#bufferedReasoningDetails || {}),
+                reasoningText: abortReasoningText,
+                sources: self.#bufferedSources,
+                files: self.#bufferedFiles,
+                toolCalls: self.#toolCalls,
+                toolResults: self.#toolResults,
+                steps: self.#bufferedSteps,
+                totalUsage: self.#getTotalUsage(),
+                content: self.messageList.get.response.aiV5.stepContent(),
+                suspendPayload: undefined,
+                resumeSchema: undefined,
+              });
+
+              self.#closeTransportIfNeeded();
+
+              self.#emitChunk(chunk);
+              controller.enqueue(chunk);
+              self.#emitter.emit('finish');
+              controller.terminate();
+              return;
+            }
             case 'error':
               const error = getErrorFromUnknown(chunk.payload.error, {
                 fallbackMessage: 'Unknown error chunk in stream',

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -572,16 +572,19 @@ interface NetworkValidationEndPayload {
 interface RoutingAgentAbortPayload {
   primitiveType: 'routing';
   primitiveId: string;
+  usage?: LanguageModelUsage;
 }
 
 interface AgentExecutionAbortPayload {
   primitiveType: 'agent';
   primitiveId: string;
+  usage?: LanguageModelUsage;
 }
 
 interface WorkflowExecutionAbortPayload {
   primitiveType: 'workflow';
   primitiveId: string;
+  usage?: LanguageModelUsage;
 }
 
 interface ToolExecutionAbortPayload {


### PR DESCRIPTION
## Description

Fixes usage/token cost data being lost when aborting a stream via AbortSignal. Previously, aborting a stream caused the `stream.usage` promise to resolve with undefined values or hang indefinitely because the `MastraModelOutput` chunk transformer had no `case 'abort':` handler — an accidental regression from commit `453693bf9e` which removed it during an unrelated controller safety refactor.

- Added `case 'abort':` handler in `MastraModelOutput` that resolves all delayed promises (including `usage`) with accumulated partial data, defaulting to zeros if no usage was tracked before abort
- Extended `handleAbort()` in the network loop to accept and propagate usage through abort event payloads across all three abort paths: agent execution, routing agent, and workflow execution
- Updated `MastraAgentNetworkStream` to extract usage from `agent-execution-abort`, `routing-agent-abort`, and `workflow-execution-abort` events (previously only `*-end` events were handled)
- Added `usage?: LanguageModelUsage` to `AgentExecutionAbortPayload`, `RoutingAgentAbortPayload`, and `WorkflowExecutionAbortPayload` types

## Related Issue(s)

Fixes #15280

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If a streaming AI response was stopped early, the system used to forget how many tokens it had already used. This PR makes sure token usage is preserved and returned even when a stream is aborted.

## Problem

An accidental removal of the `'abort'` handler caused `stream.usage` to resolve with undefined values or hang when streams were aborted via AbortSignal, breaking token/usage accounting for interrupted streams.

## Solution

Restore and propagate partial usage on abort across the streaming pipeline:

1. Reintroduced `case 'abort'` in MastraModelOutput to finalize and resolve delayed promises (including `usage`) with accumulated partial data, defaulting to zeros if nothing was tracked.
2. Extended `handleAbort()` in the network loop to accept and include usage in abort event payloads, and added guarded reads (with try/catch) of in-flight `result.usage`/`stream.usage` on three abort paths (routing-agent, agent execution, workflow execution).
3. Updated MastraAgentNetworkStream to treat `agent-execution-abort`, `routing-agent-abort`, and `workflow-execution-abort` as usage-bearing terminal chunk types (in addition to `*-end`), invoking usage accumulation when those are seen.
4. Added `usage?: LanguageModelUsage` to `AgentExecutionAbortPayload`, `RoutingAgentAbortPayload`, and `WorkflowExecutionAbortPayload` types.

## Files changed (high level)

- packages/core/src/stream/base/output.ts — add `'abort'` chunk handling that resolves pending promises with partial usage/data.
- packages/core/src/loop/network/index.ts — read and propagate usage when aborting; extend handleAbort payload.
- packages/core/src/stream/MastraAgentNetworkStream.ts — extract usage from abort event types as terminal states.
- packages/core/src/stream/types.ts — add optional usage fields to abort payload types.
- .changeset/* — release note.
- tests — new/updated tests in packages/core/src/agent/__tests__/usage-tracking.test.ts and packages/core/src/agent/agent-network.test.ts validating usage is numeric and returned on abort.

## Impact

Fixes #15280 — ensures `stream.usage` and abort event payloads reliably contain numeric token usage on aborted streams, restoring accurate token/cost accounting for interrupted operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->