### PR TITLE
ci(duckdb): add matrix coverage for min/max @duckdb/node-api versions

### DIFF
--- a/.github/workflows/secrets.test-combined-stores.yml
+++ b/.github/workflows/secrets.test-combined-stores.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Install DuckDB version (duckdb store only)
         if: matrix.store == 'duckdb'
         run: pnpm add @duckdb/node-api@${{ matrix.duckdb-version }}
+        working-directory: stores/duckdb
 
       - name: Build combined storage packages
         run: pnpm turbo --filter "@mastra/${{ matrix.store }}" build

--- a/.github/workflows/secrets.test-combined-stores.yml
+++ b/.github/workflows/secrets.test-combined-stores.yml
@@ -111,6 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         store: ${{fromJson(needs.setup.outputs.stores)}}
+        duckdb-version: [1.4.2-r.1, 1.5.9]
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -123,6 +124,10 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
+      
+      - name: Install DuckDB version (duckdb store only)
+        if: matrix.store == 'duckdb'
+        run: pnpm add @duckdb/node-api@${{ matrix.duckdb-version }}
 
       - name: Build combined storage packages
         run: pnpm turbo --filter "@mastra/${{ matrix.store }}" build


### PR DESCRIPTION
## Description
Adds CI matrix coverage to validate the supported version range of `@duckdb/node-api`.

Runs tests against:
- Minimum supported version: `1.4.2-r.1`
- Representative 1.5.x version: `1.5.9`

This ensures compatibility across the full declared range (`>=1.4.2-r.1 <1.6.0`).

## Related Issue(s)
Fixes #15364

## Type of Change
- [x] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Summary

This PR makes the project test its DuckDB support against different versions of a required library (@duckdb/node-api) to catch any compatibility issues early. Instead of testing with just one version, the CI now automatically tests against both the oldest supported version and a newer one, making sure the code works across the full range of versions users might be using.

## Changes

**File: `.github/workflows/secrets.test-combined-stores.yml`**

- Added a `duckdb-version` matrix dimension to the `test` job with two versions:
  - Minimum supported version: `1.4.2-r.1`
  - Representative 1.5.x version: `1.5.9`
- Introduced a new workflow step "Install DuckDB version" that installs `@duckdb/node-api` at the specified matrix version
- The installation step:
  - Executes only when `matrix.store` equals `duckdb` (doesn't affect other store tests)
  - Runs in the `stores/duckdb` working directory
  - Uses `pnpm add @duckdb/node-api@${{ matrix.duckdb-version }}`

## Impact

- DuckDB store tests now run against multiple @duckdb/node-api versions in CI, validating the declared compatibility range (>=1.4.2-r.1 <1.6.0)
- Other store tests remain unaffected by the new installation step
- Ensures defensive API handling and timestamp shape compatibility are validated across the full supported version range

**Related issue:** Fixes #15364

<!-- end of auto-generated comment: release notes by coderabbit.ai -->