### PR TITLE
docs: clarify sending only new messages with memory

### DIFF
--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -17,6 +17,14 @@ You can also retrieve message history to display past conversations in your UI.
 Each message belongs to a thread (the conversation) and a resource (the user or entity it's associated with). See [Threads and resources](/docs/memory/storage#threads-and-resources) for more detail.
 :::
 
+:::warning
+When you use memory with a client application, send **only the new message** from the client instead of the full conversation history.
+
+Sending the full history is redundant because Mastra loads messages from storage, and it can cause message ordering bugs when client-side timestamps conflict with stored timestamps.
+
+For an AI SDK example, see [Using Mastra Memory](/guides/build-your-ui/ai-sdk-ui#using-mastra-memory).
+:::
+
 ## Getting started
 
 Install the Mastra memory module along with a [storage adapter](/docs/memory/storage#supported-providers) for your database. The examples below use `@mastra/libsql`, which stores data locally in a `mastra.db` file.

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -47,6 +47,14 @@ const memory = new Memory({
 
 See [configuration options](/reference/memory/observational-memory) for full API details.
 
+:::warning
+When you use OM with a client application, send **only the new message** from the client instead of the full conversation history.
+
+Observational memory still relies on stored conversation history. Sending the full history is redundant and can cause message ordering bugs when client-side timestamps conflict with stored timestamps.
+
+For an AI SDK example, see [Using Mastra Memory](/guides/build-your-ui/ai-sdk-ui#using-mastra-memory).
+:::
+
 :::note
 
 OM currently only supports `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb` storage adapters.

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -248,6 +248,38 @@ export default function Chat() {
 
 Use [`prepareSendMessagesRequest`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat#transport.default-chat-transport.prepare-send-messages-request) to customize the request sent to the chat route, for example to pass additional configuration to the agent.
 
+## Using Mastra Memory
+
+When your agent has [memory](/docs/memory/overview) configured, Mastra loads conversation history from storage on the server. Send only the new message from the client instead of the full conversation history.
+
+Sending the full history is redundant and can cause message ordering bugs because client-side timestamps can conflict with the timestamps stored in your database.
+
+```typescript
+import { useChat } from '@ai-sdk/react'
+import { DefaultChatTransport } from 'ai'
+
+const { messages, sendMessage } = useChat({
+  transport: new DefaultChatTransport({
+    api: 'http://localhost:4111/chat/weatherAgent',
+    prepareSendMessagesRequest({ messages }) {
+      return {
+        body: {
+          messages: [messages[messages.length - 1]],
+          threadId: 'user-thread-123',
+          resourceId: 'user-123',
+        },
+      }
+    },
+  }),
+})
+```
+
+Set `threadId` and `resourceId` from your app's own state, such as URL params, auth context, or your database.
+
+See [Message history](/docs/memory/message-history) for more on how Mastra memory loads and stores messages.
+
+[`chatRoute()`](/reference/ai-sdk/chat-route) and [`handleChatStream()`](/reference/ai-sdk/handle-chat-stream) already work with memory. Configure the client to send only the new message and include the thread and resource identifiers.
+
 ### `useCompletion()`
 
 The `useCompletion()` hook handles single-turn completions between your frontend and a Mastra agent, allowing you to send a prompt and receive a streamed response over HTTP.


### PR DESCRIPTION
This updates the docs for using Mastra memory with chat clients.

When memory is enabled, clients should send only the new message instead of the full conversation history because Mastra loads history from storage on the server.

AI SDK example:

```ts
prepareSendMessagesRequest({ messages }) {
  return {
    body: {
      messages: [messages[messages.length - 1]],
      threadId: 'user-thread-123',
      resourceId: 'user-123',
    },
  }
}
```

The memory docs now call out that this applies to any client, and the AI SDK UI guide shows one concrete way to do it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR teaches developers how to correctly use Mastra's conversation memory feature by sending only the newest message instead of the entire chat history, since the server already saves and remembers everything. This prevents confusing bugs where the system gets mixed up about the order of messages.

## Overview

This is a documentation-only PR that clarifies best practices for using Mastra's memory system with chat clients. The PR adds warnings and guidance across three documentation files to instruct developers that when Mastra memory is enabled, client applications should send only the latest message in each request—not the full conversation history—because Mastra loads prior messages from server-side storage.

## Changes

**docs/src/content/en/docs/memory/message-history.mdx** (+8 lines)
- Added a warning callout instructing clients to send only the new message
- Notes that sending full history is redundant and can cause message ordering bugs due to timestamp conflicts between client-side and stored messages
- Links to the AI SDK implementation example

**docs/src/content/en/docs/memory/observational-memory.mdx** (+8 lines)
- Added a similar warning to the Observational Memory documentation
- Explains that resending full history is redundant and clarifies that Observational Memory still depends on stored conversation history
- Warns about message ordering issues when client-side timestamps conflict with stored timestamps
- Includes a link to the AI SDK example

**docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx** (+32 lines)
- Added a new "Using Mastra Memory" section to the `useChat()` UI guide
- Demonstrates how to use `prepareSendMessagesRequest` to send only the latest user message
- Shows how to include `threadId` and `resourceId` in the request body
- Notes that `chatRoute()` and `handleChatStream()` already support memory out of the box
- Provides guidance on sourcing thread/resource identifiers from application state

## Rationale

The changes prevent a common integration issue where developers send the full conversation history with each request when using Mastra memory, which creates ordering bugs. By clearly documenting that only the latest message should be sent (with Mastra handling history retrieval server-side), the docs reduce confusion and implementation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->