### PR TITLE
Fix strict tool propagation through router and MCP

### DIFF
--- a/.changeset/mighty-mails-divide.md
+++ b/.changeset/mighty-mails-divide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed MCP tool strict mode propagation. MCP servers now expose Mastra tool strictness in MCP metadata, and the MCP client restores that flag when rebuilding tools so strict OpenAI tool calling works for MCP-backed tools too.

--- a/.changeset/quiet-pots-sparkle.md
+++ b/.changeset/quiet-pots-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed OpenAI tool strict mode when requests pass through the model router. `strict: true` on function tools now survives compatibility prep, so OpenAI Responses models receive strict tool definitions instead of silently downgrading them to non-strict.

--- a/packages/core/src/llm/model/aisdk/v5/model.test.ts
+++ b/packages/core/src/llm/model/aisdk/v5/model.test.ts
@@ -1,0 +1,60 @@
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { describe, expect, it, vi } from 'vitest';
+import { AISDKV5LanguageModel } from './model';
+
+function createMockV2Model() {
+  return {
+    specificationVersion: 'v2',
+    provider: 'openai-compatible',
+    modelId: 'test-model',
+    defaultObjectGenerationMode: 'json',
+    supportsStructuredOutputs: true,
+    supportsImageUrls: true,
+    supportedUrls: {},
+    doGenerate: vi.fn().mockResolvedValue({
+      text: 'ok',
+      content: [],
+      warnings: [],
+      usage: { promptTokens: 1, completionTokens: 1 },
+      finishReason: 'stop',
+      request: {},
+      response: { id: 'resp_1', modelId: 'test-model' },
+    }),
+    doStream: vi.fn().mockResolvedValue({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      request: {},
+      response: { id: 'resp_1', modelId: 'test-model' },
+    }),
+  } as unknown as LanguageModelV2;
+}
+
+describe('AISDKV5LanguageModel', () => {
+  it.each(['doGenerate', 'doStream'] as const)(
+    'strips strict from function tools before calling v2 %s',
+    async method => {
+      const model = createMockV2Model();
+      const wrapped = new AISDKV5LanguageModel(model);
+
+      await wrapped[method]({
+        inputFormat: 'messages',
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+        tools: [
+          {
+            type: 'function',
+            name: 'strictTool',
+            description: 'A strict tool',
+            strict: true,
+            inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+          },
+        ],
+      } as any);
+
+      const call = (model[method] as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.tools[0]).not.toHaveProperty('strict');
+    },
+  );
+});

--- a/packages/core/src/llm/model/aisdk/v5/model.ts
+++ b/packages/core/src/llm/model/aisdk/v5/model.ts
@@ -4,6 +4,26 @@ import { createStreamFromGenerateResult } from '../generate-to-stream';
 
 type StreamResult = Awaited<ReturnType<LanguageModelV2['doStream']>>;
 
