### PR TITLE
Draft: Add DatadogBridge for real-time APM span context propagation

### DIFF
--- a/.changeset/datadog-bridge.md
+++ b/.changeset/datadog-bridge.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': minor
+---
+
+Add `DatadogBridge` for real-time APM context propagation. The new bridge creates dd-trace APM spans eagerly and activates them in dd-trace's scope during execution, so auto-instrumented HTTP and database calls inside tools and processors are correctly nested under their parent Mastra span instead of falling back to the request handler. LLM Observability annotation continues to flow through dd-trace's own LLMObs pipeline. The existing `DatadogExporter` remains available for LLMObs-only use cases.

--- a/docs/src/content/en/docs/observability/tracing/bridges/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/bridges/datadog.mdx
@@ -1,0 +1,217 @@
+---
+title: "Datadog bridge | Tracing | Observability"
+description: "Integrate Mastra tracing with Datadog APM and LLM Observability"
+packages:
+  - "@mastra/observability"
+  - "@mastra/datadog"
+---
+
+# Datadog bridge
+
+:::warning
+
+The Datadog Bridge is currently **experimental**. APIs and configuration options may change in future releases.
+
+:::
+
+The Datadog Bridge enables bidirectional integration between Mastra's tracing system and Datadog. Unlike exporters that send trace data after execution completes, the bridge creates native dd-trace spans in real time so that auto-instrumented APM operations (HTTP calls, database queries, etc.) inside your tools and processors are correctly nested under their parent Mastra spans.
+
+:::info Looking to send LLMObs data without dd-trace APM?
+
+If you don't have a local Datadog Agent and only want to ship LLM Observability data, the [Datadog Exporter](/docs/observability/tracing/exporters/datadog) may be simpler. It supports agentless mode and ships LLMObs spans directly to Datadog intake.
+
+:::
+
+## When to use the bridge
+
+Use the DatadogBridge when you:
+
+- Use `dd-trace` auto-instrumentation in your application (HTTP servers, database clients, etc.)
+- Want APM service calls made by tools, MCP tools, or output processors to appear under their parent Mastra span instead of the request handler
+- Need both APM traces and LLM Observability data to share a consistent trace topology
+- Are building a distributed system where Datadog trace context must propagate across services
+
+## How it works
+
+The DatadogBridge participates in two parts of the dd-trace pipeline:
+
+**APM context propagation (real time):**
+
+- Creates a dd-trace APM span via `tracer.startSpan()` when each Mastra span is created
+- Activates the APM span in dd-trace's scope via `tracer.scope().activate()` during execution
+- Auto-instrumented operations inside the active scope are parented to the correct Mastra span
+- Inherits the active dd-trace context (e.g., an incoming request span) when no explicit Mastra parent exists
+
+**LLM Observability emission (on span end):**
+
+- Emits LLMObs annotations (model info, token usage, input/output, errors) through dd-trace's own LLMObs pipeline
+- Maintains parent-child relationships in the LLM Observability product using nested `llmobs.trace()` calls
+- Reuses the same data shape and span-kind mapping as the [Datadog Exporter](/docs/observability/tracing/exporters/datadog#span-type-mapping)
+
+## Why this matters
+
+Without the bridge, the Datadog Exporter creates LLMObs spans only after a trace completes. During execution, no dd-trace span is active in scope, so any HTTP or database call made by a tool falls back to whatever dd-trace span is active at the time — typically the incoming request handler. The result is that service calls from MCP tools or output processors appear as children of the request span instead of the agent or processor span that actually made them.
+
+The bridge fixes this by creating real dd-trace spans up front, so the scope is correct when auto-instrumentation runs.
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/datadog dd-trace
+```
+
+The bridge requires `dd-trace` to be installed and a local Datadog Agent (or compatible OTLP receiver) to receive APM data. See the [APM prerequisites](/docs/observability/tracing/exporters/datadog#prerequisites) on the exporter page for agent setup details.
+
+## Configuration
+
+Using the DatadogBridge requires two steps:
+
+1. Initialize `dd-trace` so its auto-instrumentation patches HTTP, database, and framework libraries
+1. Add the DatadogBridge to your Mastra observability config
+
+### Step 1: Initialize dd-trace
+
+`dd-trace` must be initialized before any other imports so its auto-instrumentation can patch libraries at load time. The bridge will detect an already-initialized tracer and reuse it.
+
+```typescript title="src/mastra/index.ts"
+import tracer from 'dd-trace'
+
+tracer.init({
+  service: process.env.DD_SERVICE || 'my-mastra-app',
+  env: process.env.DD_ENV || 'production',
+  version: process.env.DD_VERSION,
+})
+
+import { Mastra } from '@mastra/core'
+import { Observability } from '@mastra/observability'
+import { DatadogBridge } from '@mastra/datadog'
+
+// ...
+```
+
+:::note
+Import and initialize `dd-trace` before all other modules. If you can't reorder imports, use the `--import` or `--require` Node flag to load a separate initialization file.
+:::
+
+### Step 2: Mastra Configuration
+
+Add the DatadogBridge to your Mastra observability config:
+
+```typescript title="src/mastra/index.ts"
+export const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'my-mastra-app',
+        bridge: new DatadogBridge({
+          mlApp: process.env.DD_LLMOBS_ML_APP!,
+        }),
+      },
+    },
+  }),
+  bundler: {
+    externals: [
+      'dd-trace',
+      '@datadog/native-metrics',
+      '@datadog/native-appsec',
+      '@datadog/native-iast-taint-tracking',
+      '@datadog/pprof',
+    ],
+  },
+})
+```
+
+```bash title=".env"
+DD_SERVICE=my-mastra-app
+DD_ENV=production
+DD_VERSION=1.0.0
+DD_LLMOBS_ML_APP=my-llm-app
+```
+
+When `dd-trace` is initialized, it routes APM data to your local Datadog Agent on `localhost:8126`. The bridge enables LLM Observability on top of the same tracer, so APM and LLMObs data appear under the same service in Datadog.
+
+No Mastra exporters are required when using the bridge — both APM and LLMObs data flow through `dd-trace`. You can still add Mastra exporters if you want to send traces to additional destinations.
+
+## Agent vs. agentless mode
+
+The bridge defaults to **agent mode** (`agentless: false`). This assumes a local Datadog Agent is running on `localhost:8126` to receive both APM and LLMObs data. This is the typical setup when using `dd-trace` auto-instrumentation, since APM data always routes through the agent.
+
+If you don't have a local Datadog Agent and only need LLM Observability data (no APM auto-instrumentation), you can enable agentless mode to ship LLMObs data directly to Datadog intake. In this case, you must provide an API key.
+
+```typescript
+new DatadogBridge({
+  mlApp: process.env.DD_LLMOBS_ML_APP!,
+  apiKey: process.env.DD_API_KEY!,
+  agentless: true,
+})
+```
+
+:::note
+For most bridge users, agent mode is the right choice. APM data cannot be sent in agentless mode, so enabling agentless splits LLMObs traffic away from APM traffic. If you want LLMObs-only without an agent, use the [Datadog Exporter](/docs/observability/tracing/exporters/datadog) instead.
+:::
+
+## Trace hierarchy
+
+With the DatadogBridge, your traces maintain proper hierarchy across dd-trace and Mastra boundaries. Service calls made by tools and processors appear under the correct Mastra span:
+
+```
+HTTP POST /api/chat (from web framework instrumentation)
+└── agent.orchestrator (from Mastra via DatadogBridge)
+    ├── chat gpt-5.4 (LLM call)
+    ├── tool.execute search (tool execution)
+    │   └── HTTP GET api.example.com (auto-instrumented from inside the tool)
+    └── processor.guardrail (output processor)
+        └── HTTP POST guardrail-service/check (auto-instrumented from inside the processor)
+```
+
+In Datadog, the APM trace shows this full topology, and the LLM Observability product shows the agent and LLM-specific spans with their inputs, outputs, and token metrics.
+
+## Span type mapping
+
+The bridge uses the same span-kind mapping as the Datadog Exporter for LLM Observability. See [span type mapping](/docs/observability/tracing/exporters/datadog#span-type-mapping) on the exporter page.
+
+## Using tags
+
+Tags help you categorize and filter traces in Datadog. Add tags when executing agents or workflows:
+
+```typescript
+const result = await agent.generate('Hello', {
+  tracingOptions: {
+    tags: ['production', 'experiment-v2', 'user-request'],
+  },
+})
+```
+
+Tags formatted as `key:value` (e.g., `instance_name:career-scout-api`) are split into structured tag entries; tags without a colon are set with a `true` value.
+
+## Promoting context keys to flat tags
+
+Use `requestContextKeys` to promote specific keys from the request context or span attributes into flat, indexable LLM Observability tags. This makes them filterable in the Datadog UI:
+
+```typescript
+new DatadogBridge({
+  mlApp: process.env.DD_LLMOBS_ML_APP!,
+  requestContextKeys: ['tenantId', 'agentId'],
+})
+```
+
+Promoted keys are removed from `annotations.metadata` and added as flat tags on each LLMObs span.
+
+## Troubleshooting
+
+If APM spans aren't connecting to Mastra spans as expected:
+
+- Verify `dd-trace` is initialized **before** any other imports (it patches libraries at load time)
+- Verify a local Datadog Agent is running and reachable at `localhost:8126`
+- Ensure the DatadogBridge is set as `bridge` (not as an entry in `exporters`) in your observability config
+- Confirm you haven't also added the `DatadogExporter` to `exporters` — using both will double-emit LLMObs data
+
+For native-module compatibility issues with `dd-trace` and bundler externals, see the [Datadog exporter troubleshooting](/docs/observability/tracing/exporters/datadog#troubleshooting) section.
+
+## Related
+
+- [Tracing Overview](/docs/observability/tracing/overview)
+- [Datadog Exporter](/docs/observability/tracing/exporters/datadog) - LLMObs-only mode without dd-trace APM
+- [DatadogBridge Reference](/reference/observability/tracing/bridges/datadog) - API documentation
+- [Datadog APM documentation](https://docs.datadoghq.com/tracing/)
+- [Datadog LLM Observability documentation](https://docs.datadoghq.com/llm_observability/)

--- a/docs/src/content/en/docs/observability/tracing/bridges/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/bridges/datadog.mdx
@@ -16,9 +16,9 @@ The Datadog Bridge is currently **experimental**. APIs and configuration options
 
 The Datadog Bridge enables bidirectional integration between Mastra's tracing system and Datadog. Unlike exporters that send trace data after execution completes, the bridge creates native dd-trace spans in real time so that auto-instrumented APM operations (HTTP calls, database queries, etc.) inside your tools and processors are correctly nested under their parent Mastra spans.
 
-:::info Looking to send LLMObs data without dd-trace APM?
+:::info Not using dd-trace APM?
 
-If you don't have a local Datadog Agent and only want to ship LLM Observability data, the [Datadog Exporter](/docs/observability/tracing/exporters/datadog) may be simpler. It supports agentless mode and ships LLMObs spans directly to Datadog intake.
+If you only need to send LLM Observability data and don't use `dd-trace` APM auto-instrumentation, the [Datadog Exporter](/docs/observability/tracing/exporters/datadog) is simpler — it supports agentless mode and sends spans directly to Datadog without a local agent.
 
 :::
 
@@ -44,13 +44,13 @@ The DatadogBridge participates in two parts of the dd-trace pipeline:
 
 **LLM Observability emission (on span end):**
 
-- Emits LLMObs annotations (model info, token usage, input/output, errors) through dd-trace's own LLMObs pipeline
-- Maintains parent-child relationships in the LLM Observability product using nested `llmobs.trace()` calls
+- Emits annotations (model info, token usage, input/output, errors) through `dd-trace`'s LLM Observability pipeline
+- Maintains parent-child relationships in Datadog LLM Observability using nested `llmobs.trace()` calls
 - Reuses the same data shape and span-kind mapping as the [Datadog Exporter](/docs/observability/tracing/exporters/datadog#span-type-mapping)
 
 ## Why this matters
 
-Without the bridge, the Datadog Exporter creates LLMObs spans only after a trace completes. During execution, no dd-trace span is active in scope, so any HTTP or database call made by a tool falls back to whatever dd-trace span is active at the time — typically the incoming request handler. The result is that service calls from MCP tools or output processors appear as children of the request span instead of the agent or processor span that actually made them.
+Without the bridge, the Datadog Exporter only creates LLM Observability spans after a trace completes. During execution, no `dd-trace` span is active in scope, so any HTTP or database call made by a tool falls back to whatever `dd-trace` span is active at the time — typically the incoming request handler. The result is that service calls from MCP tools or output processors appear as children of the request span instead of the agent or processor span that actually made them.
 
 The bridge fixes this by creating real dd-trace spans up front, so the scope is correct when auto-instrumentation runs.
 
@@ -128,15 +128,15 @@ DD_VERSION=1.0.0
 DD_LLMOBS_ML_APP=my-llm-app
 ```
 
-When `dd-trace` is initialized, it routes APM data to your local Datadog Agent on `localhost:8126`. The bridge enables LLM Observability on top of the same tracer, so APM and LLMObs data appear under the same service in Datadog.
+When `dd-trace` is initialized, it routes APM data to your local Datadog Agent on `localhost:8126`. The bridge enables LLM Observability on top of the same tracer, so both sets of data appear under the same service in Datadog.
 
-No Mastra exporters are required when using the bridge — both APM and LLMObs data flow through `dd-trace`. You can still add Mastra exporters if you want to send traces to additional destinations.
+No Mastra exporters are required when using the bridge — both APM and LLM Observability data flow through `dd-trace`. You can still add Mastra exporters if you want to send traces to additional destinations.
 
 ## Agent vs. agentless mode
 
-The bridge defaults to **agent mode** (`agentless: false`). This assumes a local Datadog Agent is running on `localhost:8126` to receive both APM and LLMObs data. This is the typical setup when using `dd-trace` auto-instrumentation, since APM data always routes through the agent.
+The bridge defaults to **agent mode** (`agentless: false`). This assumes a local Datadog Agent is running on `localhost:8126` to receive both APM and LLM Observability data. This is the typical setup when using `dd-trace` auto-instrumentation, since APM data always routes through the agent.
 
-If you don't have a local Datadog Agent and only need LLM Observability data (no APM auto-instrumentation), you can enable agentless mode to ship LLMObs data directly to Datadog intake. In this case, you must provide an API key.
+If you don't have a local Datadog Agent and only need LLM Observability data (no APM auto-instrumentation), you can enable agentless mode to send data directly to Datadog. In this case, you must provide an API key.
 
 ```typescript
 new DatadogBridge({
@@ -147,7 +147,7 @@ new DatadogBridge({
 ```
 
 :::note
-For most bridge users, agent mode is the right choice. APM data cannot be sent in agentless mode, so enabling agentless splits LLMObs traffic away from APM traffic. If you want LLMObs-only without an agent, use the [Datadog Exporter](/docs/observability/tracing/exporters/datadog) instead.
+For most bridge users, agent mode is the right choice. APM data cannot be sent in agentless mode, so enabling agentless splits LLM Observability traffic away from APM traffic. If you want LLM Observability only without an agent, use the [Datadog Exporter](/docs/observability/tracing/exporters/datadog) instead.
 :::
 
 ## Trace hierarchy
@@ -195,7 +195,7 @@ new DatadogBridge({
 })
 ```
 
-Promoted keys are removed from `annotations.metadata` and added as flat tags on each LLMObs span.
+Promoted keys are removed from `annotations.metadata` and added as flat tags on each LLM Observability span.
 
 ## Troubleshooting
 
@@ -204,14 +204,14 @@ If APM spans aren't connecting to Mastra spans as expected:
 - Verify `dd-trace` is initialized **before** any other imports (it patches libraries at load time)
 - Verify a local Datadog Agent is running and reachable at `localhost:8126`
 - Ensure the DatadogBridge is set as `bridge` (not as an entry in `exporters`) in your observability config
-- Confirm you haven't also added the `DatadogExporter` to `exporters` — using both will double-emit LLMObs data
+- Confirm you haven't also added the `DatadogExporter` to `exporters` — using both will double-emit LLM Observability data
 
 For native-module compatibility issues with `dd-trace` and bundler externals, see the [Datadog exporter troubleshooting](/docs/observability/tracing/exporters/datadog#troubleshooting) section.
 
 ## Related
 
 - [Tracing Overview](/docs/observability/tracing/overview)
-- [Datadog Exporter](/docs/observability/tracing/exporters/datadog) - LLMObs-only mode without dd-trace APM
+- [Datadog Exporter](/docs/observability/tracing/exporters/datadog) - LLM Observability only, no `dd-trace` APM
 - [DatadogBridge Reference](/reference/observability/tracing/bridges/datadog) - API documentation
 - [Datadog APM documentation](https://docs.datadoghq.com/tracing/)
 - [Datadog LLM Observability documentation](https://docs.datadoghq.com/llm_observability/)

--- a/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
@@ -9,6 +9,12 @@ packages:
 
 [Datadog](https://datadoghq.com/) is a comprehensive monitoring platform with dedicated LLM Observability features. The Datadog exporter sends your traces to Datadog's LLM Observability product, providing insights into model performance, token usage, and conversation flows.
 
+:::info Looking for correct APM parenting?
+
+If you also use `dd-trace` APM auto-instrumentation, the [Datadog Bridge](/docs/observability/tracing/bridges/datadog) is a better choice. The bridge creates dd-trace spans in real time so HTTP and database calls inside tools and processors are correctly nested under their parent Mastra span. The exporter alone emits LLMObs data retroactively, which means auto-instrumented APM spans fall back to the request handler.
+
+:::
+
 ## Installation
 
 ```bash npm2yarn

