### PR TITLE
feat(ai-sdk): add agent versioning support to chat and network route handlers

### DIFF
--- a/.changeset/fresh-owls-lay.md
+++ b/.changeset/fresh-owls-lay.md
@@ -1,0 +1,22 @@
+---
+'@mastra/ai-sdk': minor
+---
+
+Added agent versioning support to chat and network route handlers. You can now pass `agentVersion` to `chatRoute()`, `handleChatStream()`, `networkRoute()`, and `handleNetworkStream()` to target a specific agent version by ID or status (draft/published). Route handlers also accept `?versionId=<id>` or `?status=draft|published` query parameters at request time, which take precedence over static configuration. Requires the Editor to be configured.
+
+```typescript
+// Static version on route config
+chatRoute({
+  path: '/chat',
+  agent: 'weatherAgent',
+  agentVersion: { status: 'published' },
+});
+
+// Programmatic version on handler
+const stream = await handleChatStream({
+  mastra,
+  agentId: 'weatherAgent',
+  agentVersion: { versionId: 'ver_abc123' },
+  params,
+});
+```

--- a/client-sdks/ai-sdk/README.md
+++ b/client-sdks/ai-sdk/README.md
@@ -158,6 +158,33 @@ export async function POST(req: Request) {
 }
 ```
 
+## Agent versioning
+
+All route handlers and standalone stream functions accept an optional `agentVersion` parameter to target a specific agent version. This requires the [Editor](https://mastra.ai/docs/editor/overview) to be configured.
+
+Pass a version ID or resolve by status:
+
+```typescript
+chatRoute({
+  path: '/chat',
+  agent: 'weatherAgent',
+  agentVersion: { status: 'published' },
+});
+```
+
+For route handlers (`chatRoute`, `networkRoute`), callers can also override the version at request time with query parameters: `?versionId=<id>` or `?status=draft|published`. Query parameters take precedence over the static `agentVersion` option.
+
+The standalone handlers (`handleChatStream`, `handleNetworkStream`) accept `agentVersion` directly:
+
+```typescript
+const stream = await handleChatStream({
+  mastra,
+  agentId: 'weatherAgent',
+  agentVersion: { versionId: 'ver_abc123' },
+  params,
+});
+```
+
 ## Manual transformation
 
 If you have a raw Mastra `stream`, you can manually transform it to AI SDK UI message parts:

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -31,9 +31,16 @@ export type ChatStreamHandlerParams<
   trigger?: 'submit-message' | 'regenerate-message';
 };
 
+/**
+ * Extracted from the second parameter of `Mastra.getAgentById` so the type
+ * stays in sync with core automatically.
+ */
+export type AgentVersionOptions = NonNullable<Parameters<Mastra['getAgentById']>[1]>;
+
 export type ChatStreamHandlerOptions<UI_MESSAGE extends SupportedUIMessage = SupportedUIMessage, OUTPUT = undefined> = {
   mastra: Mastra;
   agentId: string;
+  agentVersion?: AgentVersionOptions;
   params: ChatStreamHandlerParams<UI_MESSAGE, OUTPUT>;
   defaultOptions?: AgentExecutionOptions<OUTPUT>;
   version?: 'v5' | 'v6';
@@ -96,6 +103,7 @@ export function handleChatStream<UI_MESSAGE extends V6UIMessage = V6UIMessage, O
 export async function handleChatStream<OUTPUT = undefined>({
   mastra,
   agentId,
+  agentVersion,
   params,
   defaultOptions,
   version = 'v5',
@@ -112,7 +120,7 @@ export async function handleChatStream<OUTPUT = undefined>({
     throw new Error('runId is required when resumeData is provided');
   }
 
-  const agentObj = mastra.getAgentById(agentId);
+  const agentObj = agentVersion ? await mastra.getAgentById(agentId, agentVersion) : mastra.getAgentById(agentId);
   if (!agentObj) {
     throw new Error(`Agent ${agentId} not found`);
   }
@@ -206,6 +214,7 @@ export async function handleChatStream<OUTPUT = undefined>({
 export type chatRouteOptions<OUTPUT = undefined> = {
   defaultOptions?: AgentExecutionOptions<OUTPUT>;
   version?: 'v5' | 'v6';
+  agentVersion?: AgentVersionOptions;
 } & (
   | {
       path: `${string}:agentId${string}`;
@@ -270,6 +279,7 @@ export function chatRoute<OUTPUT = undefined>({
   agent,
   defaultOptions,
   version = 'v5',
+  agentVersion,
   sendStart = true,
   sendFinish = true,
   sendReasoning = false,
@@ -293,6 +303,26 @@ export function chatRoute<OUTPUT = undefined>({
           description: 'The ID of the agent to chat with',
           schema: {
             type: 'string',
+          },
+        },
+        {
+          name: 'versionId',
+          in: 'query',
+          required: false,
+          description: 'Specific agent version ID to use. Mutually exclusive with status.',
+          schema: {
+            type: 'string',
+          },
+        },
+        {
+          name: 'status',
+          in: 'query',
+          required: false,
+          description:
+            'Which stored config version to resolve: draft (latest) or published (active version). Mutually exclusive with versionId.',
+          schema: {
+            type: 'string',
+            enum: ['draft', 'published'],
           },
         },
       ],
@@ -416,9 +446,19 @@ export function chatRoute<OUTPUT = undefined>({
         throw new Error('Agent ID is required');
       }
 
+      // Resolve agent version from query params, falling back to static option
+      const queryVersionId = c.req.query('versionId');
+      const queryStatus = c.req.query('status') as 'draft' | 'published' | undefined;
+      const effectiveAgentVersion: AgentVersionOptions | undefined = queryVersionId
+        ? { versionId: queryVersionId }
+        : queryStatus
+          ? { status: queryStatus }
+          : agentVersion;
+
       const handlerOptions = {
         mastra,
         agentId: agentToUse,
+        agentVersion: effectiveAgentVersion,
         params: {
           ...params,
           requestContext: effectiveRequestContext,

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -448,7 +448,17 @@ export function chatRoute<OUTPUT = undefined>({
 
       // Resolve agent version from query params, falling back to static option
       const queryVersionId = c.req.query('versionId');
-      const queryStatus = c.req.query('status') as 'draft' | 'published' | undefined;
+      const rawStatus = c.req.query('status');
+
+      if (queryVersionId && rawStatus) {
+        throw new Error('Query parameters "versionId" and "status" are mutually exclusive');
+      }
+
+      if (rawStatus && rawStatus !== 'draft' && rawStatus !== 'published') {
+        throw new Error('Query parameter "status" must be "draft" or "published"');
+      }
+
+      const queryStatus = rawStatus as 'draft' | 'published' | undefined;
       const effectiveAgentVersion: AgentVersionOptions | undefined = queryVersionId
         ? { versionId: queryVersionId }
         : queryStatus

--- a/client-sdks/ai-sdk/src/index.ts
+++ b/client-sdks/ai-sdk/src/index.ts
@@ -1,5 +1,10 @@
 export { chatRoute, handleChatStream } from './chat-route';
-export type { chatRouteOptions, ChatStreamHandlerParams, ChatStreamHandlerOptions } from './chat-route';
+export type {
+  chatRouteOptions,
+  ChatStreamHandlerParams,
+  ChatStreamHandlerOptions,
+  AgentVersionOptions,
+} from './chat-route';
 export { workflowRoute, handleWorkflowStream } from './workflow-route';
 export type { WorkflowRouteOptions, WorkflowStreamHandlerParams, WorkflowStreamHandlerOptions } from './workflow-route';
 export type { WorkflowDataPart } from './transformers';

--- a/client-sdks/ai-sdk/src/network-route.ts
+++ b/client-sdks/ai-sdk/src/network-route.ts
@@ -244,6 +244,14 @@ export function networkRoute<OUTPUT = undefined>({
           description: 'Streaming AI SDK UIMessage event stream for the agent network',
           content: { 'text/plain': { schema: { type: 'string', description: 'SSE stream' } } },
         },
+        '400': {
+          description: 'Bad request - invalid input',
+          content: {
+            'application/json': {
+              schema: { type: 'object', properties: { error: { type: 'string' } } },
+            },
+          },
+        },
         '404': {
           description: 'Agent not found',
           content: {

--- a/client-sdks/ai-sdk/src/network-route.ts
+++ b/client-sdks/ai-sdk/src/network-route.ts
@@ -292,7 +292,17 @@ export function networkRoute<OUTPUT = undefined>({
 
       // Resolve agent version from query params, falling back to static option
       const queryVersionId = c.req.query('versionId');
-      const queryStatus = c.req.query('status') as 'draft' | 'published' | undefined;
+      const rawStatus = c.req.query('status');
+
+      if (queryVersionId && rawStatus) {
+        throw new Error('Query parameters "versionId" and "status" are mutually exclusive');
+      }
+
+      if (rawStatus && rawStatus !== 'draft' && rawStatus !== 'published') {
+        throw new Error('Query parameter "status" must be "draft" or "published"');
+      }
+
+      const queryStatus = rawStatus as 'draft' | 'published' | undefined;
       const effectiveAgentVersion: AgentVersionOptions | undefined = queryVersionId
         ? { versionId: queryVersionId }
         : queryStatus

--- a/client-sdks/ai-sdk/src/network-route.ts
+++ b/client-sdks/ai-sdk/src/network-route.ts
@@ -12,6 +12,7 @@ import type { AgentExecutionOptions, NetworkOptions } from '@mastra/core/agent';
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
 import { registerApiRoute } from '@mastra/core/server';
+import type { AgentVersionOptions } from './chat-route';
 import { toAISdkStream } from './convert-streams';
 import type {
   SupportedUIMessage,
@@ -35,6 +36,7 @@ export type NetworkStreamHandlerOptions<
 > = {
   mastra: Mastra;
   agentId: string;
+  agentVersion?: AgentVersionOptions;
   params: NetworkStreamHandlerParams<UI_MESSAGE, OUTPUT>;
   defaultOptions?: NetworkOptions<OUTPUT>;
   version?: 'v5' | 'v6';
@@ -85,13 +87,14 @@ export function handleNetworkStream<UI_MESSAGE extends V6UIMessage = V6UIMessage
 export async function handleNetworkStream<OUTPUT = undefined>({
   mastra,
   agentId,
+  agentVersion,
   params,
   defaultOptions,
   version = 'v5',
 }: NetworkStreamHandlerOptions<SupportedUIMessage, OUTPUT>): Promise<SupportedUIMessageStream> {
   const { messages, ...rest } = params;
 
-  const agentObj = mastra.getAgentById(agentId);
+  const agentObj = agentVersion ? await mastra.getAgentById(agentId, agentVersion) : mastra.getAgentById(agentId);
 
   if (!agentObj) {
     throw new Error(`Agent ${agentId} not found`);
@@ -138,8 +141,15 @@ export type NetworkRouteOptions<OUTPUT = undefined> =
       agent?: never;
       defaultOptions?: NetworkOptions<OUTPUT>;
       version?: 'v5' | 'v6';
+      agentVersion?: AgentVersionOptions;
     }
-  | { path: string; agent: string; defaultOptions?: NetworkOptions<OUTPUT>; version?: 'v5' | 'v6' };
+  | {
+      path: string;
+      agent: string;
+      defaultOptions?: NetworkOptions<OUTPUT>;
+      version?: 'v5' | 'v6';
+      agentVersion?: AgentVersionOptions;
+    };
 
 /**
  * Creates a network route handler for streaming agent network execution using the AI SDK-compatible format.
@@ -172,6 +182,7 @@ export function networkRoute<OUTPUT = undefined>({
   agent,
   defaultOptions,
   version = 'v5',
+  agentVersion,
 }: NetworkRouteOptions<OUTPUT>): ReturnType<typeof registerApiRoute> {
   if (!agent && !path.includes('/:agentId')) {
     throw new Error('Path must include :agentId to route to the correct agent or pass the agent explicitly');
@@ -190,6 +201,21 @@ export function networkRoute<OUTPUT = undefined>({
           required: true,
           description: 'The ID of the routing agent to execute as a network',
           schema: { type: 'string' },
+        },
+        {
+          name: 'versionId',
+          in: 'query',
+          required: false,
+          description: 'Specific agent version ID to use. Mutually exclusive with status.',
+          schema: { type: 'string' },
+        },
+        {
+          name: 'status',
+          in: 'query',
+          required: false,
+          description:
+            'Which stored config version to resolve: draft (latest) or published (active version). Mutually exclusive with versionId.',
+          schema: { type: 'string', enum: ['draft', 'published'] },
         },
       ],
       requestBody: {
@@ -264,9 +290,19 @@ export function networkRoute<OUTPUT = undefined>({
         throw new Error('Agent ID is required');
       }
 
+      // Resolve agent version from query params, falling back to static option
+      const queryVersionId = c.req.query('versionId');
+      const queryStatus = c.req.query('status') as 'draft' | 'published' | undefined;
+      const effectiveAgentVersion: AgentVersionOptions | undefined = queryVersionId
+        ? { versionId: queryVersionId }
+        : queryStatus
+          ? { status: queryStatus }
+          : agentVersion;
+
       const handlerOptions = {
         mastra,
         agentId: agentToUse,
+        agentVersion: effectiveAgentVersion,
         params: {
           ...params,
           requestContext: effectiveRequestContext,

--- a/docs/src/content/en/reference/ai-sdk/chat-route.mdx
+++ b/docs/src/content/en/reference/ai-sdk/chat-route.mdx
@@ -87,6 +87,13 @@ export const mastra = new Mastra({
     isOptional: true,
   },
   {
+    name: 'agentVersion',
+    type: "{ versionId: string } | { status?: 'draft' | 'published' }",
+    description:
+      "Selects a specific agent version. Pass `{ versionId: '<id>' }` to target an exact version, or `{ status: 'draft' }` / `{ status: 'published' }` to resolve by status. When the route is called, query parameters `?versionId=<id>` or `?status=draft|published` take precedence over this static value. Requires the [Editor](/docs/editor/overview) to be configured.",
+    isOptional: true,
+  },
+  {
     name: 'defaultOptions',
     type: 'AgentExecutionOptions',
     description:

--- a/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
@@ -63,6 +63,13 @@ export async function POST(req: Request) {
     isOptional: false,
   },
   {
+    name: 'agentVersion',
+    type: "{ versionId: string } | { status?: 'draft' | 'published' }",
+    description:
+      "Selects a specific agent version. Pass `{ versionId: '<id>' }` to target an exact version, or `{ status: 'draft' }` / `{ status: 'published' }` to resolve by status. Requires the [Editor](/docs/editor/overview) to be configured.",
+    isOptional: true,
+  },
+  {
     name: 'params',
     type: 'ChatStreamHandlerParams',
     description: 'Parameters for the chat stream, including messages and optional resume data.',

--- a/docs/src/content/en/reference/ai-sdk/handle-network-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-network-stream.mdx
@@ -68,6 +68,13 @@ export async function POST(req: Request) {
     isOptional: false,
   },
   {
+    name: 'agentVersion',
+    type: "{ versionId: string } | { status?: 'draft' | 'published' }",
+    description:
+      "Selects a specific agent version. Pass `{ versionId: '<id>' }` to target an exact version, or `{ status: 'draft' }` / `{ status: 'published' }` to resolve by status. Requires the [Editor](/docs/editor/overview) to be configured.",
+    isOptional: true,
+  },
+  {
     name: 'params',
     type: 'NetworkStreamHandlerParams',
     description:

--- a/docs/src/content/en/reference/ai-sdk/network-route.mdx
+++ b/docs/src/content/en/reference/ai-sdk/network-route.mdx
@@ -87,6 +87,13 @@ export const mastra = new Mastra({
     isOptional: true,
   },
   {
+    name: 'agentVersion',
+    type: "{ versionId: string } | { status?: 'draft' | 'published' }",
+    description:
+      "Selects a specific agent version. Pass `{ versionId: '<id>' }` to target an exact version, or `{ status: 'draft' }` / `{ status: 'published' }` to resolve by status. When the route is called, query parameters `?versionId=<id>` or `?status=draft|published` take precedence over this static value. Requires the [Editor](/docs/editor/overview) to be configured.",
+    isOptional: true,
+  },
+  {
     name: 'defaultOptions',
     type: 'AgentExecutionOptions',
     description:


### PR DESCRIPTION
Adds an `agentVersion` parameter to `chatRoute()`, `handleChatStream()`, `networkRoute()`, and `handleNetworkStream()` so you can target a specific agent version by ID or status.

```typescript
// Static on route config
chatRoute({
  path: '/chat',
  agent: 'weatherAgent',
  agentVersion: { status: 'published' },
})

