### PR TITLE
fix(mcp): preserve recursive MCP tool schemas

### DIFF
--- a/.changeset/sour-paws-cough.md
+++ b/.changeset/sour-paws-cough.md
@@ -1,0 +1,6 @@
+---
+'@mastra/schema-compat': patch
+'@mastra/mcp': patch
+---
+
+Fixed MCP tools with recursive JSON Schema refs so they stay serializable when loaded.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -36,7 +36,6 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^14.2.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "exit-hook": "^5.1.0",
     "fast-deep-equal": "^3.1.3",

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -295,6 +295,60 @@ describe('MastraMCPClient - outputSchema without structuredContent', () => {
     // The full CallToolResult envelope is returned — no extraction, no Zod stripping
     expect(result).toEqual(callToolResult);
   });
+
+  it('should preserve recursive $ref input schemas when creating tools', async () => {
+    const sdkClient = (client as any).client as Client;
+    const recursiveInputSchema = {
+      type: 'object' as const,
+      properties: {
+        root: { $ref: '#/$defs/node' },
+      },
+      required: ['root'],
+      $defs: {
+        node: {
+          type: 'object' as const,
+          properties: {
+            name: { type: 'string' as const },
+            children: {
+              type: 'array' as const,
+              items: { $ref: '#/$defs/node' },
+            },
+          },
+          required: ['name'],
+        },
+      },
+    };
+
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'recursive_tool',
+          description: 'Returns a recursive schema',
+          inputSchema: recursiveInputSchema,
+        },
+      ],
+    });
+
+    const tools = await client.tools();
+    const recursiveTool = tools['recursive_tool'];
+    expect(recursiveTool).toBeDefined();
+
+    const storedSchema = recursiveTool.inputSchema?.['~standard'].jsonSchema.input({ target: 'draft-07' }) as {
+      properties?: { root?: { $ref?: string } };
+      $defs?: {
+        node?: {
+          properties?: {
+            children?: {
+              items?: { $ref?: string };
+            };
+          };
+        };
+      };
+    };
+
+    expect(storedSchema.properties?.root?.$ref).toBe('#/$defs/node');
+    expect(storedSchema.$defs?.node?.properties?.children?.items?.$ref).toBe('#/$defs/node');
+  });
 });
 
 describe('MastraMCPClient - no outputSchema', () => {

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -1,9 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Stream } from 'node:stream';
-import $RefParser from '@apidevtools/json-schema-ref-parser';
 import { MastraBase } from '@mastra/core/base';
 import type { RequestContext } from '@mastra/core/di';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { createTool } from '@mastra/core/tools';
 import type { Tool } from '@mastra/core/tools';
 
@@ -650,32 +648,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private async convertInputSchema(
     inputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['inputSchema'],
   ): Promise<JSONSchema7> {
-    try {
-      await $RefParser.dereference(inputSchema);
-      return ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
-    } catch (error: unknown) {
-      let errorDetails: string | undefined;
-      if (error instanceof Error) {
-        errorDetails = error.stack;
-      } else {
-        try {
-          errorDetails = JSON.stringify(error);
-        } catch {
-          errorDetails = String(error);
-        }
-      }
-      this.log('error', 'Failed to dereference JSON schema', {
-        error: errorDetails,
-        originalJsonSchema: inputSchema,
-      });
-
-      throw new MastraError({
-        id: 'MCP_TOOL_INPUT_SCHEMA_CONVERSION_FAILED',
-        domain: ErrorDomain.MCP,
-        category: ErrorCategory.USER,
-        details: { error: errorDetails ?? 'Unknown error' },
-      });
-    }
+    return ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
   }
 
   async tools(): Promise<Record<string, Tool<any, any, any, any>>> {

--- a/packages/schema-compat/src/standard-schema/adapters/json-schema.test.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/json-schema.test.ts
@@ -198,6 +198,53 @@ describe('json-schema standard-schema adapter', () => {
       expect('issues' in invalidResult).toBe(true);
     });
 
+    it('should preserve recursive $ref schemas when converting output JSON Schema', () => {
+      const jsonSchema = {
+        type: 'object',
+        properties: {
+          root: { $ref: '#/$defs/node' },
+        },
+        required: ['root'],
+        $defs: {
+          node: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              children: {
+                type: 'array',
+                items: { $ref: '#/$defs/node' },
+              },
+            },
+            required: ['name'],
+          },
+        },
+      } as JSONSchema7 & {
+        properties: {
+          root: { $ref: string };
+        };
+        $defs: {
+          node: {
+            properties: {
+              children: {
+                items: { $ref: string };
+              };
+            };
+          };
+        };
+      };
+
+      const standardSchema = toStandardSchema(jsonSchema);
+      const outputSchema = standardSchema['~standard'].jsonSchema.output({
+        target: 'draft-07',
+      }) as unknown as typeof jsonSchema & {
+        $schema?: string;
+      };
+
+      expect(outputSchema.$schema).toBe('http://json-schema.org/draft-07/schema#');
+      expect(outputSchema.properties.root).toEqual({ $ref: '#/$defs/node' });
+      expect(outputSchema.$defs.node.properties.children.items).toEqual({ $ref: '#/$defs/node' });
+    });
+
     it('should expose getSchema method', () => {
       const jsonSchema: JSONSchema7 = {
         type: 'string',

--- a/packages/schema-compat/src/standard-schema/standard-schema.test.ts
+++ b/packages/schema-compat/src/standard-schema/standard-schema.test.ts
@@ -593,6 +593,48 @@ describe('standardSchemaToJSONSchema', () => {
       expect(result.properties!.name).toEqual({ type: 'string' });
       expect(result.properties!.age).toEqual({ type: 'number' });
     });
+
+    it('should preserve recursive $ref schemas when normalizing standard schemas', () => {
+      const recursiveJsonSchema = {
+        type: 'object',
+        properties: {
+          root: { $ref: '#/$defs/node' },
+        },
+        required: ['root'],
+        $defs: {
+          node: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              children: {
+                type: 'array',
+                items: { $ref: '#/$defs/node' },
+              },
+            },
+            required: ['name'],
+          },
+        },
+      } as JSONSchema7 & {
+        properties: {
+          root: { $ref: string };
+        };
+        $defs: {
+          node: {
+            properties: {
+              children: {
+                items: { $ref: string };
+              };
+            };
+          };
+        };
+      };
+
+      const wrapped = toStandardSchema(recursiveJsonSchema);
+      const result = standardSchemaToJSONSchema(wrapped) as typeof recursiveJsonSchema;
+
+      expect(result.properties.root).toEqual({ $ref: '#/$defs/node' });
+      expect(result.$defs.node.properties.children.items).toEqual({ $ref: '#/$defs/node' });
+    });
   });
 
   describe('options', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3644,9 +3644,6 @@ importers:
 
   packages/mcp:
     dependencies:
-      '@apidevtools/json-schema-ref-parser':
-        specifier: ^14.2.1
-        version: 14.2.1(@types/json-schema@7.0.15)
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -7401,12 +7398,6 @@ packages:
   '@anush008/tokenizers@0.0.0':
     resolution: {integrity: sha512-IQD9wkVReKAhsEAbDjh/0KrBGTEXelqZLpOBRDaIRvlzZ9sjmUP+gKbpvzyJnei2JHQiE8JAgj7YcNloINbGBw==}
     engines: {node: '>= 10'}
-
-  '@apidevtools/json-schema-ref-parser@14.2.1':
-    resolution: {integrity: sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      '@types/json-schema': ^7.0.15
 
   '@appium/logger@1.7.1':
     resolution: {integrity: sha512-9C2o9X/lBEDBUnKfAi3mRo9oG7Z03nmISLwsGkWxIWjMAvBdJD0RRSJMekWVKzfXN3byrI1WlCXTITzN4LAoLw==}
@@ -26225,11 +26216,6 @@ snapshots:
       '@anush008/tokenizers-darwin-universal': 0.0.0
       '@anush008/tokenizers-linux-x64-gnu': 0.0.0
       '@anush008/tokenizers-win32-x64-msvc': 0.0.0
-
-  '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
-    dependencies:
-      '@types/json-schema': 7.0.15
-      js-yaml: 3.14.2
 
   '@appium/logger@1.7.1':
     dependencies:


### PR DESCRIPTION
This fixes recursive MCP tool schemas that were being dereferenced into circular JavaScript objects before `createTool` ran. Keeping the original `$ref`-based schema avoids the circular structure crash reported in #15341 and lets these tools load normally.

Before: a recursive input schema like `{ root: { $ref: '#/$defs/node' } }` could fail during schema normalization.
After: the same schema stays in its original `$ref` form and remains JSON-serializable.

I also added regression coverage in `@mastra/mcp` and `@mastra/schema-compat`, and removed the unused `@apidevtools/json-schema-ref-parser` dependency from `@mastra/mcp`.

Ran `pnpm --filter ./packages/mcp test:client`, `pnpm --filter ./packages/schema-compat test -- --runInBand src/standard-schema/adapters/json-schema.test.ts src/standard-schema/standard-schema.test.ts`, `pnpm --filter ./packages/mcp build:lib`, and `pnpm --filter ./packages/schema-compat build`.

Fixes https://github.com/mastra-ai/mastra/issues/15341


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
MCP tools have nested reference pointers in their descriptions (like "see definition X"). The code was expanding these pointers inline, which created impossible-to-save circular loops for tools with self-referencing structures. This fix removes that expansion step, keeping the pointers as-is so everything stays saveable and works correctly.

## Overview
This PR fixes a crash that occurred when MCP tools had recursive JSON Schema references. The root cause was that the MCP client was dereferencing JSON Schemas before tool creation, expanding `$ref` pointers into actual objects and creating circular JavaScript structures that couldn't be serialized to JSON. The PR resolves this by removing the dereferencing step entirely, allowing schemas with recursive `$ref`/`$defs` structures to remain JSON-serializable.

## Key Changes

**Removed dereferencing in MCP client** (`packages/mcp/src/client/client.ts`)
- Deleted the `$RefParser.dereference()` call from `convertInputSchema()` that was expanding `$ref` references into object references
- The function now simply unwraps and returns the JSON Schema directly without any dereferencing attempts
- Removed unused imports: `$RefParser`, `ErrorCategory`, `ErrorDomain`, and `MastraError`
- Lines changed: 1 added, 28 removed

**Removed unused dependency** (`packages/mcp/package.json`)
- Removed `@apidevtools/json-schema-ref-parser` (`^14.2.1`) from runtime dependencies since dereferencing is no longer performed

**Comprehensive test coverage**
- Added regression test in `packages/mcp/src/client/client.test.ts` verifying that when `sdkClient.listTools()` returns tools with recursive JSON Schema references, `client.tools()` preserves those `$ref` targets in the stored tool `inputSchema` after conversion through standard schema format
- Added test in `packages/schema-compat/src/standard-schema/adapters/json-schema.test.ts` verifying that converting a StandardSchema back to JSON Schema output preserves recursive `$ref` references within `$defs`-based recursive structures
- Added test in `packages/schema-compat/src/standard-schema/standard-schema.test.ts` verifying that wrapping a recursive JSON Schema via `toStandardSchema` and normalizing via `standardSchemaToJSONSchema` preserves original recursive `$ref` values
- Lines changed: 143 added total across test files

**Changeset documentation** (`.changeset/sour-paws-cough.md`)
- Documents patch version bumps for `@mastra/schema-compat` and `@mastra/mcp`
- Records fix description: "MCP tools are corrected to handle recursive JSON Schema `$ref`s so they remain serializable when loaded"

## Problem Solved
Agents using MCP tools with recursive schemas (such as Backstage's `catalog.query-catalog-entities`) would crash with "TypeError: Converting circular structure to JSON" during the prepare-tools-step. This fix ensures such tools load and handle recursive schemas normally without crashes, maintaining JSON serializability throughout the schema processing pipeline.

## Testing Verified
- `pnpm --filter ./packages/mcp test:client` - MCP client tests pass
- `pnpm --filter ./packages/schema-compat test -- --runInBand` - Schema compatibility tests pass
- `pnpm --filter ./packages/mcp build:lib` - MCP package builds successfully
- `pnpm --filter ./packages/schema-compat build` - Schema compatibility package builds successfully

## Related Issue
Fixes: https://github.com/mastra-ai/mastra/issues/15341

<!-- end of auto-generated comment: release notes by coderabbit.ai -->