+function stripStrictFromFunctionTools(options: LanguageModelV2CallOptions): LanguageModelV2CallOptions {
+  if (!options.tools?.length) {
+    return options;
+  }
+
+  const sanitizedTools = options.tools.map((tool: Record<string, unknown>) => {
+    if (tool.type !== 'function' || !('strict' in tool)) {
+      return tool;
+    }
+
+    const { strict: _strict, ...rest } = tool;
+    return rest;
+  });
+
+  return {
+    ...options,
+    tools: sanitizedTools as typeof options.tools,
+  };
+}
+
 /**
  * Wrapper class for AI SDK V5 (LanguageModelV2) that converts doGenerate to return
  * a stream format for consistency with Mastra's streaming architecture.
@@ -44,7 +64,7 @@ export class AISDKV5LanguageModel implements MastraLanguageModelV2 {
   }
 
   async doGenerate(options: LanguageModelV2CallOptions) {
-    const result = await this.#model.doGenerate(options);
+    const result = await this.#model.doGenerate(stripStrictFromFunctionTools(options));
 
     return {
       ...result,
@@ -55,6 +75,6 @@ export class AISDKV5LanguageModel implements MastraLanguageModelV2 {
   }
 
   async doStream(options: LanguageModelV2CallOptions) {
-    return await this.#model.doStream(options);
+    return await this.#model.doStream(stripStrictFromFunctionTools(options));
   }
 }

--- a/packages/core/src/llm/model/router-provider-tools.test.ts
+++ b/packages/core/src/llm/model/router-provider-tools.test.ts
@@ -2,6 +2,7 @@ import type { LanguageModelV3 } from '@ai-sdk/provider-v6';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { prepareToolsAndToolChoice } from '../../stream/aisdk/v5/compat/prepare-tools';
 import type { ModelSpecVersion } from '../../stream/aisdk/v5/compat/prepare-tools';
+import { createTool } from '../../tools/tool';
 import { MastraModelGateway } from './gateways/base';
 import type { ProviderConfig, GatewayLanguageModel } from './gateways/base';
 import { ModelRouterLanguageModel } from './router';
@@ -226,6 +227,50 @@ describe('ModelRouterLanguageModel with V3 gateway and provider tools (#13667)',
 
     expect(passedOptions.tools).toHaveLength(1);
     expect(passedOptions.tools[0].type).toBe('function');
+  });
+
+  it('should preserve strict on function tools when routing v2-prepared tools to a V3 model', async () => {
+    const router = new ModelRouterLanguageModel({ id: 'v3-gateway/openai/gpt-4o' as `${string}/${string}` }, [gateway]);
+
+    const strictTool = createTool({
+      id: 'strict-tool',
+      description: 'A strict tool',
+      strict: true,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+        },
+        required: ['query'],
+        additionalProperties: false,
+      },
+      execute: async () => ({ ok: true }),
+    });
+
+    const preparedTools = prepareToolsAndToolChoice({
+      tools: {
+        strictTool: strictTool as any,
+      },
+      toolChoice: undefined,
+      activeTools: undefined,
+      targetVersion: 'v2',
+    });
+
+    await router.doStream({
+      inputFormat: 'messages',
+      ...preparedTools,
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Use the strict tool' }] }],
+    } as any);
+
+    const doStreamCall = (mockV3Model.doStream as ReturnType<typeof vi.fn>).mock.calls[0];
+    const passedOptions = doStreamCall[0];
+
+    expect(passedOptions.tools).toHaveLength(1);
+    expect(passedOptions.tools[0]).toMatchObject({
+      type: 'function',
+      name: 'strictTool',
+      strict: true,
+    });
   });
 
   it('should handle mixed provider and function tools when routing to V3 model', async () => {

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -246,7 +246,14 @@ export abstract class MCPServerBase<TId extends string = string> extends MastraB
    * @returns An object containing an array of tool information.
    */
   public abstract getToolListInfo(): {
-    tools: Array<{ name: string; description?: string; inputSchema: any; outputSchema?: any; toolType?: MCPToolType }>;
+    tools: Array<{
+      name: string;
+      description?: string;
+      inputSchema: any;
+      outputSchema?: any;
+      toolType?: MCPToolType;
+      _meta?: Record<string, unknown>;
+    }>;
   };
 
   /**
@@ -254,9 +261,16 @@ export abstract class MCPServerBase<TId extends string = string> extends MastraB
    * @param toolId The ID/name of the tool to retrieve.
    * @returns Tool information (name, description, inputSchema) or undefined if not found.
    */
