### PR TITLE
chore: Update Mastra Cloud references

### DIFF
--- a/.changeset/curly-bears-lead.md
+++ b/.changeset/curly-bears-lead.md
@@ -1,0 +1,7 @@
+---
+'@mastra/observability': patch
+'@mastra/core': patch
+'mastra': patch
+---
+
+Update references to "Mastra Cloud" to "Mastra platform"

--- a/.claude/skills/mastra-smoke-test/references/architecture.md
+++ b/.claude/skills/mastra-smoke-test/references/architecture.md
@@ -5,7 +5,7 @@ For detailed internal architecture documentation, see the Notion page:
 
 ## High-Level Summary
 
-When you deploy a Studio or Server to Mastra Cloud:
+When you deploy a Studio or Server to Mastra platform:
 
 1. **Deploy** → CLI sends your project to platform services
 2. **Token** → Platform signs a JWT for your deployment

--- a/.claude/skills/mastra-smoke-test/references/tests/setup.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/setup.md
@@ -15,7 +15,7 @@ One project can target multiple environments using separate config files:
 | Production  | `.mastra-project.json`         | `https://platform.mastra.ai`         | `*.studio.mastra.cloud`         |
 
 - **Local** = Running your Mastra project with `pnpm dev` (no cloud deploy)
-- **Staging/Production** = Deploying to Mastra Cloud
+- **Staging/Production** = Deploying to Mastra platform
 
 ### Setting Up Multi-Environment
 

--- a/docs/src/content/en/docs/agents/adding-voice.mdx
+++ b/docs/src/content/en/docs/agents/adding-voice.mdx
@@ -362,7 +362,7 @@ Mastra supports multiple voice providers for text-to-speech (TTS) and speech-to-
 
 ## Next steps
 
