### PR TITLE
fix(cli): allow headless server deploys to use project config

### DIFF
--- a/.changeset/deep-boxes-brush.md
+++ b/.changeset/deep-boxes-brush.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed headless server deploys so they can use .mastra-project.json for org and project resolution in CI.

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn().mockReturnValue('my-app'),
+}));
+
+let closeHandler: (() => void) | undefined;
+
+vi.mock('node:fs', () => ({
+  createWriteStream: vi.fn(() => ({
+    on: vi.fn((event: string, callback: () => void) => {
+      if (event === 'close') {
+        closeHandler = callback;
+      }
+    }),
+  })),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  rm: vi.fn().mockResolvedValue(undefined),
+  stat: vi.fn().mockResolvedValue({ size: 1024 }),
+  access: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn(async (path: string) => {
+    if (path.endsWith('.env') || path.endsWith('.env.local') || path.endsWith('.env.production')) {
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    }
+    return Buffer.from('zip-data');
+  }),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  log: { step: vi.fn(), info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  note: vi.fn(),
+  confirm: vi.fn(),
+  select: vi.fn(),
+  isCancel: vi.fn(() => false),
+  cancel: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  outro: vi.fn(),
+}));
+
+vi.mock('archiver', () => ({
+  default: vi.fn(() => ({
+    on: vi.fn(),
+    pipe: vi.fn(),
+    glob: vi.fn(),
+    file: vi.fn(),
+    finalize: vi.fn(async () => {
+      closeHandler?.();
+    }),
+  })),
+}));
+
+vi.mock('../auth/credentials.js', () => ({
+  getToken: vi.fn().mockResolvedValue('test-token'),
+  getCurrentOrgId: vi.fn().mockResolvedValue('org-1'),
+}));
+
+vi.mock('../auth/api.js', () => ({
+  fetchOrgs: vi.fn().mockResolvedValue([{ id: 'org-1', name: 'Test Org', role: 'admin', isCurrent: true }]),
+}));
+
+vi.mock('../studio/project-config.js', () => ({
+  loadProjectConfig: vi.fn().mockResolvedValue(null),
+  saveProjectConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./platform-api.js', () => ({
+  fetchServerProjects: vi.fn().mockResolvedValue([]),
+  createServerProject: vi.fn().mockResolvedValue({ id: 'proj-1', name: 'my-app', slug: 'my-app' }),
+  uploadServerDeploy: vi.fn().mockResolvedValue({ id: 'deploy-1', status: 'queued' }),
+  pollServerDeploy: vi
+    .fn()
+    .mockResolvedValue({ id: 'deploy-1', status: 'running', instanceUrl: 'https://example.com' }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  closeHandler = undefined;
+});
+
+afterEach(() => {
+  delete process.env.MASTRA_API_TOKEN;
+  delete process.env.MASTRA_ORG_ID;
+  delete process.env.MASTRA_PROJECT_ID;
+});
+
+describe('serverDeployAction', () => {
+  it('throws when headless mode is missing required env vars and flags', async () => {
+    process.env.MASTRA_API_TOKEN = 'headless-token';
+    vi.resetModules();
+
+    const { serverDeployAction } = await import('./deploy.js');
+
+    await expect(serverDeployAction(undefined, {})).rejects.toThrow(
+      'MASTRA_ORG_ID and MASTRA_PROJECT_ID (or --org/--project flags, or .mastra-project.json) are required when MASTRA_API_TOKEN is set',
+    );
+  });
+
+  it('allows headless mode to rely on .mastra-project.json without env vars or flags', async () => {
+    process.env.MASTRA_API_TOKEN = 'headless-token';
+    vi.resetModules();
+
+    const { loadProjectConfig } = await import('../studio/project-config.js');
+    vi.mocked(loadProjectConfig).mockResolvedValue({
+      organizationId: 'org-1',
+      projectId: 'proj-1',
+      projectName: 'my-app',
+      projectSlug: 'my-app',
+    });
+
+    const { serverDeployAction } = await import('./deploy.js');
+
+    await expect(serverDeployAction(undefined, {})).resolves.toBeUndefined();
+  });
+
+  it('uses project config in headless mode without fetching orgs', async () => {
+    process.env.MASTRA_API_TOKEN = 'headless-token';
+    vi.resetModules();
+
+    const { loadProjectConfig } = await import('../studio/project-config.js');
+    const { fetchOrgs } = await import('../auth/api.js');
+
+    vi.mocked(loadProjectConfig).mockResolvedValue({
+      organizationId: 'org-1',
+      projectId: 'proj-1',
+      projectName: 'my-app',
+      projectSlug: 'my-app',
+    });
+    vi.mocked(fetchOrgs).mockResolvedValue([]);
+
+    const { serverDeployAction } = await import('./deploy.js');
+
+    await expect(serverDeployAction(undefined, {})).resolves.toBeUndefined();
+    expect(fetchOrgs).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -105,6 +105,7 @@ async function resolveOrg(
   projectConfig: { organizationId?: string } | null,
   flagOrg?: string,
 ): Promise<{ orgId: string; orgName: string }> {
+  const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);
   const envOrgId = process.env.MASTRA_ORG_ID;
   if (envOrgId) {
     return { orgId: envOrgId, orgName: envOrgId };
@@ -117,6 +118,9 @@ async function resolveOrg(
   }
 
   if (projectConfig?.organizationId) {
+    if (isHeadless) {
+      return { orgId: projectConfig.organizationId, orgName: projectConfig.organizationId };
+    }
     const orgs = await fetchOrgs(token);
     const match = orgs.find(o => o.id === projectConfig.organizationId);
     if (match) {


### PR DESCRIPTION
Fix `mastra server deploy` so headless CI can rely on `.mastra-project.json` again, matching the existing deploy contract and docs intent.

## What changed

- Keep the existing headless preflight behavior that accepts org/project from:
  - env vars
  - `--org` / `--project` flags
  - `.mastra-project.json`
- Fix the later org resolution step to trust `projectConfig.organizationId` in headless mode instead of re-fetching org membership first
- Add server deploy tests covering:
  - headless failure when no org/project source is available
  - headless success when `.mastra-project.json` provides org/project
  - no `fetchOrgs()` call when config is used in headless mode

## Why

- `serverDeployAction()` already implied `.mastra-project.json` was sufficient in headless mode
- but `resolveOrg()` could still fail later with `No organizations found`
- this made the server deploy contract internally inconsistent and caused CI failures

## Files changed

- `packages/cli/src/commands/server/deploy.ts`
- `packages/cli/src/commands/server/deploy.test.ts`
- `.changeset/deep-boxes-brush.md`

## Validation

- `pnpm --filter ./packages/cli test -- src/commands/server/deploy.test.ts src/commands/studio/deploy.test.ts`
- `pnpm --filter ./packages/cli typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a problem where the server deploy command wasn't working in automated environments (like CI/CD pipelines). The fix lets the deploy command use organization and project information that's already saved in a config file (`.mastra-project.json`) instead of trying to look it up online, which was failing. The PR also adds tests to make sure this works correctly.

## Overview

This PR restores support for headless CI deployments when using `mastra server deploy` with a `.mastra-project.json` configuration file. Previously, headless deployments would fail when trying to resolve organization information, even when the org and project were already specified in the project config.

## Key Changes

### Modified: `packages/cli/src/commands/server/deploy.ts`
The `resolveOrg` function now detects headless mode (by checking for `MASTRA_API_TOKEN` environment variable) and, when a `projectConfig.organizationId` is available, returns the organization immediately without attempting to fetch organization data via the API. This prevents unnecessary API calls and eliminates failures that could occur when `fetchOrgs()` returns no results in headless environments.

### Added: `packages/cli/src/commands/server/deploy.test.ts`
New test suite covering headless deployment scenarios:
- Validates that the action fails appropriately when running headless without org/project configuration
- Confirms the action succeeds when organization and project are sourced from `.mastra-project.json`
- Verifies that `fetchOrgs()` is not called when project config is available, avoiding unnecessary network calls

### Added: `.changeset/deep-boxes-brush.md`
Changelog entry documenting this patch-level fix for headless server deployments.

## Behavior

The fix maintains backward compatibility with existing deployment configuration sources (environment variables and command-line flags) while now properly trusting the `.mastra-project.json` configuration in headless CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->