### PR TITLE
feat(mcp): add requireToolApproval to MCP server configuration

### DIFF
--- a/.changeset/three-bugs-shout.md
+++ b/.changeset/three-bugs-shout.md
@@ -2,23 +2,4 @@
 '@mastra/mcp': minor
 ---
 
-Added `requireToolApproval` option to MCP server configuration. Set it to `true` to require human approval for all tools on a server, or pass a function for dynamic per-tool approval logic.
-
-```ts
-const mcp = new MCPClient({
-  servers: {
-    github: {
-      url: new URL('http://localhost:3000/mcp'),
-      // Require approval for all tools
-      requireToolApproval: true,
-      // Or use a function for dynamic approval
-      requireToolApproval: ({ toolName, args, requestContext }) => {
-        if (toolName === 'list_repos') return false;
-        return requestContext?.userRole !== 'admin';
-      },
-    },
-  },
-});
-```
-
-This integrates with the existing human-in-the-loop approval flow.
+Added `requireToolApproval` option to MCP server configuration for requiring human approval before tool execution. Supports both boolean (all tools) and function (dynamic per-tool logic).

--- a/.changeset/three-bugs-shout.md
+++ b/.changeset/three-bugs-shout.md
@@ -1,0 +1,24 @@
+---
+'@mastra/mcp': minor
+---
+
+Added `requireToolApproval` option to MCP server configuration. Set it to `true` to require human approval for all tools on a server, or pass a function for dynamic per-tool approval logic.
+
+```ts
+const mcp = new MCPClient({
+  servers: {
+    github: {
+      url: new URL('http://localhost:3000/mcp'),
+      // Require approval for all tools
+      requireToolApproval: true,
+      // Or use a function for dynamic approval
+      requireToolApproval: ({ toolName, args, requestContext }) => {
+        if (toolName === 'list_repos') return false;
+        return requestContext?.userRole !== 'admin';
+      },
+    },
+  },
+});
+```
+
+This integrates with the existing human-in-the-loop approval flow.

--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -91,6 +91,23 @@ Visit [Agent Class](/reference/agents/agent) for a full list of configuration op
 
 :::
 
+## Tool approval
+
+You can require human approval before MCP tools are executed by setting `requireToolApproval` on a server definition. This integrates with the existing [human-in-the-loop](/docs/workflows/human-in-the-loop) approval flow.
+
+```typescript
+export const mcp = new MCPClient({
+  servers: {
+    github: {
+      url: new URL('http://localhost:3000/mcp'),
+      requireToolApproval: true,
+    },
+  },
+})
+```
+
+You can also pass a function to decide dynamically per-call. See the [MCPClient reference](/reference/tools/mcp-client#tool-approval) for the full API.
+
 ## Configuring `MCPServer`
 
 To expose agents, tools, and workflows from your Mastra application to external systems over HTTP(S) use the `MCPServer` class. This makes them accessible to any system or agent that supports the protocol.

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -138,8 +138,58 @@ Each server in the `servers` map is configured using the `MastraMCPServerDefinit
     defaultValue: 'true',
     description: 'Whether to enable logging for this server.',
   },
+  {
+    name: 'requireToolApproval',
+    type: 'boolean | (params: RequireToolApprovalContext) => boolean | Promise<boolean>',
+    isOptional: true,
+    description:
+      'Require human approval before executing tools from this server. When set to `true`, all tools require approval. When set to a function, the function is called with the tool name, arguments, and request context to dynamically decide whether approval is needed.',
+  },
 ]}
 />
+
+## Tool approval
+
+Use `requireToolApproval` on a server definition to require human approval before any tool from that server is executed. This works with the existing [human-in-the-loop](/docs/agents/human-in-the-loop) approval flow.
+
+### Require approval for all tools
+
+Set `requireToolApproval` to `true` to require approval for every tool on the server:
+
+```typescript
+const mcp = new MCPClient({
+  servers: {
+    github: {
+      url: new URL('http://localhost:3000/mcp'),
+      requireToolApproval: true,
+    },
+  },
+})
+```
+
+### Dynamic approval with a function
+
+Pass a function to decide per-call whether approval is needed. The function receives the tool name, the arguments the model passed, and any request context from the incoming request:
+
+```typescript
+const mcp = new MCPClient({
+  servers: {
+    github: {
+      url: new URL('http://localhost:3000/mcp'),
+      requireToolApproval: ({ toolName, args, requestContext }) => {
+        // Read-only tools don't need approval
+        if (toolName === 'list_repos') return false
+        // Destructive tools with force flag always need approval
+        if (toolName === 'delete_repo') return args.force === true
+        // Non-admin users need approval for everything else
+        return requestContext?.userRole !== 'admin'
+      },
+    },
+  },
+})
+```
+
+The function can also be async. It receives `requestContext` from the incoming request, which you can use for auth checks or other per-request logic.
 
 ## Methods
 

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -150,7 +150,7 @@ Each server in the `servers` map is configured using the `MastraMCPServerDefinit
 
 ## Tool approval
 
-Use `requireToolApproval` on a server definition to require human approval before any tool from that server is executed. This works with the existing [human-in-the-loop](/docs/agents/human-in-the-loop) approval flow.
+Use `requireToolApproval` on a server definition to require human approval before any tool from that server is executed. This works with the existing [human-in-the-loop](/docs/workflows/human-in-the-loop) approval flow.
 
 ### Require approval for all tools
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -300,6 +300,105 @@ describe('createToolCallStep tool approval workflow', () => {
   });
 });
 
