### PR TITLE
fix(observability): prevent Anthropic cache token double-counting

### DIFF
--- a/.changeset/afraid-poems-sit.md
+++ b/.changeset/afraid-poems-sit.md
@@ -2,4 +2,4 @@
 '@mastra/observability': patch
 ---
 
-Fixed Anthropic cache tokens being double-counted in usage metrics when the raw usage structure is absent
+Fixed double-counting of Anthropic cache tokens in usage metrics

--- a/.changeset/afraid-poems-sit.md
+++ b/.changeset/afraid-poems-sit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed Anthropic cache tokens being double-counted in usage metrics when the raw usage structure is absent

--- a/observability/mastra/src/usage.test.ts
+++ b/observability/mastra/src/usage.test.ts
@@ -151,6 +151,27 @@ describe('extractUsageMetrics', () => {
       expect(result.outputDetails?.text).toBe(50);
     });
 
+    it('should not double count Anthropic cache tokens when raw field is absent but cachedInputTokens is set', () => {
+      const usage = {
+        inputTokens: 3493,
+        outputTokens: 125,
+        cachedInputTokens: 3170,
+      } as LanguageModelUsage;
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          cacheReadInputTokens: 3170,
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(3493);
+      expect(result.inputDetails?.text).toBe(323);
+      expect(result.inputDetails?.cacheRead).toBe(3170);
+      expect(result.outputTokens).toBe(125);
+    });
+
     it('should not double count Anthropic cache tokens when v6 usage already includes them', () => {
       const usage: LanguageModelUsage = {
         inputTokens: 106,

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -127,9 +127,12 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
       inputDetails.cacheWrite = anthropic.cacheCreationInputTokens;
     }
 
-    // AI SDK v6-style usage already provides total input tokens including cache details,
-    // so avoid adding cache tokens on top of an already-totaled input count.
-    if (!hasV3CachedTotals && (isDefined(inputDetails.cacheRead) || isDefined(inputDetails.cacheWrite))) {
+    // Skip adjustment when inputTokens already includes cache tokens.
+    // Detected via V3 raw structure or a positive cachedInputTokens field.
+    const inputAlreadyIncludesCache =
+      hasV3CachedTotals || (isDefined(usage.cachedInputTokens) && usage.cachedInputTokens > 0);
+
+    if (!inputAlreadyIncludesCache && (isDefined(inputDetails.cacheRead) || isDefined(inputDetails.cacheWrite))) {
       inputTokens = (usage.inputTokens ?? 0) + (inputDetails.cacheRead ?? 0) + (inputDetails.cacheWrite ?? 0);
     }
   }


### PR DESCRIPTION
## Description

Fixes Anthropic cache tokens being double-counted in `extractUsageMetrics`, which caused inflated `inputTokens` and incorrect `inputDetails.text` values for Anthropic models with prompt caching enabled.

- The Anthropic cache adjustment in `extractUsageMetrics` relied solely on `usage.raw` (V3 structure) to detect whether `inputTokens` already includes cache tokens
- `RunOutput.updateUsageCount()` drops the `raw` field when accumulating `totalUsage`, so the V3 detection failed and cache tokens were added a second time
- Added `usage.cachedInputTokens > 0` as a fallback signal — this field survives `RunOutput` accumulation and is always set alongside a pre-totaled `inputTokens`
- Added a test covering the exact scenario where `raw` is absent but `cachedInputTokens` is present

## Related Issue(s)

Fixes #15308

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When Anthropic prompt caching was used, cached tokens were sometimes counted twice, inflating reported token usage; this change makes the metrics logic detect cached tokens even when some internal raw fields are missing so cached tokens are only counted once.

## Summary of changes

- Added a fallback detection in extractUsageMetrics so Anthropic cache tokens are not double-counted when the V3 raw usage structure is unavailable but usage.cachedInputTokens is present.
- Added a unit test that reproduces the scenario where usage.raw is absent but usage.cachedInputTokens exists and verifies no double-counting occurs.
- Added a changeset entry for a patch release to @mastra/observability describing the fix.

Files changed:
- observability/mastra/src/usage.ts
  - Introduced inputAlreadyIncludesCache (uses hasV3CachedTotals OR usage.cachedInputTokens > 0) to decide whether to add providerMetadata.anthropic cacheRead/cacheWrite to usage.inputTokens.
  - Keeps behavior for AI SDK aggregated inputTokenDetails and provider-specific metadata while preventing double-counting when RunOutput accumulation removed raw.
- observability/mastra/src/usage.test.ts
  - New Vitest case: "should not double count Anthropic cache tokens when raw field is absent but cachedInputTokens is set" asserting:
    - inputTokens remains the original usage.inputTokens
    - inputDetails.text equals inputTokens minus cacheRead
    - inputDetails.cacheRead equals the providerMetadata value
- .changeset/afraid-poems-sit.md
  - Patch changeset noting the fix.

## Root cause

extractUsageMetrics previously relied solely on V3-style usage.raw to detect when inputTokens already included cache tokens. RunOutput.updateUsageCount() can drop usage.raw during accumulation, causing the V3-based detection to fail and cached tokens to be added a second time.

## Fix approach

Use usage.cachedInputTokens > 0 as a fallback signal (it survives RunOutput accumulation and is present alongside pre-totaled inputTokens) so extractUsageMetrics correctly detects when inputTokens already include cache tokens and avoids adding providerMetadata.anthropic cacheRead/cacheWrite again.

## Linked issue

Addresses and fixes issue #15308.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->