### PR TITLE
chore: group security vulnerability updates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,8 @@
   },
   "schedule": ["before 6am on monday"],
   "vulnerabilityAlerts": {
+    "groupName": "security updates",
+    "labels": ["automation", "security"],
     "schedule": []
   },
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
Groups all Renovate vulnerability alert PRs into a single PR instead of one per package.

Adds `groupName` and `labels` to the existing `vulnerabilityAlerts` config so all security updates land in one branch/PR labeled `security`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

When the code finds security problems in packages you use, Renovate (an automated tool) normally creates a separate request for each one. This PR changes it so all security fixes get bundled together into one request instead, making it easier to review and manage them all at once.

## Changes

**renovate.json** — Updated the `vulnerabilityAlerts` configuration to group all security vulnerability updates into a single PR:

- Added `groupName: "security updates"` — Groups all security update PRs under one branch/PR
- Added `labels: ["automation", "security"]` — Tags these PRs with automation and security labels for better filtering and organization

The `schedule: []` (empty array) and `osvVulnerabilityAlerts: true` settings remain unchanged, allowing security vulnerabilities to be processed on demand without waiting for the regular dependency update schedule.

## Impact

This change improves the dependency management workflow by consolidating all security-related package updates into a single, labeled pull request rather than creating separate PRs for each vulnerable package. This reduces notification noise and simplifies the review process for security updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->