### PR TITLE
fix(core): populate toolInvocations from content.parts on storage round-trip

### DIFF
--- a/.changeset/curvy-crabs-find.md
+++ b/.changeset/curvy-crabs-find.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed toolInvocations not being populated on messages retrieved from storage. When messages with tool calls were saved during streaming, the top-level toolInvocations array was missing because it was never built from the content parts. This caused downstream consumers that rely on toolInvocations (like provider compatibility layers) to see an empty field even though the tool data was present in content.parts.

--- a/packages/core/src/agent/message-list/conversion/input-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/input-converter.ts
@@ -193,26 +193,50 @@ export function hydrateMastraDBMessageFields(
     message.createdAt = new Date(message.createdAt);
   }
 
-  // Fix toolInvocations with empty args by looking in the parts array
-  // This handles messages restored from database where toolInvocations might have lost their args
-  if (message.content.toolInvocations && message.content.parts) {
-    message.content.toolInvocations = message.content.toolInvocations.map(ti => {
-      if (!ti.args || Object.keys(ti.args).length === 0) {
-        // Find the corresponding tool-invocation part with args
-        const partWithArgs = message.content.parts.find(
-          part =>
-            part.type === 'tool-invocation' &&
-            part.toolInvocation &&
-            part.toolInvocation.toolCallId === ti.toolCallId &&
-            part.toolInvocation.args &&
-            Object.keys(part.toolInvocation.args).length > 0,
+  // Build or fix toolInvocations from the parts array.
+  // During streaming, MastraDBMessages are created with tool-invocation parts
+  // but without a top-level toolInvocations array. When these messages are
+  // saved to storage and later re-loaded, consumers that rely on
+  // content.toolInvocations (e.g. convert-to-mastra-v1, provider-compat)
+  // would find it missing. This block ensures it is always populated.
+  if (message.content.parts) {
+    const toolParts = message.content.parts.filter(
+      (p): p is Extract<typeof p, { type: 'tool-invocation' }> =>
+        p.type === 'tool-invocation' && !!p.toolInvocation?.toolCallId,
+    );
+
+    if (!message.content.toolInvocations || message.content.toolInvocations.length === 0) {
+      // Build toolInvocations from parts when missing entirely
+      if (toolParts.length > 0) {
+        message.content.toolInvocations = toolParts.map(
+          p =>
+            ({
+              toolCallId: p.toolInvocation.toolCallId,
+              toolName: p.toolInvocation.toolName,
+              args: p.toolInvocation.args,
+              state: p.toolInvocation.state,
+              ...('result' in p.toolInvocation ? { result: p.toolInvocation.result } : {}),
+            }) as NonNullable<MastraDBMessage['content']['toolInvocations']>[number],
         );
-        if (partWithArgs && partWithArgs.type === 'tool-invocation') {
-          return { ...ti, args: partWithArgs.toolInvocation.args };
-        }
       }
-      return ti;
-    });
+    } else {
+      // Fix existing toolInvocations with empty args by looking in the parts array
+      // This handles messages restored from database where toolInvocations might have lost their args
+      message.content.toolInvocations = message.content.toolInvocations.map(ti => {
+        if (!ti.args || Object.keys(ti.args).length === 0) {
+          const partWithArgs = toolParts.find(
+            p =>
+              p.toolInvocation.toolCallId === ti.toolCallId &&
+              p.toolInvocation.args &&
+              Object.keys(p.toolInvocation.args).length > 0,
+          );
+          if (partWithArgs) {
+            return { ...ti, args: partWithArgs.toolInvocation.args };
+          }
+        }
+        return ti;
+      });
+    }
   }
 
   if (!message.threadId && context.memoryInfo?.threadId) {

--- a/packages/core/src/agent/message-list/tests/message-list.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list.test.ts
@@ -434,6 +434,142 @@ describe('MessageList', () => {
       expect(uiMessages[0].toolInvocations![0].args).toEqual({ query: 'mastra framework' });
     });
 
+    it('should build toolInvocations from parts when toolInvocations is missing', () => {
+      // This test simulates messages restored from storage where
+      // toolInvocations was never populated (e.g. created during streaming
+      // by llm-execution-step which only sets content.parts)
+      const dbMessage: MastraDBMessage = {
+        id: 'db-hydrate-1',
+        role: 'assistant',
+        createdAt: new Date(),
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-hydrate-1',
+                toolName: 'weatherTool',
+                args: { city: 'London' },
+                result: { temp: 20 },
+              },
+            },
+          ],
+          // toolInvocations intentionally omitted
+        },
+      };
+
+      const list = new MessageList().add(dbMessage, 'memory');
+
+      const v2Messages = list.get.all.db();
+      expect(v2Messages).toHaveLength(1);
+      expect(v2Messages[0].content.toolInvocations).toHaveLength(1);
+      expect(v2Messages[0].content.toolInvocations![0]).toMatchObject({
+        toolCallId: 'call-hydrate-1',
+        toolName: 'weatherTool',
+        args: { city: 'London' },
+        state: 'result',
+        result: { temp: 20 },
+      });
+    });
+
+    it('should build toolInvocations from multiple tool-invocation parts when missing', () => {
+      const dbMessage: MastraDBMessage = {
+        id: 'db-hydrate-2',
+        role: 'assistant',
+        createdAt: new Date(),
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+        content: {
+          format: 2,
+          parts: [
+            { type: 'text', text: 'Let me look that up' },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-a',
+                toolName: 'searchTool',
+                args: { query: 'weather' },
+                result: { results: [] },
+              },
+            },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-b',
+                toolName: 'weatherTool',
+                args: { city: 'Paris' },
+                result: { temp: 25 },
+              },
+            },
+          ],
+        },
+      };
+
+      const list = new MessageList().add(dbMessage, 'memory');
+
+      const v2Messages = list.get.all.db();
+      expect(v2Messages[0].content.toolInvocations).toHaveLength(2);
+      expect(v2Messages[0].content.toolInvocations![0].toolCallId).toBe('call-a');
+      expect(v2Messages[0].content.toolInvocations![1].toolCallId).toBe('call-b');
+    });
+
+    it('should build toolInvocations from parts when existing array is empty', () => {
+      const dbMessage: MastraDBMessage = {
+        id: 'db-hydrate-3',
+        role: 'assistant',
+        createdAt: new Date(),
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'call-empty',
+                toolName: 'myTool',
+                args: { x: 1 },
+                result: 42,
+              },
+            },
+          ],
+          toolInvocations: [],
+        },
+      };
+
+      const list = new MessageList().add(dbMessage, 'memory');
+
+      const v2Messages = list.get.all.db();
+      expect(v2Messages[0].content.toolInvocations).toHaveLength(1);
+      expect(v2Messages[0].content.toolInvocations![0].toolCallId).toBe('call-empty');
+    });
+
+    it('should not create toolInvocations when there are no tool-invocation parts', () => {
+      const dbMessage: MastraDBMessage = {
+        id: 'db-hydrate-4',
+        role: 'assistant',
+        createdAt: new Date(),
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Hello world' }],
+        },
+      };
+
+      const list = new MessageList().add(dbMessage, 'memory');
+
+      const v2Messages = list.get.all.db();
+      expect(v2Messages[0].content.toolInvocations).toBeUndefined();
+    });
+
     it('should preserve tool args when tool-result arrives in a separate message', () => {
       // This test reproduces the issue where tool args are lost when tool-result
       // messages arrive separately from tool-call messages

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -2761,6 +2761,16 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                         "type": "step-start",
                       },
                     ],