// Programmatic on handler
const stream = await handleChatStream({
  mastra,
  agentId: 'weatherAgent',
  agentVersion: { versionId: 'ver_abc123' },
  params,
})
```

Route handlers also support `?versionId=<id>` or `?status=draft|published` query parameters at request time, which take precedence over the static config. Requires the Editor to be configured.

The `AgentVersionOptions` type is derived from `Mastra['getAgentById']`'s parameter so it stays in sync with core automatically.

Reference docs and README updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

This PR lets you pick which version of an AI agent to use (e.g., a specific version ID or draft vs published). You can choose it when registering routes, when calling handlers, or by adding query parameters to requests.

## Overview

Adds agent versioning support to the AI SDK's chat and network route handlers and standalone stream handlers. Introduces an optional agentVersion parameter (accepting { versionId } or { status: 'draft' | 'published' }) to chatRoute, handleChatStream, networkRoute, and handleNetworkStream. Route query params ?versionId=<id> and ?status=draft|published override static configuration. The Editor must be configured for this feature.

## Key Changes

- New exported type
  - AgentVersionOptions — derived from NonNullable<Parameters<Mastra['getAgentById']>[1]> so it stays in sync with core.

- Route handlers
  - chatRoute and networkRoute now accept a static agentVersion option and document query params versionId and status.
  - Request-time handling:
    - versionId and status are mutually exclusive (both present => 400).
    - status validated to be draft or published (invalid => 400).
    - effectiveAgentVersion computed with precedence: query params (versionId → status) > static agentVersion.
  - networkRoute OpenAPI now advertises a 400 response for invalid version query input (aligned with chatRoute).

- Stream handlers
  - handleChatStream and handleNetworkStream accept agentVersion and call mastra.getAgentById(agentId, agentVersion) when provided.

- Docs & README
  - Added "Agent versioning" docs and updated reference pages for chatRoute, networkRoute, handleChatStream, and handleNetworkStream including examples and precedence rules.

## Implementation Notes

- agentVersion is typed to match Mastra.getAgentById parameters to avoid drift.
- Query parameters take precedence over static config and are validated to avoid ambiguity.
- Feature requires the Mastra Editor to be configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->