### PR TITLE
Fix Sentry error stack traces to point to actual error origin

### DIFF
--- a/.changeset/tough-geese-relax.md
+++ b/.changeset/tough-geese-relax.md
@@ -3,11 +3,11 @@
 '@mastra/sentry': patch
 ---
 
-Fixed Sentry error stack traces so they point to the actual error origin instead of the Mastra exporter internals.
+Fixed stack traces for errors reported to Sentry. Exceptions now point to the code that threw the error instead of `SentryExporter.handleSpanEnded` inside the exporter, so issues in Sentry are actually debuggable.
 
-Two related fixes:
+This was caused by two issues, both fixed:
 
-- **@mastra/sentry**: The exporter now passes an `Error` object (preserving the captured stack) to `Sentry.captureException` instead of a bare message string. Previously, passing a string caused Sentry to synthesize a stack trace from the exporter's call site, so every error in Sentry appeared to originate from `SentryExporter.handleSpanEnded`.
-- **@mastra/observability**: When a span is failed with a `MastraError` that wraps another error, `span.errorInfo.stack` now prefers the original cause's stack over the wrapper's stack, so downstream exporters receive the stack pointing to the true error origin.
+- `@mastra/sentry` passed the error message as a string to `Sentry.captureException`, which made Sentry synthesize a stack trace from the exporter's call site. It now passes an `Error` instance with the captured stack attached.
+- `@mastra/observability` stored the wrapping `MastraError`'s stack on the span, hiding the original error's location. When the `MastraError` has a cause, the cause's stack is now preserved.
 
