### PR TITLE
fix(cli): retry transient fetch failures in platform deploy commands

### DIFF
--- a/.changeset/fresh-points-occur.md
+++ b/.changeset/fresh-points-occur.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed `mastra studio deploy` and `mastra server deploy` so transient polling failures are retried up to 3 times before the CLI exits.

--- a/packages/cli/src/commands/server/platform-api.test.ts
+++ b/packages/cli/src/commands/server/platform-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGET = vi.fn();
 const mockPOST = vi.fn();
@@ -24,6 +24,10 @@ vi.mock('../auth/credentials.js', () => ({
 beforeEach(() => {
   vi.resetAllMocks();
   vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('fetchServerProjects', () => {
@@ -449,6 +453,111 @@ describe('pollServerDeploy', () => {
 
     expect(result.status).toBe('running');
     expect(result.instanceUrl).toBe('https://app.example');
+  });
+
+  it('retries transient polling failures up to 3 times', async () => {
+    vi.useFakeTimers();
+
+    const deploy = { id: 'd1', status: 'running' };
+    let deployFailuresRemaining = 3;
+    const networkError = new TypeError('network request failed');
+    Object.assign(networkError, { cause: { code: 'ECONNRESET' } });
+
+    mockGET.mockImplementation((path: string) => {
+      if (path === '/v1/server/deploys/{id}/logs') {
+        return Promise.resolve({
+          data: { buildLogs: [], deployLogs: [] },
+          response: { status: 200 },
+        });
+      }
+
+      if (path === '/v1/server/deploys/{id}') {
+        if (deployFailuresRemaining > 0) {
+          deployFailuresRemaining -= 1;
+          return Promise.reject(networkError);
+        }
+
+        return Promise.resolve({
+          data: deploy,
+          response: { status: 200 },
+        });
+      }
+
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { pollServerDeploy } = await import('./platform-api.js');
+    const resultPromise = pollServerDeploy('d1', 'tok', 'org-1', 10000);
+
+    await vi.advanceTimersByTimeAsync(3500);
+
+    await expect(resultPromise).resolves.toEqual(deploy);
+
+    const statusCalls = mockGET.mock.calls.filter(([path]) => path === '/v1/server/deploys/{id}');
+    expect(statusCalls).toHaveLength(4);
+  });
+
+  it('throws after exhausting transient polling retries', async () => {
+    vi.useFakeTimers();
+
+    const networkError = new TypeError('network request failed');
+    Object.assign(networkError, { cause: { code: 'ECONNRESET' } });
+
+    mockGET.mockImplementation((path: string) => {
+      if (path === '/v1/server/deploys/{id}/logs') {
+        return Promise.resolve({
+          data: { buildLogs: [], deployLogs: [] },
+          response: { status: 200 },
+        });
+      }
+
+      if (path === '/v1/server/deploys/{id}') {
+        return Promise.reject(networkError);
+      }
+
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { pollServerDeploy } = await import('./platform-api.js');
+    const resultPromise = pollServerDeploy('d1', 'tok', 'org-1', 10000);
+    const rejection = expect(resultPromise).rejects.toThrow('network request failed');
+
+    await vi.advanceTimersByTimeAsync(3500);
+
+    await rejection;
+
+    const statusCalls = mockGET.mock.calls.filter(([path]) => path === '/v1/server/deploys/{id}');
+    expect(statusCalls).toHaveLength(4);
+  });
+
+  it('does not retry non-transient polling failures', async () => {
+    vi.useFakeTimers();
+
+    mockGET.mockImplementation((path: string) => {
+      if (path === '/v1/server/deploys/{id}/logs') {
+        return Promise.resolve({
+          data: { buildLogs: [], deployLogs: [] },
+          response: { status: 200 },
+        });
+      }
+
+      if (path === '/v1/server/deploys/{id}') {
+        return Promise.reject(new Error('Invalid deploy payload'));
+      }
+
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const { pollServerDeploy } = await import('./platform-api.js');
+    const resultPromise = pollServerDeploy('d1', 'tok', 'org-1', 10000);
+    const rejection = expect(resultPromise).rejects.toThrow('Invalid deploy payload');
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    await rejection;
+
+    const statusCalls = mockGET.mock.calls.filter(([path]) => path === '/v1/server/deploys/{id}');
+    expect(statusCalls).toHaveLength(1);
   });
 });
 

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -1,4 +1,4 @@
-import { isRetryablePollingError } from '../../utils/polling.js';
+import { withPollingRetries } from '../../utils/polling.js';
 import { createApiClient, throwApiError } from '../auth/client.js';
 import { getToken } from '../auth/credentials.js';
 import type { paths } from '../platform-api.js';
@@ -141,23 +141,11 @@ export async function pollServerDeploy(
 
   try {
     while (Date.now() - start < maxWaitMs) {
-      let retryCount = 0;
-      let result: Awaited<ReturnType<typeof client.GET>> | undefined;
-
-      while (!result) {
-        try {
-          result = await client.GET('/v1/server/deploys/{id}', {
-            params: { path: { id: deployId } },
-          });
-        } catch (error) {
-          if (!isRetryablePollingError(error) || retryCount >= 3) {
-            throw error;
-          }
-
-          await new Promise(resolve => setTimeout(resolve, 500 * Math.pow(2, retryCount)));
-          retryCount += 1;
-        }
-      }
+      const result = await withPollingRetries(() =>
+        client.GET('/v1/server/deploys/{id}', {
+          params: { path: { id: deployId } },
+        }),
+      );
 
       const { data, error, response } = result;
 

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -1,3 +1,4 @@
+import { isRetryablePollingError } from '../../utils/polling.js';
 import { createApiClient, throwApiError } from '../auth/client.js';
 import { getToken } from '../auth/credentials.js';
 import type { paths } from '../platform-api.js';
@@ -140,9 +141,25 @@ export async function pollServerDeploy(
 
   try {
     while (Date.now() - start < maxWaitMs) {
-      const { data, error, response } = await client.GET('/v1/server/deploys/{id}', {
-        params: { path: { id: deployId } },
-      });
+      let retryCount = 0;
+      let result: Awaited<ReturnType<typeof client.GET>> | undefined;
+
+      while (!result) {
+        try {
+          result = await client.GET('/v1/server/deploys/{id}', {
+            params: { path: { id: deployId } },
+          });
+        } catch (error) {
+          if (!isRetryablePollingError(error) || retryCount >= 3) {
+            throw error;
+          }
+
+          await new Promise(resolve => setTimeout(resolve, 500 * Math.pow(2, retryCount)));
+          retryCount += 1;
+        }
+      }
+
+      const { data, error, response } = result;
 
       if (error) {
         if (response.status === 401) {

--- a/packages/cli/src/commands/studio/platform-api.test.ts
+++ b/packages/cli/src/commands/studio/platform-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGET = vi.fn();
 const mockPOST = vi.fn();
@@ -23,6 +23,10 @@ vi.mock('../auth/client.js', async importOriginal => {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('fetchProjects', () => {
@@ -194,5 +198,64 @@ describe('uploadDeploy', () => {
     await expect(uploadDeploy('tok', 'org-1', 'proj-1', Buffer.from('zip'))).rejects.toThrow(
       'Artifact upload failed: 403',
     );
+  });
+});
+
+describe('pollDeploy', () => {
+  it('retries transient polling failures up to 3 times', async () => {
+    vi.useFakeTimers();
+
+    const deploy = { id: 'd1', status: 'running', instanceUrl: 'https://x.com', error: null };
+    const networkError = new TypeError('network request failed');
+    Object.assign(networkError, { cause: { code: 'ECONNRESET' } });
+    mockGET
+      .mockRejectedValueOnce(networkError)
+      .mockRejectedValueOnce(networkError)
+      .mockRejectedValueOnce(networkError)
+      .mockResolvedValueOnce({ data: { deploy }, response: { status: 200 } });
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+
+    const { pollDeploy } = await import('./platform-api.js');
+    const resultPromise = pollDeploy('d1', 'tok', 'org-1', 10000);
+
+    await vi.advanceTimersByTimeAsync(3500);
+
+    await expect(resultPromise).resolves.toEqual(deploy);
+    expect(mockGET).toHaveBeenCalledTimes(4);
+  });
+
+  it('throws after exhausting transient polling retries', async () => {
+    vi.useFakeTimers();
+
+    const networkError = new TypeError('network request failed');
+    Object.assign(networkError, { cause: { code: 'ECONNRESET' } });
+    mockGET.mockRejectedValue(networkError);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+
+    const { pollDeploy } = await import('./platform-api.js');
+    const resultPromise = pollDeploy('d1', 'tok', 'org-1', 10000);
+    const rejection = expect(resultPromise).rejects.toThrow('network request failed');
+
+    await vi.advanceTimersByTimeAsync(3500);
+
+    await rejection;
+    expect(mockGET).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not retry non-transient polling failures', async () => {
+    vi.useFakeTimers();
+
+    mockGET.mockRejectedValue(new Error('Invalid deploy payload'));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+
+    const { pollDeploy } = await import('./platform-api.js');
+    const resultPromise = pollDeploy('d1', 'tok', 'org-1', 10000);
+    const rejection = expect(resultPromise).rejects.toThrow('Invalid deploy payload');
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    await rejection;
+    expect(mockGET).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/commands/studio/platform-api.ts
+++ b/packages/cli/src/commands/studio/platform-api.ts
@@ -1,3 +1,4 @@
+import { isRetryablePollingError } from '../../utils/polling.js';
 import { authHeaders, createApiClient, MASTRA_PLATFORM_API_URL, platformFetch, throwApiError } from '../auth/client.js';
 
 export interface Project {
@@ -192,9 +193,25 @@ export async function pollDeploy(
 
   try {
     while (Date.now() - start < maxWaitMs) {
-      const { data, error, response } = await client.GET('/v1/studio/deploys/{id}', {
-        params: { path: { id: deployId } },
-      });
+      let retryCount = 0;
+      let result: Awaited<ReturnType<typeof client.GET>> | undefined;
+
+      while (!result) {
+        try {
+          result = await client.GET('/v1/studio/deploys/{id}', {
+            params: { path: { id: deployId } },
+          });
+        } catch (error) {
+          if (!isRetryablePollingError(error) || retryCount >= 3) {
+            throw error;
+          }
+
+          await new Promise(resolve => setTimeout(resolve, 500 * Math.pow(2, retryCount)));
+          retryCount += 1;
+        }
+      }
+
+      const { data, error, response } = result;
 
       if (error) {
         throwApiError('Poll failed', response.status, error.detail);

--- a/packages/cli/src/commands/studio/platform-api.ts
+++ b/packages/cli/src/commands/studio/platform-api.ts
@@ -1,4 +1,4 @@
-import { isRetryablePollingError } from '../../utils/polling.js';
+import { withPollingRetries } from '../../utils/polling.js';
 import { authHeaders, createApiClient, MASTRA_PLATFORM_API_URL, platformFetch, throwApiError } from '../auth/client.js';
 
 export interface Project {
@@ -193,23 +193,11 @@ export async function pollDeploy(
 
   try {
     while (Date.now() - start < maxWaitMs) {
-      let retryCount = 0;
-      let result: Awaited<ReturnType<typeof client.GET>> | undefined;
-
-      while (!result) {
-        try {
-          result = await client.GET('/v1/studio/deploys/{id}', {
-            params: { path: { id: deployId } },
-          });
-        } catch (error) {
-          if (!isRetryablePollingError(error) || retryCount >= 3) {
-            throw error;
-          }
-
-          await new Promise(resolve => setTimeout(resolve, 500 * Math.pow(2, retryCount)));
-          retryCount += 1;
-        }
-      }
+      const result = await withPollingRetries(() =>
+        client.GET('/v1/studio/deploys/{id}', {
+          params: { path: { id: deployId } },
+        }),
+      );
 
       const { data, error, response } = result;
 

--- a/packages/cli/src/utils/polling.ts
+++ b/packages/cli/src/utils/polling.ts
@@ -16,3 +16,20 @@ export function isRetryablePollingError(error: unknown): boolean {
 
   return error instanceof TypeError && error.message.toLowerCase().includes('fetch failed');
 }
+
+export async function withPollingRetries<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T> {
+  let retryCount = 0;
+
+  while (true) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (!isRetryablePollingError(error) || retryCount >= maxRetries) {
+        throw error;
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 500 * Math.pow(2, retryCount)));
+      retryCount += 1;
+    }
+  }
+}

--- a/packages/cli/src/utils/polling.ts
+++ b/packages/cli/src/utils/polling.ts
@@ -1,0 +1,18 @@
+export function isRetryablePollingError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  if ('name' in error && error.name === 'AbortError') {
+    return true;
+  }
+
+  const cause = 'cause' in error && error.cause && typeof error.cause === 'object' ? error.cause : undefined;
+  const code = cause && 'code' in cause && typeof cause.code === 'string' ? cause.code : undefined;
+
+  if (code === 'ECONNRESET' || code === 'ETIMEDOUT' || code === 'ECONNREFUSED' || code === 'ENOTFOUND') {
+    return true;
+  }
+
+  return error instanceof TypeError && error.message.toLowerCase().includes('fetch failed');
+}


### PR DESCRIPTION
## Summary
- retry transient transport failures while polling platform deploy status in `mastra studio deploy` and `mastra server deploy`
- keep the retry loop local to these CLI platform commands
- share only the polling error predicate in a small CLI util
- add targeted tests for retryable and non-retryable polling failures

## Scope
CLI, platform commands only.

This change is intentionally limited to deploy status polling after a deploy has been accepted.

It does not change:
- artifact upload behavior
- deploy log streaming behavior
- general platform client retry behavior

## Why
Initial deploy polling could fail on transient fetch errors even when the deploy itself later succeeded. This makes the CLI tolerate up to 3 retries after the initial attempt for retryable transport failures before exiting.

## Verification
- pnpm --filter ./packages/cli typecheck
- pnpm --filter ./packages/cli test -- src/commands/studio/platform-api.test.ts src/commands/server/platform-api.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you deploy with the CLI it polls the server for status; sometimes those status checks fail due to temporary network hiccups even though the deploy succeeds. This PR makes the CLI retry those transient polling failures up to 3 times after the initial attempt, for up to 4 total attempts, before giving up, while still failing immediately for real errors.

## Changes Summary

### New Files
- **.changeset/fresh-points-occur.md**: Patch release notes documenting the fix for transient polling failures in deploy commands.

### New Utilities
- **packages/cli/src/utils/polling.ts**
  - Added `isRetryablePollingError(error: unknown): boolean` to classify retryable polling errors (AbortError by name, nested `cause.code` matching `ECONNRESET|ETIMEDOUT|ECONNREFUSED|ENOTFOUND`, or `TypeError` messages containing \"fetch failed\", case-insensitive).
  - Added `withPollingRetries<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T>` — an internal retry wrapper that retries retryable errors with exponential backoff (`500 * 2^retryCount` ms) for up to 3 retries after the initial attempt, rethrowing for non-retryable errors or when retries are exhausted.

### CLI Deploy Command Updates
- **packages/cli/src/commands/studio/platform-api.ts**
  - `pollDeploy` now calls platform GET requests via `withPollingRetries`, so transient transport/fetch failures during polling are retried per the utility. Existing polling control flow (token refresh, terminal status handling, background log streaming, 2s loop wait, timeout) is preserved.

- **packages/cli/src/commands/server/platform-api.ts**
  - `pollServerDeploy` receives the same retry wrapping for its deploy-status GET calls; behavior mirrors the studio command changes.

Notes:
- Retry loop is local to these CLI platform deploy polling paths; global platform client retry behavior, artifact upload, and deploy log streaming are unchanged.

### Tests
- **packages/cli/src/commands/studio/platform-api.test.ts**
  - Added tests for `pollDeploy` covering:
    - Transient network failure retried then succeed (expects 4 GET calls total).
    - Transient failures exhausted and rejected after retries (expects 4 GET calls).
    - Non-transient error fails immediately (expects 1 GET call).
  - Restored real timers after tests with `afterEach`.

- **packages/cli/src/commands/server/platform-api.test.ts**
  - Added equivalent tests for `pollServerDeploy` with the same three scenarios and timer handling.

### Design Decisions & Scope
- Scope is limited to CLI polling for platform deploy status after a deploy has been accepted.
- Does not change artifact upload behavior, deploy log streaming, or global client retry behavior.
- Exposes only a small polling utility (error predicate and retry wrapper) to share retryability logic between the two CLI commands.
- Default retry limit is 3 retries after the initial attempt with exponential backoff; non-retryable errors still fail immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->