### PR TITLE
fix(cli): retry upload-complete and cancel orphaned server deploys

### DIFF
--- a/.changeset/whole-places-beam.md
+++ b/.changeset/whole-places-beam.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed server deploy getting permanently stuck in 'queued' status when the upload confirmation step fails. The CLI now retries transient failures (5xx, 401) up to 3 times with exponential backoff, and automatically cancels orphaned deploys when upload or confirmation fails. Added user-visible log messages during retries and cleanup so deploy failures are no longer silent.

--- a/.changeset/whole-places-beam.md
+++ b/.changeset/whole-places-beam.md
@@ -2,4 +2,4 @@
 'mastra': patch
 ---
 
-Fixed server deploy getting permanently stuck in 'queued' status when the upload confirmation step fails. The CLI now retries transient failures (5xx, 401) up to 3 times with exponential backoff, and automatically cancels orphaned deploys when upload or confirmation fails. Added user-visible log messages during retries and cleanup so deploy failures are no longer silent.
+Fixed `mastra server deploy` getting stuck in `queued` after transient upload confirmation failures. The CLI now retries these failures and cleans up failed deploys so they no longer remain orphaned.

--- a/packages/cli/src/commands/platform-api.d.ts
+++ b/packages/cli/src/commands/platform-api.d.ts
@@ -1548,7 +1548,14 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': {
+          /** Format: uri */
+          returnTo?: string;
+        };
+      };
+    };
     responses: {
       /** @description Logged out */
       200: {
@@ -3367,7 +3374,15 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': {
+          envVars: {
+            [key: string]: string;
+          };
+        };
+      };
+    };
     responses: {
       /** @description Env vars updated */
       200: {
@@ -3401,7 +3416,15 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': {
+          envVars: {
+            [key: string]: string;
+          };
+        };
+      };
+    };
     responses: {
       /** @description Env vars updated and service restarted */
       200: {
@@ -3475,7 +3498,13 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': {
+          domain: string;
+        };
+      };
+    };
     responses: {
       /** @description Custom domain added */
       200: {

--- a/packages/cli/src/commands/platform-api.d.ts
+++ b/packages/cli/src/commands/platform-api.d.ts
@@ -329,7 +329,7 @@ export interface paths {
     };
     /**
      * Get usage activity
-     * @description Aggregated usage metrics for a project. Supports multiple granularities (1h, daily, weekly, monthly) and optional group-by dimensions (model, provider, source_category, api_key_id).
+     * @description Aggregated usage metrics for a project. Supports multiple granularities (1m, 5m, 15m, 1h, daily, weekly, monthly) and optional group-by dimensions (model, provider, source_category, api_key_id).
      */
     get: operations['getV1GatewayProjectsByIdUsageActivity'];
     put?: never;
@@ -522,6 +522,26 @@ export interface paths {
     get: operations['getV1StudioDeploysById'];
     put?: never;
     post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v1/studio/deploys/{id}/cancel': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Cancel studio deploy
+     * @description Cancel a queued or uploading deployment before the pipeline starts.
+     */
+    post: operations['postV1StudioDeploysByIdCancel'];
     delete?: never;
     options?: never;
     head?: never;
@@ -735,7 +755,7 @@ export interface paths {
     put?: never;
     /**
      * Pause server
-     * @description Pause a running server project
+     * @description Stop the currently running deploy for a server project. The server will no longer respond to requests until restarted.
      */
     post: operations['postV1ServerProjectsByIdPause'];
     delete?: never;
@@ -755,7 +775,7 @@ export interface paths {
     put?: never;
     /**
      * Restart server
-     * @description Restart a paused server project
+     * @description Trigger a new deployment for a stopped, failed, crashed, or cancelled server project.
      */
     post: operations['postV1ServerProjectsByIdRestart'];
     delete?: never;
@@ -946,6 +966,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -965,6 +987,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1016,6 +1040,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1035,6 +1061,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1085,6 +1113,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1104,6 +1134,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1123,6 +1155,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1171,6 +1205,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1213,6 +1249,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1264,6 +1302,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1310,6 +1350,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1362,6 +1404,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1414,6 +1458,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1433,6 +1479,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1482,6 +1530,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1557,6 +1607,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1576,6 +1628,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1623,6 +1677,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1642,6 +1698,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1698,6 +1756,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1717,6 +1777,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1761,6 +1823,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1780,6 +1844,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1824,6 +1890,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1843,6 +1911,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1903,6 +1973,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1922,6 +1994,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -1965,6 +2039,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2052,6 +2128,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2071,6 +2149,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2127,6 +2207,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2146,6 +2228,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2218,6 +2302,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2237,6 +2323,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2311,6 +2399,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2330,6 +2420,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2407,6 +2499,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2440,7 +2534,9 @@ export interface operations {
               studioEnabled: boolean;
               serverEnabled: boolean;
               latestDeployId: string | null;
-              latestDeployStatus: ('queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'unknown') | null;
+              latestDeployStatus:
+                | ('queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'cancelled' | 'unknown')
+                | null;
               latestDeployCreatedAt: string | null;
               latestServerDeployStatus: string | null;
               customServerApiUrl: string | null;
@@ -2464,6 +2560,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2503,7 +2601,9 @@ export interface operations {
               studioEnabled: boolean;
               serverEnabled: boolean;
               latestDeployId: string | null;
-              latestDeployStatus: ('queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'unknown') | null;
+              latestDeployStatus:
+                | ('queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'cancelled' | 'unknown')
+                | null;
               latestDeployCreatedAt: string | null;
               latestServerDeployStatus: string | null;
               customServerApiUrl: string | null;
@@ -2527,6 +2627,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2562,7 +2664,9 @@ export interface operations {
               studioEnabled: boolean;
               serverEnabled: boolean;
               latestDeployId: string | null;
-              latestDeployStatus: ('queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'unknown') | null;
+              latestDeployStatus:
+                | ('queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'cancelled' | 'unknown')
+                | null;
               latestDeployCreatedAt: string | null;
               latestServerDeployStatus: string | null;
               customServerApiUrl: string | null;
@@ -2577,7 +2681,7 @@ export interface operations {
               organizationId: string;
               projectName: string;
               /** @enum {string} */
-              status: 'queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'unknown';
+              status: 'queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'cancelled' | 'unknown';
               instanceUrl: string | null;
               error: string | null;
               createdAt: string | null;
@@ -2597,6 +2701,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2641,6 +2747,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2692,6 +2800,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2736,6 +2846,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2769,7 +2881,7 @@ export interface operations {
               organizationId: string;
               projectName: string;
               /** @enum {string} */
-              status: 'queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'unknown';
+              status: 'queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'cancelled' | 'unknown';
               instanceUrl: string | null;
               error: string | null;
               createdAt: string | null;
@@ -2789,6 +2901,76 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
+            errors?: {
+              field: string;
+              message: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  postV1StudioDeploysByIdCancel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Deploy cancelled */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            id: string;
+            /** @enum {string} */
+            status: 'queued' | 'starting' | 'running' | 'stopped' | 'failed' | 'cancelled' | 'unknown';
+          };
+        };
+      };
+      /** @description Deploy cannot be cancelled (not in queued or uploading state) */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            type: string;
+            title: string;
+            status: number;
+            detail?: string;
+            instance?: string;
+            /** Format: uri */
+            help_url?: string;
+            errors?: {
+              field: string;
+              message: string;
+            }[];
+          };
+        };
+      };
+      /** @description Deploy not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            type: string;
+            title: string;
+            status: number;
+            detail?: string;
+            instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2835,6 +3017,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -2876,6 +3060,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -3173,15 +3359,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody: {
-      content: {
-        'application/json': {
-          envVars: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
+    requestBody?: never;
     responses: {
       /** @description Env vars updated */
       200: {
@@ -3215,15 +3393,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody: {
-      content: {
-        'application/json': {
-          envVars: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
+    requestBody?: never;
     responses: {
       /** @description Env vars updated and service restarted */
       200: {
@@ -3428,12 +3598,10 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content: {
-          'application/json': Record<string, never>;
-        };
+        content?: never;
       };
-      /** @description Conflict — server not running or deploy active */
-      409: {
+      /** @description Project not found */
+      404: {
         headers: {
           [name: string]: unknown;
         };
@@ -3446,8 +3614,8 @@ export interface operations {
           };
         };
       };
-      /** @description Project not found */
-      404: {
+      /** @description Server is not running */
+      409: {
         headers: {
           [name: string]: unknown;
         };
@@ -3473,20 +3641,21 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description Restart initiated; may include the new deploy id when a deploy is queued */
+      /** @description Deploy queued */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           'application/json': {
-            id?: string;
-            status?: string;
+            id: string;
+            status: string;
+            uploadUrl?: string;
           };
         };
       };
-      /** @description Conflict — server running or deploy active */
-      409: {
+      /** @description Project not found */
+      404: {
         headers: {
           [name: string]: unknown;
         };
@@ -3499,8 +3668,8 @@ export interface operations {
           };
         };
       };
-      /** @description Project not found */
-      404: {
+      /** @description Server is already running or deploying */
+      409: {
         headers: {
           [name: string]: unknown;
         };
@@ -3746,7 +3915,12 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': {
+            id: string;
+            status: string;
+          };
+        };
       };
       /** @description Deploy not found */
       404: {
@@ -3812,6 +3986,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -3831,6 +4007,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -3850,6 +4028,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;
@@ -3869,6 +4049,8 @@ export interface operations {
             status: number;
             detail?: string;
             instance?: string;
+            /** Format: uri */
+            help_url?: string;
             errors?: {
               field: string;
               message: string;

--- a/packages/cli/src/commands/platform-api.d.ts
+++ b/packages/cli/src/commands/platform-api.d.ts
@@ -2770,7 +2770,15 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody?: {
+      content: {
+        'application/json': {
+          envVars?: {
+            [key: string]: string;
+          };
+        };
+      };
+    };
     responses: {
       /** @description Deploy queued */
       202: {

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -89,7 +89,7 @@ export async function uploadServerDeploy(
     throwApiError('Deploy failed', response.status);
   }
 
-  const { id, uploadUrl } = data;
+  const { id, status, uploadUrl } = data;
 
   if (!uploadUrl) {
     throw new Error('No upload URL returned');
@@ -131,7 +131,7 @@ export async function uploadServerDeploy(
     orgId,
   });
 
-  return { id, status: 'queued' };
+  return { id, status };
 }
 
 export async function pollServerDeploy(

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -94,33 +94,81 @@ export async function uploadServerDeploy(
     throw new Error('No upload URL returned');
   }
 
-  // Step 2: Upload artifact to the signed URL
-  if (uploadUrl.startsWith('file://')) {
-    const { writeFile } = await import('node:fs/promises');
-    const { fileURLToPath } = await import('node:url');
-    await writeFile(fileURLToPath(uploadUrl), Buffer.from(zipBuffer));
-  } else {
-    const uploadResp = await fetch(uploadUrl, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/zip' },
-      body: new Uint8Array(zipBuffer),
-    });
-    if (!uploadResp.ok) {
-      throw new Error(`Artifact upload failed: ${uploadResp.status} ${uploadResp.statusText}`);
+  // Best-effort cancel helper — used to clean up orphaned deploys on failure
+  async function cancelDeploy(deployClient: ReturnType<typeof createApiClient>) {
+    try {
+      console.warn(`Cancelling deploy ${id}...`);
+      await deployClient.POST('/v1/server/deploys/{id}/cancel', {
+        params: { path: { id } },
+      });
+    } catch {
+      console.warn(`Warning: failed to cancel deploy ${id}. It may remain in a queued state.`);
     }
   }
 
-  // Step 3: Notify API that upload is complete → triggers build pipeline
-  const { error: completeError, response: completeResponse } = await client.POST(
-    '/v1/server/deploys/{id}/upload-complete',
-    { params: { path: { id } } },
-  );
-
-  if (completeError) {
-    throwApiError('Upload confirmation failed', completeResponse.status);
+  // Step 2: Upload artifact to the signed URL
+  try {
+    if (uploadUrl.startsWith('file://')) {
+      const { writeFile } = await import('node:fs/promises');
+      const { fileURLToPath } = await import('node:url');
+      await writeFile(fileURLToPath(uploadUrl), Buffer.from(zipBuffer));
+    } else {
+      const uploadResp = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/zip' },
+        body: new Uint8Array(zipBuffer),
+      });
+      if (!uploadResp.ok) {
+        throw new Error(`Artifact upload failed: ${uploadResp.status} ${uploadResp.statusText}`);
+      }
+    }
+  } catch (uploadError) {
+    await cancelDeploy(client);
+    throw uploadError;
   }
 
-  return { id, status: 'queued' };
+  // Step 3: Notify API that upload is complete → triggers build pipeline
+  // Retry up to 3 times (4 total attempts) with exponential backoff for transient failures.
+  const maxRetries = 3;
+  let lastError: Error | undefined;
+  let currentClient = client;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const { error: completeError, response: completeResponse } = await currentClient.POST(
+      '/v1/server/deploys/{id}/upload-complete',
+      { params: { path: { id } } },
+    );
+
+    if (!completeError) {
+      return { id, status: 'queued' };
+    }
+
+    const status = completeResponse.status;
+
+    // Only retry on transient failures: 5xx, 401 (token expiry), or network errors
+    const isRetryable = status >= 500 || status === 401;
+    if (!isRetryable || attempt === maxRetries) {
+      lastError = new Error(`Upload confirmation failed: ${status}`);
+      break;
+    }
+
+    const delay = 1000 * Math.pow(2, attempt);
+    console.warn(
+      `Upload confirmation failed (${status}), retrying in ${delay / 1000}s... (attempt ${attempt + 1}/${maxRetries})`,
+    );
+
+    // On 401, refresh the token before retrying (same pattern as pollServerDeploy)
+    if (status === 401) {
+      const freshToken = await getToken();
+      currentClient = createApiClient(freshToken, orgId);
+    }
+
+    // Exponential backoff: 1s, 2s, 4s
+    await new Promise(r => setTimeout(r, delay));
+  }
+
+  // All retries exhausted — cancel the orphaned deploy and throw
+  await cancelDeploy(currentClient);
+  throw lastError ?? new Error('Upload confirmation failed');
 }
 
 export async function pollServerDeploy(

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -1,4 +1,4 @@
-import { withPollingRetries } from '../../utils/polling.js';
+import { withPollingRetries, isRetryablePollingError } from '../../utils/polling.js';
 import { createApiClient, throwApiError } from '../auth/client.js';
 import { getToken } from '../auth/credentials.js';
 import type { paths } from '../platform-api.js';
@@ -133,27 +133,38 @@ export async function uploadServerDeploy(
   let lastError: Error | undefined;
   let currentClient = client;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const { error: completeError, response: completeResponse } = await currentClient.POST(
-      '/v1/server/deploys/{id}/upload-complete',
-      { params: { path: { id } } },
-    );
+    let completeError: unknown;
+    let status: number | undefined;
 
-    if (!completeError) {
-      return { id, status: 'queued' };
+    try {
+      const result = await currentClient.POST('/v1/server/deploys/{id}/upload-complete', {
+        params: { path: { id } },
+      });
+      if (!result.error) {
+        return { id, status: 'queued' };
+      }
+      completeError = result.error;
+      status = result.response.status;
+    } catch (networkError) {
+      // Network-level failure (ECONNRESET, ETIMEDOUT, fetch failed, etc.)
+      completeError = networkError;
     }
 
-    const status = completeResponse.status;
+    // Determine if we should retry
+    const isRetryableStatus = status !== undefined && (status >= 500 || status === 401);
+    const isRetryableNetwork = isRetryablePollingError(completeError);
+    const isRetryable = isRetryableStatus || isRetryableNetwork;
 
-    // Only retry on transient failures: 5xx, 401 (token expiry), or network errors
-    const isRetryable = status >= 500 || status === 401;
     if (!isRetryable || attempt === maxRetries) {
-      lastError = new Error(`Upload confirmation failed: ${status}`);
+      const detail = status ? `${status}` : completeError instanceof Error ? completeError.message : 'unknown error';
+      lastError = new Error(`Upload confirmation failed: ${detail}`);
       break;
     }
 
     const delay = 1000 * Math.pow(2, attempt);
+    const detail = status ? `${status}` : completeError instanceof Error ? completeError.message : 'network error';
     console.warn(
-      `Upload confirmation failed (${status}), retrying in ${delay / 1000}s... (attempt ${attempt + 1}/${maxRetries})`,
+      `Upload confirmation failed (${detail}), retrying in ${delay / 1000}s... (attempt ${attempt + 1}/${maxRetries})`,
     );
 
     // On 401, refresh the token before retrying (same pattern as pollServerDeploy)

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -1,4 +1,5 @@
-import { withPollingRetries, isRetryablePollingError } from '../../utils/polling.js';
+import { bestEffortCancel, confirmUploadWithRetry } from '../../utils/deploy-upload.js';
+import { withPollingRetries } from '../../utils/polling.js';
 import { createApiClient, throwApiError } from '../auth/client.js';
 import { getToken } from '../auth/credentials.js';
 import type { paths } from '../platform-api.js';
@@ -94,25 +95,12 @@ export async function uploadServerDeploy(
     throw new Error('No upload URL returned');
   }
 
-  // Best-effort cancel helper — used to clean up orphaned deploys on failure
-  async function cancelDeploy(deployClient: ReturnType<typeof createApiClient>) {
-    try {
-      console.warn(`Cancelling deploy ${id}...`);
-      const { error: cancelError, response: cancelResponse } = await deployClient.POST(
-        '/v1/server/deploys/{id}/cancel',
-        {
-          params: { path: { id } },
-        },
-      );
-      if (cancelError) {
-        console.warn(
-          `Warning: failed to cancel deploy ${id} (${cancelResponse.status}). It may remain in a queued state.`,
-        );
-      }
-    } catch {
-      console.warn(`Warning: failed to cancel deploy ${id}. It may remain in a queued state.`);
-    }
-  }
+  const cancel = (c: ReturnType<typeof createApiClient>) =>
+    bestEffortCancel({
+      postCancel: c2 => c2.POST('/v1/server/deploys/{id}/cancel', { params: { path: { id } } }),
+      client: c,
+      deployId: id,
+    });
 
   // Step 2: Upload artifact to the signed URL
   try {
@@ -131,68 +119,19 @@ export async function uploadServerDeploy(
       }
     }
   } catch (uploadError) {
-    await cancelDeploy(client);
+    await cancel(client);
     throw uploadError;
   }
 
   // Step 3: Notify API that upload is complete → triggers build pipeline
-  // Retry up to 3 times (4 total attempts) with exponential backoff for transient failures.
-  const maxRetries = 3;
-  let lastError: Error | undefined;
-  let currentClient = client;
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    let completeError: unknown;
-    let status: number | undefined;
+  await confirmUploadWithRetry({
+    postUploadComplete: c => c.POST('/v1/server/deploys/{id}/upload-complete', { params: { path: { id } } }),
+    cancelDeploy: cancel,
+    client,
+    orgId,
+  });
 
-    try {
-      const result = await currentClient.POST('/v1/server/deploys/{id}/upload-complete', {
-        params: { path: { id } },
-      });
-      if (!result.error) {
-        return { id, status: 'queued' };
-      }
-      completeError = result.error;
-      status = result.response.status;
-    } catch (networkError) {
-      // Network-level failure (ECONNRESET, ETIMEDOUT, fetch failed, etc.)
-      completeError = networkError;
-    }
-
-    // Determine if we should retry
-    const isRetryableStatus = status !== undefined && (status >= 500 || status === 401);
-    const isRetryableNetwork = isRetryablePollingError(completeError);
-    const isRetryable = isRetryableStatus || isRetryableNetwork;
-
-    if (!isRetryable || attempt === maxRetries) {
-      const detail = status ? `${status}` : completeError instanceof Error ? completeError.message : 'unknown error';
-      lastError = new Error(`Upload confirmation failed: ${detail}`);
-      break;
-    }
-
-    const delay = 1000 * Math.pow(2, attempt);
-    const detail = status ? `${status}` : completeError instanceof Error ? completeError.message : 'network error';
-    console.warn(
-      `Upload confirmation failed (${detail}), retrying in ${delay / 1000}s... (attempt ${attempt + 1}/${maxRetries})`,
-    );
-
-    // On 401, refresh the token before retrying (same pattern as pollServerDeploy)
-    if (status === 401) {
-      try {
-        const freshToken = await getToken();
-        currentClient = createApiClient(freshToken, orgId);
-      } catch (refreshError) {
-        lastError = refreshError instanceof Error ? refreshError : new Error('Failed to refresh authentication token');
-        break;
-      }
-    }
-
-    // Exponential backoff: 1s, 2s, 4s
-    await new Promise(r => setTimeout(r, delay));
-  }
-
-  // All retries exhausted — cancel the orphaned deploy and throw
-  await cancelDeploy(currentClient);
-  throw lastError ?? new Error('Upload confirmation failed');
+  return { id, status: 'queued' };
 }
 
 export async function pollServerDeploy(

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -98,9 +98,17 @@ export async function uploadServerDeploy(
   async function cancelDeploy(deployClient: ReturnType<typeof createApiClient>) {
     try {
       console.warn(`Cancelling deploy ${id}...`);
-      await deployClient.POST('/v1/server/deploys/{id}/cancel', {
-        params: { path: { id } },
-      });
+      const { error: cancelError, response: cancelResponse } = await deployClient.POST(
+        '/v1/server/deploys/{id}/cancel',
+        {
+          params: { path: { id } },
+        },
+      );
+      if (cancelError) {
+        console.warn(
+          `Warning: failed to cancel deploy ${id} (${cancelResponse.status}). It may remain in a queued state.`,
+        );
+      }
     } catch {
       console.warn(`Warning: failed to cancel deploy ${id}. It may remain in a queued state.`);
     }
@@ -169,8 +177,13 @@ export async function uploadServerDeploy(
 
     // On 401, refresh the token before retrying (same pattern as pollServerDeploy)
     if (status === 401) {
-      const freshToken = await getToken();
-      currentClient = createApiClient(freshToken, orgId);
+      try {
+        const freshToken = await getToken();
+        currentClient = createApiClient(freshToken, orgId);
+      } catch (refreshError) {
+        lastError = refreshError instanceof Error ? refreshError : new Error('Failed to refresh authentication token');
+        break;
+      }
     }
 
     // Exponential backoff: 1s, 2s, 4s

--- a/packages/cli/src/commands/studio/platform-api.test.ts
+++ b/packages/cli/src/commands/studio/platform-api.test.ts
@@ -121,20 +121,20 @@ describe('uploadDeploy', () => {
   it('creates deploy, uploads zip via signed URL, and confirms', async () => {
     const mockFetch = vi.fn();
 
-    // POST /v1/studio/deploys → returns deploy with uploadUrl
-    mockFetch
+    // createApiClient().POST for create deploy
+    mockPOST
       .mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            deploy: { id: 'dep-1', status: 'starting', uploadUrl: 'https://storage.example.com/signed-url' },
-          }),
+        data: { deploy: { id: 'dep-1', status: 'starting', uploadUrl: 'https://storage.example.com/signed-url' } },
+        response: { status: 202 },
       })
-      // PUT to signed URL
-      .mockResolvedValueOnce({ ok: true })
       // POST upload-complete
-      .mockResolvedValueOnce({ ok: true });
+      .mockResolvedValueOnce({
+        data: { status: 'ok' },
+        response: { status: 200 },
+      });
 
+    // PUT to signed URL via global fetch
+    mockFetch.mockResolvedValueOnce({ ok: true });
     vi.stubGlobal('fetch', mockFetch);
 
     const { uploadDeploy } = await import('./platform-api.js');
@@ -144,55 +144,52 @@ describe('uploadDeploy', () => {
       envVars: { FOO: 'bar' },
     });
 
-    expect(result).toMatchObject({ id: 'dep-1', status: 'starting' });
+    expect(result).toMatchObject({ id: 'dep-1', status: 'queued' });
 
-    // 3 fetch calls: create, upload, confirm
-    expect(mockFetch).toHaveBeenCalledTimes(3);
+    // createApiClient().POST called twice: create + upload-complete
+    expect(mockPOST).toHaveBeenCalledTimes(2);
+    expect(mockPOST).toHaveBeenCalledWith(
+      '/v1/studio/deploys',
+      expect.objectContaining({
+        body: { envVars: { FOO: 'bar' } },
+      }),
+    );
+    expect(mockPOST).toHaveBeenCalledWith('/v1/studio/deploys/{id}/upload-complete', {
+      params: { path: { id: 'dep-1' } },
+    });
 
-    // First call: POST /v1/studio/deploys
-    const createCall = mockFetch.mock.calls[0]!;
-    expect(createCall[0]).toBe('http://localhost:9999/v1/studio/deploys');
-    expect(createCall[1].method).toBe('POST');
-
-    // Second call: PUT to signed URL
-    const uploadCall = mockFetch.mock.calls[1]!;
-    expect(uploadCall[0]).toBe('https://storage.example.com/signed-url');
-    expect(uploadCall[1].method).toBe('PUT');
-
-    // Third call: POST upload-complete
-    const completeCall = mockFetch.mock.calls[2]!;
-    expect(completeCall[0]).toBe('http://localhost:9999/v1/studio/deploys/dep-1/upload-complete');
-    expect(completeCall[1].method).toBe('POST');
+    // fetch called once: PUT to signed URL
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]![0]).toBe('https://storage.example.com/signed-url');
+    expect(mockFetch.mock.calls[0]![1].method).toBe('PUT');
   });
 
   it('throws when deploy creation fails', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-        json: () => Promise.resolve({ detail: 'Internal server error' }),
-      }),
-    );
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: { detail: 'Internal server error' },
+      response: { status: 500 },
+    });
 
     const { uploadDeploy } = await import('./platform-api.js');
     await expect(uploadDeploy('tok', 'org-1', 'proj-1', Buffer.from('zip'))).rejects.toThrow('Internal server error');
   });
 
   it('throws when artifact upload fails', async () => {
-    const mockFetch = vi.fn();
-    mockFetch
+    // Create deploy succeeds
+    mockPOST
       .mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            deploy: { id: 'dep-1', status: 'starting', uploadUrl: 'https://storage.example.com/signed-url' },
-          }),
+        data: { deploy: { id: 'dep-1', status: 'starting', uploadUrl: 'https://storage.example.com/signed-url' } },
+        response: { status: 202 },
       })
-      .mockResolvedValueOnce({ ok: false, status: 403, statusText: 'Forbidden' });
+      // Cancel deploy (best-effort cleanup)
+      .mockResolvedValueOnce({
+        data: { id: 'dep-1', status: 'cancelled' },
+        response: { status: 200 },
+      });
 
-    vi.stubGlobal('fetch', mockFetch);
+    // Artifact upload fails
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: false, status: 403, statusText: 'Forbidden' }));
 
     const { uploadDeploy } = await import('./platform-api.js');
     await expect(uploadDeploy('tok', 'org-1', 'proj-1', Buffer.from('zip'))).rejects.toThrow(

--- a/packages/cli/src/commands/studio/platform-api.test.ts
+++ b/packages/cli/src/commands/studio/platform-api.test.ts
@@ -144,7 +144,7 @@ describe('uploadDeploy', () => {
       envVars: { FOO: 'bar' },
     });
 
-    expect(result).toMatchObject({ id: 'dep-1', status: 'queued' });
+    expect(result).toMatchObject({ id: 'dep-1', status: 'starting' });
 
     // createApiClient().POST called twice: create + upload-complete
     expect(mockPOST).toHaveBeenCalledTimes(2);

--- a/packages/cli/src/commands/studio/platform-api.ts
+++ b/packages/cli/src/commands/studio/platform-api.ts
@@ -94,7 +94,7 @@ export async function uploadDeploy(
     throwApiError('Deploy failed', response.status, error.detail);
   }
 
-  const { id, uploadUrl } = data.deploy;
+  const { id, status, uploadUrl } = data.deploy;
 
   if (!uploadUrl) {
     throw new Error('No upload URL returned');
@@ -136,7 +136,7 @@ export async function uploadDeploy(
     orgId,
   });
 
-  return { id, status: 'queued' };
+  return { id, status };
 }
 
 async function streamDeployLogs(deployId: string, token: string, orgId: string, signal: AbortSignal): Promise<void> {

--- a/packages/cli/src/commands/studio/platform-api.ts
+++ b/packages/cli/src/commands/studio/platform-api.ts
@@ -1,4 +1,5 @@
-import { isRetryablePollingError, withPollingRetries } from '../../utils/polling.js';
+import { bestEffortCancel, confirmUploadWithRetry } from '../../utils/deploy-upload.js';
+import { withPollingRetries } from '../../utils/polling.js';
 import { authHeaders, createApiClient, MASTRA_PLATFORM_API_URL, platformFetch, throwApiError } from '../auth/client.js';
 import { getToken } from '../auth/credentials.js';
 
@@ -99,25 +100,12 @@ export async function uploadDeploy(
     throw new Error('No upload URL returned');
   }
 
-  // Best-effort cancel helper — used to clean up orphaned deploys on failure
-  async function cancelDeploy(deployClient: ReturnType<typeof createApiClient>) {
-    try {
-      console.warn(`Cancelling deploy ${id}...`);
-      const { error: cancelError, response: cancelResponse } = await deployClient.POST(
-        '/v1/studio/deploys/{id}/cancel',
-        {
-          params: { path: { id } },
-        },
-      );
-      if (cancelError) {
-        console.warn(
-          `Warning: failed to cancel deploy ${id} (${cancelResponse.status}). It may remain in a queued state.`,
-        );
-      }
-    } catch {
-      console.warn(`Warning: failed to cancel deploy ${id}. It may remain in a queued state.`);
-    }
-  }
+  const cancel = (c: ReturnType<typeof createApiClient>) =>
+    bestEffortCancel({
+      postCancel: c2 => c2.POST('/v1/studio/deploys/{id}/cancel', { params: { path: { id } } }),
+      client: c,
+      deployId: id,
+    });
 
   // Step 2: Upload artifact to the signed URL
   try {
@@ -136,68 +124,19 @@ export async function uploadDeploy(
       }
     }
   } catch (uploadError) {
-    await cancelDeploy(client);
+    await cancel(client);
     throw uploadError;
   }
 
   // Step 3: Notify API that upload is complete → triggers build pipeline
-  // Retry up to 3 times (4 total attempts) with exponential backoff for transient failures.
-  const maxRetries = 3;
-  let lastError: Error | undefined;
-  let currentClient = client;
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    let completeError: unknown;
-    let status: number | undefined;
+  await confirmUploadWithRetry({
+    postUploadComplete: c => c.POST('/v1/studio/deploys/{id}/upload-complete', { params: { path: { id } } }),
+    cancelDeploy: cancel,
+    client,
+    orgId,
+  });
 
-    try {
-      const result = await currentClient.POST('/v1/studio/deploys/{id}/upload-complete', {
-        params: { path: { id } },
-      });
-      if (!result.error) {
-        return { id, status: 'queued' };
-      }
-      completeError = result.error;
-      status = result.response.status;
-    } catch (networkError) {
-      // Network-level failure (ECONNRESET, ETIMEDOUT, fetch failed, etc.)
-      completeError = networkError;
-    }
-
-    // Determine if we should retry
-    const isRetryableStatus = status !== undefined && (status >= 500 || status === 401);
-    const isRetryableNetwork = isRetryablePollingError(completeError);
-    const isRetryable = isRetryableStatus || isRetryableNetwork;
-
-    if (!isRetryable || attempt === maxRetries) {
-      const detail = status ? `${status}` : completeError instanceof Error ? completeError.message : 'unknown error';
-      lastError = new Error(`Upload confirmation failed: ${detail}`);
-      break;
-    }
-
-    const delay = 1000 * Math.pow(2, attempt);
-    const detail = status ? `${status}` : completeError instanceof Error ? completeError.message : 'network error';
-    console.warn(
-      `Upload confirmation failed (${detail}), retrying in ${delay / 1000}s... (attempt ${attempt + 1}/${maxRetries})`,
-    );
-
-    // On 401, refresh the token before retrying
-    if (status === 401) {
-      try {
-        const freshToken = await getToken();
-        currentClient = createApiClient(freshToken, orgId);
-      } catch (refreshError) {
-        lastError = refreshError instanceof Error ? refreshError : new Error('Failed to refresh authentication token');
-        break;
-      }
-    }
-
-    // Exponential backoff: 1s, 2s, 4s
-    await new Promise(r => setTimeout(r, delay));
-  }
-
-  // All retries exhausted — cancel the orphaned deploy and throw
-  await cancelDeploy(currentClient);
-  throw lastError ?? new Error('Upload confirmation failed');
+  return { id, status: 'queued' };
 }
 
 async function streamDeployLogs(deployId: string, token: string, orgId: string, signal: AbortSignal): Promise<void> {
@@ -255,12 +194,13 @@ export async function pollDeploy(
 ): Promise<DeployStatus> {
   const start = Date.now();
   let lastStatus = '';
+  let currentToken = token;
 
   // Start streaming logs in the background via SSE
   const logAbort = new AbortController();
-  streamDeployLogs(deployId, token, orgId, logAbort.signal).catch(() => {});
+  streamDeployLogs(deployId, currentToken, orgId, logAbort.signal).catch(() => {});
 
-  const client = createApiClient(token, orgId);
+  let client = createApiClient(currentToken, orgId);
 
   try {
     while (Date.now() - start < maxWaitMs) {
@@ -273,6 +213,11 @@ export async function pollDeploy(
       const { data, error, response } = result;
 
       if (error) {
+        if (response.status === 401) {
+          currentToken = await getToken();
+          client = createApiClient(currentToken, orgId);
+          continue;
+        }
         throwApiError('Poll failed', response.status, error.detail);
       }
 

--- a/packages/cli/src/commands/studio/platform-api.ts
+++ b/packages/cli/src/commands/studio/platform-api.ts
@@ -1,5 +1,6 @@
-import { withPollingRetries } from '../../utils/polling.js';
+import { isRetryablePollingError, withPollingRetries } from '../../utils/polling.js';
 import { authHeaders, createApiClient, MASTRA_PLATFORM_API_URL, platformFetch, throwApiError } from '../auth/client.js';
+import { getToken } from '../auth/credentials.js';
 
 export interface Project {
   id: string;
@@ -73,60 +74,130 @@ export async function uploadDeploy(
   zipBuffer: Buffer,
   meta?: { gitBranch?: string; projectName?: string; envVars?: Record<string, string>; mastraVersion?: string },
 ): Promise<{ id: string; status: string }> {
-  const headers: Record<string, string> = {
-    ...authHeaders(token, orgId),
-    'Content-Type': 'application/json',
-    'x-project-id': projectId,
-  };
-  if (meta?.gitBranch) headers['x-git-branch'] = meta.gitBranch;
-  if (meta?.projectName) headers['x-project-name'] = meta.projectName;
-  if (meta?.mastraVersion) headers['x-mastra-version'] = meta.mastraVersion;
+  const client = createApiClient(token, orgId);
 
-  // Step 1: Create the deploy with optional envVars
-  const createResp = await platformFetch(`${MASTRA_PLATFORM_API_URL}/v1/studio/deploys`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ envVars: meta?.envVars }),
+  // Step 1: Create the deploy — returns upload URL
+  const { data, error, response } = await client.POST('/v1/studio/deploys', {
+    params: {
+      header: {
+        'x-project-id': projectId,
+        'x-project-name': meta?.projectName,
+        'x-git-branch': meta?.gitBranch,
+        'x-mastra-version': meta?.mastraVersion,
+      },
+    },
+    body: { envVars: meta?.envVars },
   });
-  if (!createResp.ok) {
-    const body = (await createResp.json().catch(() => ({}))) as { detail?: string };
-    throwApiError('Deploy failed', createResp.status, body.detail);
-  }
-  const { deploy } = (await createResp.json()) as {
-    deploy: { id: string; status: string; uploadUrl: string };
-  };
 
-  if (deploy.uploadUrl.startsWith('file://')) {
-    // Local FS artifact store — write zip directly to disk
-    const { writeFile } = await import('node:fs/promises');
-    const { fileURLToPath } = await import('node:url');
-    await writeFile(fileURLToPath(deploy.uploadUrl), Buffer.from(zipBuffer));
-  } else {
-    // GCS flow — upload zip directly to GCS via signed URL
-    const uploadResp = await fetch(deploy.uploadUrl, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/zip' },
-      body: new Uint8Array(zipBuffer),
-    });
-    if (!uploadResp.ok) {
-      throw new Error(`Artifact upload failed: ${uploadResp.status} ${uploadResp.statusText}`);
+  if (error) {
+    throwApiError('Deploy failed', response.status, error.detail);
+  }
+
+  const { id, uploadUrl } = data.deploy;
+
+  if (!uploadUrl) {
+    throw new Error('No upload URL returned');
+  }
+
+  // Best-effort cancel helper — used to clean up orphaned deploys on failure
+  async function cancelDeploy(deployClient: ReturnType<typeof createApiClient>) {
+    try {
+      console.warn(`Cancelling deploy ${id}...`);
+      const { error: cancelError, response: cancelResponse } = await deployClient.POST(
+        '/v1/studio/deploys/{id}/cancel',
+        {
+          params: { path: { id } },
+        },
+      );
+      if (cancelError) {
+        console.warn(
+          `Warning: failed to cancel deploy ${id} (${cancelResponse.status}). It may remain in a queued state.`,
+        );
+      }
+    } catch {
+      console.warn(`Warning: failed to cancel deploy ${id}. It may remain in a queued state.`);
     }
   }
 
-  // Notify API that upload is complete → triggers deploy pipeline
-  const completeResp = await platformFetch(
-    `${MASTRA_PLATFORM_API_URL}/v1/studio/deploys/${deploy.id}/upload-complete`,
-    {
-      method: 'POST',
-      headers: authHeaders(token, orgId),
-    },
-  );
-  if (!completeResp.ok) {
-    const body = (await completeResp.json().catch(() => ({}))) as { detail?: string };
-    throwApiError('Upload confirmation failed', completeResp.status, body.detail);
+  // Step 2: Upload artifact to the signed URL
+  try {
+    if (uploadUrl.startsWith('file://')) {
+      const { writeFile } = await import('node:fs/promises');
+      const { fileURLToPath } = await import('node:url');
+      await writeFile(fileURLToPath(uploadUrl), Buffer.from(zipBuffer));
+    } else {
+      const uploadResp = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/zip' },
+        body: new Uint8Array(zipBuffer),
+      });
+      if (!uploadResp.ok) {
+        throw new Error(`Artifact upload failed: ${uploadResp.status} ${uploadResp.statusText}`);
+      }
+    }
+  } catch (uploadError) {
+    await cancelDeploy(client);
+    throw uploadError;
   }
 
-  return deploy;
+  // Step 3: Notify API that upload is complete → triggers build pipeline
+  // Retry up to 3 times (4 total attempts) with exponential backoff for transient failures.
+  const maxRetries = 3;
+  let lastError: Error | undefined;
+  let currentClient = client;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let completeError: unknown;
+    let status: number | undefined;
+
+    try {
+      const result = await currentClient.POST('/v1/studio/deploys/{id}/upload-complete', {
+        params: { path: { id } },
+      });
+      if (!result.error) {
+        return { id, status: 'queued' };
+      }
+      completeError = result.error;
+      status = result.response.status;
+    } catch (networkError) {
+      // Network-level failure (ECONNRESET, ETIMEDOUT, fetch failed, etc.)
+      completeError = networkError;
+    }
+
+    // Determine if we should retry
+    const isRetryableStatus = status !== undefined && (status >= 500 || status === 401);
+    const isRetryableNetwork = isRetryablePollingError(completeError);
+    const isRetryable = isRetryableStatus || isRetryableNetwork;
+
+    if (!isRetryable || attempt === maxRetries) {
+      const detail = status ? `${status}` : completeError instanceof Error ? completeError.message : 'unknown error';
+      lastError = new Error(`Upload confirmation failed: ${detail}`);
+      break;
+    }
+
+    const delay = 1000 * Math.pow(2, attempt);
+    const detail = status ? `${status}` : completeError instanceof Error ? completeError.message : 'network error';
+    console.warn(
+      `Upload confirmation failed (${detail}), retrying in ${delay / 1000}s... (attempt ${attempt + 1}/${maxRetries})`,
+    );
+
+    // On 401, refresh the token before retrying
+    if (status === 401) {
+      try {
+        const freshToken = await getToken();
+        currentClient = createApiClient(freshToken, orgId);
+      } catch (refreshError) {
+        lastError = refreshError instanceof Error ? refreshError : new Error('Failed to refresh authentication token');
+        break;
+      }
+    }
+
+    // Exponential backoff: 1s, 2s, 4s
+    await new Promise(r => setTimeout(r, delay));
+  }
+
+  // All retries exhausted — cancel the orphaned deploy and throw
+  await cancelDeploy(currentClient);
+  throw lastError ?? new Error('Upload confirmation failed');
 }
 
 async function streamDeployLogs(deployId: string, token: string, orgId: string, signal: AbortSignal): Promise<void> {

--- a/packages/cli/src/utils/deploy-upload.test.ts
+++ b/packages/cli/src/utils/deploy-upload.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../commands/auth/client.js', () => ({
+  createApiClient: vi.fn(token => ({ _token: token })),
+}));
+
+vi.mock('../commands/auth/credentials.js', () => ({
+  getToken: vi.fn().mockResolvedValue('refreshed-token'),
+}));
+
+import { createApiClient } from '../commands/auth/client.js';
+import { getToken } from '../commands/auth/credentials.js';
+import { bestEffortCancel, confirmUploadWithRetry } from './deploy-upload.js';
+
+const ok = () => Promise.resolve({ error: undefined, response: { status: 200 } });
+const fail = (status: number) => Promise.resolve({ error: { detail: 'err' }, response: { status } });
+const networkError = () =>
+  Promise.reject(Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNRESET' } }));
+
+beforeEach(() => vi.resetAllMocks());
+afterEach(() => vi.useRealTimers());
+
+// ─── bestEffortCancel ──────────────────────────────────────────────
+
+describe('bestEffortCancel', () => {
+  it('calls cancel and does not throw on success', async () => {
+    const postCancel = vi.fn().mockImplementation(ok);
+    await bestEffortCancel({ postCancel, client: {} as any, deployId: 'd1' });
+    expect(postCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows API-level cancel failure', async () => {
+    const postCancel = vi.fn().mockImplementation(() => fail(404));
+    await bestEffortCancel({ postCancel, client: {} as any, deployId: 'd1' });
+    // no throw
+  });
+
+  it('swallows network exception on cancel', async () => {
+    const postCancel = vi.fn().mockImplementation(networkError);
+    await bestEffortCancel({ postCancel, client: {} as any, deployId: 'd1' });
+    // no throw
+  });
+});
+
+// ─── confirmUploadWithRetry ────────────────────────────────────────
+
+describe('confirmUploadWithRetry', () => {
+  const cancelDeploy = vi.fn();
+  const baseOpts = () => ({
+    cancelDeploy,
+    client: { _token: 'initial' } as any,
+    orgId: 'org-1',
+    maxRetries: 2, // keep tests fast: 3 total attempts
+  });
+
+  it('returns immediately on first-attempt success', async () => {
+    const post = vi.fn().mockImplementation(ok);
+    await confirmUploadWithRetry({ ...baseOpts(), postUploadComplete: post });
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(cancelDeploy).not.toHaveBeenCalled();
+  });
+
+  it('retries 5xx then succeeds', async () => {
+    vi.useFakeTimers();
+    const post = vi
+      .fn()
+      .mockImplementationOnce(() => fail(502))
+      .mockImplementationOnce(ok);
+
+    const p = confirmUploadWithRetry({ ...baseOpts(), postUploadComplete: post });
+    await vi.advanceTimersByTimeAsync(1000);
+    await p;
+
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(cancelDeploy).not.toHaveBeenCalled();
+  });
+
+  it('retries network errors then succeeds', async () => {
+    vi.useFakeTimers();
+    const post = vi.fn().mockImplementationOnce(networkError).mockImplementationOnce(ok);
+
+    const p = confirmUploadWithRetry({ ...baseOpts(), postUploadComplete: post });
+    await vi.advanceTimersByTimeAsync(1000);
+    await p;
+
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes token on 401 before retry', async () => {
+    vi.useFakeTimers();
+    vi.mocked(getToken).mockResolvedValue('fresh-tok');
+    vi.mocked(createApiClient).mockReturnValue({ _token: 'fresh' } as any);
+
+    const post = vi
+      .fn()
+      .mockImplementationOnce(() => fail(401))
+      .mockImplementationOnce(ok);
+
+    const p = confirmUploadWithRetry({ ...baseOpts(), postUploadComplete: post });
+    // Flush microtasks so the first attempt completes before advancing timers
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+    await p;
+
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(createApiClient).toHaveBeenCalledWith('fresh-tok', 'org-1');
+    // Second call uses refreshed client
+    expect(post.mock.calls[1]![0]).toEqual({ _token: 'fresh' });
+  });
+
+  it('does NOT retry 4xx other than 401', async () => {
+    const post = vi.fn().mockImplementation(() => fail(404));
+
+    await expect(confirmUploadWithRetry({ ...baseOpts(), postUploadComplete: post })).rejects.toThrow(
+      'Upload confirmation failed: 404',
+    );
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(cancelDeploy).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels deploy and throws after retries exhausted', async () => {
+    const post = vi.fn().mockImplementation(() => fail(500));
+
+    await expect(confirmUploadWithRetry({ ...baseOpts(), maxRetries: 0, postUploadComplete: post })).rejects.toThrow(
+      'Upload confirmation failed: 500',
+    );
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(cancelDeploy).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels and throws when token refresh fails', async () => {
+    vi.mocked(getToken).mockRejectedValue(new Error('no refresh token'));
+    const post = vi.fn().mockImplementation(() => fail(401));
+
+    await expect(confirmUploadWithRetry({ ...baseOpts(), maxRetries: 1, postUploadComplete: post })).rejects.toThrow(
+      'no refresh token',
+    );
+
+    expect(cancelDeploy).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/utils/deploy-upload.ts
+++ b/packages/cli/src/utils/deploy-upload.ts
@@ -1,0 +1,97 @@
+import { createApiClient } from '../commands/auth/client.js';
+import { getToken } from '../commands/auth/credentials.js';
+import { isRetryablePollingError } from './polling.js';
+
+type ApiClient = ReturnType<typeof createApiClient>;
+
+/**
+ * Best-effort cancel of a deploy. Logs warnings on failure but never throws.
+ */
+export async function bestEffortCancel(opts: {
+  postCancel: (client: ApiClient) => Promise<{ error?: unknown; response: { status: number } }>;
+  client: ApiClient;
+  deployId: string;
+}): Promise<void> {
+  try {
+    console.warn(`Cancelling deploy ${opts.deployId}...`);
+    const { error, response } = await opts.postCancel(opts.client);
+    if (error) {
+      console.warn(
+        `Warning: failed to cancel deploy ${opts.deployId} (${response.status}). It may remain in a queued state.`,
+      );
+    }
+  } catch {
+    console.warn(`Warning: failed to cancel deploy ${opts.deployId}. It may remain in a queued state.`);
+  }
+}
+
+/**
+ * Retry the upload-complete POST with exponential backoff.
+ * On exhaustion, cancels the orphaned deploy and throws.
+ *
+ * Retries on: 5xx, 401 (with token refresh), and transient network errors.
+ * Does NOT retry other 4xx (e.g. 404 = deploy not found).
+ */
+export async function confirmUploadWithRetry(opts: {
+  postUploadComplete: (client: ApiClient) => Promise<{ error?: unknown; response: { status: number } }>;
+  cancelDeploy: (client: ApiClient) => Promise<void>;
+  client: ApiClient;
+  orgId: string;
+  maxRetries?: number;
+}): Promise<void> {
+  const { postUploadComplete, cancelDeploy, orgId, maxRetries = 3 } = opts;
+  let lastError: Error | undefined;
+  let currentClient = opts.client;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let completeError: unknown;
+    let status: number | undefined;
+
+    try {
+      const result = await postUploadComplete(currentClient);
+      if (!result.error) {
+        return; // Success
+      }
+      completeError = result.error;
+      status = result.response.status;
+    } catch (networkError) {
+      // Network-level failure (ECONNRESET, ETIMEDOUT, fetch failed, etc.)
+      completeError = networkError;
+    }
+
+    // Determine if we should retry
+    const isRetryableStatus = status !== undefined && (status >= 500 || status === 401);
+    const isRetryableNetwork = isRetryablePollingError(completeError);
+    const isRetryable = isRetryableStatus || isRetryableNetwork;
+
+    if (!isRetryable || attempt === maxRetries) {
+      const detail = status ? `${status}` : completeError instanceof Error ? completeError.message : 'unknown error';
+      lastError = new Error(`Upload confirmation failed: ${detail}`);
+      break;
+    }
+
+    const delay = 1000 * Math.pow(2, attempt);
+    const detail = status ? `${status}` : completeError instanceof Error ? completeError.message : 'network error';
+    console.warn(
+      `Upload confirmation failed (${detail}), retrying in ${delay / 1000}s... (attempt ${attempt + 1}/${maxRetries})`,
+    );
+
+    // On 401, refresh the token before retrying
+    if (status === 401) {
+      try {
+        const freshToken = await getToken();
+        currentClient = createApiClient(freshToken, orgId);
+      } catch (refreshError) {
+        lastError = refreshError instanceof Error ? refreshError : new Error('Failed to refresh authentication token');
+        break;
+      }
+    }
+
+    // Exponential backoff: 1s, 2s, 4s
+    await new Promise(r => setTimeout(r, delay));
+  }
+
+  // All retries exhausted — cancel the orphaned deploy and throw
+  await cancelDeploy(currentClient);
+  throw lastError ?? new Error('Upload confirmation failed');
+}


### PR DESCRIPTION
Server deploys could get permanently stuck in 'queued' status if the upload-complete call (Step 3 of `uploadServerDeploy`) hit a transient failure — network error, 5xx, or expired token. There was no retry and no cleanup, so the deploy just sat there forever. A customer hit this twice in a row.

Now the CLI retries upload-complete up to 3 times with exponential backoff (1s, 2s, 4s), refreshes the auth token on 401, and cancels the orphaned deploy if retries are exhausted or if artifact upload fails. Also added console.warn messages so the user can actually see what's happening during retries and cleanup instead of staring at a silent spinner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If the final step of uploading a deploy fails (network hiccup or expired login), the deployment could stay stuck. This PR makes the CLI retry the confirmation step, refresh the login if needed, and cancel failed/orphaned deploys so nothing remains stuck.

## Changes

### Changeset
- Adds a patch changeset describing a fix for deploys getting stuck in `queued` when upload confirmation fails. Notes retries, user-visible retry/cleanup logs, and automatic cancellation of orphaned deploys.

### CLI Platform API (server & studio)
- uploadServerDeploy / uploadDeploy improvements:
  - Retry upload-complete on transient failures:
    - Retries up to 3 times (4 attempts total) with exponential backoff delays of 1s, 2s, and 4s.
    - Treats HTTP 5xx, 401, and network-level polling/connection errors as retryable.
  - Refresh authentication on 401:
    - Calls getToken() and recreates the typed API client before retrying; if token refresh fails, cleanup is attempted and the error is surfaced.
  - Handle network-level errors:
    - Uses isRetryablePollingError to include connection-level failures (ECONNRESET, ETIMEDOUT, ECONNREFUSED, ENOTFOUND, fetch failures) in retryable handling.
  - Cancel orphaned/failing deploys:
    - Adds a best-effort cancelDeploy helper that POSTs /v1/{server,studio}/deploys/{id}/cancel and logs warnings if cancellation fails.
    - Attempts cancellation when artifact upload fails, when confirmation retries are exhausted, or on non-retryable failures; cancellation failures are logged and do not mask the original error.
  - User-visible logging:
    - Replaces a silent spinner with console.warn messages to surface retry attempts, token refresh attempts, and cleanup actions to users.
  - API client migration:
    - Replaces raw platformFetch usage with a typed createApiClient() for create-deploy and upload-complete calls; tests updated to mock the typed client.

### Types / API contract updates
- Regenerated platform-api.d.ts with multiple request/response typing updates:
  - Added cancel endpoints for studio deploys and extended deploy status enums to include 'cancelled'.
  - Adjusted pause/restart response contracts and added optional help_url to many error payloads.
  - Added/updated several requestBody schemas (e.g., studio deploy creation now accepts optional envVars).

No exported/public function signatures were intentionally changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->