### PR TITLE
fix(editor): fork agent instead of mutating singleton in applyStoredOverrides

### DIFF
--- a/.changeset/fruity-paws-run.md
+++ b/.changeset/fruity-paws-run.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added internal `__fork()` method to Agent class for creating lightweight clones with independent instructions and tools.

--- a/.changeset/fruity-paws-run.md
+++ b/.changeset/fruity-paws-run.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Added internal `__fork()` method to Agent class for creating lightweight clones with independent instructions and tools.
+Agent instances can now create lightweight clones that preserve all configuration, so version overrides and tools are isolated without mutating the shared runtime agent.

--- a/.changeset/lovely-pandas-stick.md
+++ b/.changeset/lovely-pandas-stick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/editor': patch
+---
+
+Fixed agent version resolution to no longer mutate the singleton agent instance. `applyStoredOverrides` now forks the agent before applying overrides, making concurrent versioned agent resolution safe.

--- a/.changeset/lovely-pandas-stick.md
+++ b/.changeset/lovely-pandas-stick.md
@@ -2,4 +2,4 @@
 '@mastra/editor': patch
 ---
 
-Fixed agent version resolution to no longer mutate the singleton agent instance. `applyStoredOverrides` now forks the agent before applying overrides, making concurrent versioned agent resolution safe.
+Resolving stored agent versions no longer mutates the shared singleton agent instance. Instruction and tool overrides are now applied to an isolated clone, making concurrent version resolution safe and preventing overrides from leaking onto the global agent.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1962,6 +1962,15 @@ export class Agent<
       rawConfig: this.toRawConfig(),
     });
 
