### PR TITLE
feat(cli): add mastra run command for headless agent execution

### DIFF
--- a/.changeset/five-guests-play.md
+++ b/.changeset/five-guests-play.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added `runHeadless` orchestrator and output-formatter helpers (`formatText`, `formatJson`, `formatStreamJson`, `buildJsonEnvelope`, `buildInterruptedEnvelope`, `hasWarnings`) to `@mastra/core/harness` for running agents in headless mode with `text`, `json`, or `stream-json` output formats.

--- a/.changeset/five-guests-play.md
+++ b/.changeset/five-guests-play.md
@@ -2,4 +2,4 @@
 '@mastra/core': minor
 ---
 
-Added `runHeadless` orchestrator and output-formatter helpers (`formatText`, `formatJson`, `formatStreamJson`, `buildJsonEnvelope`, `buildInterruptedEnvelope`, `hasWarnings`) to `@mastra/core/harness` for running agents in headless mode with `text`, `json`, or `stream-json` output formats.
+Added `runHeadless` orchestrator and output-formatter helpers (`formatText`, `formatJson`, `formatStreamJson`, `hasWarnings`) to `@mastra/core/harness` for running agents in headless mode with `text`, `json`, or `stream-json` output formats. The `json` mode emits the full agent output (the shape returned by `agent.generate()`/`agent.stream()`) as a single JSON line; `stream-json` emits each chunk as NDJSON.

--- a/.changeset/thirty-regions-rush.md
+++ b/.changeset/thirty-regions-rush.md
@@ -2,18 +2,4 @@
 'mastra': minor
 ---
 
-Added `mastra run` command for headless one-shot agent invocation.
-
-```bash
-mastra run -a myAgent -p "List 3 colors" --output-format json \
-  --json-schema '{"type":"object","properties":{"colors":{"type":"array","items":{"type":"string"}}}}'
-```
-
-**Flags**
-
-- `-a, --agent <agent-id>` — required, the agent to run
-- `-p, --prompt <prompt>` — prompt text; can also be piped via stdin
-- `-f, --output-format <format>` — one of `text` (default, streamed deltas), `json` (single result envelope), or `stream-json` (NDJSON of raw chunks)
-- `--json-schema <schema>` — JSON Schema for structured output (requires `json` or `stream-json`)
-- `--strict` — treat warnings as errors (exit code 1)
-- `-d, --dir`, `-r, --root`, `-e, --env`, `--debug` — path and diagnostic overrides
+Added `mastra run` command for headless one-shot agent invocation with text, json, and stream-json output formats, JSON Schema structured output, and stdin prompt piping. See `mastra run --help` for details.

--- a/.changeset/thirty-regions-rush.md
+++ b/.changeset/thirty-regions-rush.md
@@ -1,0 +1,19 @@
+---
+'mastra': minor
+---
+
+Added `mastra run` command for headless one-shot agent invocation.
+
+```bash
+mastra run -a myAgent -p "List 3 colors" --output-format json \
+  --json-schema '{"type":"object","properties":{"colors":{"type":"array","items":{"type":"string"}}}}'
+```
+
+**Flags**
+
+- `-a, --agent <agent-id>` — required, the agent to run
+- `-p, --prompt <prompt>` — prompt text; can also be piped via stdin
+- `-f, --output-format <format>` — one of `text` (default, streamed deltas), `json` (single result envelope), or `stream-json` (NDJSON of raw chunks)
+- `--json-schema <schema>` — JSON Schema for structured output (requires `json` or `stream-json`)
+- `--strict` — treat warnings as errors (exit code 1)
+- `-d, --dir`, `-r, --root`, `-e, --env`, `--debug` — path and diagnostic overrides

--- a/packages/cli/src/commands/actions/run-agent.ts
+++ b/packages/cli/src/commands/actions/run-agent.ts
@@ -1,0 +1,33 @@
+import { analytics, origin } from '../..';
+import { run } from '../run/run';
+
+export const runAgent = async (args: {
+  prompt?: string;
+  agent: string;
+  outputFormat?: string;
+  jsonSchema?: string;
+  strict?: boolean;
+  dir?: string;
+  root?: string;
+  env?: string;
+  debug?: boolean;
+}) => {
+  await analytics.trackCommandExecution({
+    command: 'run',
+    args,
+    execution: async () => {
+      await run({
+        prompt: args.prompt,
+        agent: args.agent,
+        outputFormat: args.outputFormat ?? 'text',
+        jsonSchema: args.jsonSchema,
+        strict: args.strict ?? false,
+        dir: args.dir,
+        root: args.root,
+        env: args.env,
+        debug: args.debug ?? false,
+      });
+    },
+    origin,
+  });
+};

--- a/packages/cli/src/commands/actions/run-agent.ts
+++ b/packages/cli/src/commands/actions/run-agent.ts
@@ -14,7 +14,16 @@ export const runAgent = async (args: {
 }) => {
   await analytics.trackCommandExecution({
     command: 'run',
-    args,
+    args: {
+      outputFormat: args.outputFormat ?? 'text',
+      strict: args.strict ?? false,
+      debug: args.debug ?? false,
+      hasPrompt: Boolean(args.prompt),
+      hasJsonSchema: Boolean(args.jsonSchema),
+      hasDirOverride: Boolean(args.dir),
+      hasRootOverride: Boolean(args.root),
+      hasEnvOverride: Boolean(args.env),
+    },
     execution: async () => {
       await run({
         prompt: args.prompt,

--- a/packages/cli/src/commands/run/RunBundler.test.ts
+++ b/packages/cli/src/commands/run/RunBundler.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@mastra/deployer/build', () => ({
+  FileService: vi.fn().mockImplementation(() => ({
+    getFirstExistingFile: vi.fn().mockImplementation((files: string[]) => files[0]),
+  })),
+}));
+
+vi.mock('../build/BuildBundler.js', () => ({
+  BuildBundler: class MockBuildBundler {
+    protected platform = 'node';
+    constructor(_options?: { studio?: boolean }) {}
+    __setLogger(_logger: unknown) {}
+    getAllToolPaths(_dir: string, _extra: unknown[]) {
+      return [];
+    }
+    prepare(_path: string) {
+      return Promise.resolve();
+    }
+    loadEnvVars() {
+      return Promise.resolve(new Map());
+    }
+    protected _bundle(_entry: string, _entryFile: string, _options: unknown, _toolsPaths: unknown): Promise<void> {
+      return Promise.resolve();
+    }
+  },
+}));
+
+import { RunBundler } from './RunBundler';
+import type { RunEntryOptions } from './RunBundler';
+
+const defaultOptions: RunEntryOptions = {
+  prompt: 'Hello world',
+  agentId: 'testAgent',
+  outputFormat: 'text',
+  strict: false,
+};
+
+describe('RunBundler', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    delete process.env.MASTRA_SKIP_DOTENV;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should create bundler with entry options', () => {
+      const bundler = new RunBundler(defaultOptions);
+      expect(bundler).toBeInstanceOf(RunBundler);
+    });
+
+    it('should accept custom env file', () => {
+      const bundler = new RunBundler(defaultOptions, '.env.custom');
+      expect(bundler).toBeInstanceOf(RunBundler);
+    });
+  });
+
+  describe('getEntry bootstrap wiring', () => {
+    it('should import mastra from #mastra', () => {
+      const bundler = new RunBundler(defaultOptions);
+      const entry = (bundler as any).getEntry();
+      expect(entry).toContain("import { mastra } from '#mastra'");
+    });
+
+    it('should import runHeadless from @mastra/core/harness', () => {
+      const bundler = new RunBundler(defaultOptions);
+      const entry = (bundler as any).getEntry();
+      expect(entry).toContain("import { runHeadless } from '@mastra/core/harness'");
+    });
+
+    it('should invoke runHeadless with the mastra instance', () => {
+      const bundler = new RunBundler(defaultOptions);
+      const entry = (bundler as any).getEntry();
+      expect(entry).toContain('runHeadless(mastra,');
+    });
+
+    it('should wire process.stdout, process.stderr, process.exit, and SIGINT into the IO object', () => {
+      const bundler = new RunBundler(defaultOptions);
+      const entry = (bundler as any).getEntry();
+      expect(entry).toContain('stdout: process.stdout');
+      expect(entry).toContain('stderr: process.stderr');
+      expect(entry).toContain('process.exit(code)');
+      expect(entry).toContain("process.on('SIGINT', handler)");
+    });
+
+    it('should embed a fatal error handler that exits with code 1', () => {
+      const bundler = new RunBundler(defaultOptions);
+      const entry = (bundler as any).getEntry();
+      expect(entry).toContain('.catch((err)');
+      expect(entry).toContain('process.exit(1)');
+    });
+  });
+
+  describe('getEntry option embedding', () => {
+    it('should embed the prompt as a JSON-escaped literal', () => {
+      const bundler = new RunBundler({
+        ...defaultOptions,
+        prompt: 'Say "hello" and use a backslash \\ here',
+      });
+      const entry = (bundler as any).getEntry();
+      expect(entry).toContain('Say \\"hello\\"');
+      expect(entry).toContain('backslash \\\\');
+    });
+
+    it('should embed the agent ID', () => {
+      const bundler = new RunBundler({ ...defaultOptions, agentId: 'myCustomAgent' });
+      const entry = (bundler as any).getEntry();
+      expect(entry).toContain('agentId: "myCustomAgent"');
+    });
+
+    it('should embed the output format', () => {
+      const bundler = new RunBundler({ ...defaultOptions, outputFormat: 'json' });
+      const entry = (bundler as any).getEntry();
+      expect(entry).toContain('outputFormat: "json"');
+    });
+
+    it('should embed the strict flag as a boolean literal', () => {
+      const bundlerFalse = new RunBundler({ ...defaultOptions, strict: false });
+      expect((bundlerFalse as any).getEntry()).toContain('strict: false');
+
+      const bundlerTrue = new RunBundler({ ...defaultOptions, strict: true });
+      expect((bundlerTrue as any).getEntry()).toContain('strict: true');
+    });
+
+    it('should embed jsonSchema as a JSON-escaped string literal when provided', () => {
+      const bundler = new RunBundler({
+        ...defaultOptions,
+        jsonSchema: '{"type":"object"}',
+      });
+      const entry = (bundler as any).getEntry();
+      expect(entry).toContain('jsonSchema: "{\\"type\\":\\"object\\"}"');
+    });
+
+    it('should embed jsonSchema as undefined when not provided', () => {
+      const bundler = new RunBundler(defaultOptions);
+      const entry = (bundler as any).getEntry();
+      expect(entry).toContain('jsonSchema: undefined');
+    });
+  });
+
+  describe('getEnvFiles', () => {
+    it('should return env files when no custom env file specified', async () => {
+      const bundler = new RunBundler(defaultOptions);
+      const envFiles = await bundler.getEnvFiles();
+
+      expect(Array.isArray(envFiles)).toBe(true);
+    });
+
+    it('should return empty array when MASTRA_SKIP_DOTENV is set', async () => {
+      process.env.MASTRA_SKIP_DOTENV = 'true';
+
+      const bundler = new RunBundler(defaultOptions);
+      const envFiles = await bundler.getEnvFiles();
+
+      expect(envFiles).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/src/commands/run/RunBundler.ts
+++ b/packages/cli/src/commands/run/RunBundler.ts
@@ -1,0 +1,83 @@
+import { FileService } from '@mastra/deployer/build';
+
+import { BuildBundler } from '../build/BuildBundler.js';
+import { shouldSkipDotenvLoading } from '../utils.js';
+
+export interface RunEntryOptions {
+  prompt: string;
+  agentId: string;
+  outputFormat: 'text' | 'json' | 'stream-json';
+  jsonSchema?: string;
+  strict: boolean;
+}
+
+export class RunBundler extends BuildBundler {
+  private customEnvFile?: string;
+  private entryOptions: RunEntryOptions;
+
+  constructor(entryOptions: RunEntryOptions, customEnvFile?: string) {
+    super({ studio: false });
+    this.entryOptions = entryOptions;
+    this.customEnvFile = customEnvFile;
+  }
+
+  override getEnvFiles(): Promise<string[]> {
+    if (shouldSkipDotenvLoading()) {
+      return Promise.resolve([]);
+    }
+
+    const possibleFiles = ['.env.development', '.env.local', '.env'];
+    if (this.customEnvFile) {
+      possibleFiles.unshift(this.customEnvFile);
+    }
+
+    try {
+      const fileService = new FileService();
+      const envFile = fileService.getFirstExistingFile(possibleFiles);
+      return Promise.resolve([envFile]);
+    } catch {
+      // ignore
+    }
+
+    return Promise.resolve([]);
+  }
+
+  async bundle(
+    entryFile: string,
+    outputDirectory: string,
+    { toolsPaths, projectRoot }: { toolsPaths: (string | string[])[]; projectRoot: string },
+  ): Promise<void> {
+    return this._bundle(this.getEntry(), entryFile, { outputDirectory, projectRoot }, toolsPaths);
+  }
+
+  protected override getEntry(): string {
+    const { prompt, agentId, outputFormat, jsonSchema, strict } = this.entryOptions;
+
+    const escapedPrompt = JSON.stringify(prompt);
+    const escapedAgentId = JSON.stringify(agentId);
+    const escapedFormat = JSON.stringify(outputFormat);
+    const schemaArg = jsonSchema ? JSON.stringify(jsonSchema) : 'undefined';
+
+    return `
+    import { mastra } from '#mastra';
+    import { runHeadless } from '@mastra/core/harness';
+    import process from 'node:process';
+
+    runHeadless(mastra, {
+      prompt: ${escapedPrompt},
+      agentId: ${escapedAgentId},
+      outputFormat: ${escapedFormat},
+      jsonSchema: ${schemaArg},
+      strict: ${strict},
+    }, {
+      stdout: process.stdout,
+      stderr: process.stderr,
+      exit: (code) => process.exit(code),
+      onSigint: (handler) => process.on('SIGINT', handler),
+    }).catch((err) => {
+      process.stderr.write('Fatal: ' + (err.message || String(err)) + '\\n');
+      process.exit(1);
+    });
+    `;
+  }
+}

--- a/packages/cli/src/commands/run/run.test.ts
+++ b/packages/cli/src/commands/run/run.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@mastra/deployer', () => ({
+  FileService: vi.fn().mockImplementation(() => ({
+    getFirstExistingFile: vi.fn().mockReturnValue('/fake/src/mastra/index.ts'),
+  })),
+}));
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: vi.fn().mockReturnValue({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('./RunBundler.js', () => ({
+  RunBundler: vi.fn().mockImplementation(() => ({
+    __setLogger: vi.fn(),
+    prepare: vi.fn().mockResolvedValue(undefined),
+    getAllToolPaths: vi.fn().mockReturnValue([]),
+    bundle: vi.fn().mockResolvedValue(undefined),
+    loadEnvVars: vi.fn().mockResolvedValue(new Map()),
+  })),
+}));
+
+import { isOutputFormat, run } from './run';
+import type { RunArgs } from './run';
+
+const baseArgs: RunArgs = {
+  prompt: 'Hello',
+  agent: 'myAgent',
+  outputFormat: 'text',
+  strict: false,
+  debug: false,
+};
+
+describe('isOutputFormat', () => {
+  it('accepts valid formats', () => {
+    expect(isOutputFormat('text')).toBe(true);
+    expect(isOutputFormat('json')).toBe(true);
+    expect(isOutputFormat('stream-json')).toBe(true);
+  });
+
+  it('rejects invalid formats', () => {
+    expect(isOutputFormat('yaml')).toBe(false);
+    expect(isOutputFormat('')).toBe(false);
+    expect(isOutputFormat('TEXT')).toBe(false);
+    expect(isOutputFormat('text ')).toBe(false);
+  });
+});
+
+describe('run — input validation', () => {
+  let stderrWrites: string[];
+  let exitCalls: number[];
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let originalStdinIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    stderrWrites = [];
+    exitCalls = [];
+
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: any) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    // process.exit halts execution; throw so tests can assert without the rest of run() executing
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null): never => {
+      exitCalls.push(typeof code === 'number' ? code : 0);
+      throw new Error(`__exit_${code}__`);
+    });
+
+    // Force stdin to look like a TTY so readStdin is not triggered
+    originalStdinIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: originalStdinIsTTY });
+    vi.clearAllMocks();
+  });
+
+  it('exits 2 with usage message when no prompt is provided and stdin is a TTY', async () => {
+    await expect(run({ ...baseArgs, prompt: undefined })).rejects.toThrow('__exit_2__');
+
+    expect(exitCalls).toEqual([2]);
+    const stderrText = stderrWrites.join('');
+    expect(stderrText).toContain('No prompt provided');
+    expect(stderrText).toContain('-p "your prompt"');
+    expect(stderrText).toContain('pipe via stdin');
+  });
+
+  it('exits 2 when --output-format is invalid', async () => {
+    await expect(run({ ...baseArgs, outputFormat: 'yaml' })).rejects.toThrow('__exit_2__');
+
+    expect(exitCalls).toEqual([2]);
+    expect(stderrWrites.join('')).toContain('Invalid --output-format "yaml"');
+    expect(stderrWrites.join('')).toContain('text, json, stream-json');
+  });
+
+  it('exits 2 when --json-schema is used with --output-format text', async () => {
+    await expect(run({ ...baseArgs, outputFormat: 'text', jsonSchema: '{"type":"object"}' })).rejects.toThrow(
+      '__exit_2__',
+    );
+
+    expect(exitCalls).toEqual([2]);
+    expect(stderrWrites.join('')).toContain('--json-schema requires --output-format json or stream-json');
+  });
+
+  it('validates --output-format before prompt validity (invalid format with missing prompt still flags prompt first)', async () => {
+    // Prompt check comes first in the function; invalid format alone after valid prompt
+    await expect(run({ ...baseArgs, prompt: undefined, outputFormat: 'yaml' })).rejects.toThrow('__exit_2__');
+
+    // Should be the prompt error, not the format error
+    expect(stderrWrites.join('')).toContain('No prompt provided');
+    expect(stderrWrites.join('')).not.toContain('Invalid --output-format');
+  });
+});

