### PR TITLE
docs: clarify PrefillErrorHandler setup

### DIFF
--- a/docs/src/content/en/reference/processors/prefill-error-handler.mdx
+++ b/docs/src/content/en/reference/processors/prefill-error-handler.mdx
@@ -11,7 +11,7 @@ The `PrefillErrorHandler` is an **error processor** that handles the Anthropic "
 
 When the error is detected, the processor appends a hidden `<system-reminder>continue</system-reminder>` user message to the conversation and signals a retry. The reminder is persisted with `metadata.systemReminder = { type: 'anthropic-prefill-processor-retry' }`, which keeps it available for retry reconstruction and raw history while standard UI-facing message conversions hide it.
 
-This processor is **auto-injected** — you don't need to configure it. It runs automatically when an LLM API call fails with the prefill error.
+Add this processor to `errorProcessors` when you want Mastra to recover from Anthropic assistant message prefill errors.
 
 ## How it works
 
@@ -24,27 +24,28 @@ The processor now reacts to the API rejection itself instead of re-checking whet
 
 ## Usage example
 
-The `PrefillErrorHandler` is auto-injected and requires no setup. It activates when the specific prefill error occurs:
+Add `PrefillErrorHandler` to `errorProcessors` for any agent that should retry Anthropic prefill failures:
 
 ```typescript title="src/mastra/agents/my-agent.ts"
 import { Agent } from '@mastra/core/agent'
+import { PrefillErrorHandler } from '@mastra/core/processors'
 
-// No special configuration needed — PrefillErrorHandler is auto-injected
 export const agent = new Agent({
   name: 'my-agent',
   instructions: 'You are a helpful assistant.',
-  model: 'anthropic:claude-sonnet-4-20250514',
+  model: 'anthropic/claude-opus-4-6',
+  errorProcessors: [new PrefillErrorHandler()],
 })
 ```
 
-If you want to disable auto-injection and handle prefill errors yourself, provide your own processor with a `processAPIError` method:
+If you want custom recovery behavior, provide your own error processor with a `processAPIError` method:
 
 ```typescript title="src/mastra/agents/custom-error-handling.ts"
 import { Agent } from '@mastra/core/agent'
 import type { Processor } from '@mastra/core/processors'
 
 const customErrorHandler: Processor = {
-  id: 'prefill-error-handler', // Same ID prevents auto-injection of the built-in one
+  id: 'custom-prefill-error-handler',
   processAPIError({ error, messageList, retryCount }) {
     // Your custom logic here
   },

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -421,6 +421,8 @@ System messages are **reset to their original values** at the start of each step
 
 Handles LLM API rejection errors before they surface as final errors. This runs when the API call fails with a non-retryable error (such as a 400 or 422 status code). Unlike `processOutputStep` which runs after successful responses, this runs when the API rejects the request.
 
+Add processors that implement `processAPIError` to an agent's `errorProcessors` array.
+
 Processors can inspect the error, modify the request (for example, by appending messages to the `messageList`), and return `{ retry: true }` to signal a retry with the modified state.
 
 ```typescript prettier:false
@@ -826,6 +828,15 @@ type OutputProcessor = Processor &
 
 // Must implement processAPIError
 type ErrorProcessor = Processor & { processAPIError: required }
+```
+
+Configure processors that implement `processAPIError` in `errorProcessors`:
+
+```typescript
+const agent = new Agent({
+  // ...
+  errorProcessors: [new PrefillErrorHandler()],
+})
 ```
 
 ## Usage examples


### PR DESCRIPTION
This updates the processor docs to match the current behavior.

Before:
```ts
// implied PrefillErrorHandler was automatic
```

After:
```ts
errorProcessors: [new PrefillErrorHandler()]
```

I corrected the PrefillErrorHandler reference and added the same guidance to the main processor interface page so `processAPIError` docs point people to `errorProcessors`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR clarifies the documentation for setting up `PrefillErrorHandler` in Mastra. Previously, the docs said it "just works automatically," but it actually requires developers to explicitly add it to their agent's configuration. The PR updates the documentation to show the correct way to set it up with a simple code example.

## Changes

### Documentation Updates

**PrefillErrorHandler Documentation** (`docs/src/content/en/reference/processors/prefill-error-handler.mdx`)

- Removed the "auto-injected" claim and clarified that `PrefillErrorHandler` must be explicitly configured in an agent's `errorProcessors` array
- Updated the usage example to show explicit registration: `errorProcessors: [new PrefillErrorHandler()]`
- Updated the customization example to demonstrate overriding behavior by supplying a custom processor with the `processAPIError` method
- Changed the custom processor's `id` from `'prefill-error-handler'` to `'custom-prefill-error-handler'` to reflect the new approach

**Processor Interface Documentation** (`docs/src/content/en/reference/processors/processor-interface.mdx`)

- Added clarification text directing users to add processors that implement `processAPIError` to an agent's `errorProcessors` array
- Added a code snippet example showing how to configure error processors via the agent constructor: `new Agent({ ..., errorProcessors: [new PrefillErrorHandler()] })`

### Impact

This is a documentation-only change that corrects the setup guidance for error processors, ensuring developers understand they need to explicitly register `PrefillErrorHandler` rather than relying on automatic injection. The examples now match the actual implementation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->