### PR TITLE
fix(core): infer parsed workflow state schema output

### DIFF
--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -47,6 +47,7 @@ import type {
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from '../constants';
 import { forwardAgentStreamChunk } from '../stream-utils';
 import type { StreamChunkWriter } from '../stream-utils';
+import type { InferParsedPublicSchema } from '../types';
 import { EventedExecutionEngine } from './execution-engine';
 import { isTripwireChunk, createTripWireFromChunk, getTextDeltaFromChunk } from './helpers';
 import type { TripwireChunk } from './helpers';
@@ -166,20 +167,20 @@ function isProcessor(obj: unknown): obj is Processor {
  */
 export function createStep<
   TStepId extends string,
-  TStateSchema extends PublicSchema | undefined,
-  TInputSchema extends PublicSchema,
-  TOutputSchema extends PublicSchema,
-  TResumeSchema extends PublicSchema | undefined = undefined,
-  TSuspendSchema extends PublicSchema | undefined = undefined,
+  TStateSchema extends PublicSchema<any> | undefined,
+  TInputSchema extends PublicSchema<any>,
+  TOutputSchema extends PublicSchema<any>,
+  TResumeSchema extends PublicSchema<any> | undefined = undefined,
+  TSuspendSchema extends PublicSchema<any> | undefined = undefined,
 >(
   params: StepParams<TStepId, TStateSchema, TInputSchema, TOutputSchema, TResumeSchema, TSuspendSchema>,
 ): Step<
   TStepId,
-  TStateSchema extends PublicSchema ? InferPublicSchema<TStateSchema> : unknown,
+  TStateSchema extends PublicSchema<any> ? InferParsedPublicSchema<TStateSchema> : unknown,
   InferPublicSchema<TInputSchema>,
   InferPublicSchema<TOutputSchema>,
-  TResumeSchema extends PublicSchema ? InferPublicSchema<TResumeSchema> : unknown,
-  TSuspendSchema extends PublicSchema ? InferPublicSchema<TSuspendSchema> : unknown,
+  TResumeSchema extends PublicSchema<any> ? InferPublicSchema<TResumeSchema> : unknown,
+  TSuspendSchema extends PublicSchema<any> ? InferPublicSchema<TSuspendSchema> : unknown,
   DefaultEngineType
 >;
 
@@ -261,7 +262,7 @@ export function createStep<
   params: StepParams<TStepId, TStateSchema, TInputSchema, TOutputSchema, TResumeSchema, TSuspendSchema>,
 ): Step<
   TStepId,
-  TStateSchema extends PublicSchema<any> ? InferPublicSchema<TStateSchema> : unknown,
+  TStateSchema extends PublicSchema<any> ? InferParsedPublicSchema<TStateSchema> : unknown,
   InferPublicSchema<TInputSchema>,
   InferPublicSchema<TOutputSchema>,
   TResumeSchema extends PublicSchema<any> ? InferPublicSchema<TResumeSchema> : unknown,
@@ -319,7 +320,7 @@ function createStepFromParams<
   >,
 ): Step<
   TStepId,
-  TStateSchema extends PublicSchema<any> ? InferPublicSchema<TStateSchema> : unknown,
+  TStateSchema extends PublicSchema<any> ? InferParsedPublicSchema<TStateSchema> : unknown,
   InferPublicSchema<TInputSchema>,
   InferPublicSchema<TOutputSchema>,
   TResumeSchema extends PublicSchema<any> ? InferPublicSchema<TResumeSchema> : unknown,
@@ -344,7 +345,7 @@ function createStepFromParams<
     metadata: params.metadata,
     execute: params.execute.bind(params) as Step<
       TStepId,
-      TStateSchema extends PublicSchema<any> ? InferPublicSchema<TStateSchema> : unknown,
+      TStateSchema extends PublicSchema<any> ? InferParsedPublicSchema<TStateSchema> : unknown,
       InferPublicSchema<TInputSchema>,
       InferPublicSchema<TOutputSchema>,
       TResumeSchema extends PublicSchema<any> ? InferPublicSchema<TResumeSchema> : unknown,

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -562,7 +562,7 @@ export type StepWithComponent = Step<string, any, any, any, any, any> & {
   steps?: Record<string, StepWithComponent>;
 };
 
-type InferParsedPublicSchema<TSchema extends PublicSchema<any>> = TSchema extends { _output: infer Output }
+export type InferParsedPublicSchema<TSchema extends PublicSchema<any>> = TSchema extends { _output: infer Output }
   ? Output
   : InferPublicSchema<TSchema>;
 
@@ -596,7 +596,7 @@ export type StepParams<
   scorers?: DynamicArgument<MastraScorers>;
   metadata?: StepMetadata;
   execute: ExecuteFunction<
-    TStateSchema extends PublicSchema<any> ? InferPublicSchema<TStateSchema> : unknown,
+    TStateSchema extends PublicSchema<any> ? InferParsedPublicSchema<TStateSchema> : unknown,
     InferParsedPublicSchema<TInputSchema>,
     InferPublicSchema<TOutputSchema>,
     TResumeSchema extends PublicSchema<any> ? InferPublicSchema<TResumeSchema> : unknown,