--- a/packages/cli/src/commands/run/run.ts
+++ b/packages/cli/src/commands/run/run.ts
@@ -42,8 +42,8 @@ export async function run(args: RunArgs) {
   const mastraDir = args.dir
     ? args.dir.startsWith('/')
       ? args.dir
-      : join(process.cwd(), args.dir)
-    : join(process.cwd(), 'src', 'mastra');
+      : join(rootDir, args.dir)
+    : join(rootDir, 'src', 'mastra');
   const dotMastraPath = join(rootDir, '.mastra');
 
   // Resolve prompt: -p flag takes priority, then stdin pipe

--- a/packages/cli/src/commands/run/run.ts
+++ b/packages/cli/src/commands/run/run.ts
@@ -1,0 +1,152 @@
+import { join } from 'node:path';
+import process from 'node:process';
+import type { OutputFormat } from '@mastra/core/harness';
+import { FileService } from '@mastra/deployer';
+import { execa } from 'execa';
+import pc from 'picocolors';
+
+import { createLogger } from '../../utils/logger.js';
+import { RunBundler } from './RunBundler.js';
+import type { RunEntryOptions } from './RunBundler.js';
+
+export interface RunArgs {
+  prompt?: string;
+  agent: string;
+  outputFormat: string;
+  jsonSchema?: string;
+  strict: boolean;
+  dir?: string;
+  root?: string;
+  env?: string;
+  debug: boolean;
+}
+
+export function isOutputFormat(value: string): value is OutputFormat {
+  return (['text', 'json', 'stream-json'] as readonly string[]).includes(value);
+}
+
+/**
+ * Read prompt from stdin when piped (non-TTY).
+ */
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf-8').trim();
+}
+
+export async function run(args: RunArgs) {
+  const logger = createLogger(args.debug);
+  const rootDir = args.root || process.cwd();
+  const mastraDir = args.dir
+    ? args.dir.startsWith('/')
+      ? args.dir
+      : join(process.cwd(), args.dir)
+    : join(process.cwd(), 'src', 'mastra');
+  const dotMastraPath = join(rootDir, '.mastra');
+
+  // Resolve prompt: -p flag takes priority, then stdin pipe
+  let prompt = args.prompt;
+  if (!prompt) {
+    if (!process.stdin.isTTY) {
+      prompt = await readStdin();
+    }
+    if (!prompt) {
+      process.stderr.write(
+        'Error: No prompt provided. Use -p "your prompt" or pipe via stdin.\n' +
+          '  Example: mastra run -p "Hello" --agent myAgent\n' +
+          '  Example: echo "Hello" | mastra run --agent myAgent\n',
+      );
+      process.exit(2);
+    }
+  }
+
+  if (!isOutputFormat(args.outputFormat)) {
+    process.stderr.write(
+      `Error: Invalid --output-format "${args.outputFormat}". Must be one of: text, json, stream-json.\n`,
+    );
+    process.exit(2);
+  }
+  const outputFormat: OutputFormat = args.outputFormat;
+
+  // Validate flag combinations
+  if (args.jsonSchema && outputFormat === 'text') {
+    process.stderr.write('Error: --json-schema requires --output-format json or stream-json.\n');
+    process.exit(2);
+  }
+
+  const entryOptions: RunEntryOptions = {
+    prompt,
+    agentId: args.agent,
+    outputFormat,
+    jsonSchema: args.jsonSchema,
+    strict: args.strict,
+  };
+
+  try {
+    const fileService = new FileService();
+    const entryFile = fileService.getFirstExistingFile([join(mastraDir, 'index.ts'), join(mastraDir, 'index.js')]);
+
+    const bundler = new RunBundler(entryOptions, args.env);
+    bundler.__setLogger(logger);
+
+    if (args.outputFormat === 'text') {
+      logger.debug('Bundling project...');
+    }
+
+    await bundler.prepare(dotMastraPath);
+
+    const discoveredTools = bundler.getAllToolPaths(mastraDir, []);
+    await bundler.bundle(entryFile, dotMastraPath, {
+      toolsPaths: discoveredTools,
+      projectRoot: rootDir,
+    });
+
+    const loadedEnv = await bundler.loadEnvVars();
+
+    const childProcess = execa(process.execPath, [join(dotMastraPath, 'output', 'index.mjs')], {
+      cwd: rootDir,
+      env: {
+        NODE_ENV: 'production',
+        ...Object.fromEntries(loadedEnv),
+      },
+      // stdout: pipe to parent for output capture
+      // stderr: pipe to parent stderr
+      // stdin: not needed (prompt is embedded in the entry script)
+      stdio: ['ignore', 'pipe', 'pipe'],
+      reject: false,
+    });
+
+    // Forward child stdout directly to parent stdout (preserves streaming for text/stream-json)
+    childProcess.stdout?.pipe(process.stdout);
+
+    // Forward child stderr to parent stderr
+    childProcess.stderr?.pipe(process.stderr);
+
+    // Forward SIGINT to child process
+    const sigintHandler = () => {
+      childProcess.kill('SIGINT');
+    };
+    process.on('SIGINT', sigintHandler);
+
+    const result = await childProcess;
+
+    process.removeListener('SIGINT', sigintHandler);
+
+    process.exit(result.exitCode ?? 1);
+  } catch (error: any) {
+    if (error.code === 'ERR_MODULE_NOT_FOUND' || error.message?.includes('Cannot find module')) {
+      process.stderr.write(pc.red('Error: Could not find Mastra entry file.\n'));
+      process.stderr.write('\nMake sure you have a mastra directory with an index.ts or index.js file.\n');
+      process.stderr.write(`Expected location: ${mastraDir}\n\n`);
+      process.stderr.write(pc.cyan('  npx mastra run --dir path/to/mastra\n'));
+    } else {
+      process.stderr.write(pc.red(`Error: ${error.message}\n`));
+      if (args.debug) {
+        console.error(error);
+      }
+    }
+    process.exit(2);
+  }
+}

--- a/packages/cli/src/commands/run/run.ts
+++ b/packages/cli/src/commands/run/run.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import process from 'node:process';
 import type { OutputFormat } from '@mastra/core/harness';
-import { FileService } from '@mastra/deployer';
+import { FileService } from '@mastra/deployer/build';
 import { execa } from 'execa';
 import pc from 'picocolors';
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import { initProject } from './commands/actions/init-project';
 import { lintProject } from './commands/actions/lint-project';
 import { listScorers } from './commands/actions/list-scorers';
 import { migrate } from './commands/actions/migrate';
+import { runAgent } from './commands/actions/run-agent';
 import { startDevServer } from './commands/actions/start-dev-server';
 import { startProject } from './commands/actions/start-project';
 import { startStudio } from './commands/actions/start-studio';
@@ -215,6 +216,24 @@ const studioProjects = studioCommand
   .action(wrapAction(listProjectsAction));
 
 studioProjects.command('create').description('Create a new project').action(wrapAction(createProjectAction));
