### PR TITLE
feat(cli): add `mastra server env pull` command

### DIFF
--- a/.changeset/dull-walls-visit.md
+++ b/.changeset/dull-walls-visit.md
@@ -2,4 +2,4 @@
 'mastra': minor
 ---
 
-Added `mastra server env pull [file]` command to download environment variables from a deployed Mastra Server project into a local `.env` file. This is the inverse of `mastra server env import` — useful in CI/CD pipelines where you only need a single API token and can pull all other env vars at runtime.
+Added `mastra server env pull [file]` command. Downloads environment variables from a deployed Mastra Server project into a local `.env` file. This is the inverse of `mastra server env import` and is useful in automated pipelines where you authenticate with a single API token and pull all other variables at runtime.

--- a/.changeset/dull-walls-visit.md
+++ b/.changeset/dull-walls-visit.md
@@ -1,0 +1,5 @@
+---
+'mastra': minor
+---
+
+Added `mastra server env pull [file]` command to download environment variables from a deployed Mastra Server project into a local `.env` file. This is the inverse of `mastra server env import` — useful in CI/CD pipelines where you only need a single API token and can pull all other env vars at runtime.

--- a/packages/cli/src/commands/server/env.test.ts
+++ b/packages/cli/src/commands/server/env.test.ts
@@ -215,14 +215,17 @@ describe('envPullAction', () => {
     mockChmod.mockResolvedValue(undefined);
   });
 
-  it('prints message when no vars to pull', async () => {
+  it('writes empty env file when no vars exist', async () => {
     mockGetServerProjectEnv.mockResolvedValue({});
     const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const { envPullAction } = await import('./env.js');
     await envPullAction(undefined, {});
-    expect(mockWriteFile).not.toHaveBeenCalled();
-    expect(mockChmod).not.toHaveBeenCalled();
-    expect(spy.mock.calls.some(c => String(c[0]).includes('No environment variables to pull'))).toBe(true);
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    const [, content] = mockWriteFile.mock.calls[0]!;
+    expect(content).toContain('# Pulled from Mastra Server');
+    expect(content).not.toMatch(/^\w+=.+$/m);
+    expect(mockChmod).toHaveBeenCalled();
+    expect(spy.mock.calls.some(c => String(c[0]).includes('Wrote empty'))).toBe(true);
     spy.mockRestore();
   });
 

--- a/packages/cli/src/commands/server/env.test.ts
+++ b/packages/cli/src/commands/server/env.test.ts
@@ -264,4 +264,14 @@ describe('envPullAction', () => {
     expect(content).toContain('SECRET="has spaces and \\"quotes\\""');
     spy.mockRestore();
   });
+
+  it('escapes dollar signs, backticks, and control characters', async () => {
+    mockGetServerProjectEnv.mockResolvedValue({ TOKEN: 'price=$100`cmd`\nline2' });
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { envPullAction } = await import('./env.js');
+    await envPullAction(undefined, {});
+    const [, content] = mockWriteFile.mock.calls[0]!;
+    expect(content).toContain('TOKEN="price=\\$100\\`cmd\\`\\nline2"');
+    spy.mockRestore();
+  });
 });

--- a/packages/cli/src/commands/server/env.test.ts
+++ b/packages/cli/src/commands/server/env.test.ts
@@ -277,4 +277,18 @@ describe('envPullAction', () => {
     expect(content).toContain('TOKEN="price=\\$100\\`cmd\\`\\nline2"');
     spy.mockRestore();
   });
+
+  it('skips keys that are not valid shell identifiers', async () => {
+    mockGetServerProjectEnv.mockResolvedValue({ GOOD_KEY: 'ok', 'bad-key': 'nope', 'also bad': 'no' });
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { envPullAction } = await import('./env.js');
+    await envPullAction(undefined, {});
+    const [, content] = mockWriteFile.mock.calls[0]!;
+    expect(content).toContain('GOOD_KEY="ok"');
+    expect(content).not.toContain('bad-key=');
+    expect(content).not.toContain('also bad=');
+    expect(content).toContain('# Skipped unsafe key');
+    expect(spy.mock.calls.some(c => String(c[0]).includes('Skipped 2 unsafe key(s)'))).toBe(true);
+    spy.mockRestore();
+  });
 });

