### PR TITLE
fix(@mastra/pg): use tx() for batch writes

### DIFF
--- a/.changeset/neat-dingos-protect.md
+++ b/.changeset/neat-dingos-protect.md
@@ -1,0 +1,7 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed `batchInsert` and `batchUpdate` in `@mastra/pg` to run on a single Postgres transaction connection.
+
+This prevents pooled `BEGIN`/`COMMIT`/`ROLLBACK` calls from landing on different connections and leaving idle transactions open during batch writes.

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -18,7 +18,7 @@ import type {
 } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
 import { Pool } from 'pg';
-import type { DbClient } from '../client';
+import type { DbClient, QueryValues, TxClient } from '../client';
 import { PoolAdapter } from '../client';
 import { buildConstraintName } from './constraint-utils';
 
@@ -566,44 +566,51 @@ export class PgDB extends MastraBase {
     }
   }
 
+  private async executeInsert(
+    client: Pick<DbClient, 'none'> | Pick<TxClient, 'none'>,
+    { tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> },
+  ): Promise<void> {
+    this.addTimestampZColumns(record);
+
+    // Filter out columns that don't exist in the actual database table
+    const filteredRecord = await this.filterRecordToKnownColumns(tableName, record);
+
+    const schemaName = getSchemaName(this.schemaName);
+    const columns = Object.keys(filteredRecord).map(col => parseSqlIdentifier(col, 'column name'));
+    if (columns.length === 0) return; // No known columns after filtering - skip insert
+    const values = this.prepareValuesForInsert(filteredRecord, tableName);
+    const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
+    const fullTableName = getTableName({ indexName: tableName, schemaName });
+    const columnList = columns.map(c => `"${c}"`).join(', ');
+
+    // For spans table, use ON CONFLICT to handle duplicate (traceId, spanId) gracefully
+    if (tableName === TABLE_SPANS) {
+      // Build update clause for all columns except the primary key columns
+      const updateColumns = columns.filter(c => c !== 'traceId' && c !== 'spanId');
+
+      if (updateColumns.length > 0) {
+        const updateClause = updateColumns.map(c => `"${c}" = EXCLUDED."${c}"`).join(', ');
+        await client.none(
+          `INSERT INTO ${fullTableName} (${columnList}) VALUES (${placeholders})
+             ON CONFLICT ("traceId", "spanId") DO UPDATE SET ${updateClause}`,
+          values,
+        );
+      } else {
+        // Only PK columns provided - use DO NOTHING to avoid invalid SQL
+        await client.none(
+          `INSERT INTO ${fullTableName} (${columnList}) VALUES (${placeholders})
+             ON CONFLICT ("traceId", "spanId") DO NOTHING`,
+          values,
+        );
+      }
+    } else {
+      await client.none(`INSERT INTO ${fullTableName} (${columnList}) VALUES (${placeholders})`, values);
+    }
+  }
+
   async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
     try {
-      this.addTimestampZColumns(record);
-
-      // Filter out columns that don't exist in the actual database table
-      const filteredRecord = await this.filterRecordToKnownColumns(tableName, record);
-
-      const schemaName = getSchemaName(this.schemaName);
-      const columns = Object.keys(filteredRecord).map(col => parseSqlIdentifier(col, 'column name'));
-      if (columns.length === 0) return; // No known columns after filtering - skip insert
-      const values = this.prepareValuesForInsert(filteredRecord, tableName);
-      const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
-      const fullTableName = getTableName({ indexName: tableName, schemaName });
-      const columnList = columns.map(c => `"${c}"`).join(', ');
-
-      // For spans table, use ON CONFLICT to handle duplicate (traceId, spanId) gracefully
-      if (tableName === TABLE_SPANS) {
-        // Build update clause for all columns except the primary key columns
-        const updateColumns = columns.filter(c => c !== 'traceId' && c !== 'spanId');
-
-        if (updateColumns.length > 0) {
-          const updateClause = updateColumns.map(c => `"${c}" = EXCLUDED."${c}"`).join(', ');
-          await this.client.none(
-            `INSERT INTO ${fullTableName} (${columnList}) VALUES (${placeholders})
-             ON CONFLICT ("traceId", "spanId") DO UPDATE SET ${updateClause}`,
-            values,
-          );
-        } else {
-          // Only PK columns provided - use DO NOTHING to avoid invalid SQL
-          await this.client.none(
-            `INSERT INTO ${fullTableName} (${columnList}) VALUES (${placeholders})
-             ON CONFLICT ("traceId", "spanId") DO NOTHING`,
-            values,
-          );
-        }
-      } else {
-        await this.client.none(`INSERT INTO ${fullTableName} (${columnList}) VALUES (${placeholders})`, values);
-      }
+      await this.executeInsert(this.client, { tableName, record });
     } catch (error) {
       throw new MastraError(
         {
@@ -1198,13 +1205,12 @@ export class PgDB extends MastraBase {
 
   async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
     try {
-      await this.client.query('BEGIN');
-      for (const record of records) {
-        await this.insert({ tableName, record });
-      }
-      await this.client.query('COMMIT');
+      await this.client.tx(async tx => {
+        for (const record of records) {
+          await this.executeInsert(tx, { tableName, record });
+        }
+      });
     } catch (error) {
-      await this.client.query('ROLLBACK');
       throw new MastraError(
         {
           id: createStorageErrorId('PG', 'BATCH_INSERT', 'FAILED'),
@@ -1521,38 +1527,7 @@ export class PgDB extends MastraBase {
     data: Record<string, any>;
   }): Promise<void> {
     try {
-      // Filter out columns that don't exist in the actual database table
-      const filteredData = await this.filterRecordToKnownColumns(tableName, data);
-      if (Object.keys(filteredData).length === 0) return; // Nothing to update after filtering
-
-      const setColumns: string[] = [];
-      const setValues: any[] = [];
-      let paramIndex = 1;
-
-      Object.entries(filteredData).forEach(([key, value]) => {
-        const parsedKey = parseSqlIdentifier(key, 'column name');
-        setColumns.push(`"${parsedKey}" = $${paramIndex++}`);
-        setValues.push(this.prepareValue(value, key, tableName));
-      });
-
-      const whereConditions: string[] = [];
-      const whereValues: any[] = [];
-
-      Object.entries(keys).forEach(([key, value]) => {
-        const parsedKey = parseSqlIdentifier(key, 'column name');
-        whereConditions.push(`"${parsedKey}" = $${paramIndex++}`);
-        whereValues.push(this.prepareValue(value, key, tableName));
-      });
-
-      const tableName_ = getTableName({
-        indexName: tableName,
-        schemaName: getSchemaName(this.schemaName),
-      });
-
-      const sql = `UPDATE ${tableName_} SET ${setColumns.join(', ')} WHERE ${whereConditions.join(' AND ')}`;
-      const values = [...setValues, ...whereValues];
-
-      await this.client.none(sql, values);
+      await this.executeUpdate(this.client, { tableName, keys, data });
     } catch (error) {
       throw new MastraError(
         {
@@ -1579,13 +1554,12 @@ export class PgDB extends MastraBase {
     }>;
   }): Promise<void> {
     try {
-      await this.client.query('BEGIN');
-      for (const { keys, data } of updates) {
-        await this.update({ tableName, keys, data });
-      }
-      await this.client.query('COMMIT');
+      await this.client.tx(async tx => {
+        for (const { keys, data } of updates) {
+          await this.executeUpdate(tx, { tableName, keys, data });
+        }
+      });
     } catch (error) {
-      await this.client.query('ROLLBACK');
       throw new MastraError(
         {
           id: createStorageErrorId('PG', 'BATCH_UPDATE', 'FAILED'),
@@ -1649,5 +1623,51 @@ export class PgDB extends MastraBase {
    */
   async deleteData({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
     return this.clearTable({ tableName });
+  }
+
+  private async executeUpdate(
+    client: Pick<DbClient, 'none'> | Pick<TxClient, 'none'>,
+    {
+      tableName,
+      keys,
+      data,
+    }: {
+      tableName: TABLE_NAMES;
+      keys: Record<string, any>;
+      data: Record<string, any>;
+    },
+  ): Promise<void> {
+    // Filter out columns that don't exist in the actual database table
+    const filteredData = await this.filterRecordToKnownColumns(tableName, data);
+    if (Object.keys(filteredData).length === 0) return; // Nothing to update after filtering
+
+    const setColumns: string[] = [];
+    const setValues: QueryValues = [];
+    let paramIndex = 1;
+
+    Object.entries(filteredData).forEach(([key, value]) => {
+      const parsedKey = parseSqlIdentifier(key, 'column name');
+      setColumns.push(`"${parsedKey}" = $${paramIndex++}`);
+      setValues.push(this.prepareValue(value, key, tableName));
+    });
+
+    const whereConditions: string[] = [];
+    const whereValues: QueryValues = [];
+
+    Object.entries(keys).forEach(([key, value]) => {
+      const parsedKey = parseSqlIdentifier(key, 'column name');
+      whereConditions.push(`"${parsedKey}" = $${paramIndex++}`);
+      whereValues.push(this.prepareValue(value, key, tableName));
+    });
+
+    const tableName_ = getTableName({
+      indexName: tableName,
+      schemaName: getSchemaName(this.schemaName),
+    });
+
+    const sql = `UPDATE ${tableName_} SET ${setColumns.join(', ')} WHERE ${whereConditions.join(' AND ')}`;
+    const values = [...setValues, ...whereValues];
+
+    await client.none(sql, values);
   }
 }

--- a/stores/pg/src/storage/db/transaction-client.test.ts
+++ b/stores/pg/src/storage/db/transaction-client.test.ts
@@ -1,0 +1,106 @@
+import { TABLE_THREADS } from '@mastra/core/storage';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DbClient, QueryValues, TxClient } from '../client';
+import { PgDB } from './index';
+
+function createMockTxClient(onNone: (query: string, values?: QueryValues) => Promise<null>): TxClient {
+  return {
+    none: vi.fn(onNone),
+    one: vi.fn(async () => {
+      throw new Error('Unexpected tx.one call');
+    }),
+    oneOrNone: vi.fn(async () => {
+      throw new Error('Unexpected tx.oneOrNone call');
+    }),
+    any: vi.fn(async () => {
+      throw new Error('Unexpected tx.any call');
+    }),
+    manyOrNone: vi.fn(async () => {
+      throw new Error('Unexpected tx.manyOrNone call');
+    }),
+    many: vi.fn(async () => {
+      throw new Error('Unexpected tx.many call');
+    }),
+    query: vi.fn(async () => {
+      throw new Error('Unexpected tx.query call');
+    }),
+    batch: vi.fn(async <T>(promises: Promise<T>[]) => Promise.all(promises)),
+  } as TxClient;
+}
+
+function createMockDbClient(
+  txClient: TxClient,
+): DbClient & { querySpy: ReturnType<typeof vi.fn>; txSpy: ReturnType<typeof vi.fn> } {
+  const querySpy = vi.fn(async () => ({ rows: [] }) as any);
+  const txSpy = vi.fn(async <T>(callback: (t: TxClient) => Promise<T>) => callback(txClient));
+
+  return {
+    $pool: {} as any,
+    connect: vi.fn(async () => {
+      throw new Error('Unexpected connect call');
+    }),
+    none: vi.fn(async () => {
+      throw new Error('Unexpected none call');
+    }),
+    one: vi.fn(async () => {
+      throw new Error('Unexpected one call');
+    }),
+    oneOrNone: vi.fn(async () => null),
+    any: vi.fn(async () => []),
+    manyOrNone: vi.fn(async () => []),
+    many: vi.fn(async () => []),
+    query: querySpy,
+    tx: txSpy,
+    querySpy,
+    txSpy,
+  } as DbClient & { querySpy: ReturnType<typeof vi.fn>; txSpy: ReturnType<typeof vi.fn> };
+}
+
+describe('PgDB transaction handling', () => {
+  it('uses tx() for batchInsert instead of manual BEGIN/COMMIT/ROLLBACK queries', async () => {
+    const txStatements: string[] = [];
+    const txClient = createMockTxClient(async query => {
+      txStatements.push(query);
+      return null;
+    });
+    const client = createMockDbClient(txClient);
+    const db = new PgDB({ client });
+
+    await db.batchInsert({
+      tableName: TABLE_THREADS,
+      records: [
+        { id: 'thread-1', resourceId: 'resource-1', title: 'One', createdAt: new Date('2024-01-01T00:00:00.000Z') },
+        { id: 'thread-2', resourceId: 'resource-1', title: 'Two', createdAt: new Date('2024-01-01T00:00:01.000Z') },
+      ],
+    });
+
+    expect(client.txSpy).toHaveBeenCalledOnce();
+    expect(client.querySpy).not.toHaveBeenCalled();
+    expect(txStatements).toHaveLength(2);
+    expect(txStatements.every(query => query.startsWith('INSERT INTO'))).toBe(true);
+  });
+
+  it('uses tx() for batchUpdate instead of manual BEGIN/COMMIT/ROLLBACK queries', async () => {
+    const txStatements: string[] = [];
+    const txClient = createMockTxClient(async query => {
+      txStatements.push(query);
+      return null;
+    });
+    const client = createMockDbClient(txClient);
+    const db = new PgDB({ client });
+
+    await db.batchUpdate({
+      tableName: TABLE_THREADS,
+      updates: [
+        { keys: { id: 'thread-1' }, data: { title: 'Updated one' } },
+        { keys: { id: 'thread-2' }, data: { title: 'Updated two' } },
+      ],
+    });
+
+    expect(client.txSpy).toHaveBeenCalledOnce();
+    expect(client.querySpy).not.toHaveBeenCalled();
+    expect(txStatements).toHaveLength(2);
+    expect(txStatements.every(query => query.startsWith('UPDATE'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Fixes `@mastra/pg` batch writes so `batchInsert` and `batchUpdate` run on a single connection-scoped transaction via `tx()`. Adds a regression test that fails on the old pool-scoped transaction behavior and passes with the fix. Includes the patch changeset for `@mastra/pg`.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR fixes a bug where batch database write operations (inserting or updating multiple records at once) were accidentally leaving database connections open. The fix ensures all operations in a batch stay on a single connection from start to finish, preventing idle transactions from being left hanging.

---

## Overview

This is a bug fix for the `@mastra/pg` package that addresses transaction handling in batch write operations. The changes ensure that `batchInsert` and `batchUpdate` operations execute within a single connection-scoped transaction, preventing connection leaks that occurred under the previous pool-scoped transaction behavior.

---

## Changes

### Core Fix: Transaction Handling (`stores/pg/src/storage/db/index.ts`)

**Introduced private helper methods:**
- `executeInsert`: Encapsulates SQL construction and execution for insert operations, accepting either a base `DbClient` or transaction-scoped `TxClient`
- `executeUpdate`: Encapsulates SQL construction and execution for update operations with the same client flexibility

**Refactored batch operations to use explicit transactions:**
- `batchInsert` now wraps all inserts in `this.client.tx(async tx => ...)` and calls `executeInsert(tx, ...)` for each operation
- `batchUpdate` now wraps all updates in `this.client.tx(async tx => ...)` and calls `executeUpdate(tx, ...)` for each operation
- Removed manual `BEGIN/COMMIT/ROLLBACK` logic from both methods

**Refactored single-record operations:**
- `insert` delegates to `executeInsert(this.client, ...)`, preserving the existing special-case `ON CONFLICT ("traceId","spanId")` behavior for `TABLE_SPANS`
- `update` delegates to `executeUpdate(this.client, ...)`

### Test Coverage (`stores/pg/src/storage/db/transaction-client.test.ts`)

Added comprehensive regression tests that verify:
- `PgDB.batchInsert` calls `db.tx()` exactly once and executes all INSERT statements within a single transaction
- `PgDB.batchUpdate` calls `db.tx()` exactly once and executes all UPDATE statements within a single transaction
- No queries execute outside the transaction scope

The tests use mock clients with spies to strictly enforce that batch operations follow the intended transaction code paths.

### Changeset Entry

Added a patch-level changeset for `@mastra/pg` documenting the fix to batch insert and update transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->