+
+program
+  .command('run')
+  .description('Run an agent with a prompt in headless mode')
+  .requiredOption('-a, --agent <agent-id>', 'Agent ID to run')
+  .option('-p, --prompt <prompt>', 'Prompt to send to the agent')
+  .option(
+    '-f, --output-format <format>',
+    'Output format: text (default), json (single JSON object), stream-json (NDJSON)',
+    'text',
+  )
+  .option('--json-schema <schema>', 'JSON schema for structured output (requires json or stream-json format)')
+  .option('--strict', 'Treat warnings as errors (exit code 1)', false)
+  .option('-d, --dir <path>', 'Path to your Mastra folder')
+  .option('-r, --root <path>', 'Path to your root folder')
+  .option('-e, --env <env>', 'Custom env file to include')
+  .option('--debug', 'Enable debug logs', false)
+  .action(wrapAction(runAgent));
 
 program
   .command('migrate')

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -1,4 +1,15 @@
 export { Harness } from './harness';
+export {
+  buildJsonEnvelope,
+  buildInterruptedEnvelope,
+  formatText,
+  formatJson,
+  formatStreamJson,
+  hasWarnings,
+} from './output-formatter';
+export type { OutputFormat, JsonResultEnvelope } from './output-formatter';
+export { runHeadless } from './run-headless';
+export type { RunHeadlessOptions, RunHeadlessIO } from './run-headless';
 export { askUserTool, parseSubagentMeta, submitPlanTool, taskCheckTool, taskWriteTool } from './tools';
 export type { TaskItem } from './tools';
 export { defaultDisplayState, defaultOMProgressState } from './types';

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -1,13 +1,6 @@
 export { Harness } from './harness';
-export {
-  buildJsonEnvelope,
-  buildInterruptedEnvelope,
-  formatText,
-  formatJson,
-  formatStreamJson,
-  hasWarnings,
-} from './output-formatter';
-export type { OutputFormat, JsonResultEnvelope } from './output-formatter';
+export { formatText, formatJson, formatStreamJson, hasWarnings } from './output-formatter';
+export type { OutputFormat } from './output-formatter';
 export { runHeadless } from './run-headless';
 export type { RunHeadlessOptions, RunHeadlessIO } from './run-headless';
 export { askUserTool, parseSubagentMeta, submitPlanTool, taskCheckTool, taskWriteTool } from './tools';

--- a/packages/core/src/harness/output-formatter.test.ts
+++ b/packages/core/src/harness/output-formatter.test.ts
@@ -1,0 +1,448 @@
+import { PassThrough } from 'node:stream';
+import { ReadableStream } from 'node:stream/web';
+import { describe, it, expect } from 'vitest';
+import type { FullOutput } from '../stream/base/output';
+import type { ChunkType } from '../stream/types';
+import { ChunkFrom } from '../stream/types';
+import {
+  buildJsonEnvelope,
+  buildInterruptedEnvelope,
+  formatText,
+  formatJson,
+  formatStreamJson,
+  hasWarnings,
+} from './output-formatter';
+
+function createMockFullOutput(overrides: Partial<FullOutput<any>> = {}): FullOutput<any> {
+  return {
+    text: 'Hello world',
+    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    steps: [{ text: 'Hello world' } as any],
+    finishReason: 'end_turn' as any,
+    warnings: [],
+    providerMetadata: undefined as any,
+    request: {},
+    reasoning: [],
+    reasoningText: undefined,
+    toolCalls: [],
+    toolResults: [],
+    sources: [],
+    files: [],
+    response: { modelId: 'test-model', id: '1', timestamp: new Date(), messages: [], uiMessages: [] } as any,
+    totalUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    object: undefined,
+    error: undefined,
+    tripwire: undefined,
+    traceId: 'trace-123',
+    spanId: 'span-456',
+    runId: 'run-789',
+    suspendPayload: undefined,
+    resumeSchema: undefined,
+    messages: [],
+    rememberedMessages: [],
+    ...overrides,
+  };
+}
+
+describe('buildJsonEnvelope', () => {
+  it('should build a success envelope with correct fields', () => {
+    const fullOutput = createMockFullOutput();
+    const envelope = buildJsonEnvelope(fullOutput, 1234);
+
+    expect(envelope.type).toBe('result');
+    expect(envelope.subtype).toBe('success');
+    expect(envelope.is_error).toBe(false);
+    expect(envelope.result).toBe('Hello world');
+    expect(envelope.duration_ms).toBe(1234);
+    expect(envelope.num_turns).toBe(1);
+    expect(envelope.model_id).toBe('test-model');
+    expect(envelope.trace_id).toBe('trace-123');
+    expect(envelope.run_id).toBe('run-789');
+  });
+
+  it('should build an error envelope when error is present', () => {
+    const fullOutput = createMockFullOutput({ error: new Error('test error') });
+    const envelope = buildJsonEnvelope(fullOutput, 500);
+
+    expect(envelope.subtype).toBe('error');
+    expect(envelope.is_error).toBe(true);
+  });
+
+  it('should include usage data from totalUsage', () => {
+    const fullOutput = createMockFullOutput({
+      totalUsage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      } as any,
+    });
+    const envelope = buildJsonEnvelope(fullOutput, 1000);
+
+    expect(envelope.usage.input_tokens).toBe(100);
+    expect(envelope.usage.output_tokens).toBe(50);
+    expect(envelope.usage.total_tokens).toBe(150);
+  });
+
+  it('should map tool calls to simplified format', () => {
+    const fullOutput = createMockFullOutput({
+      toolCalls: [
+        {
+          type: 'tool-call',
+          runId: 'run-1',
+          from: 'AGENT' as any,
+          payload: {
+            toolCallId: 'tc-1',
+            toolName: 'search',
+            args: { query: 'test' },
+            toolCallType: 'function',
+          },
+        },
+      ] as any,
+    });
+    const envelope = buildJsonEnvelope(fullOutput, 1000);
+
+    expect(envelope.tool_calls).toHaveLength(1);
+    expect(envelope.tool_calls[0]).toEqual({
+      id: 'tc-1',
+      name: 'search',
+      args: { query: 'test' },
+    });
+  });
+
+  it('should map tool results to simplified format', () => {
+    const fullOutput = createMockFullOutput({
+      toolResults: [
+        {
+          type: 'tool-result',
+          runId: 'run-1',
+          from: 'AGENT' as any,
+          payload: {
+            toolCallId: 'tc-1',
+            toolName: 'search',
+            result: { data: 'found' },
+            isError: false,
+            args: { query: 'test' },
+            toolCallType: 'function',
+          },
+        },
+      ] as any,
+    });
+    const envelope = buildJsonEnvelope(fullOutput, 1000);
+
+    expect(envelope.tool_results).toHaveLength(1);
+    expect(envelope.tool_results[0]).toEqual({
+      id: 'tc-1',
+      name: 'search',
+      result: { data: 'found' },
+      isError: false,
+    });
+  });
+
+  it('should include structured output in object field', () => {
+    const fullOutput = createMockFullOutput({
+      object: { colors: ['red', 'green', 'blue'] },
+    });
+    const envelope = buildJsonEnvelope(fullOutput, 1000);
+
+    expect(envelope.object).toEqual({ colors: ['red', 'green', 'blue'] });
+  });
+
+  it('should set object to null when no structured output', () => {
+    const fullOutput = createMockFullOutput({ object: undefined });
+    const envelope = buildJsonEnvelope(fullOutput, 1000);
+
+    expect(envelope.object).toBeNull();
+  });
+
+  it('should include warnings in the envelope', () => {
+    const fullOutput = createMockFullOutput({
+      warnings: [{ type: 'unsupported-setting', setting: 'temperature' }] as any,
+    });
+    const envelope = buildJsonEnvelope(fullOutput, 1000);
+
+    expect(envelope.warnings).toHaveLength(1);
+  });
+
+  it('should include finish_reason', () => {
+    const fullOutput = createMockFullOutput({ finishReason: 'stop' as any });
+    const envelope = buildJsonEnvelope(fullOutput, 1000);
+
+    expect(envelope.finish_reason).toBe('stop');
+  });
+});
+
+describe('buildInterruptedEnvelope', () => {
+  it('should build an interrupted envelope', () => {
+    const envelope = buildInterruptedEnvelope(2500);
+
+    expect(envelope.type).toBe('result');
+    expect(envelope.subtype).toBe('interrupted');
+    expect(envelope.is_error).toBe(true);
+    expect(envelope.result).toBe('');
+    expect(envelope.duration_ms).toBe(2500);
+    expect(envelope.num_turns).toBe(0);
+    expect(envelope.object).toBeNull();
+    expect(envelope.tool_calls).toEqual([]);
+    expect(envelope.tool_results).toEqual([]);
+  });
+
+  it('should have undefined usage values', () => {
+    const envelope = buildInterruptedEnvelope(0);
+
+    expect(envelope.usage.input_tokens).toBeUndefined();
+    expect(envelope.usage.output_tokens).toBeUndefined();
+    expect(envelope.usage.total_tokens).toBeUndefined();
+  });
+});
+
+describe('hasWarnings', () => {
+  it('should return false when no warnings', () => {
+    const fullOutput = createMockFullOutput({ warnings: [] });
+    expect(hasWarnings(fullOutput)).toBe(false);
+  });
+
+  it('should return true when warnings are present', () => {
+    const fullOutput = createMockFullOutput({
+      warnings: [{ type: 'test-warning' }] as any,
+    });
+    expect(hasWarnings(fullOutput)).toBe(true);
+  });
+});
+
+/**
+ * Build a minimal MastraModelOutput-like object with a fullStream that yields the given chunks
+ * and a getFullOutput() that resolves to the given full output.
+ */
+function createMockStreamOutput(chunks: ChunkType<any>[], fullOutput: FullOutput<any>) {
+  const fullStream = new ReadableStream<ChunkType<any>>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+  return {
+    fullStream,
+    getFullOutput: async () => fullOutput,
+  } as any;
+}
+
+/**
+ * Collect everything written to a PassThrough into a string.
+ */
+async function collectStream(stream: PassThrough): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+describe('formatText', () => {
+  it('should write text-delta payloads to stdout', async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const stdoutPromise = collectStream(stdout);
+    const stderrPromise = collectStream(stderr);
+
+    const chunks: ChunkType<any>[] = [
+      { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'Hello ' } },
+      { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'world' } },
+    ];
+    const fullOutput = createMockFullOutput({ text: 'Hello world' });
+    const streamOutput = createMockStreamOutput(chunks, fullOutput);
+
+    await formatText(streamOutput, stdout, stderr);
+    stdout.end();
+    stderr.end();
+
+    const stdoutText = await stdoutPromise;
+    const stderrText = await stderrPromise;
+
+    expect(stdoutText).toBe('Hello world\n');
+    expect(stderrText).toBe('');
+  });
+
+  it('should write error chunks to stderr, not stdout', async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const stdoutPromise = collectStream(stdout);
+    const stderrPromise = collectStream(stderr);
+
+    const chunks: ChunkType<any>[] = [
+      { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'partial' } },
+      { type: 'error', runId: 'r1', from: ChunkFrom.AGENT, payload: { error: 'boom' } },
+    ];
+    const fullOutput = createMockFullOutput({ text: 'partial' });
+    const streamOutput = createMockStreamOutput(chunks, fullOutput);
+
+    await formatText(streamOutput, stdout, stderr);
+    stdout.end();
+    stderr.end();
+
+    const stdoutText = await stdoutPromise;
+    const stderrText = await stderrPromise;
+
+    expect(stdoutText).toBe('partial\n');
+    expect(stderrText).toContain('Error:');
+    expect(stderrText).toContain('boom');
+  });
+
+  it('should ignore non-text chunks (tool-call, finish, etc.) in stdout', async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const stdoutPromise = collectStream(stdout);
+    collectStream(stderr); // drain stderr
+
+    const chunks: ChunkType<any>[] = [
+      {
+        type: 'tool-call',
+        runId: 'r1',
+        from: ChunkFrom.AGENT,
+        payload: { toolCallId: 'tc1', toolName: 'search', args: {}, toolCallType: 'function' },
+      } as any,
+      { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'answer' } },
+      { type: 'finish', runId: 'r1', from: ChunkFrom.AGENT, payload: {} } as any,
+    ];
+    const fullOutput = createMockFullOutput({ text: 'answer' });
+    const streamOutput = createMockStreamOutput(chunks, fullOutput);
+
+    await formatText(streamOutput, stdout, stderr);
+    stdout.end();
+    stderr.end();
+
+    const stdoutText = await stdoutPromise;
+    expect(stdoutText).toBe('answer\n');
+  });
+
+  it('should return the FullOutput from getFullOutput', async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    collectStream(stdout);
+    collectStream(stderr);
+
+    const fullOutput = createMockFullOutput({ text: 'Hello' });
+    const streamOutput = createMockStreamOutput([], fullOutput);
+
+    const result = await formatText(streamOutput, stdout, stderr);
+    stdout.end();
+    stderr.end();
+
+    expect(result).toBe(fullOutput);
+  });
+});
+
+describe('formatJson', () => {
+  it('should write a single JSON envelope to stdout', async () => {
+    const stdout = new PassThrough();
+    const stdoutPromise = collectStream(stdout);
+
+    const fullOutput = createMockFullOutput({ text: 'Hello world' });
+    const streamOutput = createMockStreamOutput([], fullOutput);
+
+    const startTime = Date.now() - 500;
+    await formatJson(streamOutput, stdout, startTime);
+    stdout.end();
+
+    const stdoutText = await stdoutPromise;
+    const lines = stdoutText.trim().split('\n');
+    expect(lines).toHaveLength(1);
+
+    const envelope = JSON.parse(lines[0]!);
+    expect(envelope.type).toBe('result');
+    expect(envelope.subtype).toBe('success');
+    expect(envelope.result).toBe('Hello world');
+    expect(envelope.duration_ms).toBeGreaterThanOrEqual(500);
+  });
+
+  it('should emit error envelope when FullOutput contains error', async () => {
+    const stdout = new PassThrough();
+    const stdoutPromise = collectStream(stdout);
+
+    const fullOutput = createMockFullOutput({ error: new Error('failed'), text: '' });
+    const streamOutput = createMockStreamOutput([], fullOutput);
+
+    await formatJson(streamOutput, stdout, Date.now());
+    stdout.end();
+
+    const envelope = JSON.parse((await stdoutPromise).trim());
+    expect(envelope.subtype).toBe('error');
+    expect(envelope.is_error).toBe(true);
+  });
+});
+
+describe('formatStreamJson', () => {
+  it('should write each chunk as a JSON line (NDJSON)', async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const stdoutPromise = collectStream(stdout);
+    collectStream(stderr);
+
+    const chunks: ChunkType<any>[] = [
+      { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'Hello' } },
+      { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: ' world' } },
+      { type: 'finish', runId: 'r1', from: ChunkFrom.AGENT, payload: {} } as any,
+    ];
+    const fullOutput = createMockFullOutput({ text: 'Hello world' });
+    const streamOutput = createMockStreamOutput(chunks, fullOutput);
+
+    await formatStreamJson(streamOutput, stdout, stderr);
+    stdout.end();
+    stderr.end();
+
+    const stdoutText = await stdoutPromise;
+    const lines = stdoutText.trim().split('\n');
+    expect(lines).toHaveLength(3);
+
+    const parsed = lines.map(line => JSON.parse(line));
+    expect(parsed[0].type).toBe('text-delta');
+    expect(parsed[0].payload.text).toBe('Hello');
+    expect(parsed[1].type).toBe('text-delta');
+    expect(parsed[1].payload.text).toBe(' world');
+    expect(parsed[2].type).toBe('finish');
+  });
+
+  it('should preserve runId and from on each chunk', async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const stdoutPromise = collectStream(stdout);
+    collectStream(stderr);
+
+    const chunks: ChunkType<any>[] = [
+      { type: 'text-delta', runId: 'run-abc', from: ChunkFrom.AGENT, payload: { id: '1', text: 'x' } },
+    ];
+    const streamOutput = createMockStreamOutput(chunks, createMockFullOutput({ text: 'x' }));
+
+    await formatStreamJson(streamOutput, stdout, stderr);
+    stdout.end();
+    stderr.end();
+
+    const parsed = JSON.parse((await stdoutPromise).trim());
+    expect(parsed.runId).toBe('run-abc');
+    expect(parsed.from).toBe('AGENT');
+  });
+
+  it('should emit one line per chunk separated by newlines', async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const stdoutPromise = collectStream(stdout);
+    collectStream(stderr);
+
+    const chunks: ChunkType<any>[] = [
+      { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'a' } },
+      { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'b' } },
+    ];
+    const streamOutput = createMockStreamOutput(chunks, createMockFullOutput({ text: 'ab' }));
+
+    await formatStreamJson(streamOutput, stdout, stderr);
+    stdout.end();
+    stderr.end();
+
+    const stdoutText = await stdoutPromise;
+    // Each line should be a complete JSON object terminated by \n
+    expect(stdoutText.endsWith('\n')).toBe(true);
+    expect(stdoutText.split('\n').filter(Boolean)).toHaveLength(2);
+  });
+});

