### PR TITLE
fix(observability): preserve raw JSON schemas and handle v5 body.input in span serialization

### DIFF
--- a/.changeset/fix-observability-preserve-json-schema.md
+++ b/.changeset/fix-observability-preserve-json-schema.md
@@ -2,4 +2,4 @@
 '@mastra/observability': patch
 ---
 
-Fixed span serialization replacing tool parameter JSON schemas with lossy summaries like `"unknown (required)"`. JSON schemas in span data are now preserved as-is, keeping full type information for debugging in observability tools like Datadog.
+Fixed span serialization replacing tool parameter JSON schemas with lossy summaries like `"unknown (required)"`. JSON schemas in span data are now preserved as-is, keeping full type information for debugging in observability tools like Datadog. Also fixed MODEL_STEP span input showing only a keys summary instead of actual messages for AI SDK v5 providers.

--- a/.changeset/fix-observability-preserve-json-schema.md
+++ b/.changeset/fix-observability-preserve-json-schema.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed span serialization replacing tool parameter JSON schemas with lossy summaries like `"unknown (required)"`. JSON schemas in span data are now preserved as-is, keeping full type information for debugging in observability tools like Datadog.

--- a/.changeset/fix-observability-v5-span-input.md
+++ b/.changeset/fix-observability-v5-span-input.md
@@ -1,5 +1,0 @@
----
-'@mastra/observability': patch
----
-
-Fixed MODEL_STEP span input showing only a keys summary instead of actual messages for AI SDK v5 providers. The `summarizeRequestBody` function now handles the v5 `body.input` format, so the span correctly displays conversation messages.

--- a/.changeset/fix-observability-v5-span-input.md
+++ b/.changeset/fix-observability-v5-span-input.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed MODEL_STEP span input showing only a keys summary instead of actual messages for AI SDK v5 providers. The `summarizeRequestBody` function now handles the v5 `body.input` format, so the span correctly displays conversation messages.

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -1151,5 +1151,63 @@ describe('ModelSpanTracker', () => {
       expect(stepSpans).toHaveLength(1);
       expect(stepSpans[0]!.input).toEqual(messages);
     });
+
+    it('should extract messages from AI SDK v5 body.input instead of body.messages', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      // AI SDK v5 uses body.input with {type, text} content parts
+      const input = [
+        { role: 'system', content: 'You are helpful.' },
+        { role: 'user', content: [{ type: 'input_text', text: 'What is the weather?' }] },
+      ];
+
+      tracker.startStep();
+
+      const chunks = [
+        {
+          type: 'step-start',
+          payload: {
+            messageId: 'msg-1',
+            request: {
+              body: {
+                model: 'gpt-4o-mini',
+                input,
+                tools: [
+                  {
+                    type: 'function',
+                    name: 'weatherTool',
+                    parameters: { type: 'object', properties: { location: { type: 'string' } } },
+                  },
+                ],
+                tool_choice: 'auto',
+              },
+            },
+          },
+        },
+        { type: 'text-delta', payload: { text: 'Let me check.' } },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+      modelSpan.end();
+
+      const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      expect(stepSpans).toHaveLength(1);
+      // Should extract messages from body.input, not show keys summary
+      expect(stepSpans[0]!.input).toEqual([
+        { role: 'system', content: 'You are helpful.' },
+        { role: 'user', content: 'What is the weather?' },
+      ]);
+      // Should NOT contain tool definitions or fallback keys summary
+      expect(stepSpans[0]!.input).not.toHaveProperty('tools');
+      expect(Array.isArray(stepSpans[0]!.input)).toBe(true);
+    });
   });
 });

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -181,6 +181,10 @@ function summarizeRequestBody(body: unknown): StepInputPreview {
     return normalizeMessages((body as { messages: unknown[] }).messages);
   }
 
