### PR TITLE
fix(channels): support serverless cold starts for webhook handlers

### DIFF
--- a/.changeset/vast-masks-juggle.md
+++ b/.changeset/vast-masks-juggle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Channels not working on Vercel serverless (and other serverless platforms). Webhook handlers now await initialization on cold starts instead of immediately returning 503, and pass the platform's `waitUntil` to the Chat SDK so agent processing survives after the HTTP response is sent. See #15300.

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -343,6 +343,8 @@ async function headContentType(url: string, logger?: IMastraLogger): Promise<str
 export class AgentChannels {
   readonly adapters: Record<string, Adapter>;
   private chat: Chat | null = null;
+  /** Stored initialization promise so webhook handlers can await readiness on serverless cold starts. */
+  private initPromise: Promise<void> | null = null;
   private agent!: Agent<any, any, any, any>;
   private logger?: IMastraLogger;
   private customState: StateAdapter | undefined;
@@ -409,6 +411,19 @@ export class AgentChannels {
   __setLogger(logger: IMastraLogger): void {
     this.logger =
       'child' in logger && typeof (logger as any).child === 'function' ? (logger as any).child('CHANNEL') : logger;
+  }
+
+  /**
+   * Begin initialization and store the promise so webhook handlers can
+   * await readiness on serverless cold starts instead of returning 503.
+   * @internal Called by Mastra.addAgent.
+   */
+  __startInitialize(mastra: Mastra): void {
+    const promise = this.initialize(mastra);
+    // Attach a no-op catch to prevent unhandled rejection warnings.
+    // Errors are re-surfaced when the webhook handler awaits initPromise.
+    promise.catch(() => {});
+    this.initPromise = promise;
   }
 
   /**
@@ -679,6 +694,16 @@ export class AgentChannels {
         requiresAuth: false,
         createHandler: async () => {
           return async c => {
+            // Await initialization to handle serverless cold starts where
+            // the first request arrives before initialize() completes.
+            if (self.initPromise) {
+              try {
+                await self.initPromise;
+              } catch {
+                return c.json({ error: 'Chat initialization failed' }, 503);
+              }
+            }
+
             const sdkInstance = self.chat;
             if (!sdkInstance) {
               return c.json({ error: 'Chat not initialized' }, 503);
@@ -688,7 +713,12 @@ export class AgentChannels {
             if (!webhookHandler) {
               return c.json({ error: `No webhook handler for ${platform}` }, 404);
             }
-            return webhookHandler(c.req.raw);
+
+            // Pass platform execution context (e.g. Vercel/Cloudflare waitUntil)
+            // to the Chat SDK so background processing survives serverless responses.
+            const execCtx = c.executionCtx as { waitUntil?: (p: Promise<unknown>) => void } | undefined;
+            const waitUntilFn = execCtx?.waitUntil?.bind(execCtx);
+            return webhookHandler(c.req.raw, waitUntilFn ? { waitUntil: waitUntilFn } : undefined);
           };
         },
       });

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -414,19 +414,6 @@ export class AgentChannels {
   }
 
   /**
-   * Begin initialization and store the promise so webhook handlers can
-   * await readiness on serverless cold starts instead of returning 503.
-   * @internal Called by Mastra.addAgent.
-   */
-  __startInitialize(mastra: Mastra): void {
-    const promise = this.initialize(mastra);
-    // Attach a no-op catch to prevent unhandled rejection warnings.
-    // Errors are re-surfaced when the webhook handler awaits initPromise.
-    promise.catch(() => {});
-    this.initPromise = promise;
-  }
-
-  /**
    * Get the underlying Chat SDK instance.
    * Available after Mastra initialization. Use this to register additional
    * event handlers or access adapter-specific methods.
@@ -447,232 +434,246 @@ export class AgentChannels {
    * Called by Mastra.addAgent after the server is ready.
    */
   async initialize(mastra: Mastra): Promise<void> {
-    // Resolve state adapter: custom > Mastra storage > in-memory fallback
-    if (this.customState) {
-      this.stateAdapter = this.customState;
-    } else {
-      const storage = mastra.getStorage();
-      const memoryStore = storage ? await storage.getStore('memory') : undefined;
-      if (!memoryStore) {
-        throw new Error(
-          'Channels require storage to be configured on the Mastra instance. Configure a storage provider like LibSQLStore.',
-        );
-      }
-      this.stateAdapter = new MastraStateAdapter(memoryStore);
-      this.log('info', 'Using MastraStateAdapter (subscriptions persist across restarts)');
+    if (this.chat) return;
+    if (this.initPromise) {
+      return this.initPromise;
     }
 
-    const { Chat } = await getChatModule();
-    const chat = new Chat({
-      adapters: this.adapters,
-      state: this.stateAdapter,
-      userName: this.userName,
-      concurrency: { strategy: 'queue' },
-      ...this.chatOptions,
-    });
-
-    // Default handler that routes messages to the agent
-    const defaultHandler = (sdkThread: Thread, message: Message) => this.handleChatMessage(sdkThread, message, mastra);
-
-    // Register handlers with optional overrides
-    const { onDirectMessage, onMention, onSubscribedMessage } = this.handlerOverrides;
-
-    if (onDirectMessage !== false) {
-      chat.onDirectMessage((thread, message) => {
-        if (typeof onDirectMessage === 'function') {
-          return onDirectMessage(thread, message, defaultHandler);
-        }
-        return defaultHandler(thread, message);
-      });
-    }
-
-    if (onMention !== false) {
-      chat.onNewMention((thread, message) => {
-        if (typeof onMention === 'function') {
-          return onMention(thread, message, defaultHandler);
-        }
-        return defaultHandler(thread, message);
-      });
-    }
-
-    if (onSubscribedMessage !== false) {
-      chat.onSubscribedMessage((thread, message) => {
-        if (typeof onSubscribedMessage === 'function') {
-          return onSubscribedMessage(thread, message, defaultHandler);
-        }
-        return defaultHandler(thread, message);
-      });
-    }
-
-    // Tool approval buttons — id is "tool_approve:<toolCallId>" or "tool_deny:<toolCallId>"
-    chat.onAction(async event => {
-      const { actionId } = event;
-      if (!actionId.startsWith('tool_approve:') && !actionId.startsWith('tool_deny:')) return;
-      try {
-        const approved = actionId.startsWith('tool_approve:');
-        const toolCallId = actionId.split(':')[1];
-
-        // In Slack DMs, event.thread points to the approval card message rather
-        // than the top-level conversation, which can cause sub-threading.
-        // This is a known Slack adapter limitation.
-        const sdkThread = event.thread as Thread | null;
-        if (!sdkThread) {
-          this.log('info', `No thread in action event for toolCallId=${toolCallId}`);
-          return;
-        }
-        const platform = event.adapter.name;
-        const messageId = event.messageId;
-        const adapter = this.adapters[platform];
-        const adapterConfig = this.adapterConfigs[platform];
-        if (!adapter) throw new Error(`No adapter for platform "${platform}"`);
-
-        // Look up the Mastra thread to find the runId and tool metadata from pending approvals
-        // Note: In Slack DMs, sdkThread.id may point to the card message, not the conversation.
-        // We use sdkThread.channelId as the stable identifier for DMs.
-        const externalThreadId = sdkThread.isDM ? sdkThread.channelId : sdkThread.id;
-        const mastraThread = await this.getOrCreateThread({
-          externalThreadId,
-          channelId: sdkThread.channelId,
-          platform,
-          resourceId: `${platform}:${event.user.userId}`,
-          mastra,
-        });
-
-        // Find the runId from pendingToolApprovals in message history
+    this.initPromise = (async () => {
+      // Resolve state adapter: custom > Mastra storage > in-memory fallback
+      if (this.customState) {
+        this.stateAdapter = this.customState;
+      } else {
         const storage = mastra.getStorage();
         const memoryStore = storage ? await storage.getStore('memory') : undefined;
         if (!memoryStore) {
-          throw new Error('Storage is required for tool approval lookups');
+          throw new Error(
+            'Channels require storage to be configured on the Mastra instance. Configure a storage provider like LibSQLStore.',
+          );
         }
+        this.stateAdapter = new MastraStateAdapter(memoryStore);
+        this.log('info', 'Using MastraStateAdapter (subscriptions persist across restarts)');
+      }
 
-        const { messages } = await memoryStore.listMessages({
-          threadId: mastraThread.id,
-          perPage: 50,
-          orderBy: { field: 'createdAt', direction: 'DESC' },
+      const { Chat } = await getChatModule();
+      const chat = new Chat({
+        adapters: this.adapters,
+        state: this.stateAdapter,
+        userName: this.userName,
+        concurrency: { strategy: 'queue' },
+        ...this.chatOptions,
+      });
+
+      // Default handler that routes messages to the agent
+      const defaultHandler = (sdkThread: Thread, message: Message) => this.handleChatMessage(sdkThread, message, mastra);
+
+      // Register handlers with optional overrides
+      const { onDirectMessage, onMention, onSubscribedMessage } = this.handlerOverrides;
+
+      if (onDirectMessage !== false) {
+        chat.onDirectMessage((thread, message) => {
+          if (typeof onDirectMessage === 'function') {
+            return onDirectMessage(thread, message, defaultHandler);
+          }
+          return defaultHandler(thread, message);
         });
+      }
 
-        // Search for the pendingToolApprovals metadata containing our toolCallId
-        let runId: string | undefined;
-        let toolName: string | undefined;
-        let toolArgs: Record<string, unknown> | undefined;
-        for (const msg of messages) {
-          const pending = msg.content?.metadata?.pendingToolApprovals as
-            | Record<string, { toolCallId: string; runId: string; toolName: string; args: Record<string, unknown> }>
-            | undefined;
-          if (pending) {
-            for (const toolData of Object.values(pending)) {
-              if (toolData.toolCallId === toolCallId) {
-                runId = toolData.runId;
-                toolName = toolData.toolName;
-                toolArgs = toolData.args;
-                break;
+      if (onMention !== false) {
+        chat.onNewMention((thread, message) => {
+          if (typeof onMention === 'function') {
+            return onMention(thread, message, defaultHandler);
+          }
+          return defaultHandler(thread, message);
+        });
+      }
+
+      if (onSubscribedMessage !== false) {
+        chat.onSubscribedMessage((thread, message) => {
+          if (typeof onSubscribedMessage === 'function') {
+            return onSubscribedMessage(thread, message, defaultHandler);
+          }
+          return defaultHandler(thread, message);
+        });
+      }
+
+      // Tool approval buttons — id is "tool_approve:<toolCallId>" or "tool_deny:<toolCallId>"
+      chat.onAction(async event => {
+        const { actionId } = event;
+        if (!actionId.startsWith('tool_approve:') && !actionId.startsWith('tool_deny:')) return;
+        try {
+          const approved = actionId.startsWith('tool_approve:');
+          const toolCallId = actionId.split(':')[1];
+
+          // In Slack DMs, event.thread points to the approval card message rather
+          // than the top-level conversation, which can cause sub-threading.
+          // This is a known Slack adapter limitation.
+          const sdkThread = event.thread as Thread | null;
+          if (!sdkThread) {
+            this.log('info', `No thread in action event for toolCallId=${toolCallId}`);
+            return;
+          }
+          const platform = event.adapter.name;
+          const messageId = event.messageId;
+          const adapter = this.adapters[platform];
+          const adapterConfig = this.adapterConfigs[platform];
+          if (!adapter) throw new Error(`No adapter for platform "${platform}"`);
+
+          // Look up the Mastra thread to find the runId and tool metadata from pending approvals
+          // Note: In Slack DMs, sdkThread.id may point to the card message, not the conversation.
+          // We use sdkThread.channelId as the stable identifier for DMs.
+          const externalThreadId = sdkThread.isDM ? sdkThread.channelId : sdkThread.id;
+          const mastraThread = await this.getOrCreateThread({
+            externalThreadId,
+            channelId: sdkThread.channelId,
+            platform,
+            resourceId: `${platform}:${event.user.userId}`,
+            mastra,
+          });
+
+          // Find the runId from pendingToolApprovals in message history
+          const storage = mastra.getStorage();
+          const memoryStore = storage ? await storage.getStore('memory') : undefined;
+          if (!memoryStore) {
+            throw new Error('Storage is required for tool approval lookups');
+          }
+
+          const { messages } = await memoryStore.listMessages({
+            threadId: mastraThread.id,
+            perPage: 50,
+            orderBy: { field: 'createdAt', direction: 'DESC' },
+          });
+
+          // Search for the pendingToolApprovals metadata containing our toolCallId
+          let runId: string | undefined;
+          let toolName: string | undefined;
+          let toolArgs: Record<string, unknown> | undefined;
+          for (const msg of messages) {
+            const pending = msg.content?.metadata?.pendingToolApprovals as
+              | Record<string, { toolCallId: string; runId: string; toolName: string; args: Record<string, unknown> }>
+              | undefined;
+            if (pending) {
+              for (const toolData of Object.values(pending)) {
+                if (toolData.toolCallId === toolCallId) {
+                  runId = toolData.runId;
+                  toolName = toolData.toolName;
+                  toolArgs = toolData.args;
+                  break;
+                }
               }
+              if (runId) break;
             }
-            if (runId) break;
           }
-        }
 
-        if (!runId) {
-          this.log('info', `No pending approval found for toolCallId=${toolCallId}`);
-          return;
-        }
+          if (!runId) {
+            this.log('info', `No pending approval found for toolCallId=${toolCallId}`);
+            return;
+          }
 
-        // Build the card header with tool name and args
-        const displayName = toolName ? stripToolPrefix(toolName) : 'tool';
-        const argsSummary = toolArgs ? formatArgsSummary(toolArgs) : '';
-        const useCards = adapterConfig?.cards !== false;
+          // Build the card header with tool name and args
+          const displayName = toolName ? stripToolPrefix(toolName) : 'tool';
+          const argsSummary = toolArgs ? formatArgsSummary(toolArgs) : '';
+          const useCards = adapterConfig?.cards !== false;
 
-        if (!approved) {
-          const byUser = sdkThread.isDM ? undefined : event.user.fullName || event.user.userName || 'User';
+          if (!approved) {
+            const byUser = sdkThread.isDM ? undefined : event.user.fullName || event.user.userName || 'User';
+            try {
+              await adapter.editMessage(
+                sdkThread.id,
+                messageId,
+                formatToolDenied(displayName, argsSummary, byUser, useCards),
+              );
+            } catch (err) {
+              this.log('debug', 'Failed to edit denied card', err);
+            }
+            return;
+          }
+
+          // Immediately edit the card to show "Approved" and remove the buttons
           try {
-            await adapter.editMessage(
-              sdkThread.id,
-              messageId,
-              formatToolDenied(displayName, argsSummary, byUser, useCards),
-            );
+            await adapter.editMessage(sdkThread.id, messageId, formatToolApproved(displayName, argsSummary, useCards));
           } catch (err) {
-            this.log('debug', 'Failed to edit denied card', err);
+            this.log('debug', 'Failed to edit approved card', err);
           }
-          return;
-        }
 
-        // Immediately edit the card to show "Approved" and remove the buttons
-        try {
-          await adapter.editMessage(sdkThread.id, messageId, formatToolApproved(displayName, argsSummary, useCards));
+          // Build request context for the resumed stream
+          const actionAdapter = this.adapters[platform]!;
+          const actionBotUserId = actionAdapter.botUserId;
+          const actionBotMention = actionBotUserId ? sdkThread.mentionUser(actionBotUserId) : undefined;
+          const requestContext = new RequestContext();
+          requestContext.set('channel', {
+            platform,
+            eventType: 'action',
+            isDM: sdkThread.isDM,
+            threadId: sdkThread.id,
+            channelId: sdkThread.channelId,
+            messageId,
+            userId: event.user.userId,
+            userName: event.user.fullName || event.user.userName,
+            botUserId: actionBotUserId,
+            botUserName: actionAdapter.userName,
+            botMention: actionBotMention,
+          } satisfies ChannelContext);
+          // Resume the agent stream BEFORE editing the card —
+          // if the snapshot is gone (e.g. duplicate click), we bail without mangling the card
+          const resumedStream = await this.agent.approveToolCall({
+            runId,
+            toolCallId,
+            requestContext,
+          });
+
+          await this.consumeAgentStream(
+            resumedStream,
+            sdkThread,
+            platform,
+            toolCallId ? { toolCallId, messageId } : undefined,
+          );
         } catch (err) {
-          this.log('debug', 'Failed to edit approved card', err);
-        }
-
-        // Build request context for the resumed stream
-        const actionAdapter = this.adapters[platform]!;
-        const actionBotUserId = actionAdapter.botUserId;
-        const actionBotMention = actionBotUserId ? sdkThread.mentionUser(actionBotUserId) : undefined;
-        const requestContext = new RequestContext();
-        requestContext.set('channel', {
-          platform,
-          eventType: 'action',
-          isDM: sdkThread.isDM,
-          threadId: sdkThread.id,
-          channelId: sdkThread.channelId,
-          messageId,
-          userId: event.user.userId,
-          userName: event.user.fullName || event.user.userName,
-          botUserId: actionBotUserId,
-          botUserName: actionAdapter.userName,
-          botMention: actionBotMention,
-        } satisfies ChannelContext);
-        // Resume the agent stream BEFORE editing the card —
-        // if the snapshot is gone (e.g. duplicate click), we bail without mangling the card
-        const resumedStream = await this.agent.approveToolCall({
-          runId,
-          toolCallId,
-          requestContext,
-        });
-
-        await this.consumeAgentStream(
-          resumedStream,
-          sdkThread,
-          platform,
-          toolCallId ? { toolCallId, messageId } : undefined,
-        );
-      } catch (err) {
-        const isStaleApproval = err instanceof Error && err.message.includes('No snapshot found');
-        if (isStaleApproval) {
-          this.log('info', `Ignoring stale tool approval action (runId already consumed)`);
-          return;
-        }
-        this.log('error', 'Error handling tool approval action', err);
-        try {
-          const thread = event.thread;
-          if (thread) {
-            const error = err instanceof Error ? err : new Error(String(err));
-            const adapterConfig = this.adapterConfigs[event.adapter.name];
-            const errorMessage = adapterConfig?.formatError
-              ? adapterConfig.formatError(error)
-              : `❌ Error: ${error.message}`;
-            await thread.post(errorMessage);
+          const isStaleApproval = err instanceof Error && err.message.includes('No snapshot found');
+          if (isStaleApproval) {
+            this.log('info', `Ignoring stale tool approval action (runId already consumed)`);
+            return;
           }
-        } catch (err) {
-          this.log('debug', 'Failed to post error message for action', err);
+          this.log('error', 'Error handling tool approval action', err);
+          try {
+            const thread = event.thread;
+            if (thread) {
+              const error = err instanceof Error ? err : new Error(String(err));
+              const adapterConfig = this.adapterConfigs[event.adapter.name];
+              const errorMessage = adapterConfig?.formatError
+                ? adapterConfig.formatError(error)
+                : `❌ Error: ${error.message}`;
+              await thread.post(errorMessage);
+            }
+          } catch (err) {
+            this.log('debug', 'Failed to post error message for action', err);
+          }
+        }
+      });
+      await chat.initialize();
+      this.chat = chat;
+
+      // Start gateway listeners for adapters that support it (e.g. Discord)
+      for (const [name, adapter] of Object.entries(this.adapters)) {
+        if (!(this.adapterConfigs[name]?.gateway ?? true)) continue;
+
+        const adapterAny = adapter as unknown as Record<string, unknown>;
+        if (typeof adapterAny.startGatewayListener === 'function') {
+          const startGateway = adapterAny.startGatewayListener.bind(adapter) as (
+            options: { waitUntil: (p: Promise<unknown>) => void },
+            durationMs?: number,
+          ) => Promise<Response>;
+
+          this.startGatewayLoop(name, startGateway);
         }
       }
-    });
-    await chat.initialize();
-    this.chat = chat;
+    })();
 
-    // Start gateway listeners for adapters that support it (e.g. Discord)
-    for (const [name, adapter] of Object.entries(this.adapters)) {
-      if (!(this.adapterConfigs[name]?.gateway ?? true)) continue;
-
-      const adapterAny = adapter as unknown as Record<string, unknown>;
-      if (typeof adapterAny.startGatewayListener === 'function') {
-        const startGateway = adapterAny.startGatewayListener.bind(adapter) as (
-          options: { waitUntil: (p: Promise<unknown>) => void },
-          durationMs?: number,
-        ) => Promise<Response>;
-
-        this.startGatewayLoop(name, startGateway);
-      }
+    try {
+      await this.initPromise;
+    } catch (error) {
+      this.initPromise = null;
+      throw error;
     }
   }
 
@@ -680,8 +681,11 @@ export class AgentChannels {
    * Returns API routes for receiving webhook events from each adapter.
    * One POST route per adapter at `/api/agents/{agentId}/channels/{platform}/webhook`.
    */
-  getWebhookRoutes(): ApiRoute[] {
+  getWebhookRoutes(mastra?: Mastra): ApiRoute[] {
     if (!this.agent) return [];
+    if (mastra) {
+      this.initialize(mastra).catch(() => {});
+    }
 
     const agentId = this.agent.id;
     const routes: ApiRoute[] = [];

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -465,7 +465,8 @@ export class AgentChannels {
       });
 
       // Default handler that routes messages to the agent
-      const defaultHandler = (sdkThread: Thread, message: Message) => this.handleChatMessage(sdkThread, message, mastra);
+      const defaultHandler = (sdkThread: Thread, message: Message) =>
+        this.handleChatMessage(sdkThread, message, mastra);
 
       // Register handlers with optional overrides
       const { onDirectMessage, onMention, onSubscribedMessage } = this.handlerOverrides;
@@ -682,7 +683,7 @@ export class AgentChannels {
    * One POST route per adapter at `/api/agents/{agentId}/channels/{platform}/webhook`.
    */
   getWebhookRoutes(): ApiRoute[] {
-if (!this.agent) return [];
+    if (!this.agent) return [];
 
     const agentId = this.agent.id;
     const routes: ApiRoute[] = [];

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -681,11 +681,8 @@ export class AgentChannels {
    * Returns API routes for receiving webhook events from each adapter.
    * One POST route per adapter at `/api/agents/{agentId}/channels/{platform}/webhook`.
    */
-  getWebhookRoutes(mastra?: Mastra): ApiRoute[] {
-    if (!this.agent) return [];
-    if (mastra) {
-      this.initialize(mastra).catch(() => {});
-    }
+  getWebhookRoutes(): ApiRoute[] {
+if (!this.agent) return [];
 
     const agentId = this.agent.id;
     const routes: ApiRoute[] = [];

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1088,14 +1088,13 @@ export class Mastra<
     const agentChannels = mastraAgent.getChannels();
     if (agentChannels) {
       agentChannels.__setLogger(this.#logger);
-      const channelRoutes = agentChannels.getWebhookRoutes();
+      const channelRoutes = agentChannels.getWebhookRoutes(this);
       if (channelRoutes.length > 0) {
         this.#server = {
           ...this.#server,
           apiRoutes: [...(this.#server?.apiRoutes ?? []), ...channelRoutes],
         };
       }
-      agentChannels.__startInitialize(this);
     }
   }
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1088,7 +1088,7 @@ export class Mastra<
     const agentChannels = mastraAgent.getChannels();
     if (agentChannels) {
       agentChannels.__setLogger(this.#logger);
-      const channelRoutes = agentChannels.getWebhookRoutes(this);
+      const channelRoutes = agentChannels.getWebhookRoutes();
       if (channelRoutes.length > 0) {
         this.#server = {
           ...this.#server,

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1095,7 +1095,7 @@ export class Mastra<
           apiRoutes: [...(this.#server?.apiRoutes ?? []), ...channelRoutes],
         };
       }
-      void agentChannels.initialize(this);
+      agentChannels.__startInitialize(this);
     }
   }
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1095,6 +1095,7 @@ export class Mastra<
           apiRoutes: [...(this.#server?.apiRoutes ?? []), ...channelRoutes],
         };
       }
+      void agentChannels.initialize(this);
     }
   }
 


### PR DESCRIPTION
## Description

Fixes Channels (Slack, Discord, etc.) failing on Vercel and other serverless platforms due to a race condition where webhook requests arrive before `AgentChannels.initialize()` completes, and background agent processing being killed after the HTTP response is sent.

- Store the initialization promise on `AgentChannels` via new `__startInitialize()` method so webhook handlers can await readiness instead of immediately returning 503
- Pass the platform's `executionCtx.waitUntil` from Hono context to the Chat SDK webhook handler so agent processing survives after the serverless function responds
- Replace fire-and-forget `void agentChannels.initialize(this)` with `agentChannels.__startInitialize(this)` in `Mastra.addAgent()`
- No behavior change for long-running servers — the init promise resolves instantly since initialization completes before any request arrives

## Related Issue(s)

Fixes #15300

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes a timing problem where webhook requests arrive at serverless platforms (like Vercel) before the chat system is fully set up, causing them to fail with an error. The solution makes the initialization process "awaitable" so handlers can wait for it to complete, and also ensures background work isn't stopped after the HTTP response is sent.

## Changes

### Changeset (.changeset/vast-masks-juggle.md)
- Added a patch-level release note for `@mastra/core`
- Documents that Channels functionality is now fixed for Vercel serverless and other serverless platforms
- Notes that webhook handlers now await initialization instead of returning 503 errors on cold starts
- Documents that webhook handlers now pass the platform's `waitUntil` capability to the Chat SDK for continued background processing

### AgentChannels (packages/core/src/channels/agent-channels.ts)

**Initialization improvements:**
- Added `initPromise` field to store the in-flight initialization promise, making initialization idempotent and memoized
- Refactored `initialize()` method to return the stored promise when called multiple times
- Implemented initialization logic as an async IIFE that clears the promise on failure and rethrows the error
- Early-returns when `this.chat` is already initialized

**Webhook handler improvements:**
- Updated request handlers in `getWebhookRoutes()` to await `initPromise` before using `this.chat`
- Returns a 503 JSON response if initialization fails
- Modified webhook handler invocation to forward the serverless platform's execution context: passes `c.executionCtx.waitUntil` as options to the Chat SDK webhook handler when available
- Enables background agent processing to continue after the HTTP response is sent in serverless environments

## Impact

- Eliminates the race condition where concurrent cold-start requests could return 503 errors
- Allows multiple concurrent requests to share a single initialization promise
- Enables Channels to work reliably on serverless platforms by preventing premature function termination of background jobs
- Addresses issue #15300
<!-- end of auto-generated comment: release notes by coderabbit.ai -->