--- a/packages/cli/src/commands/server/env.test.ts
+++ b/packages/cli/src/commands/server/env.test.ts
@@ -238,8 +238,8 @@ describe('envPullAction', () => {
     const [filePath, content, options] = mockWriteFile.mock.calls[0]!;
     expect(filePath).toContain('.env');
     expect(content).toContain('# Pulled from Mastra Server');
-    expect(content).toContain('API_KEY=secret');
-    expect(content).toContain('DB_URL=postgres://localhost');
+    expect(content).toContain('API_KEY="secret"');
+    expect(content).toContain('DB_URL="postgres://localhost"');
     expect(options).toEqual({ encoding: 'utf-8', mode: 0o600 });
     expect(mockChmod).toHaveBeenCalledWith(filePath, 0o600);
     expect(spy.mock.calls.some(c => String(c[0]).includes('Pulled 2 variable(s)'))).toBe(true);
@@ -253,7 +253,7 @@ describe('envPullAction', () => {
     await envPullAction('.env.production', {});
     const [filePath, content] = mockWriteFile.mock.calls[0]!;
     expect(filePath).toContain('.env.production');
-    expect(content).toContain('FOO=bar');
+    expect(content).toContain('FOO="bar"');
     expect(spy.mock.calls.some(c => String(c[0]).includes('.env.production'))).toBe(true);
     spy.mockRestore();
   });

--- a/packages/cli/src/commands/server/env.test.ts
+++ b/packages/cli/src/commands/server/env.test.ts
@@ -26,10 +26,12 @@ vi.mock('../studio/project-config.js', () => ({
 
 const mockReadFile = vi.fn();
 const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+const mockChmod = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('node:fs/promises', () => ({
   readFile: mockReadFile,
   writeFile: mockWriteFile,
+  chmod: mockChmod,
 }));
 
 beforeEach(() => {
@@ -210,6 +212,7 @@ describe('envPullAction', () => {
   beforeEach(() => {
     process.env.MASTRA_PROJECT_ID = 'proj-x';
     mockWriteFile.mockResolvedValue(undefined);
+    mockChmod.mockResolvedValue(undefined);
   });
 
   it('prints message when no vars to pull', async () => {
@@ -218,21 +221,24 @@ describe('envPullAction', () => {
     const { envPullAction } = await import('./env.js');
     await envPullAction(undefined, {});
     expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockChmod).not.toHaveBeenCalled();
     expect(spy.mock.calls.some(c => String(c[0]).includes('No environment variables to pull'))).toBe(true);
     spy.mockRestore();
   });
 
-  it('writes env vars to default .env file', async () => {
+  it('writes env vars to default .env file with restrictive permissions', async () => {
     mockGetServerProjectEnv.mockResolvedValue({ DB_URL: 'postgres://localhost', API_KEY: 'secret' });
     const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const { envPullAction } = await import('./env.js');
     await envPullAction(undefined, {});
     expect(mockWriteFile).toHaveBeenCalledTimes(1);
-    const [filePath, content] = mockWriteFile.mock.calls[0]!;
+    const [filePath, content, options] = mockWriteFile.mock.calls[0]!;
     expect(filePath).toContain('.env');
     expect(content).toContain('# Pulled from Mastra Server');
     expect(content).toContain('API_KEY=secret');
     expect(content).toContain('DB_URL=postgres://localhost');
+    expect(options).toEqual({ encoding: 'utf-8', mode: 0o600 });
+    expect(mockChmod).toHaveBeenCalledWith(filePath, 0o600);
     expect(spy.mock.calls.some(c => String(c[0]).includes('Pulled 2 variable(s)'))).toBe(true);
     spy.mockRestore();
   });

--- a/packages/cli/src/commands/server/env.test.ts
+++ b/packages/cli/src/commands/server/env.test.ts
@@ -25,9 +25,11 @@ vi.mock('../studio/project-config.js', () => ({
 }));
 
 const mockReadFile = vi.fn();
+const mockWriteFile = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('node:fs/promises', () => ({
   readFile: mockReadFile,
+  writeFile: mockWriteFile,
 }));
 
 beforeEach(() => {
@@ -200,6 +202,60 @@ describe('envImportAction', () => {
       NEW: '1',
     });
     expect(spy.mock.calls.some(c => String(c[0]).includes('Imported 1 variable'))).toBe(true);
+    spy.mockRestore();
+  });
+});
+
+describe('envPullAction', () => {
+  beforeEach(() => {
+    process.env.MASTRA_PROJECT_ID = 'proj-x';
+    mockWriteFile.mockResolvedValue(undefined);
+  });
+
+  it('prints message when no vars to pull', async () => {
+    mockGetServerProjectEnv.mockResolvedValue({});
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { envPullAction } = await import('./env.js');
+    await envPullAction(undefined, {});
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(spy.mock.calls.some(c => String(c[0]).includes('No environment variables to pull'))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('writes env vars to default .env file', async () => {
+    mockGetServerProjectEnv.mockResolvedValue({ DB_URL: 'postgres://localhost', API_KEY: 'secret' });
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { envPullAction } = await import('./env.js');
+    await envPullAction(undefined, {});
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    const [filePath, content] = mockWriteFile.mock.calls[0]!;
+    expect(filePath).toContain('.env');
+    expect(content).toContain('# Pulled from Mastra Server');
+    expect(content).toContain('API_KEY=secret');
+    expect(content).toContain('DB_URL=postgres://localhost');
+    expect(spy.mock.calls.some(c => String(c[0]).includes('Pulled 2 variable(s)'))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('writes to a custom file when specified', async () => {
+    mockGetServerProjectEnv.mockResolvedValue({ FOO: 'bar' });
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { envPullAction } = await import('./env.js');
+    await envPullAction('.env.production', {});
+    const [filePath, content] = mockWriteFile.mock.calls[0]!;
+    expect(filePath).toContain('.env.production');
+    expect(content).toContain('FOO=bar');
+    expect(spy.mock.calls.some(c => String(c[0]).includes('.env.production'))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('quotes values containing special characters', async () => {
+    mockGetServerProjectEnv.mockResolvedValue({ SECRET: 'has spaces and "quotes"' });
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { envPullAction } = await import('./env.js');
+    await envPullAction(undefined, {});
+    const [, content] = mockWriteFile.mock.calls[0]!;
+    expect(content).toContain('SECRET="has spaces and \\"quotes\\""');
     spy.mockRestore();
   });
 });

--- a/packages/cli/src/commands/server/env.ts
+++ b/packages/cli/src/commands/server/env.ts
@@ -152,8 +152,15 @@ export async function envPullAction(file: string | undefined, opts: { config?: s
   const keys = Object.keys(envVars);
 
   const target = file ?? '.env';
+  const shellSafeKey = /^[A-Za-z_][A-Za-z0-9_]*$/;
   const lines = ['# Pulled from Mastra Server — do not edit manually', ''];
+  let skipped = 0;
   for (const key of keys.sort()) {
+    if (!shellSafeKey.test(key)) {
+      lines.push(`# Skipped unsafe key: ${key.replace(/[^\w.-]/g, '?')}`);
+      skipped++;
+      continue;
+    }
     const value = envVars[key]!;
     // Always quote values to prevent shell metacharacter interpretation when sourced
     const escaped = value
@@ -172,9 +179,12 @@ export async function envPullAction(file: string | undefined, opts: { config?: s
   await writeFile(outputPath, lines.join('\n'), { encoding: 'utf-8', mode: 0o600 });
   await chmod(outputPath, 0o600);
 
-  if (keys.length === 0) {
+  const written = keys.length - skipped;
+  if (written === 0) {
     console.info(`\n  No environment variables set in the project. Wrote empty ${target}.\n`);
   } else {
-    console.info(`\n  Pulled ${keys.length} variable(s) to ${target}.\n`);
+    console.info(
+      `\n  Pulled ${written} variable(s) to ${target}.${skipped > 0 ? ` Skipped ${skipped} unsafe key(s).` : ''}\n`,
+    );
   }
 }

--- a/packages/cli/src/commands/server/env.ts
+++ b/packages/cli/src/commands/server/env.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
@@ -166,7 +166,9 @@ export async function envPullAction(file: string | undefined, opts: { config?: s
   }
   lines.push(''); // trailing newline
 
-  await writeFile(resolve(target), lines.join('\n'), 'utf-8');
+  const outputPath = resolve(target);
+  await writeFile(outputPath, lines.join('\n'), { encoding: 'utf-8', mode: 0o600 });
+  await chmod(outputPath, 0o600);
 
   console.info(`\n  Pulled ${keys.length} variable(s) to ${target}.\n`);
 }

--- a/packages/cli/src/commands/server/env.ts
+++ b/packages/cli/src/commands/server/env.ts
@@ -151,11 +151,6 @@ export async function envPullAction(file: string | undefined, opts: { config?: s
   const envVars = await getServerProjectEnv(token, orgId, projectId);
   const keys = Object.keys(envVars);
 
-  if (keys.length === 0) {
-    console.info('\n  No environment variables to pull.\n');
-    return;
-  }
-
   const target = file ?? '.env';
   const lines = ['# Pulled from Mastra Server — do not edit manually', ''];
   for (const key of keys.sort()) {
@@ -177,5 +172,9 @@ export async function envPullAction(file: string | undefined, opts: { config?: s
   await writeFile(outputPath, lines.join('\n'), { encoding: 'utf-8', mode: 0o600 });
   await chmod(outputPath, 0o600);
 
-  console.info(`\n  Pulled ${keys.length} variable(s) to ${target}.\n`);
+  if (keys.length === 0) {
+    console.info(`\n  No environment variables set in the project. Wrote empty ${target}.\n`);
+  } else {
+    console.info(`\n  Pulled ${keys.length} variable(s) to ${target}.\n`);
+  }
 }

--- a/packages/cli/src/commands/server/env.ts
+++ b/packages/cli/src/commands/server/env.ts
@@ -155,16 +155,16 @@ export async function envPullAction(file: string | undefined, opts: { config?: s
   const lines = ['# Pulled from Mastra Server — do not edit manually', ''];
   for (const key of keys.sort()) {
     const value = envVars[key]!;
-    // Quote values that contain spaces, quotes, or special shell characters
-    const needsQuoting = /[\s"'\\#$`]/.test(value);
+    // Always quote values to prevent shell metacharacter interpretation when sourced
     const escaped = value
       .replace(/\\/g, '\\\\')
       .replace(/\r/g, '\\r')
       .replace(/\n/g, '\\n')
+      .replace(/\t/g, '\\t')
       .replace(/"/g, '\\"')
       .replace(/\$/g, '\\$')
       .replace(/`/g, '\\`');
-    lines.push(`${key}=${needsQuoting ? `"${escaped}"` : value}`);
+    lines.push(`${key}="${escaped}"`);
   }
   lines.push(''); // trailing newline
 

--- a/packages/cli/src/commands/server/env.ts
+++ b/packages/cli/src/commands/server/env.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
@@ -138,4 +138,35 @@ export async function envImportAction(file: string, opts: { config?: string }) {
     console.info(`    ${key}`);
   }
   console.info('');
+}
+
+/* ------------------------------------------------------------------ */
+/*  mastra server env pull                                             */
+/* ------------------------------------------------------------------ */
+
+export async function envPullAction(file: string | undefined, opts: { config?: string; project?: string }) {
+  const { token, orgId } = await resolveAuth();
+  const projectId = await resolveProjectId(opts, { token, orgId });
+
+  const envVars = await getServerProjectEnv(token, orgId, projectId);
+  const keys = Object.keys(envVars);
+
+  if (keys.length === 0) {
+    console.info('\n  No environment variables to pull.\n');
+    return;
+  }
+
+  const target = file ?? '.env';
+  const lines = ['# Pulled from Mastra Server — do not edit manually', ''];
+  for (const key of keys.sort()) {
+    const value = envVars[key]!;
+    // Quote values that contain spaces, quotes, or special shell characters
+    const needsQuoting = /[\s"'\\#$]/.test(value);
+    lines.push(`${key}=${needsQuoting ? `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"` : value}`);
+  }
+  lines.push(''); // trailing newline
+
+  await writeFile(resolve(target), lines.join('\n'), 'utf-8');
+
+  console.info(`\n  Pulled ${keys.length} variable(s) to ${target}.\n`);
 }

--- a/packages/cli/src/commands/server/env.ts
+++ b/packages/cli/src/commands/server/env.ts
@@ -161,8 +161,15 @@ export async function envPullAction(file: string | undefined, opts: { config?: s
   for (const key of keys.sort()) {
     const value = envVars[key]!;
     // Quote values that contain spaces, quotes, or special shell characters
-    const needsQuoting = /[\s"'\\#$]/.test(value);
-    lines.push(`${key}=${needsQuoting ? `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"` : value}`);
+    const needsQuoting = /[\s"'\\#$`]/.test(value);
+    const escaped = value
+      .replace(/\\/g, '\\\\')
+      .replace(/\r/g, '\\r')
+      .replace(/\n/g, '\\n')
+      .replace(/"/g, '\\"')
+      .replace(/\$/g, '\\$')
+      .replace(/`/g, '\\`');
+    lines.push(`${key}=${needsQuoting ? `"${escaped}"` : value}`);
   }
   lines.push(''); // trailing newline
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,7 +22,7 @@ import { createTokenAction, listTokensAction, revokeTokenAction } from './comman
 import { whoamiAction } from './commands/auth/whoami';
 import { COMPONENTS, LLMProvider } from './commands/init/utils';
 import { serverDeployAction } from './commands/server/deploy';
-import { envListAction, envSetAction, envUnsetAction, envImportAction } from './commands/server/env';
+import { envListAction, envSetAction, envUnsetAction, envImportAction, envPullAction } from './commands/server/env';
 import { serverPauseAction, serverRestartAction } from './commands/server/lifecycle';
 import { deployAction } from './commands/studio/deploy';
 import { deploysAction } from './commands/studio/deploy-list';
@@ -311,6 +311,13 @@ serverEnvCommand
   .description('Import environment variables from a .env file')
   .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
   .action(wrapAction(envImportAction));
+
+serverEnvCommand
+  .command('pull [file]')
+  .description('Pull environment variables into a local .env file (default: .env)')
+  .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
+  .option('--project <id>', 'Project ID or slug (overrides linked project when MASTRA_PROJECT_ID is unset)')
+  .action(wrapAction(envPullAction));
 
 program.parse(process.argv);
 


### PR DESCRIPTION
Adds `mastra server env pull [file]` — the inverse of `mastra server env import`. Fetches env vars from a deployed Mastra Server project and writes them to a local `.env` file.

Handy for CI/CD pipelines where you authenticate with a single `MASTRA_API_TOKEN` and pull the rest:

```bash
# Pull to .env (default)
mastra server env pull

# Pull to a specific file
mastra server env pull .env.production
```

Values with spaces or quotes are automatically quoted. Supports the same `--project` and `--config` flags as the other `server env` subcommands.

Tests included (4 new cases covering empty vars, default/custom file paths, and special character quoting). Typecheck and all 21 env tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR adds a new command that pulls environment variables from a deployed Mastra Server project and saves them into a local .env file (default .env), so CI/CD or other automation can fetch secrets at runtime with a single API token.

---

## Overview

- Introduces `mastra server env pull [file]` — fetches server-side environment variables for the resolved project and writes them to a local .env-style file (defaults to `.env`, accepts a custom path).
- Always writes the target file (even when the remote project has no variables); when empty the file contains a header comment and the CLI logs that an empty file was written.
- Outputs a header comment and sorted KEY="value" lines for each variable; values are now unconditionally double-quoted (the previous heuristic was removed).
- Quoted values escape backslashes, carriage returns, newlines, tabs, double quotes, dollar signs ($), backticks, and other control characters so the resulting file is safe to source.
- Writes the file with restrictive permissions: writeFile(..., { encoding: 'utf-8', mode: 0o600 }) followed by chmod(outputPath, 0o600).
- Supports the same `--project` and `--config` flags used by other `server env` subcommands.
- Intended for CI/CD workflows where a single MASTRA_API_TOKEN authenticates and remaining env vars are pulled at runtime.

---

## Changes by File

- .changeset/dull-walls-visit.md
  - Adds a changeset marking a minor release and documenting the new `mastra server env pull [file]` command.

- packages/cli/src/commands/server/env.ts
  - Added and exported: `export async function envPullAction(file: string | undefined, opts: { config?: string; project?: string })`.
  - Resolves auth and project ID, fetches server env via `getServerProjectEnv`, formats `.env` output (fixed header + sorted KEY="value" entries).
  - Values are now always double-quoted and escape backslashes, CR/LF, newlines, tabs, double quotes, dollar signs ($), backticks, and control characters.
  - Writes to `resolve(file ?? '.env')` with `{ encoding: 'utf-8', mode: 0o600 }` and enforces permissions with `chmod(outputPath, 0o600)`.
  - Logs a distinct message for the empty-vars case vs. reporting the number of variables written.

- packages/cli/src/commands/server/env.test.ts
  - Extended mocks for `node:fs/promises` to include `writeFile` and `chmod`.
  - Added `envPullAction` test suite with 4 tests:
    1. Empty remote envs: ensures the command writes a file containing the header (no KEY= lines), calls chmod, and logs that an empty file was written.
    2. Default filename: writes header and variables to `.env`, passes `{ encoding: 'utf-8', mode: 0o600 }` to `writeFile`, calls `chmod`, and logs pulled count.
    3. Custom filename: writes to the provided path (e.g., `.env.production`) and logs the provided filename.
    4. Quoting/escaping: verifies that values are quoted and that spaces, quotes, `$`, backticks, backslashes, tabs, and newline/control characters are escaped inside quoted values.

- packages/cli/src/index.ts
  - Imported `envPullAction` and registered the `pull [file]` subcommand under `server env` with `-c, --config` and `--project` options; wired via `wrapAction(envPullAction)`.

---

## Tests & Status

- Adds 4 unit tests for `envPullAction` covering empty-file behavior, default vs custom outputs, and special-character quoting/escaping.
- Per PR description: typecheck passes and env-related tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->