--- a/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
@@ -9,9 +9,9 @@ packages:
 
 [Datadog](https://datadoghq.com/) is a comprehensive monitoring platform with dedicated LLM Observability features. The Datadog exporter sends your traces to Datadog's LLM Observability product, providing insights into model performance, token usage, and conversation flows.
 
-:::info Looking for correct APM parenting?
+:::info Also using `dd-trace` APM?
 
-If you also use `dd-trace` APM auto-instrumentation, the [Datadog Bridge](/docs/observability/tracing/bridges/datadog) is a better choice. The bridge creates dd-trace spans in real time so HTTP and database calls inside tools and processors are correctly nested under their parent Mastra span. The exporter alone emits LLMObs data retroactively, which means auto-instrumented APM spans fall back to the request handler.
+If you also use `dd-trace` APM auto-instrumentation, consider the [Datadog Bridge](/docs/observability/tracing/bridges/datadog) instead. The bridge creates `dd-trace` spans in real time so HTTP and database calls inside tools and processors are correctly nested under their parent Mastra span. The exporter on its own sends LLM Observability data after execution completes, which means auto-instrumented APM spans fall back to the request handler.
 
 :::
 
@@ -123,7 +123,7 @@ Note: When using agent mode, the API key is read from the local agent's configur
 
 ## Span type mapping
 
-Mastra span types are automatically mapped to Datadog LLMObs span kinds:
+Mastra span types are automatically mapped to Datadog LLM Observability span kinds:
 
 | Mastra SpanType | Datadog Kind |
 | - | - |

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -534,6 +534,11 @@ const sidebars = {
               items: [
                 {
                   type: 'doc',
+                  id: 'observability/tracing/bridges/datadog',
+                  label: 'Datadog',
+                },
+                {
+                  type: 'doc',
                   id: 'observability/tracing/bridges/otel',
                   label: 'OpenTelemetry',
                 },

--- a/docs/src/content/en/reference/observability/tracing/bridges/datadog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/bridges/datadog.mdx
@@ -17,7 +17,7 @@ The Datadog Bridge is currently **experimental**. APIs and configuration options
 
 :::
 
-Enables bidirectional integration between Mastra tracing and Datadog. Creates native dd-trace APM spans in real time so that auto-instrumented operations inside tools and processors are correctly nested under their parent Mastra span. Emits LLM Observability data through dd-trace's own LLMObs pipeline when spans end.
+Enables bidirectional integration between Mastra tracing and Datadog. Creates native `dd-trace` APM spans in real time so that auto-instrumented operations inside tools and processors are correctly nested under their parent Mastra span. Emits LLM Observability data through `dd-trace`'s pipeline when spans end.
 
 ## Constructor
 
@@ -50,7 +50,8 @@ Extends `BaseExporterConfig`, which includes:
   {
     name: 'mlApp',
     type: 'string',
-    description: 'ML application name for grouping LLMObs traces. Required. Falls back to DD_LLMOBS_ML_APP env var.',
+    description:
+      'ML application name for grouping LLM Observability traces. Required. Falls back to DD_LLMOBS_ML_APP env var.',
     required: false,
   },
   {
@@ -96,7 +97,7 @@ Extends `BaseExporterConfig`, which includes:
     name: 'requestContextKeys',
     type: 'string[]',
     description:
-      'Keys from request context or span attributes to promote into flat, searchable LLMObs tags (e.g., tenantId, agentId). Promoted keys are removed from annotations.metadata.',
+      'Keys from request context or span attributes to promote into flat, searchable LLM Observability tags (e.g., tenantId, agentId). Promoted keys are removed from annotations.metadata.',
     required: false,
   },
 ]}
@@ -174,7 +175,7 @@ Executes a synchronous function within the dd-trace context of a Mastra span.
 async flush(): Promise<void>
 ```
 
-Force-flushes any buffered LLMObs data to Datadog without shutting down the bridge. Useful in serverless environments where you need to ensure data is exported before the runtime terminates.
+Force-flushes any buffered LLM Observability data to Datadog without shutting down the bridge. Useful in serverless environments where you need to ensure data is exported before the runtime terminates.
 
 ### `shutdown`
 
@@ -182,7 +183,7 @@ Force-flushes any buffered LLMObs data to Datadog without shutting down the brid
 async shutdown(): Promise<void>
 ```
 
-Force-finishes any APM spans that weren't properly closed, flushes pending LLMObs data, disables LLM Observability, and clears all internal state.
+Force-finishes any APM spans that weren't properly closed, flushes pending LLM Observability data, disables the LLM Observability integration, and clears all internal state.
 
 ## Usage examples
 
@@ -215,9 +216,9 @@ const mastra = new Mastra({
 })
 ```
 
-### Agentless Mode (LLMObs only, no local agent)
+### Agentless Mode (LLM Observability only, no local agent)
 
-If you don't have a local Datadog Agent and only want LLMObs data, enable agentless mode:
+If you don't have a local Datadog Agent and only want LLM Observability data, enable agentless mode:
 
 ```typescript
 new DatadogBridge({
@@ -227,7 +228,7 @@ new DatadogBridge({
 })
 ```
 
-Note: APM data cannot be sent in agentless mode. If you only need LLMObs data without dd-trace APM, the [Datadog Exporter](/reference/observability/tracing/exporters/datadog) is a simpler choice.
+Note: APM data cannot be sent in agentless mode. If you only need LLM Observability data without `dd-trace` APM, the [Datadog Exporter](/reference/observability/tracing/exporters/datadog) is a simpler choice.
 
 ### With Additional Exporters
 
@@ -315,4 +316,4 @@ The bridge reads configuration from these environment variables:
 
 - [DatadogBridge Guide](/docs/observability/tracing/bridges/datadog) - Setup guide with examples
 - [Tracing Overview](/docs/observability/tracing/overview) - General tracing concepts
-- [DatadogExporter Reference](/reference/observability/tracing/exporters/datadog) - LLMObs-only exporter (no dd-trace APM)
+- [DatadogExporter Reference](/reference/observability/tracing/exporters/datadog) - LLM Observability only, no `dd-trace` APM

--- a/docs/src/content/en/reference/observability/tracing/bridges/datadog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/bridges/datadog.mdx
@@ -1,0 +1,318 @@
+---
+title: "Reference: DatadogBridge | Observability"
+description: Datadog bridge for Tracing
+packages:
+  - "@mastra/core"
+  - "@mastra/observability"
+  - "@mastra/datadog"
+---
+
+import PropertiesTable from "@site/src/components/PropertiesTable";
+
+# DatadogBridge
+
+:::warning
+
+The Datadog Bridge is currently **experimental**. APIs and configuration options may change in future releases.
+
+:::
+
+Enables bidirectional integration between Mastra tracing and Datadog. Creates native dd-trace APM spans in real time so that auto-instrumented operations inside tools and processors are correctly nested under their parent Mastra span. Emits LLM Observability data through dd-trace's own LLMObs pipeline when spans end.
+
+## Constructor
+
+```typescript prettier:false
+new DatadogBridge(config?: DatadogBridgeConfig)
+```
+
+## `DatadogBridgeConfig`
+
+```typescript
+interface DatadogBridgeConfig extends BaseExporterConfig {
+  apiKey?: string
+  mlApp?: string
+  site?: string
+  service?: string
+  env?: string
+  agentless?: boolean
+  integrationsEnabled?: boolean
+  requestContextKeys?: string[]
+}
+```
+
+Extends `BaseExporterConfig`, which includes:
+
+- `logger?: IMastraLogger` - Logger instance
+- `logLevel?: LogLevel | 'debug' | 'info' | 'warn' | 'error'` - Log level (default: INFO)
+
+<PropertiesTable
+  props={[
+  {
+    name: 'mlApp',
+    type: 'string',
+    description: 'ML application name for grouping LLMObs traces. Required. Falls back to DD_LLMOBS_ML_APP env var.',
+    required: false,
+  },
+  {
+    name: 'apiKey',
+    type: 'string',
+    description: 'Datadog API key. Required only when agentless mode is enabled. Falls back to DD_API_KEY env var.',
+    required: false,
+  },
+  {
+    name: 'site',
+    type: 'string',
+    description:
+      "Datadog site (e.g., 'datadoghq.com', 'datadoghq.eu', 'us3.datadoghq.com'). Falls back to DD_SITE env var. Default: 'datadoghq.com'.",
+    required: false,
+  },
+  {
+    name: 'service',
+    type: 'string',
+    description: 'Service name for the application. Defaults to mlApp value.',
+    required: false,
+  },
+  {
+    name: 'env',
+    type: 'string',
+    description: "Environment name (e.g., 'production', 'staging'). Falls back to DD_ENV env var.",
+    required: false,
+  },
+  {
+    name: 'agentless',
+    type: 'boolean',
+    description:
+      'Use direct HTTPS intake (true) or local Datadog Agent (false). Default: false. Most bridge users should leave this as false because dd-trace APM data always routes through the agent.',
+    required: false,
+  },
+  {
+    name: 'integrationsEnabled',
+    type: 'boolean',
+    description:
+      'Enable dd-trace automatic integrations (HTTP, database, etc.). Default: true. The bridge enables this by default because APM context propagation depends on auto-instrumentation.',
+    required: false,
+  },
+  {
+    name: 'requestContextKeys',
+    type: 'string[]',
+    description:
+      'Keys from request context or span attributes to promote into flat, searchable LLMObs tags (e.g., tenantId, agentId). Promoted keys are removed from annotations.metadata.',
+    required: false,
+  },
+]}
+/>
+
+## Methods
+
+### `createSpan`
+
+```typescript prettier:false
+createSpan(options: CreateSpanOptions<SpanType>): SpanIds | undefined
+```
+
+Called by the Mastra observability instance during span construction. Creates a dd-trace APM span eagerly via `tracer.startSpan()` and returns Mastra-compatible identifiers. The returned IDs are used by Mastra throughout the span's lifetime; the dd-trace span object is stored internally and used for scope activation.
+
+**Returns:** `SpanIds | undefined` - `{ spanId, traceId, parentSpanId }`, or `undefined` if the bridge is disabled.
+
+### `executeInContext`
+
+```typescript prettier:false
+executeInContext<T>(spanId: string, fn: () => Promise<T>): Promise<T>
+```
+
+Executes an async function within the dd-trace context of a Mastra span. dd-trace auto-instrumented operations running inside the function (HTTP, database, etc.) will be parented to this span.
+
+<PropertiesTable
+  props={[
+  {
+    name: 'spanId',
+    type: 'string',
+    description: 'The ID of the Mastra span to use as context',
+    required: true,
+  },
+  {
+    name: 'fn',
+    type: '() => Promise<T>',
+    description: 'The async function to execute within the span context',
+    required: true,
+  },
+]}
+/>
+
+**Returns:** `Promise<T>` - The result of the function execution.
+
+### `executeInContextSync`
+
+```typescript prettier:false
+executeInContextSync<T>(spanId: string, fn: () => T): T
+```
+
+Executes a synchronous function within the dd-trace context of a Mastra span.
+
+<PropertiesTable
+  props={[
+  {
+    name: 'spanId',
+    type: 'string',
+    description: 'The ID of the Mastra span to use as context',
+    required: true,
+  },
+  {
+    name: 'fn',
+    type: '() => T',
+    description: 'The synchronous function to execute within the span context',
+    required: true,
+  },
+]}
+/>
+
+**Returns:** `T` - The result of the function execution.
+
+### `flush`
+
+```typescript prettier:false
+async flush(): Promise<void>
+```
+
+Force-flushes any buffered LLMObs data to Datadog without shutting down the bridge. Useful in serverless environments where you need to ensure data is exported before the runtime terminates.
+
+### `shutdown`
+
+```typescript prettier:false
+async shutdown(): Promise<void>
+```
+
+Force-finishes any APM spans that weren't properly closed, flushes pending LLMObs data, disables LLM Observability, and clears all internal state.
+
+## Usage examples
+
+### Basic Usage
+
+```typescript
+import tracer from 'dd-trace'
+
+tracer.init({
+  service: process.env.DD_SERVICE || 'my-mastra-app',
+  env: process.env.DD_ENV || 'production',
+})
+
+import { Mastra } from '@mastra/core'
+import { Observability } from '@mastra/observability'
+import { DatadogBridge } from '@mastra/datadog'
+
+const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'my-mastra-app',
+        bridge: new DatadogBridge({
+          mlApp: process.env.DD_LLMOBS_ML_APP!,
+        }),
+      },
+    },
+  }),
+  agents: { myAgent },
+})
+```
+
+### Agentless Mode (LLMObs only, no local agent)
+
+If you don't have a local Datadog Agent and only want LLMObs data, enable agentless mode:
+
+```typescript
+new DatadogBridge({
+  mlApp: process.env.DD_LLMOBS_ML_APP!,
+  apiKey: process.env.DD_API_KEY!,
+  agentless: true,
+})
+```
+
+Note: APM data cannot be sent in agentless mode. If you only need LLMObs data without dd-trace APM, the [Datadog Exporter](/reference/observability/tracing/exporters/datadog) is a simpler choice.
+
+### With Additional Exporters
+
+The bridge can be combined with non-Datadog exporters to send traces to additional destinations:
+
+```typescript
+import { Observability, DefaultExporter } from '@mastra/observability'
+import { DatadogBridge } from '@mastra/datadog'
+
+const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'my-mastra-app',
+        bridge: new DatadogBridge({
+          mlApp: process.env.DD_LLMOBS_ML_APP!,
+        }),
+        exporters: [
+          new DefaultExporter(), // Studio access
+        ],
+      },
+    },
+  }),
+})
+```
+
+:::note
+Don't combine `DatadogBridge` with `DatadogExporter` in the same configuration — both emit to LLM Observability and would double-write the same data.
+:::
+
+## Setup requirements
+
+The DatadogBridge requires `dd-trace` to be initialized before any other imports so its auto-instrumentation can patch HTTP, database, and framework libraries at load time.
+
+See the [DatadogBridge Guide](/docs/observability/tracing/bridges/datadog#configuration) for complete setup instructions, including dd-trace initialization, bundler externals, and agent configuration.
+
+## Span mapping
+
+Mastra span types are mapped to Datadog LLM Observability span kinds:
+
+| Mastra SpanType | Datadog Kind |
+| - | - |
+| `AGENT_RUN` | `agent` |
+| `MODEL_GENERATION` | `workflow` |
+| `MODEL_STEP` | `llm` |
+| `TOOL_CALL` | `tool` |
+| `MCP_TOOL_CALL` | `tool` |
+| `WORKFLOW_RUN` | `workflow` |
+| All other types | `task` |
+
+## Tags support
+
+Tags supplied via `tracingOptions.tags` are converted into structured LLM Observability annotation tags. Tags formatted as `key:value` are split into separate entries; tags without a colon are set with a `true` value.
+
+```typescript
+const result = await agent.generate('Hello', {
+  tracingOptions: {
+    tags: ['production', 'instance_name:career-scout-api'],
+  },
+})
+```
+
+This produces:
+
+```json
+{
+  "production": true,
+  "instance_name": "career-scout-api"
+}
+```
+
+## Environment variables
+
+The bridge reads configuration from these environment variables:
+
+| Variable | Description |
+| - | - |
+| `DD_API_KEY` | Datadog API key (only required for agentless mode) |
+| `DD_LLMOBS_ML_APP` | ML application name |
+| `DD_SITE` | Datadog site |
+| `DD_ENV` | Environment name |
+| `DD_LLMOBS_AGENTLESS_ENABLED` | Set to `'true'` or `'1'` to enable agentless mode |
+
+## Related
+
+- [DatadogBridge Guide](/docs/observability/tracing/bridges/datadog) - Setup guide with examples
+- [Tracing Overview](/docs/observability/tracing/overview) - General tracing concepts
+- [DatadogExporter Reference](/reference/observability/tracing/exporters/datadog) - LLMObs-only exporter (no dd-trace APM)

--- a/docs/src/content/en/reference/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/datadog.mdx
@@ -13,7 +13,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 Sends Tracing data to Datadog's LLM Observability product for monitoring and analytics.
 
 :::info
-For users who also need dd-trace APM auto-instrumentation to be correctly parented under Mastra spans, use the [DatadogBridge](/reference/observability/tracing/bridges/datadog) instead. The exporter emits LLMObs data retroactively, so it doesn't participate in dd-trace's live scope.
+If you also use `dd-trace` APM auto-instrumentation and need it correctly parented under Mastra spans, use the [DatadogBridge](/reference/observability/tracing/bridges/datadog) instead. The exporter sends LLM Observability data after execution completes, so it doesn't participate in `dd-trace`'s live scope.
 :::
 
 ## Constructor
@@ -151,7 +151,7 @@ const exporter = new DatadogExporter({
 
 ## Span mapping
 
-Mastra span types are mapped to Datadog LLMObs span kinds:
+Mastra span types are mapped to Datadog LLM Observability span kinds:
 
 | Mastra SpanType | Datadog Kind |
 | - | - |

--- a/docs/src/content/en/reference/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/datadog.mdx
@@ -12,6 +12,10 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 Sends Tracing data to Datadog's LLM Observability product for monitoring and analytics.
 
+:::info
+For users who also need dd-trace APM auto-instrumentation to be correctly parented under Mastra spans, use the [DatadogBridge](/reference/observability/tracing/bridges/datadog) instead. The exporter emits LLMObs data retroactively, so it doesn't participate in dd-trace's live scope.
+:::
+
 ## Constructor
 
 ```typescript prettier:false

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -320,7 +320,10 @@ const sidebars = {
             {
               type: 'category',
               label: 'Bridges',
-              items: [{ type: 'doc', id: 'observability/tracing/bridges/otel', label: 'OtelBridge' }],
+              items: [
+                { type: 'doc', id: 'observability/tracing/bridges/datadog', label: 'DatadogBridge' },
+                { type: 'doc', id: 'observability/tracing/bridges/otel', label: 'OtelBridge' },
+              ],
             },
             {
               type: 'category',

--- a/observability/datadog/INVESTIGATION-HANDOFF.md
+++ b/observability/datadog/INVESTIGATION-HANDOFF.md
@@ -1,0 +1,590 @@
+# DatadogBridge Investigation Handoff
+
+This file is a working handoff for the ongoing DatadogBridge investigation.
+
+It is intentionally long and redundant. The goal is to let a new coding agent resume quickly without needing to reconstruct the full debugging history from chat logs.
+
+## Scope
+
+This investigation is about `@mastra/datadog`, specifically bridge mode:
+
+- `observability/datadog/src/bridge.ts`
+- related tracing code in `observability/datadog/src/tracing.ts`
+- the MCP client interaction that affects trace lifecycle in `packages/mcp/src/client.ts`
+- how bridge-created dd-trace spans appear in Datadog APM and LLM Observability
+
+The external validation harness used throughout this investigation is:
+
+- `/Users/epinzur/src/mastra-test/dd-bridge`
+
+That repo is linked to the local monorepo via `pnpm link:` paths for `@mastra/*`, so monorepo source changes are consumed directly by the repro harness after rebuild.
+
+## Current High-Level State
+
+Three meaningful fixes were made during this investigation:
+
+1. `3d00c28fc7` `Use external ancestor for internal bridge context`
+2. `57fad11b3a` `fix(mcp): detach persistent streamable-http GET from active trace`
+3. `a48136d539` `fix(datadog): finalize event spans on span_ended`
+
+These three changes materially improved the situation.
+
+The original bad state was:
+
+- bridge-mode APM often retained only downstream MCP spans
+- entry service often disappeared from stored APM
+- `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=5` made entry data show up, which suggested trace lifecycle / flushability problems
+- some dependency spans were hanging under generic `handler` spans rather than logical Mastra spans
+
+The current improved state is:
+
+- entry service spans can now appear again in stored APM in bridge mode
+- entry runtime definitely emits APM trace payloads in normal bridge mode, without needing forced partial flush
+- the MCP persistent `GET` stream is detached from active trace context
+- internal Mastra spans now activate the nearest external ancestor in bridge context
+- event spans that terminate via `span_ended` are no longer leaked until shutdown
+
+The remaining open question is narrower:
+
+- whether the stored APM trace now consistently retains the full expected entry-side semantic Mastra spans, or whether some semantic spans are still missing relative to the locally encoded payload and the Datadog UI
+
+## Important Repos and Paths
+
+### Monorepo
+
+- `observability/datadog/src/bridge.ts`
+- `observability/datadog/src/bridge.test.ts`
+- `observability/datadog/src/tracing.ts`
+- `packages/mcp/src/client/client.ts`
+- `packages/mcp/src/client/client.test.ts`
+- `observability/mastra/src/spans/base.ts`
+- `observability/mastra/src/tracing.test.ts`
+
+### External Repro Harness
+
+- `/Users/epinzur/src/mastra-test/dd-bridge`
+- `/Users/epinzur/src/mastra-test/dd-bridge/datadog-journal.md`
+- `/Users/epinzur/src/mastra-test/dd-bridge/codex-handoff.md`
+- `/Users/epinzur/src/mastra-test/dd-bridge/scripts/fetch-datadog-trace-sdk.ts`
+
+## Commits Made During This Investigation
+
+### 1. Internal span context fix
+
+Commit:
+
+- `3d00c28fc7` `Use external ancestor for internal bridge context`
+
+Summary:
+
+- internal spans were calling bridge context activation with span ids that were never registered in the Datadog bridge map
+- this showed up as `executeWithSpanContext()` missing-map fallbacks during `runStep(...)`
+- the fix was to make internal spans activate their nearest external ancestor in the bridge context path
+
+Files:
+
+- `observability/mastra/src/spans/base.ts`
+- `observability/mastra/src/tracing.test.ts`
+
+Impact:
+
+- reduced bogus missing-map fallbacks
+- improved context activation for auto-instrumented dependency spans triggered under internal step execution
+
+### 2. MCP persistent GET detachment
+
+Commit:
+
+- `57fad11b3a` `fix(mcp): detach persistent streamable-http GET from active trace`
+
+Summary:
+
+- the MCP Streamable HTTP client opens a long-lived `GET` stream
+- that persistent `GET` was being created inside the active request trace
+- this likely contaminated the user request trace and contributed to entry-side APM retention problems
+- the fix detaches only the persistent stream `GET` from active dd-trace scope while keeping bootstrap and tool `POST`s in request context
+
+Files:
+
+- `packages/mcp/src/client/client.ts`
+- `packages/mcp/src/client/client.test.ts`
+
+Impact:
+
+- entry service retention improved materially
+- trace shape became healthier
+- entry was no longer disappearing as often from stored APM
+
+### 3. Event span finalization bug
+
+Commit:
+
+- `a48136d539` `fix(datadog): finalize event spans on span_ended`
+
+Summary:
+
+- the bridge used to treat event spans as terminal only on `span_started`
+- in practice, some event spans such as `chunk: 'tool-result'` reached the bridge as `span_ended`
+- those spans were logged as `Ignoring event span tracing event`
+- they stayed open in `ddSpanMap` until shutdown force-finished them
+- that likely blocked normal trace completion / flushability on entry
+
+Files:
+
+- `observability/datadog/src/bridge.ts`
+- `observability/datadog/src/bridge.test.ts`
+- `observability/datadog/src/tracing.ts`
+
+Impact:
+
+- event spans are now finalized on both `span_started` and `span_ended`
+- entry runtime started emitting a normal `/v0.4/traces` request without forced partial flush
+- this is one of the strongest candidate root-cause fixes from the whole investigation
+
+## External Repro Setup Used Repeatedly
+
+The repro app has three processes:
+
+- `entry-server`: Mastra + Koa, user-facing agent
+- `mcp-server-mastra`: Mastra + Koa exposing MCP tools
+- `mcp-server-bare`: bare MCP server on Koa
+
+Bridge-mode commands used frequently:
+
+### Bare MCP
+
+- MCP:
+  - `MASTRA_DATADOG_BRIDGE_SPAN_DEBUG=1 pnpm dev:dd:bridge:mcp:bare`
+- Entry:
+  - `MASTRA_DATADOG_BRIDGE_ENABLED=1 MASTRA_DATADOG_BRIDGE_SPAN_DEBUG=1 DD_TRACE_DEBUG=true LOG_LEVEL=debug DD_SITE=datadoghq.eu DD_LLMOBS_ENABLED=1 DD_LLMOBS_ML_APP=dd-bridge-entry DD_SERVICE=dd-bridge-entry NODE_OPTIONS='--import dd-trace/register.js ${NODE_OPTIONS:-}' MCP_BACKEND=bare node --env-file=.env --import tsx/esm src/servers/entry-server.ts`
+- Trigger request:
+  - `pnpm test:entry`
+
+### Mastra-backed MCP
+
+- MCP:
+  - `MASTRA_DATADOG_BRIDGE_SPAN_DEBUG=1 pnpm dev:dd:bridge:mcp:mastra`
+- Entry:
+  - `MASTRA_DATADOG_BRIDGE_ENABLED=1 MASTRA_DATADOG_BRIDGE_SPAN_DEBUG=1 DD_TRACE_DEBUG=true LOG_LEVEL=debug DD_SITE=datadoghq.eu DD_LLMOBS_ENABLED=1 DD_LLMOBS_ML_APP=dd-bridge-entry DD_SERVICE=dd-bridge-entry NODE_OPTIONS='--import dd-trace/register.js ${NODE_OPTIONS:-}' MCP_BACKEND=mastra node --env-file=.env --import tsx/esm src/servers/entry-server.ts`
+- Trigger request:
+  - `pnpm test:entry`
+
+Datadog fetch script:
+
+- `node --env-file=.env --import tsx/esm scripts/fetch-datadog-trace-sdk.ts <TRACE_ID> --from=now-2h --page-delay-ms=4000 --verbose`
+
+## What Was Originally Reproduced
+
+The original confirmed findings from the repro harness were:
+
+1. Baseline `dd-trace`
+
+- direct OpenAI quickstart appeared in both Datadog LLM Observability and APM
+- Mastra flows appeared in APM but not in LLM Observability
+
+2. `DatadogExporter`
+
+- LLM Observability worked for Mastra
+- APM still worked
+- cross-process LLMObs stitching did not happen
+- `mcp-mastra` APM was noisy
+- `mcp-bare` APM was cleaner
+
+3. Customer-relevant bug without bridge
+
+- downstream dependency spans in APM were parented to generic framework spans like `handler` instead of logical Mastra spans like `mcp_tool`
+
+4. Original bridge regression
+
+- LLM Observability showed the expected traces
+- but APM stored only MCP-side spans
+- entry service disappeared from stored traces
+
+## Working Theory Evolution
+
+This investigation went through several hypotheses. Some were useful, some were wrong.
+
+### Hypothesis: bad parent ids
+
+This became much less likely after logging showed:
+
+- entry semantic spans were created with valid parent ids
+- `agent run` was under the entry request / Koa handler chain, which is correct for APM
+- `llm` was a child of `agent run`
+- `step` was a child of `llm`
+- `mcp_tool` spans were children of `step`
+- local `tool:` spans were created with sensible semantic parents
+
+Conclusion:
+
+- parent ids were not the main problem
+
+### Hypothesis: bridge disabled or not creating entry spans
+
+This was partially true for one accidental repro command because of a malformed env assignment:
+
+- `MASTRA_DATADOG_BRIDGE_ENABLED=1=true`
+
+That was corrected.
+
+After correction:
+
+- entry bridge was definitely active
+- entry semantic spans were definitely being created and finished locally
+
+Conclusion:
+
+- not the root cause
+
+### Hypothesis: LLM Observability integration was poisoning APM
+
+This was tested by temporarily disabling bridge-side LLMObs registration / annotation.
+
+Result:
+
+- no clear APM improvement
+- but the experiment exposed the event span leak more clearly
+
+Conclusion:
+
+- LLMObs may still be architecturally awkward, but it was not the best immediate explanation for the missing entry APM data
+
+### Hypothesis: partial flush was the key
+
+This was strongly supported:
+
+- `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=5` caused entry APM and entry semantic spans to appear in stored APM
+- without partial flush, entry often disappeared or only partially appeared
+
+Interpretation:
+
+- something was keeping the trace from becoming flushable under default behavior
+
+This eventually pointed toward:
+
+- persistent MCP `GET` stream
+- leaked event spans
+
+### Hypothesis: shutdown was the main issue
+
+This was investigated because:
+
+- the repro servers originally did not guarantee `mastra.shutdown()` on `Ctrl-C`
+- the bridge code used a no-op `(tracer as any).flush()`
+
+Findings:
+
+- graceful shutdown in the harness was later fixed
+- `process.exit()` had been bypassing dd-trace `beforeExit` handlers, and that was corrected
+- however, graceful shutdown alone was not the main fix
+- the no-op tracer flush was removed
+
+Conclusion:
+
+- shutdown cleanup mattered for clarity, but it was not the main root cause
+
+### Hypothesis: leaked event spans were blocking trace completion
+
+This became the strongest finding.
+
+Evidence:
+
+- event spans such as `chunk: 'tool-result'` were created
+- later `span_ended` arrived
+- bridge ignored them by design
+- they remained open until shutdown
+- after fixing this, entry runtime emitted APM payloads normally
+
+Conclusion:
+
+- this is a real root-cause bug
+
+## Important dd-trace Findings
+
+### Public tracer flush does not exist on Node tracer
+
+Runtime checks in the repro showed:
+
+- `typeof tracer.flush === 'undefined'`
+- `typeof tracer._tracer?.flush === 'undefined'`
+- `typeof tracer._tracer?._exporter?.flush === 'function'`
+
+Implications:
+
+- `(tracer as any).flush()` was effectively a no-op
+- it should not be relied on for APM flushing
+
+### Default partial flush threshold
+
+The Node `dd-trace` default partial flush threshold is `1000` spans.
+
+This made the `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=5` experiment useful because it clearly changed behavior.
+
+### Exporter internals
+
+The actual APM exporter flush function exists internally:
+
+- `tracer._tracer._exporter.flush(done)`
+
+This was used only for debugging. It should not be the long-term product dependency unless absolutely necessary.
+
+### beforeExit behavior
+
+`dd-trace` relies on a `beforeExit` handler for last-chance exporter flush behavior.
+
+This matters because:
+
+- explicit `process.exit(...)` bypasses `beforeExit`
+- the repro harness originally did this
+- the harness shutdown helper was later corrected to avoid forcing `process.exit(...)` on the successful path
+
+## Why the MCP Patch Matters
+
+The MCP fix should not be treated as incidental.
+
+The persistent Streamable HTTP `GET` stream was long-lived and visible in traces:
+
+- it was opened under the active request trace originally
+- later runs showed it with durations around tens of seconds
+
+This meant:
+
+- user-request trace topology was polluted by a persistent transport stream
+- request flushability and retention were likely affected
+
+Detaching only the persistent `GET` while keeping the request-scoped `POST`s traced was the right narrow fix.
+
+That design preserves:
+
+- actual bootstrap and tool `POST`s inside request context
+- the user-visible request latency caused by bootstrap/discovery
+- the cleaner separation of long-lived transport from logical business work
+
+## Why the Event Span Fix Matters
+
+This is likely the most important product-level fix so far.
+
+Before the fix:
+
+- bridge created dd spans for some event spans
+- those event spans were never finalized in normal runtime when the terminal signal was `span_ended`
+- trace completion could be delayed or blocked until shutdown
+
+After the fix:
+
+- those event spans finish normally
+- entry can send a runtime APM payload without relying on `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS`
+
+This is a real improvement in lifecycle correctness.
+
+## Trace IDs Worth Knowing
+
+These trace ids were especially useful during debugging:
+
+### Successful partial flush proof
+
+- `69e77ee80000000079ce7b57219554fa`
+
+Important because:
+
+- with `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS=5`, Datadog stored entry semantic spans in APM
+- this proved the spans themselves were valid and storable
+
+### Event-span fix verification trace
+
+- `69e78cbb00000000733eeb03a7d94e61`
+
+Important because:
+
+- after the event-span fix, entry runtime sent a normal `/v0.4/traces` request
+- initial Datadog fetch was incomplete
+- later retry returned `83` spans and clearly included `dd-bridge-entry`
+
+This trace is the best single artifact to continue from.
+
+## Current Package State
+
+At the time this handoff file was written, the working tree had been committed and was clean.
+
+Relevant recent commits:
+
+- `a48136d539` `fix(datadog): finalize event spans on span_ended`
+- `57fad11b3a` `fix(mcp): detach persistent streamable-http GET from active trace`
+- `3d00c28fc7` `Use external ancestor for internal bridge context`
+
+If a new agent starts from these commits, it should be able to reproduce the current improved state.
+
+## Temporary Debug Logging That Exists
+
+`observability/datadog/src/bridge.ts` currently includes a large amount of temporary diagnostic logging.
+
+This includes:
+
+- `spanLifecycleDebug` config / env toggle
+- dd span open / finish logs
+- map-size logs
+- fallback logs for missing-map activation
+- call stack logging on missing-map fallback
+- trace debug state helpers
+
+This logging was useful and should be expected in the current bridge implementation.
+
+It is not necessarily intended as final product behavior.
+
+A future cleanup pass should probably reduce or remove it once the bridge investigation is fully resolved.
+
+## What Still Needs To Be Answered
+
+The investigation is now much narrower than when it started.
+
+The main remaining question is:
+
+- does Datadog stored APM now retain the full expected entry-side semantic span set consistently after the MCP and event-span fixes?
+
+This should be checked specifically for:
+
+- `agent run`
+- `llm`
+- `step`
+- `mcp_tool`
+- local `tool:` spans
+
+Possible outcomes:
+
+### Outcome A: semantic entry spans are now present in stored APM
+
+If this is true consistently, then:
+
+- the major bridge regression is basically fixed
+- remaining cleanup is mostly:
+  - removing debug logging
+  - tightening tests
+  - maybe improving docs
+
+### Outcome B: entry exists in stored APM, but some semantic spans are still missing
+
+If this is true, then:
+
+- the major lifecycle bugs were fixed
+- a smaller Datadog retention / chunking / indexing nuance remains
+- that follow-up problem is narrower and less severe than the original “entry disappears entirely” regression
+
+### Outcome C: results are inconsistent between UI and fetch script
+
+If this is true, then:
+
+- continue to account for Datadog indexing lag
+- avoid over-trusting the first fetch
+- compare:
+  - raw runtime `Encoding payload`
+  - runtime `Request to the agent: {"path":"/v0.4/traces"...}`
+  - later Datadog fetch results
+  - UI display
+
+## Recommended Next Steps For A New Agent
+
+### 1. Start from the known-good commit state
+
+Use the current commit chain:
+
+- `3d00c28fc7`
+- `57fad11b3a`
+- `a48136d539`
+
+### 2. Re-run the bare bridge repro first
+
+This is the cleanest signal and smallest span volume.
+
+Recommended sequence:
+
+1. start `mcp-bare`
+2. start bridge-enabled `entry`
+3. send one request with `pnpm test:entry`
+4. inspect entry runtime logs for:
+   - semantic span creation
+   - event span finalization
+   - runtime `/v0.4/traces` send
+5. fetch the trace later, not immediately
+
+### 3. Verify whether stored APM now contains semantic entry spans
+
+Do not stop at “entry service exists.”
+
+Specifically verify whether stored APM includes:
+
+- `agent run`
+- `llm`
+- `step`
+- `mcp_tool`
+- `tool:`
+
+### 4. Only after bare is understood, move back to `mcp-mastra`
+
+The Mastra-backed MCP case is much noisier.
+
+Use it only after the bare case is clearly understood.
+
+### 5. If semantic spans are still missing, compare payload shapes
+
+If the problem persists:
+
+- compare the locally encoded entry payload against the later Datadog stored result
+- determine whether missing spans are absent before send or lost after send
+
+### 6. Clean up temporary debug logging only after confidence is high
+
+The debug logging is noisy but helpful.
+
+Do not remove it too early if the bridge is still under active investigation.
+
+## Useful Notes For Whoever Continues This
+
+### Do not over-interpret the first Datadog fetch
+
+Several times during this investigation:
+
+- first fetch returned far too few spans
+- later retry returned a much fuller trace
+
+The trace `69e78cbb00000000733eeb03a7d94e61` is a concrete example:
+
+- initial fetch looked MCP-only
+- later retry showed `dd-bridge-entry`
+
+### The bridge issue is now much smaller than it was
+
+Earlier in the investigation, the system looked badly broken.
+
+Now the evidence is much closer to:
+
+- the bridge had a couple of real lifecycle bugs
+- those bugs have been fixed
+- the remaining issue may be limited to stored semantic retention consistency rather than total trace disappearance
+
+### The customer-facing impact should be re-evaluated after these fixes
+
+The original customer-visible bug was severe:
+
+- entry APM disappearing
+- dependency parentage wrong
+
+After the current fixes, the actual remaining customer impact may be smaller than the initial repro suggested.
+
+That should be re-measured from current commits, not inferred from the earlier broken state.
+
+## Short Executive Summary
+
+If you only read one section, read this:
+
+- The bridge had two real lifecycle bugs:
+  - internal spans activating non-registered ids
+  - event spans created by the bridge but ignored on `span_ended`
+- The MCP client also traced a persistent `GET` stream inside the user request trace, which made trace lifecycle noisier.
+- Those issues have been fixed in:
+  - `3d00c28fc7`
+  - `57fad11b3a`
+  - `a48136d539`
+- After these fixes:
+  - entry service spans can appear again in stored APM
+  - entry runtime now emits normal APM payloads without forced partial flush
+- The remaining task is to verify whether stored APM now consistently includes the full expected entry-side semantic span set, or whether a smaller Datadog retention nuance remains.

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -225,6 +225,22 @@ describe('DatadogBridge', () => {
       expect(bridge['isDisabled']).toBe(false);
     });
 
+    it('defaults agentless to false (assumes local Datadog Agent)', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test-app' });
+
+      // Bridge does not require apiKey because agentless defaults to false
+      expect(bridge['isDisabled']).toBe(false);
+    });
+
+    it('respects DD_LLMOBS_AGENTLESS_ENABLED=true env var', () => {
+      process.env.DD_LLMOBS_AGENTLESS_ENABLED = 'true';
+
+      // Without apiKey, agentless mode should disable the bridge
+      const bridge = new DatadogBridge({ mlApp: 'test-app' });
+
+      expect(bridge['isDisabled']).toBe(true);
+    });
+
     it('prefers config values over environment variables', () => {
       process.env.DD_LLMOBS_ML_APP = 'env-app';
 

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -1,0 +1,713 @@
+/**
+ * Tests for Datadog Bridge
+ *
+ * Uses mock dd-trace to test the bridge without connecting to Datadog.
+ */
+
+/// <reference types="node" />
+
+import type {
+  TracingEvent,
+  AnyExportedSpan,
+  CreateSpanOptions,
+  SpanType as SpanTypeGeneric,
+} from '@mastra/core/observability';
+import { SpanType, TracingEventType } from '@mastra/core/observability';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// Use vi.hoisted to define mocks before they're used in vi.mock
+const {
+  mockAnnotate,
+  mockTrace,
+  mockFlush,
+  mockDisable,
+  mockEnable,
+  mockInit,
+  mockStartSpan,
+  mockScopeActivate,
+  mockScopeActive,
+  traceParents,
+  capturedLLMObsSpans,
+  capturedAPMSpans,
+} = vi.hoisted(() => {
+  let currentScopeSpan: any = undefined;
+  const parents: any[] = [];
+  const llmobsSpans: any[] = [];
+  let apmSpanCounter = 0;
+
+  const activate = vi.fn((span: any, fn: () => any) => {
+    const previous = currentScopeSpan;
+    currentScopeSpan = span;
+    try {
+      return fn();
+    } finally {
+      currentScopeSpan = previous;
+    }
+  });
+
+  const active = vi.fn(() => currentScopeSpan);
+
+  const apmSpans: any[] = [];
+
+  return {
+    traceParents: parents,
+    capturedLLMObsSpans: llmobsSpans,
+    capturedAPMSpans: apmSpans,
+    mockAnnotate: vi.fn(),
+    mockTrace: vi.fn((options: any, fn: (span: any) => void) => {
+      parents.push(currentScopeSpan);
+      const ddSpan = {
+        id: `mock-llmobs-span-${parents.length}`,
+        options,
+        setTag: vi.fn(),
+        finish: vi.fn(),
+      };
+      llmobsSpans.push(ddSpan);
+      const previous = currentScopeSpan;
+      currentScopeSpan = ddSpan;
+      try {
+        return fn(ddSpan);
+      } finally {
+        currentScopeSpan = previous;
+      }
+    }),
+    mockFlush: vi.fn().mockResolvedValue(undefined),
+    mockDisable: vi.fn(),
+    mockEnable: vi.fn(),
+    mockInit: vi.fn(),
+    mockStartSpan: vi.fn((name: string, options?: any) => {
+      apmSpanCounter++;
+      const span = {
+        id: `mock-apm-span-${apmSpanCounter}`,
+        _name: name,
+        _options: options,
+        finish: vi.fn(),
+        setTag: vi.fn(),
+        context: vi.fn(() => ({
+          toSpanId: () => `apm-span-id-${apmSpanCounter}`,
+          toTraceId: () => `apm-trace-id-${apmSpanCounter}`,
+        })),
+      };
+      apmSpans.push(span);
+      return span;
+    }),
+    mockScopeActivate: activate,
+    mockScopeActive: active,
+  };
+});
+
+// Mock dd-trace before importing the bridge
+vi.mock('dd-trace', () => {
+  return {
+    default: {
+      init: mockInit,
+      startSpan: mockStartSpan,
+      llmobs: {
+        enable: mockEnable,
+        disable: mockDisable,
+        trace: mockTrace,
+        annotate: mockAnnotate,
+        flush: mockFlush,
+        exportSpan: (span: any) => ({ traceId: 'dd-trace-id', spanId: span?.id || 'dd-span-id' }),
+      },
+      _tracer: { started: false },
+      scope: () => ({
+        activate: mockScopeActivate,
+        active: mockScopeActive,
+      }),
+    },
+  };
+});
+
+import { DatadogBridge } from './bridge';
+
+/**
+ * Creates a mock span with default values
+ */
+function createMockSpan(overrides: Partial<AnyExportedSpan> = {}): AnyExportedSpan {
+  return {
+    id: 'span-1',
+    traceId: 'trace-1',
+    name: 'test-span',
+    type: SpanType.GENERIC,
+    startTime: new Date('2024-01-01T00:00:00Z'),
+    endTime: new Date('2024-01-01T00:00:01Z'),
+    isEvent: false,
+    isRootSpan: true,
+    ...overrides,
+  } as AnyExportedSpan;
+}
+
+/**
+ * Creates a tracing event
+ */
+function createTracingEvent(type: TracingEventType, span: AnyExportedSpan): TracingEvent {
+  return { type, exportedSpan: span } as TracingEvent;
+}
+
+/**
+ * Creates mock CreateSpanOptions for bridge.createSpan() testing
+ */
+function createMockSpanOptions(
+  overrides: Partial<CreateSpanOptions<SpanTypeGeneric>> = {},
+): CreateSpanOptions<SpanTypeGeneric> {
+  return {
+    name: 'test-span',
+    type: SpanType.GENERIC as SpanTypeGeneric,
+    ...overrides,
+  } as CreateSpanOptions<SpanTypeGeneric>;
+}
+
+describe('DatadogBridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    traceParents.length = 0;
+    capturedLLMObsSpans.length = 0;
+    capturedAPMSpans.length = 0;
+    // Reset environment variables
+    delete process.env.DD_API_KEY;
+    delete process.env.DD_LLMOBS_ML_APP;
+    delete process.env.DD_SITE;
+    delete process.env.DD_LLMOBS_AGENTLESS_ENABLED;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('configuration', () => {
+    it('initializes with valid config', () => {
+      const bridge = new DatadogBridge({
+        mlApp: 'test-app',
+        apiKey: 'test-key',
+        agentless: true,
+      });
+
+      expect(mockEnable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mlApp: 'test-app',
+          agentlessEnabled: true,
+        }),
+      );
+      expect(bridge.name).toBe('datadog-bridge');
+    });
+
+    it('disables bridge when mlApp is missing', () => {
+      const bridge = new DatadogBridge({});
+      expect(mockEnable).not.toHaveBeenCalled();
+      expect(bridge['isDisabled']).toBe(true);
+    });
+
+    it('disables bridge when agentless mode lacks apiKey', () => {
+      const bridge = new DatadogBridge({
+        mlApp: 'test-app',
+        agentless: true,
+      });
+      expect(mockEnable).not.toHaveBeenCalled();
+      expect(bridge['isDisabled']).toBe(true);
+    });
+
+    it('allows non-agentless mode without apiKey', () => {
+      const bridge = new DatadogBridge({
+        mlApp: 'test-app',
+        agentless: false,
+      });
+
+      expect(bridge['isDisabled']).toBe(false);
+    });
+
+    it('reads configuration from environment variables', () => {
+      process.env.DD_LLMOBS_ML_APP = 'env-app';
+      process.env.DD_API_KEY = 'env-key';
+
+      const bridge = new DatadogBridge({});
+
+      expect(bridge['isDisabled']).toBe(false);
+    });
+
+    it('prefers config values over environment variables', () => {
+      process.env.DD_LLMOBS_ML_APP = 'env-app';
+
+      const bridge = new DatadogBridge({
+        mlApp: 'config-app',
+        agentless: false,
+      });
+
+      expect(bridge['isDisabled']).toBe(false);
+      expect(bridge['config'].mlApp).toBe('config-app');
+    });
+  });
+
+  describe('createSpan', () => {
+    it('creates an APM span via tracer.startSpan()', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const result = bridge.createSpan(createMockSpanOptions({ name: 'my-agent' }));
+
+      expect(result).toBeDefined();
+      expect(result!.spanId).toBeDefined();
+      expect(result!.traceId).toBeDefined();
+      expect(mockStartSpan).toHaveBeenCalledWith('my-agent', expect.any(Object));
+    });
+
+    it('returns hex-format span and trace IDs', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const result = bridge.createSpan(createMockSpanOptions());
+
+      expect(result!.spanId).toMatch(/^[0-9a-f]{16}$/);
+      expect(result!.traceId).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it('sets parent from getExternalParentId when parent span exists in map', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      // Create parent span first
+      const parentResult = bridge.createSpan(createMockSpanOptions({ name: 'parent' }));
+      const parentApmSpan = capturedAPMSpans[0];
+
+      // Create child span with parent reference
+      const mockParent = {
+        id: parentResult!.spanId,
+        traceId: parentResult!.traceId,
+        isInternal: false,
+        getParentSpanId: () => undefined,
+      };
+
+      const childResult = bridge.createSpan(
+        createMockSpanOptions({
+          name: 'child',
+          parent: mockParent as any,
+        }),
+      );
+
+      expect(childResult).toBeDefined();
+      expect(childResult!.parentSpanId).toBe(parentResult!.spanId);
+      expect(childResult!.traceId).toBe(parentResult!.traceId);
+      // The child's APM span should have been created with childOf pointing to parent
+      expect(mockStartSpan).toHaveBeenCalledTimes(2);
+      expect(capturedAPMSpans[1]._options).toEqual({ childOf: parentApmSpan });
+    });
+
+    it('falls back to active dd-trace scope when no explicit parent', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      // Simulate an active request span in dd-trace scope
+      const requestSpan = { id: 'request-span' };
+      mockScopeActive.mockReturnValueOnce(requestSpan);
+
+      const result = bridge.createSpan(createMockSpanOptions());
+
+      expect(result).toBeDefined();
+      expect(mockStartSpan).toHaveBeenCalledWith('test-span', { childOf: requestSpan });
+    });
+
+    it('returns undefined when bridge is disabled', () => {
+      const bridge = new DatadogBridge({}); // Missing mlApp
+
+      const result = bridge.createSpan(createMockSpanOptions());
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('executeInContext', () => {
+    it('activates dd-trace span in scope for async functions', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      // Create a span to get it in the map
+      const spanResult = bridge.createSpan(createMockSpanOptions());
+      const apmSpan = capturedAPMSpans[0];
+
+      await bridge.executeInContext(spanResult!.spanId, async () => {
+        // function runs within activated scope
+      });
+
+      expect(mockScopeActivate).toHaveBeenCalledWith(apmSpan, expect.any(Function));
+    });
+
+    it('activates dd-trace span in scope for sync functions', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const spanResult = bridge.createSpan(createMockSpanOptions());
+      const apmSpan = capturedAPMSpans[0];
+
+      bridge.executeInContextSync(spanResult!.spanId, () => 'result');
+
+      expect(mockScopeActivate).toHaveBeenCalledWith(apmSpan, expect.any(Function));
+    });
+
+    it('falls back to direct execution when span not in map', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const result = await bridge.executeInContext('nonexistent-span', async () => 42);
+
+      expect(result).toBe(42);
+      expect(mockScopeActivate).not.toHaveBeenCalled();
+    });
+
+    it('returns function result through scope activation', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions());
+
+      const result = bridge.executeInContextSync(spanResult!.spanId, () => 'hello');
+
+      expect(result).toBe('hello');
+    });
+  });
+
+  describe('APM span lifecycle', () => {
+    it('finishes APM span on span_ended with correct timestamp', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const spanResult = bridge.createSpan(createMockSpanOptions());
+      const apmSpan = capturedAPMSpans[0];
+
+      const endTime = new Date('2024-01-01T00:00:05Z');
+      const span = createMockSpan({
+        id: spanResult!.spanId,
+        traceId: spanResult!.traceId,
+        endTime,
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(apmSpan.finish).toHaveBeenCalledWith(endTime.getTime());
+    });
+
+    it('removes APM span from map after finishing', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const spanResult = bridge.createSpan(createMockSpanOptions());
+
+      const span = createMockSpan({
+        id: spanResult!.spanId,
+        traceId: spanResult!.traceId,
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      // Verify span is removed by checking executeInContext falls through
+      const result = bridge.executeInContextSync(spanResult!.spanId, () => 'test');
+      expect(result).toBe('test');
+      expect(mockScopeActivate).not.toHaveBeenCalled();
+    });
+
+    it('finishes APM span for event spans on span_started', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const spanResult = bridge.createSpan(createMockSpanOptions());
+
+      const startTime = new Date('2024-01-01T00:00:00Z');
+      const eventSpan = createMockSpan({
+        id: spanResult!.spanId,
+        traceId: spanResult!.traceId,
+        isEvent: true,
+        isRootSpan: true,
+        startTime,
+        endTime: undefined,
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_STARTED, eventSpan));
+
+      // APM span should be finished with startTime (zero duration)
+      const apmSpan = capturedAPMSpans[0];
+      expect(apmSpan.finish).toHaveBeenCalledWith(startTime.getTime());
+    });
+  });
+
+  describe('LLMObs emission', () => {
+    it('emits LLMObs span via llmobs.trace() on span_ended', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const span = createMockSpan({ name: 'test-operation' });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockTrace).toHaveBeenCalledWith(expect.objectContaining({ name: 'test-operation' }), expect.any(Function));
+    });
+
+    it('does not emit on span_started for regular spans', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const span = createMockSpan({ isRootSpan: true });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_STARTED, span));
+
+      expect(mockTrace).not.toHaveBeenCalled();
+    });
+
+    it('ignores span_updated events', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const span = createMockSpan();
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_UPDATED, span));
+
+      expect(mockTrace).not.toHaveBeenCalled();
+    });
+
+    it('captures trace context and applies to all spans', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const rootSpan = createMockSpan({
+        id: 'root',
+        isRootSpan: true,
+        traceId: 'trace-123',
+        metadata: { userId: 'user-1', sessionId: 'session-1' },
+      });
+      const childSpan = createMockSpan({
+        id: 'child',
+        traceId: 'trace-123',
+        isRootSpan: false,
+        parentSpanId: 'root',
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_STARTED, rootSpan));
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, childSpan));
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, rootSpan));
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          sessionId: 'session-1',
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('emits parent-child hierarchy using nested llmobs.trace() calls', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const rootSpan = createMockSpan({ id: 'root', traceId: 'trace-1', isRootSpan: true });
+      const childSpan = createMockSpan({
+        id: 'child',
+        traceId: 'trace-1',
+        isRootSpan: false,
+        parentSpanId: 'root',
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, childSpan));
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, rootSpan));
+
+      expect(mockTrace).toHaveBeenCalledTimes(2);
+      // Root has no parent in scope
+      expect(traceParents[0]).toBeUndefined();
+      // Child is emitted inside root's callback, so root's LLMObs span is the parent
+      expect(traceParents[1]).toEqual(expect.objectContaining({ id: 'mock-llmobs-span-1' }));
+    });
+
+    it('handles late-arriving spans after tree emission', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const rootSpan = createMockSpan({ id: 'root', traceId: 'trace-late', isRootSpan: true });
+      const childSpan = createMockSpan({
+        id: 'child',
+        traceId: 'trace-late',
+        isRootSpan: false,
+        parentSpanId: 'root',
+      });
+
+      // Root ends first (triggers tree emission with just root)
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, rootSpan));
+      expect(mockTrace).toHaveBeenCalledTimes(1);
+
+      // Child arrives late
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, childSpan));
+      expect(mockTrace).toHaveBeenCalledTimes(2);
+      // Late-arriving span uses scope().activate() with parent context
+      expect(mockScopeActivate).toHaveBeenCalled();
+    });
+  });
+
+  describe('span type mapping', () => {
+    it.each([
+      [SpanType.AGENT_RUN, 'agent'],
+      [SpanType.MODEL_GENERATION, 'workflow'],
+      [SpanType.MODEL_STEP, 'llm'],
+      [SpanType.TOOL_CALL, 'tool'],
+      [SpanType.MCP_TOOL_CALL, 'tool'],
+      [SpanType.WORKFLOW_RUN, 'workflow'],
+      [SpanType.GENERIC, 'task'],
+    ])('maps %s to %s kind in LLMObs', async (spanType, expectedKind) => {
+      const bridge = new DatadogBridge({ mlApp: 'test', apiKey: 'test-key' });
+      const span = createMockSpan({ type: spanType });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockTrace).toHaveBeenCalledWith(expect.objectContaining({ kind: expectedKind }), expect.any(Function));
+    });
+  });
+
+  describe('annotations', () => {
+    it('annotates with input and output', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', apiKey: 'test-key' });
+      const span = createMockSpan({
+        input: 'hello',
+        output: 'world',
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          inputData: 'hello',
+          outputData: 'world',
+        }),
+      );
+    });
+
+    it('includes error tags and metadata for error spans', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', apiKey: 'test-key' });
+      const span = createMockSpan({
+        errorInfo: {
+          message: 'Something went wrong',
+          name: 'ValidationError',
+          stack: 'ValidationError: Something went wrong\n    at test.ts:1:1',
+        },
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      // Verify LLMObs error tags
+      const ddSpan = capturedLLMObsSpans[0];
+      expect(ddSpan.setTag).toHaveBeenCalledWith('error', true);
+      expect(ddSpan.setTag).toHaveBeenCalledWith('error.message', 'Something went wrong');
+      expect(ddSpan.setTag).toHaveBeenCalledWith('error.type', 'ValidationError');
+
+      // Verify error in annotations
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            'error.message': 'Something went wrong',
+          }),
+          tags: expect.objectContaining({
+            error: true,
+          }),
+        }),
+      );
+    });
+
+    it('includes token metrics on MODEL_STEP spans', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', apiKey: 'test-key' });
+      const span = createMockSpan({
+        type: SpanType.MODEL_STEP,
+        attributes: {
+          usage: { inputTokens: 100, outputTokens: 50 },
+        },
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          metrics: expect.objectContaining({
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+          }),
+        }),
+      );
+    });
+
+    it('promotes requestContextKeys to flat tags', async () => {
+      const bridge = new DatadogBridge({
+        mlApp: 'test',
+        apiKey: 'test-key',
+        requestContextKeys: ['tenantId'],
+      });
+      const span = createMockSpan({
+        metadata: { tenantId: 'tenant-123', other: 'value' },
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          metadata: { other: 'value' },
+          tags: { tenantId: 'tenant-123' },
+        }),
+      );
+    });
+  });
+
+  describe('flush and shutdown', () => {
+    it('flushes llmobs on flush()', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      await bridge.flush();
+
+      expect(mockFlush).toHaveBeenCalled();
+    });
+
+    it('force-finishes remaining APM spans on shutdown', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      // Create spans but don't end them
+      bridge.createSpan(createMockSpanOptions({ name: 'orphan-1' }));
+      bridge.createSpan(createMockSpanOptions({ name: 'orphan-2' }));
+
+      await bridge.shutdown();
+
+      // Both APM spans should have been force-finished
+      expect(capturedAPMSpans[0].finish).toHaveBeenCalled();
+      expect(capturedAPMSpans[1].finish).toHaveBeenCalled();
+    });
+
+    it('disables llmobs on shutdown', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      await bridge.shutdown();
+
+      expect(mockDisable).toHaveBeenCalled();
+    });
+  });
+
+  describe('end-to-end: APM + LLMObs flow', () => {
+    it('creates APM span eagerly and emits LLMObs on end', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      // 1. Bridge creates APM span eagerly
+      const spanResult = bridge.createSpan(createMockSpanOptions({ name: 'agent-run' }));
+      expect(mockStartSpan).toHaveBeenCalledWith('agent-run', expect.any(Object));
+      expect(mockTrace).not.toHaveBeenCalled(); // No LLMObs yet
+
+      // 2. During execution, scope is activated
+      let scopeWasActivated = false;
+      bridge.executeInContextSync(spanResult!.spanId, () => {
+        scopeWasActivated = true;
+      });
+      expect(scopeWasActivated).toBe(true);
+      expect(mockScopeActivate).toHaveBeenCalled();
+
+      // 3. Span ends — APM span finished + LLMObs emitted
+      const span = createMockSpan({
+        id: spanResult!.spanId,
+        traceId: spanResult!.traceId,
+        name: 'agent-run',
+        type: SpanType.AGENT_RUN,
+        input: 'user message',
+        output: 'agent response',
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      // APM span finished
+      expect(capturedAPMSpans[0].finish).toHaveBeenCalled();
+
+      // LLMObs span emitted with annotations
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'agent-run', kind: 'agent' }),
+        expect.any(Function),
+      );
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          inputData: 'user message',
+          outputData: 'agent response',
+        }),
+      );
+    });
+  });
+});

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -531,6 +531,92 @@ describe('DatadogBridge', () => {
       // Late-arriving span uses scope().activate() with parent context
       expect(mockScopeActivate).toHaveBeenCalled();
     });
