### PR TITLE
(docs) - clarify generate and stream payload docs

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -74,6 +74,8 @@ When referencing an agent from your Mastra instance, use `mastra.getAgentById()`
   <TabItem value="generate" label=".generate()">
     Returns the full response after all tool calls and steps complete. The result includes `text`, `toolCalls`, `toolResults`, `steps`, and token `usage` statistics.
 
+    See the [`Agent.generate()` reference](/reference/agents/generate) for the response shape, including tool call and tool result payloads.
+
     ```ts
     const agent = mastra.getAgentById('test-agent')
     const response = await agent.generate('Help me organize my day')
@@ -83,6 +85,8 @@ When referencing an agent from your Mastra instance, use `mastra.getAgentById()`
 
   <TabItem value="stream" label=".stream()">
     Returns a stream you can consume as tokens arrive. The result exposes `textStream` for incremental output and promises for `toolCalls`, `toolResults`, `steps`, and token `usage` that resolve when the stream finishes.
+
+    See the [`MastraModelOutput` reference](/reference/streaming/agents/MastraModelOutput) for the stream shape, including tool call and tool result payloads.
 
     ```ts
     const agent = mastra.getAgentById('test-agent')

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -926,6 +926,34 @@ const response = await agent.generate('Help me organize my day', {
 ]}
 />
 
+## Response structure
+
+`Agent.generate()` returns the final data collected during execution. `steps` is an array of step objects. The tool arrays in the result, including top-level `toolCalls` and `toolResults` and the nested `step.toolCalls` and `step.toolResults` arrays, use Mastra's chunk format.
+
+That means tool data is wrapped in `payload`:
+
+```ts
+const response = await agent.generate('Check the weather in Lagos')
+
+for (const toolCall of response.toolCalls) {
+  console.log(toolCall.type) // 'tool-call'
+  console.log(toolCall.runId)
+  console.log(toolCall.from)
+  console.log(toolCall.payload.toolName)
+  console.log(toolCall.payload.args)
+}
+
+for (const step of response.steps) {
+  for (const toolResult of step.toolResults) {
+    console.log(toolResult.type) // 'tool-result'
+    console.log(toolResult.payload.toolName)
+    console.log(toolResult.payload.result)
+  }
+}
+```
+
+For the streaming version of the same chunk shape, see the [ChunkType reference](/reference/streaming/ChunkType).
+
 ## Returns
 
 <PropertiesTable