--- a/packages/core/src/harness/output-formatter.test.ts
+++ b/packages/core/src/harness/output-formatter.test.ts
@@ -4,14 +4,7 @@ import { describe, it, expect } from 'vitest';
 import type { FullOutput } from '../stream/base/output';
 import type { ChunkType } from '../stream/types';
 import { ChunkFrom } from '../stream/types';
-import {
-  buildJsonEnvelope,
-  buildInterruptedEnvelope,
-  formatText,
-  formatJson,
-  formatStreamJson,
-  hasWarnings,
-} from './output-formatter';
+import { formatText, formatJson, formatStreamJson, hasWarnings } from './output-formatter';
 
 function createMockFullOutput(overrides: Partial<FullOutput<any>> = {}): FullOutput<any> {
   return {
@@ -43,157 +36,6 @@ function createMockFullOutput(overrides: Partial<FullOutput<any>> = {}): FullOut
     ...overrides,
   };
 }
-
-describe('buildJsonEnvelope', () => {
-  it('should build a success envelope with correct fields', () => {
-    const fullOutput = createMockFullOutput();
-    const envelope = buildJsonEnvelope(fullOutput, 1234);
-
-    expect(envelope.type).toBe('result');
-    expect(envelope.subtype).toBe('success');
-    expect(envelope.is_error).toBe(false);
-    expect(envelope.result).toBe('Hello world');
-    expect(envelope.duration_ms).toBe(1234);
-    expect(envelope.num_turns).toBe(1);
-    expect(envelope.model_id).toBe('test-model');
-    expect(envelope.trace_id).toBe('trace-123');
-    expect(envelope.run_id).toBe('run-789');
-  });
-
-  it('should build an error envelope when error is present', () => {
-    const fullOutput = createMockFullOutput({ error: new Error('test error') });
-    const envelope = buildJsonEnvelope(fullOutput, 500);
-
-    expect(envelope.subtype).toBe('error');
-    expect(envelope.is_error).toBe(true);
-  });
-
-  it('should include usage data from totalUsage', () => {
-    const fullOutput = createMockFullOutput({
-      totalUsage: {
-        inputTokens: 100,
-        outputTokens: 50,
-        totalTokens: 150,
-      } as any,
-    });
-    const envelope = buildJsonEnvelope(fullOutput, 1000);
-
-    expect(envelope.usage.input_tokens).toBe(100);
-    expect(envelope.usage.output_tokens).toBe(50);
-    expect(envelope.usage.total_tokens).toBe(150);
-  });
-
-  it('should map tool calls to simplified format', () => {
-    const fullOutput = createMockFullOutput({
-      toolCalls: [
-        {
-          type: 'tool-call',
-          runId: 'run-1',
-          from: 'AGENT' as any,
-          payload: {
-            toolCallId: 'tc-1',
-            toolName: 'search',
-            args: { query: 'test' },
-            toolCallType: 'function',
-          },
-        },
-      ] as any,
-    });
-    const envelope = buildJsonEnvelope(fullOutput, 1000);
-
-    expect(envelope.tool_calls).toHaveLength(1);
-    expect(envelope.tool_calls[0]).toEqual({
-      id: 'tc-1',
-      name: 'search',
-      args: { query: 'test' },
-    });
-  });
-
-  it('should map tool results to simplified format', () => {
-    const fullOutput = createMockFullOutput({
-      toolResults: [
-        {
-          type: 'tool-result',
-          runId: 'run-1',
-          from: 'AGENT' as any,
-          payload: {
-            toolCallId: 'tc-1',
-            toolName: 'search',
-            result: { data: 'found' },
-            isError: false,
-            args: { query: 'test' },
-            toolCallType: 'function',
-          },
-        },
-      ] as any,
-    });
-    const envelope = buildJsonEnvelope(fullOutput, 1000);
-
-    expect(envelope.tool_results).toHaveLength(1);
-    expect(envelope.tool_results[0]).toEqual({
-      id: 'tc-1',
-      name: 'search',
-      result: { data: 'found' },
-      isError: false,
-    });
-  });
-
-  it('should include structured output in object field', () => {
-    const fullOutput = createMockFullOutput({
-      object: { colors: ['red', 'green', 'blue'] },
-    });
-    const envelope = buildJsonEnvelope(fullOutput, 1000);
-
-    expect(envelope.object).toEqual({ colors: ['red', 'green', 'blue'] });
-  });
-
-  it('should set object to null when no structured output', () => {
-    const fullOutput = createMockFullOutput({ object: undefined });
-    const envelope = buildJsonEnvelope(fullOutput, 1000);
-
-    expect(envelope.object).toBeNull();
-  });
-
-  it('should include warnings in the envelope', () => {
-    const fullOutput = createMockFullOutput({
-      warnings: [{ type: 'unsupported-setting', setting: 'temperature' }] as any,
-    });
-    const envelope = buildJsonEnvelope(fullOutput, 1000);
-
-    expect(envelope.warnings).toHaveLength(1);
-  });
-
-  it('should include finish_reason', () => {
-    const fullOutput = createMockFullOutput({ finishReason: 'stop' as any });
-    const envelope = buildJsonEnvelope(fullOutput, 1000);
-
-    expect(envelope.finish_reason).toBe('stop');
-  });
-});
-
-describe('buildInterruptedEnvelope', () => {
-  it('should build an interrupted envelope', () => {
-    const envelope = buildInterruptedEnvelope(2500);
-
-    expect(envelope.type).toBe('result');
-    expect(envelope.subtype).toBe('interrupted');
-    expect(envelope.is_error).toBe(true);
-    expect(envelope.result).toBe('');
-    expect(envelope.duration_ms).toBe(2500);
-    expect(envelope.num_turns).toBe(0);
-    expect(envelope.object).toBeNull();
-    expect(envelope.tool_calls).toEqual([]);
-    expect(envelope.tool_results).toEqual([]);
-  });
-
-  it('should have undefined usage values', () => {
-    const envelope = buildInterruptedEnvelope(0);
-
-    expect(envelope.usage.input_tokens).toBeUndefined();
-    expect(envelope.usage.output_tokens).toBeUndefined();
-    expect(envelope.usage.total_tokens).toBeUndefined();
-  });
-});
 
 describe('hasWarnings', () => {
   it('should return false when no warnings', () => {
@@ -335,41 +177,69 @@ describe('formatText', () => {
 });
 
 describe('formatJson', () => {
-  it('should write a single JSON envelope to stdout', async () => {
+  it('should write the FullOutput as a single JSON line to stdout', async () => {
     const stdout = new PassThrough();
     const stdoutPromise = collectStream(stdout);
 
     const fullOutput = createMockFullOutput({ text: 'Hello world' });
     const streamOutput = createMockStreamOutput([], fullOutput);
 
-    const startTime = Date.now() - 500;
-    await formatJson(streamOutput, stdout, startTime);
+    await formatJson(streamOutput, stdout, 0);
     stdout.end();
 
     const stdoutText = await stdoutPromise;
     const lines = stdoutText.trim().split('\n');
     expect(lines).toHaveLength(1);
 
-    const envelope = JSON.parse(lines[0]!);
-    expect(envelope.type).toBe('result');
-    expect(envelope.subtype).toBe('success');
-    expect(envelope.result).toBe('Hello world');
-    expect(envelope.duration_ms).toBeGreaterThanOrEqual(500);
+    const parsed = JSON.parse(lines[0]!);
+    expect(parsed.text).toBe('Hello world');
+    expect(parsed.error).toBeFalsy();
+    expect(parsed.steps).toHaveLength(1);
+    expect(parsed.usage).toEqual({ inputTokens: 10, outputTokens: 5, totalTokens: 15 });
+    expect(parsed.finishReason).toBe('end_turn');
   });
 
-  it('should emit error envelope when FullOutput contains error', async () => {
+  it('should serialize Error instances as plain objects with name/message/stack', async () => {
     const stdout = new PassThrough();
     const stdoutPromise = collectStream(stdout);
 
-    const fullOutput = createMockFullOutput({ error: new Error('failed'), text: '' });
+    const fullOutput = createMockFullOutput({ error: new Error('boom'), text: '' });
     const streamOutput = createMockStreamOutput([], fullOutput);
 
-    await formatJson(streamOutput, stdout, Date.now());
+    await formatJson(streamOutput, stdout, 0);
     stdout.end();
 
-    const envelope = JSON.parse((await stdoutPromise).trim());
-    expect(envelope.subtype).toBe('error');
-    expect(envelope.is_error).toBe(true);
+    const parsed = JSON.parse((await stdoutPromise).trim());
+    expect(parsed.error).toBeTruthy();
+    expect(parsed.error.message).toBe('boom');
+    expect(parsed.error.name).toBe('Error');
+    expect(typeof parsed.error.stack).toBe('string');
+  });
+
+  it('should include structured output in the `object` field', async () => {
+    const stdout = new PassThrough();
+    const stdoutPromise = collectStream(stdout);
+
+    const fullOutput = createMockFullOutput({ object: { colors: ['red', 'green'] } });
+    const streamOutput = createMockStreamOutput([], fullOutput);
+
+    await formatJson(streamOutput, stdout, 0);
+    stdout.end();
+
+    const parsed = JSON.parse((await stdoutPromise).trim());
+    expect(parsed.object).toEqual({ colors: ['red', 'green'] });
+  });
+
+  it('should return the FullOutput', async () => {
+    const stdout = new PassThrough();
+    collectStream(stdout);
+    const fullOutput = createMockFullOutput({ text: 'x' });
+    const streamOutput = createMockStreamOutput([], fullOutput);
+
+    const result = await formatJson(streamOutput, stdout, 0);
+    stdout.end();
+
+    expect(result).toBe(fullOutput);
   });
 });
 

--- a/packages/core/src/harness/output-formatter.test.ts
+++ b/packages/core/src/harness/output-formatter.test.ts
@@ -1,41 +1,9 @@
 import { PassThrough } from 'node:stream';
-import { ReadableStream } from 'node:stream/web';
 import { describe, it, expect } from 'vitest';
-import type { FullOutput } from '../stream/base/output';
 import type { ChunkType } from '../stream/types';
 import { ChunkFrom } from '../stream/types';
 import { formatText, formatJson, formatStreamJson, hasWarnings } from './output-formatter';
-
-function createMockFullOutput(overrides: Partial<FullOutput<any>> = {}): FullOutput<any> {
-  return {
-    text: 'Hello world',
-    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-    steps: [{ text: 'Hello world' } as any],
-    finishReason: 'end_turn' as any,
-    warnings: [],
-    providerMetadata: undefined as any,
-    request: {},
-    reasoning: [],
-    reasoningText: undefined,
-    toolCalls: [],
-    toolResults: [],
-    sources: [],
-    files: [],
-    response: { modelId: 'test-model', id: '1', timestamp: new Date(), messages: [], uiMessages: [] } as any,
-    totalUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-    object: undefined,
-    error: undefined,
-    tripwire: undefined,
-    traceId: 'trace-123',
-    spanId: 'span-456',
-    runId: 'run-789',
-    suspendPayload: undefined,
-    resumeSchema: undefined,
-    messages: [],
-    rememberedMessages: [],
-    ...overrides,
-  };
-}
+import { createMockFullOutput, createMockStreamOutput, collectStream } from './test-utils';
 
 describe('hasWarnings', () => {
   it('should return false when no warnings', () => {
@@ -50,37 +18,6 @@ describe('hasWarnings', () => {
     expect(hasWarnings(fullOutput)).toBe(true);
   });
 });
-
-/**
- * Build a minimal MastraModelOutput-like object with a fullStream that yields the given chunks
- * and a getFullOutput() that resolves to the given full output.
- */
-function createMockStreamOutput(chunks: ChunkType<any>[], fullOutput: FullOutput<any>) {
-  const fullStream = new ReadableStream<ChunkType<any>>({
-    start(controller) {
-      for (const chunk of chunks) {
-        controller.enqueue(chunk);
-      }
-      controller.close();
-    },
-  });
-
-  return {
-    fullStream,
-    getFullOutput: async () => fullOutput,
-  } as any;
-}
-
-/**
- * Collect everything written to a PassThrough into a string.
- */
-async function collectStream(stream: PassThrough): Promise<string> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of stream) {
-    chunks.push(chunk as Buffer);
-  }
-  return Buffer.concat(chunks).toString('utf-8');
-}
 
 describe('formatText', () => {
   it('should write text-delta payloads to stdout', async () => {

--- a/packages/core/src/harness/output-formatter.ts
+++ b/packages/core/src/harness/output-formatter.ts
@@ -1,0 +1,187 @@
+import type { Writable } from 'node:stream';
+import type { MastraModelOutput, FullOutput } from '../stream/base/output';
+import type { ChunkType } from '../stream/types';
+
+/**
+ * Output format options for headless mode.
+ */
+export type OutputFormat = 'text' | 'json' | 'stream-json';
+
+/**
+ * Shape of the single-object JSON envelope emitted by `json` mode.
+ */
+export interface JsonResultEnvelope<OUTPUT = undefined> {
+  type: 'result';
+  subtype: 'success' | 'error' | 'interrupted';
+  is_error: boolean;
+  result: string;
+  object: OUTPUT | null;
+  duration_ms: number;
+  num_turns: number;
+  usage: {
+    input_tokens: number | undefined;
+    output_tokens: number | undefined;
+    total_tokens: number | undefined;
+    cached_input_tokens: number | undefined;
+    reasoning_tokens: number | undefined;
+  };
+  finish_reason: string | undefined;
+  model_id: string;
+  trace_id: string | undefined;
+  run_id: string | undefined;
+  tool_calls: Array<{ id: string; name: string; args: unknown }>;
+  tool_results: Array<{ id: string; name: string; result: unknown; isError: boolean }>;
+  warnings: unknown[];
+}
+
+/**
+ * Build the JSON result envelope from a FullOutput.
+ */
+export function buildJsonEnvelope<OUTPUT = undefined>(
+  fullOutput: FullOutput<OUTPUT>,
+  durationMs: number,
+): JsonResultEnvelope<OUTPUT> {
+  const isError = !!fullOutput.error;
+  const totalUsage = fullOutput.totalUsage;
+
+  return {
+    type: 'result',
+    subtype: isError ? 'error' : 'success',
+    is_error: isError,
+    result: fullOutput.text,
+    object: fullOutput.object ?? null,
+    duration_ms: durationMs,
+    num_turns: fullOutput.steps.length,
+    usage: {
+      input_tokens: totalUsage?.inputTokens,
+      output_tokens: totalUsage?.outputTokens,
+      total_tokens: totalUsage?.totalTokens,
+      cached_input_tokens: (totalUsage as any)?.cachedInputTokens,
+      reasoning_tokens: (totalUsage as any)?.reasoningTokens,
+    },
+    finish_reason: fullOutput.finishReason,
+    model_id: fullOutput.response?.modelId ?? '',
+    trace_id: fullOutput.traceId,
+    run_id: fullOutput.runId,
+    tool_calls: fullOutput.toolCalls.map(tc => ({
+      id: tc.payload.toolCallId,
+      name: tc.payload.toolName,
+      args: tc.payload.args,
+    })),
+    tool_results: fullOutput.toolResults.map(tr => ({
+      id: tr.payload.toolCallId,
+      name: tr.payload.toolName,
+      result: tr.payload.result,
+      isError: tr.payload.isError ?? false,
+    })),
+    warnings: fullOutput.warnings,
+  };
+}
+
+/**
+ * Build an interrupted envelope (emitted on SIGINT in json mode).
+ */
+export function buildInterruptedEnvelope(durationMs: number): JsonResultEnvelope {
+  return {
+    type: 'result',
+    subtype: 'interrupted',
+    is_error: true,
+    result: '',
+    object: null,
+    duration_ms: durationMs,
+    num_turns: 0,
+    usage: {
+      input_tokens: undefined,
+      output_tokens: undefined,
+      total_tokens: undefined,
+      cached_input_tokens: undefined,
+      reasoning_tokens: undefined,
+    },
+    finish_reason: undefined,
+    model_id: '',
+    trace_id: undefined,
+    run_id: undefined,
+    tool_calls: [],
+    tool_results: [],
+    warnings: [],
+  };
+}
+
+/**
+ * Format output in `text` mode: stream text-delta payloads to stdout,
+ * warnings/errors to stderr.
+ */
+export async function formatText<OUTPUT>(
+  streamOutput: MastraModelOutput<OUTPUT>,
+  stdout: Writable,
+  stderr: Writable,
+): Promise<FullOutput<OUTPUT>> {
+  const reader = streamOutput.fullStream.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = value as ChunkType<OUTPUT>;
+      if (chunk.type === 'text-delta') {
+        stdout.write((chunk.payload as { text: string }).text);
+      } else if (chunk.type === 'error') {
+        stderr.write(`Error: ${String((chunk.payload as { error: unknown }).error)}\n`);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  // Trailing newline for clean terminal output
+  stdout.write('\n');
+
+  return streamOutput.getFullOutput();
+}
+
+/**
+ * Format output in `json` mode: await completion, emit single JSON envelope to stdout.
+ */
+export async function formatJson<OUTPUT>(
+  streamOutput: MastraModelOutput<OUTPUT>,
+  stdout: Writable,
+  startTime: number,
+): Promise<FullOutput<OUTPUT>> {
+  const fullOutput = await streamOutput.getFullOutput();
+  const durationMs = Date.now() - startTime;
+  const envelope = buildJsonEnvelope(fullOutput, durationMs);
+  stdout.write(JSON.stringify(envelope) + '\n');
+  return fullOutput;
+}
+
+/**
+ * Format output in `stream-json` mode: emit each ChunkType as an NDJSON line to stdout.
+ */
+export async function formatStreamJson<OUTPUT>(
+  streamOutput: MastraModelOutput<OUTPUT>,
+  stdout: Writable,
+  _stderr: Writable,
+): Promise<FullOutput<OUTPUT>> {
+  const reader = streamOutput.fullStream.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      stdout.write(JSON.stringify(value) + '\n');
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return streamOutput.getFullOutput();
+}
+
+/**
+ * Determine if a FullOutput has warnings, for --strict exit code logic.
+ */
+export function hasWarnings<OUTPUT>(fullOutput: FullOutput<OUTPUT>): boolean {
+  return fullOutput.warnings.length > 0;
+}

--- a/packages/core/src/harness/output-formatter.ts
+++ b/packages/core/src/harness/output-formatter.ts
@@ -8,103 +8,14 @@ import type { ChunkType } from '../stream/types';
 export type OutputFormat = 'text' | 'json' | 'stream-json';
 
 /**
- * Shape of the single-object JSON envelope emitted by `json` mode.
+ * JSON.stringify replacer that renders Error instances as plain objects
+ * (Error's properties aren't enumerable by default).
  */
-export interface JsonResultEnvelope<OUTPUT = undefined> {
-  type: 'result';
-  subtype: 'success' | 'error' | 'interrupted';
-  is_error: boolean;
-  result: string;
-  object: OUTPUT | null;
-  duration_ms: number;
-  num_turns: number;
-  usage: {
-    input_tokens: number | undefined;
-    output_tokens: number | undefined;
-    total_tokens: number | undefined;
-    cached_input_tokens: number | undefined;
-    reasoning_tokens: number | undefined;
-  };
-  finish_reason: string | undefined;
-  model_id: string;
-  trace_id: string | undefined;
-  run_id: string | undefined;
-  tool_calls: Array<{ id: string; name: string; args: unknown }>;
-  tool_results: Array<{ id: string; name: string; result: unknown; isError: boolean }>;
-  warnings: unknown[];
-}
-
-/**
- * Build the JSON result envelope from a FullOutput.
- */
-export function buildJsonEnvelope<OUTPUT = undefined>(
-  fullOutput: FullOutput<OUTPUT>,
-  durationMs: number,
-): JsonResultEnvelope<OUTPUT> {
-  const isError = !!fullOutput.error;
-  const totalUsage = fullOutput.totalUsage;
-
-  return {
-    type: 'result',
-    subtype: isError ? 'error' : 'success',
-    is_error: isError,
-    result: fullOutput.text,
-    object: fullOutput.object ?? null,
-    duration_ms: durationMs,
-    num_turns: fullOutput.steps.length,
-    usage: {
-      input_tokens: totalUsage?.inputTokens,
-      output_tokens: totalUsage?.outputTokens,
-      total_tokens: totalUsage?.totalTokens,
-      cached_input_tokens: (totalUsage as any)?.cachedInputTokens,
-      reasoning_tokens: (totalUsage as any)?.reasoningTokens,
-    },
-    finish_reason: fullOutput.finishReason,
-    model_id: fullOutput.response?.modelId ?? '',
-    trace_id: fullOutput.traceId,
-    run_id: fullOutput.runId,
-    tool_calls: fullOutput.toolCalls.map(tc => ({
-      id: tc.payload.toolCallId,
-      name: tc.payload.toolName,
-      args: tc.payload.args,
-    })),
-    tool_results: fullOutput.toolResults.map(tr => ({
-      id: tr.payload.toolCallId,
-      name: tr.payload.toolName,
-      result: tr.payload.result,
-      isError: tr.payload.isError ?? false,
-    })),
-    warnings: fullOutput.warnings,
-  };
-}
-
-/**
- * Build an interrupted envelope (emitted on SIGINT in json mode).
- */
-export function buildInterruptedEnvelope(durationMs: number): JsonResultEnvelope {
-  return {
-    type: 'result',
-    subtype: 'interrupted',
-    is_error: true,
-    result: '',
-    object: null,
-    duration_ms: durationMs,
-    num_turns: 0,
-    usage: {
-      input_tokens: undefined,
-      output_tokens: undefined,
-      total_tokens: undefined,
-      cached_input_tokens: undefined,
-      reasoning_tokens: undefined,
-    },
-    finish_reason: undefined,
-    model_id: '',
-    trace_id: undefined,
-    run_id: undefined,
-    tool_calls: [],
-    tool_results: [],
-    warnings: [],
-  };
+function errorReplacer(_key: string, value: unknown) {
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message, stack: value.stack };
+  }
+  return value;
 }
 
 /**
@@ -141,17 +52,15 @@ export async function formatText<OUTPUT>(
 }
 
 /**
- * Format output in `json` mode: await completion, emit single JSON envelope to stdout.
+ * Format output in `json` mode: await completion, emit the FullOutput as a single JSON line to stdout.
  */
 export async function formatJson<OUTPUT>(
   streamOutput: MastraModelOutput<OUTPUT>,
   stdout: Writable,
-  startTime: number,
+  _startTime: number,
 ): Promise<FullOutput<OUTPUT>> {
   const fullOutput = await streamOutput.getFullOutput();
-  const durationMs = Date.now() - startTime;
-  const envelope = buildJsonEnvelope(fullOutput, durationMs);
-  stdout.write(JSON.stringify(envelope) + '\n');
+  stdout.write(JSON.stringify(fullOutput, errorReplacer) + '\n');
   return fullOutput;
 }
 

--- a/packages/core/src/harness/run-headless.test.ts
+++ b/packages/core/src/harness/run-headless.test.ts
@@ -1,0 +1,409 @@
+import { PassThrough } from 'node:stream';
+import { ReadableStream } from 'node:stream/web';
+import { describe, it, expect, vi } from 'vitest';
+import type { FullOutput } from '../stream/base/output';
+import type { ChunkType } from '../stream/types';
+import { ChunkFrom } from '../stream/types';
+import { runHeadless } from './run-headless';
+import type { RunHeadlessIO, RunHeadlessOptions } from './run-headless';
+
+function createMockFullOutput(overrides: Partial<FullOutput<any>> = {}): FullOutput<any> {
+  return {
+    text: 'Hello world',
+    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    steps: [{ text: 'Hello world' } as any],
+    finishReason: 'end_turn' as any,
+    warnings: [],
+    providerMetadata: undefined as any,
+    request: {},
+    reasoning: [],
+    reasoningText: undefined,
+    toolCalls: [],
+    toolResults: [],
+    sources: [],
+    files: [],
+    response: { modelId: 'test-model', id: '1', timestamp: new Date(), messages: [], uiMessages: [] } as any,
+    totalUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    object: undefined,
+    error: undefined,
+    tripwire: undefined,
+    traceId: 'trace-123',
+    spanId: 'span-456',
+    runId: 'run-789',
+    suspendPayload: undefined,
+    resumeSchema: undefined,
+    messages: [],
+    rememberedMessages: [],
+    ...overrides,
+  };
+}
+
+function createMockStreamOutput(chunks: ChunkType<any>[], fullOutput: FullOutput<any>) {
+  const fullStream = new ReadableStream<ChunkType<any>>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+  return {
+    fullStream,
+    getFullOutput: async () => fullOutput,
+  } as any;
+}
+
+async function collectStream(stream: PassThrough): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+interface Harness {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdoutPromise: Promise<string>;
+  stderrPromise: Promise<string>;
+  exits: number[];
+  sigintHandlers: Array<() => void>;
+  io: RunHeadlessIO;
+}
+
+function createHarness(): Harness {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const exits: number[] = [];
+  const sigintHandlers: Array<() => void> = [];
+
+  const io: RunHeadlessIO = {
+    stdout,
+    stderr,
+    exit: (code: number) => {
+      exits.push(code);
+    },
+    onSigint: (h: () => void) => {
+      sigintHandlers.push(h);
+    },
+  };
+
+  return {
+    stdout,
+    stderr,
+    stdoutPromise: collectStream(stdout),
+    stderrPromise: collectStream(stderr),
+    exits,
+    sigintHandlers,
+    io,
+  };
+}
+
+function createMockMastra(agentFn: (id: string) => any, agents: Record<string, unknown> = {}) {
+  return {
+    getAgent: vi.fn((id: string) => agentFn(id)),
+    getAgents: () => agents,
+  };
+}
+
+const baseOptions: RunHeadlessOptions = {
+  prompt: 'Hello',
+  agentId: 'testAgent',
+  outputFormat: 'text',
+  strict: false,
+};
+
+describe('runHeadless', () => {
+  describe('validation', () => {
+    it('should exit with config error on invalid outputFormat', async () => {
+      const h = createHarness();
+      const mastra = createMockMastra(() => ({ stream: vi.fn() }));
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'yaml' as any }, h.io);
+      h.stderr.end();
+      h.stdout.end();
+
+      expect(h.exits).toEqual([2]);
+      expect(await h.stderrPromise).toContain('Invalid outputFormat');
+    });
+
+    it('should exit with config error when agent not found', async () => {
+      const h = createHarness();
+      const mastra = createMockMastra(
+        (_id: string) => {
+          throw new Error('not found');
+        },
+        { agentA: {}, agentB: {} },
+      );
+
+      await runHeadless(mastra, { ...baseOptions, agentId: 'missing' }, h.io);
+      h.stderr.end();
+      h.stdout.end();
+
+      expect(h.exits).toEqual([2]);
+      const stderrText = await h.stderrPromise;
+      expect(stderrText).toContain('"missing"');
+      expect(stderrText).toContain('not found');
+      expect(stderrText).toContain('Available agents: agentA, agentB');
+    });
+
+    it('should exit with config error on invalid jsonSchema', async () => {
+      const h = createHarness();
+      const mastra = createMockMastra(() => ({ stream: vi.fn() }));
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'json', jsonSchema: 'not json{' }, h.io);
+      h.stderr.end();
+      h.stdout.end();
+
+      expect(h.exits).toEqual([2]);
+      expect(await h.stderrPromise).toContain('Invalid --json-schema');
+    });
+
+    it('should not register sigint handler or call stream when validation fails', async () => {
+      const h = createHarness();
+      const streamSpy = vi.fn();
+      const mastra = createMockMastra(() => ({ stream: streamSpy }));
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'nonsense' as any }, h.io);
+      h.stderr.end();
+      h.stdout.end();
+
+      expect(streamSpy).not.toHaveBeenCalled();
+      expect(h.sigintHandlers).toHaveLength(0);
+    });
+  });
+
+  describe('text mode', () => {
+    it('should stream text deltas to stdout and exit 0', async () => {
+      const h = createHarness();
+      const chunks: ChunkType<any>[] = [
+        { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'Hello ' } },
+        { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'world' } },
+      ];
+      const streamOutput = createMockStreamOutput(chunks, createMockFullOutput({ text: 'Hello world' }));
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'text' }, h.io);
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([0]);
+      expect(await h.stdoutPromise).toBe('Hello world\n');
+    });
+
+    it('should exit 1 when FullOutput has error', async () => {
+      const h = createHarness();
+      const streamOutput = createMockStreamOutput([], createMockFullOutput({ error: new Error('boom') }));
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'text' }, h.io);
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([1]);
+    });
+
+    it('should exit 1 when strict and warnings present', async () => {
+      const h = createHarness();
+      const streamOutput = createMockStreamOutput(
+        [],
+        createMockFullOutput({ warnings: [{ type: 'unsupported-setting' }] as any }),
+      );
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'text', strict: true }, h.io);
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([1]);
+      expect(await h.stderrPromise).toContain('Warnings treated as errors');
+    });
+
+    it('should exit 0 when strict is false even with warnings', async () => {
+      const h = createHarness();
+      const streamOutput = createMockStreamOutput([], createMockFullOutput({ warnings: [{ type: 'w' }] as any }));
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'text', strict: false }, h.io);
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([0]);
+    });
+  });
+
+  describe('json mode', () => {
+    it('should emit a single JSON envelope and exit 0', async () => {
+      const h = createHarness();
+      const streamOutput = createMockStreamOutput([], createMockFullOutput({ text: 'answer' }));
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'json' }, h.io);
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([0]);
+      const stdoutText = await h.stdoutPromise;
+      const envelope = JSON.parse(stdoutText.trim());
+      expect(envelope.type).toBe('result');
+      expect(envelope.subtype).toBe('success');
+      expect(envelope.result).toBe('answer');
+    });
+
+    it('should emit error envelope and exit 1 when FullOutput has error', async () => {
+      const h = createHarness();
+      const streamOutput = createMockStreamOutput([], createMockFullOutput({ error: new Error('bad') }));
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'json' }, h.io);
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([1]);
+      const envelope = JSON.parse((await h.stdoutPromise).trim());
+      expect(envelope.subtype).toBe('error');
+      expect(envelope.is_error).toBe(true);
+    });
+  });
+
+  describe('stream-json mode', () => {
+    it('should emit one JSON line per chunk and exit 0', async () => {
+      const h = createHarness();
+      const chunks: ChunkType<any>[] = [
+        { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'a' } },
+        { type: 'text-delta', runId: 'r1', from: ChunkFrom.AGENT, payload: { id: '1', text: 'b' } },
+      ];
+      const streamOutput = createMockStreamOutput(chunks, createMockFullOutput({ text: 'ab' }));
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'stream-json' }, h.io);
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([0]);
+      const lines = (await h.stdoutPromise).trim().split('\n');
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]!).type).toBe('text-delta');
+    });
+  });
+
+  describe('structured output', () => {
+    it('should pass structuredOutput to agent.stream when jsonSchema provided', async () => {
+      const h = createHarness();
+      const streamOutput = createMockStreamOutput([], createMockFullOutput());
+      const streamSpy = vi.fn().mockResolvedValue(streamOutput);
+      const mastra = createMockMastra(() => ({ stream: streamSpy }));
+
+      const schema = '{"type":"object","properties":{"color":{"type":"string"}}}';
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'json', jsonSchema: schema }, h.io);
+      h.stdout.end();
+      h.stderr.end();
+      await h.stdoutPromise;
+
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      const callArgs = streamSpy.mock.calls[0];
+      expect(callArgs?.[1]?.structuredOutput).toEqual({ schema: JSON.parse(schema) });
+    });
+
+    it('should not include structuredOutput when jsonSchema absent', async () => {
+      const h = createHarness();
+      const streamOutput = createMockStreamOutput([], createMockFullOutput());
+      const streamSpy = vi.fn().mockResolvedValue(streamOutput);
+      const mastra = createMockMastra(() => ({ stream: streamSpy }));
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'text' }, h.io);
+      h.stdout.end();
+      h.stderr.end();
+      await h.stdoutPromise;
+
+      const callArgs = streamSpy.mock.calls[0];
+      expect(callArgs?.[1]?.structuredOutput).toBeUndefined();
+    });
+  });
+
+  describe('SIGINT handling', () => {
+    it('should register a sigint handler in each mode', async () => {
+      for (const fmt of ['text', 'json', 'stream-json'] as const) {
+        const h = createHarness();
+        const streamOutput = createMockStreamOutput([], createMockFullOutput());
+        const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+        const mastra = createMockMastra(() => agent);
+
+        await runHeadless(mastra, { ...baseOptions, outputFormat: fmt }, h.io);
+        h.stdout.end();
+        h.stderr.end();
+        await h.stdoutPromise;
+
+        expect(h.sigintHandlers).toHaveLength(1);
+      }
+    });
+
+    it('json sigint handler should emit interrupted envelope and exit 1', async () => {
+      const h = createHarness();
+      // Use a stream that doesn't resolve immediately
+      const never = new ReadableStream({ start() {} });
+      const streamOutput = { fullStream: never, getFullOutput: () => new Promise(() => {}) } as any;
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      // Don't await — kick it off, then fire sigint
+      void runHeadless(mastra, { ...baseOptions, outputFormat: 'json' }, h.io);
+      await new Promise(r => setImmediate(r));
+
+      expect(h.sigintHandlers).toHaveLength(1);
+      h.sigintHandlers[0]!();
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([1]);
+      const envelope = JSON.parse((await h.stdoutPromise).trim());
+      expect(envelope.subtype).toBe('interrupted');
+      expect(envelope.is_error).toBe(true);
+    });
+
+    it('stream-json sigint handler should emit abort chunk and exit 1', async () => {
+      const h = createHarness();
+      const never = new ReadableStream({ start() {} });
+      const streamOutput = { fullStream: never, getFullOutput: () => new Promise(() => {}) } as any;
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      void runHeadless(mastra, { ...baseOptions, outputFormat: 'stream-json' }, h.io);
+      await new Promise(r => setImmediate(r));
+
+      h.sigintHandlers[0]!();
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([1]);
+      const chunk = JSON.parse((await h.stdoutPromise).trim());
+      expect(chunk.type).toBe('abort');
+      expect(chunk.payload.reason).toBe('interrupted');
+    });
+
+    it('text sigint handler should emit newline and exit 1', async () => {
+      const h = createHarness();
+      const never = new ReadableStream({ start() {} });
+      const streamOutput = { fullStream: never, getFullOutput: () => new Promise(() => {}) } as any;
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      void runHeadless(mastra, { ...baseOptions, outputFormat: 'text' }, h.io);
+      await new Promise(r => setImmediate(r));
+
+      h.sigintHandlers[0]!();
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([1]);
+      expect(await h.stdoutPromise).toBe('\n');
+    });
+  });
+});