+
+    it('preserves unresolved children when root ends before their parent', async () => {
+      // Scenario:
+      // 1. child ends (buffered; its parent hasn't ended yet)
+      // 2. root ends → tree is built, but child's parent isn't in the buffer
+      //    so child is "orphan" during initial tree emission
+      // 3. parent ends later → parent emits (parent's parent is root, in contexts)
+      // 4. child should then also emit (its parent is now in contexts)
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const rootSpan = createMockSpan({ id: 'root', traceId: 'trace-orphan', isRootSpan: true });
+      const parentSpan = createMockSpan({
+        id: 'parent',
+        traceId: 'trace-orphan',
+        isRootSpan: false,
+        parentSpanId: 'root',
+      });
+      const childSpan = createMockSpan({
+        id: 'child',
+        traceId: 'trace-orphan',
+        isRootSpan: false,
+        parentSpanId: 'parent',
+      });
+
+      // 1. Child ends first (buffered, parent not yet in buffer)
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, childSpan));
+      expect(mockTrace).not.toHaveBeenCalled();
+
+      // 2. Root ends (triggers tree emission — only root is resolvable)
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, rootSpan));
+      // Root emits, child stays buffered (its parent is not in contexts yet)
+      expect(mockTrace).toHaveBeenCalledTimes(1);
+
+      // 3. Parent ends late
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, parentSpan));
+      // Parent and child both emit now
+      expect(mockTrace).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('model attribute inheritance for late-arriving spans', () => {
+    it('passes MODEL_GENERATION model/provider to a late-arriving MODEL_STEP child', async () => {
+      // Scenario: a MODEL_STEP child arrives after its MODEL_GENERATION parent
+      // has already been emitted as part of the tree. The late-arrival path
+      // should look up the parent's stored childInheritedModelAttrs and pass
+      // them to buildSpanOptions so the LLM-kind span has modelName/modelProvider.
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const rootSpan = createMockSpan({
+        id: 'root',
+        traceId: 'trace-model-late',
+        isRootSpan: true,
+        type: SpanType.AGENT_RUN,
+      });
+      const genSpan = createMockSpan({
+        id: 'gen',
+        traceId: 'trace-model-late',
+        isRootSpan: false,
+        parentSpanId: 'root',
+        type: SpanType.MODEL_GENERATION,
+        attributes: { model: 'gpt-5.4', provider: 'openai' },
+      });
+      const stepSpan = createMockSpan({
+        id: 'step',
+        traceId: 'trace-model-late',
+        isRootSpan: false,
+        parentSpanId: 'gen',
+        type: SpanType.MODEL_STEP,
+      });
+
+      // Emit tree first: root + gen (step hasn't ended yet)
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, genSpan));
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, rootSpan));
+
+      // Now the late-arriving step
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, stepSpan));
+
+      // Find the LLMObs trace call for the step span (kind: 'llm')
+      const stepCall = mockTrace.mock.calls.find(([opts]: any) => opts.kind === 'llm');
+      expect(stepCall).toBeDefined();
+      expect(stepCall![0]).toMatchObject({
+        kind: 'llm',
+        modelName: 'gpt-5.4',
+        modelProvider: 'openai',
+      });
+    });
   });
 
   describe('span type mapping', () => {

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -1,7 +1,9 @@
 /**
  * Tests for Datadog Bridge
  *
- * Uses mock dd-trace to test the bridge without connecting to Datadog.
+ * Uses mock dd-trace to verify that the bridge keeps a single eager dd span
+ * per Mastra span lifecycle and does not create a second synthetic span tree
+ * via llmobs.trace().
  */
 
 /// <reference types="node" />
@@ -13,27 +15,28 @@ import type {
   SpanType as SpanTypeGeneric,
 } from '@mastra/core/observability';
 import { SpanType, TracingEventType } from '@mastra/core/observability';
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Use vi.hoisted to define mocks before they're used in vi.mock
 const {
+  capturedApmSpans,
+  llmobsRegistrations,
   mockAnnotate,
-  mockTrace,
-  mockFlush,
   mockDisable,
   mockEnable,
+  mockExporterFlush,
+  mockFlush,
   mockInit,
-  mockStartSpan,
   mockScopeActivate,
   mockScopeActive,
-  traceParents,
-  capturedLLMObsSpans,
-  capturedAPMSpans,
+  mockStartSpan,
+  mockTrace,
 } = vi.hoisted(() => {
   let currentScopeSpan: any = undefined;
-  const parents: any[] = [];
-  const llmobsSpans: any[] = [];
   let apmSpanCounter = 0;
+  let rootTraceCounter = 0;
+
+  const apmSpans: any[] = [];
+  const registrations: Array<{ span: any; options: any }> = [];
 
   const activate = vi.fn((span: any, fn: () => any) => {
     const previous = currentScopeSpan;
@@ -47,70 +50,69 @@ const {
 
   const active = vi.fn(() => currentScopeSpan);
 
-  const apmSpans: any[] = [];
+  const startSpan = vi.fn((name: string, options?: any) => {
+    apmSpanCounter++;
+
+    const parent = options?.childOf;
+    const spanHex = apmSpanCounter.toString(16).padStart(16, '0');
+    const traceHex = parent?.context?.()?.toTraceId?.(true) ?? (++rootTraceCounter).toString(16).padStart(32, '0');
+
+    const span = {
+      _name: name,
+      _options: options,
+      finish: vi.fn(),
+      setTag: vi.fn(),
+      context: vi.fn(() => ({
+        toSpanId: (_hex?: boolean) => spanHex,
+        toTraceId: (_hex?: boolean) => traceHex,
+      })),
+    };
+
+    apmSpans.push(span);
+    return span;
+  });
 
   return {
-    traceParents: parents,
-    capturedLLMObsSpans: llmobsSpans,
-    capturedAPMSpans: apmSpans,
+    capturedApmSpans: apmSpans,
+    llmobsRegistrations: registrations,
     mockAnnotate: vi.fn(),
-    mockTrace: vi.fn((options: any, fn: (span: any) => void) => {
-      parents.push(currentScopeSpan);
-      const ddSpan = {
-        id: `mock-llmobs-span-${parents.length}`,
-        options,
-        setTag: vi.fn(),
-        finish: vi.fn(),
-      };
-      llmobsSpans.push(ddSpan);
-      const previous = currentScopeSpan;
-      currentScopeSpan = ddSpan;
-      try {
-        return fn(ddSpan);
-      } finally {
-        currentScopeSpan = previous;
-      }
-    }),
-    mockFlush: vi.fn().mockResolvedValue(undefined),
     mockDisable: vi.fn(),
     mockEnable: vi.fn(),
+    mockExporterFlush: vi.fn((done?: (error?: unknown) => void) => done?.()),
+    mockFlush: vi.fn().mockResolvedValue(undefined),
     mockInit: vi.fn(),
-    mockStartSpan: vi.fn((name: string, options?: any) => {
-      apmSpanCounter++;
-      const span = {
-        id: `mock-apm-span-${apmSpanCounter}`,
-        _name: name,
-        _options: options,
-        finish: vi.fn(),
-        setTag: vi.fn(),
-        context: vi.fn(() => ({
-          toSpanId: () => `apm-span-id-${apmSpanCounter}`,
-          toTraceId: () => `apm-trace-id-${apmSpanCounter}`,
-        })),
-      };
-      apmSpans.push(span);
-      return span;
-    }),
     mockScopeActivate: activate,
     mockScopeActive: active,
+    mockStartSpan: startSpan,
+    mockTrace: vi.fn(),
   };
 });
 
-// Mock dd-trace before importing the bridge
 vi.mock('dd-trace', () => {
+  const mockTagger = {
+    registerLLMObsSpan: vi.fn((span: any, options: any) => {
+      llmobsRegistrations.push({ span, options });
+    }),
+  };
+
   return {
     default: {
       init: mockInit,
       startSpan: mockStartSpan,
       llmobs: {
+        _tagger: mockTagger,
         enable: mockEnable,
         disable: mockDisable,
-        trace: mockTrace,
         annotate: mockAnnotate,
         flush: mockFlush,
-        exportSpan: (span: any) => ({ traceId: 'dd-trace-id', spanId: span?.id || 'dd-span-id' }),
+        trace: mockTrace,
       },
-      _tracer: { started: false },
+      _tracer: {
+        started: false,
+        _exporter: {
+          flush: mockExporterFlush,
+        },
+      },
       scope: () => ({
         activate: mockScopeActivate,
         active: mockScopeActive,
@@ -121,13 +123,21 @@ vi.mock('dd-trace', () => {
 
 import { DatadogBridge } from './bridge';
 
-/**
- * Creates a mock span with default values
- */
+function createMockLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trackException: vi.fn(),
+    getTransports: vi.fn(() => new Map()),
+  };
+}
+
 function createMockSpan(overrides: Partial<AnyExportedSpan> = {}): AnyExportedSpan {
   return {
-    id: 'span-1',
-    traceId: 'trace-1',
+    id: '0000000000000001',
+    traceId: '00000000000000000000000000000001',
     name: 'test-span',
     type: SpanType.GENERIC,
     startTime: new Date('2024-01-01T00:00:00Z'),
@@ -138,16 +148,10 @@ function createMockSpan(overrides: Partial<AnyExportedSpan> = {}): AnyExportedSp
   } as AnyExportedSpan;
 }
 
-/**
- * Creates a tracing event
- */
 function createTracingEvent(type: TracingEventType, span: AnyExportedSpan): TracingEvent {
   return { type, exportedSpan: span } as TracingEvent;
 }
 
-/**
- * Creates mock CreateSpanOptions for bridge.createSpan() testing
- */
 function createMockSpanOptions(
   overrides: Partial<CreateSpanOptions<SpanTypeGeneric>> = {},
 ): CreateSpanOptions<SpanTypeGeneric> {
@@ -161,10 +165,9 @@ function createMockSpanOptions(
 describe('DatadogBridge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    traceParents.length = 0;
-    capturedLLMObsSpans.length = 0;
-    capturedAPMSpans.length = 0;
-    // Reset environment variables
+    capturedApmSpans.length = 0;
+    llmobsRegistrations.length = 0;
+    mockExporterFlush.mockImplementation((done?: (error?: unknown) => void) => done?.());
     delete process.env.DD_API_KEY;
     delete process.env.DD_LLMOBS_ML_APP;
     delete process.env.DD_SITE;
@@ -206,87 +209,45 @@ describe('DatadogBridge', () => {
       expect(mockEnable).not.toHaveBeenCalled();
       expect(bridge['isDisabled']).toBe(true);
     });
-
-    it('allows non-agentless mode without apiKey', () => {
-      const bridge = new DatadogBridge({
-        mlApp: 'test-app',
-        agentless: false,
-      });
-
-      expect(bridge['isDisabled']).toBe(false);
-    });
-
-    it('reads configuration from environment variables', () => {
-      process.env.DD_LLMOBS_ML_APP = 'env-app';
-      process.env.DD_API_KEY = 'env-key';
-
-      const bridge = new DatadogBridge({});
-
-      expect(bridge['isDisabled']).toBe(false);
-    });
-
-    it('defaults agentless to false (assumes local Datadog Agent)', () => {
-      const bridge = new DatadogBridge({ mlApp: 'test-app' });
-
-      // Bridge does not require apiKey because agentless defaults to false
-      expect(bridge['isDisabled']).toBe(false);
-    });
-
-    it('respects DD_LLMOBS_AGENTLESS_ENABLED=true env var', () => {
-      process.env.DD_LLMOBS_AGENTLESS_ENABLED = 'true';
-
-      // Without apiKey, agentless mode should disable the bridge
-      const bridge = new DatadogBridge({ mlApp: 'test-app' });
-
-      expect(bridge['isDisabled']).toBe(true);
-    });
-
-    it('prefers config values over environment variables', () => {
-      process.env.DD_LLMOBS_ML_APP = 'env-app';
-
-      const bridge = new DatadogBridge({
-        mlApp: 'config-app',
-        agentless: false,
-      });
-
-      expect(bridge['isDisabled']).toBe(false);
-      expect(bridge['config'].mlApp).toBe('config-app');
-    });
   });
 
   describe('createSpan', () => {
-    it('creates an APM span via tracer.startSpan()', () => {
+    it('creates a single eager APM span and returns dd-trace ids', () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
 
       const result = bridge.createSpan(createMockSpanOptions({ name: 'my-agent' }));
 
-      expect(result).toBeDefined();
-      expect(result!.spanId).toBeDefined();
-      expect(result!.traceId).toBeDefined();
       expect(mockStartSpan).toHaveBeenCalledWith('my-agent', expect.any(Object));
+      expect(result).toEqual({
+        spanId: '0000000000000001',
+        traceId: '00000000000000000000000000000001',
+        parentSpanId: undefined,
+      });
     });
 
-    it('returns hex-format span and trace IDs', () => {
+    it('registers the eager span with the LLMObs tagger', () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
 
-      const result = bridge.createSpan(createMockSpanOptions());
+      bridge.createSpan(createMockSpanOptions({ name: 'my-agent', type: SpanType.AGENT_RUN as SpanTypeGeneric }));
 
-      expect(result!.spanId).toMatch(/^[0-9a-f]{16}$/);
-      expect(result!.traceId).toMatch(/^[0-9a-f]{32}$/);
+      expect(llmobsRegistrations).toHaveLength(1);
+      expect(llmobsRegistrations[0]?.options).toMatchObject({
+        kind: 'agent',
+        name: 'my-agent',
+      });
+      expect(mockTrace).not.toHaveBeenCalled();
     });
 
-    it('sets parent from getExternalParentId when parent span exists in map', () => {
+    it('uses the parent dd span when creating a child span', () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
 
-      // Create parent span first
-      const parentResult = bridge.createSpan(createMockSpanOptions({ name: 'parent' }));
-      const parentApmSpan = capturedAPMSpans[0];
-
-      // Create child span with parent reference
+      const parentResult = bridge.createSpan(createMockSpanOptions({ name: 'parent' }))!;
+      const parentApmSpan = capturedApmSpans[0];
       const mockParent = {
-        id: parentResult!.spanId,
-        traceId: parentResult!.traceId,
+        id: parentResult.spanId,
+        traceId: parentResult.traceId,
         isInternal: false,
+        metadata: {},
         getParentSpanId: () => undefined,
       };
 
@@ -295,65 +256,114 @@ describe('DatadogBridge', () => {
           name: 'child',
           parent: mockParent as any,
         }),
-      );
+      )!;
 
-      expect(childResult).toBeDefined();
-      expect(childResult!.parentSpanId).toBe(parentResult!.spanId);
-      expect(childResult!.traceId).toBe(parentResult!.traceId);
-      // The child's APM span should have been created with childOf pointing to parent
-      expect(mockStartSpan).toHaveBeenCalledTimes(2);
-      expect(capturedAPMSpans[1]._options).toEqual({ childOf: parentApmSpan });
+      expect(childResult.parentSpanId).toBe(parentResult.spanId);
+      expect(childResult.traceId).toBe(parentResult.traceId);
+      expect(capturedApmSpans[1]._options).toEqual({ childOf: parentApmSpan });
+      expect(llmobsRegistrations[1]?.options.parent).toBe(parentApmSpan);
     });
 
-    it('falls back to active dd-trace scope when no explicit parent', () => {
+    it('falls back to the active dd-trace scope when no explicit parent exists', () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
 
-      // Simulate an active request span in dd-trace scope
-      const requestSpan = { id: 'request-span' };
+      const requestSpan = {
+        context: () => ({
+          toSpanId: () => 'aaaaaaaaaaaaaaaa',
+          toTraceId: () => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        }),
+      };
       mockScopeActive.mockReturnValueOnce(requestSpan);
 
-      const result = bridge.createSpan(createMockSpanOptions());
+      const result = bridge.createSpan(createMockSpanOptions())!;
 
-      expect(result).toBeDefined();
       expect(mockStartSpan).toHaveBeenCalledWith('test-span', { childOf: requestSpan });
+      expect(result.parentSpanId).toBe('aaaaaaaaaaaaaaaa');
+      expect(result.traceId).toBe('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
     });
 
-    it('returns undefined when bridge is disabled', () => {
-      const bridge = new DatadogBridge({}); // Missing mlApp
+    it('does not fall back to the active dd-trace scope when an explicit parent is missing from the bridge map', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
 
-      const result = bridge.createSpan(createMockSpanOptions());
+      const requestSpan = {
+        context: () => ({
+          toSpanId: () => 'aaaaaaaaaaaaaaaa',
+          toTraceId: () => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        }),
+      };
+      mockScopeActive.mockReturnValueOnce(requestSpan);
 
-      expect(result).toBeUndefined();
+      const result = bridge.createSpan(
+        createMockSpanOptions({
+          parent: {
+            id: 'missing-parent-id',
+            traceId: 'cccccccccccccccccccccccccccccccc',
+            isInternal: false,
+            metadata: {},
+            getParentSpanId: () => undefined,
+          } as any,
+        }),
+      )!;
+
+      expect(mockStartSpan).toHaveBeenCalledWith('test-span', {});
+      expect(result.parentSpanId).toBe('missing-parent-id');
+      expect(result.traceId).not.toBe('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+    });
+
+    it('inherits model info for MODEL_STEP spans from a MODEL_GENERATION parent when needed', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      bridge.createSpan(
+        createMockSpanOptions({
+          name: 'step',
+          type: SpanType.MODEL_STEP as SpanTypeGeneric,
+          parent: {
+            id: 'gen-id',
+            traceId: 'gen-trace',
+            type: SpanType.MODEL_GENERATION,
+            isInternal: false,
+            metadata: {},
+            attributes: { model: 'gpt-5.4', provider: 'openai' },
+            getParentSpanId: () => undefined,
+          } as any,
+        }),
+      );
+
+      expect(llmobsRegistrations[0]?.options).toMatchObject({
+        kind: 'llm',
+        modelName: 'gpt-5.4',
+        modelProvider: 'openai',
+      });
+    });
+
+    it('logs dd span open events when span lifecycle debug is enabled', () => {
+      const logger = createMockLogger();
+      const bridge = new DatadogBridge({
+        mlApp: 'test',
+        agentless: false,
+        spanLifecycleDebug: true,
+        logger: logger as any,
+      });
+
+      bridge.createSpan(createMockSpanOptions({ name: 'debug-span' }));
+
+      expect(logger.info).toHaveBeenCalledWith('[DatadogBridge] Enabled dd-trace span lifecycle debug logging');
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('[DatadogBridge.span.open] name=debug-span'));
     });
   });
 
   describe('executeInContext', () => {
-    it('activates dd-trace span in scope for async functions', async () => {
+    it('activates the eager dd span in scope for async functions', async () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
 
-      // Create a span to get it in the map
-      const spanResult = bridge.createSpan(createMockSpanOptions());
-      const apmSpan = capturedAPMSpans[0];
-
-      await bridge.executeInContext(spanResult!.spanId, async () => {
-        // function runs within activated scope
-      });
+      await bridge.executeInContext(spanResult.spanId, async () => {});
 
       expect(mockScopeActivate).toHaveBeenCalledWith(apmSpan, expect.any(Function));
     });
 
-    it('activates dd-trace span in scope for sync functions', () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      const spanResult = bridge.createSpan(createMockSpanOptions());
-      const apmSpan = capturedAPMSpans[0];
-
-      bridge.executeInContextSync(spanResult!.spanId, () => 'result');
-
-      expect(mockScopeActivate).toHaveBeenCalledWith(apmSpan, expect.any(Function));
-    });
-
-    it('falls back to direct execution when span not in map', async () => {
+    it('falls back to direct execution when the span is not in the map', async () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
 
       const result = await bridge.executeInContext('nonexistent-span', async () => 42);
@@ -362,286 +372,36 @@ describe('DatadogBridge', () => {
       expect(mockScopeActivate).not.toHaveBeenCalled();
     });
 
-    it('returns function result through scope activation', () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-      const spanResult = bridge.createSpan(createMockSpanOptions());
-
-      const result = bridge.executeInContextSync(spanResult!.spanId, () => 'hello');
-
-      expect(result).toBe('hello');
-    });
-  });
-
-  describe('APM span lifecycle', () => {
-    it('finishes APM span on span_ended with correct timestamp', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      const spanResult = bridge.createSpan(createMockSpanOptions());
-      const apmSpan = capturedAPMSpans[0];
-
-      const endTime = new Date('2024-01-01T00:00:05Z');
-      const span = createMockSpan({
-        id: spanResult!.spanId,
-        traceId: spanResult!.traceId,
-        endTime,
+    it('logs a call stack for missing-span fallback when span lifecycle debug is enabled', async () => {
+      const logger = createMockLogger();
+      const bridge = new DatadogBridge({
+        mlApp: 'test',
+        agentless: false,
+        spanLifecycleDebug: true,
+        logger: logger as any,
       });
 
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+      await bridge.executeInContext('nonexistent-span', async () => 42);
 
-      expect(apmSpan.finish).toHaveBeenCalledWith(endTime.getTime());
-    });
-
-    it('removes APM span from map after finishing', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      const spanResult = bridge.createSpan(createMockSpanOptions());
-
-      const span = createMockSpan({
-        id: spanResult!.spanId,
-        traceId: spanResult!.traceId,
-      });
-
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
-
-      // Verify span is removed by checking executeInContext falls through
-      const result = bridge.executeInContextSync(spanResult!.spanId, () => 'test');
-      expect(result).toBe('test');
-      expect(mockScopeActivate).not.toHaveBeenCalled();
-    });
-
-    it('finishes APM span for event spans on span_started', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      const spanResult = bridge.createSpan(createMockSpanOptions());
-
-      const startTime = new Date('2024-01-01T00:00:00Z');
-      const eventSpan = createMockSpan({
-        id: spanResult!.spanId,
-        traceId: spanResult!.traceId,
-        isEvent: true,
-        isRootSpan: true,
-        startTime,
-        endTime: undefined,
-      });
-
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_STARTED, eventSpan));
-
-      // APM span should be finished with startTime (zero duration)
-      const apmSpan = capturedAPMSpans[0];
-      expect(apmSpan.finish).toHaveBeenCalledWith(startTime.getTime());
-    });
-  });
-
-  describe('LLMObs emission', () => {
-    it('emits LLMObs span via llmobs.trace() on span_ended', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-      const span = createMockSpan({ name: 'test-operation' });
-
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
-
-      expect(mockTrace).toHaveBeenCalledWith(expect.objectContaining({ name: 'test-operation' }), expect.any(Function));
-    });
-
-    it('does not emit on span_started for regular spans', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-      const span = createMockSpan({ isRootSpan: true });
-
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_STARTED, span));
-
-      expect(mockTrace).not.toHaveBeenCalled();
-    });
-
-    it('ignores span_updated events', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-      const span = createMockSpan();
-
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_UPDATED, span));
-
-      expect(mockTrace).not.toHaveBeenCalled();
-    });
-
-    it('captures trace context and applies to all spans', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      const rootSpan = createMockSpan({
-        id: 'root',
-        isRootSpan: true,
-        traceId: 'trace-123',
-        metadata: { userId: 'user-1', sessionId: 'session-1' },
-      });
-      const childSpan = createMockSpan({
-        id: 'child',
-        traceId: 'trace-123',
-        isRootSpan: false,
-        parentSpanId: 'root',
-      });
-
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_STARTED, rootSpan));
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, childSpan));
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, rootSpan));
-
-      expect(mockTrace).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(
+        '[DatadogBridge.executeWithSpanContext] Falling back to raw execution because dd span is missing',
         expect.objectContaining({
-          userId: 'user-1',
-          sessionId: 'session-1',
+          spanId: 'nonexistent-span',
+          callStack: expect.stringContaining('DatadogBridge.executeWithSpanContext'),
         }),
-        expect.any(Function),
       );
     });
-
-    it('emits parent-child hierarchy using nested llmobs.trace() calls', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      const rootSpan = createMockSpan({ id: 'root', traceId: 'trace-1', isRootSpan: true });
-      const childSpan = createMockSpan({
-        id: 'child',
-        traceId: 'trace-1',
-        isRootSpan: false,
-        parentSpanId: 'root',
-      });
-
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, childSpan));
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, rootSpan));
-
-      expect(mockTrace).toHaveBeenCalledTimes(2);
-      // Root has no parent in scope
-      expect(traceParents[0]).toBeUndefined();
-      // Child is emitted inside root's callback, so root's LLMObs span is the parent
-      expect(traceParents[1]).toEqual(expect.objectContaining({ id: 'mock-llmobs-span-1' }));
-    });
-
-    it('handles late-arriving spans after tree emission', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      const rootSpan = createMockSpan({ id: 'root', traceId: 'trace-late', isRootSpan: true });
-      const childSpan = createMockSpan({
-        id: 'child',
-        traceId: 'trace-late',
-        isRootSpan: false,
-        parentSpanId: 'root',
-      });
-
-      // Root ends first (triggers tree emission with just root)
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, rootSpan));
-      expect(mockTrace).toHaveBeenCalledTimes(1);
-
-      // Child arrives late
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, childSpan));
-      expect(mockTrace).toHaveBeenCalledTimes(2);
-      // Late-arriving span uses scope().activate() with parent context
-      expect(mockScopeActivate).toHaveBeenCalled();
-    });
-
-    it('preserves unresolved children when root ends before their parent', async () => {
-      // Scenario:
-      // 1. child ends (buffered; its parent hasn't ended yet)
-      // 2. root ends → tree is built, but child's parent isn't in the buffer
-      //    so child is "orphan" during initial tree emission
-      // 3. parent ends later → parent emits (parent's parent is root, in contexts)
-      // 4. child should then also emit (its parent is now in contexts)
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      const rootSpan = createMockSpan({ id: 'root', traceId: 'trace-orphan', isRootSpan: true });
-      const parentSpan = createMockSpan({
-        id: 'parent',
-        traceId: 'trace-orphan',
-        isRootSpan: false,
-        parentSpanId: 'root',
-      });
-      const childSpan = createMockSpan({
-        id: 'child',
-        traceId: 'trace-orphan',
-        isRootSpan: false,
-        parentSpanId: 'parent',
-      });
-
-      // 1. Child ends first (buffered, parent not yet in buffer)
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, childSpan));
-      expect(mockTrace).not.toHaveBeenCalled();
-
-      // 2. Root ends (triggers tree emission — only root is resolvable)
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, rootSpan));
-      // Root emits, child stays buffered (its parent is not in contexts yet)
-      expect(mockTrace).toHaveBeenCalledTimes(1);
-
-      // 3. Parent ends late
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, parentSpan));
-      // Parent and child both emit now
-      expect(mockTrace).toHaveBeenCalledTimes(3);
-    });
   });
 