+    // Preserve runtime registrations that may have been applied after construction
+    // (e.g. when Mastra registers agents via __registerMastra / __registerPrimitives)
+    if (this.#mastra && !this.#config.mastra) {
+      fork.__registerMastra(this.#mastra);
+    }
+    if (this.#primitives) {
+      fork.__registerPrimitives(this.#primitives);
+    }
+
     fork.source = this.source;
     fork._agentNetworkAppend = this._agentNetworkAppend;
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -186,6 +186,7 @@ export class Agent<
   #requestContextSchema?: StandardSchemaWithJSON<TRequestContext>;
   readonly #options?: AgentCreateOptions;
   #legacyHandler?: AgentLegacyHandler;
+  #config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext>;
 
   // This flag is for agent network messages. We should change the agent network formatting and remove this flag after.
   private _agentNetworkAppend = false;
@@ -211,6 +212,8 @@ export class Agent<
    */
   constructor(config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext>) {
     super({ component: RegisteredLogger.AGENT, rawConfig: config.rawConfig });
+
+    this.#config = config;
 
     this.name = config.name;
     this.id = config.id ?? config.name;
@@ -1955,32 +1958,8 @@ export class Agent<
    */
   __fork(): Agent<TAgentId, TTools, TOutput, TRequestContext> {
     const fork = new Agent<TAgentId, TTools, TOutput, TRequestContext>({
-      id: this.id,
-      name: this.name,
-      description: this.#description,
-      instructions: this.#instructions,
-      model: this.model,
-      maxRetries: this.maxRetries,
-      tools: this.#tools,
-      workflows: this.#workflows,
-      defaultGenerateOptionsLegacy: this.#defaultGenerateOptionsLegacy,
-      defaultStreamOptionsLegacy: this.#defaultStreamOptionsLegacy,
-      defaultOptions: this.#defaultOptions,
-      defaultNetworkOptions: this.#defaultNetworkOptions,
-      mastra: this.#mastra,
-      agents: this.#agents,
-      scorers: this.#scorers,
-      memory: this.#memory,
-      skillsFormat: this.#skillsFormat,
-      browser: this.#browser,
-      workspace: this.#workspace,
-      inputProcessors: this.#inputProcessors,
-      outputProcessors: this.#outputProcessors,
-      maxProcessorRetries: this.#maxProcessorRetries,
-      options: this.#options,
+      ...this.#config,
       rawConfig: this.toRawConfig(),
-      // voice and channels are intentionally omitted — the fork gets a
-      // DefaultVoice and no channels, which is fine for versioned resolution.
     });
 
     fork.source = this.source;

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1947,6 +1947,48 @@ export class Agent<
     this.#tools = tools as DynamicArgument<TTools, TRequestContext>;
   }
 
+  /**
+   * Create a lightweight clone of this agent that can be independently mutated
+   * without affecting the original instance. Used by the editor to apply
+   * version overrides without mutating the singleton agent.
+   * @internal
+   */
+  __fork(): Agent<TAgentId, TTools, TOutput, TRequestContext> {
+    const fork = new Agent<TAgentId, TTools, TOutput, TRequestContext>({
+      id: this.id,
+      name: this.name,
+      description: this.#description,
+      instructions: this.#instructions,
+      model: this.model,
+      maxRetries: this.maxRetries,
+      tools: this.#tools,
+      workflows: this.#workflows,
+      defaultGenerateOptionsLegacy: this.#defaultGenerateOptionsLegacy,
+      defaultStreamOptionsLegacy: this.#defaultStreamOptionsLegacy,
+      defaultOptions: this.#defaultOptions,
+      defaultNetworkOptions: this.#defaultNetworkOptions,
+      mastra: this.#mastra,
+      agents: this.#agents,
+      scorers: this.#scorers,
+      memory: this.#memory,
+      skillsFormat: this.#skillsFormat,
+      browser: this.#browser,
+      workspace: this.#workspace,
+      inputProcessors: this.#inputProcessors,
+      outputProcessors: this.#outputProcessors,
+      maxProcessorRetries: this.#maxProcessorRetries,
+      options: this.#options,
+      rawConfig: this.toRawConfig(),
+      // voice and channels are intentionally omitted — the fork gets a
+      // DefaultVoice and no channels, which is fine for versioned resolution.
+    });
+
+    fork.source = this.source;
+    fork._agentNetworkAppend = this._agentNetworkAppend;
+
+    return fork;
+  }
+
   async generateTitleFromUserMessage({
     message,
     requestContext = new RequestContext(),

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1962,13 +1962,15 @@ export class Agent<
       rawConfig: this.toRawConfig(),
     });
 
-    // Preserve runtime registrations that may have been applied after construction
-    // (e.g. when Mastra registers agents via __registerMastra / __registerPrimitives)
+    // Preserve runtime state that may have been set after construction
+    // (e.g. when Mastra registers agents via __registerMastra / __registerPrimitives).
+    // Assign fields directly to avoid re-triggering tool/processor registration
+    // side effects that __registerMastra would cause.
     if (this.#mastra && !this.#config.mastra) {
-      fork.__registerMastra(this.#mastra);
+      fork.#mastra = this.#mastra;
     }
     if (this.#primitives) {
-      fork.__registerPrimitives(this.#primitives);
+      fork.#primitives = this.#primitives;
     }
 
     fork.source = this.source;

--- a/packages/editor/src/apply-stored-overrides.test.ts
+++ b/packages/editor/src/apply-stored-overrides.test.ts
@@ -93,7 +93,7 @@ describe('applyStoredOverrides', () => {
     expect(result).toBe(agent);
   });
 
-  it('mutates the same agent instance (does not create a new one)', async () => {
+  it('returns a forked agent instance (does not mutate the original)', async () => {
     const { editor, codeAgent } = await setup({
       name: 'Stored Agent',
       instructions: 'Updated instructions.',
@@ -102,8 +102,17 @@ describe('applyStoredOverrides', () => {
 
     const result = await editor.agent.applyStoredOverrides(codeAgent);
 
-    // Should be the same object reference
-    expect(result).toBe(codeAgent);
+    // Should be a different object reference — the original is not mutated
+    expect(result).not.toBe(codeAgent);
+    expect(result.id).toBe(codeAgent.id);
+
+    // Original agent should retain its code-defined instructions
+    const originalInstructions = await codeAgent.getInstructions();
+    expect(originalInstructions).toBe('You are a code-defined agent.');
+
+    // Forked agent should have the overridden instructions
+    const forkedInstructions = await result.getInstructions();
+    expect(forkedInstructions).toBe('Updated instructions.');
   });
 
   it('resolves with the published (active) version when status is "published"', async () => {

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -44,16 +44,6 @@ import { CrudEditorNamespace } from './base';
 import type { StorageAdapter } from './base';
 import { EditorMCPNamespace } from './mcp';
 
-/**
- * Stores original code-defined agent field values before stored overrides are applied,
- * so they can be restored if the stored config is later removed.
- * Only instructions and tools are tracked — these are the only fields that
- * `applyStoredOverrides` mutates.
- */
-type AgentOverridableFields = Pick<ReturnType<Agent['__getOverridableFields']>, 'instructions' | 'tools'>;
-
-const codeDefaults = new WeakMap<Agent, AgentOverridableFields>();
-
 export class EditorAgentNamespace extends CrudEditorNamespace<
   StorageCreateAgentInput,
   StorageUpdateAgentInput,
@@ -183,13 +173,6 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
    * they may contain SDK instances or dynamic functions that cannot be safely serialized.
    * Returns the (possibly mutated) agent.
    */
-  private clearResolvedVersionId(agent: Agent): void {
-    const raw = agent.toRawConfig();
-    if (!raw || !('resolvedVersionId' in raw)) return;
-    const { resolvedVersionId: _removed, ...rest } = raw;
-    agent.__setRawConfig(rest);
-  }
-
   async applyStoredOverrides(
     agent: Agent,
     options?: { status?: 'draft' | 'published' } | { versionId: string },
@@ -208,32 +191,22 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
       if (options && 'versionId' in options) {
         throw error;
       }
-      // Editor not registered, storage not available, or agent not found — restore and return unchanged
-      this.restoreCodeDefaults(agent);
-      this.clearResolvedVersionId(agent);
+      // Editor not registered, storage not available, or agent not found — return unchanged
       return agent;
     }
 
     if (!storedConfig) {
-      // No stored config — restore code defaults if previously overridden
-      this.restoreCodeDefaults(agent);
-      this.clearResolvedVersionId(agent);
       return agent;
     }
 
     // If requesting published status but no version has been published, don't override the code-defined agent
     const requestedPublished = options && !('versionId' in options) && options.status === 'published';
     if (requestedPublished && !storedConfig.activeVersionId) {
-      this.restoreCodeDefaults(agent);
-      this.clearResolvedVersionId(agent);
       return agent;
     }
 
-    // Save the original code-defined values before first override,
-    // then restore to a clean state before re-applying (so updated stored configs work correctly)
-    this.saveCodeDefaults(agent);
-    this.restoreCodeDefaults(agent);
-    this.saveCodeDefaults(agent);
+    // Fork the agent so overrides don't mutate the singleton instance
+    const fork = agent.__fork();
 
     this.logger?.debug(`[applyStoredOverrides] Applying stored overrides to code agent "${agent.id}"`);
 
@@ -241,7 +214,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
     if (storedConfig.instructions !== undefined && storedConfig.instructions !== null) {
       const resolved = this.resolveStoredInstructions(storedConfig.instructions);
       if (resolved !== undefined) {
-        agent.__updateInstructions(resolved);
+        fork.__updateInstructions(resolved);
       }
     }
 
@@ -260,7 +233,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
 
       if (isDynamicTools) {
         // Wrap in a dynamic function that merges at request time
-        const originalTools = agent.listTools.bind(agent);
+        const originalTools = fork.listTools.bind(fork);
         const toolsFn = async ({ requestContext }: { requestContext: RequestContext }): Promise<ToolsInput> => {
           const codeTools = await originalTools({ requestContext });
           const ctx = requestContext.toJSON();
@@ -293,10 +266,10 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
 
           return { ...codeTools, ...registryTools, ...mcpTools, ...integrationTools };
         };
-        agent.__setTools(toolsFn);
+        fork.__setTools(toolsFn);
       } else {
         // Static tools — resolve once and merge
-        const codeTools = await agent.listTools();
+        const codeTools = await fork.listTools();
         const registryTools = this.resolveStoredTools(
           storedConfig.tools as Record<string, StorageToolConfig> | undefined,
         );
@@ -306,48 +279,17 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
         const integrationTools = await this.resolveStoredIntegrationTools(
           storedConfig.integrationTools as Record<string, StorageMCPClientToolsConfig> | undefined,
         );
-        agent.__setTools({ ...codeTools, ...registryTools, ...mcpTools, ...integrationTools });
+        fork.__setTools({ ...codeTools, ...registryTools, ...mcpTools, ...integrationTools });
       }
     }
 
     // Persist the resolved version ID so it can be read by span attributes / handlers
     if (storedConfig.resolvedVersionId) {
-      const existing = agent.toRawConfig() ?? {};
-      agent.__setRawConfig({ ...existing, resolvedVersionId: storedConfig.resolvedVersionId });
-    } else {
-      this.clearResolvedVersionId(agent);
+      const existing = fork.toRawConfig() ?? {};
+      fork.__setRawConfig({ ...existing, resolvedVersionId: storedConfig.resolvedVersionId });
     }
 
-    return agent;
-  }
-
-  /**
-   * Save the agent's current field values to the module-level WeakMap
-   * so they can be restored if the stored config is later removed.
-   * Only saves on the first call (guards against overwriting originals with overridden values).
-   *
-   * Only instructions and tools are saved — these are the only fields
-   * that `applyStoredOverrides` mutates.
-   */
-  private saveCodeDefaults(agent: Agent): void {
-    if (codeDefaults.has(agent)) return;
-    const fields = agent.__getOverridableFields();
-    codeDefaults.set(agent, {
-      instructions: fields.instructions,
-      tools: fields.tools,
-    });
-  }
-
-  /**
-   * Restore the agent's original code-defined field values from the WeakMap.
-   * Clears the saved snapshot afterward.
-   */
-  private restoreCodeDefaults(agent: Agent): void {
-    const saved = codeDefaults.get(agent);
-    if (!saved) return;
-    agent.__updateInstructions(saved.instructions);
-    agent.__setTools(saved.tools);
-    codeDefaults.delete(agent);
+    return fork;
   }
 
   // ============================================================================


### PR DESCRIPTION
`applyStoredOverrides` was mutating the singleton agent instance in-place via `__setRawConfig()`, `__updateInstructions()`, and `__setTools()`. This meant concurrent versioned agent resolution could race on the same instance, producing unpredictable results.

Now it forks the agent first via a new `Agent.__fork()` method, applies overrides to the fork, and returns it — the original singleton is never touched.

```ts
// Before: mutates and returns the same instance
const result = await applyStoredOverrides(agent, ...);
result === agent; // true — same object, now mutated

// After: forks and returns a new instance
const result = await applyStoredOverrides(agent, ...);
result === agent; // false — independent copy with overrides applied
```

Also removes the `codeDefaults` WeakMap and the save/restore pattern since they are no longer needed when the original is never mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Before, changing an agent for one use would change it for everyone. Now, stored changes are applied to a fresh copy of the agent, leaving the original singleton untouched so concurrent users don't interfere.

## Overview

This PR prevents race/leak bugs caused by mutating the shared singleton agent when applying stored overrides. It adds Agent.__fork(), which creates a lightweight clone of an agent seeded from its stored config and current rawConfig; applyStoredOverrides() now forks the agent, applies instruction/tool/version overrides to the fork, and returns the fork. Because the original singleton is no longer mutated, the previous WeakMap save/restore pattern has been removed. __fork() preserves runtime-registered state (mastra/primitives) and other mutable runtime fields by assigning private fields directly rather than re-running registration logic, avoiding duplicate registrations and side effects.

## Changes

- packages/core
  - Agent: added a private stored #config field and a new internal method __fork(): Agent<...>.
  - __fork() seeds a new Agent from #config and the agent's current toRawConfig(), copies mutable runtime fields (e.g., source, _agentNetworkAppend), and directly propagates runtime-registered state (#mastra, #primitives) to the fork to preserve behavior without re-registering.

- packages/editor
  - applyStoredOverrides: replaced in-place mutation with forking behavior. After checks, the function calls agent.__fork(), applies instruction/tool/resolvedVersionId overrides to the fork, and returns the fork on success. On failure or when no overrides apply, it returns the original agent unchanged.
  - Removed the codeDefaults WeakMap and helper functions (saveCodeDefaults, restoreCodeDefaults, clearResolvedVersionId) since restore logic is unnecessary when not mutating the singleton.

- tests
  - Updated applyStoredOverrides tests to assert the returned agent is a different object (same id) and that the original agent's instructions remain unchanged while the fork reflects stored overrides.

- release metadata
  - Added patch changesets for @mastra/core and @mastra/editor describing the non-mutating fork behavior.

## Behavioral impact / rationale

- Fixes races/leaks where stored overrides could leak into the shared singleton during concurrent version resolution.
- Forked agents retain runtime registrations and mutable runtime state so they behave like the original without side effects from re-registering.
- Public behavior remains compatible (overrides are applied) while ensuring instance isolation and safer concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->