@@ -795,7 +795,7 @@ export type WorkflowConfig<
   description?: string | undefined;
   inputSchema: PublicSchema<TInput>;
   outputSchema: PublicSchema<TOutput>;
-  stateSchema?: PublicSchema<TState>;
+  stateSchema?: PublicSchema<TState, any>;
   /**
    * Optional schema for validating request context values.
    * When provided, the request context will be validated against this schema when the workflow starts.

--- a/packages/core/src/workflows/workflow-schema-types.test-d.ts
+++ b/packages/core/src/workflows/workflow-schema-types.test-d.ts
@@ -299,6 +299,40 @@ describe('Workflow schema type inference', () => {
       });
     });
 
+    it('should infer state output type when workflow stateSchema uses .default()', () => {
+      const stateSchema = z.object({
+        idx: z.number().default(0),
+        value: z.string(),
+      });
+
+      const step = createStep({
+        id: 'state-loop-step',
+        inputSchema: z.object({ value: z.string() }),
+        outputSchema: z.object({ value: z.string() }),
+        stateSchema,
+        execute: async ({ state }) => {
+          expectTypeOf(state.idx).toEqualTypeOf<number>();
+          expectTypeOf(state.value).toEqualTypeOf<string>();
+          return { value: state.value };
+        },
+      });
+
+      const workflow = createWorkflow({
+        id: 'state-default-workflow',
+        inputSchema: z.object({ value: z.string() }),
+        outputSchema: z.object({ value: z.string() }),
+        stateSchema,
+      });
+
+      const chained = workflow.dowhile(step, async ({ state }) => {
+        expectTypeOf(state.idx).toEqualTypeOf<number>();
+        expectTypeOf(state.value).toEqualTypeOf<string>();
+        return state.idx < 10;
+      });
+
+      expectTypeOf(chained).not.toBeNever();
+    });
+
     it('should still reject steps with incompatible input schemas', () => {
       const workflowSchema = z.object({
         name: z.string(),

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -81,6 +81,7 @@ import type {
   StepParams,
   OutputWriter,
   StepMetadata,
+  InferParsedPublicSchema,
   WorkflowRunStartOptions,
 } from './types';
 import { cleanStepResult, createTimeTravelExecutionParams } from './utils';
@@ -176,12 +177,12 @@ function findStepInGraph(graph: SerializedStepFlowEntry[], stepId: string): Seri
  */
 export function createStep<
   TStepId extends string,
-  TStateSchema extends PublicSchema | undefined,
-  TInputSchema extends PublicSchema,
-  TOutputSchema extends PublicSchema,
-  TResumeSchema extends PublicSchema | undefined = undefined,
-  TSuspendSchema extends PublicSchema | undefined = undefined,
-  TRequestContextSchema extends PublicSchema | undefined = undefined,
+  TStateSchema extends PublicSchema<any> | undefined,
+  TInputSchema extends PublicSchema<any>,
+  TOutputSchema extends PublicSchema<any>,
+  TResumeSchema extends PublicSchema<any> | undefined = undefined,
+  TSuspendSchema extends PublicSchema<any> | undefined = undefined,
+  TRequestContextSchema extends PublicSchema<any> | undefined = undefined,
 >(
   params: StepParams<
     TStepId,
@@ -194,13 +195,13 @@ export function createStep<
   >,
 ): Step<
   TStepId,
-  TStateSchema extends PublicSchema ? InferPublicSchema<TStateSchema> : unknown,
+  TStateSchema extends PublicSchema<any> ? InferParsedPublicSchema<TStateSchema> : unknown,
   InferPublicSchema<TInputSchema>,
   InferPublicSchema<TOutputSchema>,
-  TResumeSchema extends PublicSchema ? InferPublicSchema<TResumeSchema> : unknown,
-  TSuspendSchema extends PublicSchema ? InferPublicSchema<TSuspendSchema> : unknown,
+  TResumeSchema extends PublicSchema<any> ? InferPublicSchema<TResumeSchema> : unknown,
+  TSuspendSchema extends PublicSchema<any> ? InferPublicSchema<TSuspendSchema> : unknown,
   DefaultEngineType,
-  TRequestContextSchema extends PublicSchema ? InferPublicSchema<TRequestContextSchema> : unknown
+  TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
 >;
 
 /**
@@ -273,12 +274,12 @@ export function createStep<TProcessorId extends string>(
  */
 export function createStep<
   TStepId extends string,
-  TStateSchema extends PublicSchema | undefined,
-  TInputSchema extends PublicSchema,
-  TOutputSchema extends PublicSchema,
-  TResumeSchema extends PublicSchema | undefined = undefined,
-  TSuspendSchema extends PublicSchema | undefined = undefined,
-  TRequestContextSchema extends PublicSchema | undefined = undefined,
+  TStateSchema extends PublicSchema<any> | undefined,
+  TInputSchema extends PublicSchema<any>,
+  TOutputSchema extends PublicSchema<any>,
+  TResumeSchema extends PublicSchema<any> | undefined = undefined,
+  TSuspendSchema extends PublicSchema<any> | undefined = undefined,
+  TRequestContextSchema extends PublicSchema<any> | undefined = undefined,
 >(
   params: StepParams<
     TStepId,
@@ -291,13 +292,13 @@ export function createStep<
   >,
 ): Step<
   TStepId,