+                    "toolInvocations": [
+                      {
+                        "args": {
+                          "value": "value",
+                        },
+                        "state": "call",
+                        "toolCallId": "call-1",
+                        "toolName": "tool1",
+                      },
+                    ],
                   },
                   "createdAt": 2024-01-01T00:00:00.003Z,
                   "id": "msg-0",


### PR DESCRIPTION
When messages with tool calls are created during streaming, `llm-execution-step` sets `content.parts` with `tool-invocation` entries but never populates the top-level `content.toolInvocations` array. After a save/load cycle through storage, `hydrateMastraDBMessageFields` only fixed existing `toolInvocations` with empty args — it never built the array when it was missing entirely.

This meant downstream code that reads `content.toolInvocations` (provider-compat, convert-to-mastra-v1) saw nothing, even though the data was right there in `content.parts`.

The fix extends `hydrateMastraDBMessageFields` to build `toolInvocations` from `tool-invocation` parts when the array is missing or empty. The existing empty-args fix is preserved in an else branch.

Added 4 tests covering: building from parts when missing, multiple tool parts, empty array treated as missing, and text-only messages left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When messages that call tools are saved and loaded back, the system sometimes forgot those tool calls. This change makes the loader rebuild the tool-call list from the message parts so the tool calls aren't lost.

## Overview
Fixes a bug where MastraDB messages created during streaming had tool-call data in content.parts but no top-level content.toolInvocations array after a save/load round-trip. hydrateMastraDBMessageFields now builds content.toolInvocations from tool-invocation parts when the array is missing or empty, and still preserves the existing behavior of filling empty args on existing toolInvocations by copying args from matching parts.

## Changes

packages/core/src/agent/message-list/conversion/input-converter.ts
- Enhanced hydrateMastraDBMessageFields to:
  - Collect tool-invocation parts into toolParts when message.content.parts exists.
  - If content.toolInvocations is missing or empty and toolParts exist, construct content.toolInvocations from toolParts (toolCallId, toolName, args, state, and result when present).
  - Otherwise, keep the previous logic to populate empty args on existing content.toolInvocations by finding matching toolParts.

packages/core/src/agent/message-list/tests/message-list.test.ts
- Added four tests validating hydration behavior:
  - Builds toolInvocations from parts when toolInvocations is omitted.
  - Handles multiple tool-invocation parts in order.
  - Treats an empty toolInvocations array as missing and populates it.
  - Leaves messages without tool-invocation parts unchanged.

packages/core/src/loop/test-utils/options.ts
- Updated an inline snapshot used in prepareStep tests to include the newly populated toolInvocations produced by the hydration change.

.changeset/curvy-crabs-find.md
- Adds a patch changeset for @mastra/core documenting the fix.

## Impact
Downstream consumers that read content.toolInvocations (e.g., provider-compat layers, convert-to-mastra-v1) will now reliably see tool invocation data after messages are loaded from storage, preventing missing-tool-call data after save/load cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->