+describe('createToolCallStep needsApprovalFn enriched context', () => {
+  let controller: { enqueue: Mock };
+  let suspend: Mock;
+  let streamState: { serialize: Mock };
+  let messageList: MessageList;
+  let neverResolve: Promise<never>;
+
+  const makeInputData = () => ({
+    toolCallId: 'ctx-call-id',
+    toolName: 'ctx-tool',
+    args: { action: 'delete' },
+  });
+
+  const makeExecuteParams = (overrides: any = {}) => ({
+    ...makeBaseExecuteParams(suspend),
+    writer: new ToolStream({
+      prefix: 'tool',
+      callId: 'ctx-call-id',
+      name: 'ctx-tool',
+      runId: 'ctx-run-id',
+    }),
+    inputData: makeInputData(),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    controller = { enqueue: vi.fn() };
+    neverResolve = new Promise(() => {});
+    suspend = vi.fn().mockReturnValue(neverResolve);
+    streamState = { serialize: vi.fn().mockReturnValue('serialized-state') };
+    messageList = createMessageList();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('should default to requiring approval when needsApprovalFn throws', async () => {
+    const needsApprovalFn = vi.fn().mockImplementation(() => {
+      throw new Error('approval fn error');
+    });
+    const tools = {
+      'ctx-tool': {
+        execute: vi.fn(),
+        requireApproval: true,
+        needsApprovalFn,
+      },
+    };
+
+    const toolCallStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'error-run-id',
+      streamState,
+    });
+
+    const executePromise = toolCallStep.execute(makeExecuteParams());
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    // Should still suspend (default to requiring approval on error)
+    expect(suspend).toHaveBeenCalled();
+    expect(tools['ctx-tool'].execute).not.toHaveBeenCalled();
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('should skip approval when needsApprovalFn returns false', async () => {
+    const needsApprovalFn = vi.fn().mockReturnValue(false);
+    const toolResult = { deleted: true };
+    const tools = {
+      'ctx-tool': {
+        execute: vi.fn().mockResolvedValue(toolResult),
+        requireApproval: true,
+        needsApprovalFn,
+      },
+    };
+
+    const toolCallStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'skip-run-id',
+      streamState,
+    });
+
+    const result = await toolCallStep.execute(makeExecuteParams());
+
+    expect(needsApprovalFn).toHaveBeenCalled();
+    expect(suspend).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      result: toolResult,
+      ...makeInputData(),
+    });
+  });
+});
+
 describe('createToolCallStep provider-executed tools', () => {
   let controller: ReadableStreamDefaultController;
   let suspend: Mock;

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -2329,3 +2329,140 @@ describe('MastraMCPClient - Stdio stderr and cwd forwarding', () => {
     await client.disconnect();
   }, 30000);
 });
