### PR TITLE
docs: expose commands and skills in AGENTS.md for cross-agent parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,35 @@ Mastra is a modular AI framework built around central orchestration with pluggab
 - **Workflows** (`workflows/`) - Step-based execution with suspend/resume.
 - **Storage** (`storage/`) - Pluggable backends with shared interfaces.
 
+## Commands
+
+Reusable command prompts are available in `.claude/commands/`. All agents should read and follow the relevant command file when performing these tasks.
+
+- **Changeset** (`.claude/commands/changeset.md`) — Create a changeset using the CLI for changelog generation.
+- **Commit** (`.claude/commands/commit.md`) — Commit work using conventional commits with a concise message, then push.
+- **Document** (`.claude/commands/document.md`) — Examine a GitHub issue and write documentation for it.
+- **Bulk Issue Solver** (`.claude/commands/gh-bulk-issues.md`) — Orchestrate parallel headless instances to debug and fix multiple GitHub issues simultaneously.
+- **Debug Issue** (`.claude/commands/gh-debug-issue.md`) — Examine and debug a GitHub issue using the GH CLI.
+- **Fix CI** (`.claude/commands/gh-fix-ci.md`) — Diagnose and fix GitHub Actions CI failures for the current branch's PR.
+- **Fix Lint** (`.claude/commands/gh-fix-lint.md`) — Fix linting and formatting issues for a GitHub PR branch.
+- **New PR** (`.claude/commands/gh-new-pr.md`) — Open a PR for the current branch using the GH CLI.
+- **PR Comments** (`.claude/commands/gh-pr-comments.md`) — View and handle PR review comments.
+- **Make Moves** (`.claude/commands/make-moves.md`) — Examine a GitHub issue and implement the fix as an engineer on the Mastra framework.
+- **PR** (`.claude/commands/pr.md`) — Create a changeset and open a PR for the current branch.
+- **Ralph Plan** (`.claude/commands/ralph-plan.md`) — Interactive assistant for building focused ralph-loop commands.
+
+## Skills
+
+This repository includes domain-specific guidance as skills in `.claude/skills/`. All agents should read the relevant skill file before performing work in that area.
+
+- **E2E Tests for Studio** (`.claude/skills/e2e-tests-studio/SKILL.md`) — REQUIRED when modifying any file in `packages/playground-ui` or `packages/playground`. Covers Playwright E2E test generation that validates product behavior.
+- **Mastra Docs** (`.claude/skills/mastra-docs/SKILL.md`) — Guidelines for writing or editing Mastra documentation.
+- **React Best Practices** (`.claude/skills/react-best-practices/SKILL.md`) — React performance optimization patterns. Read when writing, reviewing, or refactoring React components.
+- **Tailwind Best Practices** (`.claude/skills/tailwind-best-practices/SKILL.md`) — Tailwind CSS and design-system guidelines for `packages/playground-ui` and `packages/playground`.
+- **Mastra Smoke Test** (`.claude/skills/mastra-smoke-test/SKILL.md`) — Procedures for smoke testing Mastra projects locally or against staging/production.
+- **Smoke Test** (`.claude/skills/smoke-test/SKILL.md`) — Creating a Mastra project with `create-mastra` and smoke testing the studio in Chrome.
+- **Ralph Plan** (`.claude/skills/ralph-plan/SKILL.md`) — Interactive planning assistant for building ralph-loop commands.
+
 ## Enterprise Edition (EE) licensing
 
 - Any directory named `ee/` is licensed under the Mastra Enterprise License.


### PR DESCRIPTION
## Description

Adds Commands and Skills sections to AGENTS.md so that non-Claude agents (e.g. OpenAI Codex) can discover and use the same reusable command prompts and domain-specific skill files that Claude agents access via `.claude/commands/` and `.claude/skills/`. This gives all coding agents parity regardless of which provider they come from.

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR adds a helpful instruction guide to AGENTS.md that lists all the reusable command templates and skill guides that AI agents can use when working on the project. Think of it like adding a table of contents or a menu that shows agents what tools and best practices they can follow, whether they're Claude or another AI provider.

## Overview
Updates the root `AGENTS.md` file to expose Commands and Skills sections, enabling agents of any provider to discover and reference reusable command prompts and domain-specific skill documentation for cross-agent parity.

## Changes
Adds two new sections to `AGENTS.md`:

**Commands** — Lists 13 reusable command prompts available in `.claude/commands/` including:
- Changeset creation, conventional commits, and PR workflows
- GitHub issue debugging and CI/lint fixes
- Documentation generation
- Bulk issue solving and planning

**Skills** — Documents 7 domain-specific guidance files in `.claude/skills/` covering:
- E2E testing for Studio (required for `packages/playground-ui` and `packages/playground` changes)
- Documentation, React, and Tailwind best practices
- Smoke testing procedures and Ralph planning

## Impact
Documentation-only update (+29 lines). No code changes or exported entities modified. Enables non-Claude agents to access the same reusable prompts and skill documentation that were previously only documented for Claude-specific workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->