### PR TITLE
fix(deployer-cloudflare): pass env to mastra factory in generated entry

### DIFF
--- a/.changeset/cf-deployer-env-factory.md
+++ b/.changeset/cf-deployer-env-factory.md
@@ -1,0 +1,23 @@
+---
+"@mastra/deployer-cloudflare": patch
+---
+
+Pass `env` to the user-exported `mastra` factory in the generated Worker entry, and let users opt into an explicit `(env) => new Mastra(...)` factory pattern.
+
+Previously, the Cloudflare deployer's auto-generated entry called `mastra()` without arguments, which meant user code had no way to access Cloudflare runtime bindings (`env.D1Database`, `env.MY_KV`, etc.) when constructing storage adapters. Users were forced to work around this with global state and request middleware.
+
+Now two patterns are supported:
+
+```ts
+// Pattern A (existing, unchanged) — auto-wrapped to () => new Mastra(...)
+export const mastra = new Mastra({ /* ... */ });
+
+// Pattern B (new) — explicit factory receives env
+export const mastra = (env) =>
+  new Mastra({
+    storage: new D1Store({ binding: env.D1Database }),
+    /* ... */
+  });
+```
+
+Backward compatible: the auto-wrapped form continues to work and silently ignores the new env argument.

--- a/deployers/cloudflare/src/babel/mastra-instance-wrapper.ts
+++ b/deployers/cloudflare/src/babel/mastra-instance-wrapper.ts
@@ -6,21 +6,26 @@ import * as babel from '@babel/core';
  *
  * This plugin:
  * 1. Identifies named exports of the 'mastra' variable
- * 2. Checks if the export is a new instance of the 'Mastra' class
- * 3. Wraps the Mastra instantiation in an arrow function to ensure proper initialization
- *    in the Cloudflare Workers environment
+ * 2. If the export is `new Mastra(...)`, wraps it in an arrow function so that
+ *    instantiation is deferred until request time (Workers bindings are available)
+ * 3. If the export is already a function (arrow or function expression), it is
+ *    left untouched — this lets users write a factory that takes `env` directly:
+ *      `export const mastra = (env) => new Mastra({ storage: new D1Store({ binding: env.D1Database }), ... })`
  *
- * The transformation ensures the Mastra instance is properly scoped and initialized
- * for each request in the Cloudflare Workers environment.
+ * The generated worker entry calls `mastra(env)` so both forms work:
+ * - Auto-wrapped `() => new Mastra(...)` accepts and ignores the env arg
+ * - Explicit factory `(env) => new Mastra(...)` receives the bindings
  *
  * @returns {PluginObj} A Babel plugin object with a visitor that performs the transformation
  *
  * @example
- * // Before transformation:
+ * // Pattern A (existing) — wrapper transforms to () => new Mastra()
  * export const mastra = new Mastra();
  *
