### PR TITLE
fix(pg,libsql): add schema backfill for experiment table columns

### DIFF
--- a/.changeset/old-guests-lie.md
+++ b/.changeset/old-guests-lie.md
@@ -3,4 +3,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed missing schema backfill for experiment tables. Existing databases created before the review pipeline feature would fail with 'column status does not exist' because the experiments init() was not calling alterTable to add newer columns (status, tags, agentVersion). Now properly adds missing columns on startup, matching the pattern used by other storage domains.
+Fixed "column does not exist" errors when using experiment review features on databases created before the review pipeline was introduced. Startup now automatically migrates older experiment tables to the latest schema.

--- a/.changeset/old-guests-lie.md
+++ b/.changeset/old-guests-lie.md
@@ -1,0 +1,6 @@
+---
+'@mastra/libsql': patch
+'@mastra/pg': patch
+---
+
+Fixed missing schema backfill for experiment tables. Existing databases created before the review pipeline feature would fail with 'column status does not exist' because the experiments init() was not calling alterTable to add newer columns (status, tags, agentVersion). Now properly adds missing columns on startup, matching the pattern used by other storage domains.

--- a/stores/libsql/src/storage/domains/experiments/index.ts
+++ b/stores/libsql/src/storage/domains/experiments/index.ts
@@ -46,6 +46,17 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: EXPERIMENT_RESULTS_SCHEMA,
     });
+    // Add columns introduced after initial schema for backwards compatibility
+    await this.#db.alterTable({
+      tableName: TABLE_EXPERIMENTS,
+      schema: EXPERIMENTS_SCHEMA,
+      ifNotExists: ['agentVersion'],
+    });
+    await this.#db.alterTable({
+      tableName: TABLE_EXPERIMENT_RESULTS,
+      schema: EXPERIMENT_RESULTS_SCHEMA,
+      ifNotExists: ['status', 'tags'],
+    });
 
     // Indexes — idempotent, safe to run on every init
     await this.#client.execute({

--- a/stores/pg/src/storage/domains/experiments/index.ts
+++ b/stores/pg/src/storage/domains/experiments/index.ts
@@ -65,6 +65,17 @@ export class ExperimentsPG extends ExperimentsStorage {
   async init(): Promise<void> {
     await this.#db.createTable({ tableName: TABLE_EXPERIMENTS, schema: EXPERIMENTS_SCHEMA });
     await this.#db.createTable({ tableName: TABLE_EXPERIMENT_RESULTS, schema: EXPERIMENT_RESULTS_SCHEMA });
+    // Add columns introduced after initial schema for backwards compatibility
+    await this.#db.alterTable({
+      tableName: TABLE_EXPERIMENTS,
+      schema: EXPERIMENTS_SCHEMA,
+      ifNotExists: ['agentVersion'],
+    });
+    await this.#db.alterTable({
+      tableName: TABLE_EXPERIMENT_RESULTS,
+      schema: EXPERIMENT_RESULTS_SCHEMA,
+      ifNotExists: ['status', 'tags'],
+    });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
   }


### PR DESCRIPTION
Existing databases created before #14470 are missing `status` and `tags` on `mastra_experiment_results` and `agentVersion` on `mastra_experiments`. This causes `column "status" does not exist` when hitting `/experiments/review-summary`.

The fix adds `alterTable` calls in the experiments `init()` for both PG and LibSQL, same pattern the agents/memory/observability domains already use:

```ts
await this.#db.alterTable({
  tableName: TABLE_EXPERIMENT_RESULTS,
  schema: EXPERIMENT_RESULTS_SCHEMA,
  ifNotExists: ['status', 'tags'],
});
```

Columns use `ADD COLUMN IF NOT EXISTS`, so it's idempotent and a no-op on fresh databases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Older databases were missing a few columns the app now expects, causing crashes. This PR makes the app automatically add those missing columns at startup so everything keeps working without manual DB changes.

## Overview

Adds idempotent schema backfill to the experiments domain so databases created before PR #14470 gain the missing columns required by the review pipeline, preventing runtime "column does not exist" errors.

## Changes

**New Changeset**
- `.changeset/old-guests-lie.md`: Marks `@mastra/libsql` and `@mastra/pg` for a patch release describing the startup migration/backfill.

**PostgreSQL (stores/pg/src/storage/domains/experiments/index.ts)**
- In `ExperimentsPG.init()`, added `alterTable` calls to conditionally add:
  - `agentVersion` on `TABLE_EXPERIMENTS`
  - `status` and `tags` on `TABLE_EXPERIMENT_RESULTS`
- Uses `ifNotExists` → generates `ADD COLUMN IF NOT EXISTS` (idempotent).

**LibSQL (stores/libsql/src/storage/domains/experiments/index.ts)**
- In `ExperimentsLibSQL.init()`, added the same idempotent `alterTable` calls to add:
  - `agentVersion` on `TABLE_EXPERIMENTS`
  - `status` and `tags` on `TABLE_EXPERIMENT_RESULTS`

## Impact

- Backward-compatible: no-op on fresh databases.
- Automatically fixes missing columns during initialization—no manual migration required.
- Resolves runtime errors like `column "status" does not exist` when using experiment review features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->