### PR TITLE
docs(cli): add `mastra server env pull` to CLI reference

### DIFF
--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -371,6 +371,16 @@ Imports variables from a file (for example a `.env` file) and merges them into t
 mastra server env import <file>
 ```
 
+### `mastra server env pull`
+
+Downloads environment variables from the linked project and writes them to a local file. This is the inverse of `mastra server env import`. Defaults to `.env` when no file is specified.
+
+```bash
+mastra server env pull [file]
+```
+
+All values are double-quoted and escaped for safe shell sourcing. Keys that are not valid shell identifiers are skipped.
+
 ## `mastra auth`
 
 Manages authentication for Mastra platform. Credentials are stored in `~/.mastra/credentials.json`. You can also set the `MASTRA_API_TOKEN` environment variable as an alternative to interactive login.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -373,13 +373,26 @@ mastra server env import <file>
 
 ### `mastra server env pull`
 
-Downloads environment variables from the linked project and writes them to a local file. This is the inverse of `mastra server env import`. Defaults to `.env` when no file is specified.
+Downloads environment variables from the linked project and writes them to a local file. This is the inverse of [`mastra server env import`](#mastra-server-env-import).
 
 ```bash
 mastra server env pull [file]
 ```
 
-All values are double-quoted and escaped for safe shell sourcing. Keys that are not valid shell identifiers are skipped.
+The file defaults to `.env` when no argument is given. All values are double-quoted and escaped for safe shell sourcing. Keys that aren't valid shell identifiers are skipped. The output file is created with restrictive permissions (`0600`) since it contains secrets.
+
+#### `--project`
+
+Project ID or slug. Overrides the linked project when `MASTRA_PROJECT_ID` isn't set.
+
+#### CI usage
+
+In a continuous-integration pipeline, authenticate with `MASTRA_API_TOKEN` and pull the environment before running your app:
+
+```bash
+export MASTRA_API_TOKEN="..."
+mastra server env pull .env.production --project my-project
+```
 
 ## `mastra auth`
 


### PR DESCRIPTION
Follow-up to #15355. Adds the `mastra server env pull [file]` subcommand to the CLI reference page alongside the existing `list`, `set`, `unset`, and `import` docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds docs for a new CLI command, mastra server env pull, which downloads environment variables from a remote project and writes them into a local file (like .env) so you can use them locally or in CI.

## Changes

File modified: docs/src/content/en/reference/cli/mastra.mdx

- Added documentation for the new subcommand `mastra server env pull [file]`.
- Documents behavior and defaults:
  - Writes environment variables to a local file (default: `.env`).
  - Values are double-quoted and shell-escaped for sourcing.
  - Keys that are not valid shell identifiers are skipped.
  - Output file is created with restrictive permissions (0600) because it may contain secrets.
- Documents flags and overrides:
  - `--project` flag to override the linked project when `MASTRA_PROJECT_ID` is not set.
- Includes required permissions note and a CI example:
  - Shows authenticating via `MASTRA_API_TOKEN` in CI, then running `mastra server env pull` to produce e.g. `.env.production`.
- Positioned as the inverse of the existing `mastra server env import` command.

Lines changed: +589 insertions

Related issue: Follow-up to PR #15355
<!-- end of auto-generated comment: release notes by coderabbit.ai -->