-- [Voice API Reference](/reference/voice/mastra-voice) - Detailed API documentation for voice capabilities
-- [Text to Speech Examples](https://github.com/mastra-ai/voice-examples/tree/main/text-to-speech) - Interactive story generator and other TTS implementations
-- [Speech to Text Examples](https://github.com/mastra-ai/voice-examples/tree/main/speech-to-text) - Voice memo app and other STT implementations
-- [Speech to Speech Examples](https://github.com/mastra-ai/voice-examples/tree/main/speech-to-speech) - Real-time voice conversation with call analysis
+- [Voice API Reference](/reference/voice/mastra-voice): Detailed API documentation for voice capabilities
+- [Text to Speech Examples](https://github.com/mastra-ai/voice-examples/tree/main/text-to-speech): Interactive story generator and other TTS implementations
+- [Speech to Text Examples](https://github.com/mastra-ai/voice-examples/tree/main/speech-to-text): Voice memo app and other STT implementations
+- [Speech to Speech Examples](https://github.com/mastra-ai/voice-examples/tree/main/speech-to-speech): Real-time voice conversation with call analysis

--- a/docs/src/content/en/docs/deployment/mastra-server.mdx
+++ b/docs/src/content/en/docs/deployment/mastra-server.mdx
@@ -135,7 +135,7 @@ NODE_OPTIONS="--max-old-space-size=4096" mastra build
 
 ## Related
 
-- [Server Overview](/docs/server/mastra-server) - Configure server behavior, middleware, and authentication
-- [Server Adapters](/docs/server/server-adapters) - Use Express or Hono instead of `mastra build`
-- [Custom API Routes](/docs/server/custom-api-routes) - Add custom HTTP endpoints
-- [Configuration Reference](/reference/configuration) - Full configuration options
+- [Server Overview](/docs/server/mastra-server): Configure server behavior, middleware, and authentication
+- [Server Adapters](/docs/server/server-adapters): Use Express or Hono instead of `mastra build`
+- [Custom API Routes](/docs/server/custom-api-routes): Add custom HTTP endpoints
+- [Configuration Reference](/reference/configuration): Full configuration options

--- a/docs/src/content/en/docs/deployment/monorepo.mdx
+++ b/docs/src/content/en/docs/deployment/monorepo.mdx
@@ -143,6 +143,6 @@ If you see type errors from uncompiled workspace packages, either:
 
 ## Related
 
-- [Deploy a Mastra Server](/docs/deployment/mastra-server) - Core build and deployment guide
-- [Configuration Reference](/reference/configuration) - `bundler.transpilePackages` and other options
-- [CLI Reference](/reference/cli/mastra) - Build command flags
+- [Deploy a Mastra Server](/docs/deployment/mastra-server): Core build and deployment guide
+- [Configuration Reference](/reference/configuration): `bundler.transpilePackages` and other options
+- [CLI Reference](/reference/cli/mastra): Build command flags

--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -525,5 +525,5 @@ console.log('Reason:', result.reason)
 
 **Examples and Resources:**
 
-- [createScorer API Reference](/reference/evals/create-scorer) - Complete technical documentation
-- [Built-in Scorers Source Code](https://github.com/mastra-ai/mastra/tree/main/packages/evals/src/scorers) - Real implementations for reference
+- [createScorer API Reference](/reference/evals/create-scorer): Complete technical documentation
+- [Built-in Scorers Source Code](https://github.com/mastra-ai/mastra/tree/main/packages/evals/src/scorers): Real implementations for reference

--- a/docs/src/content/en/docs/mastra-platform/overview.mdx
+++ b/docs/src/content/en/docs/mastra-platform/overview.mdx
@@ -8,7 +8,7 @@ import StepItem from "@site/src/components/StepItem";
 
 # Mastra platform
 
-The Mastra platform provides two products for deploying and managing AI applications built with the Mastra framework:
+The [Mastra platform](https://projects.mastra.ai) provides two products for deploying and managing AI applications built with the Mastra framework:
 
 - **Studio**: A hosted visual environment for testing agents, running workflows, and inspecting traces
 - **Server**: A production deployment target that runs your Mastra application as an API server

--- a/docs/src/content/en/docs/memory/memory-processors.mdx
+++ b/docs/src/content/en/docs/memory/memory-processors.mdx
@@ -318,8 +318,8 @@ Both scenarios are safe - guardrails prevent inappropriate content from being pe
 
 ## Related documentation
 
-- [Processors](/docs/agents/processors) - General processor concepts and custom processor creation
-- [Guardrails](/docs/agents/guardrails) - Security and validation processors
-- [Memory Overview](/docs/memory/overview) - Memory types and configuration
+- [Processors](/docs/agents/processors): General processor concepts and custom processor creation
+- [Guardrails](/docs/agents/guardrails): Security and validation processors
+- [Memory Overview](/docs/memory/overview): Memory types and configuration
 
 When creating custom processors avoid mutating the input `messages` array or its objects directly.

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -97,8 +97,8 @@ Threads and messages are created automatically when you call `agent.generate()` 
 
 You can use this history in two ways:
 
-- **Automatic inclusion** - Mastra automatically fetches and includes recent messages in the context window. By default, it includes the last 10 messages, keeping agents grounded in the conversation. You can adjust this number with `lastMessages`, but in most cases you don't need to think about it.
-- [**Manual querying**](#querying) - For more control, use the `recall()` function to query threads and messages directly. This lets you choose exactly which memories are included in the context window, or fetch messages to render conversation history in your UI.
+- **Automatic inclusion**: Mastra automatically fetches and includes recent messages in the context window. By default, it includes the last 10 messages, keeping agents grounded in the conversation. You can adjust this number with `lastMessages`, but in most cases you don't need to think about it.
+- [**Manual querying**](#querying): For more control, use the `recall()` function to query threads and messages directly. This lets you choose exactly which memories are included in the context window, or fetch messages to render conversation history in your UI.
 
 :::tip
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -170,7 +170,7 @@ With retrieval mode enabled, OM:
 - Keeps range metadata visible in the agent's context so the agent knows which observations map to which messages
 - Registers a `recall` tool the agent can call to:
   - Page through the raw messages behind any observation group range
-  - Search by semantic similarity (`mode: "search"` with a `query` string) — requires `vector: true`
+  - Search by semantic similarity (`mode: "search"` with a `query` string); requires `vector: true`
   - List all threads (`mode: "threads"`), browse other threads (`threadId`), and search across all threads (default `scope: 'resource'`)
   - When `scope: 'thread'`: restrict browsing and search to the current thread only
 

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -420,4 +420,4 @@ const response = await agent.generate('What do you know about me?', {
 
 - [Working memory with template](https://github.com/mastra-ai/mastra/tree/main/examples/memory-with-template)
 - [Working memory with schema](https://github.com/mastra-ai/mastra/tree/main/examples/memory-with-schema)
-- [Per-resource working memory](https://github.com/mastra-ai/mastra/tree/main/examples/memory-per-resource-example) - Complete example showing resource-scoped memory persistence
+- [Per-resource working memory](https://github.com/mastra-ai/mastra/tree/main/examples/memory-per-resource-example): Complete example showing resource-scoped memory persistence

--- a/docs/src/content/en/docs/observability/overview.mdx
+++ b/docs/src/content/en/docs/observability/overview.mdx
@@ -70,7 +70,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends observability data to Mastra platform (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/docs/src/content/en/docs/observability/tracing/bridges/otel.mdx
+++ b/docs/src/content/en/docs/observability/tracing/bridges/otel.mdx
@@ -201,5 +201,5 @@ If traces aren't displaying or connecting as expected:
 ## Related
 
 - [Tracing Overview](/docs/observability/tracing/overview)
-- [OpenTelemetry Exporter](/docs/observability/tracing/exporters/otel) - For sending traces to OTEL backends
-- [OtelBridge Reference](/reference/observability/tracing/bridges/otel) - API documentation
+- [OpenTelemetry Exporter](/docs/observability/tracing/exporters/otel): For sending traces to OTEL backends
+- [OtelBridge Reference](/reference/observability/tracing/bridges/otel): API documentation

--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -66,7 +66,7 @@ MASTRA_PROJECT_ID=<your-project-id>
 
 Tokens created with `mastra auth tokens create` are organization-scoped, so `MASTRA_PROJECT_ID` is required.
 
-If you use a project-scoped token from Mastra Cloud instead, `CloudExporter` can route without `projectId`, but setting it explicitly is still supported.
+If you use a project-scoped token from the Mastra platform instead, `CloudExporter` can route without `projectId`, but setting it explicitly is still supported.
 
 Add both values to your environment:
 
@@ -137,7 +137,7 @@ If you prefer, rely entirely on environment variables:
 new CloudExporter()
 ```
 
-With `MASTRA_CLOUD_ACCESS_TOKEN` and `MASTRA_PROJECT_ID` set, `CloudExporter` automatically sends data to the correct Mastra Cloud project.
+With `MASTRA_CLOUD_ACCESS_TOKEN` and `MASTRA_PROJECT_ID` set, `CloudExporter` automatically sends data to the correct Mastra platform project.
 
 :::note
 
@@ -186,9 +186,9 @@ new CloudExporter({
 })
 ```
 
-## Viewing data in Mastra Cloud
+## Viewing data in Mastra Studio
 
-After you enable `CloudExporter`, open your project in [Mastra Cloud](https://cloud.mastra.ai) to inspect the exported data.
+After you enable `CloudExporter`, open your project in [Mastra Studio](https://projects.mastra.ai) to inspect the exported data.
 
 - Open your project and select **Open Studio**.
 - In Studio, go to **Traces** to inspect agent and workflow traces.
@@ -200,7 +200,7 @@ After you enable `CloudExporter`, open your project in [Mastra Cloud](https://cl
 If you use a project-scoped token, open the project that issued the token. If you use an organization-scoped token, open the project named by `MASTRA_PROJECT_ID`.
 :::
 
-When you deploy with Mastra Cloud, set **Deployment → Service Name** to a stable value and keep it aligned with the `serviceName` in your observability config. This makes traces easier to filter in Studio through **Deployments → Service Name** when multiple services or deployments send data to the same project.
+When you deploy with Mastra Studio, set **Deployment → Service Name** to a stable value and keep it aligned with the `serviceName` in your observability config. This makes traces easier to filter in Studio through **Deployments → Service Name** when multiple services or deployments send data to the same project.
 
 ## Performance
 
@@ -215,7 +215,7 @@ CloudExporter uses batching to optimize network usage. Events are buffered and s
 - Events are batched up to `maxBatchSize` (default: 1000).
 - Batches are sent when full or after `maxBatchWaitMs` (default: 5 seconds).
 - Failed batches are retried with exponential backoff.
-- The exporter degrades gracefully if Mastra Cloud is unreachable.
+- The exporter degrades gracefully if Mastra Studio is unreachable.
 
 ## Related
 

--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -23,7 +23,7 @@ mastra auth tokens create exporter-token
 
 This command prints a token secret that you can use as `MASTRA_CLOUD_ACCESS_TOKEN`.
 
-If you already have a Mastra Cloud access token, copy the **Observability** value from Mastra Cloud instead. You can find it in either of these places:
+If you already have an access token, copy the **Observability** value from the Mastra platform instead. You can find it in either of these places:
 
 - On the **Projects** page, open the project list and find the **Observability** row on the project card.
 - On the project **Overview** page, find the **Observability** row directly below the deployment URL.

--- a/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
@@ -68,7 +68,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Studio
-          new CloudExporter(), // Sends observability data to Mastra platform (requires MASTRA_CLOUD_ACCESS_TOKEN)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (requires MASTRA_CLOUD_ACCESS_TOKEN)
         ],
         spanOutputProcessors: [new SensitiveDataFilter()],
       },

--- a/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
@@ -212,5 +212,5 @@ new DefaultExporter({
 
 - [Tracing Overview](/docs/observability/tracing/overview)
 - [CloudExporter](/docs/observability/tracing/exporters/cloud)
-- [Composite Storage](/reference/storage/composite) - Combine multiple storage providers
+- [Composite Storage](/reference/storage/composite): Combine multiple storage providers
 - [Storage Configuration](/docs/memory/storage)

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -39,7 +39,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Studio
-          new CloudExporter(), // Sends observability data to Mastra platform (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys
@@ -60,7 +60,7 @@ This configuration includes:
 - **Sampling**: `"always"` by default (100% of traces)
 - **Exporters**:
   - `DefaultExporter` - Persists traces to your configured storage for Studio
-  - `CloudExporter` - Sends observability data to Mastra platform (requires `MASTRA_CLOUD_ACCESS_TOKEN`)
+  - `CloudExporter` - Sends observability data to hosted Mastra Studio (requires `MASTRA_CLOUD_ACCESS_TOKEN`)
 - **Span Output Processors**: `SensitiveDataFilter` - Redacts sensitive fields
 
 ## Exporters
@@ -72,7 +72,7 @@ Exporters determine where your trace data is sent and how it's stored. They inte
 Mastra provides two built-in exporters:
 
 - **[Default](/docs/observability/tracing/exporters/default)** - Persists traces to local storage for viewing in Studio
-- **[Cloud](/docs/observability/tracing/exporters/cloud)** - Sends observability data to Mastra platform for production monitoring and collaboration
+- **[Cloud](/docs/observability/tracing/exporters/cloud)** - Sends observability data to hosted Mastra Studio for production monitoring and collaboration
 
 ### External Exporters
 

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -279,9 +279,9 @@ export const mastra = new Mastra({
 
 ### Common Configuration Patterns & Troubleshooting
 
-#### Maintaining Studio and Cloud Access
+#### Maintaining Studio access
 
-When adding external exporters, include `DefaultExporter` and `CloudExporter` to maintain access to Studio and Mastra Cloud:
+When adding external exporters, include `DefaultExporter` and `CloudExporter` to maintain access to Studio:
 
 ```ts title="src/mastra/index.ts"
 import {
@@ -316,7 +316,7 @@ This configuration sends traces to all three destinations simultaneously:
 
 - **Arize Phoenix/AX** for external observability
 - **DefaultExporter** for Studio
-- **CloudExporter** for Mastra Cloud dashboard
+- **CloudExporter** for hosted Studio dashboard
 
 :::info
 
@@ -1147,27 +1147,27 @@ Mastra automatically creates spans for:
 
 ### Reference Documentation
 
-- [Configuration API](/reference/observability/tracing/configuration) - ObservabilityConfig details
-- [Tracing Classes](/reference/observability/tracing/instances) - Core classes and methods
-- [Span Interfaces](/reference/observability/tracing/spans) - Span types and lifecycle
-- [Type Definitions](/reference/observability/tracing/interfaces) - Complete interface reference
-- [Span filtering](/reference/observability/tracing/span-filtering) - Filtering behavior, span types, and examples
+- [Configuration API](/reference/observability/tracing/configuration): ObservabilityConfig details
+- [Tracing Classes](/reference/observability/tracing/instances): Core classes and methods
+- [Span Interfaces](/reference/observability/tracing/spans): Span types and lifecycle
+- [Type Definitions](/reference/observability/tracing/interfaces): Complete interface reference
+- [Span filtering](/reference/observability/tracing/span-filtering): Filtering behavior, span types, and examples
 
 ### Exporters
 
-- [DefaultExporter](/reference/observability/tracing/exporters/default-exporter) - Storage persistence
-- [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter) - Mastra Cloud integration
-- [ConsoleExporter](/reference/observability/tracing/exporters/console-exporter) - Debug output
-- [Arize](/reference/observability/tracing/exporters/arize) - Arize Phoenix and Arize AX integration
-- [Braintrust](/reference/observability/tracing/exporters/braintrust) - Braintrust integration
-- [Langfuse](/reference/observability/tracing/exporters/langfuse) - Langfuse integration
-- [MLflow](/docs/observability/tracing/exporters/otel#mlflow) - MLflow OTLP endpoint setup
-- [OpenTelemetry](/reference/observability/tracing/exporters/otel) - OTEL-compatible platforms
+- [DefaultExporter](/reference/observability/tracing/exporters/default-exporter): Storage persistence
+- [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter): Mastra platform integration
+- [ConsoleExporter](/reference/observability/tracing/exporters/console-exporter): Debug output
+- [Arize](/reference/observability/tracing/exporters/arize): Arize Phoenix and Arize AX integration
+- [Braintrust](/reference/observability/tracing/exporters/braintrust): Braintrust integration
+- [Langfuse](/reference/observability/tracing/exporters/langfuse): Langfuse integration
+- [MLflow](/docs/observability/tracing/exporters/otel#mlflow): MLflow OTLP endpoint setup
+- [OpenTelemetry](/reference/observability/tracing/exporters/otel): OTEL-compatible platforms
 
 ### Bridges
 
-- [OpenTelemetry Bridge](/reference/observability/tracing/bridges/otel) - OTEL context integration
+- [OpenTelemetry Bridge](/reference/observability/tracing/bridges/otel): OTEL context integration
 
 ### Processors
 
-- [Sensitive Data Filter](/docs/observability/tracing/processors/sensitive-data-filter) - Data redaction
+- [Sensitive Data Filter](/docs/observability/tracing/processors/sensitive-data-filter): Data redaction

--- a/docs/src/content/en/docs/server/custom-adapters.mdx
+++ b/docs/src/content/en/docs/server/custom-adapters.mdx
@@ -395,8 +395,8 @@ If you want to use [Studio](/docs/studio/overview) with your server adapter, use
 
 ## Related
 
-- [Server Adapters](/docs/server/server-adapters) - Overview and shared concepts
-- [Hono Adapter](/reference/server/hono-adapter) - Reference implementation
-- [Express Adapter](/reference/server/express-adapter) - Reference implementation
-- [MastraServer Reference](/reference/server/mastra-server) - Full API reference
-- [createRoute() Reference](/reference/server/create-route) - Creating type-safe custom routes
+- [Server Adapters](/docs/server/server-adapters): Overview and shared concepts
+- [Hono Adapter](/reference/server/hono-adapter): Reference implementation
+- [Express Adapter](/reference/server/express-adapter): Reference implementation
+- [MastraServer Reference](/reference/server/mastra-server): Full API reference
+- [createRoute() Reference](/reference/server/create-route): Creating type-safe custom routes

--- a/docs/src/content/en/docs/server/custom-api-routes.mdx
+++ b/docs/src/content/en/docs/server/custom-api-routes.mdx
@@ -328,6 +328,6 @@ Use this pattern only when you intentionally want work to continue after the HTT
 
 ## Related
 
-- [registerApiRoute() Reference](/reference/server/register-api-route) - Full API reference
-- [Server Middleware](/docs/server/middleware) - Global middleware configuration
-- [Mastra Server](/docs/server/mastra-server) - Server configuration options
+- [registerApiRoute() Reference](/reference/server/register-api-route): Full API reference
+- [Server Middleware](/docs/server/middleware): Global middleware configuration
+- [Mastra Server](/docs/server/mastra-server): Server configuration options

--- a/docs/src/content/en/docs/server/middleware.mdx
+++ b/docs/src/content/en/docs/server/middleware.mdx
@@ -248,31 +248,6 @@ This is useful when you want to restrict operations to a specific thread that yo
 }
 ```
 
-### Special Mastra headers
-
-When integrating with Mastra Cloud or custom clients the following headers can
-be inspected by middleware to tailor behavior:
-
-```typescript prettier:false
-{
-  handler: async (c, next) => {
-    const isFromMastraCloud = c.req.header('x-mastra-cloud') === 'true';
-    const clientType = c.req.header('x-mastra-client-type');
-    const isStudio =
-      c.req.header('x-studio') === 'true';
-
-    if (isFromMastraCloud) {
-      // Special handling
-    }
-    await next();
-  },
-}
-```
-
-- `x-mastra-cloud`: request originates from Mastra Cloud
-- `x-mastra-client-type`: identifies the client SDK, e.g. `js` or `python`
-- `x-studio`: request triggered from Studio
-
 # Related
 
 - [Request Context](/docs/server/request-context)

--- a/docs/src/content/en/docs/studio/observability.mdx
+++ b/docs/src/content/en/docs/studio/observability.mdx
@@ -85,7 +85,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends observability data to Mastra platform (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/docs/src/content/en/docs/voice/speech-to-text.mdx
+++ b/docs/src/content/en/docs/voice/speech-to-text.mdx
@@ -38,13 +38,13 @@ const voice = new OpenAIVoice()
 
 Mastra supports several Speech-to-Text providers, each with their own capabilities and strengths:
 
-- [**OpenAI**](/reference/voice/openai/) - High-accuracy transcription with Whisper models
-- [**Azure**](/reference/voice/azure/) - Microsoft's speech recognition with enterprise-grade reliability
-- [**ElevenLabs**](/reference/voice/elevenlabs/) - Advanced speech recognition with support for multiple languages
-- [**Google**](/reference/voice/google/) - Google's speech recognition with extensive language support
-- [**Cloudflare**](/reference/voice/cloudflare/) - Edge-optimized speech recognition for low-latency applications
-- [**Deepgram**](/reference/voice/deepgram/) - AI-powered speech recognition with high accuracy for various accents
-- [**Sarvam**](/reference/voice/sarvam/) - Specialized in Indic languages and accents
+- [**OpenAI**](/reference/voice/openai/): High-accuracy transcription with Whisper models
+- [**Azure**](/reference/voice/azure/): Microsoft's speech recognition with enterprise-grade reliability
+- [**ElevenLabs**](/reference/voice/elevenlabs/): Advanced speech recognition with support for multiple languages
+- [**Google**](/reference/voice/google/): Google's speech recognition with extensive language support
+- [**Cloudflare**](/reference/voice/cloudflare/): Edge-optimized speech recognition for low-latency applications
+- [**Deepgram**](/reference/voice/deepgram/): AI-powered speech recognition with high accuracy for various accents
+- [**Sarvam**](/reference/voice/sarvam/): Specialized in Indic languages and accents
 
 Each provider is implemented as a separate package that you can install as needed:
 

--- a/docs/src/content/en/docs/voice/text-to-speech.mdx
+++ b/docs/src/content/en/docs/voice/text-to-speech.mdx
@@ -42,16 +42,16 @@ const voice = new OpenAIVoice()
 
 Mastra supports a wide range of Text-to-Speech providers, each with their own unique capabilities and voice options. You can choose the provider that best suits your application's needs:
 
-- [**OpenAI**](/reference/voice/openai/) - High-quality voices with natural intonation and expression
-- [**Azure**](/reference/voice/azure/) - Microsoft's speech service with a wide range of voices and languages
-- [**ElevenLabs**](/reference/voice/elevenlabs/) - Ultra-realistic voices with emotion and fine-grained control
-- [**PlayAI**](/reference/voice/playai/) - Specialized in natural-sounding voices with various styles
-- [**Google**](/reference/voice/google/) - Google's speech synthesis with multilingual support
-- [**Cloudflare**](/reference/voice/cloudflare/) - Edge-optimized speech synthesis for low-latency applications
-- [**Deepgram**](/reference/voice/deepgram/) - AI-powered speech technology with high accuracy
-- [**Speechify**](/reference/voice/speechify/) - Text-to-speech optimized for readability and accessibility
-- [**Sarvam**](/reference/voice/sarvam/) - Specialized in Indic languages and accents
-- [**Murf**](/reference/voice/murf/) - Studio-quality voice overs with customizable parameters
+- [**OpenAI**](/reference/voice/openai/): High-quality voices with natural intonation and expression
+- [**Azure**](/reference/voice/azure/): Microsoft's speech service with a wide range of voices and languages
+- [**ElevenLabs**](/reference/voice/elevenlabs/): Ultra-realistic voices with emotion and fine-grained control
+- [**PlayAI**](/reference/voice/playai/): Specialized in natural-sounding voices with various styles
+- [**Google**](/reference/voice/google/): Google's speech synthesis with multilingual support
+- [**Cloudflare**](/reference/voice/cloudflare/): Edge-optimized speech synthesis for low-latency applications
+- [**Deepgram**](/reference/voice/deepgram/): AI-powered speech technology with high accuracy
+- [**Speechify**](/reference/voice/speechify/): Text-to-speech optimized for readability and accessibility
+- [**Sarvam**](/reference/voice/sarvam/): Specialized in Indic languages and accents
+- [**Murf**](/reference/voice/murf/): Studio-quality voice overs with customizable parameters
 
 Each provider is implemented as a separate package that you can install as needed:
 

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -25,10 +25,10 @@ A filesystem provider handles all file operations for a workspace:
 
 Available providers:
 
-- [`LocalFilesystem`](/reference/workspace/local-filesystem) - Stores files in a directory on disk
-- [`S3Filesystem`](/reference/workspace/s3-filesystem) - Stores files in Amazon S3 or S3-compatible storage (R2, MinIO)
-- [`GCSFilesystem`](/reference/workspace/gcs-filesystem) - Stores files in Google Cloud Storage
-- [`AgentFSFilesystem`](/reference/workspace/agentfs-filesystem) - Stores files in a Turso/SQLite database via AgentFS
+- [`LocalFilesystem`](/reference/workspace/local-filesystem): Stores files in a directory on disk
+- [`S3Filesystem`](/reference/workspace/s3-filesystem): Stores files in Amazon S3 or S3-compatible storage (R2, MinIO)
+- [`GCSFilesystem`](/reference/workspace/gcs-filesystem): Stores files in Google Cloud Storage
+- [`AgentFSFilesystem`](/reference/workspace/agentfs-filesystem): Stores files in a Turso/SQLite database via AgentFS
 
 :::tip
 

--- a/docs/src/content/en/docs/workspace/skills.mdx
+++ b/docs/src/content/en/docs/workspace/skills.mdx
@@ -191,9 +191,9 @@ const workspace = new Workspace({
 
 `VersionedSkillSource` accepts three parameters:
 
-- **`versionTree`** (`SkillVersionTree`) — A manifest mapping relative file paths to blob entries (`{ entries: Record<string, { blobHash, size, mimeType?, encoding? }> }`).
-- **`blobStore`** (`BlobStore`) — A content-addressable blob store instance that holds the actual file contents referenced by hash.
-- **`versionCreatedAt`** (`Date`) — The timestamp when this skill version was published. Used as the modification time for all files in the version.
+- **`versionTree`** (`SkillVersionTree`): A manifest mapping relative file paths to blob entries (`{ entries: Record<string, { blobHash, size, mimeType?, encoding? }> }`).
+- **`blobStore`** (`BlobStore`): A content-addressable blob store instance that holds the actual file contents referenced by hash.
+- **`versionCreatedAt`** (`Date`): The timestamp when this skill version was published. Used as the modification time for all files in the version.
 
 When `skillSource` is provided, it's used instead of the workspace filesystem for skill discovery.
 

--- a/docs/src/content/en/guides/agent-frameworks/ai-sdk.mdx
+++ b/docs/src/content/en/guides/agent-frameworks/ai-sdk.mdx
@@ -127,7 +127,7 @@ const { text } = await generateText({
 
 ## Related
 
-- [`withMastra()`](/reference/ai-sdk/with-mastra) - API reference for `withMastra()`
-- [Processors](/docs/agents/processors) - Learn about input and output processors
-- [Memory](/docs/memory/overview) - Overview of Mastra's memory system
-- [AI SDK UI](/guides/build-your-ui/ai-sdk-ui) - Using AI SDK UI hooks with Mastra agents, workflows, and networks
+- [`withMastra()`](/reference/ai-sdk/with-mastra): API reference for `withMastra()`
+- [Processors](/docs/agents/processors): Learn about input and output processors
+- [Memory](/docs/memory/overview): Overview of Mastra's memory system
+- [AI SDK UI](/guides/build-your-ui/ai-sdk-ui): Using AI SDK UI hooks with Mastra agents, workflows, and networks

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -893,10 +893,10 @@ Tools can also stream data using `context.writer.write()` for lower-level contro
 
 For live examples of Custom UI patterns, visit [Mastra's UI Dojo](https://ui-dojo.mastra.ai/). The repository includes implementations for:
 
-- [Generative UIs](https://github.com/mastra-ai/ui-dojo/blob/main/src/pages/ai-sdk/generative-user-interfaces.tsx) - Custom components for tool outputs
-- [Workflows](https://github.com/mastra-ai/ui-dojo/blob/main/src/pages/ai-sdk/workflow.tsx) - Workflow step visualization
-- [Agent Networks](https://github.com/mastra-ai/ui-dojo/blob/main/src/pages/ai-sdk/network.tsx) - Network execution display
-- [Custom Events](https://github.com/mastra-ai/ui-dojo/blob/main/src/pages/ai-sdk/generative-user-interfaces-with-custom-events.tsx) - Progress indicators with custom events
+- [Generative UIs](https://github.com/mastra-ai/ui-dojo/blob/main/src/pages/ai-sdk/generative-user-interfaces.tsx): Custom components for tool outputs
+- [Workflows](https://github.com/mastra-ai/ui-dojo/blob/main/src/pages/ai-sdk/workflow.tsx): Workflow step visualization
+- [Agent Networks](https://github.com/mastra-ai/ui-dojo/blob/main/src/pages/ai-sdk/network.tsx): Network execution display
+- [Custom Events](https://github.com/mastra-ai/ui-dojo/blob/main/src/pages/ai-sdk/generative-user-interfaces-with-custom-events.tsx): Progress indicators with custom events
 
 ## Recipes
 

--- a/docs/src/content/en/guides/migrations/mastra-cloud.mdx
+++ b/docs/src/content/en/guides/migrations/mastra-cloud.mdx
@@ -105,7 +105,7 @@ export const mastra = new Mastra({
 ```
 
 - `DefaultExporter` persists traces to your storage backend for [Studio](/docs/studio/observability).
-- `CloudExporter` sends traces to the Mastra platform when `MASTRA_CLOUD_ACCESS_TOKEN` is set.
+- `CloudExporter` Sends observability data to hosted Mastra Studio when `MASTRA_CLOUD_ACCESS_TOKEN` is set.
 - `SensitiveDataFilter` redacts passwords, tokens, and keys from span data before export.
 
 See the [observability overview](/docs/observability/overview) for the full configuration, including composite storage with DuckDB for metrics.

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/tracing.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/tracing.mdx
@@ -51,7 +51,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Studio
-          new CloudExporter(), // Sends observability data to Mastra platform (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/docs/src/content/en/models/embeddings.mdx
+++ b/docs/src/content/en/models/embeddings.mdx
@@ -167,6 +167,6 @@ try {
 
 ## Next Steps
 
-- [Memory & Semantic Recall](/docs/memory/semantic-recall) - Use embeddings for agent memory
-- [RAG & Chunking](/docs/rag/chunking-and-embedding) - Build retrieval-augmented generation systems
-- [Vector Databases](/docs/rag/vector-databases) - Store and query embeddings
+- [Memory & Semantic Recall](/docs/memory/semantic-recall): Use embeddings for agent memory
+- [RAG & Chunking](/docs/rag/chunking-and-embedding): Build retrieval-augmented generation systems
+- [Vector Databases](/docs/rag/vector-databases): Store and query embeddings

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -269,6 +269,6 @@ type InlineLinkEntry =
 
 ## Related
 
-- [Channels guide](/docs/agents/channels) — concepts, quickstart, and platform setup
-- [Agent class](/reference/agents/agent) — constructor parameters and methods
-- [Chat SDK adapters](https://chat-sdk.dev/adapters) — adapter configuration and platform setup
+- [Channels guide](/docs/agents/channels): Concepts, quickstart, and platform setup
+- [Agent class](/reference/agents/agent): Constructor parameters and methods
+- [Chat SDK adapters](https://chat-sdk.dev/adapters): Adapter configuration and platform setup

--- a/docs/src/content/en/reference/client-js/observability.mdx
+++ b/docs/src/content/en/reference/client-js/observability.mdx
@@ -75,5 +75,5 @@ const scores = await mastraClient.listScoresBySpan({
 
 ## Related
 
-- [Agents API](./agents) - Learn about agent interactions that generate traces
-- [Workflows API](./workflows) - Understand workflow execution monitoring
+- [Agents API](./agents): Learn about agent interactions that generate traces
+- [Workflows API](./workflows): Understand workflow execution monitoring

--- a/docs/src/content/en/reference/core/addGateway.mdx
+++ b/docs/src/content/en/reference/core/addGateway.mdx
@@ -54,8 +54,8 @@ Void. The gateway is added to the internal registry.
 
 ## Related
 
-- [Mastra.getGateway()](/reference/core/getGateway) - Get gateway by registration key
-- [Mastra.getGatewayById()](/reference/core/getGatewayById) - Get gateway by ID
-- [Mastra.listGateways()](/reference/core/listGateways) - List all gateways
-- [MastraModelGateway](/reference/core/mastra-model-gateway) - Gateway base class
-- [Custom Gateways Guide](/models/gateways/custom-gateways) - Creating custom gateways
+- [Mastra.getGateway()](/reference/core/getGateway): Get gateway by registration key
+- [Mastra.getGatewayById()](/reference/core/getGatewayById): Get gateway by ID
+- [Mastra.listGateways()](/reference/core/listGateways): List all gateways
+- [MastraModelGateway](/reference/core/mastra-model-gateway): Gateway base class
+- [Custom Gateways Guide](/models/gateways/custom-gateways): Creating custom gateways

--- a/docs/src/content/en/reference/core/getGateway.mdx
+++ b/docs/src/content/en/reference/core/getGateway.mdx
@@ -54,8 +54,8 @@ Throws an error if no gateway is found with the specified key.
 
 ## Related
 
-- [Mastra.getGatewayById()](/reference/core/getGatewayById) - Get gateway by ID
-- [Mastra.listGateways()](/reference/core/listGateways) - List all gateways
-- [Mastra.addGateway()](/reference/core/addGateway) - Add a gateway
-- [MastraModelGateway](/reference/core/mastra-model-gateway) - Gateway base class
-- [Custom Gateways Guide](/models/gateways/custom-gateways) - Creating custom gateways
+- [Mastra.getGatewayById()](/reference/core/getGatewayById): Get gateway by ID
+- [Mastra.listGateways()](/reference/core/listGateways): List all gateways
+- [Mastra.addGateway()](/reference/core/addGateway): Add a gateway
+- [MastraModelGateway](/reference/core/mastra-model-gateway): Gateway base class
+- [Custom Gateways Guide](/models/gateways/custom-gateways): Creating custom gateways

--- a/docs/src/content/en/reference/core/getGatewayById.mdx
+++ b/docs/src/content/en/reference/core/getGatewayById.mdx
@@ -57,8 +57,8 @@ console.log(gateway.name) // 'My Custom Gateway'
 
 ## Related
 
-- [Mastra.getGateway()](/reference/core/getGateway) - Get gateway by registration key
-- [Mastra.listGateways()](/reference/core/listGateways) - List all gateways
-- [Mastra.addGateway()](/reference/core/addGateway) - Add a gateway
-- [MastraModelGateway](/reference/core/mastra-model-gateway) - Gateway base class
-- [Custom Gateways Guide](/models/gateways/custom-gateways) - Creating custom gateways
+- [Mastra.getGateway()](/reference/core/getGateway): Get gateway by registration key
+- [Mastra.listGateways()](/reference/core/listGateways): List all gateways
+- [Mastra.addGateway()](/reference/core/addGateway): Add a gateway
+- [MastraModelGateway](/reference/core/mastra-model-gateway): Gateway base class
+- [Custom Gateways Guide](/models/gateways/custom-gateways): Creating custom gateways

--- a/docs/src/content/en/reference/core/getMCPServer.mdx
+++ b/docs/src/content/en/reference/core/getMCPServer.mdx
@@ -62,8 +62,8 @@ const serverById = mastra.getMCPServerById('my-mcp-server')
 
 ## Related methods
 
-- [Mastra.getMCPServerById()](/reference/core/getMCPServerById) - Retrieve an MCP server by its intrinsic `id` property
-- [Mastra.listMCPServers()](/reference/core/listMCPServers) - List all registered MCP servers
+- [Mastra.getMCPServerById()](/reference/core/getMCPServerById): Retrieve an MCP server by its intrinsic `id` property
+- [Mastra.listMCPServers()](/reference/core/listMCPServers): List all registered MCP servers
 
 ## See also
 

--- a/docs/src/content/en/reference/core/getMCPServerById.mdx
+++ b/docs/src/content/en/reference/core/getMCPServerById.mdx
@@ -73,8 +73,8 @@ const serverByKey = mastra.getMCPServer('customKey')
 
 ## Related methods
 
-- [Mastra.getMCPServer()](/reference/core/getMCPServer) - Retrieve an MCP server by its registry key
-- [Mastra.listMCPServers()](/reference/core/listMCPServers) - List all registered MCP servers
+- [Mastra.getMCPServer()](/reference/core/getMCPServer): Retrieve an MCP server by its registry key
+- [Mastra.listMCPServers()](/reference/core/listMCPServers): List all registered MCP servers
 
 ## See also
 

--- a/docs/src/content/en/reference/core/getScorer.mdx
+++ b/docs/src/content/en/reference/core/getScorer.mdx
@@ -74,6 +74,6 @@ try {
 
 ## Related
 
-- [listScorers()](/reference/core/listScorers) - Get all registered scorers
-- [getScorerById()](/reference/core/getScorerById) - Get a scorer by its id property
-- [Custom Scorers](/docs/evals/custom-scorers) - Learn how to create custom scorers
+- [listScorers()](/reference/core/listScorers): Get all registered scorers
+- [getScorerById()](/reference/core/getScorerById): Get a scorer by its id property
+- [Custom Scorers](/docs/evals/custom-scorers): Learn how to create custom scorers

--- a/docs/src/content/en/reference/core/getScorerById.mdx
+++ b/docs/src/content/en/reference/core/getScorerById.mdx
@@ -74,6 +74,6 @@ try {
 
 ## Related
 
-- [getScorer()](/reference/core/getScorer) - Get a scorer by its registration key
-- [listScorers()](/reference/core/listScorers) - Get all registered scorers
-- [createScorer()](/reference/evals/create-scorer) - Learn how to create scorers with ids
+- [getScorer()](/reference/core/getScorer): Get a scorer by its registration key
+- [listScorers()](/reference/core/listScorers): Get all registered scorers
+- [createScorer()](/reference/evals/create-scorer): Learn how to create scorers with ids

--- a/docs/src/content/en/reference/core/listGateways.mdx
+++ b/docs/src/content/en/reference/core/listGateways.mdx
@@ -48,8 +48,8 @@ None.
 
 ## Related
 
-- [Mastra.getGateway()](/reference/core/getGateway) - Get gateway by registration key
-- [Mastra.getGatewayById()](/reference/core/getGatewayById) - Get gateway by ID
-- [Mastra.addGateway()](/reference/core/addGateway) - Add a gateway
-- [MastraModelGateway](/reference/core/mastra-model-gateway) - Gateway base class
-- [Custom Gateways Guide](/models/gateways/custom-gateways) - Creating custom gateways
+- [Mastra.getGateway()](/reference/core/getGateway): Get gateway by registration key
+- [Mastra.getGatewayById()](/reference/core/getGatewayById): Get gateway by ID
+- [Mastra.addGateway()](/reference/core/addGateway): Add a gateway
+- [MastraModelGateway](/reference/core/mastra-model-gateway): Gateway base class
+- [Custom Gateways Guide](/models/gateways/custom-gateways): Creating custom gateways

--- a/docs/src/content/en/reference/core/listMCPServers.mdx
+++ b/docs/src/content/en/reference/core/listMCPServers.mdx
@@ -62,8 +62,8 @@ This method doesn't accept any parameters.
 
 ## Related methods
 
-- [Mastra.getMCPServer()](/reference/core/getMCPServer) - Retrieve an MCP server by its registry key
-- [Mastra.getMCPServerById()](/reference/core/getMCPServerById) - Retrieve an MCP server by its intrinsic `id` property
+- [Mastra.getMCPServer()](/reference/core/getMCPServer): Retrieve an MCP server by its registry key
+- [Mastra.getMCPServerById()](/reference/core/getMCPServerById): Retrieve an MCP server by its intrinsic `id` property
 
 ## See also
 

--- a/docs/src/content/en/reference/core/listScorers.mdx
+++ b/docs/src/content/en/reference/core/listScorers.mdx
@@ -40,6 +40,6 @@ This method takes no parameters.
 
 ## Related
 
-- [getScorer()](/reference/core/getScorer) - Get a specific scorer by key
-- [getScorerById()](/reference/core/getScorerById) - Get a scorer by its id property
-- [Scorers Overview](/docs/evals/overview) - Learn about creating and using scorers
+- [getScorer()](/reference/core/getScorer): Get a specific scorer by key
+- [getScorerById()](/reference/core/getScorerById): Get a scorer by its id property
+- [Scorers Overview](/docs/evals/overview): Learn about creating and using scorers

--- a/docs/src/content/en/reference/core/mastra-model-gateway.mdx
+++ b/docs/src/content/en/reference/core/mastra-model-gateway.mdx
@@ -230,8 +230,8 @@ Examples:
 
 ## Related
 
-- [Custom Gateways Guide](/models/gateways/custom-gateways) - Complete guide to creating custom gateways
-- [Mastra.addGateway()](/reference/core/addGateway) - Add a gateway to Mastra
-- [Mastra.getGateway()](/reference/core/getGateway) - Get gateway by registration key
-- [Mastra.getGatewayById()](/reference/core/getGatewayById) - Get gateway by ID
-- [Mastra.listGateways()](/reference/core/listGateways) - List all gateways
+- [Custom Gateways Guide](/models/gateways/custom-gateways): Complete guide to creating custom gateways
+- [Mastra.addGateway()](/reference/core/addGateway): Add a gateway to Mastra
+- [Mastra.getGateway()](/reference/core/getGateway): Get gateway by registration key
+- [Mastra.getGatewayById()](/reference/core/getGatewayById): Get gateway by ID
+- [Mastra.listGateways()](/reference/core/listGateways): List all gateways

--- a/docs/src/content/en/reference/evals/context-precision.mdx
+++ b/docs/src/content/en/reference/evals/context-precision.mdx
@@ -245,6 +245,6 @@ Choose the right scorer for your needs:
 
 ## Related
 
-- [Answer Relevancy Scorer](/reference/evals/answer-relevancy) - Evaluates if answers address the question
-- [Faithfulness Scorer](/reference/evals/faithfulness) - Measures answer groundedness in context
-- [Custom Scorers](/docs/evals/custom-scorers) - Creating your own evaluation metrics
+- [Answer Relevancy Scorer](/reference/evals/answer-relevancy): Evaluates if answers address the question
+- [Faithfulness Scorer](/reference/evals/faithfulness): Measures answer groundedness in context
+- [Custom Scorers](/docs/evals/custom-scorers): Creating your own evaluation metrics

--- a/docs/src/content/en/reference/evals/context-relevance.mdx
+++ b/docs/src/content/en/reference/evals/context-relevance.mdx
@@ -603,6 +603,6 @@ Choose the right scorer for your needs:
 
 ## Related
 
-- [Context Precision Scorer](/reference/evals/context-precision) - Evaluates context ranking using MAP
-- [Faithfulness Scorer](/reference/evals/faithfulness) - Measures answer groundedness in context
-- [Custom Scorers](/docs/evals/custom-scorers) - Creating your own evaluation metrics
+- [Context Precision Scorer](/reference/evals/context-precision): Evaluates context ranking using MAP
+- [Faithfulness Scorer](/reference/evals/faithfulness): Measures answer groundedness in context
+- [Custom Scorers](/docs/evals/custom-scorers): Creating your own evaluation metrics

--- a/docs/src/content/en/reference/evals/mastra-scorer.mdx
+++ b/docs/src/content/en/reference/evals/mastra-scorer.mdx
@@ -138,10 +138,10 @@ const result = await scorer.run({
 
 When you call `.run()`, the MastraScorer executes the defined steps in this order:
 
-1. **preprocess** (optional) - Extracts or transforms data
-1. **analyze** (optional) - Processes the input/output and preprocessed data
-1. **generateScore** (required) - Computes the numerical score
-1. **generateReason** (optional) - Provides explanation for the score
+1. **preprocess** (optional): Extracts or transforms data
+1. **analyze** (optional): Processes the input/output and preprocessed data
+1. **generateScore** (required): Computes the numerical score
+1. **generateReason** (optional): Provides explanation for the score
 
 Each step receives the results from previous steps, allowing you to build complex evaluation pipelines.
 

--- a/docs/src/content/en/reference/evals/noise-sensitivity.mdx
+++ b/docs/src/content/en/reference/evals/noise-sensitivity.mdx
@@ -242,7 +242,7 @@ Checks if noise causes the agent to generate false or fabricated information tha
 ### Formula
 
 ```
-Final Score = max(0, min(llm_score, calculated_score) - issues_penalty)
+Final Score = max(0, min(llm_score, calculated_score): issues_penalty)
 ```
 
 Where:
@@ -788,7 +788,7 @@ jobs:
       - run: npm run test:noise-sensitivity
       - name: Check robustness threshold
         run: |
-          if [ $(npm run test:noise-sensitivity -- --json | jq '.score') -lt 0.8 ]; then
+          if [ $(npm run test:noise-sensitivity -- --json | jq '.score'):lt 0.8 ]; then
             echo "Agent failed noise sensitivity threshold"
             exit 1
           fi
@@ -796,7 +796,7 @@ jobs:
 
 ## Related
 
-- [Scorers Overview](/docs/evals/overview) - Setting up scorer pipelines
-- [Hallucination Scorer](/reference/evals/hallucination) - Evaluates fabricated content
-- [Answer Relevancy Scorer](/reference/evals/answer-relevancy) - Measures response focus
-- [Custom Scorers](/docs/evals/custom-scorers) - Creating your own evaluation metrics
+- [Scorers Overview](/docs/evals/overview): Setting up scorer pipelines
+- [Hallucination Scorer](/reference/evals/hallucination): Evaluates fabricated content
+- [Answer Relevancy Scorer](/reference/evals/answer-relevancy): Measures response focus
+- [Custom Scorers](/docs/evals/custom-scorers): Creating your own evaluation metrics

--- a/docs/src/content/en/reference/evals/prompt-alignment.mdx
+++ b/docs/src/content/en/reference/evals/prompt-alignment.mdx
@@ -124,19 +124,19 @@ Prompt Alignment evaluates responses across four key dimensions with weighted sc
 
 Evaluates alignment with user prompts only:
 
-1. **Intent Alignment** (40% weight) - Whether the response addresses the user's core request
-1. **Requirements Fulfillment** (30% weight) - If all user requirements are met
-1. **Completeness** (20% weight) - Whether the response is comprehensive for user needs
-1. **Response Appropriateness** (10% weight) - If format and tone match user expectations
+1. **Intent Alignment** (40% weight): Whether the response addresses the user's core request
+1. **Requirements Fulfillment** (30% weight): If all user requirements are met
+1. **Completeness** (20% weight): Whether the response is comprehensive for user needs
+1. **Response Appropriateness** (10% weight): If format and tone match user expectations
 
 #### System Mode ('system')
 
 Evaluates compliance with system guidelines only:
 
-1. **Intent Alignment** (35% weight) - Whether the response follows system behavioral guidelines
-1. **Requirements Fulfillment** (35% weight) - If all system constraints are respected
-1. **Completeness** (15% weight) - Whether the response adheres to all system rules
-1. **Response Appropriateness** (15% weight) - If format and tone match system specifications
+1. **Intent Alignment** (35% weight): Whether the response follows system behavioral guidelines
+1. **Requirements Fulfillment** (35% weight): If all system constraints are respected
+1. **Completeness** (15% weight): Whether the response adheres to all system rules
+1. **Response Appropriateness** (15% weight): If format and tone match system specifications
 
 #### Both Mode ('both' - default)
 
@@ -656,7 +656,7 @@ const result = await scorer.run({
 
 ## Related
 
-- [Answer Relevancy Scorer](/reference/evals/answer-relevancy) - Evaluates query-response relevance
-- [Faithfulness Scorer](/reference/evals/faithfulness) - Measures context groundedness
-- [Tool Call Accuracy Scorer](/reference/evals/tool-call-accuracy) - Evaluates tool selection
-- [Custom Scorers](/docs/evals/custom-scorers) - Creating your own evaluation metrics
+- [Answer Relevancy Scorer](/reference/evals/answer-relevancy): Evaluates query-response relevance
+- [Faithfulness Scorer](/reference/evals/faithfulness): Measures context groundedness
+- [Tool Call Accuracy Scorer](/reference/evals/tool-call-accuracy): Evaluates tool selection
+- [Custom Scorers](/docs/evals/custom-scorers): Creating your own evaluation metrics

--- a/docs/src/content/en/reference/evals/run-evals.mdx
+++ b/docs/src/content/en/reference/evals/run-evals.mdx
@@ -364,9 +364,9 @@ const result = await runEvals({
 
 ## Related
 
-- [createScorer()](/reference/evals/create-scorer) - Create custom scorers for experiments
-- [MastraScorer](/reference/evals/mastra-scorer) - Learn about scorer structure and methods
-- [Trajectory Accuracy](/reference/evals/trajectory-accuracy) - Built-in trajectory evaluation scorers
-- [Scorer Utilities](/reference/evals/scorer-utils) - Helper functions for extracting trajectory data
-- [Custom Scorers](/docs/evals/custom-scorers) - Guide to building evaluation logic
-- [Scorers Overview](/docs/evals/overview) - Understanding scorer concepts
+- [createScorer()](/reference/evals/create-scorer): Create custom scorers for experiments
+- [MastraScorer](/reference/evals/mastra-scorer): Learn about scorer structure and methods
+- [Trajectory Accuracy](/reference/evals/trajectory-accuracy): Built-in trajectory evaluation scorers
+- [Scorer Utilities](/reference/evals/scorer-utils): Helper functions for extracting trajectory data
+- [Custom Scorers](/docs/evals/custom-scorers): Guide to building evaluation logic
+- [Scorers Overview](/docs/evals/overview): Understanding scorer concepts

--- a/docs/src/content/en/reference/evals/scorer-utils.mdx
+++ b/docs/src/content/en/reference/evals/scorer-utils.mdx
@@ -368,10 +368,10 @@ const trajectory = extractTrajectoryFromTrace(traceData.spans, rootSpanId)
 
 **Parameters:**
 
-- `spans` (`SpanRecord[]`) — Array of span records from a trace query.
-- `rootSpanId` (`string`, optional) — Span ID to use as the starting point. When omitted, uses spans with no parent.
+- `spans` (`SpanRecord[]`): Array of span records from a trace query.
+- `rootSpanId` (`string`, optional): Span ID to use as the starting point. When omitted, uses spans with no parent.
 
-**Returns:** `Trajectory` — Contains `steps: TrajectoryStep[]` with recursive `children` and `totalDurationMs`.
+**Returns:** `Trajectory`: Contains `steps: TrajectoryStep[]` with recursive `children` and `totalDurationMs`.
 
 #### Span type mapping
 

--- a/docs/src/content/en/reference/evals/trajectory-accuracy.mdx
+++ b/docs/src/content/en/reference/evals/trajectory-accuracy.mdx
@@ -820,6 +820,6 @@ const result = await runEvals({
 
 ## Related
 
-- [runEvals reference](./run-evals) — Pipeline that extracts trajectories and passes them to scorers
-- [MastraScorer reference](./mastra-scorer) — Base scorer interface
-- [Scorer utils](./scorer-utils) — Utility functions including `extractTrajectory` and `compareTrajectories`
+- [runEvals reference](./run-evals): Pipeline that extracts trajectories and passes them to scorers
+- [MastraScorer reference](./mastra-scorer): Base scorer interface
+- [Scorer utils](./scorer-utils): Utility functions including `extractTrajectory` and `compareTrajectories`

--- a/docs/src/content/en/reference/observability/tracing/bridges/otel.mdx
+++ b/docs/src/content/en/reference/observability/tracing/bridges/otel.mdx
@@ -176,6 +176,6 @@ This format ensures compatibility with all OTEL-compatible backends and collecto
 
 ## Related
 
-- [OtelBridge Guide](/docs/observability/tracing/bridges/otel) - Setup guide with examples
-- [Tracing Overview](/docs/observability/tracing/overview) - General tracing concepts
-- [OtelExporter Reference](/reference/observability/tracing/exporters/otel) - OTEL exporter for sending traces
+- [OtelBridge Guide](/docs/observability/tracing/bridges/otel): Setup guide with examples
+- [Tracing Overview](/docs/observability/tracing/overview): General tracing concepts
+- [OtelExporter Reference](/reference/observability/tracing/exporters/otel): OTEL exporter for sending traces

--- a/docs/src/content/en/reference/observability/tracing/configuration.mdx
+++ b/docs/src/content/en/reference/observability/tracing/configuration.mdx
@@ -306,21 +306,21 @@ Shuts down all observability instances and clears the registry.
 
 ### Documentation
 
-- [Tracing Overview](/docs/observability/tracing/overview) - Concepts and usage guide
-- [Sampling Strategies](/docs/observability/tracing/overview#sampling-strategies) - Sampling configuration details
-- [Multi-Config Setup](/docs/observability/tracing/overview#multi-config-setup) - Using multiple configurations
+- [Tracing Overview](/docs/observability/tracing/overview): Concepts and usage guide
+- [Sampling Strategies](/docs/observability/tracing/overview#sampling-strategies): Sampling configuration details
+- [Multi-Config Setup](/docs/observability/tracing/overview#multi-config-setup): Using multiple configurations
 
 ### Reference
 
-- [Tracing Classes](/reference/observability/tracing/instances) - Core tracing classes
-- [Interfaces](/reference/observability/tracing/interfaces) - Type definitions
-- [Spans Reference](/reference/observability/tracing/spans) - Span lifecycle
+- [Tracing Classes](/reference/observability/tracing/instances): Core tracing classes
+- [Interfaces](/reference/observability/tracing/interfaces): Type definitions
+- [Spans Reference](/reference/observability/tracing/spans): Span lifecycle
 
 ### Exporters
 
-- [DefaultExporter](/reference/observability/tracing/exporters/default-exporter) - Storage configuration
-- [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter) - Cloud setup
-- [Braintrust](/reference/observability/tracing/exporters/braintrust) - Braintrust integration
-- [Langfuse](/reference/observability/tracing/exporters/langfuse) - Langfuse integration
-- [LangSmith](/reference/observability/tracing/exporters/langsmith) - LangSmith integration
-- [Span filtering](/reference/observability/tracing/span-filtering) - Selectively exclude spans
+- [DefaultExporter](/reference/observability/tracing/exporters/default-exporter): Storage configuration
+- [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter): Cloud setup
+- [Braintrust](/reference/observability/tracing/exporters/braintrust): Braintrust integration
+- [Langfuse](/reference/observability/tracing/exporters/langfuse): Langfuse integration
+- [LangSmith](/reference/observability/tracing/exporters/langsmith): LangSmith integration
+- [Span filtering](/reference/observability/tracing/span-filtering): Selectively exclude spans

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -9,7 +9,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 # CloudExporter
 
-Sends tracing spans, logs, metrics, scores, and feedback to Mastra Cloud for online visualization and monitoring.
+Sends tracing spans, logs, metrics, scores, and feedback to the Mastra platform for online visualization and monitoring.
 
 ## Constructor
 
@@ -209,7 +209,7 @@ Every `FeedbackEvent` passed to this handler is buffered and exported to the Clo
 async flush(): Promise<void>
 ```
 
-Force flushes any buffered events to Mastra Cloud without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+Force flushes any buffered events to the Mastra platform without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
 
 ### shutdown
 
@@ -301,17 +301,17 @@ const customExporter = new CloudExporter({
 
 ### Documentation
 
-- [Tracing Overview](/docs/observability/tracing/overview) - Complete guide
-- [Exporters](/docs/observability/tracing/overview#exporters) - Exporter concepts
+- [Tracing Overview](/docs/observability/tracing/overview): Complete guide
+- [Exporters](/docs/observability/tracing/overview#exporters): Exporter concepts
 
 ### Other Exporters
 
-- [DefaultExporter](/reference/observability/tracing/exporters/default-exporter) - Storage persistence
-- [ConsoleExporter](/reference/observability/tracing/exporters/console-exporter) - Debug output
-- [Langfuse](/reference/observability/tracing/exporters/langfuse) - Langfuse integration
-- [Braintrust](/reference/observability/tracing/exporters/braintrust) - Braintrust integration
+- [DefaultExporter](/reference/observability/tracing/exporters/default-exporter): Storage persistence
+- [ConsoleExporter](/reference/observability/tracing/exporters/console-exporter): Debug output
+- [Langfuse](/reference/observability/tracing/exporters/langfuse): Langfuse integration
+- [Braintrust](/reference/observability/tracing/exporters/braintrust): Braintrust integration
 
 ### Reference
 
-- [Configuration](/reference/observability/tracing/configuration) - Configuration options
-- [Interfaces](/reference/observability/tracing/interfaces) - Type definitions
+- [Configuration](/reference/observability/tracing/configuration): Configuration options
+- [Interfaces](/reference/observability/tracing/interfaces): Type definitions

--- a/docs/src/content/en/reference/observability/tracing/exporters/console-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/console-exporter.mdx
@@ -164,17 +164,17 @@ const exporterWithLogger = new ConsoleExporter({
 
 ### Documentation
 
-- [Tracing Overview](/docs/observability/tracing/overview) - Complete guide
-- [Exporters](/docs/observability/tracing/overview#exporters) - Exporter concepts
+- [Tracing Overview](/docs/observability/tracing/overview): Complete guide
+- [Exporters](/docs/observability/tracing/overview#exporters): Exporter concepts
 
 ### Other Exporters
 
-- [DefaultExporter](/reference/observability/tracing/exporters/default-exporter) - Storage persistence
-- [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter) - Mastra Cloud
-- [Langfuse](/reference/observability/tracing/exporters/langfuse) - Langfuse integration
-- [Braintrust](/reference/observability/tracing/exporters/braintrust) - Braintrust integration
+- [DefaultExporter](/reference/observability/tracing/exporters/default-exporter): Storage persistence
+- [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter): Mastra platform
+- [Langfuse](/reference/observability/tracing/exporters/langfuse): Langfuse integration
+- [Braintrust](/reference/observability/tracing/exporters/braintrust): Braintrust integration
 
 ### Reference
 
-- [Configuration](/reference/observability/tracing/configuration) - Configuration options
-- [Interfaces](/reference/observability/tracing/interfaces) - Type definitions
+- [Configuration](/reference/observability/tracing/configuration): Configuration options
+- [Interfaces](/reference/observability/tracing/interfaces): Type definitions

--- a/docs/src/content/en/reference/observability/tracing/exporters/default-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/default-exporter.mdx
@@ -200,17 +200,17 @@ const customExporter = new DefaultExporter({
 
 ### Documentation
 
-- [Tracing Overview](/docs/observability/tracing/overview) - Complete guide
-- [Exporters](/docs/observability/tracing/overview#exporters) - Exporter concepts
+- [Tracing Overview](/docs/observability/tracing/overview): Complete guide
+- [Exporters](/docs/observability/tracing/overview#exporters): Exporter concepts
 
 ### Other Exporters
 
-- [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter) - Mastra Cloud
-- [ConsoleExporter](/reference/observability/tracing/exporters/console-exporter) - Debug output
-- [Langfuse](/reference/observability/tracing/exporters/langfuse) - Langfuse integration
-- [Braintrust](/reference/observability/tracing/exporters/braintrust) - Braintrust integration
+- [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter): Mastra platform
+- [ConsoleExporter](/reference/observability/tracing/exporters/console-exporter): Debug output
+- [Langfuse](/reference/observability/tracing/exporters/langfuse): Langfuse integration
+- [Braintrust](/reference/observability/tracing/exporters/braintrust): Braintrust integration
 
 ### Reference
 
-- [Configuration](/reference/observability/tracing/configuration) - Configuration options
-- [Interfaces](/reference/observability/tracing/interfaces) - Type definitions
+- [Configuration](/reference/observability/tracing/configuration): Configuration options
+- [Interfaces](/reference/observability/tracing/interfaces): Type definitions

--- a/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
@@ -368,6 +368,6 @@ While the OpenTelemetry specification supports native array attributes, many bac
 
 ## Related
 
-- [OtelExporter Guide](/docs/observability/tracing/exporters/otel) - Setup guide with provider configurations
-- [OtelBridge](/docs/observability/tracing/bridges/otel) - For bidirectional OTEL context integration
-- [Tracing Overview](/docs/observability/tracing/overview) - General tracing concepts
+- [OtelExporter Guide](/docs/observability/tracing/exporters/otel): Setup guide with provider configurations
+- [OtelBridge](/docs/observability/tracing/bridges/otel): For bidirectional OTEL context integration
+- [Tracing Overview](/docs/observability/tracing/overview): General tracing concepts

--- a/docs/src/content/en/reference/observability/tracing/instances.mdx
+++ b/docs/src/content/en/reference/observability/tracing/instances.mdx
@@ -151,13 +151,13 @@ class CustomObservabilityInstance extends BaseObservabilityInstance {
 
 ### Documentation
 
-- [Tracing Overview](/docs/observability/tracing/overview) - Concepts and usage guide
-- [Configuration Reference](/reference/observability/tracing/configuration) - Configuration options
-- [Interfaces Reference](/reference/observability/tracing/interfaces) - Type definitions
-- [Spans Reference](/reference/observability/tracing/spans) - Span lifecycle and methods
+- [Tracing Overview](/docs/observability/tracing/overview): Concepts and usage guide
+- [Configuration Reference](/reference/observability/tracing/configuration): Configuration options
+- [Interfaces Reference](/reference/observability/tracing/interfaces): Type definitions
+- [Spans Reference](/reference/observability/tracing/spans): Span lifecycle and methods
 
 ### Exporters
 
-- [DefaultExporter](/reference/observability/tracing/exporters/default-exporter) - Storage persistence
-- [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter) - Mastra Cloud integration
-- [ConsoleExporter](/reference/observability/tracing/exporters/console-exporter) - Debug output
+- [DefaultExporter](/reference/observability/tracing/exporters/default-exporter): Storage persistence
+- [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter): Mastra platform integration
+- [ConsoleExporter](/reference/observability/tracing/exporters/console-exporter): Debug output

--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -744,12 +744,12 @@ enum InternalSpans {
 
 ### Documentation
 
-- [Tracing Overview](/docs/observability/tracing/overview) - Complete guide to Tracing
-- [Creating Child Spans](/docs/observability/tracing/overview#creating-child-spans) - Working with span hierarchies
-- [Adding Custom Metadata](/docs/observability/tracing/overview#adding-custom-metadata) - Enriching traces
+- [Tracing Overview](/docs/observability/tracing/overview): Complete guide to Tracing
+- [Creating Child Spans](/docs/observability/tracing/overview#creating-child-spans): Working with span hierarchies
+- [Adding Custom Metadata](/docs/observability/tracing/overview#adding-custom-metadata): Enriching traces
 
 ### Reference
 
-- [Configuration](/reference/observability/tracing/configuration) - Registry and configuration
-- [Tracing Classes](/reference/observability/tracing/instances) - Core implementations
-- [Spans Reference](/reference/observability/tracing/spans) - Span lifecycle methods
+- [Configuration](/reference/observability/tracing/configuration): Registry and configuration
+- [Tracing Classes](/reference/observability/tracing/instances): Core implementations
+- [Spans Reference](/reference/observability/tracing/spans): Span lifecycle methods

--- a/docs/src/content/en/reference/observability/tracing/spans.mdx
+++ b/docs/src/content/en/reference/observability/tracing/spans.mdx
@@ -381,12 +381,12 @@ A span that performs no operations. All methods are no-ops:
 
 ### Documentation
 
-- [Tracing Overview](/docs/observability/tracing/overview) - Concepts and usage
-- [Creating Child Spans](/docs/observability/tracing/overview#creating-child-spans) - Practical examples
-- [Retrieving Trace IDs](/docs/observability/tracing/overview#retrieving-trace-ids) - Using trace IDs
+- [Tracing Overview](/docs/observability/tracing/overview): Concepts and usage
+- [Creating Child Spans](/docs/observability/tracing/overview#creating-child-spans): Practical examples
+- [Retrieving Trace IDs](/docs/observability/tracing/overview#retrieving-trace-ids): Using trace IDs
 
 ### Reference
 
-- [Tracing Classes](/reference/observability/tracing/instances) - Core tracing classes
-- [Interfaces](/reference/observability/tracing/interfaces) - Complete type reference
-- [Configuration](/reference/observability/tracing/configuration) - Configuration options
+- [Tracing Classes](/reference/observability/tracing/instances): Core tracing classes
+- [Interfaces](/reference/observability/tracing/interfaces): Complete type reference
+- [Configuration](/reference/observability/tracing/configuration): Configuration options

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -834,6 +834,6 @@ export class WordCounter implements Processor {
 
 ## Related
 
-- [Processors overview](/docs/agents/processors) - Conceptual guide to processors
-- [Guardrails](/docs/agents/guardrails) - Security and validation processors
-- [Memory Processors](/docs/memory/memory-processors) - Memory-specific processors
+- [Processors overview](/docs/agents/processors): Conceptual guide to processors
+- [Guardrails](/docs/agents/guardrails): Security and validation processors
+- [Memory Processors](/docs/memory/memory-processors): Memory-specific processors

--- a/docs/src/content/en/reference/server/create-route.mdx
+++ b/docs/src/content/en/reference/server/create-route.mdx
@@ -335,6 +335,6 @@ Common status codes:
 
 ## Related
 
-- [Server Routes](/reference/server/routes) - Default Mastra routes
-- [MastraServer](/reference/server/mastra-server) - Server adapter class
-- [Server Adapters](/docs/server/server-adapters) - Using adapters
+- [Server Routes](/reference/server/routes): Default Mastra routes
+- [MastraServer](/reference/server/mastra-server): Server adapter class
+- [Server Adapters](/docs/server/server-adapters): Using adapters

--- a/docs/src/content/en/reference/server/express-adapter.mdx
+++ b/docs/src/content/en/reference/server/express-adapter.mdx
@@ -244,10 +244,10 @@ For custom middleware ordering, call each method separately instead of `init()`.
 
 ## Examples
 
-- [Express Adapter](https://github.com/mastra-ai/mastra/tree/main/examples/server-express-adapter) - Basic Express server setup
+- [Express Adapter](https://github.com/mastra-ai/mastra/tree/main/examples/server-express-adapter): Basic Express server setup
 
 ## Related
 
-- [Server Adapters](/docs/server/server-adapters) - Shared adapter concepts
-- [MastraServer Reference](/reference/server/mastra-server) - Full API reference
-- [createRoute() Reference](/reference/server/create-route) - Creating type-safe custom routes
+- [Server Adapters](/docs/server/server-adapters): Shared adapter concepts
+- [MastraServer Reference](/reference/server/mastra-server): Full API reference
+- [createRoute() Reference](/reference/server/create-route): Creating type-safe custom routes

--- a/docs/src/content/en/reference/server/fastify-adapter.mdx
+++ b/docs/src/content/en/reference/server/fastify-adapter.mdx
@@ -159,10 +159,10 @@ For custom middleware ordering, call each method separately instead of `init()`.
 
 ## Examples
 
-- [Fastify Adapter](https://github.com/mastra-ai/mastra/tree/main/examples/server-fastify-adapter) - Basic Fastify server setup
+- [Fastify Adapter](https://github.com/mastra-ai/mastra/tree/main/examples/server-fastify-adapter): Basic Fastify server setup
 
 ## Related
 
-- [Server Adapters](/docs/server/server-adapters) - Shared adapter concepts
-- [MastraServer Reference](/reference/server/mastra-server) - Full API reference
-- [createRoute() Reference](/reference/server/create-route) - Creating type-safe custom routes
+- [Server Adapters](/docs/server/server-adapters): Shared adapter concepts
+- [MastraServer Reference](/reference/server/mastra-server): Full API reference
+- [createRoute() Reference](/reference/server/create-route): Creating type-safe custom routes

--- a/docs/src/content/en/reference/server/hono-adapter.mdx
+++ b/docs/src/content/en/reference/server/hono-adapter.mdx
@@ -225,10 +225,10 @@ For custom middleware ordering, call each method separately instead of `init()`.
 
 ## Examples
 
-- [Hono Adapter](https://github.com/mastra-ai/mastra/tree/main/examples/server-hono-adapter) - Basic Hono server setup
+- [Hono Adapter](https://github.com/mastra-ai/mastra/tree/main/examples/server-hono-adapter): Basic Hono server setup
 
 ## Related
 
-- [Server Adapters](/docs/server/server-adapters) - Shared adapter concepts
-- [MastraServer Reference](/reference/server/mastra-server) - Full API reference
-- [createRoute() Reference](/reference/server/create-route) - Creating type-safe custom routes
+- [Server Adapters](/docs/server/server-adapters): Shared adapter concepts
+- [MastraServer Reference](/reference/server/mastra-server): Full API reference
+- [createRoute() Reference](/reference/server/create-route): Creating type-safe custom routes

--- a/docs/src/content/en/reference/server/koa-adapter.mdx
+++ b/docs/src/content/en/reference/server/koa-adapter.mdx
@@ -191,10 +191,10 @@ For custom middleware ordering, call each method separately instead of `init()`.
 
 ## Examples
 
-- [Koa Adapter](https://github.com/mastra-ai/mastra/tree/main/examples/server-koa-adapter) - Basic Koa server setup
+- [Koa Adapter](https://github.com/mastra-ai/mastra/tree/main/examples/server-koa-adapter): Basic Koa server setup
 
 ## Related
 
-- [Server Adapters](/docs/server/server-adapters) - Shared adapter concepts
-- [MastraServer Reference](/reference/server/mastra-server) - Full API reference
-- [createRoute() Reference](/reference/server/create-route) - Creating type-safe custom routes
+- [Server Adapters](/docs/server/server-adapters): Shared adapter concepts
+- [MastraServer Reference](/reference/server/mastra-server): Full API reference
+- [createRoute() Reference](/reference/server/create-route): Creating type-safe custom routes

--- a/docs/src/content/en/reference/server/mastra-server.mdx
+++ b/docs/src/content/en/reference/server/mastra-server.mdx
@@ -352,6 +352,6 @@ export class MyServer extends MastraServer<MyApp, MyRequest, MyResponse> {
 
 ## Related
 
-- [Server Adapters](/docs/server/server-adapters) - Using adapters
-- [Custom Adapters](/docs/server/custom-adapters) - Creating custom adapters
-- [createRoute()](/reference/server/create-route) - Creating custom routes
+- [Server Adapters](/docs/server/server-adapters): Using adapters
+- [Custom Adapters](/docs/server/custom-adapters): Creating custom adapters
+- [createRoute()](/reference/server/create-route): Creating custom routes

--- a/docs/src/content/en/reference/server/register-api-route.mdx
+++ b/docs/src/content/en/reference/server/register-api-route.mdx
@@ -314,7 +314,7 @@ registerApiRoute('/items/:itemId', {
 
 ## Related
 
-- [Custom API Routes Guide](/docs/server/custom-api-routes) - Usage guide with examples
-- [Server Middleware](/docs/server/middleware) - Global middleware configuration
-- [createRoute()](/reference/server/create-route) - Type-safe route creation for server adapters
-- [Server Routes](/reference/server/routes) - Built-in Mastra server routes
+- [Custom API Routes Guide](/docs/server/custom-api-routes): Usage guide with examples
+- [Server Middleware](/docs/server/middleware): Global middleware configuration
+- [createRoute()](/reference/server/create-route): Type-safe route creation for server adapters
+- [Server Routes](/reference/server/routes): Built-in Mastra server routes

--- a/docs/src/content/en/reference/server/routes.mdx
+++ b/docs/src/content/en/reference/server/routes.mdx
@@ -350,5 +350,5 @@ Common status codes:
 
 ## Related
 
-- [createRoute()](/reference/server/create-route) - Creating custom routes
-- [Server Adapters](/docs/server/server-adapters) - Using adapters
+- [createRoute()](/reference/server/create-route): Creating custom routes
+- [Server Adapters](/docs/server/server-adapters): Using adapters

--- a/docs/src/content/en/reference/storage/overview.mdx
+++ b/docs/src/content/en/reference/storage/overview.mdx
@@ -187,7 +187,7 @@ The schema definitions below cover the built-in database-backed tables documente
   {
     name: 'id',
     type: 'text',
-    description: 'Resource identifier (user or entity ID) - same as resourceId used in threads and agent calls',
+    description: 'Resource identifier (user or entity ID): same as resourceId used in threads and agent calls',
     constraints: [{ type: 'primaryKey' }, { type: 'nullable', value: false }],
   },
   {

--- a/docs/src/content/en/reference/streaming/ChunkType.mdx
+++ b/docs/src/content/en/reference/streaming/ChunkType.mdx
@@ -1339,6 +1339,6 @@ for await (const chunk of stream.fullStream) {
 
 ## Related types
 
-- [.stream()](./agents/stream) - Method that returns streams emitting these chunks
-- [MastraModelOutput](./agents/MastraModelOutput) - The stream object that emits these chunks
-- [workflow.stream()](./workflows/stream) - Method that returns streams emitting these chunks for workflows
+- [.stream()](./agents/stream): Method that returns streams emitting these chunks
+- [MastraModelOutput](./agents/MastraModelOutput): The stream object that emits these chunks
+- [workflow.stream()](./workflows/stream): Method that returns streams emitting these chunks for workflows

--- a/docs/src/content/en/reference/streaming/agents/MastraModelOutput.mdx
+++ b/docs/src/content/en/reference/streaming/agents/MastraModelOutput.mdx
@@ -527,5 +527,5 @@ if (stream.error) {
 
 ## Related types
 
-- [.stream()](./stream) - Method that returns MastraModelOutput
-- [ChunkType](../ChunkType) - All possible chunk types in the full stream
+- [.stream()](./stream): Method that returns MastraModelOutput
+- [ChunkType](../ChunkType): All possible chunk types in the full stream

--- a/docs/src/content/en/reference/voice/cloudflare.mdx
+++ b/docs/src/content/en/reference/voice/cloudflare.mdx
@@ -163,6 +163,6 @@ Returns an array of available voice options, where each node contains:
 
 If you need speech-to-text capabilities in addition to text-to-speech, consider using one of these providers:
 
-- [OpenAI](./openai) - Provides both TTS and STT
-- [Google](./google) - Provides both TTS and STT
-- [Azure](./azure) - Provides both TTS and STT
+- [OpenAI](./openai): Provides both TTS and STT
+- [Google](./google): Provides both TTS and STT
+- [Azure](./azure): Provides both TTS and STT

--- a/docs/src/content/en/reference/voice/voice.connect.mdx
+++ b/docs/src/content/en/reference/voice/voice.connect.mdx
@@ -134,7 +134,7 @@ await voice.connect()
 
 ## Related methods
 
-- [voice.send()](./voice.send) - Sends audio data to the voice provider
-- [voice.answer()](./voice.answer) - Triggers the voice provider to respond
-- [voice.close()](./voice.close) - Disconnects from the real-time service
-- [voice.on()](./voice.on) - Registers an event listener for voice events
+- [voice.send()](./voice.send): Sends audio data to the voice provider
+- [voice.answer()](./voice.answer): Triggers the voice provider to respond
+- [voice.close()](./voice.close): Disconnects from the real-time service
+- [voice.on()](./voice.on): Registers an event listener for voice events

--- a/docs/src/content/en/reference/voice/voice.listen.mdx
+++ b/docs/src/content/en/reference/voice/voice.listen.mdx
@@ -270,6 +270,6 @@ await voice.listen(microphoneStream)
 
 ## Related methods
 
-- [voice.speak()](./voice.speak) - Converts text to speech
-- [voice.send()](./voice.send) - Sends audio data to the voice provider in real-time
-- [voice.on()](./voice.on) - Registers an event listener for voice events
+- [voice.speak()](./voice.speak): Converts text to speech
+- [voice.send()](./voice.send): Sends audio data to the voice provider in real-time
+- [voice.on()](./voice.on): Registers an event listener for voice events

--- a/docs/src/content/en/reference/workflows/run-methods/startAsync.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/startAsync.mdx
@@ -138,6 +138,6 @@ if (result?.status === 'success') {
 
 ## Related
 
-- [Run.start()](./start) - Start a workflow and wait for completion
+- [Run.start()](./start): Start a workflow and wait for completion
 - [Workflows overview](/docs/workflows/overview)
 - [Workflow.createRun()](../workflow-methods/create-run)

--- a/docs/src/content/en/reference/workspace/vercel.mdx
+++ b/docs/src/content/en/reference/workspace/vercel.mdx
@@ -175,4 +175,4 @@ VercelSandbox uses serverless functions under the hood, which means:
 
 - [WorkspaceSandbox interface](/reference/workspace/sandbox)
 - [Workspace class](/reference/workspace/workspace-class)
-- [E2BSandbox](/reference/workspace/e2b-sandbox) — full-featured cloud sandbox with persistent filesystem and process management
+- [E2BSandbox](/reference/workspace/e2b-sandbox): Full-featured cloud sandbox with persistent filesystem and process management

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -197,7 +197,7 @@ const workspace = new Workspace({
 
 The config object has two parts:
 
-- **Global defaults** (`enabled`, `requireApproval`) - Apply to all tools unless overridden
+- **Global defaults** (`enabled`, `requireApproval`): Apply to all tools unless overridden
 - **Per-tool overrides** - Use `WORKSPACE_TOOLS` constants as keys to configure individual tools
 
 See [workspace overview](/docs/workspace/overview#tool-configuration) for more examples.

--- a/docs/styles/config/vocabularies/Mastra/accept.txt
+++ b/docs/styles/config/vocabularies/Mastra/accept.txt
@@ -69,7 +69,6 @@ LanceDB
 LLM
 (?i)MAP
 (?i)Mastra
-Mastra Cloud
 (?i)MCP
 MinIO
 MLflow

--- a/e2e-tests/no-bundling/template/src/mastra/index.ts
+++ b/e2e-tests/no-bundling/template/src/mastra/index.ts
@@ -26,7 +26,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/examples/agent-v6/src/mastra/index.ts
+++ b/examples/agent-v6/src/mastra/index.ts
@@ -28,7 +28,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/examples/agent/src/mastra/auth/cloud.ts
+++ b/examples/agent/src/mastra/auth/cloud.ts
@@ -1,5 +1,5 @@
 /**
- * Mastra Cloud auth provider - OAuth SSO with PKCE.
+ * Mastra platform auth provider - OAuth SSO with PKCE.
  * Requires MASTRA_PROJECT_ID, MASTRA_CLOUD_URL, and MASTRA_CALLBACK_URL environment variables.
  */
 
@@ -31,6 +31,6 @@ export async function initCloud(): Promise<AuthResult> {
     },
   });
 
-  console.log('[Auth] Using Mastra Cloud authentication');
+  console.log('[Auth] Using the Mastra platform authentication');
   return { mastraAuth, rbacProvider };
 }

--- a/examples/agent/src/mastra/auth/index.ts
+++ b/examples/agent/src/mastra/auth/index.ts
@@ -5,7 +5,7 @@
  * - simple: Token-based authentication for development/testing
  * - better-auth: Credentials-based authentication with SQLite
  * - workos: Enterprise SSO (SAML, OIDC)
- * - cloud: Mastra Cloud OAuth with PKCE
+ * - cloud: Mastra platform OAuth with PKCE
  * - composite: Combines SimpleAuth + MastraCloudAuth via CompositeAuth
  * - auth0-okta: Auth0 for authentication + Okta for RBAC (cross-provider)
  * - okta: Full Okta for both authentication and RBAC

--- a/examples/agent/src/mastra/auth/studio.ts
+++ b/examples/agent/src/mastra/auth/studio.ts
@@ -30,6 +30,6 @@ export async function initStudio(): Promise<AuthResult> {
     },
   });
 
-  console.log('[Auth] Using Mastra Cloud authentication');
+  console.log('[Auth] Using the Mastra platform authentication');
   return { mastraAuth, rbacProvider };
 }

--- a/observability/mastra/README.md
+++ b/observability/mastra/README.md
@@ -21,7 +21,7 @@ export const mastra = new Mastra({
         serviceName: 'my-app',
         exporters: [
           new DefaultExporter(), // Persists traces for Mastra Studio
-          new CloudExporter(), // Sends to Mastra Cloud
+          new CloudExporter(), // Sends to Mastra platform
         ],
         spanOutputProcessors: [new SensitiveDataFilter()],
       },
@@ -33,7 +33,7 @@ export const mastra = new Mastra({
 ## Features
 
 - **Auto-instrumentation** - Traces agent runs, LLM calls, tool executions, and workflows
-- **Pluggable Exporters** - Exporters for Studio and Cloud, plus integrations for Arize, Braintrust, Langfuse, LangSmith, and OpenTelemetry
+- **Pluggable Exporters** - Exporters for Studio, plus integrations for Arize, Braintrust, Langfuse, LangSmith, and OpenTelemetry
 - **Sampling Strategies** - Always, ratio-based, or custom sampling
 - **Span Processors** - Transform or filter span data before export
 - **OpenTelemetry Compatible** - Standard trace/span ID formats for integration

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -102,13 +102,16 @@ You can start editing files inside the \`src/mastra\` directory. The development
 
 To learn more about Mastra, visit our [documentation](https://mastra.ai/docs/). Your bootstrapped project includes example code for [agents](https://mastra.ai/docs/agents/overview), [tools](https://mastra.ai/docs/agents/using-tools), [workflows](https://mastra.ai/docs/workflows/overview), [scorers](https://mastra.ai/docs/evals/overview), and [observability](https://mastra.ai/docs/observability/overview).
 
-If you're new to AI agents, check out our [course](https://mastra.ai/course) and [YouTube videos](https://youtube.com/@mastra-ai). You can also join our [Discord](https://discord.gg/BTYqqHKUrf) community to get help and share your projects.
+If you're new to AI agents, check out our [course](https://mastra.ai/learn) and [YouTube videos](https://youtube.com/@mastra-ai). You can also join our [Discord](https://discord.gg/BTYqqHKUrf) community to get help and share your projects.
 
-## Deploy on Mastra Cloud
+## Deploy to the Mastra platform
 
-[Mastra Cloud](https://cloud.mastra.ai/) gives you a serverless agent environment with atomic deployments. Access your agents from anywhere and monitor performance. Make sure they don't go off the rails with evals and tracing.
+The [Mastra platform](https://projects.mastra.ai) provides two products for deploying and managing AI applications built with the Mastra framework:
 
-Check out the [deployment guide](https://mastra.ai/docs/deployment/overview) for more details.`;
+- **Studio**: A hosted visual environment for testing agents, running workflows, and inspecting traces
+- **Server**: A production deployment target that runs your Mastra application as an API server
+
+Learn more in the [Mastra platform documentation](https://mastra.ai/docs/mastra-platform/overview).`;
 
   const formattedContent = await prettier.format(content, {
     parser: 'markdown',

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -524,7 +524,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/packages/core/scripts/generate-model-docs.ts
+++ b/packages/core/scripts/generate-model-docs.ts
@@ -614,13 +614,13 @@ Mastra provides a unified interface for working with LLMs across multiple provid
 
 ## Features
 
-- **One API for any model** - Access any model without having to install and manage additional provider dependencies.
+- **One API for any model**: Access any model without having to install and manage additional provider dependencies.
 
-- **Access the newest AI** - Use new models the moment they're released, no matter which provider they come from. Avoid vendor lock-in with Mastra's provider-agnostic interface.
+- **Access the newest AI**: Use new models the moment they're released, no matter which provider they come from. Avoid vendor lock-in with Mastra's provider-agnostic interface.
 
-- [**Mix and match models**](#mix-and-match-models) - Use different models for different tasks. For example, run GPT-5-mini for large-context processing, then switch to Claude Opus 4.6 for reasoning tasks.
+- [**Mix and match models**](#mix-and-match-models): Use different models for different tasks. For example, run GPT-5-mini for large-context processing, then switch to Claude Opus 4.6 for reasoning tasks.
 
-- [**Model fallbacks**](#model-fallbacks) - If a provider experiences an outage, Mastra can automatically switch to another provider at the application level, minimizing latency compared to API gateways.
+- [**Model fallbacks**](#model-fallbacks): If a provider experiences an outage, Mastra can automatically switch to another provider at the application level, minimizing latency compared to API gateways.
 
 ## Basic usage
 

--- a/templates/template-browsing-agent/src/mastra/index.ts
+++ b/templates/template-browsing-agent/src/mastra/index.ts
@@ -21,7 +21,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/templates/template-chat-with-youtube/src/mastra/index.ts
+++ b/templates/template-chat-with-youtube/src/mastra/index.ts
@@ -21,7 +21,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/templates/template-csv-to-questions/src/mastra/index.ts
+++ b/templates/template-csv-to-questions/src/mastra/index.ts
@@ -26,7 +26,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/templates/template-docs-chatbot/src/mastra/index.ts
+++ b/templates/template-docs-chatbot/src/mastra/index.ts
@@ -22,7 +22,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/templates/template-google-sheets/src/mastra/index.ts
+++ b/templates/template-google-sheets/src/mastra/index.ts
@@ -92,7 +92,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys

--- a/templates/weather-agent/src/mastra/index.ts
+++ b/templates/weather-agent/src/mastra/index.ts
@@ -25,7 +25,7 @@ export const mastra = new Mastra({
         serviceName: 'mastra',
         exporters: [
           new DefaultExporter(), // Persists traces to storage for Mastra Studio
-          new CloudExporter(), // Sends traces to Mastra Cloud (if MASTRA_CLOUD_ACCESS_TOKEN is set)
+          new CloudExporter(), // Sends observability data to hosted Mastra Studio (if MASTRA_CLOUD_ACCESS_TOKEN is set)
         ],
         spanOutputProcessors: [
           new SensitiveDataFilter(), // Redacts sensitive data like passwords, tokens, keys


### PR DESCRIPTION
## Description

Update docs, code, READMEs, and our create-mastra to no longer mention Mastra Cloud but "Mastra platform"

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the entire Mastra codebase to use clearer naming. Instead of calling it "Mastra Cloud," the project now refers to it as "Mastra platform" or "hosted Mastra Studio" in different contexts. It's like renaming a product to better describe what it does. Additionally, documentation links are reformatted to use colons instead of dashes for consistency.

## Summary of Changes

This PR systematically updates references throughout the Mastra codebase from "Mastra Cloud" to "Mastra platform" or "hosted Mastra Studio," along with standardizing documentation link formatting.

### Documentation Reference Updates

The majority of changes involve replacing "Mastra Cloud" terminology with more accurate descriptions:
- References to "Mastra Cloud" are replaced with "Mastra platform" in observability, deployment, and migration documentation
- `CloudExporter` descriptions are updated to reference "hosted Mastra Studio" instead of "Mastra Cloud"
- Documentation comments clarifying the purpose of various services and exporters are updated for consistency

### Link Formatting Standardization

Across numerous documentation files, link formatting is standardized by:
- Changing separator style from ` - ` (dash with spaces) to `: ` (colon) between link text and descriptions
- Applied consistently across: guides, deployment docs, observability docs, reference documentation for agents, evals, servers, storage, voice, workflows, and workspace
- No changes to actual link targets or content, purely punctuation/formatting updates

### Code Comment Updates

Inline comments in example files and templates are updated:
- `CloudExporter` comments updated from "sends traces to Mastra Cloud" to "sends observability data to hosted Mastra Studio"
- Auth provider comments updated from "Mastra Cloud" references to "Mastra platform"
- Applies to: examples, templates, and test configuration files

### Specific Content Changes

**docs/src/content/en/docs/server/middleware.mdx**: Removed the "Special Mastra headers" section including `x-mastra-cloud`, `x-mastra-client-type`, and `x-studio` header documentation (25 lines removed)

**packages/cli/src/commands/create/utils.ts**: Updated generated README to replace "Deploy on Mastra Cloud" section with "Deploy to the Mastra platform," updated course link from `mastra.ai/course` to `mastra.ai/learn`

**docs/styles/config/vocabularies/Mastra/accept.txt**: Removed "Mastra Cloud" from the vocabulary accept list

**observability/mastra/README.md**: Updated feature descriptions to reference "Mastra platform" instead of "Mastra Cloud"

### Release Notes

**Changeset**: Marked `@mastra/observability`, `@mastra/core`, and `mastra` for patch version bumps to reflect these terminology updates.

## Review Effort

All changes are low-effort: documentation and comment updates only. No functional code logic is modified, no exported API signatures changed, and no breaking changes introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->