-Fixes #15337.
+Fixes [#15337](https://github.com/mastra-ai/mastra/issues/15337).

--- a/.changeset/tough-geese-relax.md
+++ b/.changeset/tough-geese-relax.md
@@ -1,0 +1,13 @@
+---
+'@mastra/observability': patch
+'@mastra/sentry': patch
+---
+
+Fixed Sentry error stack traces so they point to the actual error origin instead of the Mastra exporter internals.
+
+Two related fixes:
+
+- **@mastra/sentry**: The exporter now passes an `Error` object (preserving the captured stack) to `Sentry.captureException` instead of a bare message string. Previously, passing a string caused Sentry to synthesize a stack trace from the exporter's call site, so every error in Sentry appeared to originate from `SentryExporter.handleSpanEnded`.
+- **@mastra/observability**: When a span is failed with a `MastraError` that wraps another error, `span.errorInfo.stack` now prefers the original cause's stack over the wrapper's stack, so downstream exporters receive the stack pointing to the true error origin.
+
+Fixes #15337.

--- a/observability/mastra/src/spans/default.ts
+++ b/observability/mastra/src/spans/default.ts
@@ -94,7 +94,10 @@ export class DefaultSpan<TType extends SpanType> extends BaseSpan<TType> {
             domain: error.domain,
             message: error.message,
             name: error.name,
-            stack: error.stack,
+            // Prefer the original cause's stack when available. MastraError wraps
+            // thrown errors, so its own stack points to the wrapping site rather
+            // than where the underlying error was thrown.
+            stack: (error.cause instanceof Error && error.cause.stack) || error.stack,
           }
         : {
             message: error.message,

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -372,6 +372,69 @@ describe('Tracing', () => {
       expect(testExporter.events).toHaveLength(2); // start + update
       expect(testExporter.events[1].type).toBe(TracingEventType.SPAN_UPDATED);
     });
+
+    it('should prefer original cause stack when error is a MastraError wrapper', () => {
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test-tracing',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [testExporter],
+      });
+
+      const span = tracing.startSpan({
+        type: SpanType.TOOL_CALL,
+        name: 'error-tool',
+        attributes: { toolId: 'failing-tool' },
+      });
+
+      const originalError = new Error('Original failure');
+      const originalStack =
+        'Error: Original failure\n    at userCode (/app/src/tool.ts:42:7)\n    at run (/app/src/runner.ts:10:3)';
+      originalError.stack = originalStack;
+
+      const wrappedError = new MastraError(
+        {
+          id: 'TOOL_ERROR',
+          text: 'Tool failed',
+          domain: 'TOOL',
+          category: 'SYSTEM',
+        },
+        originalError,
+      );
+
+      span.error({ error: wrappedError });
+
+      // errorInfo should carry the original cause's stack, not the wrapper's
+      expect(span.errorInfo?.stack).toBe(originalStack);
+      expect(span.errorInfo?.message).toBe('Tool failed');
+      expect(span.errorInfo?.id).toBe('TOOL_ERROR');
+    });
+
+    it('should fall back to MastraError stack when there is no cause', () => {
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test-tracing',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [testExporter],
+      });
+
+      const span = tracing.startSpan({
+        type: SpanType.TOOL_CALL,
+        name: 'error-tool',
+        attributes: { toolId: 'failing-tool' },
+      });
+
+      const wrappedError = new MastraError({
+        id: 'TOOL_ERROR',
+        text: 'Tool failed',
+        domain: 'TOOL',
+        category: 'SYSTEM',
+      });
+
+      span.error({ error: wrappedError });
+
+      expect(span.errorInfo?.stack).toBe(wrappedError.stack);
+    });
   });
 
   describe('Sampling Strategies', () => {

--- a/observability/sentry/src/tracing.test.ts
+++ b/observability/sentry/src/tracing.test.ts
@@ -709,7 +709,7 @@ describe('SentryExporter', () => {
       expect(mockSpan.end).toHaveBeenCalledWith(endTime.getTime());
     });
 
-    it('should handle errors and capture exception', async () => {
+    it('should handle errors and capture exception with the original stack trace', async () => {
       const span = createMockSpan({
         id: 'error-span',
         name: 'failing-tool',
@@ -725,7 +725,61 @@ describe('SentryExporter', () => {
         exportedSpan: span,
       });
 
+      const originalStack =
+        'Error: Tool execution failed\n    at userCode (/app/src/tool.ts:42:7)\n    at run (/app/src/runner.ts:10:3)';
+
       // Add error info before ending
+      span.errorInfo = {
+        message: 'Tool execution failed',
+        id: 'TOOL_ERROR',
+        category: 'EXECUTION',
+        name: 'ToolError',
+        stack: originalStack,
+      };
+      span.endTime = new Date();
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: span,
+      });
+
+      // captureException should receive an Error instance so Sentry preserves the
+      // real stack trace instead of synthesizing one from the exporter's call site.
+      expect(SentryMock.captureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          contexts: expect.objectContaining({
+            trace: expect.objectContaining({
+              trace_id: span.traceId,
+              span_id: span.id,
+            }),
+          }),
+        }),
+      );
+
+      const [capturedError] = SentryMock.captureException.mock.calls[0];
+      expect(capturedError).toBeInstanceOf(Error);
+      expect(capturedError.message).toBe('Tool execution failed');
+      expect(capturedError.name).toBe('ToolError');
+      expect(capturedError.stack).toBe(originalStack);
+    });
+
+    it('should still capture exception when errorInfo has no stack', async () => {
+      const span = createMockSpan({
+        id: 'error-span-no-stack',
+        name: 'failing-tool',
+        type: SpanType.TOOL_CALL,
+        isRoot: true,
+        attributes: {
+          toolId: 'failing-tool',
+        },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: span,
+      });
+
       span.errorInfo = {
         message: 'Tool execution failed',
         id: 'TOOL_ERROR',
@@ -738,17 +792,10 @@ describe('SentryExporter', () => {
         exportedSpan: span,
       });
 
-      expect(SentryMock.captureException).toHaveBeenCalledWith(
-        'Tool execution failed',
-        expect.objectContaining({
-          contexts: expect.objectContaining({
-            trace: expect.objectContaining({
-              trace_id: span.traceId,
-              span_id: span.id,
-            }),
-          }),
-        }),
-      );
+      expect(SentryMock.captureException).toHaveBeenCalledWith(expect.any(Error), expect.any(Object));
+      const [capturedError] = SentryMock.captureException.mock.calls[0];
+      expect(capturedError).toBeInstanceOf(Error);
+      expect(capturedError.message).toBe('Tool execution failed');
     });
 
     it('should remove span from map after ending', async () => {

--- a/observability/sentry/src/tracing.ts
+++ b/observability/sentry/src/tracing.ts
@@ -287,7 +287,19 @@ export class SentryExporter extends BaseExporter {
         message: span.errorInfo.message,
       });
 
-      Sentry.captureException(span.errorInfo.message, {
+      // Build an Error instance so Sentry can use the real stack trace captured
+      // by observability rather than synthesizing one from this exporter's call site.
+      // Passing a string to Sentry.captureException produces a stack that points to
+      // handleSpanEnded, hiding the real error origin.
+      const error = new Error(span.errorInfo.message);
+      if (span.errorInfo.name) {
+        error.name = span.errorInfo.name;
+      }
+      if (span.errorInfo.stack) {
+        error.stack = span.errorInfo.stack;
+      }
+
+      Sentry.captureException(error, {
         contexts: {
           trace: { trace_id: span.traceId, span_id: span.id },
           span_info: {


### PR DESCRIPTION
## Description

Fixed Sentry error stack traces so they point to the actual error origin instead of the Mastra exporter internals.

Two related fixes:

1. **@mastra/sentry**: The exporter now passes an `Error` object (preserving the captured stack) to `Sentry.captureException` instead of a bare message string. Previously, passing a string caused Sentry to synthesize a stack trace from the exporter's call site, so every error in Sentry appeared to originate from `SentryExporter.handleSpanEnded`.

2. **@mastra/observability**: When a span is failed with a `MastraError` that wraps another error, `span.errorInfo.stack` now prefers the original cause's stack over the wrapper's stack, so downstream exporters receive the stack pointing to the true error origin.

## Related Issue(s)

Fixes #15337

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Tests added to verify stack trace handling in both observability and Sentry exporter

https://claude.ai/code/session_01EcjkUuaWpXuwA3J9NAdEF7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When Mastra caught errors and reported them to Sentry (an error tracking service), Sentry was showing that the error came from deep inside Mastra's code instead of from the actual place where the error originally happened. This PR fixes that by properly passing the original error information to Sentry, so developers can see where problems actually started.

## Overview

This PR fixes Sentry error stack traces to point to the original error origin rather than Mastra exporter internals, addressing issue #15337. The issue occurred because stack trace information was being lost or misattributed when errors were wrapped and reported to Sentry.

## Root Cause

The problem had two contributing factors:
1. **@mastra/sentry**: was passing only an error message string to `Sentry.captureException`, causing Sentry to synthesize a stack trace from the exporter call site rather than preserving the original stack
2. **@mastra/observability**: was storing the wrapper error's stack (`MastraError.stack`) instead of the original cause's stack when building `span.errorInfo`

## Solution

### observability/mastra/src/spans/default.ts
Updated `DefaultSpan.error()` to prefer the original error's stack when available. When a `MastraError` wraps another error as its cause, the span now captures `error.cause.stack` instead of the wrapper's stack, preserving the true error origin for downstream exporters.

### observability/sentry/src/tracing.ts
Modified the Sentry exporter to construct a proper `Error` object (with message, name, and stack from `span.errorInfo`) before passing it to `Sentry.captureException`, instead of passing just the error message string. This ensures Sentry receives an Error instance with the correct stack trace rather than synthesizing one.

## Testing

Added comprehensive test coverage:
- **observability/mastra/src/tracing.test.ts**: Two new tests verifying that `span.errorInfo.stack` correctly uses the original cause's stack when a `MastraError` wraps another error, and falls back to the wrapper's stack when no cause exists
- **observability/sentry/src/tracing.test.ts**: Updated existing test and added new test to verify that `SentryMock.captureException` receives a proper `Error` instance with correct `message`, `name`, and `stack` properties, including handling the case where `span.errorInfo` has no stack

## Release

Marked as patch releases for both `@mastra/observability` and `@mastra/sentry` packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->