+
+describe('MastraMCPClient - requireToolApproval', () => {
+  let testServer: {
+    httpServer: HttpServer;
+    mcpServer: McpServer;
+    serverTransport: StreamableHTTPServerTransport;
+    baseUrl: URL;
+  };
+
+  afterEach(async () => {
+    await testServer?.mcpServer.close().catch(() => {});
+    await testServer?.serverTransport?.close().catch(() => {});
+    testServer?.httpServer.close();
+  });
+
+  it('should set requireApproval=true on all tools when requireToolApproval is true', async () => {
+    testServer = await setupTestServer(false);
+    const client = new InternalMastraMCPClient({
+      name: 'approval-bool-client',
+      server: {
+        url: testServer.baseUrl,
+        requireToolApproval: true,
+      },
+    });
+    await client.connect();
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+    expect(greetTool).toBeDefined();
+    expect(greetTool.requireApproval).toBe(true);
+    // No needsApprovalFn when boolean
+    expect((greetTool as any).needsApprovalFn).toBeUndefined();
+    await client.disconnect();
+  });
+
+  it('should not set requireApproval when requireToolApproval is false', async () => {
+    testServer = await setupTestServer(false);
+    const client = new InternalMastraMCPClient({
+      name: 'approval-false-client',
+      server: {
+        url: testServer.baseUrl,
+        requireToolApproval: false,
+      },
+    });
+    await client.connect();
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+    expect(greetTool).toBeDefined();
+    expect(greetTool.requireApproval).toBe(false);
+    expect((greetTool as any).needsApprovalFn).toBeUndefined();
+    await client.disconnect();
+  });
+
+  it('should not set requireApproval when requireToolApproval is omitted', async () => {
+    testServer = await setupTestServer(false);
+    const client = new InternalMastraMCPClient({
+      name: 'approval-omitted-client',
+      server: {
+        url: testServer.baseUrl,
+      },
+    });
+    await client.connect();
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+    expect(greetTool).toBeDefined();
+    expect(greetTool.requireApproval).toBe(false);
+    expect((greetTool as any).needsApprovalFn).toBeUndefined();
+    await client.disconnect();
+  });
+
+  it('should set requireApproval=true and needsApprovalFn when requireToolApproval is a function', async () => {
+    testServer = await setupTestServer(false);
+    const approvalFn = vi.fn().mockReturnValue(true);
+    const client = new InternalMastraMCPClient({
+      name: 'approval-fn-client',
+      server: {
+        url: testServer.baseUrl,
+        requireToolApproval: approvalFn,
+      },
+    });
+    await client.connect();
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+    expect(greetTool).toBeDefined();
+    expect(greetTool.requireApproval).toBe(true);
+    expect((greetTool as any).needsApprovalFn).toBeTypeOf('function');
+    await client.disconnect();
+  });
+
+  it('should pass toolName and args to the wrapped needsApprovalFn', async () => {
+    testServer = await setupTestServer(false);
+    const approvalFn = vi.fn().mockReturnValue(false);
+    const client = new InternalMastraMCPClient({
+      name: 'approval-fn-args-client',
+      server: {
+        url: testServer.baseUrl,
+        requireToolApproval: approvalFn,
+      },
+    });
+    await client.connect();
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+
+    // Call the wrapped needsApprovalFn directly
+    const testArgs = { name: 'test' };
+    const testCtx = { requestContext: { userId: '123' } };
+    const result = await (greetTool as any).needsApprovalFn(testArgs, testCtx);
+
+    expect(result).toBe(false);
+    expect(approvalFn).toHaveBeenCalledWith({
+      toolName: 'greet',
+      args: testArgs,
+      requestContext: { userId: '123' },
+    });
+    await client.disconnect();
+  });
+
+  it('should support async approval functions', async () => {
+    testServer = await setupTestServer(false);
+    const approvalFn = vi.fn().mockImplementation(async ({ toolName }) => {
+      return toolName === 'greet';
+    });
+    const client = new InternalMastraMCPClient({
+      name: 'approval-async-client',
+      server: {
+        url: testServer.baseUrl,
+        requireToolApproval: approvalFn,
+      },
+    });
+    await client.connect();
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+
+    const result = await (greetTool as any).needsApprovalFn({ name: 'test' }, {});
+    expect(result).toBe(true);
+    await client.disconnect();
+  });
+});

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -2337,8 +2337,10 @@ describe('MastraMCPClient - requireToolApproval', () => {
     serverTransport: StreamableHTTPServerTransport;
     baseUrl: URL;
   };
+  let client: InternalMastraMCPClient;
 
   afterEach(async () => {
+    await client?.disconnect().catch(() => {});
     await testServer?.mcpServer.close().catch(() => {});
     await testServer?.serverTransport?.close().catch(() => {});
     testServer?.httpServer.close();
@@ -2346,7 +2348,7 @@ describe('MastraMCPClient - requireToolApproval', () => {
 
   it('should set requireApproval=true on all tools when requireToolApproval is true', async () => {
     testServer = await setupTestServer(false);
-    const client = new InternalMastraMCPClient({
+    client = new InternalMastraMCPClient({
       name: 'approval-bool-client',
       server: {
         url: testServer.baseUrl,
@@ -2360,12 +2362,11 @@ describe('MastraMCPClient - requireToolApproval', () => {
     expect(greetTool.requireApproval).toBe(true);
     // No needsApprovalFn when boolean
     expect((greetTool as any).needsApprovalFn).toBeUndefined();
-    await client.disconnect();
   });
 
   it('should not set requireApproval when requireToolApproval is false', async () => {
     testServer = await setupTestServer(false);
-    const client = new InternalMastraMCPClient({
+    client = new InternalMastraMCPClient({
       name: 'approval-false-client',
       server: {
         url: testServer.baseUrl,
@@ -2378,12 +2379,11 @@ describe('MastraMCPClient - requireToolApproval', () => {
     expect(greetTool).toBeDefined();
     expect(greetTool.requireApproval).toBe(false);
     expect((greetTool as any).needsApprovalFn).toBeUndefined();
-    await client.disconnect();
   });
 
   it('should not set requireApproval when requireToolApproval is omitted', async () => {
     testServer = await setupTestServer(false);
-    const client = new InternalMastraMCPClient({
+    client = new InternalMastraMCPClient({
       name: 'approval-omitted-client',
       server: {
         url: testServer.baseUrl,
@@ -2395,13 +2395,12 @@ describe('MastraMCPClient - requireToolApproval', () => {
     expect(greetTool).toBeDefined();
     expect(greetTool.requireApproval).toBe(false);
     expect((greetTool as any).needsApprovalFn).toBeUndefined();
-    await client.disconnect();
   });
 
   it('should set requireApproval=true and needsApprovalFn when requireToolApproval is a function', async () => {
     testServer = await setupTestServer(false);
     const approvalFn = vi.fn().mockReturnValue(true);
-    const client = new InternalMastraMCPClient({
+    client = new InternalMastraMCPClient({
       name: 'approval-fn-client',
       server: {
         url: testServer.baseUrl,
@@ -2414,13 +2413,12 @@ describe('MastraMCPClient - requireToolApproval', () => {
     expect(greetTool).toBeDefined();
     expect(greetTool.requireApproval).toBe(true);
     expect((greetTool as any).needsApprovalFn).toBeTypeOf('function');
-    await client.disconnect();
   });
 
   it('should pass toolName and args to the wrapped needsApprovalFn', async () => {
     testServer = await setupTestServer(false);
     const approvalFn = vi.fn().mockReturnValue(false);
-    const client = new InternalMastraMCPClient({
+    client = new InternalMastraMCPClient({
       name: 'approval-fn-args-client',
       server: {
         url: testServer.baseUrl,
@@ -2442,7 +2440,6 @@ describe('MastraMCPClient - requireToolApproval', () => {
       args: testArgs,
       requestContext: { userId: '123' },
     });
-    await client.disconnect();
   });
 
   it('should support async approval functions', async () => {
@@ -2450,7 +2447,7 @@ describe('MastraMCPClient - requireToolApproval', () => {
     const approvalFn = vi.fn().mockImplementation(async ({ toolName }) => {
       return toolName === 'greet';
     });
-    const client = new InternalMastraMCPClient({
+    client = new InternalMastraMCPClient({
       name: 'approval-async-client',
       server: {
         url: testServer.baseUrl,
@@ -2463,6 +2460,5 @@ describe('MastraMCPClient - requireToolApproval', () => {
 
     const result = await (greetTool as any).needsApprovalFn({ name: 'test' }, {});
     expect(result).toBe(true);
-    await client.disconnect();
   });
 });

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -687,17 +687,20 @@ export class InternalMastraMCPClient extends MastraBase {
         let needsApprovalFn: ((args: any, ctx: any) => boolean | Promise<boolean>) | undefined;
 
         if (typeof this.requireToolApproval === 'function') {
-          // Wrap the server-level function to match the per-tool needsApprovalFn signature
-          // (args, ctx) => the server function receives { toolName, args, ...ctx }
+          // Wrap the server-level function to match the per-tool needsApprovalFn signature.
+          // Note: ctx may be undefined when called via network/index.ts (which only passes args).
+          // We default ctx to {} so the spread doesn't fail and approval fn receives partial context.
           const serverApprovalFn = this.requireToolApproval;
           const toolName = tool.name;
           requireApproval = true; // Signal that approval check is needed
-          needsApprovalFn = (args: Record<string, unknown>, ctx: Record<string, unknown>) => {
+          needsApprovalFn = (args: Record<string, unknown>, ctx: Record<string, unknown> = {}) => {
             return serverApprovalFn({ toolName, args, ...ctx });
           };
         } else if (this.requireToolApproval === true) {
           requireApproval = true;
         }
+        // When requireToolApproval is false/undefined, requireApproval stays undefined
+        // and createTool defaults it to false
 
         const mastraTool = createTool({
           id: `${this.name}_${tool.name}`,
@@ -707,7 +710,7 @@ export class InternalMastraMCPClient extends MastraBase {
           // already validates structuredContent against the tool's outputSchema using AJV.
           // Passing it here causes Zod to strip unrecognized keys from the CallToolResult
           // envelope, returning {} for tools without structuredContent.
-          ...(requireApproval !== undefined ? { requireApproval } : {}),
+          requireApproval,
           mcpMetadata: {
             serverName: this.name,
             serverVersion: this.client.getServerVersion()?.version,

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -54,6 +54,7 @@ import type {
   MastraMCPServerDefinition,
   InternalMastraMCPClientOptions,
   Root,
+  RequireToolApproval,
 } from './types';
 
 // Re-export types for convenience
@@ -67,6 +68,9 @@ export type {
   MastraMCPServerDefinition,
   InternalMastraMCPClientOptions,
   Root,
+  RequireToolApproval,
+  RequireToolApprovalFn,
+  RequireToolApprovalContext,
 } from './types';
 
 const DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC = 3000;
@@ -119,6 +123,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private sigTermHandler?: () => void;
   private sigHupHandler?: () => void;
   private _roots: Root[];
+  private readonly requireToolApproval: RequireToolApproval | undefined;
 
   /** Provides access to resource operations (list, read, subscribe, etc.) */
   public readonly resources: ResourceClientActions;
@@ -146,6 +151,7 @@ export class InternalMastraMCPClient extends MastraBase {
     this.enableServerLogs = server.enableServerLogs ?? true;
     this.serverConfig = server;
     this.enableProgressTracking = !!server.enableProgressTracking;
+    this.requireToolApproval = server.requireToolApproval;
 
     // Initialize roots from server config
     this._roots = server.roots ?? [];
@@ -676,6 +682,23 @@ export class InternalMastraMCPClient extends MastraBase {
     for (const tool of tools) {
       this.log('debug', `Processing tool: ${tool.name}`);
       try {
+        // Resolve requireToolApproval for this tool
+        let requireApproval: boolean | undefined;
+        let needsApprovalFn: ((args: any, ctx: any) => boolean | Promise<boolean>) | undefined;
+
+        if (typeof this.requireToolApproval === 'function') {
+          // Wrap the server-level function to match the per-tool needsApprovalFn signature
+          // (args, ctx) => the server function receives { toolName, args, ...ctx }
+          const serverApprovalFn = this.requireToolApproval;
+          const toolName = tool.name;
+          requireApproval = true; // Signal that approval check is needed
+          needsApprovalFn = (args: Record<string, unknown>, ctx: Record<string, unknown>) => {
+            return serverApprovalFn({ toolName, args, ...ctx });
+          };
+        } else if (this.requireToolApproval === true) {
+          requireApproval = true;
+        }
+
         const mastraTool = createTool({
           id: `${this.name}_${tool.name}`,
           description: tool.description || '',
@@ -684,6 +707,7 @@ export class InternalMastraMCPClient extends MastraBase {
           // already validates structuredContent against the tool's outputSchema using AJV.
           // Passing it here causes Zod to strip unrecognized keys from the CallToolResult
           // envelope, returning {} for tools without structuredContent.
+          ...(requireApproval !== undefined ? { requireApproval } : {}),
           mcpMetadata: {
             serverName: this.name,
             serverVersion: this.client.getServerVersion()?.version,
@@ -770,6 +794,12 @@ export class InternalMastraMCPClient extends MastraBase {
             });
           },
         });
+
+        // Set needsApprovalFn directly on the tool instance (same pattern as tool-builder).
+        // This is accessed via (tool as any).needsApprovalFn in tool-call-step.ts.
+        if (needsApprovalFn) {
+          (mastraTool as any).needsApprovalFn = needsApprovalFn;
+        }
 
         if (tool.name) {
           toolsRes[tool.name] = mastraTool;

--- a/packages/mcp/src/client/index.ts
+++ b/packages/mcp/src/client/index.ts
@@ -1,11 +1,14 @@
 export type {
-    LoggingLevel,
-    LogMessage,
-    LogHandler,
-    MastraMCPServerDefinition,
-    ElicitationHandler,
-    ProgressHandler,
-    InternalMastraMCPClientOptions,
+  LoggingLevel,
+  LogMessage,
+  LogHandler,
+  MastraMCPServerDefinition,
+  ElicitationHandler,
+  ProgressHandler,
+  InternalMastraMCPClientOptions,
+  RequireToolApproval,
+  RequireToolApprovalFn,
+  RequireToolApprovalContext,
 } from './types';
 export * from './client';
 export * from './configuration';

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -109,6 +109,34 @@ export interface Root {
 }
 
 /**
+ * Context passed to `requireToolApproval` when it's a function.
+ * Provides information about the tool call and the current execution environment.
+ */
+export interface RequireToolApprovalContext {
+  /** Name of the tool being called */
+  toolName: string;
+  /** Arguments the LLM is passing to the tool */
+  args: Record<string, unknown>;
+  /** Request-scoped context (e.g., user info, auth data) as a plain object */
+  requestContext?: Record<string, unknown>;
+}
+
+/**
+ * Function type for dynamic tool approval logic.
+ * Return `true` to require approval, `false` to allow execution.
+ */
+export type RequireToolApprovalFn = (ctx: RequireToolApprovalContext) => boolean | Promise<boolean>;
+
+/**
+ * Whether tools from this server require explicit user approval before execution.
+ *
+ * - `true`: All tools from this server require approval.
+ * - `false` or omitted: No approval required (default).
+ * - Function: Called per tool invocation to dynamically decide.
+ */
+export type RequireToolApproval = boolean | RequireToolApprovalFn;
+
+/**
  * Base options common to all MCP server definitions.
  */
 export type BaseServerOptions = {
@@ -122,6 +150,27 @@ export type BaseServerOptions = {
   enableServerLogs?: boolean;
   /** Whether to enable progress tracking (default: false) */
   enableProgressTracking?: boolean;
+  /**
+   * Whether tools from this server require explicit user approval before execution.
+   *
+   * - `true`: All tools require approval before running.
+   * - `false` or omitted: Tools run without approval (default).
+   * - Function: Called per tool invocation with context to dynamically decide.
+   *
+   * @example
+   * ```typescript
+   * // Require approval for all tools
+   * requireToolApproval: true
+   *
+   * // Dynamic approval based on tool name or args
+   * requireToolApproval: ({ toolName, args }) => {
+   *   if (toolName === 'list_repos') return false;
+   *   if (toolName === 'delete_repo') return true;
+   *   return false;
+   * }
+   * ```
+   */
+  requireToolApproval?: RequireToolApproval;
   /**
    * List of filesystem roots to expose to the MCP server.
    *


### PR DESCRIPTION
Adds a `requireToolApproval` option to MCP server definitions so you can require human approval for MCP tool calls at the server level.

Supports a boolean for blanket approval, or a function for dynamic per-tool logic:

```ts
const mcp = new MCPClient({
  servers: {
    github: {
      url: new URL('http://localhost:3000/mcp'),
      requireToolApproval: ({ toolName, args, requestContext }) => {
        if (toolName === 'list_repos') return false
        return requestContext?.userRole !== 'admin'
      },
    },
  },
})
```

This hooks into the existing human-in-the-loop approval flow — no changes to the core Tool class or execution pipeline. The MCP client sets `requireApproval` and `needsApprovalFn` on tool instances directly (same pattern as the AI SDK tool-builder).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a server-level "ask a human first" setting for MCP servers so tool calls can require human approval; it can apply to all tools or decide per-call with a function.

---

## Summary

Adds requireToolApproval to MCP server definitions in @mastra/mcp to enable server-level human approval gating for MCP tool calls. The option accepts:
- a boolean: true requires approval for all tools, false/omitted means no approval; or
- a function (sync or async) called per invocation with { toolName, args, requestContext } that returns a boolean to decide whether approval is required.

The MCP client translates server-level requireToolApproval into per-tool properties (requireApproval and an attached needsApprovalFn) so the existing human-in-the-loop approval flow is reused without changing the Tool class or core execution pipeline.

### Key Changes

- Types
  - New types in packages/mcp/src/client/types.ts:
    - RequireToolApprovalContext
    - RequireToolApprovalFn
    - RequireToolApproval (boolean | function)
  - BaseServerOptions now includes requireToolApproval?: RequireToolApproval.

- MCP Client
  - InternalMastraMCPClient stores server.requireToolApproval and computes per-tool approval settings when creating tools.
  - When requireToolApproval is a function, the client wraps it into a needsApprovalFn that forwards { toolName, args, requestContext } (defaults requestContext to {} when absent) and sets requireApproval = true.
  - When requireToolApproval is true, requireApproval is set to true with no custom needsApprovalFn.
  - When unset/false, requireApproval is left undefined so tools default to no approval enforcement.
  - The computed requireApproval is passed into createTool, and the computed needsApprovalFn (when present) is attached to the tool instance for downstream use.

- Execution Flow Integration
  - Wires server-level config into existing approval suspension/resume logic. Tool-call step tests exercise behavior when needsApprovalFn is present (suspends on throw, proceeds when it returns false).

- Documentation & Changeset
  - docs updated: new "Tool approval" section in MCP overview and MCPClient reference with examples for static and dynamic configuration.
  - Added changeset documenting the new option.

- Tests
  - New tests in packages/mcp/src/client/client.test.ts covering boolean and function variants (including async) and verifying needsApprovalFn is set and gets correct context.
  - Extended core tool-call-step tests to verify behavior when needsApprovalFn is present.

### Commit / Implementation notes

- Small robustness/follow-up fixes: the wrapper defaults ctx/requestContext to {} to support network-path callers, added comments documenting the ctx limitation and false/undefined fall-through behavior, and simplified the tool-creation wiring to use a plain requireApproval property.
- No changes to the public Tool class or core execution pipeline APIs; changes are types, client wiring, docs, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->