-  public abstract getToolInfo(
-    toolId: string,
-  ): { name: string; description?: string; inputSchema: any; outputSchema?: any; toolType?: MCPToolType } | undefined;
+  public abstract getToolInfo(toolId: string):
+    | {
+        name: string;
+        description?: string;
+        inputSchema: any;
+        outputSchema?: any;
+        toolType?: MCPToolType;
+        _meta?: Record<string, unknown>;
+      }
+    | undefined;
 
   /**
    * Executes a specific tool provided by this MCP server.

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -207,7 +207,7 @@ describe('prepareToolsAndToolChoice', () => {
       });
     });
 
-    it('should omit strict for v2 function tools', () => {
+    it('should preserve strict in prepared v2 function tools for downstream router handoff', () => {
       const strictTool = createTool({
         id: 'strict-tool-v2',
         description: 'A strict test tool for v2',
@@ -225,7 +225,11 @@ describe('prepareToolsAndToolChoice', () => {
         targetVersion: 'v2',
       });
 
-      expect(result.tools![0]).not.toHaveProperty('strict');
+      expect(result.tools![0]).toMatchObject({
+        type: 'function',
+        name: 'strictTool',
+        strict: true,
+      });
     });
 
     it('should not treat regular tools with no id as provider tools', () => {

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -197,7 +197,10 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
                 name,
                 description: sdkTool.description,
                 inputSchema: fixTypelessProperties(parameters as Record<string, unknown>),
-                ...(targetVersion === 'v3' && strict != null ? { strict } : {}),
+                // Preserve strict through v2 preparation because the model router may
+                // still forward these tools to an AI SDK v6 / V3 model later. Actual
+                // V2 model calls strip this field at the AISDKV5LanguageModel boundary.
+                ...(strict != null ? { strict } : {}),
                 providerOptions: sdkTool.providerOptions,
               };
             case 'provider-defined': {

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -2183,6 +2183,34 @@ describe('MastraMCPClient - mcpMetadata on tools', () => {
     expect(greetTool.mcpMetadata).toBeDefined();
     expect(greetTool.mcpMetadata!.serverVersion).toBe('1.0.0');
   });
+
+  it('should preserve strict mode from MCP tool metadata', async () => {
+    const sdkClient = (client as any).client as Client;
+
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'strict_tool',
+          description: 'A strict MCP tool',
+          inputSchema: {
+            type: 'object' as const,
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+          },
+          _meta: {
+            mastra: {
+              strict: true,
+            },
+          },
+        },
+      ],
+    });
+
+    const tools = await client.tools();
+    expect(tools.strict_tool).toBeDefined();
+    expect(tools.strict_tool.strict).toBe(true);
+  });
 });
 
 describe('MastraMCPClient fetch with requestContext', () => {

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -41,6 +41,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import { asyncExitHook, gracefulExit } from 'exit-hook';
+import { getMastraToolStrictMeta } from '../shared/mastra-tool-meta';
 import { ElicitationClientActions } from './actions/elicitation';
 import { ProgressClientActions } from './actions/progress';
 import { PromptClientActions } from './actions/prompt';
@@ -709,6 +710,7 @@ export class InternalMastraMCPClient extends MastraBase {
           id: `${this.name}_${tool.name}`,
           description: tool.description || '',
           inputSchema: await this.convertInputSchema(tool.inputSchema),
+          strict: getMastraToolStrictMeta((tool as { _meta?: Record<string, unknown> })._meta),
           // Don't pass outputSchema to createTool — the MCP SDK's Client.callTool()
           // already validates structuredContent against the tool's outputSchema using AJV.
           // Passing it here causes Zod to strip unrecognized keys from the CallToolResult

--- a/packages/mcp/src/server/server-tool-annotations.test.ts
+++ b/packages/mcp/src/server/server-tool-annotations.test.ts
@@ -30,6 +30,7 @@ describe('MCPServer Tool Annotations (Issue #9859)', () => {
     const annotatedTool = createTool({
       id: 'annotated-tool',
       description: 'A tool with MCP annotations for OpenAI Apps SDK compatibility',
+      strict: true,
       inputSchema: z.object({
         query: z.string().describe('The query to process'),
       }),
@@ -127,5 +128,6 @@ describe('MCPServer Tool Annotations (Issue #9859)', () => {
     expect((annotatedTool as any)._meta).toBeDefined();
     expect((annotatedTool as any)._meta?.customField).toBe('custom-value');
     expect((annotatedTool as any)._meta?.version).toBe('1.0.0');
+    expect((annotatedTool as any)._meta?.mastra?.strict).toBe(true);
   });
 });

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -50,6 +50,7 @@ import type { SSEStreamingApi } from 'hono/streaming';
 import { streamSSE } from 'hono/streaming';
 import { SSETransport } from 'hono-mcp-server-sse-transport';
 
+import { withMastraToolStrictMeta } from '../shared/mastra-tool-meta';
 import { ServerPromptActions } from './promptActions';
 import { ServerResourceActions } from './resourceActions';
 import type { MCPServerPrompts, MCPServerResources, ElicitationActions, MastraPrompt } from './types';
@@ -428,9 +429,9 @@ export class MCPServer extends MCPServerBase {
           if (tool.mcp?.annotations) {
             toolSpec.annotations = tool.mcp.annotations;
           }
-          // Include _meta if present
-          if (tool.mcp?._meta) {
-            toolSpec._meta = tool.mcp._meta;
+          const toolMeta = withMastraToolStrictMeta(tool.mcp?._meta, tool.strict);
+          if (toolMeta) {
+            toolSpec._meta = toolMeta;
           }
           return toolSpec;
         }),
@@ -1879,7 +1880,14 @@ export class MCPServer extends MCPServerBase {
    * ```
    */
   public getToolListInfo(): {
-    tools: Array<{ name: string; description?: string; inputSchema: any; outputSchema?: any; toolType?: MCPToolType }>;
+    tools: Array<{
+      name: string;
+      description?: string;
+      inputSchema: any;
+      outputSchema?: any;
+      toolType?: MCPToolType;
+      _meta?: Record<string, unknown>;
+    }>;
   } {
     this.logger.debug('Getting tool list', { server: this.name });
     return {
@@ -1890,6 +1898,7 @@ export class MCPServer extends MCPServerBase {
         inputSchema: this.convertSchema(tool.parameters),
         outputSchema: this.convertSchema(tool.parameters),
         toolType: tool.mcp?.toolType,
+        _meta: withMastraToolStrictMeta(tool.mcp?._meta, tool.strict),
       })),
     };
   }
