### PR TITLE
fix(cli): fix flaky login test in CI

### DIFF
--- a/packages/cli/src/commands/auth/login.test.ts
+++ b/packages/cli/src/commands/auth/login.test.ts
@@ -89,9 +89,12 @@ describe('login() server lifecycle', () => {
     const loginPromise = login();
 
     // Wait for the server to start and openBrowser to be called.
-    await vi.waitFor(() => {
-      extractPort();
-    });
+    await vi.waitFor(
+      () => {
+        extractPort();
+      },
+      { timeout: 5000 },
+    );
     const port = extractPort();
     const state = extractState();
 
@@ -111,9 +114,12 @@ describe('login() server lifecycle', () => {
 
     const loginPromise = login();
 
-    await vi.waitFor(() => {
-      extractPort();
-    });
+    await vi.waitFor(
+      () => {
+        extractPort();
+      },
+      { timeout: 5000 },
+    );
     const port = extractPort();
     const state = extractState();
 
@@ -139,9 +145,12 @@ describe('login() server lifecycle', () => {
 
     const loginPromise = login();
 
-    await vi.waitFor(() => {
-      extractPort();
-    });
+    await vi.waitFor(
+      () => {
+        extractPort();
+      },
+      { timeout: 5000 },
+    );
     const port = extractPort();
     const state = extractState();
 


### PR DESCRIPTION
## Problem

The `login() server lifecycle > returns credentials after a valid callback` test fails intermittently in CI ([example](https://github.com/mastra-ai/mastra/actions/runs/24439013495/job/71399542669)):

```
× returns credentials after a valid callback 1008ms
  → Could not find login URL in execFileSync calls
```

## Root cause

`vi.waitFor` defaults to a 1000ms timeout. The test dynamically imports `credentials.js`, starts an HTTP server, then waits for `execFileSync` to be called (via `openBrowser`). In CI under load, this startup takes longer than 1000ms, so `waitFor` times out before the server is ready.

## Fix

Increase the `vi.waitFor` timeout from the default 1000ms to 5000ms for all three login test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A test that checks if login works was failing randomly in CI because it gave up waiting too quickly for the server to start. The fix makes it wait longer (5 seconds instead of 1 second) before timing out, so the server has enough time to get ready under heavy load.

## Changes

**File: `packages/cli/src/commands/auth/login.test.ts`**

Updated three `login() server lifecycle` test cases to increase the timeout for `vi.waitFor()` calls from the default 1000ms to 5000ms. Each test case's synchronization logic now explicitly waits up to 5 seconds for `execFileSync` to be invoked with a `cli_port` URL, rather than timing out prematurely during server startup under CI load conditions.

## Context

The "login() server lifecycle > returns credentials after a valid callback" test was failing intermittently in CI with the error "Could not find login URL in execFileSync calls". Under high CI load, the server startup and HTTP request handling exceeded the default 1-second timeout threshold, causing the test to fail before the server was ready to accept requests.

Lines changed: +18/-9

<!-- end of auto-generated comment: release notes by coderabbit.ai -->