### PR TITLE
fix: remove unused CI secrets

### DIFF
--- a/.github/workflows/secrets.test-memory.yml
+++ b/.github/workflows/secrets.test-memory.yml
@@ -122,11 +122,6 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
           DB_URL: 'postgresql://postgres:postgres@localhost:5432/mastra'
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
-          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
   test-success:
     needs: [check-changes, test]

--- a/.github/workflows/vitest-all.yml
+++ b/.github/workflows/vitest-all.yml
@@ -120,21 +120,11 @@ jobs:
             --passWithNoTests
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
-          # LLM API Keys
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-          # Store API Keys
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           ASTRA_DB_ENDPOINT: ${{ secrets.ASTRA_DB_ENDPOINT }}
           ASTRA_DB_TOKEN: ${{ secrets.ASTRA_DB_TOKEN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.ABHI_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ABHI_CLOUDFLARE_ACCOUNT_ID }}
-          # Upstash
-          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
-          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/vitest-changed.yml
+++ b/.github/workflows/vitest-changed.yml
@@ -197,21 +197,6 @@ jobs:
             --passWithNoTests
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
-          # LLM API Keys
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-          # Store API Keys
-          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          ASTRA_DB_ENDPOINT: ${{ secrets.ASTRA_DB_ENDPOINT }}
-          ASTRA_DB_TOKEN: ${{ secrets.ASTRA_DB_TOKEN }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.ABHI_CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ABHI_CLOUDFLARE_ACCOUNT_ID }}
-          # Upstash
-          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
-          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary
- remove unused secrets from the packages e2e job in 
- remove unused LLM and Upstash secrets from 
- keep only required store secrets in 

## Test Plan
- git diff --check -- .github/workflows/vitest-changed.yml .github/workflows/secrets.test-memory.yml .github/workflows/vitest-all.yml
- pnpm exec prettier --check .github/workflows/vitest-changed.yml .github/workflows/secrets.test-memory.yml .github/workflows/vitest-all.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes secret credentials (like API keys) from GitHub Actions workflows that don't actually use them—think of it like cleaning up your desk by removing tools you're not using. This makes the CI/CD pipeline leaner and safer, since jobs won't have access to credentials they don't need, without changing how the tests actually run.

## Changes Overview

The PR removes unused secret environment variables from three GitHub Actions workflow files. The removed secrets include credentials for LLM providers (OpenAI, OpenRouter, Anthropic, Google Generative AI, Cohere), store/API services (Upstash, Pinecone, Astra DB), and Cloudflare, from jobs that don't consume them.

### `.github/workflows/secrets.test-memory.yml`
Removed 5 secret environment variables from the `test` job:
- `OPENAI_API_KEY`
- `KV_REST_API_URL`
- `KV_REST_API_TOKEN`
- `GOOGLE_GENERATIVE_AI_API_KEY`
- `OPENROUTER_API_KEY`

### `.github/workflows/vitest-all.yml`
Removed 7 secret environment variables from the `e2e-test` job:
- LLM provider credentials: `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `COHERE_API_KEY`
- Upstash credentials: `KV_REST_API_URL`, `KV_REST_API_TOKEN`

Kept environment variables for Pinecone, Astra DB, and Cloudflare unchanged.

### `.github/workflows/vitest-changed.yml`
Removed 12 secret environment variables from the `test` job step environment:
- LLM providers: `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `COHERE_API_KEY`
- Database/storage services: `PINECONE_API_KEY`, `ASTRA_DB_ENDPOINT`, `ASTRA_DB_TOKEN`
- Cloudflare: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`
- Upstash: `KV_REST_API_URL`, `KV_REST_API_TOKEN`

## Test Plan
Validated with:
- `git diff --check` on the modified workflow files
- `pnpm exec prettier --check` to ensure formatting compliance

## Impact
Makes fork PR CI lean by removing unnecessary secret injection, while maintaining test behavior and keeping only required credentials in the workflow environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->