### PR TITLE
fix(ai-sdk): support AI SDK v6 native tool approval flow

### DIFF
--- a/.changeset/seven-suns-dress.md
+++ b/.changeset/seven-suns-dress.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed tool call approvals in AI SDK v6: `handleChatStream` now automatically routes to `resumeStream` when the AI SDK v6 `approve()` method is used on the client, enabling the suspend/resume flow without any extra server-side wiring. The v6 stream now also emits native `tool-approval-request` parts alongside the existing `data-tool-call-approval` chunk for backwards compatibility with `@mastra/react`.

--- a/.changeset/seven-suns-dress.md
+++ b/.changeset/seven-suns-dress.md
@@ -2,4 +2,4 @@
 '@mastra/ai-sdk': patch
 ---
 
-Fixed tool call approvals in AI SDK v6: `handleChatStream` now automatically routes to `resumeStream` when the AI SDK v6 `approve()` method is used on the client, enabling the suspend/resume flow without any extra server-side wiring. The v6 stream now also emits native `tool-approval-request` parts alongside the existing `data-tool-call-approval` chunk for backwards compatibility with `@mastra/react`.
+Fixed tool call approvals in AI SDK v6: `handleChatStream` now automatically routes to `resumeStream` when the AI SDK v6 native approval flow is used on the client (no extra server-side wiring required). The v6 stream now emits native `tool-approval-request` parts so `useChat` can surface approval UI and call `addToolApprovalResponse()`, while also emitting the existing `data-tool-call-approval` chunk for backwards compatibility.

--- a/.changeset/tired-comics-cover.md
+++ b/.changeset/tired-comics-cover.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed AI SDK v6 tool approval streams so requireApproval works with handleChatStream and AssistantChatTransport.

--- a/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
@@ -1,9 +1,66 @@
 import { ReadableStream } from 'node:stream/web';
+import { readUIMessageStream } from '@internal/ai-v6';
 import { ChunkFrom } from '@mastra/core/stream';
 import type { MastraModelOutput } from '@mastra/core/stream';