-  describe('model attribute inheritance for late-arriving spans', () => {
-    it('passes MODEL_GENERATION model/provider to a late-arriving MODEL_STEP child', async () => {
-      // Scenario: a MODEL_STEP child arrives after its MODEL_GENERATION parent
-      // has already been emitted as part of the tree. The late-arrival path
-      // should look up the parent's stored childInheritedModelAttrs and pass
-      // them to buildSpanOptions so the LLM-kind span has modelName/modelProvider.
+  describe('span lifecycle', () => {
+    it('annotates and finishes the eager dd span on span_ended', async () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
 
-      const rootSpan = createMockSpan({
-        id: 'root',
-        traceId: 'trace-model-late',
-        isRootSpan: true,
-        type: SpanType.AGENT_RUN,
-      });
-      const genSpan = createMockSpan({
-        id: 'gen',
-        traceId: 'trace-model-late',
-        isRootSpan: false,
-        parentSpanId: 'root',
-        type: SpanType.MODEL_GENERATION,
-        attributes: { model: 'gpt-5.4', provider: 'openai' },
-      });
-      const stepSpan = createMockSpan({
-        id: 'step',
-        traceId: 'trace-model-late',
-        isRootSpan: false,
-        parentSpanId: 'gen',
-        type: SpanType.MODEL_STEP,
-      });
-
-      // Emit tree first: root + gen (step hasn't ended yet)
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, genSpan));
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, rootSpan));
-
-      // Now the late-arriving step
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, stepSpan));
-
-      // Find the LLMObs trace call for the step span (kind: 'llm')
-      const stepCall = mockTrace.mock.calls.find(([opts]: any) => opts.kind === 'llm');
-      expect(stepCall).toBeDefined();
-      expect(stepCall![0]).toMatchObject({
-        kind: 'llm',
-        modelName: 'gpt-5.4',
-        modelProvider: 'openai',
-      });
-    });
-  });
-
-  describe('span type mapping', () => {
-    it.each([
-      [SpanType.AGENT_RUN, 'agent'],
-      [SpanType.MODEL_GENERATION, 'workflow'],
-      [SpanType.MODEL_STEP, 'llm'],
-      [SpanType.TOOL_CALL, 'tool'],
-      [SpanType.MCP_TOOL_CALL, 'tool'],
-      [SpanType.WORKFLOW_RUN, 'workflow'],
-      [SpanType.GENERIC, 'task'],
-    ])('maps %s to %s kind in LLMObs', async (spanType, expectedKind) => {
-      const bridge = new DatadogBridge({ mlApp: 'test', apiKey: 'test-key' });
-      const span = createMockSpan({ type: spanType });
-
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
-
-      expect(mockTrace).toHaveBeenCalledWith(expect.objectContaining({ kind: expectedKind }), expect.any(Function));
-    });
-  });
-
-  describe('annotations', () => {
-    it('annotates with input and output', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
         input: 'hello',
         output: 'world',
       });
@@ -649,76 +409,116 @@ describe('DatadogBridge', () => {
       await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
 
       expect(mockAnnotate).toHaveBeenCalledWith(
-        expect.anything(),
+        apmSpan,
         expect.objectContaining({
           inputData: 'hello',
           outputData: 'world',
         }),
       );
+      expect(apmSpan.finish).toHaveBeenCalledWith(span.endTime!.getTime());
+      expect(mockTrace).not.toHaveBeenCalled();
     });
 
-    it('includes error tags and metadata for error spans', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', apiKey: 'test-key' });
+    it('annotates and finishes event spans on span_started', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      const startTime = new Date('2024-01-01T00:00:00Z');
+      const eventSpan = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+        isEvent: true,
+        startTime,
+        endTime: undefined,
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_STARTED, eventSpan));
+
+      expect(apmSpan.finish).toHaveBeenCalledWith(startTime.getTime());
+      expect(mockTrace).not.toHaveBeenCalled();
+    });
+
+    it('annotates and finishes event spans on span_ended', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      const endTime = new Date('2024-01-01T00:00:05Z');
+      const eventSpan = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+        isEvent: true,
+        output: 'tool-result',
+        endTime,
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, eventSpan));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        apmSpan,
+        expect.objectContaining({
+          outputData: 'tool-result',
+        }),
+      );
+      expect(apmSpan.finish).toHaveBeenCalledWith(endTime.getTime());
+      expect(mockTrace).not.toHaveBeenCalled();
+    });
+
+    it('sets native Datadog error tags before finishing', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
       const span = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
         errorInfo: {
           message: 'Something went wrong',
           name: 'ValidationError',
-          stack: 'ValidationError: Something went wrong\n    at test.ts:1:1',
+          stack: 'ValidationError: Something went wrong',
         },
       });
 
       await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
 