@@ -1912,9 +1921,16 @@ export class MCPServer extends MCPServerBase {
    * }
    * ```
    */
-  public getToolInfo(
-    toolId: string,
-  ): { name: string; description?: string; inputSchema: any; outputSchema?: any; toolType?: MCPToolType } | undefined {
+  public getToolInfo(toolId: string):
+    | {
+        name: string;
+        description?: string;
+        inputSchema: any;
+        outputSchema?: any;
+        toolType?: MCPToolType;
+        _meta?: Record<string, unknown>;
+      }
+    | undefined {
     const tool = this.convertedTools[toolId];
     if (!tool) {
       this.logger.debug('Tool not found', { tool: toolId, server: this.name });
@@ -1927,6 +1943,7 @@ export class MCPServer extends MCPServerBase {
       inputSchema: this.convertSchema(tool.parameters),
       outputSchema: this.convertSchema(tool.outputSchema),
       toolType: tool.mcp?.toolType,
+      _meta: withMastraToolStrictMeta(tool.mcp?._meta, tool.strict),
     };
   }
 

--- a/packages/mcp/src/shared/mastra-tool-meta.ts
+++ b/packages/mcp/src/shared/mastra-tool-meta.ts
@@ -1,0 +1,34 @@
+const MASTRA_META_KEY = 'mastra';
+const STRICT_META_KEY = 'strict';
+
+export function withMastraToolStrictMeta(
+  meta: Record<string, unknown> | undefined,
+  strict: boolean | undefined,
+): Record<string, unknown> | undefined {
+  if (strict == null) {
+    return meta;
+  }
+
+  const mastraMeta =
+    meta?.[MASTRA_META_KEY] && typeof meta[MASTRA_META_KEY] === 'object'
+      ? (meta[MASTRA_META_KEY] as Record<string, unknown>)
+      : undefined;
+
+  return {
+    ...(meta ?? {}),
+    [MASTRA_META_KEY]: {
+      ...(mastraMeta ?? {}),
+      [STRICT_META_KEY]: strict,
+    },
+  };
+}
+
+export function getMastraToolStrictMeta(meta: Record<string, unknown> | undefined): boolean | undefined {
+  const mastraMeta = meta?.[MASTRA_META_KEY];
+  if (!mastraMeta || typeof mastraMeta !== 'object') {
+    return undefined;
+  }
+
+  const strict = (mastraMeta as Record<string, unknown>)[STRICT_META_KEY];
+  return typeof strict === 'boolean' ? strict : undefined;
+}


### PR DESCRIPTION
## Description

Preserve `strict: true` on function tools through the router handoff so OpenAI `responses` models receive it, while still stripping `strict` at the real AI SDK v2 boundary. Propagate the same flag across MCP by storing it in Mastra-scoped tool metadata and restoring it on the client, and add focused regression tests for the router, v2 wrapper, and MCP round-trip.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a bug where OpenAI's "strict tools" feature (a special mode that makes tools follow a schema exactly) was losing its strict setting when being routed through the system or passed through MCP (a protocol for sharing tools). The PR ensures the strict flag stays with the tool throughout its entire journey—through routers to different models, and when tools are shared via MCP servers and clients—while also making sure it's properly removed at the final step when reaching the actual AI model.

## Overview

This PR implements strict tool propagation across three critical boundaries in the Mastra framework:

1. **Router Handoff**: Preserves `strict: true` when tools are routed through `ModelRouterLanguageModel` so OpenAI Responses models receive the correct tool definitions
2. **AI SDK V5 Boundary**: Strips `strict` at the final AI SDK v2 boundary to avoid compatibility issues with underlying AI model implementations
3. **MCP Round-trip**: Propagates the strict flag through MCP by storing it in tool metadata (`_meta.mastra.strict`) on the server and restoring it when the MCP client rebuilds tools

## Changes by Component

### Core Tool Preparation (`prepare-tools.ts`)
- Modified to always preserve the `strict` field when present on input tools, regardless of `targetVersion`
- Previously, `strict` was only retained for `targetVersion: 'v3'`; now it's preserved for all versions to support router handoff

### AI SDK V5 Wrapper (`v5/model.ts`)
- Added `stripStrictFromFunctionTools()` helper that removes the `strict` property from function tools before delegating to the underlying AI SDK V5 model
- Prevents compatibility issues by ensuring strict constraints are removed only at the real AI SDK v2 boundary, not before router handoff

### Router (`router-provider-tools.ts`)
- New test verifies that strict tools are preserved when routed through `ModelRouterLanguageModel` to downstream v3 models
- Confirms that `strict: true` is forwarded intact during v2→v3 routing

### MCP Server (`server.ts`, `server-tool-annotations.test.ts`)
- Updated return types for `getToolListInfo()` and `getToolInfo()` to include optional `_meta?: Record<string, unknown>` field
- Added `withMastraToolStrictMeta()` integration to store `strict` flag in `_meta.mastra.strict` when exposing tools via MCP protocol

### MCP Client (`client.ts`, `client.test.ts`)
- Added `getMastraToolStrictMeta()` import to extract strict flag from MCP tool metadata
- When creating tool wrappers via `createTool()`, now sets the `strict` option by reading from `_meta.mastra.strict`
- Ensures MCP-backed tools restore their strictness when the client rebuilds them

### MCP Metadata Helpers (`mastra-tool-meta.ts`)
- New shared module with two helpers:
  - `withMastraToolStrictMeta(meta, strict)`: Augments metadata to include `mastra.strict` when strict is provided
  - `getMastraToolStrictMeta(meta)`: Reads `mastra.strict` from metadata if present
- Handles edge cases like null/undefined inputs and ensures metadata objects are properly initialized

## Testing

Added comprehensive regression tests covering:
- Router propagation of strict tools through v2→v3 handoff
- AI SDK V5 wrapper correctly stripping strict before delegation
- MCP server correctly storing strict in `_meta.mastra.strict`
- MCP client correctly restoring strict from metadata

## Changeset Entries

- `@mastra/core` (patch): Fixes OpenAI tool strict mode preservation through model router
- `@mastra/mcp` (patch): Fixes MCP propagation of tool strict mode via metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->