### PR TITLE
fix(core): remove noisy browser not running reminder

### DIFF
--- a/.changeset/remove-browser-not-running-reminder.md
+++ b/.changeset/remove-browser-not-running-reminder.md
@@ -2,12 +2,4 @@
 '@mastra/core': patch
 ---
 
-Remove noisy "Browser is not currently running" system reminder.
-
-**What changed**
-
-- Removed the `isRunning` field from `BrowserContext` interface
-- The `<system-reminder>` tag is now only injected when there's meaningful browser context (current URL or page title)
-- Previously, the reminder was injected on every turn even when the user wasn't doing anything browser-related
-
-This reduces noise in agent conversations when browser tools are available but not actively in use.
+Fixed noisy browser reminders being added to non-browser turns. Browser reminders are now added only when browser context exists (for example, current page URL or title).

--- a/.changeset/remove-browser-not-running-reminder.md
+++ b/.changeset/remove-browser-not-running-reminder.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': patch
+---
+
+Remove noisy "Browser is not currently running" system reminder.
+
+**What changed**
+
+- Removed the `isRunning` field from `BrowserContext` interface
+- The `<system-reminder>` tag is now only injected when there's meaningful browser context (current URL or page title)
+- Previously, the reminder was injected on every turn even when the user wasn't doing anything browser-related
+
+This reduces noise in agent conversations when browser tools are available but not actively in use.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4693,8 +4693,7 @@ export class Agent<
         provider: this.#browser.provider,
         sessionId: this.#browser.getSessionId(browserThreadId),
         headless: this.#browser.headless,
-        currentUrl: (await this.#browser.getCurrentUrl(browserThreadId)) ?? undefined,
-        isRunning: isThreadRunning,
+        currentUrl: isThreadRunning ? ((await this.#browser.getCurrentUrl(browserThreadId)) ?? undefined) : undefined,
       };
       requestContext.set('browser', browserCtx);
     }

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -128,6 +128,32 @@ describe('BrowserContextProcessor', () => {
       expect(textPart.text).toContain('Hello');
     });
 
+    it('should prepend system-reminder when only page title is available', () => {
+      const requestContext = new RequestContext();
+      const browserCtx: BrowserContext = {
+        provider: 'agent-browser',
+        pageTitle: 'Example Page',
+      };
+      requestContext.set('browser', browserCtx);
+
+      const messages = [
+        {
+          role: 'user' as const,
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: 'Hello' }],
+          },
+        },
+      ] as any;
+
+      const result = processor.processInputStep(createInputStepArgs({ messages, requestContext }));
+
+      expect(result).toBeDefined();
+      const textPart = (result as any).messages[0].content.parts[0];
+      expect(textPart.text).toContain('<system-reminder>');
+      expect(textPart.text).toContain('Example Page');
+    });
+
     it('should return undefined when no per-request data available', () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -128,37 +128,11 @@ describe('BrowserContextProcessor', () => {
       expect(textPart.text).toContain('Hello');
     });
 
-    it('should indicate browser not running', () => {
-      const requestContext = new RequestContext();
-      const browserCtx: BrowserContext = {
-        provider: 'agent-browser',
-        isRunning: false,
-      };
-      requestContext.set('browser', browserCtx);
-
-      const messages = [
-        {
-          role: 'user' as const,
-          content: {
-            format: 2,
-            parts: [{ type: 'text', text: 'Hello' }],
-          },
-        },
-      ] as any;
-
-      const result = processor.processInputStep(createInputStepArgs({ messages, requestContext }));
-
-      expect(result).toBeDefined();
-      const resultMessages = (result as any).messages;
-      const textPart = resultMessages[0].content.parts[0];
-      expect(textPart.text).toContain('Browser is not currently running');
-    });
-
     it('should return undefined when no per-request data available', () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
-        // No currentUrl, pageTitle, or isRunning=false
+        // No currentUrl or pageTitle
       };
       requestContext.set('browser', browserCtx);
 

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -45,9 +45,6 @@ export interface BrowserContext {
 
   /** Current page title (updated per-request) */
   pageTitle?: string;
-
-  /** Whether browser is currently running */
-  isRunning?: boolean;
 }
 
 /**
@@ -90,10 +87,6 @@ export class BrowserContextProcessor {
 
     if (ctx.pageTitle) {
       parts.push(`Page title: ${ctx.pageTitle}`);
-    }
-
-    if (ctx.isRunning === false) {
-      parts.push('Browser is not currently running.');
     }
 
     if (parts.length === 0) return;


### PR DESCRIPTION
## Description

Remove the "Browser is not currently running" system reminder that was injected on every turn even when the user wasn't doing browser-related tasks. Now the system-reminder only appears when there's meaningful browser context (URL or page title).

## Related Issue(s)

N/A - Internal improvement

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

Previously the agent would nag "Browser is not currently running" on every turn even when you weren't doing anything with the browser. This PR stops that noise so the agent only injects browser reminders when there's actual browser context (like a page URL or title).

## Changes

- Remove `isRunning` from `BrowserContext`
  - The optional `isRunning?: boolean` field was removed from the `BrowserContext` interface in packages/core/src/browser/processor.ts.

- Only inject per-request browser reminders when meaningful context exists
  - The processor no longer prepends a "Browser is not currently running" reminder on every turn. processInputStep now injects a <system-reminder> only when per-request browser data is present (currentUrl and/or pageTitle).

- Agent browser context initialization adjusted
  - In packages/core/src/agent/agent.ts, the agent now fetches browserCtx.currentUrl only when the relevant browser thread is running (isThreadRunning), aligning initialization with the conditional reminder injection.

- Tests updated
  - packages/core/src/browser/processor.test.ts: removed tests that expected the global "browser not running" reminder and added/updated tests to cover URL+title and pageTitle-only injection behavior and the "no per-request data" case.

- Changeset
  - .changeset/remove-browser-not-running-reminder.md added to document the patch release for @mastra/core describing the fix.

This is classified as a bug fix with accompanying test updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->