### PR TITLE
fix(observability): handle model date suffixes in pricing lookup

### DIFF
--- a/.changeset/fix-pricing-date-suffix.md
+++ b/.changeset/fix-pricing-date-suffix.md
@@ -1,0 +1,5 @@
+---
+"@mastra/observability": patch
+---
+
+Fixed cost lookup for models with date suffixes. Providers like OpenAI often return model names with date suffixes (e.g., `gpt-5.4-mini-2026-03-17`) that don't exactly match pricing data entries. The lookup now tries multiple variants including stripping date suffixes and converting dots to dashes.

--- a/observability/mastra/src/metrics/estimator.test.ts
+++ b/observability/mastra/src/metrics/estimator.test.ts
@@ -263,4 +263,109 @@ describe('estimateCosts', () => {
       },
     });
   });
+
+  it('falls back to base model pricing when model name has date suffix', () => {
+    // Model names like "gpt-4o-mini-2024-07-18" should match "gpt-4o-mini" pricing
+    const costs = estimateCosts(
+      {
+        provider: 'openai',
+        model: 'gpt-4o-mini-2024-07-18',
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 100,
+        },
+      },
+      pricingRegistry,
+    );
+
+    // The cost context reflects the matched pricing model's name (base model)
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toEqual({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      estimatedCost: 0.00015,
+      costUnit: 'USD',
+      costMetadata: {
+        pricing_id: 'openai-gpt-4o-mini',
+        tier_index: 0,
+      },
+    });
+  });
+
+  it('falls back to base model pricing when model name has dots and date suffix', () => {
+    // Model names like "gpt-5.4-mini-2026-03-17" should match "gpt-5-4-mini" pricing
+    // (dots converted to dashes, then date suffix stripped)
+    const costs = estimateCosts(
+      {
+        provider: 'openai',
+        model: 'gpt-4o.mini-2024-07-18',
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 100,
+        },
+      },
+      pricingRegistry,
+    );
+
+    // gpt-4o.mini-2024-07-18 -> gpt-4o-mini (dots to dashes, strip date)
+    // Cost context reflects the matched pricing model
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toEqual({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      estimatedCost: 0.00015,
+      costUnit: 'USD',
+      costMetadata: {
+        pricing_id: 'openai-gpt-4o-mini',
+        tier_index: 0,
+      },
+    });
+  });
+
+  it('strips Anthropic-style date suffix (YYYYMMDD format)', () => {
+    // Anthropic uses YYYYMMDD format: claude-sonnet-4-5-20250929
+    const costs = estimateCosts(
+      {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5-20250929',
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 100,
+        },
+      },
+      pricingRegistry,
+    );
+
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toEqual({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      estimatedCost: 0.003,
+      costUnit: 'USD',
+      costMetadata: {
+        pricing_id: 'anthropic-claude-sonnet-4-5',
+        tier_index: 0,
+      },
+    });
+  });
+
+  it('strips Anthropic-style date suffix with trailing suffix (e.g., -thinking)', () => {
+    // Anthropic sometimes has suffixes after the date: claude-sonnet-4-5-20250929-thinking
+    const costs = estimateCosts(
+      {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5-20250929-thinking',
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 100,
+        },
+      },
+      pricingRegistry,
+    );
+
+    // Should strip date but keep -thinking suffix for lookup
+    // Falls back to claude-sonnet-4-5 since claude-sonnet-4-5-thinking isn't in fixture
+    // But the stripping produces claude-sonnet-4-5-thinking, which won't match
+    // So it should fail to find the model
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)?.costMetadata).toEqual({
+      error: 'no_matching_model',
+    });
+  });
 });

--- a/observability/mastra/src/metrics/pricing-registry.ts
+++ b/observability/mastra/src/metrics/pricing-registry.ts
@@ -73,16 +73,13 @@ export class PricingRegistry {
   }
 
   get(args: { provider: string; model: string }): PricingModel | null {
-    const key = makePricingKey(args);
-    const exact = this.pricingModels.get(key);
-    if (exact) return exact;
-
-    // Fallback: dots → dashes in model name (e.g. "gpt-5.2" → "gpt-5-2")
-    const dashedKey = makePricingKey({ provider: args.provider, model: args.model.replace(/\./g, '-') });
-    if (dashedKey !== key) {
-      return this.pricingModels.get(dashedKey) ?? null;
+    // Try all model name variants in order of preference
+    const variants = getModelVariants(args.model);
+    for (const variant of variants) {
+      const key = makePricingKey({ provider: args.provider, model: variant });
+      const match = this.pricingModels.get(key);
+      if (match) return match;
     }
-
     return null;
   }
 }