-import { describe, expect, it } from 'vitest';
-import { toAISdkV5Stream } from '../convert-streams';
-import { convertMastraChunkToAISDKv5 } from '../helpers';
+import { describe, expect, it, vi } from 'vitest';
+import { handleChatStream, extractV6NativeApproval } from '../chat-route';
+import { toAISdkStream, toAISdkV5Stream } from '../convert-streams';
+import { convertMastraChunkToAISDKv5, convertMastraChunkToAISDKv6, APPROVAL_ID_SEPARATOR } from '../helpers';
+
+async function collectChunks(stream: ReadableStream) {
+  const chunks: any[] = [];
+
+  for await (const chunk of stream as any) {
+    chunks.push(chunk);
+  }
+
+  return chunks;
+}
+
+function createApprovalStream() {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({
+        type: 'start',
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+        payload: { id: 'msg-1' },
+      });
+
+      controller.enqueue({
+        type: 'step-start',
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+        payload: { messageId: 'msg-1' },
+      });
+
+      controller.enqueue({
+        type: 'tool-call',
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+        payload: {
+          toolCallId: 'tooluse_abc123',
+          toolName: 'myTool',
+          args: { param: 'value' },
+        },
+      });
+
+      controller.enqueue({
+        type: 'tool-call-approval',
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+        payload: {
+          toolCallId: 'tooluse_abc123',
+          toolName: 'myTool',
+          args: { param: 'value' },
+          resumeSchema: '{"type":"object","properties":{"approved":{"type":"boolean"}}}',
+        },
+      });
+
+      controller.close();
+    },
+  });
+}
 
 describe('tool-call-approval chunk conversion (issue #12878)', () => {
   describe('convertMastraChunkToAISDKv5', () => {
@@ -60,55 +117,8 @@ describe('tool-call-approval chunk conversion (issue #12878)', () => {
 
   describe('end-to-end: tool-call-approval through agent stream', () => {
     it('should emit data-tool-call-approval with state field when tool requires approval', async () => {
-      const mockStream = new ReadableStream({
-        async start(controller) {
-          controller.enqueue({
-            type: 'start',
-            runId: 'run-123',
-            from: ChunkFrom.AGENT,
-            payload: { id: 'msg-1' },
-          });
-
-          controller.enqueue({
-            type: 'step-start',
-            runId: 'run-123',
-            from: ChunkFrom.AGENT,
-            payload: { messageId: 'msg-1' },
-          });
-
-          controller.enqueue({
-            type: 'tool-call',
-            runId: 'run-123',
-            from: ChunkFrom.AGENT,
-            payload: {
-              toolCallId: 'tooluse_abc123',
-              toolName: 'myTool',
-              args: { param: 'value' },
-            },
-          });
-
-          controller.enqueue({
-            type: 'tool-call-approval',
-            runId: 'run-123',
-            from: ChunkFrom.AGENT,
-            payload: {
-              toolCallId: 'tooluse_abc123',
-              toolName: 'myTool',
-              args: { param: 'value' },
-              resumeSchema: '{"type":"object","properties":{"approved":{"type":"boolean"}}}',
-            },
-          });
-
-          controller.close();
-        },
-      });
-
-      const aiSdkStream = toAISdkV5Stream(mockStream as unknown as MastraModelOutput, { from: 'agent' });
-
-      const chunks: any[] = [];
-      for await (const chunk of aiSdkStream) {
-        chunks.push(chunk);
-      }
+      const aiSdkStream = toAISdkV5Stream(createApprovalStream() as unknown as MastraModelOutput, { from: 'agent' });
+      const chunks = await collectChunks(aiSdkStream);
 
       // Should have the tool-input-available chunk for the tool call
       const toolInputChunk = chunks.find(chunk => chunk.type === 'tool-input-available');
@@ -130,6 +140,354 @@ describe('tool-call-approval chunk conversion (issue #12878)', () => {
       expect(approvalChunk.data.toolName).toBe('myTool');
       expect(approvalChunk.data.args).toEqual({ param: 'value' });
       expect(approvalChunk.data.resumeSchema).toBe('{"type":"object","properties":{"approved":{"type":"boolean"}}}');
+    });
+  });
+});
+
+describe('extractV6NativeApproval', () => {
+  it('returns runId and approved:true from an approval-responded part', () => {
+    const approvalId = `run-123${APPROVAL_ID_SEPARATOR}tooluse_abc123`;
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'msg-1',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'tooluse_abc123',
+            state: 'approval-responded' as const,
+            input: { param: 'value' },
+            approval: { id: approvalId, approved: true },
+          },
+        ],
+      },
+    ];
+
+    const result = extractV6NativeApproval(messages as any);
+
+    expect(result).toEqual({ resumeData: { approved: true }, runId: 'run-123' });
+  });
+
+  it('includes reason when the user denied with a reason', () => {
+    const approvalId = `run-456${APPROVAL_ID_SEPARATOR}tooluse_xyz`;
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'msg-1',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'tooluse_xyz',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: approvalId, approved: false, reason: 'Not safe' },
+          },
+        ],
+      },
+    ];
+
+    const result = extractV6NativeApproval(messages as any);
+
+    expect(result).toEqual({ resumeData: { approved: false, reason: 'Not safe' }, runId: 'run-456' });
+  });
+
+  it('omits reason when not provided', () => {
+    const approvalId = `run-789${APPROVAL_ID_SEPARATOR}tooluse_abc`;
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'msg-1',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'tooluse_abc',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: approvalId, approved: true },
+          },
+        ],
+      },
+    ];
+
+    const result = extractV6NativeApproval(messages as any);
+
+    expect(result?.resumeData).not.toHaveProperty('reason');
+  });
+
+  it('returns null when no approval-responded part exists', () => {
+    const messages = [
+      { role: 'user' as const, id: 'msg-1', parts: [{ type: 'text', text: 'hello' }] },
+      {
+        role: 'assistant' as const,
+        id: 'msg-2',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'tooluse_abc123',
+            state: 'approval-requested' as const,
+            input: {},
+            approval: { id: 'run-123::tooluse_abc123' },
+          },
+        ],
+      },
+    ];
+
+    expect(extractV6NativeApproval(messages as any)).toBeNull();
+  });
+
+  it('returns null when the approval id has no separator', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'msg-1',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'tooluse_abc123',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: 'no-separator-here', approved: true },
+          },
+        ],
+      },
+    ];
+
+    expect(extractV6NativeApproval(messages as any)).toBeNull();
+  });
+
+  it('scans from the end and picks the most recent approval-responded part', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'msg-1',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'old-call',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: `old-run${APPROVAL_ID_SEPARATOR}old-call`, approved: true },
+          },
+        ],
+      },
+      {
+        role: 'assistant' as const,
+        id: 'msg-2',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'new-call',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: `new-run${APPROVAL_ID_SEPARATOR}new-call`, approved: false },
+          },
+        ],
+      },
+    ];
+
+    const result = extractV6NativeApproval(messages as any);
+
+    expect(result?.runId).toBe('new-run');
+    expect(result?.resumeData.approved).toBe(false);
+  });
+});
+
+describe('handleChatStream v6 native approve() resume flow', () => {
+  const emptyStream = {
+    fullStream: new ReadableStream({
+      start(c) {
+        c.close();
+      },
+    }),
+  };
+
+  const mockAgent = {
+    stream: vi.fn().mockResolvedValue(emptyStream),
+    resumeStream: vi.fn().mockResolvedValue(emptyStream),
+  };
+
+  const mockMastra = {
+    getAgentById: vi.fn().mockReturnValue(mockAgent),
+  };
+
+  it('calls resumeStream with correct runId and resumeData when messages contain approval-responded', async () => {
+    vi.clearAllMocks();
+
+    const messages = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'tooluse_abc123',
+            state: 'approval-responded',
+            input: { param: 'value' },
+            approval: { id: `run-123${APPROVAL_ID_SEPARATOR}tooluse_abc123`, approved: true },
+          },
+        ],
+      },
+    ];
+
+    await handleChatStream({
+      mastra: mockMastra as any,
+      agentId: 'test-agent',
+      version: 'v6',
+      params: { messages } as any,
+    });
+
+    expect(mockAgent.resumeStream).toHaveBeenCalledTimes(1);
+    expect(mockAgent.resumeStream).toHaveBeenCalledWith(
+      { approved: true },
+      expect.objectContaining({ runId: 'run-123' }),
+    );
+    expect(mockAgent.stream).not.toHaveBeenCalled();
+  });
+
+  it('calls stream() for a normal (non-approval) message', async () => {
+    vi.clearAllMocks();
+
+    const messages = [{ id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hello' }] }];
+
+    await handleChatStream({
+      mastra: mockMastra as any,
+      agentId: 'test-agent',
+      version: 'v6',
+      params: { messages } as any,
+    });
+
+    expect(mockAgent.stream).toHaveBeenCalledTimes(1);
+    expect(mockAgent.resumeStream).not.toHaveBeenCalled();
+  });
+
+  it('explicit resumeData/runId takes precedence over message scanning', async () => {
+    vi.clearAllMocks();
+
+    const messages = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'tooluse_abc123',
+            state: 'approval-responded',
+            input: {},
+            approval: { id: `run-from-msg${APPROVAL_ID_SEPARATOR}tooluse_abc123`, approved: true },
+          },
+        ],
+      },
+    ];
+
+    await handleChatStream({
+      mastra: mockMastra as any,
+      agentId: 'test-agent',
+      version: 'v6',
+      params: { messages, resumeData: { approved: true }, runId: 'explicit-run' } as any,
+    });
+
+    expect(mockAgent.resumeStream).toHaveBeenCalledWith(
+      { approved: true },
+      expect.objectContaining({ runId: 'explicit-run' }),
+    );
+  });
+});
+
+describe('tool-call-approval conversion', () => {
+  it('keeps the v5 data-tool-call-approval shape', () => {
+    const chunk = {
+      type: 'tool-call-approval' as const,
+      runId: 'run-123',
+      from: ChunkFrom.AGENT,
+      payload: {
+        toolCallId: 'tooluse_abc123',
+        toolName: 'myTool',
+        args: { param: 'value' },
+        resumeSchema: '{"type":"object","properties":{"approved":{"type":"boolean"}}}',
+      },
+    };
+
+    const result = convertMastraChunkToAISDKv5({ chunk, mode: 'stream' }) as any;
+
+    expect(result.type).toBe('data-tool-call-approval');
+    expect(result.data.runId).toBe('run-123');
+  });
+
+  it('maps v6 approvals to both tool-approval-request and data-tool-call-approval', () => {
+    const chunk = {
+      type: 'tool-call-approval' as const,
+      runId: 'run-123',
+      from: ChunkFrom.AGENT,
+      payload: {
+        toolCallId: 'tooluse_abc123',
+        toolName: 'myTool',
+        args: { param: 'value' },
+        resumeSchema: '{"type":"object","properties":{"approved":{"type":"boolean"}}}',
+      },
+    };
+
+    const result = convertMastraChunkToAISDKv6({ chunk, mode: 'stream' }) as any[];
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result[0]).toEqual({
+      type: 'tool-approval-request',
+      approvalId: 'run-123::tooluse_abc123',
+      toolCallId: 'tooluse_abc123',
+    });
+    expect(result[1]).toMatchObject({
+      type: 'data-tool-call-approval',
+      id: 'tooluse_abc123',
+      data: expect.objectContaining({
+        state: 'data-tool-call-approval',
+        runId: 'run-123',
+        toolCallId: 'tooluse_abc123',
+      }),
+    });
+  });
+
+  it('keeps v5 streaming behavior unchanged', async () => {
+    const aiSdkStream = toAISdkV5Stream(createApprovalStream() as unknown as MastraModelOutput, { from: 'agent' });
+    const chunks = await collectChunks(aiSdkStream);
+
+    expect(chunks.find(chunk => chunk.type === 'data-tool-call-approval')).toBeDefined();
+    expect(chunks.find(chunk => chunk.type === 'tool-approval-request')).toBeUndefined();
+  });
+
+  it('emits both tool-approval-request and data-tool-call-approval on the v6 stream', async () => {
+    const aiSdkStream = toAISdkStream(createApprovalStream() as unknown as MastraModelOutput, {
+      from: 'agent',
+      version: 'v6',
+    });
+    const chunks = await collectChunks(aiSdkStream);
+
+    expect(chunks.find(chunk => chunk.type === 'tool-input-available')).toBeDefined();
+    expect(chunks.find(chunk => chunk.type === 'tool-approval-request')).toBeDefined();
+    expect(chunks.find(chunk => chunk.type === 'data-tool-call-approval')).toBeDefined();
+  });
+
+  it('is interpreted by the v6 UI message reader as approval-requested', async () => {
+    const aiSdkStream = toAISdkStream(createApprovalStream() as unknown as MastraModelOutput, {
+      from: 'agent',
+      version: 'v6',
+    });
+
+    const messages = [] as any[];
+    for await (const message of readUIMessageStream({ stream: aiSdkStream as any })) {
+      messages.push(message);
+    }
+
+    const lastMessage = messages.at(-1);
+    expect(lastMessage?.role).toBe('assistant');
+
+    const approvalPart = lastMessage?.parts.find(
+      (part: any) => part.type === 'tool-myTool' && part.state === 'approval-requested',
+    );
+
+    expect(approvalPart).toMatchObject({
+      type: 'tool-myTool',
+      toolCallId: 'tooluse_abc123',
+      state: 'approval-requested',
+      approval: { id: 'run-123::tooluse_abc123' },
     });
   });
 });

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -6,6 +6,7 @@ import type { UIMessageStreamOptions as UIMessageStreamOptionsV5 } from '@intern
 import {
   createUIMessageStream as createUIMessageStreamV6,
   createUIMessageStreamResponse as createUIMessageStreamResponseV6,
+  isToolUIPart,
 } from '@internal/ai-v6';
 import type { UIMessageStreamOptions as UIMessageStreamOptionsV6 } from '@internal/ai-v6';
 import type { AgentExecutionOptions, AgentExecutionOptionsBase } from '@mastra/core/agent';