-      // Verify LLMObs error tags
-      const ddSpan = capturedLLMObsSpans[0];
-      expect(ddSpan.setTag).toHaveBeenCalledWith('error', true);
-      expect(ddSpan.setTag).toHaveBeenCalledWith('error.message', 'Something went wrong');
-      expect(ddSpan.setTag).toHaveBeenCalledWith('error.type', 'ValidationError');
-
-      // Verify error in annotations
-      expect(mockAnnotate).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          metadata: expect.objectContaining({
-            'error.message': 'Something went wrong',
-          }),
-          tags: expect.objectContaining({
-            error: true,
-          }),
-        }),
-      );
+      expect(apmSpan.setTag).toHaveBeenCalledWith('error', true);
+      expect(apmSpan.setTag).toHaveBeenCalledWith('error.message', 'Something went wrong');
+      expect(apmSpan.setTag).toHaveBeenCalledWith('error.type', 'ValidationError');
     });
 
-    it('includes token metrics on MODEL_STEP spans', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', apiKey: 'test-key' });
+    it('still finishes the eager dd span when LLMObs annotation throws', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      mockAnnotate.mockImplementationOnce(() => {
+        throw new Error('annotation failed');
+      });
+
       const span = createMockSpan({
-        type: SpanType.MODEL_STEP,
-        attributes: {
-          usage: { inputTokens: 100, outputTokens: 50 },
-        },
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+        input: { prompt: 'hello' },
       });
 
       await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
 
-      expect(mockAnnotate).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          metrics: expect.objectContaining({
-            inputTokens: 100,
-            outputTokens: 50,
-            totalTokens: 150,
-          }),
-        }),
-      );
+      expect(mockAnnotate).toHaveBeenCalled();
+      expect(apmSpan.finish).toHaveBeenCalledWith(span.endTime!.getTime());
     });
 
-    it('promotes requestContextKeys to flat tags', async () => {
+    it('promotes requestContextKeys to flat LLMObs tags during annotation', async () => {
       const bridge = new DatadogBridge({
         mlApp: 'test',
-        apiKey: 'test-key',
+        agentless: false,
         requestContextKeys: ['tenantId'],
       });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+
       const span = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
         metadata: { tenantId: 'tenant-123', other: 'value' },
       });
 
@@ -734,82 +534,19 @@ describe('DatadogBridge', () => {
     });
   });
 
