### PR TITLE
Fix/cloudexporter domain

### DIFF
--- a/.changeset/mighty-yaks-take.md
+++ b/.changeset/mighty-yaks-take.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed CloudExporter to default to observability.mastra.ai for Mastra platform exports.

--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -9,6 +9,12 @@ packages:
 
 The `CloudExporter` sends traces, logs, metrics, scores, and feedback to the Mastra platform. Use it to route observability data from any Mastra app to a hosted project in the Mastra platform.
 
+## Version compatibility
+
+- Use `CloudExporter` with `@mastra/observability@1.8.0` or later.
+- If you use `@mastra/observability@1.8.0` through `1.9.1`, set `MASTRA_CLOUD_TRACES_ENDPOINT=https://observability.mastra.ai` in addition to `MASTRA_CLOUD_ACCESS_TOKEN` and `MASTRA_PROJECT_ID`.
+- Starting in `@mastra/observability@1.9.2`, `CloudExporter` defaults to `https://observability.mastra.ai`, so `MASTRA_CLOUD_TRACES_ENDPOINT` is only required when you want to send telemetry to a different collector.
+
 ## Quickstart
 
 To connect `CloudExporter`, create an access token, find the destination `projectId`, and add the exporter to your observability config.
@@ -69,6 +75,12 @@ Set both values in your environment so `CloudExporter` can authenticate and rout
 ```bash title=".env"
 MASTRA_CLOUD_ACCESS_TOKEN=<your-cloud-access-token>
 MASTRA_PROJECT_ID=<your-project-id>
+```
+
+If you use `@mastra/observability@1.8.0` through `1.9.1`, also set the Mastra platform collector explicitly:
+
+```bash title=".env"
+MASTRA_CLOUD_TRACES_ENDPOINT=https://observability.mastra.ai
 ```
 
 If you want to send telemetry somewhere other than Mastra platform, set `MASTRA_CLOUD_TRACES_ENDPOINT` as well. Pass either a base origin or a full traces publish URL ending in `/spans/publish`.

--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -64,52 +64,24 @@ MASTRA_PROJECT_ID=<your-project-id>
 
 ### 3. Set your environment variables
 
-Tokens created with `mastra auth tokens create` are organization-scoped, so `MASTRA_PROJECT_ID` is required.
-
-If you use a project-scoped token from the Mastra platform instead, `CloudExporter` can route without `projectId`, but setting it explicitly is still supported.
-
-Add both values to your environment:
+Set both values in your environment so `CloudExporter` can authenticate and route telemetry to the correct project:
 
 ```bash title=".env"
 MASTRA_CLOUD_ACCESS_TOKEN=<your-cloud-access-token>
 MASTRA_PROJECT_ID=<your-project-id>
 ```
 
-For example:
+If you want to send telemetry somewhere other than Mastra platform, set `MASTRA_CLOUD_TRACES_ENDPOINT` as well. Pass either a base origin or a full traces publish URL ending in `/spans/publish`.
 
 ```bash title=".env"
-MASTRA_CLOUD_ACCESS_TOKEN=<your-cloud-access-token>
-MASTRA_PROJECT_ID=<your-project-id>
+MASTRA_CLOUD_TRACES_ENDPOINT=https://collector.example.com
 ```
+
+When you pass a base origin, `CloudExporter` derives the matching publish URLs for traces, logs, metrics, scores, and feedback automatically.
 
 ### 4. Enable `CloudExporter`
 
 The following example demonstrates how to add `CloudExporter` to your observability config:
-
-```ts title="src/mastra/index.ts"
-import { Mastra } from '@mastra/core'
-import { Observability, CloudExporter } from '@mastra/observability'
-
-export const mastra = new Mastra({
-  observability: new Observability({
-    configs: {
-      production: {
-        serviceName: 'my-service',
-        exporters: [
-          new CloudExporter({
-            accessToken: process.env.MASTRA_CLOUD_ACCESS_TOKEN,
-            projectId: process.env.MASTRA_PROJECT_ID,
-          }),
-        ],
-      },
-    },
-  }),
-})
-```
-
-Set `serviceName` in code on the observability config, not on `CloudExporter` itself. In the example above, the value is `configs.production.serviceName`.
-
-For example:
 
 ```ts title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -127,6 +99,8 @@ export const mastra = new Mastra({
 })
 ```
 
+Set `serviceName` on the observability config, not on `CloudExporter` itself.
+
 Use a stable `serviceName` value. In Studio, traces can be filtered by **Deployments → Service Name**, so a consistent name makes traces easier to find.
 
 Visit [Observability configuration reference](/reference/observability/tracing/configuration) for the full observability config shape.
