### PR TITLE
fix(upstash): use msg-idx index instead of scanKeys in saveMessages and updateMessages

### DIFF
--- a/.changeset/jolly-ants-attend.md
+++ b/.changeset/jolly-ants-attend.md
@@ -1,0 +1,5 @@
+---
+'@mastra/upstash': patch
+---
+
+Fixed slow Upstash message saves by using the message index before falling back to scans. Addresses #15386.

--- a/.changeset/jolly-ants-attend.md
+++ b/.changeset/jolly-ants-attend.md
@@ -2,4 +2,4 @@
 '@mastra/upstash': patch
 ---
 
-Fixed slow Upstash message saves by using the message index before falling back to scans. Addresses #15386.
+Fixed slow Upstash message saves by using the message index and treating unindexed messages as new, avoiding full database scans. Also adds index-first lookups to updateMessages. Addresses #15386.

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -485,38 +485,15 @@ export class StoreMemoryUpstash extends MemoryStorage {
     messageIds.forEach(messageId => indexPipeline.get(getMessageIndexKey(messageId)));
     const indexResults = await indexPipeline.exec();
 
-    const unindexedMessageIds: string[] = [];
     messageIds.forEach((messageId, index) => {
       const threadId = indexResults[index] as string | null;
       if (!threadId) {
-        unindexedMessageIds.push(messageId);
+        // No index entry — treat as a new message (skip expensive scan)
         return;
       }
 
       locationsByMessageId.set(messageId, [{ key: getMessageKey(threadId, messageId), threadId }]);
     });
-
-    for (const messageId of unindexedMessageIds) {
-      const keys = await this.#db.scanKeys(getMessageKey('*', messageId));
-      if (keys.length === 0) continue;
-
-      const messagePipeline = this.client.pipeline();
-      keys.forEach(key => messagePipeline.get(key));
-      const existingMessages = await messagePipeline.exec();
-
-      const locations: ExistingMessageLocation[] = [];
-      existingMessages.forEach((existingMessage, index) => {
-        const message = existingMessage as MastraDBMessage | null;
-        const key = keys[index];
-        if (!message?.threadId || !key || message.id !== messageId) return;
-
-        locations.push({ key, threadId: message.threadId });
-      });
-
-      if (locations.length > 0) {
-        locationsByMessageId.set(messageId, locations);
-      }
-    }
 
     return locationsByMessageId;
   }

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -44,6 +44,11 @@ function getMessageIndexKey(messageId: string): string {
   return `msg-idx:${messageId}`;
 }
 
+type ExistingMessageLocation = {
+  key: string;
+  threadId: string;
+};
+
 export class StoreMemoryUpstash extends MemoryStorage {
   private client: Redis;
   #db: UpstashDB;
@@ -330,28 +335,6 @@ export class StoreMemoryUpstash extends MemoryStorage {
     const { messages } = args;
     if (messages.length === 0) return { messages: [] };
 
-    const threadId = messages[0]?.threadId;
-    try {
-      if (!threadId) {
-        throw new Error('Thread ID is required');
-      }
-
-      // Check if thread exists
-      const thread = await this.getThreadById({ threadId });
-      if (!thread) {
-        throw new Error(`Thread ${threadId} not found`);
-      }
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: createStorageErrorId('UPSTASH', 'SAVE_MESSAGES', 'INVALID_ARGS'),
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.USER,
-        },
-        error,
-      );
-    }
-
     // Add an index to each message to maintain order
     const messagesWithIndex = messages.map((message, index) => {
       if (!message.threadId) {
@@ -370,38 +353,63 @@ export class StoreMemoryUpstash extends MemoryStorage {
       };
     });
 
-    // Get current thread data once (all messages belong to same thread)
-    const threadKey = getKey(TABLE_THREADS, { id: threadId });
-    const existingThread = await this.client.get<StorageThreadType>(threadKey);
+    const threadIds = Array.from(new Set(messagesWithIndex.map(message => message.threadId!)));
+    const threadKeysById = new Map(threadIds.map(threadId => [threadId, getKey(TABLE_THREADS, { id: threadId })]));
+    let threadCache = new Map<string, StorageThreadType>();
+
+    try {
+      const threadPipeline = this.client.pipeline();
+      threadIds.forEach(threadId => threadPipeline.get(threadKeysById.get(threadId)!));
+      const threadResults = await threadPipeline.exec();
+
+      const missingThreadIds: string[] = [];
+      threadIds.forEach((threadId, index) => {
+        const thread = threadResults[index] as StorageThreadType | null;
+        if (!thread) {
+          missingThreadIds.push(threadId);
+          return;
+        }
+
+        threadCache.set(threadId, thread);
+      });
+
+      if (missingThreadIds.length > 0) {
+        const missingThreadLabel =
+          missingThreadIds.length === 1 ? `Thread ${missingThreadIds[0]}` : `Threads ${missingThreadIds.join(', ')}`;
+        throw new Error(`${missingThreadLabel} not found`);
+      }
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('UPSTASH', 'SAVE_MESSAGES', 'INVALID_ARGS'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+        },
+        error,
+      );
+    }
 
     try {
       const batchSize = 1000;
       for (let i = 0; i < messagesWithIndex.length; i += batchSize) {
         const batch = messagesWithIndex.slice(i, i + batchSize);
         const pipeline = this.client.pipeline();
+        const existingLocationsByMessageId = await this._findExistingMessageLocations(batch.map(message => message.id));
+        const touchedThreadIds = new Set(batch.map(message => message.threadId!));
+        const now = new Date();
 
         for (const message of batch) {
           const key = getMessageKey(message.threadId!, message.id);
           const createdAtScore = new Date(message.createdAt).getTime();
           const score = message._index !== undefined ? message._index : createdAtScore;
 
-          // Check if this message id exists in another thread
-          const existingKeyPattern = getMessageKey('*', message.id);
-          const keys = await this.#db.scanKeys(existingKeyPattern);
+          const existingLocations = existingLocationsByMessageId.get(message.id) ?? [];
+          for (const location of existingLocations) {
+            if (location.threadId === message.threadId) continue;
 
-          if (keys.length > 0) {
-            const pipeline2 = this.client.pipeline();
-            keys.forEach(key => pipeline2.get(key));
-            const results = await pipeline2.exec();
-            const existingMessages = results.filter((msg): msg is MastraDBMessage => msg !== null) as MastraDBMessage[];
-            for (const existingMessage of existingMessages) {
-              const existingMessageKey = getMessageKey(existingMessage.threadId!, existingMessage.id);
-              if (existingMessage && existingMessage.threadId !== message.threadId) {
-                pipeline.del(existingMessageKey);
-                // Remove from old thread's sorted set
-                pipeline.zrem(getThreadMessagesKey(existingMessage.threadId!), existingMessage.id);
-              }
-            }
+            touchedThreadIds.add(location.threadId);
+            pipeline.del(location.key);
+            pipeline.zrem(getThreadMessagesKey(location.threadId), message.id);
           }
 
           // Store the message data
@@ -417,13 +425,34 @@ export class StoreMemoryUpstash extends MemoryStorage {
           });
         }
 
-        // Update the thread's updatedAt field (only in the first batch)
-        if (i === 0 && existingThread) {
+        const uncachedThreadIds = Array.from(touchedThreadIds).filter(threadId => !threadCache.has(threadId));
+        if (uncachedThreadIds.length > 0) {
+          const missingThreadPipeline = this.client.pipeline();
+          uncachedThreadIds.forEach(threadId => {
+            const threadKey = threadKeysById.get(threadId) ?? getKey(TABLE_THREADS, { id: threadId });
+            threadKeysById.set(threadId, threadKey);
+            missingThreadPipeline.get(threadKey);
+          });
+          const missingThreadResults = await missingThreadPipeline.exec();
+
+          uncachedThreadIds.forEach((threadId, index) => {
+            const thread = missingThreadResults[index] as StorageThreadType | null;
+            if (thread) {
+              threadCache.set(threadId, thread);
+            }
+          });
+        }
+
+        for (const threadId of touchedThreadIds) {
+          const existingThread = threadCache.get(threadId);
+          if (!existingThread) continue;
+
           const updatedThread = {
             ...existingThread,
-            updatedAt: new Date(),
+            updatedAt: now,
           };
-          pipeline.set(threadKey, processRecord(TABLE_THREADS, updatedThread).processedRecord);
+          threadCache.set(threadId, updatedThread);
+          pipeline.set(threadKeysById.get(threadId)!, processRecord(TABLE_THREADS, updatedThread).processedRecord);
         }
 
         await pipeline.exec();
@@ -438,12 +467,58 @@ export class StoreMemoryUpstash extends MemoryStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: {
-            threadId,
+            threadId: threadIds.join(','),
           },
         },
         error,
       );
     }
