### PR TITLE
feat(mastracode): add share and import for model packs

### DIFF
--- a/.changeset/fancy-buckets-retire.md
+++ b/.changeset/fancy-buckets-retire.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added share and import features for model packs. You can now share a custom model pack configuration by copying it to the clipboard, and import a shared pack from someone else using the new Import Pack option in the /models command.

--- a/mastracode/src/clipboard/index.ts
+++ b/mastracode/src/clipboard/index.ts
@@ -54,6 +54,43 @@ export function getClipboardText(): string | null {
 }
 
 /**
+ * Write plain text to the system clipboard.
+ * Returns true on success, false on failure.
+ */
+export function setClipboardText(text: string): boolean {
+  try {
+    if (process.platform === 'darwin') {
+      execSync('pbcopy', {
+        input: text,
+        timeout: 3000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      return true;
+    }
+    if (process.platform === 'linux') {
+      try {
+        execSync('xclip -selection clipboard', {
+          input: text,
+          timeout: 3000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        return true;
+      } catch {
+        execSync('wl-copy', {
+          input: text,
+          timeout: 3000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Check the system clipboard for image data and return it as base64.
  * Returns null if no image data is found or extraction fails.
  */

--- a/mastracode/src/tui/commands/__tests__/models-pack.test.ts
+++ b/mastracode/src/tui/commands/__tests__/models-pack.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import type { ModePack } from '../../../onboarding/packs.js';
 import type { GlobalSettings, StorageSettings } from '../../../onboarding/settings.js';
-import { removeCustomPackFromSettings, upsertCustomPackInSettings } from '../models-pack.js';
+import {
+  deserializePack,
+  removeCustomPackFromSettings,
+  serializePack,
+  upsertCustomPackInSettings,
+} from '../models-pack.js';
 
 function createSettings(overrides?: Partial<GlobalSettings>): GlobalSettings {
   const storage: StorageSettings = { backend: 'libsql', libsql: {}, pg: {} };
@@ -303,5 +308,63 @@ describe('removeCustomPackFromSettings', () => {
     expect(settings.customModelPacks).toHaveLength(1);
     expect(settings.models.activeModelPackId).toBe('custom:Alpha');
     expect(settings.onboarding.modePackId).toBe('custom:Alpha');
+  });
+});
+
+describe('serializePack / deserializePack', () => {
+  it('round-trips a custom pack', () => {
+    const serialized = serializePack(alphaPack);
+    expect(serialized).toMatch(/^mastra-pack:/);
+
+    const deserialized = deserializePack(serialized);
+    expect(deserialized).not.toBeNull();
+    expect(deserialized!.name).toBe('Alpha');
+    expect(deserialized!.id).toBe('custom:Alpha');
+    expect(deserialized!.models).toEqual(alphaPack.models);
+  });
+
+  it('round-trips a built-in pack', () => {
+    const builtIn: ModePack = {
+      id: 'anthropic',
+      name: 'Anthropic',
+      description: 'All Anthropic models',
+      models: {
+        build: 'anthropic/claude-sonnet-4-5',
+        plan: 'anthropic/claude-sonnet-4-5',
+        fast: 'anthropic/claude-haiku-4-5',
+      },
+    };
+    const serialized = serializePack(builtIn);
+    const deserialized = deserializePack(serialized);
+    expect(deserialized).not.toBeNull();
+    expect(deserialized!.name).toBe('Anthropic');
+    expect(deserialized!.models).toEqual(builtIn.models);
+    // Imported packs always get the custom: prefix
+    expect(deserialized!.id).toBe('custom:Anthropic');
+  });
+
+  it('returns null for invalid strings', () => {
+    expect(deserializePack('')).toBeNull();
+    expect(deserializePack('not-a-pack')).toBeNull();
+    expect(deserializePack('mastra-pack:!!invalid-base64!!')).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    const noName = Buffer.from(JSON.stringify({ models: { build: 'a', plan: 'b', fast: 'c' } })).toString('base64');
+    expect(deserializePack(`mastra-pack:${noName}`)).toBeNull();
+
+    const noModels = Buffer.from(JSON.stringify({ name: 'Test' })).toString('base64');
+    expect(deserializePack(`mastra-pack:${noModels}`)).toBeNull();
+
+    const partialModels = Buffer.from(JSON.stringify({ name: 'Test', models: { build: 'a' } })).toString('base64');
+    expect(deserializePack(`mastra-pack:${partialModels}`)).toBeNull();
+  });
+
+  it('trims whitespace from pasted input', () => {
+    const serialized = serializePack(alphaPack);
+    const padded = `  \n  ${serialized}  \n  `;
+    const deserialized = deserializePack(padded);
+    expect(deserialized).not.toBeNull();
+    expect(deserialized!.name).toBe('Alpha');
   });
 });

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -568,9 +568,7 @@ async function askImportCollision(
 
   return new Promise(resolve => {
     const container = new Box(1, 1);
-    container.addChild(
-      new Text(theme.bold(theme.fg('accent', `A pack named "${existingName}" already exists`)), 0, 0),
-    );
+    container.addChild(new Text(theme.bold(theme.fg('accent', `A pack named "${existingName}" already exists`)), 0, 0));
     container.addChild(new Spacer(1));
 
     const items: SelectItem[] = actions.map(a => ({

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -734,6 +734,12 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
               resolve();
               return;
             }
+            if (s.customModelPacks.some(p => p.name === newName)) {
+              collapseResult('cancelled');
+              ctx.showInfo(`A custom pack named "${newName}" already exists. Rename or delete it first.`);
+              resolve();
+              return;
+            }
             imported.name = newName;
             imported.id = `custom:${newName}`;
           }

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -2,6 +2,7 @@ import { Box, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { SelectItem } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 
+import { setClipboardText } from '../../clipboard/index.js';
 import type { ModePack, ProviderAccess, ProviderAccessLevel } from '../../onboarding/packs.js';
 import { getAvailableModePacks } from '../../onboarding/packs.js';
 import {
@@ -18,6 +19,54 @@ import { promptForApiKeyIfNeeded } from '../prompt-api-key.js';
 import { updateStatusLine } from '../status-line.js';
 import { getSelectListTheme, mastra, theme } from '../theme.js';
 import type { SlashCommandContext } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Pack sharing — serialize/deserialize
+// ---------------------------------------------------------------------------
+
+const SHARE_PREFIX = 'mastra-pack:';
+
+interface SharedPackPayload {
+  name: string;
+  models: { build: string; plan: string; fast: string };
+}
+
+export function serializePack(pack: ModePack): string {
+  const payload: SharedPackPayload = {
+    name: pack.name,
+    models: { build: pack.models.build, plan: pack.models.plan, fast: pack.models.fast },
+  };
+  return SHARE_PREFIX + Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
+}
+
+export function deserializePack(input: string): ModePack | null {
+  try {
+    const trimmed = input.trim();
+    if (!trimmed.startsWith(SHARE_PREFIX)) return null;
+    const json = Buffer.from(trimmed.slice(SHARE_PREFIX.length), 'base64').toString('utf-8');
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+
+    const name = typeof parsed.name === 'string' ? parsed.name.trim() : '';
+    if (!name) return null;
+
+    const models = parsed.models as Record<string, unknown> | undefined;
+    if (!models || typeof models !== 'object') return null;
+
+    const build = typeof models.build === 'string' ? models.build : '';
+    const plan = typeof models.plan === 'string' ? models.plan : '';
+    const fast = typeof models.fast === 'string' ? models.fast : '';
+    if (!build || !plan || !fast) return null;
+
+    return {
+      id: `custom:${name}`,
+      name,
+      description: 'Imported custom pack',
+      models: { build, plan, fast },
+    };
+  } catch {
+    return null;
+  }
+}
 
 async function selectModel(
   ctx: SlashCommandContext,
@@ -90,10 +139,11 @@ async function askCustomPackName(ctx: SlashCommandContext, defaultName?: string)
 async function askCustomPackAction(
   ctx: SlashCommandContext,
   pack: ModePack,
-): Promise<'activate' | 'edit' | 'delete' | null> {
+): Promise<'activate' | 'edit' | 'share' | 'delete' | null> {
   const actions = [
     { id: 'activate', label: 'Activate', description: 'Use this pack as-is' },
     { id: 'edit', label: 'Edit', description: 'Update this pack' },
+    { id: 'share', label: 'Share', description: 'Copy to clipboard' },
     { id: 'delete', label: 'Delete', description: 'Remove this custom pack' },
   ] as const;
 
@@ -112,6 +162,7 @@ async function askCustomPackAction(
     const detailById: Record<string, string> = {
       activate: getPackDetail(pack),
       edit: theme.fg('dim', '  Edit one setting at a time (Rename, plan, build, fast).'),
+      share: theme.fg('dim', '  Copy shareable config to clipboard. Paste it to import elsewhere.'),
       delete: theme.fg('error', '  Permanently removes this custom pack from settings.'),
     };
 
@@ -127,7 +178,7 @@ async function askCustomPackAction(
         new Text(theme.fg('text', `${theme.fg('success', '✓')} ${pack.name} → ${theme.bold(item.value)}`), 0, 0),
       );
       ctx.state.ui.requestRender();
-      resolve(item.value as 'activate' | 'edit' | 'delete');
+      resolve(item.value as 'activate' | 'edit' | 'share' | 'delete');
     };
 
     selectList.onCancel = () => {
@@ -467,6 +518,44 @@ async function deleteCustomPack(ctx: SlashCommandContext, pack: ModePack): Promi
   }
 }
 
+function sharePack(ctx: SlashCommandContext, pack: ModePack): void {
+  const serialized = serializePack(pack);
+  const copied = setClipboardText(serialized);
+  if (copied) {
+    ctx.showInfo(`Copied ${pack.name} pack to clipboard`);
+  } else {
+    ctx.showInfo(`Share string for ${pack.name}:\n${serialized}`);
+  }
+}
+
+async function askImportPackString(ctx: SlashCommandContext): Promise<string | null> {
+  return new Promise(resolve => {
+    const question = new AskQuestionInlineComponent(
+      {
+        question: 'Paste the shared model pack string',
+        formatResult: answer => `Import: ${answer.slice(0, 40)}${answer.length > 40 ? '…' : ''}`,
+        onSubmit: answer => {
+          ctx.state.activeInlineQuestion = undefined;
+          const trimmed = answer.trim();
+          resolve(trimmed.length > 0 ? trimmed : null);
+        },
+        onCancel: () => {
+          ctx.state.activeInlineQuestion = undefined;
+          resolve(null);
+        },
+      },
+      ctx.state.ui,
+    );
+
+    ctx.state.activeInlineQuestion = question;
+    ctx.state.chatContainer.addChild(new Spacer(1));
+    ctx.state.chatContainer.addChild(question);
+    ctx.state.chatContainer.addChild(new Spacer(1));
+    ctx.state.ui.requestRender();
+    ctx.state.chatContainer.invalidate();
+  });
+}
+
 export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise<void> {
   const harness = ctx.state.harness;
   const models = await harness.listAvailableModels();
@@ -513,6 +602,10 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
     value: p.id,
     label: `  ${p.name}  ${theme.fg('dim', p.description)}${p.id === currentPackId ? theme.fg('dim', ' (current)') : ''}`,
   }));
+  items.push({
+    value: '__import__',
+    label: `  Import Pack  ${theme.fg('dim', 'Paste a shared pack config')}`,
+  });
 
   return new Promise<void>(resolve => {
     const container = new Box(1, 1);
@@ -523,6 +616,11 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
     const detailText = new Text('', 0, 0);
 
     const updateDetail = (packId: string) => {
+      if (packId === '__import__') {
+        detailText.setText(theme.fg('dim', '  Paste a mastra-pack:... string from someone else to import their pack.'));
+        ctx.state.ui.requestRender();
+        return;
+      }
       const pack = packs.find(p => p.id === packId);
       if (!pack) return;
       detailText.setText(getPackDetail(pack));
@@ -541,6 +639,36 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
 
     selectList.onSelect = async (item: SelectItem) => {
       ctx.state.activeInlineQuestion = undefined;
+
+      if (item.value === '__import__') {
+        collapseResult(null);
+        const importStr = await askImportPackString(ctx);
+        if (!importStr) {
+          collapseResult('cancelled');
+          resolve();
+          return;
+        }
+        const imported = deserializePack(importStr);
+        if (!imported) {
+          collapseResult('cancelled');
+          ctx.showInfo('Invalid pack string. Expected a mastra-pack:... value.');
+          resolve();
+          return;
+        }
+        const s = loadSettings();
+        const modeDefaults: Record<string, string> = {
+          plan: imported.models.plan,
+          build: imported.models.build,
+          fast: imported.models.fast,
+        };
+        upsertCustomPackInSettings(s, imported, modeDefaults);
+        saveSettings(s);
+        await applyPack(ctx, imported);
+        collapseResult(`Imported pack → ${theme.bold(imported.name)}`);
+        ctx.showInfo(`Imported and activated ${imported.name} pack`);
+        resolve();
+        return;
+      }
 
       let pack: ModePack | null | undefined = packs.find(p => p.id === item.value);
       let previousPackId: string | undefined;
@@ -568,6 +696,11 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
             ctx.showInfo(`Deleted custom pack: ${pack.name}`);
             resolve();
             return;
+          }
+
+          if (action === 'share') {
+            sharePack(ctx, pack);
+            continue;
           }
 
           if (action === 'activate') {

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -556,6 +556,57 @@ async function askImportPackString(ctx: SlashCommandContext): Promise<string | n
   });
 }
 
+async function askImportCollision(
+  ctx: SlashCommandContext,
+  existingName: string,
+): Promise<'overwrite' | 'rename' | 'cancel'> {
+  const actions = [
+    { id: 'overwrite', label: 'Overwrite', description: `Replace the existing "${existingName}" pack` },
+    { id: 'rename', label: 'Rename', description: 'Choose a different name for the imported pack' },
+    { id: 'cancel', label: 'Cancel', description: 'Abort import' },
+  ] as const;
+
+  return new Promise(resolve => {
+    const container = new Box(1, 1);
+    container.addChild(
+      new Text(theme.bold(theme.fg('accent', `A pack named "${existingName}" already exists`)), 0, 0),
+    );
+    container.addChild(new Spacer(1));
+
+    const items: SelectItem[] = actions.map(a => ({
+      value: a.id,
+      label: `  ${a.label}  ${theme.fg('dim', a.description)}`,
+    }));
+
+    const selectList = new SelectList(items, items.length, getSelectListTheme());
+
+    selectList.onSelect = (selected: SelectItem) => {
+      ctx.state.activeInlineQuestion = undefined;
+      container.clear();
+      container.addChild(new Text(theme.fg('dim', `${existingName}: ${selected.value}`), 0, 0));
+      ctx.state.ui.requestRender();
+      resolve(selected.value as 'overwrite' | 'rename' | 'cancel');
+    };
+
+    selectList.onCancel = () => {
+      ctx.state.activeInlineQuestion = undefined;
+      container.clear();
+      container.addChild(new Text(theme.fg('dim', `${existingName}: cancelled`), 0, 0));
+      ctx.state.ui.requestRender();
+      resolve('cancel');
+    };
+
+    container.addChild(selectList);
+
+    const inputShim = { handleInput: (data: string) => selectList.handleInput(data) } as any;
+    ctx.state.activeInlineQuestion = inputShim;
+    ctx.state.chatContainer.addChild(container);
+    ctx.state.chatContainer.addChild(new Spacer(1));
+    ctx.state.ui.requestRender();
+    ctx.state.chatContainer.invalidate();
+  });
+}
+
 export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise<void> {
   const harness = ctx.state.harness;
   const models = await harness.listAvailableModels();
@@ -655,7 +706,42 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
           resolve();
           return;
         }
+
+        // Validate that the imported model IDs are available in this environment
+        const availableModelIds = new Set(models.map(m => m.id));
+        const unavailable = Object.entries(imported.models)
+          .filter(([, modelId]) => !availableModelIds.has(modelId))
+          .map(([mode, modelId]) => `${mode}: ${modelId}`);
+        if (unavailable.length > 0) {
+          collapseResult('cancelled');
+          ctx.showInfo(`Can't import — these models aren't available:\n${unavailable.join('\n')}`);
+          resolve();
+          return;
+        }
+
+        // Handle name collision with existing custom pack
         const s = loadSettings();
+        const existing = s.customModelPacks.find(p => p.name === imported.name);
+        if (existing) {
+          const collision = await askImportCollision(ctx, imported.name);
+          if (collision === 'cancel') {
+            collapseResult('cancelled');
+            resolve();
+            return;
+          }
+          if (collision === 'rename') {
+            const newName = await askCustomPackName(ctx, imported.name);
+            if (!newName) {
+              collapseResult('cancelled');
+              resolve();
+              return;
+            }
+            imported.name = newName;
+            imported.id = `custom:${newName}`;
+          }
+          // collision === 'overwrite' falls through
+        }
+
         const modeDefaults: Record<string, string> = {
           plan: imported.models.plan,
           build: imported.models.build,

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -746,13 +746,6 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
           // collision === 'overwrite' falls through
         }
 
-        const modeDefaults: Record<string, string> = {
-          plan: imported.models.plan,
-          build: imported.models.build,
-          fast: imported.models.fast,
-        };
-        upsertCustomPackInSettings(s, imported, modeDefaults);
-        saveSettings(s);
         await applyPack(ctx, imported);
         collapseResult(`Imported pack → ${theme.bold(imported.name)}`);
         ctx.showInfo(`Imported and activated ${imported.name} pack`);


### PR DESCRIPTION
Adds two new features to the `/models` command:

**Share** — Custom packs now have a "Share" action that serializes the pack config into a compact `mastra-pack:...` string and copies it to the clipboard. If clipboard access fails, it prints the string inline instead.

**Import** — A new "Import Pack" option at the bottom of the pack list lets you paste a `mastra-pack:...` string to import and activate someone else's pack.

The format is a base64-encoded JSON payload with the pack name and model IDs for each mode (plan/build/fast). Imported packs are saved as custom packs and activated immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

You can now turn a custom model pack into a short shareable code, copy it, and paste someone else's code into the /models UI to import and immediately use their pack.

---

## Summary of Changes

Adds share and import features for model packs in the Mastra TUI.

- Share:
  - Custom packs gain a "Share" action that produces a mastra-pack:... string — a base64-encoded JSON payload containing the pack name and model IDs for build/plan/fast — via serializePack(pack).
  - The UI attempts to copy the string to the system clipboard using setClipboardText; if clipboard write fails the share string is displayed inline.

- Import:
  - An "Import Pack" option is available in the pack selector (special `__import__` option) which prompts the user to paste a mastra-pack:... string and uses deserializePack(input) to parse it.
  - Deserialization trims input, validates the mastra-pack: prefix, requires a non-empty name and model IDs for build/plan/fast, and returns a ModePack with id `custom:<Name>` or null on failure.
  - Imported packs are validated against available models (import aborts with feedback if referenced model IDs are unavailable).
  - Name-collision handling supports overwrite, rename, or cancel. On rename the code re-checks for collisions before upserting.
  - Imported packs are saved as custom packs and activated immediately (applyPack performs the upsert/save; a prior redundant save before applyPack was removed to avoid partially-applied state if apply fails).

- Clipboard support:
  - Added setClipboardText(text: string): boolean in mastracode/src/clipboard/index.ts with platform-specific macOS/Linux implementations (pbcopy, xclip/wl-copy). The share flow uses this helper and falls back to printing the share string if clipboard access fails.

- New/changed APIs and UI flow:
  - Added serializePack(pack: ModePack): string and deserializePack(input: string): ModePack | null exported from mastracode/src/tui/commands/models-pack.ts.
  - askCustomPackAction now includes 'share' and the custom-pack action loop handles the share action without exiting the loop.

- Tests:
  - mastracode/src/tui/commands/__tests__/models-pack.test.ts updated with tests for serializePack/deserializePack (round-trip, built-in->custom conversion, invalid payloads, missing fields, whitespace tolerance) in addition to existing custom-pack behavior tests.

Files modified:
- .changeset/fancy-buckets-retire.md — release note for mastracode minor bump
- mastracode/src/clipboard/index.ts — added setClipboardText
- mastracode/src/tui/commands/models-pack.ts — serialize/deserialize, share/import UI flows, collision handling, use of applyPack (redundant pre-save removed)
- mastracode/src/tui/commands/__tests__/models-pack.test.ts — tests for serialization/deserialization and settings behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->