-  TStateSchema extends PublicSchema ? InferPublicSchema<TStateSchema> : unknown,
+  TStateSchema extends PublicSchema<any> ? InferParsedPublicSchema<TStateSchema> : unknown,
   InferPublicSchema<TInputSchema>,
   InferPublicSchema<TOutputSchema>,
-  TResumeSchema extends PublicSchema ? InferPublicSchema<TResumeSchema> : unknown,
-  TSuspendSchema extends PublicSchema ? InferPublicSchema<TSuspendSchema> : unknown,
+  TResumeSchema extends PublicSchema<any> ? InferPublicSchema<TResumeSchema> : unknown,
+  TSuspendSchema extends PublicSchema<any> ? InferPublicSchema<TSuspendSchema> : unknown,
   DefaultEngineType,
-  TRequestContextSchema extends PublicSchema ? InferPublicSchema<TRequestContextSchema> : unknown
+  TRequestContextSchema extends PublicSchema<any> ? InferPublicSchema<TRequestContextSchema> : unknown
 >;
 
 // ============================================
@@ -343,7 +344,7 @@ function createStepFromParams<
   params: StepParams<TStepId, TStateSchema, TInputSchema, TOutputSchema, TResumeSchema, TSuspendSchema>,
 ): Step<
   TStepId,
-  TStateSchema extends PublicSchema<any> ? InferPublicSchema<TStateSchema> : unknown,
+  TStateSchema extends PublicSchema<any> ? InferParsedPublicSchema<TStateSchema> : unknown,
   InferPublicSchema<TInputSchema>,
   InferPublicSchema<TOutputSchema>,
   TResumeSchema extends PublicSchema<any> ? InferPublicSchema<TResumeSchema> : unknown,
@@ -367,7 +368,7 @@ function createStepFromParams<
     metadata: params.metadata,
     execute: params.execute.bind(params) as Step<
       TStepId,
-      TStateSchema extends PublicSchema<any> ? InferPublicSchema<TStateSchema> : unknown,
+      TStateSchema extends PublicSchema<any> ? InferParsedPublicSchema<TStateSchema> : unknown,
       InferPublicSchema<TInputSchema>,
       InferPublicSchema<TOutputSchema>,
       TResumeSchema extends PublicSchema<any> ? InferPublicSchema<TResumeSchema> : unknown,


### PR DESCRIPTION
## Summary
- infer workflow \ from parsed schema output instead of collapsing to the wider input type
- align \ typing in both core and evented workflows so state passed to \ uses parsed state output
- add a workflow schema type test covering \ with Zod \

Fixes https://github.com/mastra-ai/mastra/issues/14627

## Test plan
- npx vitest typecheck --run src/workflows/workflow-schema-types.test-d.ts
- pnpm build:core
- pnpm --filter ./packages/core check
- pnpm --filter ./packages/core exec vitest run src/workflows/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When defining workflow steps with state schemas that have default values (like "count: 5"), the code wasn't recognizing that those fields would always exist after parsing. This fix makes the TypeScript types accurately reflect that the parsed state includes the defaults, eliminating type errors when using these fields.

## Summary

This PR fixes type inference for workflow state schemas to properly account for parsed schema outputs, particularly when using Zod schemas with `.default()` values.

### Changes Made

1. **New Type Export (`InferParsedPublicSchema`)**: Added a new exported type alias in `types.ts` that intelligently infers schema output types. It checks if a schema has an `_output` property (like Zod does) and uses that; otherwise, it falls back to the standard `InferPublicSchema` inference. This is critical for Zod schemas with defaults, where `_output` represents the fully-parsed type including default values.

2. **Updated Type Constraints**: Widened generic constraints across three files from `PublicSchema` to `PublicSchema<any>` for consistency and to ensure compatibility with schemas that carry output type information.

3. **Core Type Changes**:
   - In `types.ts`: Updated `StepParams.execute` to use `InferParsedPublicSchema` for state type inference, and changed `WorkflowConfig.stateSchema` generic from `PublicSchema<TState>` to `PublicSchema<TState, any>`
   - In `workflow.ts` and `evented/workflow.ts`: Updated `createStep` overloads and internal `createStepFromParams` to use `InferParsedPublicSchema` for state type mapping instead of `InferPublicSchema`

4. **Type Test Coverage**: Added a comprehensive test case verifying that workflow state schemas with Zod `.default()` fields properly infer the output type, including the defaulted fields, so they're accessible without type errors in step callbacks.

### Impact

- Workflow state types now correctly reflect the parsed schema output, including default values
- Both standard core workflows and evented workflows have aligned typing
- Developers can safely use fields with Zod defaults in workflow state without TypeScript errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->