+  }
+
+  private async _findExistingMessageLocations(messageIds: string[]): Promise<Map<string, ExistingMessageLocation[]>> {
+    const locationsByMessageId = new Map<string, ExistingMessageLocation[]>();
+    if (messageIds.length === 0) {
+      return locationsByMessageId;
+    }
+
+    const indexPipeline = this.client.pipeline();
+    messageIds.forEach(messageId => indexPipeline.get(getMessageIndexKey(messageId)));
+    const indexResults = await indexPipeline.exec();
+
+    const unindexedMessageIds: string[] = [];
+    messageIds.forEach((messageId, index) => {
+      const threadId = indexResults[index] as string | null;
+      if (!threadId) {
+        unindexedMessageIds.push(messageId);
+        return;
+      }
+
+      locationsByMessageId.set(messageId, [{ key: getMessageKey(threadId, messageId), threadId }]);
+    });
+
+    for (const messageId of unindexedMessageIds) {
+      const keys = await this.#db.scanKeys(getMessageKey('*', messageId));
+      if (keys.length === 0) continue;
+
+      const messagePipeline = this.client.pipeline();
+      keys.forEach(key => messagePipeline.get(key));
+      const existingMessages = await messagePipeline.exec();
+
+      const locations: ExistingMessageLocation[] = [];
+      existingMessages.forEach((existingMessage, index) => {
+        const message = existingMessage as MastraDBMessage | null;
+        const key = keys[index];
+        if (!message?.threadId || !key || message.id !== messageId) return;
+
+        locations.push({ key, threadId: message.threadId });
+      });
+
+      if (locations.length > 0) {
+        locationsByMessageId.set(messageId, locations);
+      }
+    }
+
+    return locationsByMessageId;
   }
 
   /**

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -357,35 +357,43 @@ export class StoreMemoryUpstash extends MemoryStorage {
     const threadKeysById = new Map(threadIds.map(threadId => [threadId, getKey(TABLE_THREADS, { id: threadId })]));
     let threadCache = new Map<string, StorageThreadType>();
 
+    let threadResults: unknown[];
     try {
       const threadPipeline = this.client.pipeline();
       threadIds.forEach(threadId => threadPipeline.get(threadKeysById.get(threadId)!));
-      const threadResults = await threadPipeline.exec();
-
-      const missingThreadIds: string[] = [];
-      threadIds.forEach((threadId, index) => {
-        const thread = threadResults[index] as StorageThreadType | null;
-        if (!thread) {
-          missingThreadIds.push(threadId);
-          return;
-        }
-
-        threadCache.set(threadId, thread);
-      });
-
-      if (missingThreadIds.length > 0) {
-        const missingThreadLabel =
-          missingThreadIds.length === 1 ? `Thread ${missingThreadIds[0]}` : `Threads ${missingThreadIds.join(', ')}`;
-        throw new Error(`${missingThreadLabel} not found`);
-      }
+      threadResults = await threadPipeline.exec();
     } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('UPSTASH', 'SAVE_MESSAGES', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+
+    const missingThreadIds: string[] = [];
+    threadIds.forEach((threadId, index) => {
+      const thread = threadResults[index] as StorageThreadType | null;
+      if (!thread) {
+        missingThreadIds.push(threadId);
+        return;
+      }
+
+      threadCache.set(threadId, thread);
+    });
+
+    if (missingThreadIds.length > 0) {
+      const missingThreadLabel =
+        missingThreadIds.length === 1 ? `Thread ${missingThreadIds[0]}` : `Threads ${missingThreadIds.join(', ')}`;
       throw new MastraError(
         {
           id: createStorageErrorId('UPSTASH', 'SAVE_MESSAGES', 'INVALID_ARGS'),
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.USER,
         },
-        error,
+        new Error(`${missingThreadLabel} not found`),
       );
     }
 

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -379,14 +379,20 @@ export class StoreMemoryUpstash extends MemoryStorage {
       for (let i = 0; i < messagesWithIndex.length; i += batchSize) {
         const batch = messagesWithIndex.slice(i, i + batchSize);
         const pipeline = this.client.pipeline();
+        const indexLookupPipeline = this.client.pipeline();
 
-        for (const message of batch) {
+        batch.forEach(message => {
+          indexLookupPipeline.get(getMessageIndexKey(message.id));
+        });
+        const existingThreadIds = (await indexLookupPipeline.exec()) as (string | null)[];
+
+        for (const [batchIndex, message] of batch.entries()) {
           const key = getMessageKey(message.threadId!, message.id);
           const createdAtScore = new Date(message.createdAt).getTime();
           const score = message._index !== undefined ? message._index : createdAtScore;
 
           // Check if this message id exists in another thread (index lookup, no scan)
-          const existingThreadId = await this.client.get<string>(getMessageIndexKey(message.id));
+          const existingThreadId = existingThreadIds[batchIndex];
           if (existingThreadId && existingThreadId !== message.threadId) {
             pipeline.del(getMessageKey(existingThreadId, message.id));
             pipeline.zrem(getThreadMessagesKey(existingThreadId), message.id);
@@ -902,20 +908,44 @@ export class StoreMemoryUpstash extends MemoryStorage {
       // Find all existing messages — try index first, fall back to scan
       const existingMessages: MastraDBMessage[] = [];
       const messageIdToKey: Record<string, string> = {};
+      const backfillIndexValues: Record<string, string> = {};
 
-      for (const messageId of messageIds) {
-        // Try the index first (fast path)
-        const indexedThreadId = await this.client.get<string>(getMessageIndexKey(messageId));
+      const indexPipeline = this.client.pipeline();
+      messageIds.forEach(messageId => indexPipeline.get(getMessageIndexKey(messageId)));
+      const indexResults = (await indexPipeline.exec()) as (string | null)[];
+
+      const indexedLookups: { messageId: string; threadId: string }[] = [];
+      const fallbackMessageIds: string[] = [];
+
+      messageIds.forEach((messageId, index) => {
+        const indexedThreadId = indexResults[index];
         if (indexedThreadId) {
-          const key = getMessageKey(indexedThreadId, messageId);
-          const message = await this.client.get<MastraDBMessage>(key);
+          indexedLookups.push({ messageId, threadId: indexedThreadId });
+        } else {
+          fallbackMessageIds.push(messageId);
+        }
+      });
+
+      if (indexedLookups.length > 0) {
+        const messagePipeline = this.client.pipeline();
+        indexedLookups.forEach(({ messageId, threadId }) => {
+          messagePipeline.get(getMessageKey(threadId, messageId));
+        });
+        const indexedMessages = (await messagePipeline.exec()) as (MastraDBMessage | null)[];
+
+        indexedLookups.forEach(({ messageId, threadId }, index) => {
+          const key = getMessageKey(threadId, messageId);
+          const message = indexedMessages[index];
           if (message && message.id === messageId) {
             existingMessages.push(message);
             messageIdToKey[messageId] = key;
-            continue;
+          } else {
+            fallbackMessageIds.push(messageId);
           }
-        }
+        });
+      }
 
+      for (const messageId of fallbackMessageIds) {
         // Fall back to scan for backwards compatibility (old messages without index)
         const pattern = getMessageKey('*', messageId);
         const keys = await this.#db.scanKeys(pattern);
@@ -927,11 +957,19 @@ export class StoreMemoryUpstash extends MemoryStorage {
             messageIdToKey[messageId] = key;
             // Backfill the index for future lookups
             if (message.threadId) {
-              await this.client.set(getMessageIndexKey(messageId), message.threadId);
+              backfillIndexValues[messageId] = message.threadId;
             }
             break;
           }
         }
+      }
+
+      if (Object.keys(backfillIndexValues).length > 0) {
+        const backfillPipeline = this.client.pipeline();
+        for (const [messageId, threadId] of Object.entries(backfillIndexValues)) {
+          backfillPipeline.set(getMessageIndexKey(messageId), threadId);
+        }
+        await backfillPipeline.exec();
       }
 
       if (existingMessages.length === 0) {
@@ -989,6 +1027,8 @@ export class StoreMemoryUpstash extends MemoryStorage {
         if (key) {
           // If the message is being moved to a different thread, we need to handle the key change
           if (updatePayload.threadId && updatePayload.threadId !== existingMessage.threadId) {
+            const newThreadId = updatedMessage.threadId!;
+
             // Remove from old thread's sorted set
             const oldThreadMessagesKey = getThreadMessagesKey(existingMessage.threadId!);
             pipeline.zrem(oldThreadMessagesKey, id);
@@ -997,11 +1037,13 @@ export class StoreMemoryUpstash extends MemoryStorage {
             pipeline.del(key);
 
             // Create new message key with new threadId
-            const newKey = getMessageKey(updatePayload.threadId, id);
+            const newKey = getMessageKey(newThreadId, id);
             pipeline.set(newKey, updatedMessage);
+            pipeline.set(getMessageIndexKey(id), newThreadId);
+            messageIdToKey[id] = newKey;
 
             // Add to new thread's sorted set
-            const newThreadMessagesKey = getThreadMessagesKey(updatePayload.threadId);
+            const newThreadMessagesKey = getThreadMessagesKey(newThreadId);
             const score =
               (updatedMessage as any)._index !== undefined
                 ? (updatedMessage as any)._index

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -44,11 +44,6 @@ function getMessageIndexKey(messageId: string): string {
   return `msg-idx:${messageId}`;
 }
 
-type ExistingMessageLocation = {
-  key: string;
-  threadId: string;
-};
-
 export class StoreMemoryUpstash extends MemoryStorage {
   private client: Redis;
   #db: UpstashDB;
@@ -335,6 +330,28 @@ export class StoreMemoryUpstash extends MemoryStorage {
     const { messages } = args;
     if (messages.length === 0) return { messages: [] };
 
+    const threadId = messages[0]?.threadId;
+    try {
+      if (!threadId) {
+        throw new Error('Thread ID is required');
+      }
+
+      // Check if thread exists
+      const thread = await this.getThreadById({ threadId });
+      if (!thread) {
+        throw new Error(`Thread ${threadId} not found`);
+      }
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('UPSTASH', 'SAVE_MESSAGES', 'INVALID_ARGS'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+        },
+        error,
+      );
+    }
+
     // Add an index to each message to maintain order
     const messagesWithIndex = messages.map((message, index) => {
       if (!message.threadId) {
@@ -353,71 +370,26 @@ export class StoreMemoryUpstash extends MemoryStorage {
       };
     });
 
-    const threadIds = Array.from(new Set(messagesWithIndex.map(message => message.threadId!)));
-    const threadKeysById = new Map(threadIds.map(threadId => [threadId, getKey(TABLE_THREADS, { id: threadId })]));
-    let threadCache = new Map<string, StorageThreadType>();
-
-    let threadResults: unknown[];
-    try {
-      const threadPipeline = this.client.pipeline();
-      threadIds.forEach(threadId => threadPipeline.get(threadKeysById.get(threadId)!));
-      threadResults = await threadPipeline.exec();
-    } catch (error) {
-      throw new MastraError(
-        {
-          id: createStorageErrorId('UPSTASH', 'SAVE_MESSAGES', 'FAILED'),
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.THIRD_PARTY,
-        },
-        error,
-      );
-    }
-
-    const missingThreadIds: string[] = [];
-    threadIds.forEach((threadId, index) => {
-      const thread = threadResults[index] as StorageThreadType | null;
-      if (!thread) {
-        missingThreadIds.push(threadId);
-        return;
-      }
-
-      threadCache.set(threadId, thread);
-    });
-
-    if (missingThreadIds.length > 0) {
-      const missingThreadLabel =
-        missingThreadIds.length === 1 ? `Thread ${missingThreadIds[0]}` : `Threads ${missingThreadIds.join(', ')}`;
-      throw new MastraError(
-        {
-          id: createStorageErrorId('UPSTASH', 'SAVE_MESSAGES', 'INVALID_ARGS'),
-          domain: ErrorDomain.STORAGE,
-          category: ErrorCategory.USER,
-        },
-        new Error(`${missingThreadLabel} not found`),
-      );
-    }
+    // Get current thread data once (all messages belong to same thread)
+    const threadKey = getKey(TABLE_THREADS, { id: threadId });
+    const existingThread = await this.client.get<StorageThreadType>(threadKey);
 
     try {
       const batchSize = 1000;
       for (let i = 0; i < messagesWithIndex.length; i += batchSize) {
         const batch = messagesWithIndex.slice(i, i + batchSize);
         const pipeline = this.client.pipeline();
-        const existingLocationsByMessageId = await this._findExistingMessageLocations(batch.map(message => message.id));
-        const touchedThreadIds = new Set(batch.map(message => message.threadId!));
-        const now = new Date();
 
         for (const message of batch) {
           const key = getMessageKey(message.threadId!, message.id);
           const createdAtScore = new Date(message.createdAt).getTime();
           const score = message._index !== undefined ? message._index : createdAtScore;
 
-          const existingLocations = existingLocationsByMessageId.get(message.id) ?? [];
-          for (const location of existingLocations) {
-            if (location.threadId === message.threadId) continue;
-
-            touchedThreadIds.add(location.threadId);
-            pipeline.del(location.key);
-            pipeline.zrem(getThreadMessagesKey(location.threadId), message.id);
+          // Check if this message id exists in another thread (index lookup, no scan)
+          const existingThreadId = await this.client.get<string>(getMessageIndexKey(message.id));
+          if (existingThreadId && existingThreadId !== message.threadId) {
+            pipeline.del(getMessageKey(existingThreadId, message.id));
+            pipeline.zrem(getThreadMessagesKey(existingThreadId), message.id);
           }
 
           // Store the message data
@@ -433,34 +405,13 @@ export class StoreMemoryUpstash extends MemoryStorage {
           });
         }
 
-        const uncachedThreadIds = Array.from(touchedThreadIds).filter(threadId => !threadCache.has(threadId));
-        if (uncachedThreadIds.length > 0) {
-          const missingThreadPipeline = this.client.pipeline();
-          uncachedThreadIds.forEach(threadId => {
-            const threadKey = threadKeysById.get(threadId) ?? getKey(TABLE_THREADS, { id: threadId });
-            threadKeysById.set(threadId, threadKey);
-            missingThreadPipeline.get(threadKey);
-          });
-          const missingThreadResults = await missingThreadPipeline.exec();
-
-          uncachedThreadIds.forEach((threadId, index) => {
-            const thread = missingThreadResults[index] as StorageThreadType | null;
-            if (thread) {
-              threadCache.set(threadId, thread);
-            }
-          });
-        }
-
-        for (const threadId of touchedThreadIds) {
-          const existingThread = threadCache.get(threadId);
-          if (!existingThread) continue;
-
+        // Update the thread's updatedAt field (only in the first batch)
+        if (i === 0 && existingThread) {
           const updatedThread = {
             ...existingThread,
-            updatedAt: now,
+            updatedAt: new Date(),
           };
-          threadCache.set(threadId, updatedThread);
-          pipeline.set(threadKeysById.get(threadId)!, processRecord(TABLE_THREADS, updatedThread).processedRecord);
+          pipeline.set(threadKey, processRecord(TABLE_THREADS, updatedThread).processedRecord);
         }
 
         await pipeline.exec();
@@ -475,35 +426,12 @@ export class StoreMemoryUpstash extends MemoryStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: {
-            threadId: threadIds.join(','),
+            threadId,
           },
         },
         error,
       );
     }
-  }
-
-  private async _findExistingMessageLocations(messageIds: string[]): Promise<Map<string, ExistingMessageLocation[]>> {
-    const locationsByMessageId = new Map<string, ExistingMessageLocation[]>();
-    if (messageIds.length === 0) {
-      return locationsByMessageId;
-    }
-
-    const indexPipeline = this.client.pipeline();
-    messageIds.forEach(messageId => indexPipeline.get(getMessageIndexKey(messageId)));
-    const indexResults = await indexPipeline.exec();
-
-    messageIds.forEach((messageId, index) => {
-      const threadId = indexResults[index] as string | null;
-      if (!threadId) {
-        // No index entry — treat as a new message (skip expensive scan)
-        return;
-      }
-
-      locationsByMessageId.set(messageId, [{ key: getMessageKey(threadId, messageId), threadId }]);
-    });
-
-    return locationsByMessageId;
   }
 
   /**
@@ -971,44 +899,24 @@ export class StoreMemoryUpstash extends MemoryStorage {
       // Get all message IDs to update
       const messageIds = messages.map(m => m.id);
 
-      // Find all existing messages using the msg-idx index first
+      // Find all existing messages — try index first, fall back to scan
       const existingMessages: MastraDBMessage[] = [];
       const messageIdToKey: Record<string, string> = {};
 
-      // Try index first for each message (fast path)
-      const indexPipeline = this.client.pipeline();
-      messageIds.forEach(id => indexPipeline.get(getMessageIndexKey(id)));
-      const indexResults = await indexPipeline.exec();
-
-      const indexedKeys: { messageId: string; key: string }[] = [];
-      const unindexedMessageIds: string[] = [];
-
-      messageIds.forEach((messageId, i) => {
-        const threadId = indexResults[i] as string | null;
-        if (threadId) {
-          indexedKeys.push({ messageId, key: getMessageKey(threadId, messageId) });
-        } else {
-          unindexedMessageIds.push(messageId);
-        }
-      });
-
-      // Fetch indexed messages in a single pipeline
-      if (indexedKeys.length > 0) {
-        const messagePipeline = this.client.pipeline();
-        indexedKeys.forEach(({ key }) => messagePipeline.get(key));
-        const messageResults = await messagePipeline.exec();
-
-        indexedKeys.forEach(({ messageId, key }, i) => {
-          const message = messageResults[i] as MastraDBMessage | null;
+      for (const messageId of messageIds) {
+        // Try the index first (fast path)
+        const indexedThreadId = await this.client.get<string>(getMessageIndexKey(messageId));
+        if (indexedThreadId) {
+          const key = getMessageKey(indexedThreadId, messageId);
+          const message = await this.client.get<MastraDBMessage>(key);
           if (message && message.id === messageId) {
             existingMessages.push(message);
             messageIdToKey[messageId] = key;
+            continue;
           }
-        });
-      }
+        }
 
-      // Fall back to scan for unindexed messages (backwards compatibility)
-      for (const messageId of unindexedMessageIds) {
+        // Fall back to scan for backwards compatibility (old messages without index)
         const pattern = getMessageKey('*', messageId);
         const keys = await this.#db.scanKeys(pattern);
 
@@ -1017,7 +925,7 @@ export class StoreMemoryUpstash extends MemoryStorage {
           if (message && message.id === messageId) {
             existingMessages.push(message);
             messageIdToKey[messageId] = key;
-            // Backfill the index so future lookups hit the fast path
+            // Backfill the index for future lookups
             if (message.threadId) {
               await this.client.set(getMessageIndexKey(messageId), message.threadId);
             }

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -1017,6 +1017,10 @@ export class StoreMemoryUpstash extends MemoryStorage {
           if (message && message.id === messageId) {
             existingMessages.push(message);
             messageIdToKey[messageId] = key;
+            // Backfill the index so future lookups hit the fast path
+            if (message.threadId) {
+              await this.client.set(getMessageIndexKey(messageId), message.threadId);
+            }
             break;
           }
         }

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -330,16 +330,16 @@ export class StoreMemoryUpstash extends MemoryStorage {
     const { messages } = args;
     if (messages.length === 0) return { messages: [] };
 
-    const threadId = messages[0]?.threadId;
     try {
-      if (!threadId) {
-        throw new Error('Thread ID is required');
-      }
-
-      // Check if thread exists
-      const thread = await this.getThreadById({ threadId });
-      if (!thread) {
-        throw new Error(`Thread ${threadId} not found`);
+      for (const message of messages) {
+        if (!message.threadId) {
+          throw new Error('Thread ID is required');
+        }
+        if (!message.resourceId) {
+          throw new Error(
+            `Expected to find a resourceId for message, but couldn't find one. An unexpected error has occurred.`,
+          );
+        }
       }
     } catch (error) {
       throw new MastraError(
@@ -354,48 +354,82 @@ export class StoreMemoryUpstash extends MemoryStorage {
 
     // Add an index to each message to maintain order
     const messagesWithIndex = messages.map((message, index) => {
-      if (!message.threadId) {
-        throw new Error(
-          `Expected to find a threadId for message, but couldn't find one. An unexpected error has occurred.`,
-        );
-      }
-      if (!message.resourceId) {
-        throw new Error(
-          `Expected to find a resourceId for message, but couldn't find one. An unexpected error has occurred.`,
-        );
-      }
       return {
         ...message,
         _index: index,
       };
     });
 
-    // Get current thread data once (all messages belong to same thread)
-    const threadKey = getKey(TABLE_THREADS, { id: threadId });
-    const existingThread = await this.client.get<StorageThreadType>(threadKey);
-
     try {
       const batchSize = 1000;
+      const targetThreadIds = new Set(messagesWithIndex.map(message => message.threadId!));
+      const existingThreadIds: (string | null)[] = [];
+      const touchedThreadIds = new Set<string>(targetThreadIds);
+
+      // Read index entries up front so all touched threads can be validated/loaded before writes.
       for (let i = 0; i < messagesWithIndex.length; i += batchSize) {
         const batch = messagesWithIndex.slice(i, i + batchSize);
-        const pipeline = this.client.pipeline();
         const indexLookupPipeline = this.client.pipeline();
 
         batch.forEach(message => {
           indexLookupPipeline.get(getMessageIndexKey(message.id));
         });
-        const existingThreadIds = (await indexLookupPipeline.exec()) as (string | null)[];
+        const batchExistingThreadIds = (await indexLookupPipeline.exec()) as (string | null)[];
+        existingThreadIds.push(...batchExistingThreadIds);
+
+        batchExistingThreadIds.forEach(existingThreadId => {
+          if (existingThreadId) {
+            touchedThreadIds.add(existingThreadId);
+          }
+        });
+      }
+
+      const touchedThreadIdList = Array.from(touchedThreadIds);
+      const threadLookupPipeline = this.client.pipeline();
+      touchedThreadIdList.forEach(touchedThreadId => {
+        threadLookupPipeline.get(getKey(TABLE_THREADS, { id: touchedThreadId }));
+      });
+      const threadLookupResults = (await threadLookupPipeline.exec()) as (StorageThreadType | null)[];
+      const threadRecordsById = new Map<string, StorageThreadType>();
+
+      touchedThreadIdList.forEach((touchedThreadId, index) => {
+        const threadRecord = threadLookupResults[index];
+        if (threadRecord) {
+          threadRecordsById.set(touchedThreadId, threadRecord);
+        }
+      });
+
+      for (const targetThreadId of targetThreadIds) {
+        if (!threadRecordsById.has(targetThreadId)) {
+          throw new MastraError(
+            {
+              id: createStorageErrorId('UPSTASH', 'SAVE_MESSAGES', 'INVALID_ARGS'),
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+            },
+            new Error(`Thread ${targetThreadId} not found`),
+          );
+        }
+      }
+
+      for (let i = 0; i < messagesWithIndex.length; i += batchSize) {
+        const batch = messagesWithIndex.slice(i, i + batchSize);
+        const pipeline = this.client.pipeline();
+        const batchTouchedThreadIds = new Set<string>();
+        const batchExistingThreadIds = existingThreadIds.slice(i, i + batch.length);
 
         for (const [batchIndex, message] of batch.entries()) {
           const key = getMessageKey(message.threadId!, message.id);
           const createdAtScore = new Date(message.createdAt).getTime();
           const score = message._index !== undefined ? message._index : createdAtScore;
+          batchTouchedThreadIds.add(message.threadId!);
 
           // Check if this message id exists in another thread (index lookup, no scan)
-          const existingThreadId = existingThreadIds[batchIndex];
+          const existingThreadId = batchExistingThreadIds[batchIndex];
           if (existingThreadId && existingThreadId !== message.threadId) {
             pipeline.del(getMessageKey(existingThreadId, message.id));
             pipeline.zrem(getThreadMessagesKey(existingThreadId), message.id);
+            batchTouchedThreadIds.add(existingThreadId);
           }
 
           // Store the message data
@@ -411,13 +445,19 @@ export class StoreMemoryUpstash extends MemoryStorage {
           });
         }
 
-        // Update the thread's updatedAt field (only in the first batch)
-        if (i === 0 && existingThread) {
+        const now = new Date();
+        for (const touchedThreadId of batchTouchedThreadIds) {
+          const existingThread = threadRecordsById.get(touchedThreadId);
+          if (!existingThread) {
+            continue;
+          }
           const updatedThread = {
             ...existingThread,
-            updatedAt: new Date(),
+            updatedAt: now,
           };
+          const threadKey = getKey(TABLE_THREADS, { id: touchedThreadId });
           pipeline.set(threadKey, processRecord(TABLE_THREADS, updatedThread).processedRecord);
+          threadRecordsById.set(touchedThreadId, updatedThread);
         }
 
         await pipeline.exec();
@@ -426,13 +466,16 @@ export class StoreMemoryUpstash extends MemoryStorage {
       const list = new MessageList().add(messages as any, 'memory');
       return { messages: list.get.all.db() };
     } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
       throw new MastraError(
         {
           id: createStorageErrorId('UPSTASH', 'SAVE_MESSAGES', 'FAILED'),
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: {
-            threadId,
+            threadIds: Array.from(new Set(messages.map(message => message.threadId).filter(Boolean))).join(','),
           },
         },
         error,
@@ -904,6 +947,7 @@ export class StoreMemoryUpstash extends MemoryStorage {
     try {
       // Get all message IDs to update
       const messageIds = messages.map(m => m.id);
+      const updatesById = new Map(messages.map(message => [message.id, message]));
 
       // Find all existing messages — try index first, fall back to scan
       const existingMessages: MastraDBMessage[] = [];
@@ -977,21 +1021,62 @@ export class StoreMemoryUpstash extends MemoryStorage {
       }
 
       const threadIdsToUpdate = new Set<string>();
+      const destinationThreadIds = new Set<string>();
+
+      for (const existingMessage of existingMessages) {
+        const updatePayload = updatesById.get(existingMessage.id);
+        if (!updatePayload) continue;
+
+        const { id: _id, ...fieldsToUpdate } = updatePayload;
+        if (Object.keys(fieldsToUpdate).length === 0) continue;
+
+        threadIdsToUpdate.add(existingMessage.threadId!);
+        if (updatePayload.threadId && updatePayload.threadId !== existingMessage.threadId) {
+          threadIdsToUpdate.add(updatePayload.threadId);
+          destinationThreadIds.add(updatePayload.threadId);
+        }
+      }
+
+      const threadRecordsById = new Map<string, StorageThreadType>();
+      if (threadIdsToUpdate.size > 0) {
+        const threadIdList = Array.from(threadIdsToUpdate);
+        const threadLookupPipeline = this.client.pipeline();
+
+        threadIdList.forEach(threadId => {
+          threadLookupPipeline.get(getKey(TABLE_THREADS, { id: threadId }));
+        });
+        const threadLookupResults = (await threadLookupPipeline.exec()) as (StorageThreadType | null)[];
+
+        threadIdList.forEach((threadId, index) => {
+          const threadRecord = threadLookupResults[index];
+          if (threadRecord) {
+            threadRecordsById.set(threadId, threadRecord);
+          }
+        });
+      }
+
+      for (const destinationThreadId of destinationThreadIds) {
+        if (!threadRecordsById.has(destinationThreadId)) {
+          throw new MastraError(
+            {
+              id: createStorageErrorId('UPSTASH', 'UPDATE_MESSAGES', 'INVALID_ARGS'),
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+            },
+            new Error(`Thread ${destinationThreadId} not found`),
+          );
+        }
+      }
+
       const pipeline = this.client.pipeline();
 
       // Process each existing message for updates
       for (const existingMessage of existingMessages) {
-        const updatePayload = messages.find(m => m.id === existingMessage.id);
+        const updatePayload = updatesById.get(existingMessage.id);
         if (!updatePayload) continue;
 
         const { id, ...fieldsToUpdate } = updatePayload;
         if (Object.keys(fieldsToUpdate).length === 0) continue;
-
-        // Track thread IDs that need updating
-        threadIdsToUpdate.add(existingMessage.threadId!);
-        if (updatePayload.threadId && updatePayload.threadId !== existingMessage.threadId) {
-          threadIdsToUpdate.add(updatePayload.threadId);
-        }
 
         // Create updated message object
         const updatedMessage = { ...existingMessage };
@@ -1060,14 +1145,15 @@ export class StoreMemoryUpstash extends MemoryStorage {
       const now = new Date();
       for (const threadId of threadIdsToUpdate) {
         if (threadId) {
-          const threadKey = getKey(TABLE_THREADS, { id: threadId });
-          const existingThread = await this.client.get<StorageThreadType>(threadKey);
+          const existingThread = threadRecordsById.get(threadId);
           if (existingThread) {
             const updatedThread = {
               ...existingThread,
               updatedAt: now,
             };
+            const threadKey = getKey(TABLE_THREADS, { id: threadId });
             pipeline.set(threadKey, processRecord(TABLE_THREADS, updatedThread).processedRecord);
+            threadRecordsById.set(threadId, updatedThread);
           }
         }
       }
@@ -1089,6 +1175,9 @@ export class StoreMemoryUpstash extends MemoryStorage {
 
       return updatedMessages;
     } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
       throw new MastraError(
         {
           id: createStorageErrorId('UPSTASH', 'UPDATE_MESSAGES', 'FAILED'),

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -963,12 +963,44 @@ export class StoreMemoryUpstash extends MemoryStorage {
       // Get all message IDs to update
       const messageIds = messages.map(m => m.id);
 
-      // Find all existing messages by scanning for their keys
+      // Find all existing messages using the msg-idx index first
       const existingMessages: MastraDBMessage[] = [];
       const messageIdToKey: Record<string, string> = {};
 
-      // Scan for all message keys that match any of the IDs
-      for (const messageId of messageIds) {
+      // Try index first for each message (fast path)
+      const indexPipeline = this.client.pipeline();
+      messageIds.forEach(id => indexPipeline.get(getMessageIndexKey(id)));
+      const indexResults = await indexPipeline.exec();
+
+      const indexedKeys: { messageId: string; key: string }[] = [];
+      const unindexedMessageIds: string[] = [];
+
+      messageIds.forEach((messageId, i) => {
+        const threadId = indexResults[i] as string | null;
+        if (threadId) {
+          indexedKeys.push({ messageId, key: getMessageKey(threadId, messageId) });
+        } else {
+          unindexedMessageIds.push(messageId);
+        }
+      });
+
+      // Fetch indexed messages in a single pipeline
+      if (indexedKeys.length > 0) {
+        const messagePipeline = this.client.pipeline();
+        indexedKeys.forEach(({ key }) => messagePipeline.get(key));
+        const messageResults = await messagePipeline.exec();
+
+        indexedKeys.forEach(({ messageId, key }, i) => {
+          const message = messageResults[i] as MastraDBMessage | null;
+          if (message && message.id === messageId) {
+            existingMessages.push(message);
+            messageIdToKey[messageId] = key;
+          }
+        });
+      }
+
+      // Fall back to scan for unindexed messages (backwards compatibility)
+      for (const messageId of unindexedMessageIds) {
         const pattern = getMessageKey('*', messageId);
         const keys = await this.#db.scanKeys(pattern);
 
@@ -977,7 +1009,7 @@ export class StoreMemoryUpstash extends MemoryStorage {
           if (message && message.id === messageId) {
             existingMessages.push(message);
             messageIdToKey[messageId] = key;
-            break; // Found the message, no need to continue scanning
+            break;
           }
         }
       }

--- a/stores/upstash/src/storage/index.test.ts
+++ b/stores/upstash/src/storage/index.test.ts
@@ -1,11 +1,13 @@
+import { randomUUID } from 'node:crypto';
 import {
   createTestSuite,
   createConfigValidationTests,
   createClientAcceptanceTests,
   createDomainDirectTests,
 } from '@internal/storage-test-utils';
+import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import { Redis } from '@upstash/redis';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { StoreMemoryUpstash } from './domains/memory';
 import { ScoresUpstash } from './domains/scores';
@@ -25,6 +27,32 @@ const createTestClient = () =>
     url: TEST_CONFIG.url,
     token: TEST_CONFIG.token,
   });
+
+const createThread = (resourceId = `resource-${randomUUID()}`): StorageThreadType => ({
+  id: `thread-${randomUUID()}`,
+  resourceId,
+  title: 'Test Thread',
+  metadata: {},
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+const createMessage = (thread: StorageThreadType, overrides: Partial<MastraDBMessage> = {}): MastraDBMessage => ({
+  id: overrides.id ?? randomUUID(),
+  threadId: overrides.threadId ?? thread.id,
+  resourceId: overrides.resourceId ?? thread.resourceId,
+  role: overrides.role ?? 'user',
+  createdAt: overrides.createdAt ?? new Date(),
+  content: overrides.content ?? {
+    format: 2,
+    parts: [{ type: 'text', text: 'Test message' }],
+    content: 'Test message',
+  },
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 createTestSuite(
   new UpstashStore({
@@ -109,5 +137,95 @@ describe('Upstash Domain with URL/token config', () => {
     expect(savedThread.id).toBe(thread.id);
 
     await memoryDomain.deleteThread({ threadId: thread.id });
+  });
+});
+
+describe('StoreMemoryUpstash saveMessages index behavior', () => {
+  it('avoids scans for indexed message moves and updates all touched threads', async () => {
+    const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
+    await memoryDomain.init();
+
+    const sourceThread = createThread();
+    const targetThread = createThread(sourceThread.resourceId);
+    await memoryDomain.saveThread({ thread: sourceThread });
+    await memoryDomain.saveThread({ thread: targetThread });
+
+    const initialSourceThread = await memoryDomain.getThreadById({ threadId: sourceThread.id });
+    const initialTargetThread = await memoryDomain.getThreadById({ threadId: targetThread.id });
+    const originalMessage = createMessage(sourceThread);
+    await memoryDomain.saveMessages({ messages: [originalMessage] });
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    const client = (memoryDomain as any).client as Redis;
+    const scanSpy = vi.spyOn(client, 'scan');
+
+    const movedMessage = createMessage(targetThread, {
+      id: originalMessage.id,
+      resourceId: targetThread.resourceId,
+      content: {
+        format: 2,
+        parts: [{ type: 'text', text: 'Moved message' }],
+        content: 'Moved message',
+      },
+    });
+
+    await memoryDomain.saveMessages({ messages: [movedMessage] });
+
+    expect(scanSpy).not.toHaveBeenCalled();
+
+    const { messages: sourceMessages } = await memoryDomain.listMessages({ threadId: sourceThread.id });
+    const { messages: targetMessages } = await memoryDomain.listMessages({ threadId: targetThread.id });
+    expect(sourceMessages.find(message => message.id === originalMessage.id)).toBeUndefined();
+    expect(targetMessages.find(message => message.id === originalMessage.id)?.threadId).toBe(targetThread.id);
+
+    const updatedSourceThread = await memoryDomain.getThreadById({ threadId: sourceThread.id });
+    const updatedTargetThread = await memoryDomain.getThreadById({ threadId: targetThread.id });
+    expect(updatedSourceThread).not.toBeNull();
+    expect(updatedTargetThread).not.toBeNull();
+    expect(new Date(updatedSourceThread!.updatedAt).getTime()).toBeGreaterThan(
+      new Date(initialSourceThread!.updatedAt).getTime(),
+    );
+    expect(new Date(updatedTargetThread!.updatedAt).getTime()).toBeGreaterThan(
+      new Date(initialTargetThread!.updatedAt).getTime(),
+    );
+  });
+
+  it('falls back to scan when the index is missing and recreates the index during save', async () => {
+    const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
+    await memoryDomain.init();
+
+    const sourceThread = createThread();
+    const targetThread = createThread(sourceThread.resourceId);
+    await memoryDomain.saveThread({ thread: sourceThread });
+    await memoryDomain.saveThread({ thread: targetThread });
+
+    const originalMessage = createMessage(sourceThread);
+    await memoryDomain.saveMessages({ messages: [originalMessage] });
+
+    const client = (memoryDomain as any).client as Redis;
+    const messageIndexKey = `msg-idx:${originalMessage.id}`;
+    await client.del(messageIndexKey);
+
+    const scanSpy = vi.spyOn(client, 'scan');
+    const movedMessage = createMessage(targetThread, {
+      id: originalMessage.id,
+      resourceId: targetThread.resourceId,
+      content: {
+        format: 2,
+        parts: [{ type: 'text', text: 'Recovered message' }],
+        content: 'Recovered message',
+      },
+    });
+
+    await memoryDomain.saveMessages({ messages: [movedMessage] });
+
+    expect(scanSpy).toHaveBeenCalled();
+    await expect(client.get<string>(messageIndexKey)).resolves.toBe(targetThread.id);
+
+    const { messages: sourceMessages } = await memoryDomain.listMessages({ threadId: sourceThread.id });
+    const { messages: targetMessages } = await memoryDomain.listMessages({ threadId: targetThread.id });
+    expect(sourceMessages.find(message => message.id === originalMessage.id)).toBeUndefined();
+    expect(targetMessages.find(message => message.id === originalMessage.id)?.threadId).toBe(targetThread.id);
   });
 });

--- a/stores/upstash/src/storage/index.test.ts
+++ b/stores/upstash/src/storage/index.test.ts
@@ -191,7 +191,7 @@ describe('StoreMemoryUpstash saveMessages index behavior', () => {
     );
   });
 
-  it('falls back to scan when the index is missing and recreates the index during save', async () => {
+  it('skips scan when the index is missing and treats message as new', async () => {
     const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
     await memoryDomain.init();
 
@@ -220,12 +220,14 @@ describe('StoreMemoryUpstash saveMessages index behavior', () => {
 
     await memoryDomain.saveMessages({ messages: [movedMessage] });
 
-    expect(scanSpy).toHaveBeenCalled();
+    // No scan should occur — unindexed messages are treated as new
+    expect(scanSpy).not.toHaveBeenCalled();
+
+    // Index should be recreated after the save
     await expect(client.get<string>(messageIndexKey)).resolves.toBe(targetThread.id);
 
-    const { messages: sourceMessages } = await memoryDomain.listMessages({ threadId: sourceThread.id });
+    // Message now exists in target thread (source thread still has old copy since no scan found it)
     const { messages: targetMessages } = await memoryDomain.listMessages({ threadId: targetThread.id });
-    expect(sourceMessages.find(message => message.id === originalMessage.id)).toBeUndefined();
     expect(targetMessages.find(message => message.id === originalMessage.id)?.threadId).toBe(targetThread.id);
   });
 });

--- a/stores/upstash/src/storage/index.test.ts
+++ b/stores/upstash/src/storage/index.test.ts
@@ -226,7 +226,7 @@ describe('StoreMemoryUpstash saveMessages index behavior', () => {
     // Index should be recreated after the save
     await expect(client.get<string>(messageIndexKey)).resolves.toBe(targetThread.id);
 
-    // Message now exists in target thread (source thread still has old copy since no scan found it)
+    // Message now exists in target thread (source still has old copy since no scan found it)
     const { messages: targetMessages } = await memoryDomain.listMessages({ threadId: targetThread.id });
     expect(targetMessages.find(message => message.id === originalMessage.id)?.threadId).toBe(targetThread.id);
   });

--- a/stores/upstash/src/storage/index.test.ts
+++ b/stores/upstash/src/storage/index.test.ts
@@ -140,8 +140,8 @@ describe('Upstash Domain with URL/token config', () => {
   });
 });
 
-describe('StoreMemoryUpstash saveMessages index behavior', () => {
-  it('avoids scans for indexed message moves and updates all touched threads', async () => {
+describe('saveMessages uses msg-idx index instead of scanning', () => {
+  it('uses index lookup instead of scan when moving a message between threads', async () => {
     const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
     await memoryDomain.init();
 
@@ -150,8 +150,7 @@ describe('StoreMemoryUpstash saveMessages index behavior', () => {
     await memoryDomain.saveThread({ thread: sourceThread });
     await memoryDomain.saveThread({ thread: targetThread });
 
-    const initialSourceThread = await memoryDomain.getThreadById({ threadId: sourceThread.id });
-    const initialTargetThread = await memoryDomain.getThreadById({ threadId: targetThread.id });
+    // Save message to source thread (creates msg-idx entry)
     const originalMessage = createMessage(sourceThread);
     await memoryDomain.saveMessages({ messages: [originalMessage] });
 
@@ -160,74 +159,42 @@ describe('StoreMemoryUpstash saveMessages index behavior', () => {
     const client = (memoryDomain as any).client as Redis;
     const scanSpy = vi.spyOn(client, 'scan');
 
+    // Move same message ID to target thread
     const movedMessage = createMessage(targetThread, {
       id: originalMessage.id,
       resourceId: targetThread.resourceId,
-      content: {
-        format: 2,
-        parts: [{ type: 'text', text: 'Moved message' }],
-        content: 'Moved message',
-      },
     });
-
     await memoryDomain.saveMessages({ messages: [movedMessage] });
 
+    // Should not scan — used msg-idx index
     expect(scanSpy).not.toHaveBeenCalled();
 
+    // Message should be removed from source and exist in target
     const { messages: sourceMessages } = await memoryDomain.listMessages({ threadId: sourceThread.id });
     const { messages: targetMessages } = await memoryDomain.listMessages({ threadId: targetThread.id });
-    expect(sourceMessages.find(message => message.id === originalMessage.id)).toBeUndefined();
-    expect(targetMessages.find(message => message.id === originalMessage.id)?.threadId).toBe(targetThread.id);
-
-    const updatedSourceThread = await memoryDomain.getThreadById({ threadId: sourceThread.id });
-    const updatedTargetThread = await memoryDomain.getThreadById({ threadId: targetThread.id });
-    expect(updatedSourceThread).not.toBeNull();
-    expect(updatedTargetThread).not.toBeNull();
-    expect(new Date(updatedSourceThread!.updatedAt).getTime()).toBeGreaterThan(
-      new Date(initialSourceThread!.updatedAt).getTime(),
-    );
-    expect(new Date(updatedTargetThread!.updatedAt).getTime()).toBeGreaterThan(
-      new Date(initialTargetThread!.updatedAt).getTime(),
-    );
+    expect(sourceMessages.find(m => m.id === originalMessage.id)).toBeUndefined();
+    expect(targetMessages.find(m => m.id === originalMessage.id)?.threadId).toBe(targetThread.id);
   });
 
-  it('skips scan when the index is missing and treats message as new', async () => {
+  it('does not scan for new messages without an index entry', async () => {
     const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
     await memoryDomain.init();
 
-    const sourceThread = createThread();
-    const targetThread = createThread(sourceThread.resourceId);
-    await memoryDomain.saveThread({ thread: sourceThread });
-    await memoryDomain.saveThread({ thread: targetThread });
-
-    const originalMessage = createMessage(sourceThread);
-    await memoryDomain.saveMessages({ messages: [originalMessage] });
+    const thread = createThread();
+    await memoryDomain.saveThread({ thread });
 
     const client = (memoryDomain as any).client as Redis;
-    const messageIndexKey = `msg-idx:${originalMessage.id}`;
-    await client.del(messageIndexKey);
-
     const scanSpy = vi.spyOn(client, 'scan');
-    const movedMessage = createMessage(targetThread, {
-      id: originalMessage.id,
-      resourceId: targetThread.resourceId,
-      content: {
-        format: 2,
-        parts: [{ type: 'text', text: 'Recovered message' }],
-        content: 'Recovered message',
-      },
-    });
 
-    await memoryDomain.saveMessages({ messages: [movedMessage] });
+    // Save a brand new message
+    const message = createMessage(thread);
+    await memoryDomain.saveMessages({ messages: [message] });
 
-    // No scan should occur — unindexed messages are treated as new
+    // Should not scan — new message, no index, just skip
     expect(scanSpy).not.toHaveBeenCalled();
 
-    // Index should be recreated after the save
-    await expect(client.get<string>(messageIndexKey)).resolves.toBe(targetThread.id);
-
-    // Message now exists in target thread (source still has old copy since no scan found it)
-    const { messages: targetMessages } = await memoryDomain.listMessages({ threadId: targetThread.id });
-    expect(targetMessages.find(message => message.id === originalMessage.id)?.threadId).toBe(targetThread.id);
+    // Message should exist
+    const { messages } = await memoryDomain.listMessages({ threadId: thread.id });
+    expect(messages.find(m => m.id === message.id)?.threadId).toBe(thread.id);
   });
 });

--- a/stores/upstash/src/storage/index.test.ts
+++ b/stores/upstash/src/storage/index.test.ts
@@ -198,3 +198,32 @@ describe('saveMessages uses msg-idx index instead of scanning', () => {
     expect(messages.find(m => m.id === message.id)?.threadId).toBe(thread.id);
   });
 });
+
+describe('updateMessages keeps msg-idx index in sync', () => {
+  it('updates the index and returns the moved message when a message changes threads', async () => {
+    const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
+    await memoryDomain.init();
+
+    const sourceThread = createThread();
+    const targetThread = createThread(sourceThread.resourceId);
+    await memoryDomain.saveThread({ thread: sourceThread });
+    await memoryDomain.saveThread({ thread: targetThread });
+
+    const originalMessage = createMessage(sourceThread);
+    await memoryDomain.saveMessages({ messages: [originalMessage] });
+
+    const updatedMessages = await memoryDomain.updateMessages({
+      messages: [{ id: originalMessage.id, threadId: targetThread.id }],
+    });
+
+    expect(updatedMessages).toHaveLength(1);
+    expect(updatedMessages[0]!.threadId).toBe(targetThread.id);
+
+    const client = (memoryDomain as any).client as Redis;
+    expect(await client.get<string>(`msg-idx:${originalMessage.id}`)).toBe(targetThread.id);
+
+    const { messages } = await memoryDomain.listMessagesById({ messageIds: [originalMessage.id] });
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.threadId).toBe(targetThread.id);
+  });
+});

--- a/stores/upstash/src/storage/index.test.ts
+++ b/stores/upstash/src/storage/index.test.ts
@@ -197,6 +197,61 @@ describe('saveMessages uses msg-idx index instead of scanning', () => {
     const { messages } = await memoryDomain.listMessages({ threadId: thread.id });
     expect(messages.find(m => m.id === message.id)?.threadId).toBe(thread.id);
   });
+
+  it('updates both touched thread timestamps when moving a message between threads', async () => {
+    const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
+    await memoryDomain.init();
+
+    const sourceThread = createThread();
+    const targetThread = createThread(sourceThread.resourceId);
+    await memoryDomain.saveThread({ thread: sourceThread });
+    await memoryDomain.saveThread({ thread: targetThread });
+
+    const originalMessage = createMessage(sourceThread);
+    await memoryDomain.saveMessages({ messages: [originalMessage] });
+
+    const beforeMoveSourceThread = await memoryDomain.getThreadById({ threadId: sourceThread.id });
+    const beforeMoveTargetThread = await memoryDomain.getThreadById({ threadId: targetThread.id });
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    const movedMessage = createMessage(targetThread, {
+      id: originalMessage.id,
+      resourceId: targetThread.resourceId,
+    });
+    await memoryDomain.saveMessages({ messages: [movedMessage] });
+
+    const afterMoveSourceThread = await memoryDomain.getThreadById({ threadId: sourceThread.id });
+    const afterMoveTargetThread = await memoryDomain.getThreadById({ threadId: targetThread.id });
+
+    expect(new Date(afterMoveSourceThread!.updatedAt).getTime()).toBeGreaterThan(
+      new Date(beforeMoveSourceThread!.updatedAt).getTime(),
+    );
+    expect(new Date(afterMoveTargetThread!.updatedAt).getTime()).toBeGreaterThan(
+      new Date(beforeMoveTargetThread!.updatedAt).getTime(),
+    );
+  });
+
+  it('rejects the batch when any target thread does not exist', async () => {
+    const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
+    await memoryDomain.init();
+
+    const existingThread = createThread();
+    const missingThread = createThread(existingThread.resourceId);
+    await memoryDomain.saveThread({ thread: existingThread });
+
+    const validMessage = createMessage(existingThread);
+    const invalidMessage = createMessage(missingThread);
+
+    await expect(
+      memoryDomain.saveMessages({
+        messages: [validMessage, invalidMessage],
+      }),
+    ).rejects.toThrow(`Thread ${missingThread.id} not found`);
+
+    const { messages } = await memoryDomain.listMessages({ threadId: existingThread.id });
+    expect(messages).toHaveLength(0);
+  });
 });
 
 describe('updateMessages keeps msg-idx index in sync', () => {
@@ -225,5 +280,30 @@ describe('updateMessages keeps msg-idx index in sync', () => {
     const { messages } = await memoryDomain.listMessagesById({ messageIds: [originalMessage.id] });
     expect(messages).toHaveLength(1);
     expect(messages[0]!.threadId).toBe(targetThread.id);
+  });
+
+  it('rejects moving a message to a missing thread without mutating stored data', async () => {
+    const memoryDomain = new StoreMemoryUpstash({ client: createTestClient() });
+    await memoryDomain.init();
+
+    const sourceThread = createThread();
+    const missingThread = createThread(sourceThread.resourceId);
+    await memoryDomain.saveThread({ thread: sourceThread });
+
+    const originalMessage = createMessage(sourceThread);
+    await memoryDomain.saveMessages({ messages: [originalMessage] });
+
+    await expect(
+      memoryDomain.updateMessages({
+        messages: [{ id: originalMessage.id, threadId: missingThread.id }],
+      }),
+    ).rejects.toThrow(`Thread ${missingThread.id} not found`);
+
+    const client = (memoryDomain as any).client as Redis;
+    expect(await client.get<string>(`msg-idx:${originalMessage.id}`)).toBe(sourceThread.id);
+
+    const { messages } = await memoryDomain.listMessages({ threadId: sourceThread.id });
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.threadId).toBe(sourceThread.id);
   });
 });


### PR DESCRIPTION
## Description

Fixes 10+ second latency in `saveMessages` by replacing the `scanKeys` wildcard call with a direct `msg-idx` index lookup. Also applies the same index-first pattern to `updateMessages`.

- `saveMessages`: replaces `scanKeys('mastra_messages:threadId:*:id:...')` with `GET msg-idx:<messageId>` for O(1) lookup instead of full database scan
- `updateMessages`: adds index-first lookup before the scan fallback, with backfill when scan finds a message (same pattern as `_getThreadIdForMessage`)
- Adds two regression tests verifying no scan occurs during normal message saves and message moves

## Related Issue(s)

Fixes #15386

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Saving and updating messages was slow because the code searched the whole database for each message. This PR makes those operations instant by using an existing message index (msg-idx:<messageId>) to find messages directly, avoiding expensive scans.

## Overview

Replaces per-message SCAN-based lookups with index-first lookups using msg-idx:<messageId> to dramatically reduce latency in Upstash Redis for saveMessages and updateMessages. Adds batching, backfill behavior for unindexed (pre-migration) messages, improved error classification, and tests to prevent regressions.

## Changes

### Core Logic (stores/upstash/src/storage/domains/memory/index.ts)
- Introduces getMessageIndexKey(messageId) and a batch index-fetch pattern used across saveMessages and updateMessages.
- saveMessages:
  - Replaces scanKeys('...messageId...') with batch GET of msg-idx:<messageId> (O(1) lookup).
  - Adds _findExistingMessageLocations() that pipelines msg-idx GETs and treats messages with no index entry as new (no SCAN fallback).
  - When an indexed message is found in a different thread, deletes only the prior message key and removes it from the old thread's sorted set.
- updateMessages:
  - Queries msg-idx for all message IDs first; for IDs missing an index entry, falls back to scanKeys (only for genuinely unindexed/pre-migration items).
  - Backfills msg-idx when a message is found by scan so future lookups use the fast path.
  - Keeps msg-idx in sync when messages move threads by updating the index and message key mappings.
- Thread validation and caching:
  - Validates and caches referenced threads up-front for multi-message batches.
  - Updates updatedAt on all threads touched when messages move between threads.
- Error handling:
  - Redis pipeline failures are surfaced as THIRD_PARTY storage errors.
  - Missing threads are surfaced as USER errors with INVALID_ARGS.

### Tests (stores/upstash/src/storage/index.test.ts)
- Added deterministic factories createThread and createMessage and test isolation via afterEach.
- Added regression tests:
  - "saveMessages uses msg-idx index instead of scanning": verifies no Redis SCAN when moving an indexed message between threads and when saving a brand-new unindexed message.
  - "updateMessages keeps msg-idx index in sync": verifies updateMessages moves messages between threads and updates the msg-idx:<id> mapping (and listMessagesById reflects the move).

### Release
- .changeset/jolly-ants-attend.md: patch changeset documenting the fix and referencing #15386.

## Impact

- Performance: Eliminates multi-second (>10s) latency caused by per-message SCANs on Upstash by using O(1) index lookups and batching.
- Backward compatibility: updateMessages retains a SCAN fallback for unindexed (pre-migration) messages and backfills the index; saveMessages treats unindexed messages as new (no scan fallback) to optimize the common case.
- Reliability: Clearer error categorization and guaranteed thread timestamp updates when messages move.
- Tests: New regression tests ensure the fast-path index usage and index sync behavior are preserved.

Fixes #15386.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->