@@ -13,6 +14,7 @@ import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
 import { registerApiRoute } from '@mastra/core/server';
 import { toAISdkStream } from './convert-streams';
+import { APPROVAL_ID_SEPARATOR } from './helpers';
 import type {
   SupportedUIMessage,
   V5UIMessage,
@@ -20,6 +22,41 @@ import type {
   V6UIMessage,
   V6UIMessageStream,
 } from './public-types';
+
+/**
+ * Scans a v6 UIMessage array (most-recent-first) for a tool part in
+ * 'approval-responded' state. When found, splits the composite approvalId
+ * ("${runId}::${toolCallId}") to recover the runId needed for resumeStream.
+ *
+ * Returns null when no approval response is present (normal chat turn).
+ */
+export function extractV6NativeApproval(
+  messages: V6UIMessage[],
+): { resumeData: Record<string, unknown>; runId: string } | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]!;
+    if (message.role !== 'assistant') continue;
+
+    for (const part of message.parts ?? []) {
+      if (!isToolUIPart(part) || part.state !== 'approval-responded') continue;
+
+      const lastSep = part.approval.id.lastIndexOf(APPROVAL_ID_SEPARATOR);
+      if (lastSep === -1) continue;
+      const runId = part.approval.id.slice(0, lastSep);
+      if (!runId) continue;
+
+      return {
+        resumeData: {
+          approved: part.approval.approved,
+          ...(part.approval.reason != null ? { reason: part.approval.reason } : {}),
+        },
+        runId,
+      };
+    }
+  }
+
+  return null;
+}
 
 export type ChatStreamHandlerParams<
   UI_MESSAGE extends SupportedUIMessage = SupportedUIMessage,
