### PR TITLE
fix(renovate): prioritize lock file maintenance PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,10 @@
       "minimumReleaseAge": "3 days"
     },
     {
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "prPriority": 10
+    },
+    {
       "matchPackageNames": ["@types/node"],
       "matchUpdateTypes": ["major"],
       "enabled": false


### PR DESCRIPTION
## Summary
- add a Renovate package rule to give lock file maintenance PRs higher priority
- keep existing weekly lock file maintenance + automerge behavior unchanged
- help Renovate consume open PR capacity with lockfile refreshes before lower-priority updates

## Testing
- jq empty renovate.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

Renovate is a tool that automatically updates packages in your project. This PR tells Renovate to prioritize refreshing lock files (which ensure everyone uses the exact same package versions) before updating regular packages. It's like making sure the team's shared recipe is up-to-date before trying new ingredients.

## Changes

Added a new package rule to `renovate.json` that increases the priority of lock file maintenance PRs. The rule matches `lockFileMaintenance` update types and assigns them a `prPriority` of 10, ensuring these PRs are created before lower-priority dependency updates when the concurrent PR limit is reached.

This complements the existing configuration which already enables weekly lock file maintenance with automerge via the `:maintainLockFilesWeekly` preset and the `lockFileMaintenance` section.

## Impact

- Lock file maintenance PRs now have higher priority in Renovate's queue
- Ensures available PR capacity is used for lock file refreshes before regular package updates
- Preserves existing weekly schedule (Wednesday mornings) and automerge behavior for lock file maintenance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->