@@ -190,4 +187,37 @@ function normalizeProvider(provider: string): string {
   const normalized = provider.trim().toLowerCase();
   const dotIndex = normalized.indexOf('.');
   return dotIndex !== -1 ? normalized.substring(0, dotIndex) : normalized;
+}
+
+/**
+ * Generate model name variants to try during lookup, in priority order:
+ * 1. Original model name
+ * 2. Dots converted to dashes (e.g., "gpt-5.4" → "gpt-5-4")
+ * 3. Date suffix stripped from original
+ * 4. Date suffix stripped from dashed version
+ */
+function getModelVariants(model: string): string[] {
+  const dashed = model.replace(/\./g, '-');
+  return [model, dashed, stripDateSuffix(model), stripDateSuffix(dashed)];
+}
+
+/**
+ * Strip date suffix from model names.
+ * Handles multiple date formats used by different providers:
+ * - OpenAI: YYYY-MM-DD at end (e.g., "gpt-5-4-mini-2026-03-17" → "gpt-5-4-mini")
+ * - Anthropic: YYYYMMDD with optional suffix (e.g., "claude-sonnet-4-5-20250929-thinking" → "claude-sonnet-4-5-thinking")
+ * - Cohere/Gemini: MM-YYYY at end (e.g., "command-r-08-2024" → "command-r")
+ */
+function stripDateSuffix(model: string): string {
+  // OpenAI format: -YYYY-MM-DD at end
+  let stripped = model.replace(/-20\d{2}-\d{2}-\d{2}$/, '');
+  if (stripped !== model) return stripped;
+
+  // Anthropic format: -YYYYMMDD, possibly followed by suffix like -thinking
+  stripped = model.replace(/-20\d{6}(-[a-z]+)?$/, '$1');
+  if (stripped !== model) return stripped;
+
+  // Cohere/Gemini format: -MM-YYYY at end
+  stripped = model.replace(/-\d{2}-20\d{2}$/, '');
+  return stripped;
 }


### PR DESCRIPTION
Providers like OpenAI return model names with date suffixes (e.g., `gpt-5.4-mini-2026-03-17`) that don't match pricing data entries. This was causing cost to not display in Studio.

The pricing lookup now tries multiple model name variants:

```ts
// For input: gpt-5.4-mini-2026-03-17
// Tries: gpt-5.4-mini-2026-03-17, gpt-5-4-mini-2026-03-17, gpt-5.4-mini, gpt-5-4-mini
```

Also handles Anthropic (`YYYYMMDD`) and Cohere (`MM-YYYY`) date formats.

Fixes the issue Alex reported where cost wasn't showing for `gpt-5.4-mini`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When AI providers give model names with dates at the end (like `gpt-4-mini-2026-03-17`), the cost calculator couldn't find prices for them because the price database uses simpler names without dates. This PR makes the price lookup smarter by trying multiple name variations—removing the dates, changing dots to dashes—so it can find the right price even when the model name includes a date.

## Changes

### Changeset
Added documentation for a patch release to `@mastra/observability` describing the update to cost lookup behavior for model identifiers with date suffixes.

### Core Logic Updates
Updated `PricingRegistry.get()` in `pricing-registry.ts` to intelligently handle model names with date suffixes:
- Instead of a simple exact match followed by a single dot-to-dash fallback, the lookup now tries a prioritized list of model name variants
- New helper functions `getModelVariants()` and `stripDateSuffix()` generate variants by:
  - Keeping the original model name
  - Creating a dashed variant (replacing dots with dashes)
  - Removing provider-specific date suffix patterns:
    - OpenAI format: `-YYYY-MM-DD`
    - Anthropic format: `-YYYYMMDD` (with optional trailing suffix)
    - Cohere/Gemini format: `-MM-YYYY`
  - Applying the same transformations to both original and dashed forms
- Returns `null` if no variant matches any pricing entry

### Test Coverage
Added four new test cases in `estimator.test.ts` validating:
- Successful cost estimation fallback for OpenAI models with `-YYYY-MM-DD` date suffixes
- Successful cost estimation fallback for OpenAI models with dots and date suffixes
- Successful cost estimation fallback for Anthropic models with `-YYYYMMDD` date suffixes
- Proper failure case when a date suffix is followed by additional trailing text (e.g., `-thinking`), returning `{ error: 'no_matching_model' }`

All tests verify that matched costs reflect the base model name along with correct pricing tier information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->