### PR TITLE
fix(core): add browser reminders as new messages to preserve prompt cache

### DIFF
--- a/.changeset/browser-reminder-prompt-cache.md
+++ b/.changeset/browser-reminder-prompt-cache.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed browser context reminders breaking prompt cache. Browser reminders are now added as new user messages instead of modifying existing message history.

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import type { MastraDBMessage } from '../agent/message-list';
 import type { ProcessInputArgs, ProcessInputStepArgs } from '../processors';
 import { RequestContext } from '../request-context';
 import { BrowserContextProcessor } from './processor';
@@ -19,11 +20,26 @@ describe('BrowserContextProcessor', () => {
     ...overrides,
   });
 
+  // Helper to create a mock messageList
+  const createMockMessageList = (existingMessages: MastraDBMessage[] = []) => {
+    const messages = [...existingMessages];
+    return {
+      get: {
+        all: {
+          db: () => messages,
+        },
+      },
+      add: vi.fn((msg: MastraDBMessage) => {
+        messages.push(msg);
+      }),
+    };
+  };
+
   // Helper to create minimal args for processInputStep
   const createInputStepArgs = (overrides: Partial<ProcessInputStepArgs> = {}): ProcessInputStepArgs => ({
     messages: [],
     systemMessages: [],
-    messageList: {} as any,
+    messageList: createMockMessageList() as any,
     requestContext: new RequestContext(),
     stepNumber: 0,
     steps: [],
@@ -31,6 +47,7 @@ describe('BrowserContextProcessor', () => {
     model: undefined as any,
     retryCount: 0,
     abort: vi.fn(),
+    rotateResponseMessageId: vi.fn(),
     ...overrides,
   });
 
@@ -97,7 +114,7 @@ describe('BrowserContextProcessor', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should prepend system-reminder to user message with URL and title', () => {
+    it('should add a new user message with system-reminder containing URL and title', () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -106,29 +123,35 @@ describe('BrowserContextProcessor', () => {
       };
       requestContext.set('browser', browserCtx);
 
-      const messages = [
-        {
-          role: 'user' as const,
-          content: {
-            format: 2,
-            parts: [{ type: 'text', text: 'Hello' }],
-          },
-        },
-      ] as any;
+      const mockMessageList = createMockMessageList();
+      const rotateResponseMessageId = vi.fn();
 
-      const result = processor.processInputStep(createInputStepArgs({ messages, requestContext }));
+      const result = processor.processInputStep(
+        createInputStepArgs({
+          requestContext,
+          messageList: mockMessageList as any,
+          rotateResponseMessageId,
+        }),
+      );
 
-      expect(result).toBeDefined();
-      const resultMessages = (result as any).messages;
-      expect(resultMessages).toHaveLength(1);
-      const textPart = resultMessages[0].content.parts[0];
-      expect(textPart.text).toContain('<system-reminder>');
+      expect(result).toBe(mockMessageList);
+      expect(mockMessageList.add).toHaveBeenCalledTimes(1);
+
+      const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
+      expect(addedMessage.role).toBe('user');
+      expect(addedMessage.content.metadata).toEqual({
+        systemReminder: { type: 'browser-context' },
+      });
+
+      const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
+      expect(textPart.text).toContain('<system-reminder type="browser-context">');
       expect(textPart.text).toContain('https://example.com/page');
       expect(textPart.text).toContain('Example Page');
-      expect(textPart.text).toContain('Hello');
+
+      expect(rotateResponseMessageId).toHaveBeenCalled();
     });
 
-    it('should prepend system-reminder when only page title is available', () => {
+    it('should add system-reminder when only page title is available', () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -136,21 +159,21 @@ describe('BrowserContextProcessor', () => {
       };
       requestContext.set('browser', browserCtx);
 
-      const messages = [
-        {
-          role: 'user' as const,
-          content: {
-            format: 2,
-            parts: [{ type: 'text', text: 'Hello' }],
-          },
-        },
-      ] as any;
+      const mockMessageList = createMockMessageList();
 
-      const result = processor.processInputStep(createInputStepArgs({ messages, requestContext }));
+      const result = processor.processInputStep(
+        createInputStepArgs({
+          requestContext,
+          messageList: mockMessageList as any,
+        }),
+      );
 
-      expect(result).toBeDefined();
-      const textPart = (result as any).messages[0].content.parts[0];
-      expect(textPart.text).toContain('<system-reminder>');
+      expect(result).toBe(mockMessageList);
+      expect(mockMessageList.add).toHaveBeenCalledTimes(1);
+
+      const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
+      const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
+      expect(textPart.text).toContain('<system-reminder type="browser-context">');
       expect(textPart.text).toContain('Example Page');
     });
 
@@ -165,6 +188,93 @@ describe('BrowserContextProcessor', () => {
       const result = processor.processInputStep(createInputStepArgs({ requestContext }));
 
       expect(result).toBeUndefined();
+    });
+
+    it('should not add duplicate reminder if same content already exists', () => {
+      const requestContext = new RequestContext();
+      const browserCtx: BrowserContext = {
+        provider: 'agent-browser',
+        currentUrl: 'https://example.com/page',
+        pageTitle: 'Example Page',
+      };
+      requestContext.set('browser', browserCtx);
+
+      // Create messageList with an existing browser reminder
+      const existingReminder: MastraDBMessage = {
+        id: 'existing-reminder',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'text',
+              text: '<system-reminder type="browser-context">Current URL: https://example.com/page | Page title: Example Page</system-reminder>',
+            },
+          ],
+          metadata: {
+            systemReminder: { type: 'browser-context' },
+          },
+        },
+        createdAt: new Date(),
+      };
+
+      const mockMessageList = createMockMessageList([existingReminder]);
+
+      const result = processor.processInputStep(
+        createInputStepArgs({
+          requestContext,
+          messageList: mockMessageList as any,
+        }),
+      );
+
+      expect(result).toBeUndefined();
+      expect(mockMessageList.add).not.toHaveBeenCalled();
+    });
+
+    it('should add new reminder if URL changed from previous reminder', () => {
+      const requestContext = new RequestContext();
+      const browserCtx: BrowserContext = {
+        provider: 'agent-browser',
+        currentUrl: 'https://example.com/new-page',
+        pageTitle: 'New Page',
+      };
+      requestContext.set('browser', browserCtx);
+
+      // Create messageList with an existing browser reminder for a different URL
+      const existingReminder: MastraDBMessage = {
+        id: 'existing-reminder',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'text',
+              text: '<system-reminder type="browser-context">Current URL: https://example.com/old-page | Page title: Old Page</system-reminder>',
+            },
+          ],
+          metadata: {
+            systemReminder: { type: 'browser-context' },
+          },
+        },
+        createdAt: new Date(),
+      };
+
+      const mockMessageList = createMockMessageList([existingReminder]);
+
+      const result = processor.processInputStep(
+        createInputStepArgs({
+          requestContext,
+          messageList: mockMessageList as any,
+        }),
+      );
+
+      expect(result).toBe(mockMessageList);
+      expect(mockMessageList.add).toHaveBeenCalledTimes(1);
+
+      const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
+      const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
+      expect(textPart.text).toContain('https://example.com/new-page');
+      expect(textPart.text).toContain('New Page');
     });
   });
 });

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -289,7 +289,7 @@ describe('BrowserContextProcessor', () => {
       expect(textPart.text).toContain('New Page');
     });
 
