### PR TITLE
[fix] DataList adaptive height

### DIFF
--- a/.changeset/young-paws-float.md
+++ b/.changeset/young-paws-float.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed DataList to only take as much height as its content needs instead of always stretching to fill available space

--- a/packages/playground-ui/src/domains/logs/components/logs-list.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-list.tsx
@@ -201,47 +201,45 @@ export function LogsList({
     <div
       className={cn('grid h-full min-h-0 gap-4 items-start', hasSidePanel ? 'grid-cols-[1fr_1fr]' : 'grid-cols-[1fr]')}
     >
-      <div className="h-full overflow-auto">
-        <LogsDataList columns={COLUMNS} className="min-w-0">
-          <LogsDataList.Top>
-            <LogsDataList.TopCell>Date</LogsDataList.TopCell>
-            <LogsDataList.TopCell>Time</LogsDataList.TopCell>
-            <LogsDataList.TopCell>Level</LogsDataList.TopCell>
-            <LogsDataList.TopCell>Entity</LogsDataList.TopCell>
-            <LogsDataList.TopCell>Message</LogsDataList.TopCell>
-            <LogsDataList.TopCell>Data</LogsDataList.TopCell>
-          </LogsDataList.Top>
+      <LogsDataList columns={COLUMNS} className="min-w-0">
+        <LogsDataList.Top>
+          <LogsDataList.TopCell>Date</LogsDataList.TopCell>
+          <LogsDataList.TopCell>Time</LogsDataList.TopCell>
+          <LogsDataList.TopCell>Level</LogsDataList.TopCell>
+          <LogsDataList.TopCell>Entity</LogsDataList.TopCell>
+          <LogsDataList.TopCell>Message</LogsDataList.TopCell>
+          <LogsDataList.TopCell>Data</LogsDataList.TopCell>
+        </LogsDataList.Top>
 
-          {logs.length === 0 ? (
-            <LogsDataList.NoMatch message="No logs match your search" />
-          ) : (
-            logs.map(log => {
-              const id = logIdMap.get(log)!;
-              const isFeatured = id === featuredLogId;
+        {logs.length === 0 ? (
+          <LogsDataList.NoMatch message="No logs match your search" />
+        ) : (
+          logs.map(log => {
+            const id = logIdMap.get(log)!;
+            const isFeatured = id === featuredLogId;
 
-              return (
-                <LogsDataList.RowButton
-                  key={id}
-                  onClick={() => handleLogClick(log)}
-                  className={cn(isFeatured && 'bg-surface4')}
-                >
-                  <LogsDataList.DateCell timestamp={log.timestamp} />
-                  <LogsDataList.TimeCell timestamp={log.timestamp} />
-                  <LogsDataList.LevelCell level={log.level} />
-                  <LogsDataList.EntityCell entityType={log.entityType} entityName={log.entityName} />
-                  <LogsDataList.MessageCell message={log.message} />
-                  <LogsDataList.DataCell data={log.data} />
-                </LogsDataList.RowButton>
-              );
-            })
-          )}
-          <LogsDataList.NextPageLoading
-            isLoading={isFetchingNextPage}
-            hasMore={hasNextPage}
-            setEndOfListElement={setEndOfListElement}
-          />
-        </LogsDataList>
-      </div>
+            return (
+              <LogsDataList.RowButton
+                key={id}
+                onClick={() => handleLogClick(log)}
+                className={cn(isFeatured && 'bg-surface4')}
+              >
+                <LogsDataList.DateCell timestamp={log.timestamp} />
+                <LogsDataList.TimeCell timestamp={log.timestamp} />
+                <LogsDataList.LevelCell level={log.level} />
+                <LogsDataList.EntityCell entityType={log.entityType} entityName={log.entityName} />
+                <LogsDataList.MessageCell message={log.message} />
+                <LogsDataList.DataCell data={log.data} />
+              </LogsDataList.RowButton>
+            );
+          })
+        )}
+        <LogsDataList.NextPageLoading
+          isLoading={isFetchingNextPage}
+          hasMore={hasNextPage}
+          setEndOfListElement={setEndOfListElement}
+        />
+      </LogsDataList>
 
       {featuredLog && (
         <div

--- a/packages/playground-ui/src/domains/traces/components/observability-traces-list.tsx
+++ b/packages/playground-ui/src/domains/traces/components/observability-traces-list.tsx
@@ -297,66 +297,64 @@ export function ObservabilityTracesList({
     <div
       className={cn('grid h-full min-h-0 gap-4 items-start ', hasSidePanel ? 'grid-cols-[1fr_1fr]' : 'grid-cols-[1fr]')}
     >
-      <div className="h-full overflow-auto">
-        <TracesDataList columns={COLUMNS} className="min-w-0">
-          <TracesDataList.Top>
-            <TracesDataList.TopCell>ID</TracesDataList.TopCell>
-            <TracesDataList.TopCell>Date</TracesDataList.TopCell>
-            <TracesDataList.TopCell>Time</TracesDataList.TopCell>
-            <TracesDataList.TopCell>Name</TracesDataList.TopCell>
-            <TracesDataList.TopCell>Input</TracesDataList.TopCell>
-            <TracesDataList.TopCell>Entity</TracesDataList.TopCell>
-            <TracesDataList.TopCell>Status</TracesDataList.TopCell>
-          </TracesDataList.Top>
+      <TracesDataList columns={COLUMNS} className="min-w-0">
+        <TracesDataList.Top>
+          <TracesDataList.TopCell>ID</TracesDataList.TopCell>
+          <TracesDataList.TopCell>Date</TracesDataList.TopCell>
+          <TracesDataList.TopCell>Time</TracesDataList.TopCell>
+          <TracesDataList.TopCell>Name</TracesDataList.TopCell>
+          <TracesDataList.TopCell>Input</TracesDataList.TopCell>
+          <TracesDataList.TopCell>Entity</TracesDataList.TopCell>
+          <TracesDataList.TopCell>Status</TracesDataList.TopCell>
+        </TracesDataList.Top>
 
-          {traces.length === 0 ? (
-            <TracesDataList.NoMatch
-              message={filtersApplied ? 'No traces found for applied filters' : 'No traces found yet'}
-            />
-          ) : groupByThread ? (
-            (() => {
-              const { groups, ungrouped } = groupTracesByThread(traces);
-              return (
-                <>
-                  {groups.map(group => (
-                    <React.Fragment key={group.threadId}>
-                      <TracesDataList.Subheader>
-                        <TracesDataList.SubHeading className="flex gap-2">
-                          <span className="uppercase">Thread</span>
-                          {threadTitles?.[group.threadId] && <b>'{threadTitles[group.threadId]}'</b>}
-                          <b># {group.threadId}</b>
-                          <span className="text-neutral2">({group.traces.length})</span>
-                        </TracesDataList.SubHeading>
-                      </TracesDataList.Subheader>
-                      {renderTraceRows(group.traces)}
-                    </React.Fragment>
-                  ))}
-                  {ungrouped.length > 0 && (
-                    <>
-                      <TracesDataList.Subheader>
-                        <TracesDataList.SubHeading className="flex gap-2 uppercase">
-                          <span>No thread</span>
-                          <span className="text-neutral2">({ungrouped.length})</span>
-                        </TracesDataList.SubHeading>
-                      </TracesDataList.Subheader>
-                      {renderTraceRows(ungrouped)}
-                    </>
-                  )}
-                </>
-              );
-            })()
-          ) : (
-            renderTraceRows(traces)
-          )}
-          {traces.length > 0 && (
-            <TracesDataList.NextPageLoading
-              isLoading={isFetchingNextPage}
-              hasMore={hasNextPage}
-              setEndOfListElement={setEndOfListElement}
-            />
-          )}
-        </TracesDataList>
-      </div>
+        {traces.length === 0 ? (
+          <TracesDataList.NoMatch
+            message={filtersApplied ? 'No traces found for applied filters' : 'No traces found yet'}
+          />
+        ) : groupByThread ? (
+          (() => {
+            const { groups, ungrouped } = groupTracesByThread(traces);
+            return (
+              <>
+                {groups.map(group => (
+                  <React.Fragment key={group.threadId}>
+                    <TracesDataList.Subheader>
+                      <TracesDataList.SubHeading className="flex gap-2">
+                        <span className="uppercase">Thread</span>
+                        {threadTitles?.[group.threadId] && <b>'{threadTitles[group.threadId]}'</b>}
+                        <b># {group.threadId}</b>
+                        <span className="text-neutral2">({group.traces.length})</span>
+                      </TracesDataList.SubHeading>
+                    </TracesDataList.Subheader>
+                    {renderTraceRows(group.traces)}
+                  </React.Fragment>
+                ))}
+                {ungrouped.length > 0 && (
+                  <>
+                    <TracesDataList.Subheader>
+                      <TracesDataList.SubHeading className="flex gap-2 uppercase">
+                        <span>No thread</span>
+                        <span className="text-neutral2">({ungrouped.length})</span>
+                      </TracesDataList.SubHeading>
+                    </TracesDataList.Subheader>
+                    {renderTraceRows(ungrouped)}
+                  </>
+                )}
+              </>
+            );
+          })()
+        ) : (
+          renderTraceRows(traces)
+        )}
+        {traces.length > 0 && (
+          <TracesDataList.NextPageLoading
+            isLoading={isFetchingNextPage}
+            hasMore={hasNextPage}
+            setEndOfListElement={setEndOfListElement}
+          />
+        )}
+      </TracesDataList>
 
       {featuredTraceId && (
         <div

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
@@ -11,7 +11,7 @@ export function DataListRoot({ children, columns, className }: DataListRootProps
   return (
     <div
       className={cn(
-        'grid bg-surface2 border h-full border-border1 rounded-xl overflow-y-auto content-start',
+        'grid bg-surface2 border max-h-full border-border1 rounded-xl overflow-y-auto content-start',
         className,
       )}
       style={{ gridTemplateColumns: columns }}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

DataList should not spread across all available height if it's not necessary. It should take only as much space to render available rows.

before
<img width="1435" height="780" alt="CleanShot 2026-04-13 at 12 26 34" src="https://github.com/user-attachments/assets/37f94348-6f4e-480f-9917-88eb43e44392" />


after

<img width="1435" height="779" alt="CleanShot 2026-04-13 at 12 26 50" src="https://github.com/user-attachments/assets/6485b85c-b6eb-4973-a758-7ea974abd45f" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The DataList component was using too much space on the screen — it would stretch to fill all available height even when it didn't need to. This fix makes it only take up as much vertical space as its content requires, making the interface more compact and responsive.

## Changes Overview

This PR fixes the adaptive height behavior of the `DataList` component to prevent it from unnecessarily expanding to fill all available vertical space. The component now constrains itself to only use the height needed for its content.

## Key Changes

**Core DataList Fix** (`packages/playground-ui/src/ds/components/DataList/data-list-root.tsx`)
- Changed the root container from using `h-full` (full height) to `max-h-full` (maximum height constraint)
- Preserves the `overflow-y-auto` scrolling behavior while allowing the component to shrink when content is smaller than the container

**Consumer Components Updated**
- **Logs List** (`packages/playground-ui/src/domains/logs/components/logs-list.tsx`): Removed the intermediate scroll wrapper div and rendered `LogsDataList` directly, relying on the DataList component's own height management
- **Observability Traces List** (`packages/playground-ui/src/domains/traces/components/observability-traces-list.tsx`): Similarly removed the dedicated scroll container, allowing `TracesDataList` to manage its own layout

Both components retain all their original functionality including empty states, row rendering, and pagination logic.

## Release

A changeset was added for a patch release of `@mastra/playground-ui` documenting the DataList component behavior adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->