@@ -949,13 +977,124 @@ const response = await agent.generate('Help me organize my day', {
   },
   {
     name: 'toolCalls',
-    type: 'ToolCall[]',
-    description: 'Array of tool calls made during generation.',
+    type: 'ToolCallChunk[]',
+    description: 'Array of tool call chunks made during generation.',
+    properties: [
+      {
+        type: 'ToolCallChunk',
+        parameters: [
+          {
+            name: 'type',
+            type: "'tool-call'",
+            description: 'Chunk type identifier.',
+          },
+          {
+            name: 'runId',
+            type: 'string',
+            description: 'Execution run identifier.',
+          },
+          {
+            name: 'from',
+            type: 'ChunkFrom',
+            description: 'Source of the chunk, such as AGENT or WORKFLOW.',
+          },
+          {
+            name: 'payload',
+            type: 'ToolCallPayload',
+            description: 'Tool call data.',
+            properties: [
+              {
+                type: 'ToolCallPayload',
+                parameters: [
+                  {
+                    name: 'toolCallId',
+                    type: 'string',
+                    description: 'Unique identifier for the tool call.',
+                  },
+                  {
+                    name: 'toolName',
+                    type: 'string',
+                    description: 'Name of the tool that was called.',
+                  },
+                  {
+                    name: 'args',
+                    type: 'Record<string, unknown>',
+                    isOptional: true,
+                    description: 'Arguments passed to the tool.',
+                  },
+                  {
+                    name: 'providerExecuted',
+                    type: 'boolean',
+                    isOptional: true,
+                    description: 'Whether the model provider executed the tool directly.',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'toolResults',
-    type: 'ToolResult[]',
-    description: 'Array of results from tool executions.',
+    type: 'ToolResultChunk[]',
+    description: 'Array of tool result chunks from tool executions.',
+    properties: [
+      {
+        type: 'ToolResultChunk',
+        parameters: [
+          {
+            name: 'type',
+            type: "'tool-result'",
+            description: 'Chunk type identifier.',
+          },
+          {
+            name: 'runId',
+            type: 'string',
+            description: 'Execution run identifier.',
+          },
+          {
+            name: 'from',
+            type: 'ChunkFrom',
+            description: 'Source of the chunk, such as AGENT or WORKFLOW.',
+          },
+          {
+            name: 'payload',
+            type: 'ToolResultPayload',
+            description: 'Tool result data.',
+            properties: [
+              {
+                type: 'ToolResultPayload',
+                parameters: [
+                  {
+                    name: 'toolCallId',
+                    type: 'string',
+                    description: 'Unique identifier for the tool call.',
+                  },
+                  {
+                    name: 'toolName',
+                    type: 'string',
+                    description: 'Name of the tool that produced the result.',
+                  },
+                  {
+                    name: 'result',
+                    type: 'unknown',
+                    description: 'Value returned by the tool.',
+                  },
+                  {
+                    name: 'isError',
+                    type: 'boolean',
+                    isOptional: true,
+                    description: 'Whether the tool execution failed.',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'usage',
@@ -964,8 +1103,51 @@ const response = await agent.generate('Help me organize my day', {
   },
   {
     name: 'steps',
-    type: 'Step[]',
+    type: 'object[]',
     description: 'Array of execution steps, useful for debugging multi-step generations.',
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'text',
+            type: 'string',
+            description: 'Text generated in this step.',
+          },
+          {
+            name: 'toolCalls',
+            type: 'ToolCallChunk[]',
+            description: 'Tool calls emitted during this step.',
+          },
+          {
+            name: 'toolResults',
+            type: 'ToolResultChunk[]',
+            description: 'Tool results emitted during this step.',
+          },
+          {
+            name: 'finishReason',
+            type: 'string',
+            isOptional: true,
+            description: 'Why this step finished.',
+          },
+          {
+            name: 'usage',
+            type: 'LanguageModelUsage',
+            description: 'Token usage for this step.',
+          },
+          {
+            name: 'request',
+            type: '{ body?: unknown }',
+            description: 'Request metadata for this step.',
+          },
+          {
+            name: 'response',
+            type: 'object',
+            description: 'Response metadata for this step.',
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'finishReason',


### PR DESCRIPTION
Clarifies the documented shape of `agent.generate()` results so tool calls and tool results are shown with their `payload` fields.

Before, the overview page implied the high-level result shape but did not point readers to the exact payload structure. Now the generate tab links to the detailed reference, the stream tab links to `MastraModelOutput`, and the `Agent.generate()` reference documents the returned tool call, tool result, and step shapes more explicitly.

Example:

```ts
const response = await agent.generate('Check the weather in Lagos')
console.log(response.toolCalls[0].payload.toolName)
console.log(response.toolResults[0].payload.result)
```

Fixes #15220


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR updates the Agents docs to show that tool calls and results returned by Agent.generate() are wrapped inside a payload object, and updates examples so developers know to access fields like payload.toolName and payload.result.

## Overview

Documentation-only change clarifying the exact response shape of Agent.generate() and the stream output: tool calls, tool results, and per-step tool arrays use Mastra's chunk wrapper format ({ type, runId, from, payload: { ... } }). The overview tabs now link to the detailed reference pages so readers can find the precise payload fields and examples.

## Changes

- docs/src/content/en/docs/agents/overview.mdx
  - Added cross-reference in the .generate() tab to the Agent.generate() reference for the full response shape (including tool call/result payloads).
  - Added cross-reference in the .stream() tab to the MastraModelOutput reference for stream shape (including tool call/result payloads).

- docs/src/content/en/reference/agents/generate.mdx
  - Added a "Response structure" section documenting that Agent.generate() returns steps and tool arrays in Mastra's chunk format with tool data under payload.
  - Updated Returns documentation:
    - toolCalls: ToolCallChunk[] — documents fields: type, runId, from, payload { toolCallId, toolName, args? , providerExecuted? }.
    - toolResults: ToolResultChunk[] — documents fields: type, runId, from, payload { toolCallId, toolName, result, isError? }.
    - steps: object[] — documents per-step properties including text, toolCalls (ToolCallChunk[]), toolResults (ToolResultChunk[]), optional finishReason, usage, request, and response metadata.
  - Added explicit code examples demonstrating access via payload (e.g., response.toolCalls[0].payload.toolName and response.toolResults[0].payload.result).

## Related Issues

Fixes #15220 — addresses developer confusion where code expecting the AI SDK's flat generateText() shape received undefined because Mastra's Agent.generate() wraps tool fields under payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->