-  describe('flush and shutdown', () => {
-    it('flushes llmobs on flush()', async () => {
+  describe('shutdown', () => {
+    it('force-finishes remaining spans on shutdown', async () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
 
-      await bridge.flush();
-
-      expect(mockFlush).toHaveBeenCalled();
-    });
-
-    it('force-finishes remaining APM spans on shutdown', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      // Create spans but don't end them
       bridge.createSpan(createMockSpanOptions({ name: 'orphan-1' }));
       bridge.createSpan(createMockSpanOptions({ name: 'orphan-2' }));
 
       await bridge.shutdown();
 
-      // Both APM spans should have been force-finished
-      expect(capturedAPMSpans[0].finish).toHaveBeenCalled();
-      expect(capturedAPMSpans[1].finish).toHaveBeenCalled();
-    });
-
-    it('disables llmobs on shutdown', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      await bridge.shutdown();
-
+      expect(capturedApmSpans[0].finish).toHaveBeenCalled();
+      expect(capturedApmSpans[1].finish).toHaveBeenCalled();
+      expect(mockExporterFlush).toHaveBeenCalled();
       expect(mockDisable).toHaveBeenCalled();
-    });
-  });
-
-  describe('end-to-end: APM + LLMObs flow', () => {
-    it('creates APM span eagerly and emits LLMObs on end', async () => {
-      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
-
-      // 1. Bridge creates APM span eagerly
-      const spanResult = bridge.createSpan(createMockSpanOptions({ name: 'agent-run' }));
-      expect(mockStartSpan).toHaveBeenCalledWith('agent-run', expect.any(Object));
-      expect(mockTrace).not.toHaveBeenCalled(); // No LLMObs yet
-
-      // 2. During execution, scope is activated
-      let scopeWasActivated = false;
-      bridge.executeInContextSync(spanResult!.spanId, () => {
-        scopeWasActivated = true;
-      });
-      expect(scopeWasActivated).toBe(true);
-      expect(mockScopeActivate).toHaveBeenCalled();
-
-      // 3. Span ends — APM span finished + LLMObs emitted
-      const span = createMockSpan({
-        id: spanResult!.spanId,
-        traceId: spanResult!.traceId,
-        name: 'agent-run',
-        type: SpanType.AGENT_RUN,
-        input: 'user message',
-        output: 'agent response',
-      });
-
-      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
-
-      // APM span finished
-      expect(capturedAPMSpans[0].finish).toHaveBeenCalled();
-
-      // LLMObs span emitted with annotations
-      expect(mockTrace).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'agent-run', kind: 'agent' }),
-        expect.any(Function),
-      );
-      expect(mockAnnotate).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          inputData: 'user message',
-          outputData: 'agent response',
-        }),
-      );
     });
   });
 });

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -62,7 +62,17 @@ interface TraceContext {
 
 type TraceState = {
   buffer: Map<string, AnyExportedSpan>;
-  contexts: Map<string, { ddSpan: any; exported?: { traceId: string; spanId: string } }>;
+  contexts: Map<
+    string,
+    {
+      ddSpan: any;
+      exported?: { traceId: string; spanId: string };
+      // Effective model/provider to pass DOWN to this span's children. Used so
+      // late-arriving descendants can inherit MODEL_GENERATION attrs the same
+      // way they would during recursive tree emission.
+      childInheritedModelAttrs?: { model?: string; provider?: string };
+    }
+  >;
   rootEnded: boolean;
   treeEmitted: boolean;
   createdAt: number;
@@ -425,6 +435,11 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
     const state = this.traceState.get(traceId);
     if (!state) return;
 
+    // Phase 1: emit the initial tree once the root span ends. Any spans
+    // whose parent wasn't in the buffer at this point (e.g., child ended
+    // before its parent did and the root ended in between) stay buffered
+    // and may be emitted via the late-arrival path below once their parent
+    // shows up in state.contexts.
     if (!state.treeEmitted) {
       if (!state.rootEnded) return;
 
@@ -433,24 +448,34 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
         this.emitSpanTree(tree, state);
       }
 
-      state.buffer.clear();
-      state.treeEmitted = true;
-    } else {
-      let emitted = false;
-      do {
-        emitted = false;
-        for (const [spanId, span] of state.buffer) {
-          const parentCtx = span.parentSpanId ? state.contexts.get(span.parentSpanId) : undefined;
-          if (span.parentSpanId && !parentCtx) {
-            continue;
-          }
-
-          this.emitSingleSpan(span, state, parentCtx?.ddSpan);
+      // Remove only spans that were actually emitted (those now in
+      // state.contexts). Unresolved spans stay buffered.
+      for (const spanId of Array.from(state.buffer.keys())) {
+        if (state.contexts.has(spanId)) {
           state.buffer.delete(spanId);
-          emitted = true;
         }
-      } while (emitted);
+      }
+
+      state.treeEmitted = true;
     }
+
+    // Phase 2: emit late-arriving / previously-unresolved spans whose parent
+    // context now exists. Iterate to a fixed point so a chain of late spans
+    // (parent emits, then child can emit) all flush.
+    let emitted = false;
+    do {
+      emitted = false;
+      for (const [spanId, span] of state.buffer) {
+        const parentCtx = span.parentSpanId ? state.contexts.get(span.parentSpanId) : undefined;
+        if (span.parentSpanId && !parentCtx) {
+          continue;
+        }
+
+        this.emitSingleSpan(span, state, parentCtx?.ddSpan, parentCtx?.childInheritedModelAttrs);
+        state.buffer.delete(spanId);
+        emitted = true;
+      }
+    } while (emitted);
 
     // Schedule cleanup if root has ended and buffer is empty
     if (state.rootEnded && state.buffer.size === 0 && !state.cleanupTimer) {
@@ -547,7 +572,10 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       }
 
       const exported = tracer.llmobs.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
-      state.contexts.set(span.id, { ddSpan, exported });
+      // Store childInheritedModelAttrs so any late-arriving descendants of this
+      // span (emitted via emitSingleSpan) can inherit the same model/provider
+      // attrs that recursive tree emission would have propagated.
+      state.contexts.set(span.id, { ddSpan, exported, childInheritedModelAttrs });
 
       for (const child of node.children) {
         this.emitSpanTree(child, state, childInheritedModelAttrs);
@@ -562,9 +590,28 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
   /**
    * Emit a single span with the proper Datadog parent context.
    * Used for late-arriving spans after the main tree has been emitted.
+   *
+   * Receives `inheritedModelAttrs` from the parent's stored context so that
+   * MODEL_STEP children of MODEL_GENERATION parents get model/provider names
+   * even when they arrive after the initial tree was emitted.
    */
-  private emitSingleSpan(span: AnyExportedSpan, state: TraceState, parent?: any) {
-    const { traceOptions, endTimeMs } = this.buildSpanOptions(span);
+  private emitSingleSpan(
+    span: AnyExportedSpan,
+    state: TraceState,
+    parent?: any,
+    inheritedModelAttrs?: { model?: string; provider?: string },
+  ) {
+    const { traceOptions, endTimeMs } = this.buildSpanOptions(span, inheritedModelAttrs);
+
+    // Compute what THIS span's own descendants should inherit, mirroring the
+    // logic in emitSpanTree.
+    const childInheritedModelAttrs =
+      span.type === SpanTypeEnum.MODEL_GENERATION
+        ? {
+            model: (span.attributes as ModelGenerationAttributes | undefined)?.model,
+            provider: (span.attributes as ModelGenerationAttributes | undefined)?.provider,
+          }
+        : inheritedModelAttrs;
 
     const runTrace = () =>
       tracer.llmobs.trace(traceOptions as any, (ddSpan: any) => {
@@ -578,7 +625,7 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
         }
 
         const exported = tracer.llmobs.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
-        state.contexts.set(span.id, { ddSpan, exported });
+        state.contexts.set(span.id, { ddSpan, exported, childInheritedModelAttrs });
 
         if (typeof ddSpan.finish === 'function') {
           ddSpan.finish(endTimeMs);

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -5,18 +5,14 @@
  * 1. Creates real dd-trace APM spans eagerly when Mastra spans are created
  * 2. Activates spans in dd-trace's scope so auto-instrumented operations
  *    (HTTP requests, database queries, etc.) have correct parent spans
- * 3. Emits LLMObs data retroactively when spans end, using dd-trace's
- *    own LLMObs pipeline for annotation and export
+ * 3. Registers those same spans with Datadog LLMObs and annotates them
+ *    before finish, avoiding a second synthetic APM span tree
  *
- * This solves the core problem with the DatadogExporter: because the exporter
+ * This fixes the core problem with the DatadogExporter: because the exporter
  * creates LLMObs spans retroactively (after execution completes), there is no
  * active dd-trace span in scope when tools and processors make outbound calls.
  * dd-trace's auto-instrumentation can't find the correct parent, so APM spans
  * fall back to the nearest active span (typically the request handler).
- *
- * The bridge uses two different dd-trace APIs for their respective strengths:
- * - tracer.startSpan() for eager APM spans (long-lived, manual finish)
- * - tracer.llmobs.trace() for retroactive LLMObs annotation (callback-scoped)
  */
 
 import type {
@@ -35,68 +31,57 @@ import { BaseExporter, getExternalParentId } from '@mastra/observability';
 import type { BaseExporterConfig } from '@mastra/observability';
 import tracer from 'dd-trace';
 import { formatUsageMetrics } from './metrics';
-import { ensureTracer, kindFor, toDate, formatInput, formatOutput } from './utils';
+import { ensureTracer, formatInput, formatOutput, kindFor, toDate } from './utils';
 import type { DatadogSpanKind } from './utils';
 
-/**
- * LLMObs span options passed to dd-trace's llmobs.trace().
- */
-interface LLMObsSpanOptions {
-  kind: DatadogSpanKind;
-  name: string;
-  sessionId?: string;
-  userId?: string;
-  mlApp?: string;
-  modelName?: string;
-  modelProvider?: string;
-  startTime?: Date;
-}
-
-/**
- * Minimal per-trace context for user/session tagging.
- */
-interface TraceContext {
-  userId?: string;
-  sessionId?: string;
-}
-
-type TraceState = {
-  buffer: Map<string, AnyExportedSpan>;
-  contexts: Map<
-    string,
-    {
-      ddSpan: any;
-      exported?: { traceId: string; spanId: string };
-      // Effective model/provider to pass DOWN to this span's children. Used so
-      // late-arriving descendants can inherit MODEL_GENERATION attrs the same
-      // way they would during recursive tree emission.
-      childInheritedModelAttrs?: { model?: string; provider?: string };
-    }
-  >;
-  rootEnded: boolean;
-  treeEmitted: boolean;
-  createdAt: number;
-  cleanupTimer?: ReturnType<typeof setTimeout>;
-  maxLifetimeTimer?: ReturnType<typeof setTimeout>;
+type LLMObsTagger = {
+  registerLLMObsSpan: (
+    span: any,
+    options: {
+      parent?: any;
+      kind: DatadogSpanKind;
+      name: string;
+      sessionId?: string;
+      modelName?: string;
+      modelProvider?: string;
+    },
+  ) => void;
 };
 
-/**
- * Tree node representing a span and its children for recursive emission.
- */
-interface SpanNode {
-  span: AnyExportedSpan;
-  children: SpanNode[];
+type LifecycleLogger = Pick<DatadogBridge['logger'], 'debug' | 'info' | 'warn' | 'error'>;
+
+let spanLifecycleLogger: LifecycleLogger | undefined;
+let spanLifecyclePatchInstalled = false;
+const lifecycleWrappedSpans = new WeakSet<object>();
+
+function flushApmExporter(): Promise<void> {
+  const exporterFlush = (tracer as any)?._tracer?._exporter?.flush;
+  if (typeof exporterFlush !== 'function') {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const done = (error?: unknown) => {
+      if (settled) return;
+      settled = true;
+
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    };
+
+    try {
+      exporterFlush.call((tracer as any)._tracer._exporter, done);
+    } catch (error) {
+      reject(error);
+    }
+  });
 }
-
-/**
- * Maximum lifetime for a trace state entry (30 minutes).
- */
-const MAX_TRACE_LIFETIME_MS = 30 * 60 * 1000;
-
-/**
- * Regular cleanup interval for trace state entries (1 minute).
- */
-const REGULAR_CLEANUP_INTERVAL_MS = 1 * 60 * 1000;
 
 /**
  * Configuration options for the Datadog Bridge.
@@ -156,48 +141,33 @@ export interface DatadogBridgeConfig extends BaseExporterConfig {
   /**
    * Keys from the request context that should be promoted to flat Datadog
    * LLM Observability tags instead of being nested in annotations.metadata.
-   *
-   * @example
-   * ```typescript
-   * new DatadogBridge({
-   *   mlApp: 'my-app',
-   *   requestContextKeys: ['tenantId', 'agentId'],
-   * })
-   * ```
    */
   requestContextKeys?: string[];
+
+  /**
+   * Enable verbose dd-trace span lifecycle logging for troubleshooting.
+   *
+   * When enabled, the bridge wraps `tracer.startSpan()` and logs each dd span
+   * open/finish event it can observe, including ids and parent ids.
+   *
+   * This is intentionally noisy and should only be used for debugging.
+   * Falls back to `MASTRA_DATADOG_BRIDGE_SPAN_DEBUG`.
+   */
+  spanLifecycleDebug?: boolean;
 }
 
 /**
  * Datadog Bridge for Mastra Observability.
  *
- * Creates native dd-trace spans in real-time during execution for proper
- * APM context propagation, and emits LLMObs annotation data retroactively
- * through dd-trace's own pipeline.
- *
- * @example
- * ```typescript
- * import { DatadogBridge } from '@mastra/datadog';
- *
- * const mastra = new Mastra({
- *   observability: {
- *     configs: {
- *       default: {
- *         serviceName: 'my-service',
- *         bridge: new DatadogBridge({ mlApp: 'my-app' }),
- *       }
- *     }
- *   }
- * });
- * ```
+ * Creates native dd-trace spans in real time during execution for proper APM
+ * context propagation, and uses the same live dd span for Datadog LLMObs
+ * tagging and annotations.
  */
 export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
   name = 'datadog-bridge';
 
   private config: Required<Pick<DatadogBridgeConfig, 'mlApp' | 'site'>> & DatadogBridgeConfig;
   private ddSpanMap = new Map<string, any>();
-  private traceContext = new Map<string, TraceContext>();
-  private traceState = new Map<string, TraceState>();
 
   constructor(config: DatadogBridgeConfig = {}) {
     super(config);
@@ -211,6 +181,7 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
     // present (required for the APM auto-instrumentation the bridge enables)
     const envAgentless = process.env.DD_LLMOBS_AGENTLESS_ENABLED?.toLowerCase();
     const agentless = config.agentless ?? (envAgentless === 'true' || envAgentless === '1' ? true : false);
+    const spanLifecycleDebug = config.spanLifecycleDebug ?? isTruthyEnv(process.env.MASTRA_DATADOG_BRIDGE_SPAN_DEBUG);
 
     if (!mlApp) {
       this.setDisabled(`Missing required mlApp. Set DD_LLMOBS_ML_APP environment variable or pass mlApp in config.`);
@@ -226,7 +197,7 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       return;
     }
 
-    this.config = { ...config, mlApp, site, apiKey, agentless, env };
+    this.config = { ...config, mlApp, site, apiKey, agentless, env, spanLifecycleDebug };
 
     ensureTracer({
       mlApp,
@@ -235,61 +206,106 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       agentless,
       service: config.service,
       env,
-      // Default to true — the bridge is designed for APM integration
       integrationsEnabled: config.integrationsEnabled ?? true,
+    });
+
+    if (spanLifecycleDebug) {
+      spanLifecycleLogger = this.logger;
+      installSpanLifecycleDebugPatch();
+      this.logger.info('[DatadogBridge] Enabled dd-trace span lifecycle debug logging');
+    }
+
+    this.logger.debug('[DatadogBridge] Tracer ready', {
+      mlApp,
+      service: config.service ?? mlApp,
+      env,
+      agentless,
+      tracerStarted: Boolean((tracer as any)._tracer?.started),
+      llmobsAvailable: Boolean((tracer as any).llmobs),
+      activeScopeSpan: Boolean(tracer.scope().active()),
     });
 
     this.logger.info('Datadog bridge initialized', { mlApp, site, agentless });
   }
 
-  // ---------------------------------------------------------------------------
-  // ObservabilityBridge interface
-  // ---------------------------------------------------------------------------
+  override __setLogger(logger: any): void {
+    super.__setLogger(logger);
+    if (this.config?.spanLifecycleDebug) {
+      spanLifecycleLogger = this.logger;
+    }
+  }
 
   /**
-   * Create a dd-trace APM span eagerly when a Mastra span is constructed.
-   *
-   * This is the core of the fix: the APM span is active in dd-trace's scope
-   * during execution, so auto-instrumented calls (HTTP, DB, etc.) made by
-   * tools and processors are parented correctly.
+   * Create a dd-trace span eagerly when a Mastra span is constructed.
    */
   createSpan(options: CreateSpanOptions<SpanType>): SpanIds | undefined {
     if (this.isDisabled) return undefined;
 
     try {
-      // Determine parent dd-trace span
       let parentDdSpan: any = undefined;
+      let parentSource: 'external-parent' | 'active-scope' | 'none' = 'none';
 
       const externalParentId = getExternalParentId(options);
       if (externalParentId) {
         parentDdSpan = this.ddSpanMap.get(externalParentId);
+        if (parentDdSpan) {
+          parentSource = 'external-parent';
+        } else {
+          this.logger.warn('[DatadogBridge.createSpan] External parent span not found in bridge map', {
+            spanName: options.name,
+            spanType: options.type,
+            externalParentId,
+            hasMastraParent: Boolean(options.parent),
+          });
+        }
       }
 
-      // Fall back to whatever is currently active in dd-trace scope
-      // (e.g., an incoming request span from framework instrumentation)
-      if (!parentDdSpan) {
+      if (!parentDdSpan && !externalParentId) {
         parentDdSpan = tracer.scope().active() ?? undefined;
+        if (parentDdSpan) {
+          parentSource = 'active-scope';
+        } else {
+          this.logger.debug('[DatadogBridge.createSpan] No active dd-trace scope for new root span', {
+            spanName: options.name,
+            spanType: options.type,
+            mapSize: this.ddSpanMap.size,
+          });
+        }
       }
 
-      // Create the APM span eagerly
       const ddSpan = tracer.startSpan(options.name, {
         ...(parentDdSpan ? { childOf: parentDdSpan } : {}),
+        ...(options.startTime ? { startTime: toDate(options.startTime).getTime() } : {}),
       });
 
-      // Generate Mastra-compatible hex IDs
-      const spanId = generateSpanId();
-      const traceId = externalParentId
-        ? // Inherit parent's trace ID by looking up what Mastra assigned to the parent
-          (options.parent?.traceId ?? generateTraceId())
-        : generateTraceId();
-      const parentSpanId = externalParentId;
+      const ddContext = ddSpan.context?.() as
+        | {
+            toSpanId?: (hex?: boolean) => string;
+            toTraceId?: (hex?: boolean) => string;
+          }
+        | undefined;
+      const spanId = ddContext?.toSpanId?.(true) ?? generateSpanId();
+      const traceId =
+        ddContext?.toTraceId?.(true) ??
+        (externalParentId ? (options.parent?.traceId ?? generateTraceId()) : generateTraceId());
+      const parentContext = parentDdSpan?.context?.() as { toSpanId?: (hex?: boolean) => string } | undefined;
+      const parentSpanId = parentContext?.toSpanId?.(true) ?? externalParentId;
 
-      // Store the dd-trace span keyed by Mastra span ID
       this.ddSpanMap.set(spanId, ddSpan);
+      this.registerLlmObsSpan(ddSpan, options, parentDdSpan);
 
       this.logger.debug(
         `[DatadogBridge.createSpan] Created APM span [spanId=${spanId}] [traceId=${traceId}] ` +
-          `[parentSpanId=${parentSpanId}] [type=${options.type}] [mapSize=${this.ddSpanMap.size}]`,
+          `[parentSpanId=${parentSpanId}] [type=${options.type}] [mapSize=${this.ddSpanMap.size}] ` +
+          `[parentSource=${parentSource}] [externalParentId=${externalParentId ?? 'none'}]`,
+        {
+          ...(this.config.spanLifecycleDebug
+            ? {
+                ddTraceState: getTraceDebugState(ddSpan),
+                parentDdTraceState: parentDdSpan ? getTraceDebugState(parentDdSpan) : undefined,
+              }
+            : {}),
+        },
       );
 
       return { spanId, traceId, parentSpanId };
@@ -301,7 +317,6 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
 
   /**
    * Execute an async function within the dd-trace context of a Mastra span.
-   * Auto-instrumented operations inside fn will be parented under this span.
    */
   executeInContext<T>(spanId: string, fn: () => Promise<T>): Promise<T> {
     return this.executeWithSpanContext(spanId, fn);
@@ -322,46 +337,54 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
     if (ddSpan) {
       return tracer.scope().activate(ddSpan, fn);
     }
+
+    this.logger.debug(
+      '[DatadogBridge.executeWithSpanContext] Falling back to raw execution because dd span is missing',
+      {
+        spanId,
+        mapSize: this.ddSpanMap.size,
+        openSpanIds: this.previewOpenSpanIds(),
+        ...(this.config.spanLifecycleDebug ? { callStack: captureCallStack('executeWithSpanContext') } : {}),
+      },
+    );
+
     return fn();
   }
 
-  // ---------------------------------------------------------------------------
-  // BaseExporter override — tracing events from the bus
-  // ---------------------------------------------------------------------------
-
   /**
    * Handle tracing events from the observability bus.
-   *
-   * - SPAN_STARTED: Capture trace context (userId/sessionId)
-   * - SPAN_ENDED: Finish APM span + enqueue for LLMObs emission
    */
   protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
-    if (this.isDisabled || !(tracer as any).llmobs) return;
+    if (this.isDisabled) return;
 
     try {
       const span = event.exportedSpan;
 
-      // Handle event spans (zero-duration)
       if (span.isEvent) {
-        if (event.type === 'span_started') {
-          this.captureTraceContext(span);
-          this.finishApmSpan(span);
-          this.enqueueSpan(span);
+        if (event.type === 'span_started' || event.type === 'span_ended') {
+          this.annotateAndFinishSpan(span);
+        } else {
+          this.logger.debug('[DatadogBridge] Ignoring event span tracing event', {
+            eventType: event.type,
+            spanId: span.id,
+            spanName: span.name,
+          });
         }
         return;
       }
 
       switch (event.type) {
         case 'span_started':
-          this.captureTraceContext(span);
-          return;
-
         case 'span_updated':
+          this.logger.debug('[DatadogBridge] Observed non-terminal tracing event', {
+            eventType: event.type,
+            spanId: span.id,
+            spanName: span.name,
+            spanType: span.type,
+          });
           return;
-
         case 'span_ended':
-          this.finishApmSpan(span);
-          this.enqueueSpan(span);
+          this.annotateAndFinishSpan(span);
           return;
       }
     } catch (error) {
@@ -374,306 +397,152 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // APM span management
-  // ---------------------------------------------------------------------------
+  private registerLlmObsSpan(ddSpan: any, options: CreateSpanOptions<SpanType>, parentDdSpan?: any): void {
+    const tagger = this.getLlmObsTagger();
+    if (!tagger) {
+      this.logger.debug('[DatadogBridge] Skipping LLMObs registration because no tagger is available', {
+        spanName: options.name,
+        spanType: options.type,
+      });
+      return;
+    }
+
+    try {
+      const kind = kindFor(options.type);
+      const ownAttrs = options.attributes as ModelGenerationAttributes | undefined;
+      const inheritedModelAttrs =
+        options.parent?.type === SpanTypeEnum.MODEL_GENERATION
+          ? (options.parent.attributes as ModelGenerationAttributes | undefined)
+          : undefined;
+      const sessionId =
+        typeof options.metadata?.sessionId === 'string'
+          ? options.metadata.sessionId
+          : typeof options.parent?.metadata?.sessionId === 'string'
+            ? options.parent.metadata.sessionId
+            : undefined;
+
+      tagger.registerLLMObsSpan(ddSpan, {
+        parent: parentDdSpan,
+        kind,
+        name: options.name,
+        sessionId,
+        ...(kind === 'llm' && (ownAttrs?.model ?? inheritedModelAttrs?.model)
+          ? { modelName: ownAttrs?.model ?? inheritedModelAttrs?.model }
+          : {}),
+        ...(kind === 'llm' && (ownAttrs?.provider ?? inheritedModelAttrs?.provider)
+          ? { modelProvider: ownAttrs?.provider ?? inheritedModelAttrs?.provider }
+          : {}),
+      });
+      this.logger.debug('[DatadogBridge] Registered LLMObs span', {
+        spanName: options.name,
+        spanType: options.type,
+        kind,
+        hasParent: Boolean(parentDdSpan),
+        sessionId,
+      });
+    } catch (error) {
+      this.logger.warn('[DatadogBridge] Failed to register LLMObs span', {
+        error,
+        spanName: options.name,
+        spanType: options.type,
+      });
+    }
+  }
+
+  private getLlmObsTagger(): LLMObsTagger | undefined {
+    const tagger = (tracer as any).llmobs?._tagger;
+    if (tagger && typeof tagger.registerLLMObsSpan === 'function') {
+      return tagger as LLMObsTagger;
+    }
+    return undefined;
+  }
 
   /**
-   * Finish the eagerly-created APM span and remove it from the map.
+   * Annotate the eagerly-created dd span and finish it using the final Mastra
+   * span state.
    */
-  private finishApmSpan(span: AnyExportedSpan): void {
+  private annotateAndFinishSpan(span: AnyExportedSpan): void {
     const ddSpan = this.ddSpanMap.get(span.id);
-    if (!ddSpan) return;
+    if (!ddSpan) {
+      this.logger.warn('[DatadogBridge] No dd span found when finalizing Mastra span', {
+        spanId: span.id,
+        spanName: span.name,
+        spanType: span.type,
+        mapSize: this.ddSpanMap.size,
+        openSpanIds: this.previewOpenSpanIds(),
+      });
+      return;
+    }
 
     const endTime = span.endTime ? toDate(span.endTime) : span.isEvent ? toDate(span.startTime) : new Date();
+
+    const annotations = this.buildAnnotations(span);
+
+    try {
+      if (Object.keys(annotations).length > 0 && tracer.llmobs?.annotate) {
+        tracer.llmobs.annotate(ddSpan, annotations);
+        this.logger.debug('[DatadogBridge] Annotated dd span before finish', {
+          spanId: span.id,
+          spanName: span.name,
+          annotationKeys: Object.keys(annotations),
+        });
+      } else {
+        this.logger.debug('[DatadogBridge] Skipping LLMObs annotation before finish', {
+          spanId: span.id,
+          spanName: span.name,
+          hasAnnotations: Object.keys(annotations).length > 0,
+          llmobsAvailable: Boolean(tracer.llmobs),
+        });
+      }
+    } catch (error) {
+      this.logger.error('[DatadogBridge] Failed to annotate span before finish', {
+        error,
+        spanId: span.id,
+        spanName: span.name,
+      });
+    }
+
+    try {
+      if (span.errorInfo) {
+        this.setErrorTags(ddSpan, span.errorInfo);
+      }
+    } catch (error) {
+      this.logger.error('[DatadogBridge] Failed to set error tags on dd span', {
+        error,
+        spanId: span.id,
+        spanName: span.name,
+      });
+    }
 
     try {
       if (typeof ddSpan.finish === 'function') {
         ddSpan.finish(endTime.getTime());
+        this.logger.debug('[DatadogBridge] Finished dd span', {
+          spanId: span.id,
+          spanName: span.name,
+          endTimeMs: endTime.getTime(),
+          ...(this.config.spanLifecycleDebug ? { ddTraceState: getTraceDebugState(ddSpan) } : {}),
+        });
       }
     } catch (error) {
-      this.logger.error('[DatadogBridge] Failed to finish APM span', {
+      this.logger.error('[DatadogBridge] Failed to finish dd span', {
         error,
         spanId: span.id,
+        spanName: span.name,
       });
-    }
-
-    this.ddSpanMap.delete(span.id);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Trace context capture
-  // ---------------------------------------------------------------------------
-
-  private captureTraceContext(span: AnyExportedSpan): void {
-    if (span.isRootSpan && !this.traceContext.has(span.traceId)) {
-      this.traceContext.set(span.traceId, {
-        userId: span.metadata?.userId,
-        sessionId: span.metadata?.sessionId,
+    } finally {
+      this.ddSpanMap.delete(span.id);
+      this.logger.debug('[DatadogBridge] Removed dd span from bridge map', {
+        spanId: span.id,
+        spanName: span.name,
+        remainingMapSize: this.ddSpanMap.size,
+        remainingOpenSpanIds: this.previewOpenSpanIds(),
       });
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // LLMObs emission (retroactive, using dd-trace's LLMObs pipeline)
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Queue span for LLMObs emission. Same buffering strategy as DatadogExporter.
-   */
-  private enqueueSpan(span: AnyExportedSpan): void {
-    const state = this.getOrCreateTraceState(span.traceId);
-    if (span.isRootSpan) {
-      state.rootEnded = true;
-    }
-
-    state.buffer.set(span.id, span);
-    this.tryEmitReadySpans(span.traceId);
-  }
-
-  private tryEmitReadySpans(traceId: string): void {
-    const state = this.traceState.get(traceId);
-    if (!state) return;
-
-    // Phase 1: emit the initial tree once the root span ends. Any spans
-    // whose parent wasn't in the buffer at this point (e.g., child ended
-    // before its parent did and the root ended in between) stay buffered
-    // and may be emitted via the late-arrival path below once their parent
-    // shows up in state.contexts.
-    if (!state.treeEmitted) {
-      if (!state.rootEnded) return;
-
-      const tree = this.buildSpanTree(state.buffer);
-      if (tree) {
-        this.emitSpanTree(tree, state);
-      }
-
-      // Remove only spans that were actually emitted (those now in
-      // state.contexts). Unresolved spans stay buffered.
-      for (const spanId of Array.from(state.buffer.keys())) {
-        if (state.contexts.has(spanId)) {
-          state.buffer.delete(spanId);
-        }
-      }
-
-      state.treeEmitted = true;
-    }
-
-    // Phase 2: emit late-arriving / previously-unresolved spans whose parent
-    // context now exists. Iterate to a fixed point so a chain of late spans
-    // (parent emits, then child can emit) all flush.
-    let emitted = false;
-    do {
-      emitted = false;
-      for (const [spanId, span] of state.buffer) {
-        const parentCtx = span.parentSpanId ? state.contexts.get(span.parentSpanId) : undefined;
-        if (span.parentSpanId && !parentCtx) {
-          continue;
-        }
-
-        this.emitSingleSpan(span, state, parentCtx?.ddSpan, parentCtx?.childInheritedModelAttrs);
-        state.buffer.delete(spanId);
-        emitted = true;
-      }
-    } while (emitted);
-
-    // Schedule cleanup if root has ended and buffer is empty
-    if (state.rootEnded && state.buffer.size === 0 && !state.cleanupTimer) {
-      const timer = setTimeout(() => {
-        const currentState = this.traceState.get(traceId);
-        if (currentState) {
-          if (currentState.buffer.size > 0) {
-            this.logger.warn('Discarding orphaned spans during cleanup', {
-              traceId,
-              orphanedCount: currentState.buffer.size,
-              spanIds: Array.from(currentState.buffer.keys()),
-            });
-          }
-          if (currentState.maxLifetimeTimer) {
-            clearTimeout(currentState.maxLifetimeTimer);
-          }
-        }
-        this.traceState.delete(traceId);
-        this.traceContext.delete(traceId);
-      }, REGULAR_CLEANUP_INTERVAL_MS);
-      (timer as any).unref?.();
-      state.cleanupTimer = timer;
-    }
-  }
-
-  private buildSpanTree(buffer: Map<string, AnyExportedSpan>): SpanNode | undefined {
-    const nodes = new Map<string, SpanNode>();
-    let rootNode: SpanNode | undefined;
-
-    for (const span of buffer.values()) {
-      nodes.set(span.id, { span, children: [] });
-    }
-
-    for (const node of nodes.values()) {
-      if (node.span.isRootSpan) {
-        rootNode = node;
-      } else if (node.span.parentSpanId) {
-        const parentNode = nodes.get(node.span.parentSpanId);
-        if (parentNode) {
-          parentNode.children.push(node);
-        } else {
-          this.logger.warn('Orphaned span detected during tree build', {
-            spanId: node.span.id,
-            parentSpanId: node.span.parentSpanId,
-            traceId: node.span.traceId,
-          });
-        }
-      }
-    }
-
-    // Sort children by start time for consistent ordering
-    for (const node of nodes.values()) {
-      node.children.sort((a, b) => {
-        const aTime =
-          a.span.startTime instanceof Date ? a.span.startTime.getTime() : new Date(a.span.startTime).getTime();
-        const bTime =
-          b.span.startTime instanceof Date ? b.span.startTime.getTime() : new Date(b.span.startTime).getTime();
-        return aTime - bTime;
-      });
-    }
-
-    return rootNode;
-  }
-
-  /**
-   * Recursively emits a span tree using nested llmobs.trace() calls.
-   * This ensures parent-child relationships are properly established in
-   * Datadog's LLM Observability product.
-   */
-  private emitSpanTree(
-    node: SpanNode,
-    state: TraceState,
-    inheritedModelAttrs?: { model?: string; provider?: string },
-  ): void {
-    const span = node.span;
-    const { traceOptions, endTimeMs } = this.buildSpanOptions(span, inheritedModelAttrs);
-
-    const childInheritedModelAttrs =
-      span.type === SpanTypeEnum.MODEL_GENERATION
-        ? {
-            model: (span.attributes as ModelGenerationAttributes | undefined)?.model,
-            provider: (span.attributes as ModelGenerationAttributes | undefined)?.provider,
-          }
-        : inheritedModelAttrs;
-
-    tracer.llmobs.trace(traceOptions as any, (ddSpan: any) => {
-      const annotations = this.buildAnnotations(span);
-      if (Object.keys(annotations).length > 0) {
-        tracer.llmobs.annotate(ddSpan, annotations);
-      }
-
-      if (span.errorInfo) {
-        this.setErrorTags(ddSpan, span.errorInfo);
-      }
-
-      const exported = tracer.llmobs.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
-      // Store childInheritedModelAttrs so any late-arriving descendants of this
-      // span (emitted via emitSingleSpan) can inherit the same model/provider
-      // attrs that recursive tree emission would have propagated.
-      state.contexts.set(span.id, { ddSpan, exported, childInheritedModelAttrs });
-
-      for (const child of node.children) {
-        this.emitSpanTree(child, state, childInheritedModelAttrs);
-      }
-
-      if (typeof ddSpan.finish === 'function') {
-        ddSpan.finish(endTimeMs);
-      }
-    });
-  }
-
-  /**
-   * Emit a single span with the proper Datadog parent context.
-   * Used for late-arriving spans after the main tree has been emitted.
-   *
-   * Receives `inheritedModelAttrs` from the parent's stored context so that
-   * MODEL_STEP children of MODEL_GENERATION parents get model/provider names
-   * even when they arrive after the initial tree was emitted.
-   */
-  private emitSingleSpan(
-    span: AnyExportedSpan,
-    state: TraceState,
-    parent?: any,
-    inheritedModelAttrs?: { model?: string; provider?: string },
-  ) {
-    const { traceOptions, endTimeMs } = this.buildSpanOptions(span, inheritedModelAttrs);
-
-    // Compute what THIS span's own descendants should inherit, mirroring the
-    // logic in emitSpanTree.
-    const childInheritedModelAttrs =
-      span.type === SpanTypeEnum.MODEL_GENERATION
-        ? {
-            model: (span.attributes as ModelGenerationAttributes | undefined)?.model,
-            provider: (span.attributes as ModelGenerationAttributes | undefined)?.provider,
-          }
-        : inheritedModelAttrs;
-
-    const runTrace = () =>
-      tracer.llmobs.trace(traceOptions as any, (ddSpan: any) => {
-        const annotations = this.buildAnnotations(span);
-        if (Object.keys(annotations).length > 0) {
-          tracer.llmobs.annotate(ddSpan, annotations);
-        }
-
-        if (span.errorInfo) {
-          this.setErrorTags(ddSpan, span.errorInfo);
-        }
-
-        const exported = tracer.llmobs.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
-        state.contexts.set(span.id, { ddSpan, exported, childInheritedModelAttrs });
-
-        if (typeof ddSpan.finish === 'function') {
-          ddSpan.finish(endTimeMs);
-        }
-      });
-
-    if (parent) {
-      tracer.scope().activate(parent, runTrace);
-    } else {
-      runTrace();
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // LLMObs span options and annotations
-  // ---------------------------------------------------------------------------
-
-  private buildSpanOptions(
-    span: AnyExportedSpan,
-    inheritedModelAttrs?: { model?: string; provider?: string },
-  ): { traceOptions: LLMObsSpanOptions; endTimeMs: number } {
-    const traceCtx = this.traceContext.get(span.traceId) || {
-      userId: span.metadata?.userId,
-      sessionId: span.metadata?.sessionId,
-    };
-
-    const kind = kindFor(span.type);
-    const ownAttrs = span.attributes as ModelGenerationAttributes | undefined;
-    const attrs = {
-      model: ownAttrs?.model ?? inheritedModelAttrs?.model,
-      provider: ownAttrs?.provider ?? inheritedModelAttrs?.provider,
-    };
-
-    const startTime = toDate(span.startTime);
-    const endTime = span.endTime ? toDate(span.endTime) : span.isEvent ? startTime : new Date();
-
-    return {
-      traceOptions: {
-        kind,
-        name: span.name,
-        sessionId: traceCtx.sessionId,
-        userId: traceCtx.userId,
-        startTime,
-        ...(kind === 'llm' && attrs?.model ? { modelName: attrs.model } : {}),
-        ...(kind === 'llm' && attrs?.provider ? { modelProvider: attrs.provider } : {}),
-      },
-      endTimeMs: endTime.getTime(),
-    };
+  private previewOpenSpanIds(limit = 8): string[] {
+    return Array.from(this.ddSpanMap.keys()).slice(0, limit);
   }
 
   private buildAnnotations(span: AnyExportedSpan): Record<string, any> {
@@ -776,61 +645,8 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Trace state management
-  // ---------------------------------------------------------------------------
-
-  private getOrCreateTraceState(traceId: string): TraceState {
-    const existing = this.traceState.get(traceId);
-    if (existing) {
-      if (existing.cleanupTimer) {
-        clearTimeout(existing.cleanupTimer);
-        existing.cleanupTimer = undefined;
-      }
-      return existing;
-    }
-
-    const created: TraceState = {
-      buffer: new Map<string, AnyExportedSpan>(),
-      contexts: new Map<string, { ddSpan: any; exported?: { traceId: string; spanId: string } }>(),
-      rootEnded: false,
-      treeEmitted: false,
-      createdAt: Date.now(),
-      cleanupTimer: undefined,
-      maxLifetimeTimer: undefined,
-    };
-
-    const maxLifetimeTimer = setTimeout(() => {
-      const state = this.traceState.get(traceId);
-      if (state) {
-        if (state.buffer.size > 0 || state.contexts.size > 0) {
-          this.logger.warn('Discarding trace due to max lifetime exceeded', {
-            traceId,
-            bufferedSpans: state.buffer.size,
-            emittedSpans: state.contexts.size,
-            lifetimeMs: Date.now() - state.createdAt,
-          });
-        }
-        if (state.cleanupTimer) {
-          clearTimeout(state.cleanupTimer);
-        }
-        this.traceState.delete(traceId);
-        this.traceContext.delete(traceId);
-      }
-    }, MAX_TRACE_LIFETIME_MS);
-    (maxLifetimeTimer as any).unref?.();
-    created.maxLifetimeTimer = maxLifetimeTimer;
-
-    this.traceState.set(traceId, created);
-    return created;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Lifecycle
-  // ---------------------------------------------------------------------------
-
   async flush(): Promise<void> {
-    if (this.isDisabled || !(tracer as any).llmobs) return;
+    if (this.isDisabled) return;
 
     if (tracer.llmobs?.flush) {
       try {
@@ -839,36 +655,17 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       } catch (e) {
         this.logger.error('Error flushing llmobs', { error: e });
       }
-    } else if ((tracer as any).flush) {
-      try {
-        await (tracer as any).flush();
-        this.logger.debug('Datadog tracer flushed');
-      } catch (e) {
-        this.logger.error('Error flushing tracer', { error: e });
-      }
+    }
+
+    try {
+      await flushApmExporter();
+      this.logger.debug('Datadog APM exporter flushed');
+    } catch (e) {
+      this.logger.error('Error flushing Datadog APM exporter', { error: e });
     }
   }
 
   async shutdown(): Promise<void> {
-    // Cancel all pending cleanup timers and clear state
-    for (const [traceId, state] of this.traceState) {
-      if (state.cleanupTimer) {
-        clearTimeout(state.cleanupTimer);
-      }
-      if (state.maxLifetimeTimer) {
-        clearTimeout(state.maxLifetimeTimer);
-      }
-      if (state.buffer.size > 0) {
-        this.logger.warn('Shutdown with pending spans', {
-          traceId,
-          pendingCount: state.buffer.size,
-          spanIds: Array.from(state.buffer.keys()),
-        });
-      }
-    }
-    this.traceState.clear();
-
-    // Force-finish any remaining APM spans
     for (const [spanId, ddSpan] of this.ddSpanMap) {
       this.logger.warn(`[DatadogBridge] Force-finishing APM span that was not properly closed [id=${spanId}]`);
       try {
@@ -891,15 +688,9 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       }
     }
 
-    this.traceContext.clear();
-
     await super.shutdown();
   }
 }
-
-// ---------------------------------------------------------------------------
-// ID generation helpers (same format as DefaultSpan)
-// ---------------------------------------------------------------------------
 
 function fillRandomBytes(bytes: Uint8Array): void {
   try {
@@ -926,4 +717,124 @@ function generateTraceId(): string {
   const bytes = new Uint8Array(16);
   fillRandomBytes(bytes);
   return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+function captureCallStack(marker?: string, maxFrames = 8): string | undefined {
+  const stack = new Error(marker ? `[DatadogBridge] ${marker}` : undefined).stack;
+  if (!stack) return undefined;
+
+  const lines = stack
+    .split('\n')
+    .slice(1)
+    .filter(line => !line.includes('captureCallStack'))
+    .slice(0, maxFrames)
+    .map(line => line.trim());
+
+  return lines.length > 0 ? lines.join('\n') : undefined;
+}
+
+function getTraceDebugState(ddSpan: any):
+  | {
+      traceRecord?: boolean;
+      traceIsRecording?: boolean;
+      startedCount?: number;
+      finishedCount?: number;
+      openSpans?: string[];
+    }
+  | undefined {
+  const trace = ddSpan?.context?.()?._trace;
+  if (!trace) return undefined;
+
+  const openSpans = Array.isArray(trace.started)
+    ? trace.started
+        .filter((span: any) => span?._duration === undefined)
+        .slice(0, 12)
+        .map((span: any) => {
+          const context = span?.context?.();
+          const name = context?._name ?? span?._name ?? 'unknown';
+          const resource = context?._tags?.['resource.name'];
+          return resource ? `${name}:${resource}` : name;
+        })
+    : undefined;
+
+  return {
+    traceRecord: trace.record,
+    traceIsRecording: trace.isRecording,
+    startedCount: Array.isArray(trace.started) ? trace.started.length : undefined,
+    finishedCount: Array.isArray(trace.finished) ? trace.finished.length : undefined,
+    openSpans: openSpans && openSpans.length > 0 ? openSpans : undefined,
+  };
+}
+
+function installSpanLifecycleDebugPatch(): void {
+  if (spanLifecyclePatchInstalled) return;
+
+  const originalStartSpan = tracer.startSpan.bind(tracer);
+
+  (tracer as any).startSpan = function patchedStartSpan(name: string, options?: Record<string, unknown>) {
+    const span = originalStartSpan(name, options);
+    logSpanLifecycleOpen(name, span, options);
+    wrapSpanFinishForLifecycleDebug(span, name);
+    return span;
+  };
+
+  spanLifecyclePatchInstalled = true;
+}
+
+function wrapSpanFinishForLifecycleDebug(span: any, name: string): void {
+  if (!span || typeof span !== 'object' || typeof span.finish !== 'function') return;
+  if (lifecycleWrappedSpans.has(span)) return;
+
+  const originalFinish = span.finish;
+
+  // Preserve mocked finish functions in tests to avoid altering matcher behavior.
+  if ((originalFinish as any).mock) return;
+
+  span.finish = function patchedFinish(this: any, ...args: any[]) {
+    logSpanLifecycleFinish(name, span, args);
+    return originalFinish.apply(this, args);
+  };
+
+  lifecycleWrappedSpans.add(span);
+}
+
+function logSpanLifecycleOpen(name: string, span: any, options?: Record<string, unknown>): void {
+  const ids = getDdSpanIds(span);
+  const parentIds = getDdSpanIds((options?.childOf as any) ?? undefined);
+  const message =
+    `[DatadogBridge.span.open] name=${name} traceId=${ids.traceId ?? 'unknown'} ` +
+    `spanId=${ids.spanId ?? 'unknown'} parentSpanId=${parentIds.spanId ?? 'none'} ` +
+    `hasChildOf=${Boolean(options?.childOf)}`;
+
+  spanLifecycleLogger?.debug(message);
+  console.error(message);
+}
+
+function logSpanLifecycleFinish(name: string, span: any, finishArgs: unknown[]): void {
+  const ids = getDdSpanIds(span);
+  const finishTime = finishArgs[0];
+  const message =
+    `[DatadogBridge.span.finish] name=${name} traceId=${ids.traceId ?? 'unknown'} ` +
+    `spanId=${ids.spanId ?? 'unknown'} finishArg=${String(finishTime ?? 'none')}`;
+
+  spanLifecycleLogger?.debug(message);
+  console.error(message);
+}
+
+function getDdSpanIds(span: any): { spanId?: string; traceId?: string } {
+  try {
+    const context = span?.context?.();
+    return {
+      spanId: context?.toSpanId?.(true),
+      traceId: context?.toTraceId?.(true),
+    };
+  } catch {
+    return {};
+  }
 }

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -123,10 +123,17 @@ export interface DatadogBridgeConfig extends BaseExporterConfig {
   env?: string;
 
   /**
-   * Use agentless mode (direct HTTPS intake without local Datadog Agent).
-   * Defaults to true for consistency with other Mastra exporters.
-   * Set to false to use a local Datadog Agent instead.
-   * Falls back to DD_LLMOBS_AGENTLESS_ENABLED environment variable.
+   * Use agentless mode (direct HTTPS intake without a local Datadog Agent).
+   *
+   * Defaults to `false` for the bridge — most users running dd-trace
+   * auto-instrumentation already have a local Datadog Agent (required for
+   * APM data). Agentless mode only routes LLMObs data directly to Datadog
+   * intake, which would split your APM and LLMObs telemetry across two
+   * paths.
+   *
+   * Set to `true` if you only want LLMObs data (no APM auto-instrumentation)
+   * and don't have a local Datadog Agent. Falls back to the
+   * `DD_LLMOBS_AGENTLESS_ENABLED` environment variable.
    */
   agentless?: boolean;
 
@@ -190,8 +197,10 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
     const site = config.site ?? process.env.DD_SITE ?? 'datadoghq.com';
     const env = config.env ?? process.env.DD_ENV;
 
+    // Default to false for the bridge — assume a local Datadog Agent is
+    // present (required for the APM auto-instrumentation the bridge enables)
     const envAgentless = process.env.DD_LLMOBS_AGENTLESS_ENABLED?.toLowerCase();
-    const agentless = config.agentless ?? (envAgentless === 'false' || envAgentless === '0' ? false : true);
+    const agentless = config.agentless ?? (envAgentless === 'true' || envAgentless === '1' ? true : false);
 
     if (!mlApp) {
       this.setDisabled(`Missing required mlApp. Set DD_LLMOBS_ML_APP environment variable or pass mlApp in config.`);

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -1,0 +1,873 @@
+/**
+ * Datadog Bridge for Mastra Observability
+ *
+ * This bridge enables bidirectional integration with dd-trace:
+ * 1. Creates real dd-trace APM spans eagerly when Mastra spans are created
+ * 2. Activates spans in dd-trace's scope so auto-instrumented operations
+ *    (HTTP requests, database queries, etc.) have correct parent spans
+ * 3. Emits LLMObs data retroactively when spans end, using dd-trace's
+ *    own LLMObs pipeline for annotation and export
+ *
+ * This solves the core problem with the DatadogExporter: because the exporter
+ * creates LLMObs spans retroactively (after execution completes), there is no
+ * active dd-trace span in scope when tools and processors make outbound calls.
+ * dd-trace's auto-instrumentation can't find the correct parent, so APM spans
+ * fall back to the nearest active span (typically the request handler).
+ *
+ * The bridge uses two different dd-trace APIs for their respective strengths:
+ * - tracer.startSpan() for eager APM spans (long-lived, manual finish)
+ * - tracer.llmobs.trace() for retroactive LLMObs annotation (callback-scoped)
+ */
+
+import type {
+  TracingEvent,
+  AnyExportedSpan,
+  ModelGenerationAttributes,
+  ModelStepAttributes,
+  ObservabilityBridge,
+  CreateSpanOptions,
+  SpanType,
+  SpanIds,
+} from '@mastra/core/observability';
+import { SpanType as SpanTypeEnum } from '@mastra/core/observability';
+import { omitKeys } from '@mastra/core/utils';
+import { BaseExporter, getExternalParentId } from '@mastra/observability';
+import type { BaseExporterConfig } from '@mastra/observability';
+import tracer from 'dd-trace';
+import { formatUsageMetrics } from './metrics';
+import { ensureTracer, kindFor, toDate, formatInput, formatOutput } from './utils';
+import type { DatadogSpanKind } from './utils';
+
+/**
+ * LLMObs span options passed to dd-trace's llmobs.trace().
+ */
+interface LLMObsSpanOptions {
+  kind: DatadogSpanKind;
+  name: string;
+  sessionId?: string;
+  userId?: string;
+  mlApp?: string;
+  modelName?: string;
+  modelProvider?: string;
+  startTime?: Date;
+}
+
+/**
+ * Minimal per-trace context for user/session tagging.
+ */
+interface TraceContext {
+  userId?: string;
+  sessionId?: string;
+}
+
+type TraceState = {
+  buffer: Map<string, AnyExportedSpan>;
+  contexts: Map<string, { ddSpan: any; exported?: { traceId: string; spanId: string } }>;
+  rootEnded: boolean;
+  treeEmitted: boolean;
+  createdAt: number;
+  cleanupTimer?: ReturnType<typeof setTimeout>;
+  maxLifetimeTimer?: ReturnType<typeof setTimeout>;
+};
+
+/**
+ * Tree node representing a span and its children for recursive emission.
+ */
+interface SpanNode {
+  span: AnyExportedSpan;
+  children: SpanNode[];
+}
+
+/**
+ * Maximum lifetime for a trace state entry (30 minutes).
+ */
+const MAX_TRACE_LIFETIME_MS = 30 * 60 * 1000;
+
+/**
+ * Regular cleanup interval for trace state entries (1 minute).
+ */
+const REGULAR_CLEANUP_INTERVAL_MS = 1 * 60 * 1000;
+
+/**
+ * Configuration options for the Datadog Bridge.
+ */
+export interface DatadogBridgeConfig extends BaseExporterConfig {
+  /**
+   * Datadog API key. Required in agentless mode.
+   * Falls back to DD_API_KEY environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * ML application name for grouping traces.
+   * Required - falls back to DD_LLMOBS_ML_APP environment variable.
+   */
+  mlApp?: string;
+
+  /**
+   * Datadog site (e.g., 'datadoghq.com', 'datadoghq.eu').
+   * Falls back to DD_SITE environment variable, defaults to 'datadoghq.com'.
+   */
+  site?: string;
+
+  /**
+   * Service name for the application.
+   * Falls back to mlApp if not specified.
+   */
+  service?: string;
+
+  /**
+   * Environment name (e.g., 'production', 'staging').
+   * Falls back to DD_ENV environment variable.
+   */
+  env?: string;
+
+  /**
+   * Use agentless mode (direct HTTPS intake without local Datadog Agent).
+   * Defaults to true for consistency with other Mastra exporters.
+   * Set to false to use a local Datadog Agent instead.
+   * Falls back to DD_LLMOBS_AGENTLESS_ENABLED environment variable.
+   */
+  agentless?: boolean;
+
+  /**
+   * Enable dd-trace automatic integrations (HTTP, database, etc.).
+   * Defaults to true since the bridge is designed for APM integration.
+   */
+  integrationsEnabled?: boolean;
+
+  /**
+   * Keys from the request context that should be promoted to flat Datadog
+   * LLM Observability tags instead of being nested in annotations.metadata.
+   *
+   * @example
+   * ```typescript
+   * new DatadogBridge({
+   *   mlApp: 'my-app',
+   *   requestContextKeys: ['tenantId', 'agentId'],
+   * })
+   * ```
+   */
+  requestContextKeys?: string[];
+}
+
+/**
+ * Datadog Bridge for Mastra Observability.
+ *
+ * Creates native dd-trace spans in real-time during execution for proper
+ * APM context propagation, and emits LLMObs annotation data retroactively
+ * through dd-trace's own pipeline.
+ *
+ * @example
+ * ```typescript
+ * import { DatadogBridge } from '@mastra/datadog';
+ *
+ * const mastra = new Mastra({
+ *   observability: {
+ *     configs: {
+ *       default: {
+ *         serviceName: 'my-service',
+ *         bridge: new DatadogBridge({ mlApp: 'my-app' }),
+ *       }
+ *     }
+ *   }
+ * });
+ * ```
+ */
+export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
+  name = 'datadog-bridge';
+
+  private config: Required<Pick<DatadogBridgeConfig, 'mlApp' | 'site'>> & DatadogBridgeConfig;
+  private ddSpanMap = new Map<string, any>();
+  private traceContext = new Map<string, TraceContext>();
+  private traceState = new Map<string, TraceState>();
+
+  constructor(config: DatadogBridgeConfig = {}) {
+    super(config);
+
+    const mlApp = config.mlApp ?? process.env.DD_LLMOBS_ML_APP;
+    const apiKey = config.apiKey ?? process.env.DD_API_KEY;
+    const site = config.site ?? process.env.DD_SITE ?? 'datadoghq.com';
+    const env = config.env ?? process.env.DD_ENV;
+
+    const envAgentless = process.env.DD_LLMOBS_AGENTLESS_ENABLED?.toLowerCase();
+    const agentless = config.agentless ?? (envAgentless === 'false' || envAgentless === '0' ? false : true);
+
+    if (!mlApp) {
+      this.setDisabled(`Missing required mlApp. Set DD_LLMOBS_ML_APP environment variable or pass mlApp in config.`);
+      this.config = config as any;
+      return;
+    }
+
+    if (agentless && !apiKey) {
+      this.setDisabled(
+        `Missing required apiKey for agentless mode. Set DD_API_KEY environment variable or pass apiKey in config.`,
+      );
+      this.config = config as any;
+      return;
+    }
+
+    this.config = { ...config, mlApp, site, apiKey, agentless, env };
+
+    ensureTracer({
+      mlApp,
+      site,
+      apiKey,
+      agentless,
+      service: config.service,
+      env,
+      // Default to true — the bridge is designed for APM integration
+      integrationsEnabled: config.integrationsEnabled ?? true,
+    });
+
+    this.logger.info('Datadog bridge initialized', { mlApp, site, agentless });
+  }
+
+  // ---------------------------------------------------------------------------
+  // ObservabilityBridge interface
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a dd-trace APM span eagerly when a Mastra span is constructed.
+   *
+   * This is the core of the fix: the APM span is active in dd-trace's scope
+   * during execution, so auto-instrumented calls (HTTP, DB, etc.) made by
+   * tools and processors are parented correctly.
+   */
+  createSpan(options: CreateSpanOptions<SpanType>): SpanIds | undefined {
+    if (this.isDisabled) return undefined;
+
+    try {
+      // Determine parent dd-trace span
+      let parentDdSpan: any = undefined;
+
+      const externalParentId = getExternalParentId(options);
+      if (externalParentId) {
+        parentDdSpan = this.ddSpanMap.get(externalParentId);
+      }
+
+      // Fall back to whatever is currently active in dd-trace scope
+      // (e.g., an incoming request span from framework instrumentation)
+      if (!parentDdSpan) {
+        parentDdSpan = tracer.scope().active() ?? undefined;
+      }
+
+      // Create the APM span eagerly
+      const ddSpan = tracer.startSpan(options.name, {
+        ...(parentDdSpan ? { childOf: parentDdSpan } : {}),
+      });
+
+      // Generate Mastra-compatible hex IDs
+      const spanId = generateSpanId();
+      const traceId = externalParentId
+        ? // Inherit parent's trace ID by looking up what Mastra assigned to the parent
+          (options.parent?.traceId ?? generateTraceId())
+        : generateTraceId();
+      const parentSpanId = externalParentId;
+
+      // Store the dd-trace span keyed by Mastra span ID
+      this.ddSpanMap.set(spanId, ddSpan);
+
+      this.logger.debug(
+        `[DatadogBridge.createSpan] Created APM span [spanId=${spanId}] [traceId=${traceId}] ` +
+          `[parentSpanId=${parentSpanId}] [type=${options.type}] [mapSize=${this.ddSpanMap.size}]`,
+      );
+
+      return { spanId, traceId, parentSpanId };
+    } catch (error) {
+      this.logger.error('[DatadogBridge] Failed to create span:', error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Execute an async function within the dd-trace context of a Mastra span.
+   * Auto-instrumented operations inside fn will be parented under this span.
+   */
+  executeInContext<T>(spanId: string, fn: () => Promise<T>): Promise<T> {
+    return this.executeWithSpanContext(spanId, fn);
+  }
+
+  /**
+   * Execute a synchronous function within the dd-trace context of a Mastra span.
+   */
+  executeInContextSync<T>(spanId: string, fn: () => T): T {
+    return this.executeWithSpanContext(spanId, fn);
+  }
+
+  private executeWithSpanContext<T>(spanId: string, fn: () => T): T {
+    const ddSpan = this.ddSpanMap.get(spanId);
+
+    this.logger.debug(`[DatadogBridge.executeWithSpanContext] spanId=${spanId}, inMap=${!!ddSpan}`);
+
+    if (ddSpan) {
+      return tracer.scope().activate(ddSpan, fn);
+    }
+    return fn();
+  }
+
+  // ---------------------------------------------------------------------------
+  // BaseExporter override — tracing events from the bus
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Handle tracing events from the observability bus.
+   *
+   * - SPAN_STARTED: Capture trace context (userId/sessionId)
+   * - SPAN_ENDED: Finish APM span + enqueue for LLMObs emission
+   */
+  protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
+    if (this.isDisabled || !(tracer as any).llmobs) return;
+
+    try {
+      const span = event.exportedSpan;
+
+      // Handle event spans (zero-duration)
+      if (span.isEvent) {
+        if (event.type === 'span_started') {
+          this.captureTraceContext(span);
+          this.finishApmSpan(span);
+          this.enqueueSpan(span);
+        }
+        return;
+      }
+
+      switch (event.type) {
+        case 'span_started':
+          this.captureTraceContext(span);
+          return;
+
+        case 'span_updated':
+          return;
+
+        case 'span_ended':
+          this.finishApmSpan(span);
+          this.enqueueSpan(span);
+          return;
+      }
+    } catch (error) {
+      this.logger.error('Datadog bridge error', {
+        error,
+        eventType: event.type,
+        spanId: event.exportedSpan?.id,
+        spanName: event.exportedSpan?.name,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // APM span management
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Finish the eagerly-created APM span and remove it from the map.
+   */
+  private finishApmSpan(span: AnyExportedSpan): void {
+    const ddSpan = this.ddSpanMap.get(span.id);
+    if (!ddSpan) return;
+
+    const endTime = span.endTime ? toDate(span.endTime) : span.isEvent ? toDate(span.startTime) : new Date();
+
+    try {
+      if (typeof ddSpan.finish === 'function') {
+        ddSpan.finish(endTime.getTime());
+      }
+    } catch (error) {
+      this.logger.error('[DatadogBridge] Failed to finish APM span', {
+        error,
+        spanId: span.id,
+      });
+    }
+
+    this.ddSpanMap.delete(span.id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Trace context capture
+  // ---------------------------------------------------------------------------
+
+  private captureTraceContext(span: AnyExportedSpan): void {
+    if (span.isRootSpan && !this.traceContext.has(span.traceId)) {
+      this.traceContext.set(span.traceId, {
+        userId: span.metadata?.userId,
+        sessionId: span.metadata?.sessionId,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // LLMObs emission (retroactive, using dd-trace's LLMObs pipeline)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Queue span for LLMObs emission. Same buffering strategy as DatadogExporter.
+   */
+  private enqueueSpan(span: AnyExportedSpan): void {
+    const state = this.getOrCreateTraceState(span.traceId);
+    if (span.isRootSpan) {
+      state.rootEnded = true;
+    }
+
+    state.buffer.set(span.id, span);
+    this.tryEmitReadySpans(span.traceId);
+  }
+
+  private tryEmitReadySpans(traceId: string): void {
+    const state = this.traceState.get(traceId);
+    if (!state) return;
+
+    if (!state.treeEmitted) {
+      if (!state.rootEnded) return;
+
+      const tree = this.buildSpanTree(state.buffer);
+      if (tree) {
+        this.emitSpanTree(tree, state);
+      }
+
+      state.buffer.clear();
+      state.treeEmitted = true;
+    } else {
+      let emitted = false;
+      do {
+        emitted = false;
+        for (const [spanId, span] of state.buffer) {
+          const parentCtx = span.parentSpanId ? state.contexts.get(span.parentSpanId) : undefined;
+          if (span.parentSpanId && !parentCtx) {
+            continue;
+          }
+
+          this.emitSingleSpan(span, state, parentCtx?.ddSpan);
+          state.buffer.delete(spanId);
+          emitted = true;
+        }
+      } while (emitted);
+    }
+
+    // Schedule cleanup if root has ended and buffer is empty
+    if (state.rootEnded && state.buffer.size === 0 && !state.cleanupTimer) {
+      const timer = setTimeout(() => {
+        const currentState = this.traceState.get(traceId);
+        if (currentState) {
+          if (currentState.buffer.size > 0) {
+            this.logger.warn('Discarding orphaned spans during cleanup', {
+              traceId,
+              orphanedCount: currentState.buffer.size,
+              spanIds: Array.from(currentState.buffer.keys()),
+            });
+          }
+          if (currentState.maxLifetimeTimer) {
+            clearTimeout(currentState.maxLifetimeTimer);
+          }
+        }
+        this.traceState.delete(traceId);
+        this.traceContext.delete(traceId);
+      }, REGULAR_CLEANUP_INTERVAL_MS);
+      (timer as any).unref?.();
+      state.cleanupTimer = timer;
+    }
+  }
+
+  private buildSpanTree(buffer: Map<string, AnyExportedSpan>): SpanNode | undefined {
+    const nodes = new Map<string, SpanNode>();
+    let rootNode: SpanNode | undefined;
+
+    for (const span of buffer.values()) {
+      nodes.set(span.id, { span, children: [] });
+    }
+
+    for (const node of nodes.values()) {
+      if (node.span.isRootSpan) {
+        rootNode = node;
+      } else if (node.span.parentSpanId) {
+        const parentNode = nodes.get(node.span.parentSpanId);
+        if (parentNode) {
+          parentNode.children.push(node);
+        } else {
+          this.logger.warn('Orphaned span detected during tree build', {
+            spanId: node.span.id,
+            parentSpanId: node.span.parentSpanId,
+            traceId: node.span.traceId,
+          });
+        }
+      }
+    }
+
+    // Sort children by start time for consistent ordering
+    for (const node of nodes.values()) {
+      node.children.sort((a, b) => {
+        const aTime =
+          a.span.startTime instanceof Date ? a.span.startTime.getTime() : new Date(a.span.startTime).getTime();
+        const bTime =
+          b.span.startTime instanceof Date ? b.span.startTime.getTime() : new Date(b.span.startTime).getTime();
+        return aTime - bTime;
+      });
+    }
+
+    return rootNode;
+  }
+
+  /**
+   * Recursively emits a span tree using nested llmobs.trace() calls.
+   * This ensures parent-child relationships are properly established in
+   * Datadog's LLM Observability product.
+   */
+  private emitSpanTree(
+    node: SpanNode,
+    state: TraceState,
+    inheritedModelAttrs?: { model?: string; provider?: string },
+  ): void {
+    const span = node.span;
+    const { traceOptions, endTimeMs } = this.buildSpanOptions(span, inheritedModelAttrs);
+
+    const childInheritedModelAttrs =
+      span.type === SpanTypeEnum.MODEL_GENERATION
+        ? {
+            model: (span.attributes as ModelGenerationAttributes | undefined)?.model,
+            provider: (span.attributes as ModelGenerationAttributes | undefined)?.provider,
+          }
+        : inheritedModelAttrs;
+
+    tracer.llmobs.trace(traceOptions as any, (ddSpan: any) => {
+      const annotations = this.buildAnnotations(span);
+      if (Object.keys(annotations).length > 0) {
+        tracer.llmobs.annotate(ddSpan, annotations);
+      }
+
+      if (span.errorInfo) {
+        this.setErrorTags(ddSpan, span.errorInfo);
+      }
+
+      const exported = tracer.llmobs.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
+      state.contexts.set(span.id, { ddSpan, exported });
+
+      for (const child of node.children) {
+        this.emitSpanTree(child, state, childInheritedModelAttrs);
+      }
+
+      if (typeof ddSpan.finish === 'function') {
+        ddSpan.finish(endTimeMs);
+      }
+    });
+  }
+
+  /**
+   * Emit a single span with the proper Datadog parent context.
+   * Used for late-arriving spans after the main tree has been emitted.
+   */
+  private emitSingleSpan(span: AnyExportedSpan, state: TraceState, parent?: any) {
+    const { traceOptions, endTimeMs } = this.buildSpanOptions(span);
+
+    const runTrace = () =>
+      tracer.llmobs.trace(traceOptions as any, (ddSpan: any) => {
+        const annotations = this.buildAnnotations(span);
+        if (Object.keys(annotations).length > 0) {
+          tracer.llmobs.annotate(ddSpan, annotations);
+        }
+
+        if (span.errorInfo) {
+          this.setErrorTags(ddSpan, span.errorInfo);
+        }
+
+        const exported = tracer.llmobs.exportSpan ? tracer.llmobs.exportSpan(ddSpan) : undefined;
+        state.contexts.set(span.id, { ddSpan, exported });
+
+        if (typeof ddSpan.finish === 'function') {
+          ddSpan.finish(endTimeMs);
+        }
+      });
+
+    if (parent) {
+      tracer.scope().activate(parent, runTrace);
+    } else {
+      runTrace();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // LLMObs span options and annotations
+  // ---------------------------------------------------------------------------
+
+  private buildSpanOptions(
+    span: AnyExportedSpan,
+    inheritedModelAttrs?: { model?: string; provider?: string },
+  ): { traceOptions: LLMObsSpanOptions; endTimeMs: number } {
+    const traceCtx = this.traceContext.get(span.traceId) || {
+      userId: span.metadata?.userId,
+      sessionId: span.metadata?.sessionId,
+    };
+
+    const kind = kindFor(span.type);
+    const ownAttrs = span.attributes as ModelGenerationAttributes | undefined;
+    const attrs = {
+      model: ownAttrs?.model ?? inheritedModelAttrs?.model,
+      provider: ownAttrs?.provider ?? inheritedModelAttrs?.provider,
+    };
+
+    const startTime = toDate(span.startTime);
+    const endTime = span.endTime ? toDate(span.endTime) : span.isEvent ? startTime : new Date();
+
+    return {
+      traceOptions: {
+        kind,
+        name: span.name,
+        sessionId: traceCtx.sessionId,
+        userId: traceCtx.userId,
+        startTime,
+        ...(kind === 'llm' && attrs?.model ? { modelName: attrs.model } : {}),
+        ...(kind === 'llm' && attrs?.provider ? { modelProvider: attrs.provider } : {}),
+      },
+      endTimeMs: endTime.getTime(),
+    };
+  }
+
+  private buildAnnotations(span: AnyExportedSpan): Record<string, any> {
+    const annotations: Record<string, any> = {};
+
+    if (span.input !== undefined) {
+      annotations.inputData = formatInput(span.input, span.type);
+    }
+
+    if (span.output !== undefined) {
+      annotations.outputData = formatOutput(span.output, span.type);
+    }
+
+    if (span.type === SpanTypeEnum.MODEL_STEP) {
+      const usage = (span.attributes as ModelStepAttributes)?.usage;
+      const metrics = formatUsageMetrics(usage);
+      if (metrics) {
+        annotations.metrics = metrics;
+      }
+    }
+
+    const knownFields = ['usage', 'model', 'provider', 'parameters'];
+    const otherAttributes = omitKeys((span.attributes ?? {}) as Record<string, any>, knownFields);
+
+    const contextKeySet = new Set(this.config.requestContextKeys ?? []);
+    const flatContextTags: Record<string, any> = {};
+    const remainingMetadata: Record<string, any> = {};
+
+    for (const [key, value] of Object.entries(span.metadata ?? {})) {
+      if (contextKeySet.has(key)) {
+        flatContextTags[key] = value;
+      } else {
+        remainingMetadata[key] = value;
+      }
+    }
+
+    const remainingAttributes: Record<string, any> = {};
+    for (const [key, value] of Object.entries(otherAttributes)) {
+      if (contextKeySet.has(key)) {
+        if (!(key in flatContextTags)) {
+          flatContextTags[key] = value;
+        }
+      } else {
+        remainingAttributes[key] = value;
+      }
+    }
+
+    const combinedMetadata: Record<string, any> = {
+      ...remainingMetadata,
+      ...remainingAttributes,
+    };
+    if (span.errorInfo) {
+      combinedMetadata['error.message'] = span.errorInfo.message;
+    }
+    if (Object.keys(combinedMetadata).length > 0) {
+      annotations.metadata = combinedMetadata;
+    }
+
+    const tags: Record<string, any> = {
+      ...flatContextTags,
+    };
+
+    if (span.tags?.length) {
+      for (const tag of span.tags) {
+        const colonIndex = tag.indexOf(':');
+        if (colonIndex > 0) {
+          tags[tag.substring(0, colonIndex)] = tag.substring(colonIndex + 1);
+        } else {
+          tags[tag] = true;
+        }
+      }
+    }
+
+    if (span.errorInfo) {
+      tags.error = true;
+      if (span.errorInfo.id) {
+        tags['error.id'] = span.errorInfo.id;
+      }
+      if (span.errorInfo.domain) {
+        tags['error.domain'] = span.errorInfo.domain;
+      }
+      if (span.errorInfo.category) {
+        tags['error.category'] = span.errorInfo.category;
+      }
+    }
+
+    if (Object.keys(tags).length > 0) {
+      annotations.tags = tags;
+    }
+
+    return annotations;
+  }
+
+  private setErrorTags(ddSpan: any, errorInfo: NonNullable<AnyExportedSpan['errorInfo']>): void {
+    ddSpan.setTag('error', true);
+    ddSpan.setTag('error.message', errorInfo.message);
+    ddSpan.setTag('error.type', errorInfo.name ?? errorInfo.category ?? 'Error');
+    if (errorInfo.stack) {
+      ddSpan.setTag('error.stack', errorInfo.stack);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Trace state management
+  // ---------------------------------------------------------------------------
+
+  private getOrCreateTraceState(traceId: string): TraceState {
+    const existing = this.traceState.get(traceId);
+    if (existing) {
+      if (existing.cleanupTimer) {
+        clearTimeout(existing.cleanupTimer);
+        existing.cleanupTimer = undefined;
+      }
+      return existing;
+    }
+
+    const created: TraceState = {
+      buffer: new Map<string, AnyExportedSpan>(),
+      contexts: new Map<string, { ddSpan: any; exported?: { traceId: string; spanId: string } }>(),
+      rootEnded: false,
+      treeEmitted: false,
+      createdAt: Date.now(),
+      cleanupTimer: undefined,
+      maxLifetimeTimer: undefined,
+    };
+
+    const maxLifetimeTimer = setTimeout(() => {
+      const state = this.traceState.get(traceId);
+      if (state) {
+        if (state.buffer.size > 0 || state.contexts.size > 0) {
+          this.logger.warn('Discarding trace due to max lifetime exceeded', {
+            traceId,
+            bufferedSpans: state.buffer.size,
+            emittedSpans: state.contexts.size,
+            lifetimeMs: Date.now() - state.createdAt,
+          });
+        }
+        if (state.cleanupTimer) {
+          clearTimeout(state.cleanupTimer);
+        }
+        this.traceState.delete(traceId);
+        this.traceContext.delete(traceId);
+      }
+    }, MAX_TRACE_LIFETIME_MS);
+    (maxLifetimeTimer as any).unref?.();
+    created.maxLifetimeTimer = maxLifetimeTimer;
+
+    this.traceState.set(traceId, created);
+    return created;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  async flush(): Promise<void> {
+    if (this.isDisabled || !(tracer as any).llmobs) return;
+
+    if (tracer.llmobs?.flush) {
+      try {
+        await tracer.llmobs.flush();
+        this.logger.debug('Datadog llmobs flushed');
+      } catch (e) {
+        this.logger.error('Error flushing llmobs', { error: e });
+      }
+    } else if ((tracer as any).flush) {
+      try {
+        await (tracer as any).flush();
+        this.logger.debug('Datadog tracer flushed');
+      } catch (e) {
+        this.logger.error('Error flushing tracer', { error: e });
+      }
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    // Cancel all pending cleanup timers and clear state
+    for (const [traceId, state] of this.traceState) {
+      if (state.cleanupTimer) {
+        clearTimeout(state.cleanupTimer);
+      }
+      if (state.maxLifetimeTimer) {
+        clearTimeout(state.maxLifetimeTimer);
+      }
+      if (state.buffer.size > 0) {
+        this.logger.warn('Shutdown with pending spans', {
+          traceId,
+          pendingCount: state.buffer.size,
+          spanIds: Array.from(state.buffer.keys()),
+        });
+      }
+    }
+    this.traceState.clear();
+
+    // Force-finish any remaining APM spans
+    for (const [spanId, ddSpan] of this.ddSpanMap) {
+      this.logger.warn(`[DatadogBridge] Force-finishing APM span that was not properly closed [id=${spanId}]`);
+      try {
+        if (typeof ddSpan.finish === 'function') {
+          ddSpan.finish();
+        }
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+    this.ddSpanMap.clear();
+
+    await this.flush();
+
+    if (tracer.llmobs?.disable) {
+      try {
+        tracer.llmobs.disable();
+      } catch (e) {
+        this.logger.error('Error disabling llmobs', { error: e });
+      }
+    }
+
+    this.traceContext.clear();
+
+    await super.shutdown();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ID generation helpers (same format as DefaultSpan)
+// ---------------------------------------------------------------------------
+
+function fillRandomBytes(bytes: Uint8Array): void {
+  try {
+    const webCrypto = globalThis.crypto;
+    if (webCrypto?.getRandomValues) {
+      webCrypto.getRandomValues.call(webCrypto, bytes);
+      return;
+    }
+  } catch {
+    // Fall through to fallback
+  }
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Math.floor(Math.random() * 256);
+  }
+}
+
+function generateSpanId(): string {
+  const bytes = new Uint8Array(8);
+  fillRandomBytes(bytes);
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function generateTraceId(): string {
+  const bytes = new Uint8Array(16);
+  fillRandomBytes(bytes);
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/observability/datadog/src/index.ts
+++ b/observability/datadog/src/index.ts
@@ -1,9 +1,20 @@
 /**
- * Datadog LLM Observability Exporter for Mastra
+ * Datadog integration for Mastra Observability
  *
- * Exports Mastra observability data to Datadog's LLM Observability product.
- * Uses a completion-only pattern where spans are emitted on span_ended events.
+ * Provides two integration modes:
+ *
+ * - DatadogBridge: Recommended for most users. Creates native dd-trace spans
+ *   in real-time for proper APM context propagation, and emits LLMObs data
+ *   through dd-trace's own pipeline. Use as an observability bridge.
+ *
+ * - DatadogExporter: Legacy exporter-only mode. Emits LLMObs spans
+ *   retroactively after execution completes. Does not participate in
+ *   dd-trace's live scope, so auto-instrumented APM spans (HTTP, DB)
+ *   will not be parented under Mastra spans.
  */
+
+export { DatadogBridge } from './bridge';
+export type { DatadogBridgeConfig } from './bridge';
 
 export { DatadogExporter } from './tracing';
 export type { DatadogExporterConfig } from './tracing';

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -423,13 +423,6 @@ export class DatadogExporter extends BaseExporter {
       } catch (e) {
         this.logger.error('Error flushing llmobs', { error: e });
       }
-    } else if ((tracer as any).flush) {
-      try {
-        await (tracer as any).flush();
-        this.logger.debug('Datadog tracer flushed');
-      } catch (e) {
-        this.logger.error('Error flushing tracer', { error: e });
-      }
     }
   }
 

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -407,7 +407,8 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     const bridge = this.observabilityInstance.getBridge();
 
     if (bridge?.executeInContext) {
-      return bridge.executeInContext(this.id, fn);
+      const bridgeContextSpan = this.isInternal ? this.getParentSpan(false) : this;
+      return bridge.executeInContext(bridgeContextSpan?.id ?? this.id, fn);
     }
 
     return fn();
@@ -421,7 +422,8 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     const bridge = this.observabilityInstance.getBridge();
 
     if (bridge?.executeInContextSync) {
-      return bridge.executeInContextSync(this.id, fn);
+      const bridgeContextSpan = this.isInternal ? this.getParentSpan(false) : this;
+      return bridge.executeInContextSync(bridgeContextSpan?.id ?? this.id, fn);
     }
 
     return fn();

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -1,6 +1,6 @@
 import { RequestContext } from '@mastra/core/di';
 import { MastraError } from '@mastra/core/error';
-import { SpanType, SamplingStrategyType, TracingEventType } from '@mastra/core/observability';
+import { InternalSpans, SpanType, SamplingStrategyType, TracingEventType } from '@mastra/core/observability';
 import type {
   TracingEvent,
   ObservabilityExporter,
@@ -9,6 +9,7 @@ import type {
   ExportedSpan,
   LogEvent,
   MetricEvent,
+  ObservabilityBridge,
 } from '@mastra/core/observability';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DefaultObservabilityInstance } from './instances';
@@ -108,6 +109,33 @@ class TestExporter implements ObservabilityExporter {
     this.logEvents = [];
     this.metricEvents = [];
   }
+}
+
+function createMockBridge(overrides: Partial<ObservabilityBridge> = {}): ObservabilityBridge {
+  return {
+    name: 'mock-bridge',
+    exportTracingEvent: vi.fn().mockResolvedValue(undefined),
+    createSpan: vi.fn().mockImplementation(({ parent }: any) => {
+      if (parent) {
+        return {
+          spanId: `bridge-${parent.id}-child`,
+          traceId: parent.traceId,
+          parentSpanId: parent.id,
+        };
+      }
+
+      return {
+        spanId: 'bridge-root-span',
+        traceId: 'bridge-root-trace',
+        parentSpanId: undefined,
+      };
+    }),
+    executeInContext: vi.fn().mockImplementation(async (_spanId: string, fn: () => Promise<any>) => fn()),
+    executeInContextSync: vi.fn().mockImplementation((_spanId: string, fn: () => any) => fn()),
+    flush: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
 }
 
 describe('Tracing', () => {
@@ -223,6 +251,33 @@ describe('Tracing', () => {
       // Grandchild should have correct parent and isRootSpan should be false
       expect(grandchildSpan.parent).toBe(childSpan);
       expect(grandchildSpan.isRootSpan).toBe(false);
+    });
+
+    it('should use the nearest external ancestor when executing an internal span in bridge context', async () => {
+      const bridge = createMockBridge();
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test-tracing',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [testExporter],
+        bridge,
+      });
+
+      const agentSpan = tracing.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'root-agent',
+        attributes: { agentId: 'agent-123' },
+      });
+
+      const internalStep = agentSpan.createChildSpan({
+        type: SpanType.MODEL_STEP,
+        name: 'internal-step',
+        tracingPolicy: { internal: InternalSpans.MODEL },
+      });
+
+      await internalStep.executeInContext(async () => 'ok');
+
+      expect(bridge.executeInContext).toHaveBeenCalledWith(agentSpan.id, expect.any(Function));
     });
 
     it('should maintain consistent traceId across span hierarchy', () => {

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -2268,6 +2268,7 @@ describe('MastraMCPClient - mcpMetadata on tools', () => {
 });
 
 describe('MastraMCPClient fetch with requestContext', () => {
+  const datadogTracerTestSymbol = Symbol.for('mastra.mcp.dd-trace-test-tracer');
   let testServer: {
     httpServer: HttpServer;
     mcpServer: McpServer;
@@ -2281,6 +2282,7 @@ describe('MastraMCPClient fetch with requestContext', () => {
     await testServer?.mcpServer.close().catch(() => {});
     await testServer?.serverTransport?.close().catch(() => {});
     testServer?.httpServer.close();
+    delete (globalThis as Record<PropertyKey, unknown>)[datadogTracerTestSymbol];
   });
 
   it('should pass requestContext to the custom fetch function during tool execution', async () => {
@@ -2404,6 +2406,50 @@ describe('MastraMCPClient fetch with requestContext', () => {
     // The third argument should be defined (either null or an empty RequestContext)
     const lastToolCallFetch = callsDuringToolExec[callsDuringToolExec.length - 1];
     expect(lastToolCallFetch!.length).toBeGreaterThanOrEqual(3);
+  }, 15000);
+
+  it('should detach only the persistent stream GET from the active Datadog span', async () => {
+    testServer = await setupTestServer(true);
+    const fetchSpy = vi.fn((url: string | URL, init?: RequestInit, _requestContext?: RequestContext | null) => {
+      return fetch(url, init);
+    });
+    const activateSpy = vi.fn((_span: unknown, callback: () => unknown) => callback());
+
+    (globalThis as Record<PropertyKey, unknown>)[datadogTracerTestSymbol] = {
+      scope: () => ({
+        activate: activateSpy,
+      }),
+    };
+
+    client = new InternalMastraMCPClient({
+      name: 'fetch-datadog-stream-test',
+      server: {
+        url: testServer.baseUrl,
+        fetch: fetchSpy,
+      },
+    });
+
+    await client.connect();
+
+    const streamFetchCalls = fetchSpy.mock.calls.filter(([, init]) => {
+      return (
+        (init?.method ?? 'GET').toUpperCase() === 'GET' &&
+        new Headers(init?.headers).get('accept')?.toLowerCase().includes('text/event-stream')
+      );
+    });
+
+    expect(streamFetchCalls.length).toBeGreaterThan(0);
+    expect(activateSpy).toHaveBeenCalledTimes(streamFetchCalls.length);
+    expect(activateSpy).toHaveBeenNthCalledWith(1, null, expect.any(Function));
+
+    activateSpy.mockClear();
+    fetchSpy.mockClear();
+
+    await client.tools();
+
+    const postFetchCalls = fetchSpy.mock.calls.filter(([, init]) => (init?.method ?? 'GET').toUpperCase() === 'POST');
+    expect(postFetchCalls.length).toBeGreaterThan(0);
+    expect(activateSpy).not.toHaveBeenCalled();
   }, 15000);
 });
 

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { createRequire } from 'node:module';
 import type { Stream } from 'node:stream';
 import { MastraBase } from '@mastra/core/base';
 import type { RequestContext } from '@mastra/core/di';
@@ -73,9 +74,90 @@ export type {
 } from './types';
 
 const DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC = 3000;
+const require = createRequire(import.meta.url);
 
 // Per MCP spec, only fallback to SSE for these status codes
 const SSE_FALLBACK_STATUS_CODES = [400, 404, 405];
+const DATADOG_TRACER_TEST_SYMBOL = Symbol.for('mastra.mcp.dd-trace-test-tracer');
+
+type DatadogScopeLike = {
+  activate<T>(span: unknown, callback: () => T): T;
+};
+
+type DatadogTracerLike = {
+  scope?: () => DatadogScopeLike;
+  default?: {
+    scope?: () => DatadogScopeLike;
+  };
+};
+
+function shouldDetachPersistentTransportRequest(init?: RequestInit): boolean {
+  if ((init?.method ?? 'GET').toUpperCase() !== 'GET') {
+    return false;
+  }
+
+  const accept = new Headers(init?.headers).get('accept');
+  return typeof accept === 'string' && accept.toLowerCase().includes('text/event-stream');
+}
+
+function getDatadogScope(): DatadogScopeLike | null {
+  const testTracer = (globalThis as Record<PropertyKey, unknown>)[DATADOG_TRACER_TEST_SYMBOL] as
+    | DatadogTracerLike
+    | undefined;
+  const tracer = testTracer ?? loadDatadogTracer();
+
+  if (typeof tracer?.scope === 'function') {
+    return tracer.scope();
+  }
+
+  if (typeof tracer?.default?.scope === 'function') {
+    return tracer.default.scope();
+  }
+
+  return null;
+}
+
+function loadDatadogTracer(): DatadogTracerLike | null {
+  if (!isDatadogTracerLikelyLoaded()) {
+    return null;
+  }
+
+  try {
+    return require('dd-trace') as DatadogTracerLike;
+  } catch {
+    return null;
+  }
+}
+
+function isDatadogTracerLikelyLoaded(): boolean {
+  if ((globalThis as Record<PropertyKey, unknown>)[DATADOG_TRACER_TEST_SYMBOL]) {
+    return true;
+  }
+
+  if (process.execArgv.some(arg => arg.includes('dd-trace'))) {
+    return true;
+  }
+
+  if (process.env.NODE_OPTIONS?.includes('dd-trace')) {
+    return true;
+  }
+
+  try {
+    const resolvedPath = require.resolve('dd-trace');
+    return Boolean(require.cache[resolvedPath]);
+  } catch {
+    return false;
+  }
+}
+
+function runOutsideDatadogTraceScope<T>(callback: () => T): T {
+  const scope = getDatadogScope();
+  if (!scope) {
+    return callback();
+  }
+
+  return scope.activate(null, callback);
+}
 
 /**
  * Convert an MCP LoggingLevel to a logger method name that exists in our logger
@@ -310,12 +392,15 @@ export class InternalMastraMCPClient extends MastraBase {
   private async connectHttp(url: URL) {
     const { requestInit, eventSourceInit, authProvider, connectTimeout, fetch: userFetch } = this.serverConfig;
 
-    // Wrap the user's fetch function to inject requestContext as the third argument.
-    // The transport calls fetch with standard (url, init) signature, but we forward
-    // the current operation context so users can access request-scoped data (e.g., auth cookies).
-    const fetch: FetchLike | undefined = userFetch
-      ? (url: string | URL, init?: RequestInit) => userFetch(url, init, this.operationContextStore.getStore() ?? null)
-      : undefined;
+    // Wrap fetch so request-scoped metadata still flows through normal MCP POSTs, while
+    // the long-lived Streamable HTTP event stream does not inherit the active Datadog span.
+    const fetch: FetchLike = (requestUrl: string | URL, init?: RequestInit) => {
+      const requestContext = this.operationContextStore.getStore() ?? null;
+      const executeFetch = () =>
+        userFetch ? userFetch(requestUrl, init, requestContext) : globalThis.fetch(requestUrl, init);
+
+      return shouldDetachPersistentTransportRequest(init) ? runOutsideDatadogTraceScope(executeFetch) : executeFetch();
+    };
 
     this.log('debug', `Attempting to connect to URL: ${url}`);
 
@@ -356,7 +441,7 @@ export class InternalMastraMCPClient extends MastraBase {
         // Fallback to SSE transport
         // If fetch is provided, ensure it's also in eventSourceInit for the EventSource connection
         // The top-level fetch is used for POST requests, but eventSourceInit.fetch is needed for the SSE stream
-        const sseEventSourceInit = fetch ? { ...eventSourceInit, fetch } : eventSourceInit;
+        const sseEventSourceInit = { ...eventSourceInit, fetch };
 
         const sseTransport = new SSEClientTransport(url, {
           requestInit,


### PR DESCRIPTION
## Description

Introduces `DatadogBridge`, a new observability bridge that solves a critical issue with APM span parenting in Datadog integrations. The bridge creates native dd-trace APM spans eagerly during execution (rather than retroactively) so that auto-instrumented operations (HTTP requests, database queries, etc.) made by tools and processors have the correct parent span context.

### Problem Solved

The existing `DatadogExporter` creates LLMObs spans retroactively after execution completes. This means when tools and processors make outbound calls, there is no active dd-trace span in scope, causing dd-trace's auto-instrumentation to fall back to the nearest active span (typically the request handler) instead of the actual parent span.

### Solution

`DatadogBridge` uses a dual-API approach:
- **`tracer.startSpan()`** for eager APM span creation and activation in dd-trace's scope during execution
- **`tracer.llmobs.trace()`** for retroactive LLMObs annotation and export after spans complete

This ensures:
1. APM spans are active in dd-trace's scope when tools/processors execute
2. Auto-instrumented calls are parented correctly
3. LLMObs data is still emitted through dd-trace's pipeline for proper annotation and export

### Key Features

- **Real-time APM context**: Spans are created eagerly and activated in dd-trace scope
- **Proper parent-child relationships**: Both APM and LLMObs spans maintain correct hierarchy
- **Flexible configuration**: Supports agentless mode, custom ML app names, and context key promotion
- **Trace state management**: Handles buffering, late-arriving spans, and cleanup with configurable timeouts
- **Error handling**: Properly tags and annotates error spans in both APM and LLMObs

### Configuration

```typescript
const bridge = new DatadogBridge({
  mlApp: 'my-app',           // Required
  apiKey: 'xxx',             // Required for agentless mode
  agentless: true,           // Default: true
  requestContextKeys: ['tenantId', 'userId'],  // Promote to flat tags
});
```

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have added comprehensive unit tests (713 lines of test coverage)
- [x] I have updated the index.ts exports to include the new bridge
- [x] Tests cover configuration, span creation, APM lifecycle, LLMObs emission, and error handling

https://claude.ai/code/session_01Q7w4QfZvEXyUvyY2y4XQe1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

This PR makes Mastra create live Datadog APM spans while tasks run so automatic instrumentation (like HTTP or DB calls) becomes children of the correct Mastra task, and still sends LLM Observability annotations to Datadog after spans finish.

---

## Overview

Adds DatadogBridge: an observability bridge that eagerly creates and activates native dd-trace APM spans during execution so dd-trace auto-instrumentation is parented under the correct Mastra span, while continuing to emit LLM Observability annotations retroactively via dd-trace’s llmobs API. This resolves incorrect parenting when using the DatadogExporter alone.

DatadogBridge exposes a dual API:
- Real-time APM: tracer.startSpan() + tracer.scope().activate() to create/activate dd-trace spans during execution.
- Retroactive LLM Observability: tracer.llmobs.trace()/annotate()/flush() to export LLM Observability data after spans end.

---

## Key Features

- Real-time APM context propagation so auto-instrumented operations are children of the correct Mastra span.
- Dual emission model: eager dd-trace APM spans during execution + retroactive LLM Observability annotations on span end.
- Parent selection precedence: external parent mapping → ddSpanMap → active dd-trace scope fallback.
- executeInContext()/executeInContextSync() helpers to run callbacks with the dd-trace span active.
- Per-trace buffering and traceState management to assemble and emit span trees when the root ends; supports late-arriving spans and iterative emission of previously unresolved children.
- Inherits and preserves model/provider attributes for late-arriving MODEL_STEP spans by storing and reusing parent model attributes.
- Configurable via DatadogBridgeConfig: mlApp (required to enable), apiKey (agentless), agentless, site, service, env, integrationsEnabled, requestContextKeys (promote request metadata to flat tags).
- Error tagging/annotation, span type → Datadog LLM Observability kind mapping, and token metrics for MODEL_STEP spans.
- Cleanup timers including max-lifetime window for traces and deterministic shutdown (flush, force-finish APM spans, disable llmobs).

---

## Changes

- New: observability/datadog/src/bridge.ts
  - Exports DatadogBridgeConfig and DatadogBridge.
  - DatadogBridge extends BaseExporter and implements ObservabilityBridge.
  - Public API: createSpan(), executeInContext(), executeInContextSync(), flush(), shutdown().
  - Implements ensureTracer(), ddSpanMap tracking, per-trace buffering, LLM Observability emission, late-arrival handling, model attribute inheritance, and lifecycle management.

- New: observability/datadog/src/bridge.test.ts
  - Comprehensive Vitest suite (~713 lines) that fully mocks dd-trace.
  - Tests cover enablement/disablement rules, createSpan id/parent behavior, sync/async context activation, APM finishing semantics, LLM Observability emission and annotation enrichment, late-arriving spans and buffered child emission, model/provider propagation for late MODEL_STEP spans, flush/shutdown behavior, and an end-to-end eager APM + LLM Observability flow.

- Modified: observability/datadog/src/index.ts
  - Exports DatadogBridge and DatadogBridgeConfig alongside existing DatadogExporter exports.
  - Documentation updated to describe two modes: DatadogBridge (recommended for correct APM parenting) and DatadogExporter (LLM Observability-only, retroactive).

- Docs & Changeset
  - New user guide and reference docs for DatadogBridge (usage, config, initialization order, agent vs agentless, span mappings, requestContextKeys promotion, troubleshooting).
  - Sidebar and reference updates and a changeset announcing the new DatadogBridge.

---

## Fixes / Notable Behavior Changes

- Avoids dropping unresolved child spans; buffered children are emitted when parent context becomes available.
- Preserves model/provider metadata for late MODEL_STEP spans by storing inherited attributes and applying them to descendants.
- Bridge enables only if mlApp is provided (constructor config overrides env); agentless mode requires DD_API_KEY.
- Produces Mastra-compatible hex span/trace IDs and tracks dd-trace span objects in ddSpanMap.
- On span end, finishes the eager APM span with the correct timestamp, buffers the Mastra span for LLM Observability emission, and emits the tree via nested tracer.llmobs.trace() when the root ends.

---

## Review Impact

- Large new implementation and tests: high review effort for bridge.ts, medium for tests/docs.
- Backward-compatible: DatadogExporter remains available; DatadogBridge is recommended when dd-trace auto-instrumentation requires correct parenting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->