### PR TITLE
fix(cli): resolve actual installed mastra version instead of raw specifier

### DIFF
--- a/.changeset/warm-monkeys-know.md
+++ b/.changeset/warm-monkeys-know.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed `mastra studio deploy` reporting raw version specifiers (e.g. `catalog:`, `workspace:*`) instead of the actual installed version. The deploy command now resolves the real semver version from node_modules.

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -1,4 +1,67 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+describe('getMastraVersion', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mastra-version-test-'));
+    // Write a package.json so createRequire has a valid base
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ name: 'test' }));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function loadGetMastraVersion() {
+    // Dynamic import to get the real (unmocked) function
+    const mod = await import('./deploy.js');
+    return mod.getMastraVersion;
+  }
+
+  it('resolves the installed version of mastra from node_modules', async () => {
+    const getMastraVersion = await loadGetMastraVersion();
+
+    // Create a fake node_modules/mastra/package.json
+    const mastraDir = join(tmpDir, 'node_modules', 'mastra');
+    mkdirSync(mastraDir, { recursive: true });
+    writeFileSync(join(mastraDir, 'package.json'), JSON.stringify({ name: 'mastra', version: '1.2.3' }));
+
+    const result = getMastraVersion(tmpDir);
+    expect(result).toBe('1.2.3');
+  });
+
+  it('returns null when mastra package.json has no version field', async () => {
+    const getMastraVersion = await loadGetMastraVersion();
+
+    // Create a mastra package without a version field
+    const mastraDir = join(tmpDir, 'node_modules', 'mastra');
+    mkdirSync(mastraDir, { recursive: true });
+    writeFileSync(join(mastraDir, 'package.json'), JSON.stringify({ name: 'mastra' }));
+
+    const result = getMastraVersion(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it('returns the version even when package.json has a catalog: specifier', async () => {
+    const getMastraVersion = await loadGetMastraVersion();
+
+    // Simulate a project that has catalog: in package.json but real version in node_modules
+    writeFileSync(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'my-app', dependencies: { mastra: 'catalog:' } }),
+    );
+    const mastraDir = join(tmpDir, 'node_modules', 'mastra');
+    mkdirSync(mastraDir, { recursive: true });
+    writeFileSync(join(mastraDir, 'package.json'), JSON.stringify({ name: 'mastra', version: '0.9.0' }));
+
+    const result = getMastraVersion(tmpDir);
+    expect(result).toBe('0.9.0');
+  });
+});
 
 // Mock all external dependencies
 vi.mock('@clack/prompts', () => ({

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { createWriteStream, readFileSync } from 'node:fs';
 import { mkdir, rm, stat, access, readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import * as p from '@clack/prompts';
@@ -46,12 +47,14 @@ function getGitBranch(projectDir: string): string | null {
   }
 }
 
-function getMastraVersion(projectDir: string): string | null {
+export function getMastraVersion(projectDir: string): string | null {
   try {
-    const pkgPath = join(projectDir, 'package.json');
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-    return deps['mastra'] ?? null;
+    // Resolve the actual installed version from node_modules rather than the raw
+    // specifier in package.json (which may be "catalog:", "workspace:*", etc.)
+    const req = createRequire(join(projectDir, 'package.json'));
+    const pkgJsonPath = req.resolve('mastra/package.json');
+    const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+    return pkgJson.version ?? null;
   } catch {
     return null;
   }


### PR DESCRIPTION
\`getMastraVersion()\` in the studio deploy command was reading the version specifier directly from \`package.json\`, so monorepos using pnpm catalogs would see \`catalog:\` as their Mastra version in the deploy UI and in the \`x-mastra-version\` header.

Now it uses \`createRequire\` to resolve the actual installed \`mastra/package.json\` from \`node_modules\` and reads the real semver version from there.

Added tests for version resolution, missing version field, and the \`catalog:\` specifier case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The deploy command was showing weird version numbers like "catalog:" instead of real version numbers. This fix makes it read the actual installed version of the mastra package instead of the raw version text from the configuration file.

## Changes

### Implementation
- **Modified `packages/cli/src/commands/studio/deploy.ts`:**
  - Updated `getMastraVersion()` to resolve the actual installed `mastra` package version from `node_modules` instead of reading the raw specifier from the project's `package.json`
  - Added `createRequire` import for module resolution
  - Now reads the `version` field from `mastra/package.json` in `node_modules`, returning `null` if unavailable
  - Exported the function to make it publicly accessible for testing

### Tests
- **Added `packages/cli/src/commands/studio/deploy.test.ts`:**
  - Three new test cases for `getMastraVersion()` behavior:
    1. Returns the actual version when `node_modules/mastra/package.json` contains a `version` field
    2. Returns `null` when the `version` field is missing
    3. Returns the installed version from `node_modules` even when the project `package.json` specifies `catalog:` as the version specifier
  - Includes per-test filesystem setup/teardown using temporary directories

### Documentation
- **Added changeset** (`.changeset/warm-monkeys-know.md`) documenting the fix for the `mastra` patch release

## Impact
This ensures the deploy UI and `x-mastra-version` header display the correct semver version instead of pnpm workspace specifiers like `catalog:` or `workspace:*`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->