@@ -129,6 +166,14 @@ export async function handleChatStream<OUTPUT = undefined>({
     throw new Error('Messages must be an array of UIMessage objects');
   }
 
+  // For v6: if the user called approve() on the client, AI SDK v6 re-submits the
+  // conversation with the tool part transitioned to 'approval-responded'. Detect
+  // this and route to resumeStream instead of stream.
+  const nativeApproval = version === 'v6' && !resumeData ? extractV6NativeApproval(messages as V6UIMessage[]) : null;
+
+  const effectiveResumeData = nativeApproval?.resumeData ?? resumeData;
+  const effectiveRunId = nativeApproval?.runId ?? runId;
+
   // Capture the last assistant message ID for the stream response.
   // This helps the frontend identify which message the response corresponds to.
   let lastMessageId: string | undefined;
@@ -158,15 +203,15 @@ export async function handleChatStream<OUTPUT = undefined>({
   const baseOptions = {
     ...defaultOptionsRest,
     ...restOptions,
-    ...(runId && { runId }),
+    ...(effectiveRunId && { runId: effectiveRunId }),
     requestContext: requestContext || defaultOptions?.requestContext,
     ...(Object.keys(mergedProviderOptions).length > 0 && { providerOptions: mergedProviderOptions }),
   };
 
-  const result = resumeData
+  const result = effectiveResumeData
     ? structuredOutput
-      ? await agentObj.resumeStream(resumeData, { ...baseOptions, structuredOutput })
-      : await agentObj.resumeStream(resumeData, baseOptions as AgentExecutionOptionsBase<unknown>)
+      ? await agentObj.resumeStream(effectiveResumeData, { ...baseOptions, structuredOutput })
+      : await agentObj.resumeStream(effectiveResumeData, baseOptions as AgentExecutionOptionsBase<unknown>)
     : structuredOutput
       ? await agentObj.stream(messagesToSend, { ...baseOptions, structuredOutput })
       : await agentObj.stream(messagesToSend, baseOptions as AgentExecutionOptionsBase<unknown>);

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -24,35 +24,46 @@ import type {
 } from './public-types';
 
 /**
- * Scans a v6 UIMessage array (most-recent-first) for a tool part in
- * 'approval-responded' state. When found, splits the composite approvalId
- * ("${runId}::${toolCallId}") to recover the runId needed for resumeStream.
+ * Scans a v6 UIMessage array for an 'approval-responded' tool part in the
+ * last trailing assistant message only. When found, splits the composite
+ * approvalId ("${runId}::${toolCallId}") to recover the runId needed for
+ * resumeStream.
+ *
+ * Only the last trailing assistant message is inspected so that approval
+ * responses from earlier turns are never re-processed.
  *
  * Returns null when no approval response is present (normal chat turn).
  */
 export function extractV6NativeApproval(
   messages: V6UIMessage[],
 ): { resumeData: Record<string, unknown>; runId: string } | null {
+  // Find the last trailing assistant message — stop as soon as we see one.
+  let lastAssistantMsg: V6UIMessage | undefined;
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i]!;
-    if (message.role !== 'assistant') continue;
-
-    for (const part of message.parts ?? []) {
-      if (!isToolUIPart(part) || part.state !== 'approval-responded') continue;
-
-      const lastSep = part.approval.id.lastIndexOf(APPROVAL_ID_SEPARATOR);
-      if (lastSep === -1) continue;
-      const runId = part.approval.id.slice(0, lastSep);
-      if (!runId) continue;
-
-      return {
-        resumeData: {
-          approved: part.approval.approved,
-          ...(part.approval.reason != null ? { reason: part.approval.reason } : {}),
-        },
-        runId,
-      };
+    if (message.role === 'assistant') {
+      lastAssistantMsg = message;
+      break;
     }
+  }
+
+  if (!lastAssistantMsg) return null;
+
+  for (const part of lastAssistantMsg.parts ?? []) {
+    if (!isToolUIPart(part) || part.state !== 'approval-responded') continue;
+
+    const lastSep = part.approval.id.lastIndexOf(APPROVAL_ID_SEPARATOR);
+    if (lastSep === -1) continue;
+    const runId = part.approval.id.slice(0, lastSep);
+    if (!runId) continue;
+
+    return {
+      resumeData: {
+        approved: part.approval.approved,
+        ...(part.approval.reason != null ? { reason: part.approval.reason } : {}),
+      },
+      runId,
+    };
   }
 
   return null;

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -10,12 +10,22 @@ import type {
 import type {
   CallWarning as AISDKCallWarningV6,
   FinishReason as FinishReasonV6,
+  InferUIMessageChunk as InferUIMessageChunkV6,
   LanguageModelUsage as AISDKLanguageModelUsageV6,
+  ToolApprovalRequest,
+  UIMessage as UIMessageV6,
 } from '@internal/ai-v6';
 import { DefaultGeneratedFile, DefaultGeneratedFileWithType } from '@mastra/core/stream';
 import type { DataChunkType, ChunkType, MastraFinishReason } from '@mastra/core/stream';
-
 import { isDataChunkType } from './utils';
+
+/**
+ * Separator used to encode both runId and toolCallId into a single approvalId string.
+ * Chosen because neither runId nor toolCallId can contain ":" in normal usage
+ * (UUIDs are hex + hyphens; provider tool call IDs are alphanumeric + underscores).
+ * The server splits on this separator to recover the runId for resumeStream.
+ */
+export const APPROVAL_ID_SEPARATOR = '::';
 
 /**
  * Maps Mastra's extended finish reasons to AI SDK-compatible values.
@@ -32,6 +42,7 @@ export function toAISDKFinishReason(reason: MastraFinishReason): FinishReason {
 export type OutputChunkType<OUTPUT = undefined> =
   | TextStreamPart<ToolSet>
   | ObjectStreamPart<Partial<OUTPUT>>
+  | ToolApprovalRequest
   | DataChunkType
   | undefined;
 
@@ -393,7 +404,31 @@ export function convertMastraChunkToAISDKv6<OUTPUT = undefined>({
 }: {
   chunk: ChunkType<OUTPUT>;
   mode?: 'generate' | 'stream';
-}): OutputChunkType<OUTPUT> {
+}): OutputChunkType<OUTPUT> | OutputChunkType<OUTPUT>[] {
+  if (chunk.type === 'tool-call-approval') {
+    // Emit both the native v6 tool-approval-request AND the legacy data-tool-call-approval
+    // so that consumers using the data stream protocol remain backwards-compatible.
+    return [
+      {
+        type: 'tool-approval-request',
+        approvalId: `${chunk.runId}${APPROVAL_ID_SEPARATOR}${chunk.payload.toolCallId}`,
+        toolCallId: chunk.payload.toolCallId,
+      } as OutputChunkType<OUTPUT>,
+      {
+        type: 'data-tool-call-approval',
+        id: chunk.payload.toolCallId,
+        data: {
+          state: 'data-tool-call-approval',
+          runId: chunk.runId,
+          toolCallId: chunk.payload.toolCallId,
+          toolName: chunk.payload.toolName,
+          args: chunk.payload.args,
+          resumeSchema: chunk.payload.resumeSchema,
+        },
+      } satisfies DataChunkType,
+    ];
+  }
+
   return convertMastraChunkToAISDKBase({
     chunk,
     mode,
@@ -415,7 +450,11 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
   responseMessageId,
 }: {
   // tool-output is a custom mastra chunk type used in ToolStream
-  part: TextStreamPart<ToolSet> | DataChunkType | { type: 'tool-output'; toolCallId: string; output: any };
+  part:
+    | TextStreamPart<ToolSet>
+    | DataChunkType
+    | ToolApprovalRequest
+    | { type: 'tool-output'; toolCallId: string; output: any };
   messageMetadataValue?: unknown;
   sendReasoning?: boolean;
   sendSources?: boolean;
@@ -423,7 +462,13 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
   sendStart?: boolean;
   sendFinish?: boolean;
   responseMessageId?: string;
-}): InferUIMessageChunk<UI_MESSAGE> | ToolAgentChunkType | ToolWorkflowChunkType | ToolNetworkChunkType | undefined {
+}):
+  | InferUIMessageChunk<UI_MESSAGE>
+  | InferUIMessageChunkV6<UIMessageV6>
+  | ToolAgentChunkType
+  | ToolWorkflowChunkType
+  | ToolNetworkChunkType
+  | undefined {
   const partType = part?.type;
 
   switch (partType) {
@@ -545,6 +590,14 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
         ...(part.providerExecuted != null ? { providerExecuted: part.providerExecuted } : {}),
         ...(part.providerMetadata != null ? { providerMetadata: part.providerMetadata } : {}),
         ...(part.dynamic != null ? { dynamic: part.dynamic } : {}),
+      };
+    }
+
+    case 'tool-approval-request': {
+      return {
+        type: 'tool-approval-request',
+        approvalId: part.approvalId,
+        toolCallId: part.toolCallId,
       };
     }
 

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -323,7 +323,13 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
           } else if (transformedChunk.type === 'tool-network') {
             const payload = transformedChunk.payload;
             const networkChunk = transformNetwork(payload, bufferedSteps, true);
-            if (networkChunk) controller.enqueue(networkChunk);
+            if (Array.isArray(networkChunk)) {
+              for (const c of networkChunk) {
+                if (c) controller.enqueue(c);
+              }
+            } else if (networkChunk) {
+              controller.enqueue(networkChunk);
+            }
           } else {
             controller.enqueue(transformedChunk as any);
           }

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -152,7 +152,13 @@ export function createWorkflowStreamToAISDKTransformer<UI_CHUNK>(
         },
         convertMastraChunkToAISDK,
       );
-      if (transformed) controller.enqueue(transformed as UI_CHUNK);
+      if (Array.isArray(transformed)) {
+        for (const c of transformed) {
+          if (c) controller.enqueue(c as UI_CHUNK);
+        }
+      } else if (transformed) {
+        controller.enqueue(transformed as UI_CHUNK);
+      }
     },
   });
 }
@@ -307,7 +313,13 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
               undefined,
               convertMastraChunkToAISDK,
             );
-            if (workflowChunk) controller.enqueue(workflowChunk);
+            if (Array.isArray(workflowChunk)) {
+              for (const c of workflowChunk) {
+                if (c) controller.enqueue(c);
+              }
+            } else if (workflowChunk) {
+              controller.enqueue(workflowChunk);
+            }
           } else if (transformedChunk.type === 'tool-network') {
             const payload = transformedChunk.payload;
             const networkChunk = transformNetwork(payload, bufferedSteps, true);
@@ -724,6 +736,22 @@ export function transformWorkflow<OUTPUT>(
       if (includeTextStreamParts && output && isMastraTextStreamChunk(output)) {
         // @ts-expect-error - generic type mismatch in conversion
         const part = convertMastraChunkToAISDK<OUTPUT>({ chunk: output, mode: 'stream' });
+
+        // convertMastraChunkToAISDK can return an array (e.g. for tool-call-approval v6 chunks)
+        if (Array.isArray(part)) {
+          return part
+            .map(p =>
+              convertFullStreamChunkToUIMessageStream({
+                part: p as any,
+                sendReasoning: streamOptions?.sendReasoning,
+                sendSources: streamOptions?.sendSources,
+                onError(error) {
+                  return safeParseErrorObject(error);
+                },
+              }),
+            )
+            .filter(Boolean);
+        }
 
         const transformedChunk = convertFullStreamChunkToUIMessageStream({
           part: part as any,

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -278,42 +278,52 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
 
       const part = convertMastraChunkToAISDK({ chunk, mode: 'stream' });
 
-      const transformedChunk = convertFullStreamChunkToUIMessageStream<any>({
-        part: part as any,
-        sendReasoning,
-        sendSources,
-        messageMetadataValue: part ? messageMetadata?.({ part: part as TextStreamPart<ToolSet> }) : undefined,
-        sendStart,
-        sendFinish,
-        responseMessageId: lastMessageId,
-        onError(error) {
-          return onError ? onError(error) : safeParseErrorObject(error);
-        },
-      });
+      const enqueueTransformedPart = (p: any) => {
+        const transformedChunk = convertFullStreamChunkToUIMessageStream<any>({
+          part: p as any,
+          sendReasoning,
+          sendSources,
+          messageMetadataValue: p ? messageMetadata?.({ part: p as TextStreamPart<ToolSet> }) : undefined,
+          sendStart,
+          sendFinish,
+          responseMessageId: lastMessageId,
+          onError(error) {
+            return onError ? onError(error) : safeParseErrorObject(error);
+          },
+        });
 
-      if (transformedChunk) {
-        if (transformedChunk.type === 'tool-agent') {
-          const payload = transformedChunk.payload;
-          const agentTransformed = transformAgent<OUTPUT>(payload, bufferedSteps);
-          if (agentTransformed) controller.enqueue(agentTransformed);
-        } else if (transformedChunk.type === 'tool-workflow') {
-          const payload = transformedChunk.payload;
-          const workflowChunk = transformWorkflow(
-            payload,
-            bufferedSteps,
-            true,
-            undefined,
-            undefined,
-            convertMastraChunkToAISDK,
-          );
-          if (workflowChunk) controller.enqueue(workflowChunk);
-        } else if (transformedChunk.type === 'tool-network') {
-          const payload = transformedChunk.payload;
-          const networkChunk = transformNetwork(payload, bufferedSteps, true);
-          if (networkChunk) controller.enqueue(networkChunk);
-        } else {
-          controller.enqueue(transformedChunk as any);
+        if (transformedChunk) {
+          if (transformedChunk.type === 'tool-agent') {
+            const payload = transformedChunk.payload;
+            const agentTransformed = transformAgent<OUTPUT>(payload, bufferedSteps);
+            if (agentTransformed) controller.enqueue(agentTransformed);
+          } else if (transformedChunk.type === 'tool-workflow') {
+            const payload = transformedChunk.payload;
+            const workflowChunk = transformWorkflow(
+              payload,
+              bufferedSteps,
+              true,
+              undefined,
+              undefined,
+              convertMastraChunkToAISDK,
+            );
+            if (workflowChunk) controller.enqueue(workflowChunk);
+          } else if (transformedChunk.type === 'tool-network') {
+            const payload = transformedChunk.payload;
+            const networkChunk = transformNetwork(payload, bufferedSteps, true);
+            if (networkChunk) controller.enqueue(networkChunk);
+          } else {
+            controller.enqueue(transformedChunk as any);
+          }
         }
+      };
+
+      if (Array.isArray(part)) {
+        for (const p of part) {
+          enqueueTransformedPart(p);
+        }
+      } else {
+        enqueueTransformedPart(part);
       }
     },
     flush(controller) {


### PR DESCRIPTION
Fixes #14818 and #15268.

Two related problems with tool call approvals in AI SDK v6:

**1. handleChatStream didn't detect native approve() calls**

When the client uses AI SDK v6's `approve()` method, the SDK re-submits the conversation with an `approval-responded` part in the messages. `handleChatStream` was treating this as a normal chat turn and calling `stream()` instead of `resumeStream()`.

Now `handleChatStream` scans the incoming messages for `approval-responded` parts, extracts the `runId` from the composite `approvalId` (`"${runId}::${toolCallId}"`), and routes to `resumeStream` automatically — no extra wiring needed in user code.

**2. v6 stream wasn't emitting native tool-approval-request parts**

`convertMastraChunkToAISDKv6` was routing `tool-call-approval` through the base converter which only produced `data-tool-call-approval`. AI SDK v6's `useChat` needs a `tool-approval-request` part to wire up `approve()` on the client side.

Now for v6, both are emitted: `tool-approval-request` (for native `approve()` support) and `data-tool-call-approval` (backwards compat with `@mastra/react` hooks that read `runId` from the data chunk).

If you're on v6 and using `useChat`, tool approvals now just work without needing to manually post to `/approve-tool-call`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes the approval flow so that when a user clicks the built‑in "approve" button in AI SDK v6 chat, the conversation correctly resumes and the SDK emits the right approval messages—no extra server wiring required.

## Overview

Fixes tool-call approval handling in AI SDK v6 by:
- Detecting native approve() re-submissions and routing them to resumeStream.
- Emitting AI SDK v6 native approval parts so useChat/approve() wiring works, while retaining legacy data chunks for backward compatibility.

## Key Changes

- Native V6 approval detection
  - Added extractV6NativeApproval(messages) in client-sdks/ai-sdk/src/chat-route.ts which inspects the last trailing assistant message for a tool part with state === 'approval-responded', parses a composite approvalId ("${runId}::${toolCallId}") to recover runId, and returns { resumeData, runId } or null.
  - Updated handleChatStream to use extractV6NativeApproval (when version === 'v6' and no explicit resumeData) and route to agentObj.resumeStream(...) instead of agentObj.stream(...) when appropriate; base options use the recovered runId.

- Dual-emission of approval parts (v6 + legacy)
  - Added APPROVAL_ID_SEPARATOR = '::' constant in client-sdks/ai-sdk/src/helpers.ts for composing/parsing approvalId.
  - convertMastraChunkToAISDKv6 now returns two parts for tool-call-approval: a v6 ToolApprovalRequest (tool-approval-request with computed approvalId) and the legacy data-tool-call-approval DataChunkType (runId, toolCallId, toolName, args, resumeSchema) to preserve backwards compatibility.
  - Output types updated to allow convertMastraChunkToAISDK to return an array of parts.

- Stream conversion & transformer updates
  - createAgentStreamToAISDKTransformer and createWorkflowStreamToAISDKTransformer updated to handle arrays returned from conversion functions by enqueueing each element individually (skip falsy items), enabling multiple parts emitted from a single Mastra chunk to be processed correctly.

- Tests
  - Added comprehensive tests in client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts:
    - Unit tests for extractV6NativeApproval (parsing, runId extraction, reason handling, edge cases).
    - Control-flow tests ensuring handleChatStream calls resumeStream (not stream) when approval-responded parts are present.
    - Conversion and integration tests asserting v6 output contains both tool-approval-request and data-tool-call-approval and that UI message stream reflects approval-requested state.
  - Adjusted helpers/transformer tests to cover array-return conversion behavior.

## Impact

- v6 useChat clients can resolve tool approvals with native approve()/resume() flows without manual POSTs.
- Resume operations correctly trigger when clients use native AI SDK v6 approval mechanisms.
- Backwards compatibility with existing @mastra/react consumers preserved via legacy data chunks.
- Addresses issues #14818 and #15268.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->