- * // After transformation:
- * export const mastra = () => new Mastra();
+ * // Pattern B (new) — explicit factory, wrapper leaves it alone
+ * export const mastra = (env) => new Mastra({
+ *   storage: new D1Store({ binding: env.D1Database }),
+ * });
  */
 export function mastraInstanceWrapper(): PluginObj {
   const exportName = 'mastra';
@@ -33,8 +38,18 @@ export function mastraInstanceWrapper(): PluginObj {
       ExportNamedDeclaration(path) {
         if (t.isVariableDeclaration(path.node?.declaration)) {
           for (const declaration of path.node.declaration.declarations) {
+            if (!t.isIdentifier(declaration?.id, { name: exportName })) continue;
+
+            // Already a factory (arrow/function expression) — user opted into the
+            // env-aware form, leave it unchanged.
             if (
-              t.isIdentifier(declaration?.id, { name: exportName }) &&
+              t.isArrowFunctionExpression(declaration?.init) ||
+              t.isFunctionExpression(declaration?.init)
+            ) {
+              break;
+            }
+
+            if (
               t.isNewExpression(declaration?.init) &&
               t.isIdentifier(declaration.init.callee, { name: className })
             ) {

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -225,7 +225,9 @@ export default stream;
         const {createHonoServer, getToolExports} = await import('#server');
         // Pass env so user factories can access Workers bindings (D1, KV, R2, etc.).
         // Backward compatible: factories created by the auto-wrap simply ignore the arg.
-        const _mastra = mastra(env);
+        // Awaited so users can also export an async factory if their setup needs it
+        // (await on a non-Promise simply resolves to the value).
+        const _mastra = await mastra(env);
 
         if (_mastra.getStorage()) {
           _mastra.__registerInternalWorkflow(scoreTracesWorkflow);

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -223,7 +223,9 @@ export default stream;
         const { mastra } = await import('#mastra');
         const { tools } = await import('#tools');
         const {createHonoServer, getToolExports} = await import('#server');
-        const _mastra = mastra();
+        // Pass env so user factories can access Workers bindings (D1, KV, R2, etc.).
+        // Backward compatible: factories created by the auto-wrap simply ignore the arg.
+        const _mastra = mastra(env);
 
         if (_mastra.getStorage()) {
           _mastra.__registerInternalWorkflow(scoreTracesWorkflow);

--- a/deployers/cloudflare/src/plugins/__fixtures__/factory-function-expression.js
+++ b/deployers/cloudflare/src/plugins/__fixtures__/factory-function-expression.js
@@ -1,0 +1,8 @@
+import { Mastra } from '@mastra/core/mastra';
+import { D1Store } from '@mastra/cloudflare-d1';
+
+export const mastra = function (env) {
+  return new Mastra({
+    storage: new D1Store({ binding: env.D1Database }),
+  });
+};

--- a/deployers/cloudflare/src/plugins/__fixtures__/factory.js
+++ b/deployers/cloudflare/src/plugins/__fixtures__/factory.js
@@ -1,0 +1,7 @@
+import { Mastra } from '@mastra/core/mastra';
+import { D1Store } from '@mastra/cloudflare-d1';
+
+export const mastra = env =>
+  new Mastra({
+    storage: new D1Store({ binding: env.D1Database }),
+  });

--- a/deployers/cloudflare/src/plugins/__snapshots__/mastra-instance-wrapper.test.ts.snap
+++ b/deployers/cloudflare/src/plugins/__snapshots__/mastra-instance-wrapper.test.ts.snap
@@ -59,3 +59,19 @@ const mastra = env => new Mastra({
 export { mastra };
 "
 `;
+
+exports[`Wrap Mastra instance > should wrap Mastra instance in ./__fixtures__/factory-function-expression.js 1`] = `
+"import { Mastra } from '@mastra/core/mastra';
+import { D1Store } from '@mastra/cloudflare-d1';
+
+const mastra = function (env) {
+  return new Mastra({
+    storage: new D1Store({
+      binding: env.D1Database
+    })
+  });
+};
+
+export { mastra };
+"
+`;

--- a/deployers/cloudflare/src/plugins/__snapshots__/mastra-instance-wrapper.test.ts.snap
+++ b/deployers/cloudflare/src/plugins/__snapshots__/mastra-instance-wrapper.test.ts.snap
@@ -45,3 +45,17 @@ const mastra = () => new Mastra();
 export { mastra };
 "
 `;
+
+exports[`Wrap Mastra instance > should wrap Mastra instance in ./__fixtures__/factory.js 1`] = `
+"import { Mastra } from '@mastra/core/mastra';
+import { D1Store } from '@mastra/cloudflare-d1';
+
+const mastra = env => new Mastra({
+  storage: new D1Store({
+    binding: env.D1Database
+  })
+});
+
+export { mastra };
+"
+`;

--- a/deployers/cloudflare/src/plugins/mastra-instance-wrapper.test.ts
+++ b/deployers/cloudflare/src/plugins/mastra-instance-wrapper.test.ts
@@ -8,7 +8,12 @@ import { mastraInstanceWrapper } from '../plugins/mastra-instance-wrapper';
 describe('Wrap Mastra instance', () => {
   const _dirname = dirname(fileURLToPath(import.meta.url));
 
-  it.for([['./__fixtures__/empty-mastra.js'], ['./__fixtures__/basic.js'], ['./__fixtures__/factory.js']])(
+  it.for([
+    ['./__fixtures__/empty-mastra.js'],
+    ['./__fixtures__/basic.js'],
+    ['./__fixtures__/factory.js'],
+    ['./__fixtures__/factory-function-expression.js'],
+  ])(
     'should wrap Mastra instance in %s',
     async ([fileName]) => {
       const file = join(_dirname, fileName as string);

--- a/deployers/cloudflare/src/plugins/mastra-instance-wrapper.test.ts
+++ b/deployers/cloudflare/src/plugins/mastra-instance-wrapper.test.ts
@@ -8,7 +8,7 @@ import { mastraInstanceWrapper } from '../plugins/mastra-instance-wrapper';
 describe('Wrap Mastra instance', () => {
   const _dirname = dirname(fileURLToPath(import.meta.url));
 
-  it.for([['./__fixtures__/empty-mastra.js'], ['./__fixtures__/basic.js']])(
+  it.for([['./__fixtures__/empty-mastra.js'], ['./__fixtures__/basic.js'], ['./__fixtures__/factory.js']])(
     'should wrap Mastra instance in %s',
     async ([fileName]) => {
       const file = join(_dirname, fileName as string);


### PR DESCRIPTION
## Description

Fixes a gap between the [Cloudflare D1 storage docs](https://mastra.ai/reference/storage/cloudflare-d1) and the actual behavior of `mastra build`.

The docs show this pattern:

```ts
function createMastra(env: Env) {
  return new Mastra({
    storage: new D1Store({ binding: env.D1Database }),
    /* ... */
  })
}
```

But the CF deployer's auto-generated worker entry calls the user-exported `mastra` factory **with no arguments**, so `env` is never available to the factory body. The auto-wrap (`export const mastra = new Mastra({...})` → `export const mastra = () => new Mastra({...})`) defers instantiation to request time, but the body still has no way to access Cloudflare runtime bindings.

Result: any storage adapter that needs an `env.*` binding (`D1Store`, KV, R2, …) cannot be used with `mastra build`. Users have to either bypass the deployer entirely or implement an undocumented lazy-binding workaround (queue-backed proxy + middleware that captures `env` and stuffs it into module-level state).

This PR makes two small changes:

**1.** `deployers/cloudflare/src/index.ts` — generated entry now passes `env` to the factory:

```diff
- const _mastra = mastra();
+ const _mastra = mastra(env);
```

**2.** `deployers/cloudflare/src/babel/mastra-instance-wrapper.ts` — the wrapper now skips wrapping when the user's `mastra` export is already an arrow/function expression. This lets users opt into an explicit env-aware factory:

```ts
// Pattern A (existing, unchanged) — wrapper auto-wraps to () => new Mastra(...)
export const mastra = new Mastra({...});

// Pattern B (new) — explicit factory, wrapper leaves it alone, receives env
export const mastra = (env) =>
  new Mastra({
    storage: new D1Store({ binding: env.D1Database }),
    /* ... */
  });
```

Backward compatible: existing `export const mastra = new Mastra(...)` projects continue to work — the auto-wrapped arrow function silently ignores the new `env` argument.

A new fixture (`factory.js`) plus a snapshot assertion confirms the wrapper does not touch already-factored exports. Existing snapshots for `empty-mastra.js` and `basic.js` are unchanged.

Changeset added: `@mastra/deployer-cloudflare`: patch.

## Related Issue(s)

Fixes #15380

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Cloudflare deployer wasn't giving the user's factory function access to Cloudflare's special runtime settings (the `env` object). This PR fixes that by passing `env` to the factory when it's called, so users can now use Cloudflare features like databases. It also makes sure not to accidentally wrap factories that the user already designed to accept `env`.

---

## Changes

### Generated Cloudflare Worker Entry
Modified the generated entry point (`deployers/cloudflare/src/index.ts`) to pass the Worker's `env` bindings to the user's `mastra` factory:
- Changed from: `mastra()`
- Changed to: `await mastra(env)`

This enables factories to access Cloudflare runtime bindings (D1, KV, R2, etc.) during initialization.

### Babel Plugin Update
Updated the Babel wrapper (`deployers/cloudflare/src/babel/mastra-instance-wrapper.ts`) to detect and preserve user-provided factories:
- Detects when the user exports `mastra` as a function expression (arrow function or regular function)
- Skips wrapping in these cases, allowing explicit `export const mastra = (env) => new Mastra(...)` patterns to work unchanged
- Continues to wrap only the `new Mastra(...)` initializer pattern, transforming it to `() => new Mastra(...)`
- Maintains backward compatibility: auto-wrapped factories silently accept the `env` argument even if they don't use it

### Test Fixtures and Coverage
Added new test fixtures to validate both factory patterns:
- `deployers/cloudflare/src/plugins/__fixtures__/factory.js`: User-exported factory function that accepts `env` and uses it to configure D1 storage
- `deployers/cloudflare/src/plugins/__fixtures__/factory-function-expression.js`: Function expression variant of the factory pattern
- Extended test parameterization to verify the wrapper handles all expected patterns correctly

### Documentation
Added a Changeset entry (`@mastra/deployer-cloudflare` patch) documenting the two supported `mastra` export patterns and clarifying that generated worker code now invokes factories with the `env` argument.

---

## Impact

Fixes the mismatch between Cloudflare D1 storage documentation and `mastra build` behavior. Users can now define factories that access Cloudflare runtime bindings:
```javascript
export const mastra = (env) => new Mastra({
  storage: new D1Store({ binding: env.D1Database })
})
```

Maintains backward compatibility with existing projects that export `mastra` as an instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->