### PR TITLE
feat: compress mastracode OM memory with caveman speak

### DIFF
--- a/.changeset/wise-carrots-heal.md
+++ b/.changeset/wise-carrots-heal.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved observational memory summaries to use caveman-style custom instructions for terser stored observations.

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -47,6 +47,30 @@ function getReflectorModel({ requestContext }: { requestContext: RequestContext 
   });
 }
 
+// Derived from https://github.com/JuliusBrussee/caveman and adapted for OM use with fixed full-level compression.
+const CAVEMAN_OM_INSTRUCTION = `Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+Use full caveman compression style.
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact. Leave out the words "agent" and "assistant" at the start of each observation line, it is assumed each line is referring to the assistant unless it specifically says it was about the user. Leave out parenthesis and other text characters like * that would not contribute to understanding the observations.
+
+Pattern: \`[thing] [action] [reason]. [next step]\`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use < not <=. Fix:"
+
+Example 1
+🔴 14:31 user asks why React component rerenders
+🟡 14:32 saw inline object prop create new ref each render, cause rerender
+✅ 14:34 fixed render issue by wrap object in useMemo
+
+Example 2
+🟡 15:10 explained pool reuse DB connections, skip repeat handshake overhead"
+
+Don't say "Agent did x", say "did x". It will be assumed the agent did what was observed. The who should only be specified for the user or other third parties: "user asked x"
+
+Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question, and anything that requires remembering verbatim content. Resume caveman after clear part done`;
+
 /**
  * Dynamic memory factory function.
  * Reads OM thresholds from harness state via requestContext.
@@ -87,13 +111,15 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
             previousObserverTokens: observerPreviousObservationTokens,
             threadTitle: true,
             instruction:
-              'Messages wrapped in <system-reminder type="dynamic-agents-md" ...>...</system-reminder> are ephemeral project-context instructions injected from files on disk. Do NOT observe or extract information from these messages — they are reloaded automatically when needed and should not be stored in memory.',
+              'Messages wrapped in <system-reminder type="dynamic-agents-md" ...>...</system-reminder> are ephemeral project-context instructions injected from files on disk. Do NOT observe or extract information from these messages — they are reloaded automatically when needed and should not be stored in memory.\n\n' +
+              CAVEMAN_OM_INSTRUCTION,
           },
           reflection: {
             bufferActivation: isResourceScope ? undefined : 1 / 2,
             blockAfter: 1.1,
             model: getReflectorModel,
             observationTokens: refThreshold,
+            instruction: CAVEMAN_OM_INSTRUCTION,
           },
         },
       },

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -65,7 +65,7 @@ Example 1
 ✅ 14:34 fixed render issue by wrap object in useMemo
 
 Example 2
-🟡 15:10 explained pool reuse DB connections, skip repeat handshake overhead"
+🟡 15:10 explained pool reuse DB connections, skip repeat handshake overhead
 
 Don't say "Agent did x", say "did x". It will be assumed the agent did what was observed. The who should only be specified for the user or other third parties: "user asked x"
 

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -28,6 +28,12 @@ Current mode: ${ctx.mode}
 
 ${ctx.toolGuidance}
 
+# Memory Style
+- Your memory system may contain observations or reflections written in terse caveman-speak to reduce token usage.
+- Treat that compressed memory style as storage format only.
+- Do NOT imitate or adopt caveman-speak in your user-facing responses unless the user explicitly asks for that style.
+- Use the memory content for facts and context, but respond in your normal clear professional style by default.
+
 # How to Work on Tasks
 
 ## Start by Understanding


### PR DESCRIPTION
This updates mastracode OM instruction to store denser notes in a caveman-style shorthand, while keeping the main agent's user-facing responses in normal prose.

We're thinking of adding this directly to observer/reflector prompts, so I'm adding it to mastracode first as an experiment.

I ran a code deep research prompt with minimax 2.7 as main agent and grok 4.1 fast as observer, I saw that the same deep research task was generally completed with 1-3k fewer observation tokens. Not exactly scientific but I ran the same prompt with/without 4 times each.

Without caveman, the final observation token size:
- 7.5k
- 7.1k
- 6.9k
- 7k

with caveman:
- 6.6k
- 3.4k
- 5.5k
- 3.9k

talking with the agent after (and spot checking in the db by reading observations) it doesn't seem to have reduced the quality. We can run this in mc for a bit and if we don't run into any weirdness, then move it over into OM itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The assistant now saves its internal notes in a very short "caveman-speak" shorthand to use fewer tokens, while still talking to users in normal, clear language.

## Overview
Introduce a caveman-style instruction for observational memory (OM) so stored observations/reflections are terser (token-compressed) while preserving normal prose for user-facing responses. Change is applied in mastracode for trial before considering broader OM/observer/reflector rollout.

## Changes Made

- Changeset
  - .changeset/wise-carrots-heal.md: Added patch changeset noting observational memory summaries now use caveman-style instructions.

- Memory configuration (mastracode/src/agents/memory.ts)
  - Added CAVEMAN_OM_INSTRUCTION constant containing the caveman-style compression rules, examples, and exceptions (when not to compress).
  - Appended CAVEMAN_OM_INSTRUCTION to observationalMemory.observation.instruction (after the existing dynamic-agents-md system-reminder text).
  - Set observationalMemory.reflection.instruction to CAVEMAN_OM_INSTRUCTION.
  - Other OM settings preserved (buffering, models, token thresholds, etc.).

- Base system prompt (mastracode/src/agents/prompts/base.ts)
  - Added "Memory Style" section instructing that internal memory may be stored in terse caveman-speak for token efficiency, that the agent should treat it as storage-only, and must not adopt that style in user-facing responses unless explicitly requested.

- Commit message fix
  - fix(mastracode): removed a stray quote from an OM prompt example to keep prompt text clean.

## Rationale & Validation
Informal experiment (mc as main agent) showed reduced observational token counts across runs:
- Without caveman: 7.5k, 7.1k, 6.9k, 7.0k
- With caveman: 6.6k, 3.4k, 5.5k, 3.9k
Author performed spot checks and agent interactions and did not observe obvious quality regressions; proposed to run the change in mastracode for further validation before broader adoption.

## Notes for reviewers
- Caveman instruction includes explicit exceptions (security, irreversible actions, verbatim needs) — verify those are sufficient for safety/clarity.
- Prompt text and instruction concatenation should be reviewed for ordering and any edge cases where ephemeral system reminders might be inadvertently stored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->