--- a/packages/core/src/harness/run-headless.test.ts
+++ b/packages/core/src/harness/run-headless.test.ts
@@ -159,6 +159,20 @@ describe('runHeadless', () => {
       expect(await h.stderrPromise).toContain('Invalid --json-schema');
     });
 
+    it('should exit with config error when jsonSchema is provided with text outputFormat', async () => {
+      const h = createHarness();
+      const streamSpy = vi.fn();
+      const mastra = createMockMastra(() => ({ stream: streamSpy }));
+
+      await runHeadless(mastra, { ...baseOptions, outputFormat: 'text', jsonSchema: '{"type":"object"}' }, h.io);
+      h.stderr.end();
+      h.stdout.end();
+
+      expect(h.exits).toEqual([2]);
+      expect(await h.stderrPromise).toContain('jsonSchema requires outputFormat "json" or "stream-json"');
+      expect(streamSpy).not.toHaveBeenCalled();
+    });
+
     it('should not register sigint handler or call stream when validation fails', async () => {
       const h = createHarness();
       const streamSpy = vi.fn();
@@ -404,6 +418,64 @@ describe('runHeadless', () => {
 
       expect(h.exits).toEqual([1]);
       expect(await h.stdoutPromise).toBe('\n');
+    });
+
+    it('should not call io.exit with success code after SIGINT even when io.exit does not terminate', async () => {
+      const h = createHarness();
+      let resolveFullOutput!: (value: any) => void;
+      const pendingFullOutput = new Promise<any>(r => {
+        resolveFullOutput = r;
+      });
+      const streamOutput = {
+        fullStream: new ReadableStream({
+          start(c) {
+            c.close();
+          },
+        }),
+        getFullOutput: () => pendingFullOutput,
+      } as any;
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      const runPromise = runHeadless(mastra, { ...baseOptions, outputFormat: 'json' }, h.io);
+      // Let runHeadless reach formatJson and suspend on getFullOutput
+      await new Promise(r => setImmediate(r));
+
+      // Fire SIGINT while runHeadless is mid-await
+      h.sigintHandlers[0]!();
+      // Let SIGINT handler finish its writes/exit
+      await new Promise(r => setImmediate(r));
+
+      // Resolve getFullOutput so runHeadless can continue past formatJson
+      resolveFullOutput(createMockFullOutput({ text: 'done' }));
+      await runPromise;
+
+      h.stdout.end();
+      h.stderr.end();
+      await h.stdoutPromise;
+
+      // exit(1) from SIGINT handler — NOT followed by exit(0) from the success path
+      expect(h.exits).toEqual([1]);
+    });
+
+    it('should ignore repeated SIGINT events', async () => {
+      const h = createHarness();
+      const never = new ReadableStream({ start() {} });
+      const streamOutput = { fullStream: never, getFullOutput: () => new Promise(() => {}) } as any;
+      const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
+      const mastra = createMockMastra(() => agent);
+
+      void runHeadless(mastra, { ...baseOptions, outputFormat: 'json' }, h.io);
+      await new Promise(r => setImmediate(r));
+
+      h.sigintHandlers[0]!();
+      h.sigintHandlers[0]!();
+      h.stdout.end();
+      h.stderr.end();
+
+      expect(h.exits).toEqual([1]);
+      const lines = (await h.stdoutPromise).trim().split('\n').filter(Boolean);
+      expect(lines).toHaveLength(1);
     });
   });
 });