@@ -137,7 +111,7 @@ If you prefer, rely entirely on environment variables:
 new CloudExporter()
 ```
 
-With `MASTRA_CLOUD_ACCESS_TOKEN` and `MASTRA_PROJECT_ID` set, `CloudExporter` automatically sends data to the correct Mastra platform project.
+With `MASTRA_CLOUD_ACCESS_TOKEN` and `MASTRA_PROJECT_ID` set, `CloudExporter` sends data to the Mastra platform project you configured. If you also set `MASTRA_CLOUD_TRACES_ENDPOINT`, it sends data to that collector instead.
 
 :::note
 
@@ -173,13 +147,17 @@ export const mastra = new Mastra({
 
 ## Complete configuration
 
-The following example demonstrates how to configure custom endpoints and batching behavior:
+`CloudExporter` defaults to Mastra platform. If you want to send telemetry to a different collector, set `MASTRA_CLOUD_TRACES_ENDPOINT` in your environment or pass `endpoint` in code.
+
+```bash title=".env"
+MASTRA_CLOUD_TRACES_ENDPOINT=https://collector.example.com
+```
+
+The following example demonstrates how to override the collector endpoint and batching behavior in code:
 
 ```ts title="src/mastra/index.ts"
 new CloudExporter({
-  accessToken: process.env.MASTRA_CLOUD_ACCESS_TOKEN,
-  projectId: process.env.MASTRA_PROJECT_ID,
-  endpoint: 'https://cloud.your-domain.com',
+  endpoint: 'https://collector.example.com',
   maxBatchSize: 1000,
   maxBatchWaitMs: 5000,
   logLevel: 'info',
@@ -190,15 +168,10 @@ new CloudExporter({
 
 After you enable `CloudExporter`, open your project in [Mastra Studio](https://projects.mastra.ai) to inspect the exported data.
 
-- Open your project and select **Open Studio**.
+- Open the project you set `MASTRA_PROJECT_ID` to and select **Open Studio**.
 - In Studio, go to **Traces** to inspect agent and workflow traces.
 - Open the filter menu and use **Deployments → Service Name** to isolate traces from a specific app or deployment.
 - Use the **Logs** page in the project dashboard to inspect exported logs.
-- Use the project named by `MASTRA_PROJECT_ID` when you work with organization-scoped tokens.
-
-:::note
-If you use a project-scoped token, open the project that issued the token. If you use an organization-scoped token, open the project named by `MASTRA_PROJECT_ID`.
-:::
 
 When you deploy with Mastra Studio, set **Deployment → Service Name** to a stable value and keep it aligned with the `serviceName` in your observability config. This makes traces easier to filter in Studio through **Deployments → Service Name** when multiple services or deployments send data to the same project.
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -9,6 +9,8 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 # CloudExporter
 
+**Added in:** `@mastra/observability@1.8.0`
+
 Sends tracing spans, logs, metrics, scores, and feedback to the Mastra platform for online visualization and monitoring.
 
 ## Constructor
@@ -78,7 +80,7 @@ The exporter reads these environment variables if not provided in config:
 
 - `MASTRA_CLOUD_ACCESS_TOKEN` - Authentication token for `CloudExporter` requests
 - `MASTRA_PROJECT_ID` - Project ID to use when deriving project-scoped collector routes such as `/projects/:projectId/ai/spans/publish`
-- `MASTRA_CLOUD_TRACES_ENDPOINT` - Traces endpoint override. Pass either a base origin or a full traces publish URL. Defaults to `https://observability.mastra.ai`
+- `MASTRA_CLOUD_TRACES_ENDPOINT` - Traces endpoint override. Pass either a base origin or a full traces publish URL. Defaults to `https://observability.mastra.ai` in `@mastra/observability@1.9.2` and later
 
 ## Properties
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -76,9 +76,9 @@ Extends `BaseExporterConfig`, which includes:
 
 The exporter reads these environment variables if not provided in config:
 
-- `MASTRA_CLOUD_ACCESS_TOKEN` - Authentication token. Project-scoped tokens work with the default `/ai/{signal}/publish` routes. Organization API keys require `projectId` or `MASTRA_PROJECT_ID`.
+- `MASTRA_CLOUD_ACCESS_TOKEN` - Authentication token for `CloudExporter` requests
 - `MASTRA_PROJECT_ID` - Project ID to use when deriving project-scoped collector routes such as `/projects/:projectId/ai/spans/publish`
-- `MASTRA_CLOUD_TRACES_ENDPOINT` - Traces endpoint override. Pass either a base origin or a full traces publish URL. Defaults to `https://api.mastra.ai`
+- `MASTRA_CLOUD_TRACES_ENDPOINT` - Traces endpoint override. Pass either a base origin or a full traces publish URL. Defaults to `https://observability.mastra.ai`
 
 ## Properties
 

--- a/observability/mastra/src/exporters/cloud.test.ts
+++ b/observability/mastra/src/exporters/cloud.test.ts
@@ -901,6 +901,26 @@ describe('CloudExporter', () => {
       mockFetchWithRetry.mockResolvedValue(new Response('{}', { status: 200 }));
     });
 
+    it('should default to observability.mastra.ai when no endpoint override is configured', async () => {
+      const derivedExporter = new CloudExporter({
+        accessToken: testJWT,
+      });
+
+      await derivedExporter.onMetricEvent(getMockMetricEvent());
+      await derivedExporter.flush();
+
+      expect(mockFetchWithRetry).toHaveBeenCalledWith(
+        'https://observability.mastra.ai/ai/metrics/publish',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(String),
+        }),
+        3,
+      );
+
+      await derivedExporter.shutdown();
+    });
+
     it('should upload logs, metrics, scores, and feedback to their derived endpoints', async () => {
       const multiSignalExporter = new CloudExporter({
         accessToken: testJWT,

--- a/observability/mastra/src/exporters/cloud.ts
+++ b/observability/mastra/src/exporters/cloud.ts
@@ -47,8 +47,6 @@ const SIGNAL_PUBLISH_SEGMENTS: Record<CloudSignal, string> = {
   feedback: 'feedback',
 };
 
-const DEFAULT_CLOUD_ENDPOINT = 'https://api.mastra.ai';
-
 function trimTrailingSlashes(value: string): string {
   let end = value.length;
   while (end > 0 && value.charCodeAt(end - 1) === 47) {
@@ -247,7 +245,7 @@ export class CloudExporter extends BaseExporter {
     if (tracesEndpointOverride) {
       tracesEndpoint = resolveExplicitSignalEndpoint('traces', tracesEndpointOverride, projectId);
     } else {
-      baseEndpoint = resolveBaseEndpoint(config.endpoint ?? DEFAULT_CLOUD_ENDPOINT);
+      baseEndpoint = resolveBaseEndpoint(config.endpoint ?? 'https://observability.mastra.ai');
       tracesEndpoint = buildSignalEndpoint(baseEndpoint, 'traces', projectId);
     }
 


### PR DESCRIPTION
## Description

This PR fixes `CloudExporter` to default to `https://observability.mastra.ai` instead of `https://api.mastra.ai` for Mastra platform exports.

It also updates the Cloud exporter docs to match the new behavior and clean up the setup flow:

- Change the default `CloudExporter` base URL to `https://observability.mastra.ai`
- Add a regression test that verifies the default collector URL when no override is configured
- Update the Cloud exporter docs to call out `MASTRA_CLOUD_TRACES_ENDPOINT` as the env var for sending telemetry to a non-platform collector
- Consolidate the redundant setup examples in `cloud.mdx`
- Remove customer-facing references to project-scoped tokens from the docs

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Validation

- `pnpm test src/exporters/cloud.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR changes where Mastra's CloudExporter sends telemetry by default — from api.mastra.ai to observability.mastra.ai — adds a test to lock that behavior, and updates docs to explain the new default and how to override it.

## Changes

### Code
- observability/mastra/src/exporters/cloud.ts
  - Removed module-level DEFAULT_CLOUD_ENDPOINT constant.
  - CloudExporter now derives its default base origin from config.endpoint ?? 'https://observability.mastra.ai' when no tracesEndpoint override is provided (previously defaulted to https://api.mastra.ai).

### Tests
- observability/mastra/src/exporters/cloud.test.ts
  - Added a regression test in the "Additional Signal Support" suite verifying that when CloudExporter is constructed without an endpoint override, metric uploads are sent to the default derived metrics publish URL (https://observability.mastra.ai/ai/metrics/publish).

### Documentation
- docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
  - Added "Version compatibility" guidance (noting that @mastra/observability@1.9.2+ defaults to observability.mastra.ai).
  - Clarified usage of MASTRA_CLOUD_TRACES_ENDPOINT for non-platform collectors and when it's required for older versions.
  - Consolidated setup examples to prefer env vars and removed customer-facing references implying project-scoped vs org-scoped token differences.
  - Updated "Viewing data" instructions to reference the project set in MASTRA_PROJECT_ID.
- docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
  - Updated environment variable docs: MASTRA_CLOUD_TRACES_ENDPOINT default changed to https://observability.mastra.ai (documented as effective in @mastra/observability@1.9.2+).
  - Clarified that MASTRA_CLOUD_ACCESS_TOKEN is the auth token for CloudExporter requests.

### Release / Changeset
- .changeset/mighty-yaks-take.md
  - Patch bump for @mastra/observability documenting the fix: CloudExporter defaults to observability.mastra.ai for Mastra platform exports.

## Type of change
- Bug fix (default endpoint), test addition, and documentation updates.

## Validation
- Tests: pnpm test src/exporters/cloud.test.ts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->