+  if (Array.isArray((body as { input?: unknown }).input)) {
+    return normalizeMessages((body as { input: unknown[] }).input);
+  }
+
   if (Array.isArray((body as { contents?: unknown }).contents)) {
     return (body as { contents: Array<{ role?: unknown; parts?: unknown[] }> }).contents.map(item => ({
       role: typeof item?.role === 'string' ? item.role : 'user',

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -791,7 +791,7 @@ describe('Span', () => {
       });
     });
 
-    it('should summarize composition-root JSON schemas instead of treating them as circular', () => {
+    it('should preserve JSON schemas as-is instead of compressing them', () => {
       const schema = {
         $schema: 'https://json-schema.org/draft/2020-12/schema',
         oneOf: [{ type: 'string' }, { type: 'number' }],
@@ -800,8 +800,31 @@ describe('Span', () => {
       const result = deepClean(schema);
 
       expect(result).toEqual({
-        oneOf: ['string', 'number'],
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        oneOf: [{ type: 'string' }, { type: 'number' }],
       });
+    });
+
+    it('should preserve tool parameter JSON schemas with full type information', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'object',
+            properties: {
+              what: { type: 'string' },
+              where: { type: 'string' },
+            },
+            required: ['what', 'where'],
+          },
+        },
+        required: ['query'],
+        $schema: 'http://json-schema.org/draft-07/schema#',
+      };
+
+      const result = deepClean(schema);
+
+      expect(result).toEqual(schema);
     });
 
     it('should not abort when array element getters throw', () => {
@@ -832,7 +855,7 @@ describe('Span', () => {
       expect(result).toBe('[serializeForSpan failed: probe failed]');
     });
 
-    it('should fall back to guarded object traversal when JSON schema probes throw', () => {
+    it('should handle objects with throwing getter properties gracefully', () => {
       const input: Record<string, unknown> = {
         type: 'object',
         properties: { safe: { type: 'string' } },

--- a/observability/mastra/src/spans/serialization.ts
+++ b/observability/mastra/src/spans/serialization.ts
@@ -175,95 +175,6 @@ function isJsonSchema(val: any): boolean {
 }
 
 /**
- * Compress a JSON Schema to a more readable format for tracing.
- * Extracts just the essential structure: property names and their types.
- * Recursively handles nested object schemas.
- *
- * @example
- * Input:
- * {
- *   type: "object",
- *   properties: {
- *     name: { type: "string" },
- *     address: {
- *       type: "object",
- *       properties: { city: { type: "string" }, zip: { type: "string" } }
- *     }
- *   },
- *   required: ["name"],
- *   $schema: "http://json-schema.org/draft-07/schema#"
- * }
- *
- * Output:
- * { name: "string (required)", address: { city: "string", zip: "string" } }
- */
-function compressJsonSchema(schema: any, depth: number = 0): any {
-  // Limit recursion depth to avoid overly verbose output
-  if (depth > 3) {
-    return schema.type || 'object';
-  }
-
-  const compositionKeys = ['oneOf', 'anyOf', 'allOf'].filter(key => Array.isArray(schema[key]));
-  if (compositionKeys.length > 0) {
-    const compressed: Record<string, any> = {};
-
-    for (const key of compositionKeys) {
-      compressed[key] = schema[key].map((entry: any) => compressJsonSchema(entry, depth + 1));
-    }
-
-    if (typeof schema.type === 'string') {
-      compressed.type = schema.type;
-    }
-
-    return compressed;
-  }
-
-  if (schema.type !== 'object' || !schema.properties) {
-    // For non-object schemas, just return the type
-    return schema.type || schema;
-  }
-
-  const required = new Set(Array.isArray(schema.required) ? schema.required : []);
-  const compressed: Record<string, any> = {};
-
-  for (const [key, propSchema] of Object.entries(schema.properties)) {
-    const prop = propSchema as any;
-    let value: any = prop.type || 'unknown';
-
-    // Handle nested objects recursively
-    if (prop.type === 'object' && prop.properties) {
-      value = compressJsonSchema(prop, depth + 1);
-      if (required.has(key)) {
-        // For nested objects, we can't append to the object, so wrap it
-        compressed[key + ' (required)'] = value;
-        continue;
-      }
-    }
-    // Handle arrays with item types
-    else if (prop.type === 'array' && prop.items) {
-      if (prop.items.type === 'object' && prop.items.properties) {
-        value = [compressJsonSchema(prop.items, depth + 1)];
-      } else {
-        value = `${prop.items.type || 'any'}[]`;
-      }
-    }
-    // Handle enums
-    else if (prop.enum) {
-      value = prop.enum.map((v: any) => JSON.stringify(v)).join(' | ');
-    }
-
-    // Mark required fields (for non-object types)
-    if (required.has(key) && typeof value === 'string') {
-      value += ' (required)';
-    }
-
-    compressed[key] = value;
-  }
-
-  return compressed;
-}
-
-/**
  * Recursively cleans a value by removing circular references, stripping problematic keys,
  * and enforcing size limits on strings, arrays, and objects.
  *
@@ -499,8 +410,9 @@ export function deepClean(value: any, options: DeepCleanOptions = DEFAULT_DEEP_C
         }
       }
 
-      // Handle JSON Schema objects - compress to a more readable format
-      // Pass the compressed result back through helper to apply size limits
+      // Handle JSON Schema objects - return as-is to preserve raw schemas for debugging.
+      // JSON schemas are plain serializable objects (no circular refs, functions, etc.)
+      // so we skip recursive traversal for performance.
       let looksLikeJsonSchema = false;
       try {
         looksLikeJsonSchema = isJsonSchema(val);
@@ -509,12 +421,7 @@ export function deepClean(value: any, options: DeepCleanOptions = DEFAULT_DEEP_C
       }
 
       if (looksLikeJsonSchema) {
-        try {
-          const compressed = compressJsonSchema(val);
-          return compressed === val ? '[JSONSchema]' : helper(compressed, depth);
-        } catch {
-          // Fall back to guarded object traversal below.
-        }
+        return val;
       }
 
       // Handle objects - enforce key limit


### PR DESCRIPTION
Two fixes for observability span data:

**AI SDK v5 span input** — `summarizeRequestBody` didn't handle v5's `body.input` format, so MODEL_STEP spans showed `{ model: "gpt-4o-mini", keys: ["model", "input", ...] }` instead of actual messages. Added the `body.input` branch so messages display correctly.

**JSON schema compression** — `deepClean` was running `compressJsonSchema` on tool parameter schemas, replacing types with `"unknown (required)"` and losing structure. Now detected JSON schemas pass through as-is, keeping full type info for debugging in Datadog/etc while still skipping expensive recursive traversal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes two issues with how Mastra records observability data (traces/spans). First, when using the latest version of the AI SDK, actual messages weren't showing up in traces—instead, just a summary of keys appeared. Second, when recording JSON schemas for tools, the system was simplifying them and losing details. The fix makes messages display correctly and preserves JSON schemas exactly as they are.

## Changes

### Changeset Entry
Added a patch release note for `@mastra/observability` documenting that span serialization now preserves JSON schemas exactly as provided instead of replacing them with simplified summary strings, and that `MODEL_STEP` span inputs now correctly display actual messages for AI SDK v5 providers.

### Request Body Handling for AI SDK v5
Extended `summarizeRequestBody` in `model-tracing.ts` to detect and properly handle the AI SDK v5 request format, which uses a `body.input` property (an array) rather than the traditional `body.messages` format. This ensures that actual message content is extracted and displayed in `MODEL_STEP` spans instead of falling back to a keys-summary object.

### JSON Schema Preservation
Removed the `compressJsonSchema` helper function from `spans/serialization.ts` that was previously transforming JSON schemas into simplified representations (e.g., converting type information to `"unknown (required)"` strings). Updated `deepClean` to recognize JSON schemas and return them unchanged, bypassing the lossy compression and recursive traversal that was removing structural information needed by observability platforms like Datadog.

### Test Coverage
- Added test in `model-tracing.test.ts` validating that `MODEL_STEP` spans correctly extract messages from AI SDK v5's `body.input` format
- Updated `base.test.ts` to verify JSON schemas are preserved with full type information and structure intact, rather than being compressed or summarized
<!-- end of auto-generated comment: release notes by coderabbit.ai -->