-    it('should add reminder for A→B→A navigation (only checks most recent reminder)', () => {
+    it('should add reminder for A→B→A navigation (trailing reminder B differs from current A)', () => {
       const requestContext = new RequestContext();
       // Current state: back on page A
       const browserCtx: BrowserContext = {
@@ -299,7 +299,7 @@ describe('BrowserContextProcessor', () => {
       };
       requestContext.set('browser', browserCtx);
 
-      // History: A, then B (most recent is B, so A should be added)
+      // History: A, then B (trailing is B, so A should be added)
       const reminderA: MastraDBMessage = {
         id: 'reminder-a',
         role: 'user',
@@ -334,13 +334,97 @@ describe('BrowserContextProcessor', () => {
         }),
       );
 
-      // Should add new reminder because most recent (B) doesn't match current (A)
+      // Should add new reminder because trailing (B) doesn't match current (A)
       expect(result).toBe(mockMessageList);
       expect(mockMessageList.add).toHaveBeenCalledTimes(1);
 
       const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
       const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
       expect(textPart.text).toContain('page-a');
+    });
+
+    it('should add reminder when trailing message is not a browser reminder (user → reminder → assistant → user)', () => {
+      const requestContext = new RequestContext();
+      const browserCtx: BrowserContext = {
+        provider: 'agent-browser',
+        currentUrl: 'https://example.com/page-a',
+        pageTitle: 'Page A',
+      };
+      requestContext.set('browser', browserCtx);
+
+      // History: reminder(A), then assistant response, then new user message
+      const reminderA: MastraDBMessage = {
+        id: 'reminder-a',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: '<system-reminder type="browser-context">Page A</system-reminder>' }],
+          metadata: {
+            systemReminder: { type: 'browser-context', url: 'https://example.com/page-a', title: 'Page A' },
+          },
+        },
+        createdAt: new Date(),
+      };
+      const assistantResponse: MastraDBMessage = {
+        id: 'assistant-response',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Here is the page content...' }],
+        },
+        createdAt: new Date(),
+      };
+      const userMessage: MastraDBMessage = {
+        id: 'user-message',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Now do something else' }],
+        },
+        createdAt: new Date(),
+      };
+
+      const mockMessageList = createMockMessageList([reminderA, assistantResponse, userMessage]);
+
+      const result = processor.processInputStep(
+        createInputStepArgs({
+          requestContext,
+          messageList: mockMessageList as any,
+        }),
+      );
+
+      // Should add reminder because trailing message is a regular user message, not a browser reminder
+      expect(result).toBe(mockMessageList);
+      expect(mockMessageList.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('should escape XML special characters in URL and title', () => {
+      const requestContext = new RequestContext();
+      const browserCtx: BrowserContext = {
+        provider: 'agent-browser',
+        currentUrl: 'https://example.com/search?q=foo&bar=1',
+        pageTitle: 'Search <Results> & More',
+      };
+      requestContext.set('browser', browserCtx);
+
+      const mockMessageList = createMockMessageList();
+
+      processor.processInputStep(
+        createInputStepArgs({
+          requestContext,
+          messageList: mockMessageList as any,
+        }),
+      );
+
+      const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
+      const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
+
+      // Should escape &, <, > in the markup text
+      expect(textPart.text).toContain('&amp;');
+      expect(textPart.text).toContain('&lt;');
+      expect(textPart.text).toContain('&gt;');
+      expect(textPart.text).not.toContain('q=foo&bar'); // Should be escaped
+      expect(textPart.text).not.toContain('<Results>'); // Should be escaped
     });
   });
 });

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -140,7 +140,11 @@ describe('BrowserContextProcessor', () => {
       const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
       expect(addedMessage.role).toBe('user');
       expect(addedMessage.content.metadata).toEqual({
-        systemReminder: { type: 'browser-context' },
+        systemReminder: {
+          type: 'browser-context',
+          url: 'https://example.com/page',
+          title: 'Example Page',
+        },
       });
 
       const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
@@ -199,7 +203,7 @@ describe('BrowserContextProcessor', () => {
       };
       requestContext.set('browser', browserCtx);
 
-      // Create messageList with an existing browser reminder
+      // Create messageList with an existing browser reminder (matching URL/title in metadata)
       const existingReminder: MastraDBMessage = {
         id: 'existing-reminder',
         role: 'user',
@@ -212,7 +216,11 @@ describe('BrowserContextProcessor', () => {
             },
           ],
           metadata: {
-            systemReminder: { type: 'browser-context' },
+            systemReminder: {
+              type: 'browser-context',
+              url: 'https://example.com/page',
+              title: 'Example Page',
+            },
           },
         },
         createdAt: new Date(),
@@ -253,7 +261,11 @@ describe('BrowserContextProcessor', () => {
             },
           ],
           metadata: {
-            systemReminder: { type: 'browser-context' },
+            systemReminder: {
+              type: 'browser-context',
+              url: 'https://example.com/old-page',
+              title: 'Old Page',
+            },
           },
         },
         createdAt: new Date(),
@@ -275,6 +287,60 @@ describe('BrowserContextProcessor', () => {
       const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
       expect(textPart.text).toContain('https://example.com/new-page');
       expect(textPart.text).toContain('New Page');
+    });
+
+    it('should add reminder for A→B→A navigation (only checks most recent reminder)', () => {
+      const requestContext = new RequestContext();
+      // Current state: back on page A
+      const browserCtx: BrowserContext = {
+        provider: 'agent-browser',
+        currentUrl: 'https://example.com/page-a',
+        pageTitle: 'Page A',
+      };
+      requestContext.set('browser', browserCtx);
+
+      // History: A, then B (most recent is B, so A should be added)
+      const reminderA: MastraDBMessage = {
+        id: 'reminder-a',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: '<system-reminder type="browser-context">Page A</system-reminder>' }],
+          metadata: {
+            systemReminder: { type: 'browser-context', url: 'https://example.com/page-a', title: 'Page A' },
+          },
+        },
+        createdAt: new Date(),
+      };
+      const reminderB: MastraDBMessage = {
+        id: 'reminder-b',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: '<system-reminder type="browser-context">Page B</system-reminder>' }],
+          metadata: {
+            systemReminder: { type: 'browser-context', url: 'https://example.com/page-b', title: 'Page B' },
+          },
+        },
+        createdAt: new Date(),
+      };
+
+      const mockMessageList = createMockMessageList([reminderA, reminderB]);
+
+      const result = processor.processInputStep(
+        createInputStepArgs({
+          requestContext,
+          messageList: mockMessageList as any,
+        }),
+      );
+
+      // Should add new reminder because most recent (B) doesn't match current (A)
+      expect(result).toBe(mockMessageList);
+      expect(mockMessageList.add).toHaveBeenCalledTimes(1);
+
+      const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
+      const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
+      expect(textPart.text).toContain('page-a');
     });
   });
 });

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -93,14 +93,14 @@ export class BrowserContextProcessor {
     const reminderText = parts.join(' | ');
     const reminderMarkup = `<system-reminder type="${REMINDER_TYPE}">${reminderText}</system-reminder>`;
 
-    // Check if we already have this exact reminder to avoid duplicates
+    // Check if we already have a reminder with the same URL/title (scan from newest)
     const existingMessages = args.messageList.get.all.db();
-    if (hasExistingBrowserReminder(existingMessages, reminderMarkup)) {
+    if (hasExistingBrowserReminder(existingMessages, ctx.currentUrl, ctx.pageTitle)) {
       return;
     }
 
     // Add as a new user message at the end of history to preserve prompt cache
-    const reminderMessage = createBrowserReminderMessage(reminderMarkup);
+    const reminderMessage = createBrowserReminderMessage(reminderMarkup, ctx.currentUrl, ctx.pageTitle);
     args.messageList.add(reminderMessage, 'user');
     args.rotateResponseMessageId?.();
 
@@ -108,14 +108,28 @@ export class BrowserContextProcessor {
   }
 }
 
-function createBrowserReminderMessage(reminderMarkup: string): MastraDBMessage {
+interface BrowserReminderMetadata {
+  type: typeof REMINDER_TYPE;
+  url?: string;
+  title?: string;
+}
+
+function createBrowserReminderMessage(
+  reminderMarkup: string,
+  url: string | undefined,
+  title: string | undefined,
+): MastraDBMessage {
+  const reminderMeta: BrowserReminderMetadata = {
+    type: REMINDER_TYPE,
+    url,
+    title,
+  };
+
   const content: MastraMessageContentV2 = {
     format: 2,
     parts: [{ type: 'text', text: reminderMarkup }],
     metadata: {
-      systemReminder: {
-        type: REMINDER_TYPE,
-      },
+      systemReminder: reminderMeta,
     },
   };
 
@@ -127,19 +141,26 @@ function createBrowserReminderMessage(reminderMarkup: string): MastraDBMessage {
   };
 }
 
-function hasExistingBrowserReminder(messages: MastraDBMessage[], reminderMarkup: string): boolean {
-  for (const msg of messages) {
+/**
+ * Check if we already have a browser reminder with the same URL/title.
+ * Scans from the end (newest first) to handle navigation sequences like A→B→A.
+ */
+function hasExistingBrowserReminder(
+  messages: MastraDBMessage[],
+  url: string | undefined,
+  title: string | undefined,
+): boolean {
+  // Scan from end to find the most recent browser reminder
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]!;
     if (msg.role !== 'user') continue;
 
     const metadata = msg.content.metadata;
     if (typeof metadata === 'object' && metadata !== null && 'systemReminder' in metadata) {
-      const reminder = (metadata as { systemReminder?: { type?: string } }).systemReminder;
+      const reminder = (metadata as { systemReminder?: BrowserReminderMetadata }).systemReminder;
       if (reminder?.type === REMINDER_TYPE) {
-        // Check if the content matches (same URL/title)
-        const textPart = msg.content.parts?.find((p): p is { type: 'text'; text: string } => p.type === 'text');
-        if (textPart?.text === reminderMarkup) {
-          return true;
-        }
+        // Found the most recent browser reminder - check if URL/title match
+        return reminder.url === url && reminder.title === title;
       }
     }
   }

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -81,11 +81,11 @@ export class BrowserContextProcessor {
     const parts: string[] = [];
 
     if (ctx.currentUrl) {
-      parts.push(`Current URL: ${ctx.currentUrl}`);
+      parts.push(`Current URL: ${escapeXml(ctx.currentUrl)}`);
     }
 
     if (ctx.pageTitle) {
-      parts.push(`Page title: ${ctx.pageTitle}`);
+      parts.push(`Page title: ${escapeXml(ctx.pageTitle)}`);
     }
 
     if (parts.length === 0) return;
@@ -93,9 +93,9 @@ export class BrowserContextProcessor {
     const reminderText = parts.join(' | ');
     const reminderMarkup = `<system-reminder type="${REMINDER_TYPE}">${reminderText}</system-reminder>`;
 
-    // Check if we already have a reminder with the same URL/title (scan from newest)
+    // Only suppress if the trailing message is already the same browser reminder
     const existingMessages = args.messageList.get.all.db();
-    if (hasExistingBrowserReminder(existingMessages, ctx.currentUrl, ctx.pageTitle)) {
+    if (hasTrailingBrowserReminder(existingMessages, ctx.currentUrl, ctx.pageTitle)) {
       return;
     }
 
@@ -142,27 +142,31 @@ function createBrowserReminderMessage(
 }
 
 /**
- * Check if we already have a browser reminder with the same URL/title.
- * Scans from the end (newest first) to handle navigation sequences like A→B→A.
+ * Escape XML special characters in browser-derived values.
+ * Prevents URLs or page titles containing <, &, or </system-reminder> from breaking the markup.
  */
-function hasExistingBrowserReminder(
+function escapeXml(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+/**
+ * Check if the trailing message is already a browser reminder with the same URL/title.
+ * Only checks the last message to avoid suppressing reminders when the browser context
+ * is no longer at the tail (e.g., user → reminder(A) → assistant → user should get a fresh reminder).
+ */
+function hasTrailingBrowserReminder(
   messages: MastraDBMessage[],
   url: string | undefined,
   title: string | undefined,
 ): boolean {
-  // Scan from end to find the most recent browser reminder
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]!;
-    if (msg.role !== 'user') continue;
+  const msg = messages[messages.length - 1];
+  if (!msg || msg.role !== 'user') return false;
 
-    const metadata = msg.content.metadata;
-    if (typeof metadata === 'object' && metadata !== null && 'systemReminder' in metadata) {
-      const reminder = (metadata as { systemReminder?: BrowserReminderMetadata }).systemReminder;
-      if (reminder?.type === REMINDER_TYPE) {
-        // Found the most recent browser reminder - check if URL/title match
-        return reminder.url === url && reminder.title === title;
-      }
-    }
+  const metadata = msg.content.metadata;
+  if (typeof metadata !== 'object' || metadata === null || !('systemReminder' in metadata)) {
+    return false;
   }
-  return false;
+
+  const reminder = (metadata as { systemReminder?: BrowserReminderMetadata }).systemReminder;
+  return reminder?.type === REMINDER_TYPE && reminder.url === url && reminder.title === title;
 }

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -5,8 +5,8 @@
  * Similar to ChatChannelProcessor for channels.
  *
  * - `processInput`: Adds a system message with stable context (provider, sessionId, headless mode).
- * - `processInputStep`: At step 0, prepends a `<system-reminder>` to the user's message
- *   with per-request data (current URL, page title).
+ * - `processInputStep`: At step 0, adds a new user message with browser context as a `<system-reminder>`.
+ *   This preserves prompt cache by not modifying existing messages in history.
  *
  * Reads from `requestContext.get('browser')`.
  *
@@ -19,12 +19,11 @@
  * ```
  */
 
-import type {
-  ProcessInputArgs,
-  ProcessInputResult,
-  ProcessInputStepArgs,
-  ProcessInputStepResult,
-} from '../processors/index';
+import type { MessageList, MastraDBMessage } from '../agent/message-list';
+import type { MastraMessageContentV2 } from '../agent/message-list/state/types';
+import type { ProcessInputArgs, ProcessInputResult, ProcessInputStepArgs } from '../processors/index';
+
+const REMINDER_TYPE = 'browser-context';
 
 /**
  * Browser context stored in RequestContext.
@@ -72,7 +71,7 @@ export class BrowserContextProcessor {
     return { messages: args.messages, systemMessages };
   }
 
-  processInputStep(args: ProcessInputStepArgs): ProcessInputStepResult | undefined {
+  processInputStep(args: ProcessInputStepArgs): MessageList | undefined {
     // Only inject per-request context at the first step
     if (args.stepNumber !== 0) return;
 
@@ -91,37 +90,58 @@ export class BrowserContextProcessor {
 
     if (parts.length === 0) return;
 
-    const reminder = `<system-reminder>${parts.join(' | ')}</system-reminder>\n\n`;
+    const reminderText = parts.join(' | ');
+    const reminderMarkup = `<system-reminder type="${REMINDER_TYPE}">${reminderText}</system-reminder>`;
 
-    // Prepend reminder to the last user message's text parts
-    const messages = [...args.messages];
-
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i]!;
-      if (msg.role === 'user') {
-        const content = msg.content;
-        // MastraMessageContentV2: { format: 2, parts: [...] }
-        const existingParts = content.parts ?? [];
-        const firstTextIdx = existingParts.findIndex((p: { type: string }) => p.type === 'text');
-
-        if (firstTextIdx >= 0) {
-          const textPart = existingParts[firstTextIdx] as { type: 'text'; text: string };
-          const newParts = [...existingParts];
-          newParts[firstTextIdx] = { ...textPart, text: reminder + textPart.text };
-          messages[i] = { ...msg, content: { ...content, parts: newParts } };
-        } else {
-          messages[i] = {
-            ...msg,
-            content: {
-              ...content,
-              parts: [{ type: 'text' as const, text: reminder }, ...existingParts],
-            },
-          };
-        }
-        break;
-      }
+    // Check if we already have this exact reminder to avoid duplicates
+    const existingMessages = args.messageList.get.all.db();
+    if (hasExistingBrowserReminder(existingMessages, reminderMarkup)) {
+      return;
     }
 
-    return { messages };
+    // Add as a new user message at the end of history to preserve prompt cache
+    const reminderMessage = createBrowserReminderMessage(reminderMarkup);
+    args.messageList.add(reminderMessage, 'user');
+    args.rotateResponseMessageId?.();
+
+    return args.messageList;
   }
+}
+
+function createBrowserReminderMessage(reminderMarkup: string): MastraDBMessage {
+  const content: MastraMessageContentV2 = {
+    format: 2,
+    parts: [{ type: 'text', text: reminderMarkup }],
+    metadata: {
+      systemReminder: {
+        type: REMINDER_TYPE,
+      },
+    },
+  };
+
+  return {
+    id: crypto.randomUUID(),
+    role: 'user',
+    content,
+    createdAt: new Date(),
+  };
+}
+
+function hasExistingBrowserReminder(messages: MastraDBMessage[], reminderMarkup: string): boolean {
+  for (const msg of messages) {
+    if (msg.role !== 'user') continue;
+
+    const metadata = msg.content.metadata;
+    if (typeof metadata === 'object' && metadata !== null && 'systemReminder' in metadata) {
+      const reminder = (metadata as { systemReminder?: { type?: string } }).systemReminder;
+      if (reminder?.type === REMINDER_TYPE) {
+        // Check if the content matches (same URL/title)
+        const textPart = msg.content.parts?.find((p): p is { type: 'text'; text: string } => p.type === 'text');
+        if (textPart?.text === reminderMarkup) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
## Description

Instead of prepending browser context to existing user messages (which breaks prompt cache), browser context reminders are now added as **new user messages** at the end of history. This follows the same pattern as `AgentsMDInjector`.

The messages include `systemReminder` metadata to prevent them from leaking into the UI.

**Changes:**
- Add new user message with `systemReminder: { type: 'browser-context' }` metadata
- Call `rotateResponseMessageId()` after adding reminder
- Skip duplicate reminders if same content already exists
- Remove `isRunning` field from `BrowserContext` interface (also removes the noisy "Browser is not currently running" reminder from #15416)

## Related Issue(s)

Follow-up to #15416 (review comment from @TylerBarnes)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Testing

The unit tests cover:
- Adding new user message with correct metadata
- URL and title in reminder content
- Title-only reminder
- No reminder when no browser context
- Duplicate prevention (same content)
- New reminder when URL changes

**To verify prompt caching works:** We should test that the message history before the browser reminder is unchanged, allowing the LLM provider to cache it. This could be validated by checking that `messageList.add()` is called rather than modifying existing messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Instead of changing the user's last message to add a browser reminder, the code now appends the reminder as a brand-new user message so the AI's prompt cache isn't broken and the UI doesn't accidentally show system reminder data.

## Overview

This PR changes browser context reminder injection to preserve prompt caching by appending reminders as new user messages (with explicit reminder metadata) and adding deduplication and escaping logic. It also removes an obsolete BrowserContext field and adds tests covering the new behavior.

## Changes

### Core Implementation (packages/core/src/browser/processor.ts)
- Reminder injection now appends a new user message (MastraMessageContentV2) containing a <system-reminder type="browser-context"> payload instead of prepending markup into the last user message.
- Reminder messages include content.metadata.systemReminder (at minimum { type: 'browser-context' } — tests contain { type: 'browser-context', url, title }) so UI rendering won’t leak system reminder content.
- XML-escapes URL/title before inserting them into reminder markup.
- Adds helper functions: createBrowserReminderMessage, escapeXml, hasTrailingBrowserReminder, and a REMINDER_TYPE constant.
- Implements deduplication: reads persisted history (messageList.get.all.db()) and skips injection when the trailing reminder already matches current url/title; injects a new reminder when the URL changes (including navigation sequences like A→B→A).
- Calls rotateResponseMessageId() after successfully adding a reminder.
- Returns the messageList (MessageList | undefined) flow instead of mutating/returning modified existing messages.
- Removes isRunning from BrowserContext (and thereby removes the "Browser is not currently running" reminder path introduced earlier).

### Tests (packages/core/src/browser/processor.test.ts)
- Adds createMockMessageList test helper and updates createInputStepArgs to use it.
- Asserts reminder insertion via messageList.add() (verifying prompt cache preservation) and that rotateResponseMessageId() is invoked.
- Tests include:
  - Creation of new user reminder message with correct metadata and markup.
  - URL + title content and title-only reminders.
  - No reminder when no browser context.
  - Deduplication: identical reminders are skipped.
  - New reminder added when URL changes (including A→B→A sequences and when trailing message is non-reminder).
  - XML escaping of special characters in URL/title.
- Adjusts assertions to validate messageList.add() usage rather than mutating existing messages.

### Changeset
- .changeset/browser-reminder-prompt-cache.md added for @mastra/core (patch).

## Impact
- Preserves prompt cache by keeping prior message history immutable before reminder injection.
- Prevents duplicate reminders while allowing updates on URL changes.
- Keeps system reminder data separated from UI-visible message content via metadata.
- Removes obsolete BrowserContext field and its related "browser not running" reminder.

## Testing notes
- Verify prompt caching by asserting messageList.add() is called (i.e., prior message objects are not modified).
- Confirm rotateResponseMessageId() is called after adding the reminder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->