--- a/packages/core/src/harness/run-headless.test.ts
+++ b/packages/core/src/harness/run-headless.test.ts
@@ -1,65 +1,11 @@
 import { PassThrough } from 'node:stream';
 import { ReadableStream } from 'node:stream/web';
 import { describe, it, expect, vi } from 'vitest';
-import type { FullOutput } from '../stream/base/output';
 import type { ChunkType } from '../stream/types';
 import { ChunkFrom } from '../stream/types';
 import { runHeadless } from './run-headless';
 import type { RunHeadlessIO, RunHeadlessOptions } from './run-headless';
-
-function createMockFullOutput(overrides: Partial<FullOutput<any>> = {}): FullOutput<any> {
-  return {
-    text: 'Hello world',
-    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-    steps: [{ text: 'Hello world' } as any],
-    finishReason: 'end_turn' as any,
-    warnings: [],
-    providerMetadata: undefined as any,
-    request: {},
-    reasoning: [],
-    reasoningText: undefined,
-    toolCalls: [],
-    toolResults: [],
-    sources: [],
-    files: [],
-    response: { modelId: 'test-model', id: '1', timestamp: new Date(), messages: [], uiMessages: [] } as any,
-    totalUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-    object: undefined,
-    error: undefined,
-    tripwire: undefined,
-    traceId: 'trace-123',
-    spanId: 'span-456',
-    runId: 'run-789',
-    suspendPayload: undefined,
-    resumeSchema: undefined,
-    messages: [],
-    rememberedMessages: [],
-    ...overrides,
-  };
-}
-
-function createMockStreamOutput(chunks: ChunkType<any>[], fullOutput: FullOutput<any>) {
-  const fullStream = new ReadableStream<ChunkType<any>>({
-    start(controller) {
-      for (const chunk of chunks) {
-        controller.enqueue(chunk);
-      }
-      controller.close();
-    },
-  });
-  return {
-    fullStream,
-    getFullOutput: async () => fullOutput,
-  } as any;
-}
-
-async function collectStream(stream: PassThrough): Promise<string> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of stream) {
-    chunks.push(chunk as Buffer);
-  }
-  return Buffer.concat(chunks).toString('utf-8');
-}
+import { createMockFullOutput, createMockStreamOutput, collectStream } from './test-utils';
 
 interface Harness {
   stdout: PassThrough;

--- a/packages/core/src/harness/run-headless.test.ts
+++ b/packages/core/src/harness/run-headless.test.ts
@@ -251,7 +251,7 @@ describe('runHeadless', () => {
   });
 
   describe('json mode', () => {
-    it('should emit a single JSON envelope and exit 0', async () => {
+    it('should emit the FullOutput as a single JSON line and exit 0', async () => {
       const h = createHarness();
       const streamOutput = createMockStreamOutput([], createMockFullOutput({ text: 'answer' }));
       const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
@@ -263,13 +263,12 @@ describe('runHeadless', () => {
 
       expect(h.exits).toEqual([0]);
       const stdoutText = await h.stdoutPromise;
-      const envelope = JSON.parse(stdoutText.trim());
-      expect(envelope.type).toBe('result');
-      expect(envelope.subtype).toBe('success');
-      expect(envelope.result).toBe('answer');
+      const parsed = JSON.parse(stdoutText.trim());
+      expect(parsed.text).toBe('answer');
+      expect(parsed.error).toBeFalsy();
     });
 
-    it('should emit error envelope and exit 1 when FullOutput has error', async () => {
+    it('should emit FullOutput with serialized error and exit 1 when FullOutput has error', async () => {
       const h = createHarness();
       const streamOutput = createMockStreamOutput([], createMockFullOutput({ error: new Error('bad') }));
       const agent = { stream: vi.fn().mockResolvedValue(streamOutput) };
@@ -280,9 +279,9 @@ describe('runHeadless', () => {
       h.stderr.end();
 
       expect(h.exits).toEqual([1]);
-      const envelope = JSON.parse((await h.stdoutPromise).trim());
-      expect(envelope.subtype).toBe('error');
-      expect(envelope.is_error).toBe(true);
+      const parsed = JSON.parse((await h.stdoutPromise).trim());
+      expect(parsed.error).toBeTruthy();
+      expect(parsed.error.message).toBe('bad');
     });
   });
 
@@ -359,7 +358,7 @@ describe('runHeadless', () => {
       }
     });
 
-    it('json sigint handler should emit interrupted envelope and exit 1', async () => {
+    it('json sigint handler should emit abort chunk and exit 1', async () => {
       const h = createHarness();
       // Use a stream that doesn't resolve immediately
       const never = new ReadableStream({ start() {} });
@@ -377,9 +376,9 @@ describe('runHeadless', () => {
       h.stderr.end();
 
       expect(h.exits).toEqual([1]);
-      const envelope = JSON.parse((await h.stdoutPromise).trim());
-      expect(envelope.subtype).toBe('interrupted');
-      expect(envelope.is_error).toBe(true);
+      const chunk = JSON.parse((await h.stdoutPromise).trim());
+      expect(chunk.type).toBe('abort');
+      expect(chunk.payload.reason).toBe('interrupted');
     });
 
     it('stream-json sigint handler should emit abort chunk and exit 1', async () => {

--- a/packages/core/src/harness/run-headless.ts
+++ b/packages/core/src/harness/run-headless.ts
@@ -1,0 +1,120 @@
+import type { Writable } from 'node:stream';
+import type { FullOutput, MastraModelOutput } from '../stream/base/output';
+import { buildInterruptedEnvelope, formatJson, formatStreamJson, formatText, hasWarnings } from './output-formatter';
+import type { OutputFormat } from './output-formatter';
+
+const EXIT_SUCCESS = 0;
+const EXIT_RUNTIME_ERROR = 1;
+const EXIT_CONFIG_ERROR = 2;
+
+const VALID_FORMATS: readonly OutputFormat[] = ['text', 'json', 'stream-json'];
+
+export interface RunHeadlessOptions {
+  prompt: string;
+  agentId: string;
+  outputFormat: OutputFormat;
+  jsonSchema?: string;
+  strict: boolean;
+}
+
+export interface RunHeadlessIO {
+  stdout: Writable;
+  stderr: Writable;
+  exit: (code: number) => void;
+  onSigint: (handler: () => void) => void;
+}
+
+interface MinimalAgent {
+  stream(
+    messages: Array<{ role: 'user'; content: string }>,
+    options?: { structuredOutput?: { schema: unknown } },
+  ): Promise<MastraModelOutput<any>>;
+}
+
+interface MinimalMastra {
+  getAgent(id: string): MinimalAgent;
+  getAgents?(): Record<string, unknown>;
+}
+
+export async function runHeadless(
+  mastra: MinimalMastra,
+  options: RunHeadlessOptions,
+  io: RunHeadlessIO,
+): Promise<void> {
+  const { prompt, agentId, outputFormat, jsonSchema, strict } = options;
+
+  if (!VALID_FORMATS.includes(outputFormat)) {
+    io.stderr.write(`Error: Invalid outputFormat "${outputFormat}". Must be one of: ${VALID_FORMATS.join(', ')}.\n`);
+    io.exit(EXIT_CONFIG_ERROR);
+    return;
+  }
+
+  let agent: MinimalAgent;
+  try {
+    agent = mastra.getAgent(agentId);
+  } catch {
+    io.stderr.write(`Error: Agent ${JSON.stringify(agentId)} not found.\n`);
+    const agentKeys = Object.keys(mastra.getAgents?.() ?? {});
+    if (agentKeys.length > 0) {
+      io.stderr.write(`Available agents: ${agentKeys.join(', ')}\n`);
+    }
+    io.exit(EXIT_CONFIG_ERROR);
+    return;
+  }
+
+  let structuredOutput: { schema: unknown } | undefined;
+  if (jsonSchema) {
+    try {
+      structuredOutput = { schema: JSON.parse(jsonSchema) };
+    } catch (e) {
+      io.stderr.write(`Error: Invalid --json-schema: ${(e as Error).message}\n`);
+      io.exit(EXIT_CONFIG_ERROR);
+      return;
+    }
+  }
+
+  const startTime = Date.now();
+
+  const streamOutput = await agent.stream([{ role: 'user', content: prompt }], {
+    ...(structuredOutput ? { structuredOutput } : {}),
+  });
+
+  registerSigint(outputFormat, io, startTime);
+
+  let fullOutput: FullOutput<any>;
+  if (outputFormat === 'text') {
+    fullOutput = await formatText(streamOutput, io.stdout, io.stderr);
+  } else if (outputFormat === 'json') {
+    fullOutput = await formatJson(streamOutput, io.stdout, startTime);
+  } else {
+    fullOutput = await formatStreamJson(streamOutput, io.stdout, io.stderr);
+  }
+
+  if (fullOutput.error) {
+    io.exit(EXIT_RUNTIME_ERROR);
+    return;
+  }
+  if (strict && hasWarnings(fullOutput)) {
+    io.stderr.write('Warnings treated as errors (--strict):\n');
+    for (const w of fullOutput.warnings) {
+      io.stderr.write(`  ${JSON.stringify(w)}\n`);
+    }
+    io.exit(EXIT_RUNTIME_ERROR);
+    return;
+  }
+  io.exit(EXIT_SUCCESS);
+}
+
+function registerSigint(outputFormat: OutputFormat, io: RunHeadlessIO, startTime: number): void {
+  io.onSigint(() => {
+    if (outputFormat === 'text') {
+      io.stdout.write('\n');
+    } else if (outputFormat === 'json') {
+      const envelope = buildInterruptedEnvelope(Date.now() - startTime);
+      io.stdout.write(JSON.stringify(envelope) + '\n');
+    } else {
+      io.stdout.write(JSON.stringify({ type: 'abort', payload: { reason: 'interrupted' } }) + '\n');
+    }
+    io.exit(EXIT_RUNTIME_ERROR);
+  });
+}

--- a/packages/core/src/harness/run-headless.ts
+++ b/packages/core/src/harness/run-headless.ts
@@ -64,6 +64,11 @@ export async function runHeadless(
 
   let structuredOutput: { schema: unknown } | undefined;
   if (jsonSchema) {
+    if (outputFormat === 'text') {
+      io.stderr.write('Error: jsonSchema requires outputFormat "json" or "stream-json".\n');
+      io.exit(EXIT_CONFIG_ERROR);
+      return;
+    }
     try {
       structuredOutput = { schema: JSON.parse(jsonSchema) };
     } catch (e) {
@@ -73,13 +78,15 @@ export async function runHeadless(
     }
   }
 
+  const abortController = new AbortController();
   const startTime = Date.now();
+
+  registerSigint(outputFormat, io, startTime, abortController);
 
   const streamOutput = await agent.stream([{ role: 'user', content: prompt }], {
     ...(structuredOutput ? { structuredOutput } : {}),
   });
-
-  registerSigint(outputFormat, io, startTime);
+  if (abortController.signal.aborted) return;
 
   let fullOutput: FullOutput<any>;
   if (outputFormat === 'text') {
@@ -89,6 +96,7 @@ export async function runHeadless(
   } else {
     fullOutput = await formatStreamJson(streamOutput, io.stdout, io.stderr);
   }
+  if (abortController.signal.aborted) return;
 
   if (fullOutput.error) {
     io.exit(EXIT_RUNTIME_ERROR);
@@ -105,8 +113,15 @@ export async function runHeadless(
   io.exit(EXIT_SUCCESS);
 }
 
-function registerSigint(outputFormat: OutputFormat, io: RunHeadlessIO, startTime: number): void {
+function registerSigint(
+  outputFormat: OutputFormat,
+  io: RunHeadlessIO,
+  startTime: number,
+  controller: AbortController,
+): void {
   io.onSigint(() => {
+    if (controller.signal.aborted) return;
+    controller.abort();
     if (outputFormat === 'text') {
       io.stdout.write('\n');
     } else if (outputFormat === 'json') {

--- a/packages/core/src/harness/run-headless.ts
+++ b/packages/core/src/harness/run-headless.ts
@@ -1,6 +1,6 @@
 import type { Writable } from 'node:stream';
 import type { FullOutput, MastraModelOutput } from '../stream/base/output';
-import { buildInterruptedEnvelope, formatJson, formatStreamJson, formatText, hasWarnings } from './output-formatter';
+import { formatJson, formatStreamJson, formatText, hasWarnings } from './output-formatter';
 import type { OutputFormat } from './output-formatter';
 
 const EXIT_SUCCESS = 0;
@@ -79,9 +79,8 @@ export async function runHeadless(
   }
 
   const abortController = new AbortController();
-  const startTime = Date.now();
 
-  registerSigint(outputFormat, io, startTime, abortController);
+  registerSigint(outputFormat, io, abortController);
 
   const streamOutput = await agent.stream([{ role: 'user', content: prompt }], {
     ...(structuredOutput ? { structuredOutput } : {}),
@@ -92,7 +91,7 @@ export async function runHeadless(
   if (outputFormat === 'text') {
     fullOutput = await formatText(streamOutput, io.stdout, io.stderr);
   } else if (outputFormat === 'json') {
-    fullOutput = await formatJson(streamOutput, io.stdout, startTime);
+    fullOutput = await formatJson(streamOutput, io.stdout, 0);
   } else {
     fullOutput = await formatStreamJson(streamOutput, io.stdout, io.stderr);
   }
@@ -113,20 +112,12 @@ export async function runHeadless(
   io.exit(EXIT_SUCCESS);
 }
 
-function registerSigint(
-  outputFormat: OutputFormat,
-  io: RunHeadlessIO,
-  startTime: number,
-  controller: AbortController,
-): void {
+function registerSigint(outputFormat: OutputFormat, io: RunHeadlessIO, controller: AbortController): void {
   io.onSigint(() => {
     if (controller.signal.aborted) return;
     controller.abort();
     if (outputFormat === 'text') {
       io.stdout.write('\n');
-    } else if (outputFormat === 'json') {
-      const envelope = buildInterruptedEnvelope(Date.now() - startTime);
-      io.stdout.write(JSON.stringify(envelope) + '\n');
     } else {
       io.stdout.write(JSON.stringify({ type: 'abort', payload: { reason: 'interrupted' } }) + '\n');
     }

--- a/packages/core/src/harness/test-utils.ts
+++ b/packages/core/src/harness/test-utils.ts
@@ -1,0 +1,59 @@
+import type { PassThrough } from 'node:stream';
+import { ReadableStream } from 'node:stream/web';
+import type { FullOutput } from '../stream/base/output';
+import type { ChunkType } from '../stream/types';
+
+export function createMockFullOutput(overrides: Partial<FullOutput<any>> = {}): FullOutput<any> {
+  return {
+    text: 'Hello world',
+    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    steps: [{ text: 'Hello world' } as any],
+    finishReason: 'end_turn' as any,
+    warnings: [],
+    providerMetadata: undefined as any,
+    request: {},
+    reasoning: [],
+    reasoningText: undefined,
+    toolCalls: [],
+    toolResults: [],
+    sources: [],
+    files: [],
+    response: { modelId: 'test-model', id: '1', timestamp: new Date(), messages: [], uiMessages: [] } as any,
+    totalUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    object: undefined,
+    error: undefined,
+    tripwire: undefined,
+    traceId: 'trace-123',
+    spanId: 'span-456',
+    runId: 'run-789',
+    suspendPayload: undefined,
+    resumeSchema: undefined,
+    messages: [],
+    rememberedMessages: [],
+    ...overrides,
+  };
+}
+
+export function createMockStreamOutput(chunks: ChunkType<any>[], fullOutput: FullOutput<any>) {
+  const fullStream = new ReadableStream<ChunkType<any>>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+  return {
+    fullStream,
+    getFullOutput: async () => fullOutput,
+  } as any;
+}
+
+export async function collectStream(stream: PassThrough): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Summary
This PR adds a new "mastra run" command so you can run a Mastra agent from the terminal without running a server: provide an agent ID and a prompt (or pipe input), choose an output format (text, JSON, or streaming JSON), and it runs the agent and prints the results. It also adds a headless runner and output-formatting helpers to support that command.

## Overview
Adds a headless, one‑shot CLI workflow to execute Mastra agents locally with selectable output formats, optional structured output via JSON Schema, SIGINT handling, and clear exit-code semantics. Exposes a runHeadless orchestrator and output-formatting utilities from @mastra/core/harness and wires a top-level mastra run command in the CLI.

## Key Changes

- CLI
  - packages/cli/src/index.ts: adds top-level mastra run command wired to runAgent.
  - packages/cli/src/commands/actions/run-agent.ts: analytics-wrapped action forwarding args to run.
  - packages/cli/src/commands/run/run.ts: main CLI handler that resolves prompt (flag or piped stdin), validates inputs (output formats: text|json|stream-json), enforces --json-schema only for JSON modes, bundles the project entry, loads env, executes bundled output via execa, streams child stdout/stderr, forwards SIGINT, and maps exit codes (config error: 2, runtime error: 1, success: 0).
  - packages/cli/src/commands/run/RunBundler.ts: BuildBundler subclass generating an injected entry that calls runHeadless(mastra, ...), embeds runtime options, and discovers dotenv files (respects MASTRA_SKIP_DOTENV).
  - packages/cli/src/commands/run/RunBundler.test.ts and packages/cli/src/commands/run/run.test.ts: Vitest coverage for bundler entry generation, env-file discovery, argument validation, and error-exit behavior.

- Core headless orchestrator & exports
  - packages/core/src/harness/run-headless.ts: new runHeadless function that validates args, resolves agent (printing available agents when resolution fails), parses optional jsonSchema, registers SIGINT via AbortController, invokes agent.stream (optionally with structuredOutput), formats output per selected mode, and enforces strict-mode/warnings semantics.
  - packages/core/src/harness/output-formatter.ts: adds OutputFormat type and three formatters:
    - formatText: streams text-delta chunks to stdout, routes error chunks to stderr, ensures trailing newline.
    - formatJson: emits the final FullOutput as a single newline-delimited JSON object (serializing Error objects).
    - formatStreamJson: emits NDJSON one line per streamed chunk.
    - hasWarnings: detects presence of warnings in FullOutput.
  - packages/core/src/harness/index.ts: re-exports runHeadless and formatter helpers/types.
  - packages/core/src/harness/test-utils.ts: test helpers for building mock stream/full outputs.

- Tests
  - packages/core/src/harness/output-formatter.test.ts and packages/core/src/harness/run-headless.test.ts: comprehensive tests covering formatter behavior, full-output serialization, structured-output wiring, SIGINT handling, strict-mode, and exit-code semantics.

- Releases / metadata
  - .changeset entries added indicating minor releases:
    - @mastra/core: exposes runHeadless and harness output-formatting helpers.
    - mastra: introduces mastra run CLI command and documents supported output modes and flags.

## Output & Signal Behavior (summary)
- text: streams text-delta to stdout, error chunks to stderr, appends trailing newline; SIGINT emits a newline and exits with runtime error code.
- json: emits one JSON envelope for final FullOutput (errors serialized); SIGINT emits an interrupted envelope; errors -> exit code 1.
- stream-json: emits NDJSON per chunk; SIGINT emits an abort chunk with payload.reason === "interrupted".

## Validation & Errors
- outputFormat must be one of text | json | stream-json (configuration error, exit 2).
- --json-schema is allowed only with json or stream-json (configuration error, exit 2); schema JSON is parsed and parse errors produce clear stderr and exit 2.
- Missing agent or failed agent resolution prints guidance (including available agents when possible) and exits with configuration error code 2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->