### PR TITLE
feat: activate observations on provider changes

### DIFF
--- a/.changeset/smooth-parts-bet.md
+++ b/.changeset/smooth-parts-bet.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved OM activation output to show when a provider or model switch triggered buffered observation activation.

--- a/.changeset/smooth-parts-bet.md
+++ b/.changeset/smooth-parts-bet.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Improved OM activation output to show when a provider or model switch triggered buffered observation activation.
+Improved observational memory activation output to show when a provider or model switch triggered buffered observation activation.

--- a/.changeset/tricky-memes-repair.md
+++ b/.changeset/tricky-memes-repair.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added model metadata to step-start parts so model changes can be detected across steps, including within a single assistant message.

--- a/.changeset/vast-trees-punch.md
+++ b/.changeset/vast-trees-punch.md
@@ -1,0 +1,18 @@
+---
+'@mastra/memory': minor
+---
+
+Added `activateOnProviderChange` so observational memory can activate buffered observations and reflections before switching to a different provider or model.
+
+```ts
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      model: 'google/gemini-2.5-flash',
+      activateOnProviderChange: true,
+    },
+  },
+});
+```
+
+This helps keep prompt-cache savings when the next step cannot reuse the previous provider's cache.

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -379,7 +379,7 @@ const memory = new Memory({
 
 With a 5-minute prompt cache TTL, this activates buffered context after 5 minutes of inactivity so the next uncached prompt uses observations and reflections instead of a larger raw message window. If you prefer, `300_000` works the same way.
 
-If your agent can switch between providers or models mid-thread, `activateOnProviderChange: true` forces buffered context to activate before the new provider runs. That avoids sending a large raw window to a provider that cannot reuse the previous prompt cache.
+Changing model or providers mid-thread will invalidate the prompt cache. If your agent can switch between providers or models mid-thread, `activateOnProviderChange: true` forces buffered context to activate before the new provider runs. That avoids sending a large raw window to a provider that cannot reuse the previous prompt cache.
 
 ### Disabling
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -359,6 +359,7 @@ Reflection works similarly — the Reflector runs in the background when observa
 | `observation.bufferActivation` | `0.8` | How aggressively to clear the message window on activation. `0.8` means remove enough messages to keep only 20% of `messageTokens` remaining. Lower values keep more message history. |
 | `observation.blockAfter` | `1.2` | Safety threshold as a multiplier of `messageTokens`. At `1.2`, synchronous observation is forced at 36k tokens (1.2 × 30k). Only matters if buffering can't keep up. |
 | `activateAfterIdle` | none | Forces buffered observations and buffered reflections to activate after a period of inactivity, even if their token thresholds have not been reached yet. Accepts milliseconds or duration strings like `300_000`, `"5m"`, or `"1hr"`. Set this to your prompt cache TTL if you want activation to happen before the next cold prompt. |
+| `activateOnProviderChange` | `false` | Forces buffered observations and reflections to activate when the next step uses a different `provider/model` than the one that produced the latest assistant step. Use this when switching providers or models would invalidate prompt cache reuse. |
 | `reflection.bufferActivation` | `0.5` | When to start background reflection. `0.5` means reflection begins when observations reach 50% of the `observationTokens` threshold. |
 | `reflection.blockAfter` | `1.2` | Safety threshold for reflection, same logic as observation. |
 
@@ -370,12 +371,15 @@ const memory = new Memory({
     observationalMemory: {
       model: 'google/gemini-2.5-flash',
       activateAfterIdle: '5m',
+      activateOnProviderChange: true,
     },
   },
 })
 ```
 
 With a 5-minute prompt cache TTL, this activates buffered context after 5 minutes of inactivity so the next uncached prompt uses observations and reflections instead of a larger raw message window. If you prefer, `300_000` works the same way.
+
+If your agent can switch between providers or models mid-thread, `activateOnProviderChange: true` forces buffered context to activate before the new provider runs. That avoids sending a large raw window to a provider that cannot reuse the previous prompt cache.
 
 ### Disabling
 

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -103,6 +103,7 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
           retrieval: vector ? { vector: true } : true,
           scope: omScope,
           activateAfterIdle: '5m',
+          activateOnProviderChange: true,
           observation: {
             bufferTokens: isResourceScope ? false : 1 / 5,
             bufferActivation: isResourceScope ? undefined : 2000,

--- a/mastracode/src/tui/components/__tests__/om-marker.test.ts
+++ b/mastracode/src/tui/components/__tests__/om-marker.test.ts
@@ -46,6 +46,29 @@ describe('OMMarkerComponent activation rendering', () => {
     expect(activationText).not.toContain('TTL');
   });
 
+  it('renders provider-change activation as a separate muted line', () => {
+    const providerChangeMarker = new OMMarkerComponent({
+      type: 'om_activation_provider_change',
+      previousModel: 'openai/gpt-4o',
+      currentModel: 'anthropic/claude-3-7-sonnet',
+    });
+
+    const activationMarker = new OMMarkerComponent({
+      type: 'om_activation',
+      operationType: 'observation',
+      tokensActivated: 7300,
+      observationTokens: 400,
+    });
+
+    const providerChangeText = stripAnsi(providerChangeMarker.render(120).join('\n'));
+    const activationText = stripAnsi(activationMarker.render(120).join('\n'));
+
+    expect(providerChangeText).toContain(
+      'Model changed openai/gpt-4o → anthropic/claude-3-7-sonnet, activating observations',
+    );
+    expect(activationText).toContain('✓ Activated observations: -7.3k msg tokens, +0.4k obs tokens');
+  });
+
   it('renders reflection activation without TTL suffix', () => {
     const activationMarker = new OMMarkerComponent({
       type: 'om_activation',

--- a/mastracode/src/tui/components/om-marker.ts
+++ b/mastracode/src/tui/components/om-marker.ts
@@ -77,6 +77,11 @@ export type OMMarkerData =
       ttlExpiredMs: number;
     }
   | {
+      type: 'om_activation_provider_change';
+      previousModel: string;
+      currentModel: string;
+    }
+  | {
       type: 'om_thread_title_updated';
       oldTitle?: string;
       newTitle: string;
@@ -159,6 +164,9 @@ function formatMarker(data: OMMarkerData): string {
         'muted',
         `  Idle timeout (${formatDuration(data.activateAfterIdle)}) exceeded by ${formatDuration(data.ttlExpiredMs)}, activating observations`,
       );
+    }
+    case 'om_activation_provider_change': {
+      return theme.fg('muted', `  Model changed ${data.previousModel} → ${data.currentModel}, activating observations`);
     }
     case 'om_thread_title_updated': {
       return theme.fg('muted', `  thread title updated: ${data.newTitle}`);

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -218,10 +218,12 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
 
     case 'om_activation': {
       const activationEvent = event as Extract<HarnessEvent, { type: 'om_activation' }> & {
-        triggeredBy?: 'threshold' | 'ttl';
+        triggeredBy?: 'threshold' | 'ttl' | 'provider_change';
         lastActivityAt?: number;
         ttlExpiredMs?: number;
         activateAfterIdle?: number;
+        previousModel?: string;
+        currentModel?: string;
       };
       handleOMActivation(
         ectx,
@@ -231,6 +233,8 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
         activationEvent.triggeredBy,
         activationEvent.activateAfterIdle,
         activationEvent.ttlExpiredMs,
+        activationEvent.previousModel,
+        activationEvent.currentModel,
       );
       break;
     }

--- a/mastracode/src/tui/handlers/om.ts
+++ b/mastracode/src/tui/handlers/om.ts
@@ -155,6 +155,7 @@ export function handleOMBufferingStart(
   const { state } = ctx;
   state.activeActivationMarker = undefined;
   state.activeActivationTTLMarker = undefined;
+  state.activeActivationProviderChangeMarker = undefined;
   state.activeBufferingMarker = new OMMarkerComponent({
     type: 'om_buffering_start',
     operationType,
@@ -207,9 +208,11 @@ export function handleOMActivation(
   operationType: 'observation' | 'reflection',
   tokensActivated: number,
   observationTokens: number,
-  triggeredBy?: 'threshold' | 'ttl',
+  triggeredBy?: 'threshold' | 'ttl' | 'provider_change',
   activateAfterIdle?: number,
   ttlExpiredMs?: number,
+  previousModel?: string,
+  currentModel?: string,
 ): void {
   const { state } = ctx;
 
@@ -225,6 +228,21 @@ export function handleOMActivation(
     } else {
       state.activeActivationTTLMarker = new OMMarkerComponent(ttlData);
       addChildBeforeStreaming(ctx, state.activeActivationTTLMarker);
+    }
+  }
+
+  if (triggeredBy === 'provider_change' && previousModel && currentModel) {
+    const providerChangeData: OMMarkerData = {
+      type: 'om_activation_provider_change',
+      previousModel,
+      currentModel,
+    };
+
+    if (state.activeActivationProviderChangeMarker) {
+      state.activeActivationProviderChangeMarker.update(providerChangeData);
+    } else {
+      state.activeActivationProviderChangeMarker = new OMMarkerComponent(providerChangeData);
+      addChildBeforeStreaming(ctx, state.activeActivationProviderChangeMarker);
     }
   }
 

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -166,6 +166,7 @@ export interface TUIState {
   activeBufferingMarker?: OMMarkerComponent;
   activeActivationMarker?: OMMarkerComponent;
   activeActivationTTLMarker?: OMMarkerComponent;
+  activeActivationProviderChangeMarker?: OMMarkerComponent;
 
   // ── Tasks ─────────────────────────────────────────────────────────────
   taskProgress?: TaskProgressComponent;

--- a/observability/mastra/src/__snapshots__/agent-processors-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace-generate.json
@@ -606,7 +606,8 @@
                       }
                     ],
                     "metadata": {
-                      "modelId": "mock-model-id"
+                      "modelId": "mock-model-id",
+                      "provider": "mock-provider"
                     },
                     "content": "Mock V2 generate response"
                   },

--- a/observability/mastra/src/__snapshots__/agent-processors-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace.json
@@ -588,7 +588,8 @@
                       }
                     ],
                     "metadata": {
-                      "modelId": "mock-model-id"
+                      "modelId": "mock-model-id",
+                      "provider": "mock-provider"
                     },
                     "content": "Mock V2 stream response"
                   },

--- a/packages/core/src/agent/message-list/merge/MessageMerger.ts
+++ b/packages/core/src/agent/message-list/merge/MessageMerger.ts
@@ -306,10 +306,12 @@ export class MessageMerger {
         latestMessage.content.parts.at(-1)?.type === 'tool-invocation';
 
       const previousStepStart = [...latestMessage.content.parts].reverse().find(p => p.type === 'step-start');
-      const stepStartPart = stampPart({
-        type: 'step-start' as const,
-        model: previousStepStart?.model,
-      });
+      const stepStartPart = previousStepStart?.model
+        ? stampPart({
+            type: 'step-start' as const,
+            model: previousStepStart.model,
+          })
+        : ({ type: 'step-start' as const } as MastraMessageContentV2['parts'][number]);
 
       if (typeof insertAt === 'number') {
         if (needsStepStart) {

--- a/packages/core/src/agent/message-list/merge/MessageMerger.ts
+++ b/packages/core/src/agent/message-list/merge/MessageMerger.ts
@@ -1,5 +1,6 @@
 import { CacheKeyGenerator } from '../cache/CacheKeyGenerator';
 import type { MastraDBMessage, MastraMessageContentV2 } from '../state/types';
+import { stampPart } from '../utils/stamp-part';
 
 /**
  * MessageMerger - Handles complex logic for merging assistant messages
@@ -304,16 +305,22 @@ export class MessageMerger {
         latestMessage.content.parts.length > 0 &&
         latestMessage.content.parts.at(-1)?.type === 'tool-invocation';
 
+      const previousStepStart = [...latestMessage.content.parts].reverse().find(p => p.type === 'step-start');
+      const stepStartPart = stampPart({
+        type: 'step-start' as const,
+        model: previousStepStart?.model,
+      });
+
       if (typeof insertAt === 'number') {
         if (needsStepStart) {
-          latestMessage.content.parts.splice(insertAt, 0, { type: 'step-start' });
+          latestMessage.content.parts.splice(insertAt, 0, stepStartPart);
           latestMessage.content.parts.splice(insertAt + 1, 0, part);
         } else {
           latestMessage.content.parts.splice(insertAt, 0, part);
         }
       } else {
         if (needsStepStart) {
-          latestMessage.content.parts.push({ type: 'step-start' });
+          latestMessage.content.parts.push(stepStartPart);
         }
         latestMessage.content.parts.push(part);
       }

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -797,6 +797,35 @@ export class MessageList {
     return true;
   }
 
+  public enrichLastStepStart(model: string): boolean {
+    const lastMsg = this.messages[this.messages.length - 1];
+    if (!lastMsg || lastMsg.role !== 'assistant' || !lastMsg.content?.parts) {
+      return false;
+    }
+
+    if (MessageMerger.isSealed(lastMsg)) {
+      return false;
+    }
+
+    for (let i = lastMsg.content.parts.length - 1; i >= 0; i--) {
+      const part = lastMsg.content.parts[i];
+      if (part?.type !== 'step-start') {
+        continue;
+      }
+
+      part.model = model;
+
+      if (!this.stateManager.isResponseMessage(lastMsg)) {
+        this.stateManager.removeMessage(lastMsg);
+        this.stateManager.addToSource(lastMsg, 'response');
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
   public getSystemMessages(tag?: string): CoreMessageV4[] {
     if (tag) {
       return this.taggedSystemMessages[tag] || [];

--- a/packages/core/src/agent/message-list/state/types.ts
+++ b/packages/core/src/agent/message-list/state/types.ts
@@ -28,6 +28,10 @@ type LegacyToolInvocation = NonNullable<UIMessageV4['toolInvocations']>[number];
 export type MastraProviderMetadata = AIV5Type.ProviderMetadata;
 type MastraPartExtensions = { providerMetadata?: MastraProviderMetadata; createdAt?: number };
 type PartWithProviderMetadata<T> = T & MastraPartExtensions;
+export type MastraStepStartPart = {
+  type: 'step-start';
+  model?: string;
+} & MastraPartExtensions;
 
 // Approval payload stored alongside tool invocations so v6 approval flows can
 // round-trip through MessageList.
@@ -73,7 +77,10 @@ export type MastraSourceUrlPart = Omit<LegacySourcePart, 'providerMetadata'> & {
 // it with provider metadata, AI SDK v5 data parts, and v6-only persisted parts
 // such as approval-aware tool invocations and source documents.
 export type MastraMessagePart =
-  | PartWithProviderMetadata<Exclude<UIMessageV4['parts'][number], { type: 'tool-invocation' | 'source' }>>
+  | PartWithProviderMetadata<
+      Exclude<UIMessageV4['parts'][number], { type: 'tool-invocation' | 'source' | 'step-start' }>
+    >
+  | MastraStepStartPart
   | MastraToolInvocationPart
   | MastraSourceUrlPart
   | MastraSourceDocumentPart

--- a/packages/core/src/agent/message-list/tests/step-start.test.ts
+++ b/packages/core/src/agent/message-list/tests/step-start.test.ts
@@ -117,4 +117,69 @@ describe('MessageList.stepStart', () => {
     expect(drained?.content.parts.at(-1)).toMatchObject({ type: 'step-start' });
     expect(drained?.content.parts.at(-1)).toEqual(expect.objectContaining({ createdAt: expect.any(Number) }));
   });
+
+  it('should enrich the latest step-start with the resolved model', () => {
+    const messageList = new MessageList();
+    const msg = makeAssistantMessage([
+      { type: 'text', text: 'hello' },
+      { type: 'step-start', createdAt: Date.now() },
+    ]);
+    messageList.add(msg, 'response');
+
+    const result = messageList.enrichLastStepStart('openai/gpt-4o');
+
+    expect(result).toBe(true);
+    expect(messageList.get.all.db()[0]?.content.parts.at(-1)).toMatchObject({
+      type: 'step-start',
+      model: 'openai/gpt-4o',
+    });
+  });
+
+  it('should return false when no step-start exists to enrich', () => {
+    const messageList = new MessageList();
+    messageList.add(makeAssistantMessage([{ type: 'text', text: 'hello' }]), 'response');
+
+    const result = messageList.enrichLastStepStart('openai/gpt-4o');
+
+    expect(result).toBe(false);
+  });
+
+  it('preserves step-start metadata when merge inserts a synthetic step-start', () => {
+    const messageList = new MessageList();
+    const stepStartCreatedAt = 1234567890;
+
+    messageList.add(
+      makeAssistantMessage(
+        [
+          { type: 'text', text: 'First step' },
+          { type: 'step-start', createdAt: stepStartCreatedAt, model: 'openai/gpt-4o' },
+          { type: 'text', text: 'Starting second step' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tc-1',
+              toolName: 'weather',
+              args: { city: 'London' },
+              result: { temp: 72 },
+            },
+          },
+        ],
+        'assistant-1',
+      ),
+      'response',
+    );
+
+    messageList.add(makeAssistantMessage([{ type: 'text', text: 'Second step' }], 'assistant-1'), 'response');
+
+    const stepStarts = messageList.get.all.db()[0]?.content.parts.filter(p => p.type === 'step-start') ?? [];
+
+    expect(stepStarts).toHaveLength(2);
+    expect(stepStarts[1]).toMatchObject({
+      type: 'step-start',
+      model: 'openai/gpt-4o',
+    });
+    expect(stepStarts[1]?.createdAt).toEqual(expect.any(Number));
+    expect(stepStarts[1]?.createdAt).not.toBe(stepStartCreatedAt);
+  });
 });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -2086,6 +2086,8 @@ export class Harness<TState = {}> {
               lastActivityAt: payload.lastActivityAt,
               ttlExpiredMs: payload.ttlExpiredMs,
               activateAfterIdle: payload.config?.activateAfterIdle,
+              previousModel: payload.previousModel,
+              currentModel: payload.currentModel,
             });
           }
           break;

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -760,10 +760,12 @@ export type HarnessEvent =
       observationTokens: number;
       messagesActivated: number;
       generationCount: number;
-      triggeredBy?: 'threshold' | 'ttl';
+      triggeredBy?: 'threshold' | 'ttl' | 'provider_change';
       lastActivityAt?: number;
       ttlExpiredMs?: number;
       activateAfterIdle?: number;
+      previousModel?: string;
+      currentModel?: string;
     }
   | { type: 'om_thread_title_updated'; cycleId: string; threadId: string; oldTitle?: string; newTitle: string }
   | { type: 'sandbox_access_request'; questionId: string; path: string; reason: string }

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -5172,6 +5172,7 @@ exports[`Loop Tests > AISDK v5 > result.response > should resolve with response 
         "format": 2,
         "metadata": {
           "modelId": "mock-model-id",
+          "provider": "mock-provider",
         },
         "parts": [
           {
@@ -5212,6 +5213,7 @@ exports[`Loop Tests > AISDK v5 > result.response > should resolve with response 
       "id": "msg-0",
       "metadata": {
         "modelId": "mock-model-id",
+        "provider": "mock-provider",
       },
       "parts": [
         {
@@ -5356,6 +5358,7 @@ exports[`Loop Tests > AISDK v5 > result.steps > should add the files from the mo
             "format": 2,
             "metadata": {
               "modelId": "mock-model-id",
+              "provider": "mock-provider",
             },
             "parts": [
               {
@@ -5459,6 +5462,7 @@ exports[`Loop Tests > AISDK v5 > result.steps > should add the files from the mo
           "metadata": {
             "createdAt": 2024-01-01T00:00:00.001Z,
             "modelId": "mock-model-id",
+            "provider": "mock-provider",
           },
           "parts": [
             {
@@ -11765,6 +11769,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.response > should resolve wi
         "format": 2,
         "metadata": {
           "modelId": "mock-model-id",
+          "provider": "mock-provider",
         },
         "parts": [
           {
@@ -11805,6 +11810,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.response > should resolve wi
       "id": "msg-0",
       "metadata": {
         "modelId": "mock-model-id",
+        "provider": "mock-provider",
       },
       "parts": [
         {
@@ -11949,6 +11955,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.steps > should add the files
             "format": 2,
             "metadata": {
               "modelId": "mock-model-id",
+              "provider": "mock-provider",
             },
             "parts": [
               {
@@ -12052,6 +12059,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.steps > should add the files
           "metadata": {
             "createdAt": 2024-01-01T00:00:00.001Z,
             "modelId": "mock-model-id",
+            "provider": "mock-provider",
           },
           "parts": [
             {

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -2742,6 +2742,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                     "format": 2,
                     "metadata": {
                       "modelId": "mock-model-id",
+                      "provider": "mock-provider",
                     },
                     "parts": [
                       {

--- a/packages/core/src/loop/test-utils/streamObject.ts
+++ b/packages/core/src/loop/test-utils/streamObject.ts
@@ -878,6 +878,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                       "format": 2,
                       "metadata": {
                         "modelId": "mock-model-id",
+                        "provider": "mock-provider",
                         "structuredOutput": {
                           "content": "Hello, world!",
                         },
@@ -926,6 +927,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "metadata": {
                       "createdAt": 2024-01-01T00:00:00.001Z,
                       "modelId": "mock-model-id",
+                      "provider": "mock-provider",
                       "structuredOutput": {
                         "content": "Hello, world!",
                       },
@@ -981,6 +983,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                           "format": 2,
                           "metadata": {
                             "modelId": "mock-model-id",
+                            "provider": "mock-provider",
                             "structuredOutput": {
                               "content": "Hello, world!",
                             },
@@ -1029,6 +1032,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                         "metadata": {
                           "createdAt": 2024-01-01T00:00:00.001Z,
                           "modelId": "mock-model-id",
+                          "provider": "mock-provider",
                           "structuredOutput": {
                             "content": "Hello, world!",
                           },
@@ -1176,6 +1180,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                       "format": 2,
                       "metadata": {
                         "modelId": "mock-model-id",
+                        "provider": "mock-provider",
                       },
                       "parts": [
                         {
@@ -1221,6 +1226,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "metadata": {
                       "createdAt": 2024-01-01T00:00:00.001Z,
                       "modelId": "mock-model-id",
+                      "provider": "mock-provider",
                     },
                     "parts": [
                       {
@@ -1269,6 +1275,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                           "format": 2,
                           "metadata": {
                             "modelId": "mock-model-id",
+                            "provider": "mock-provider",
                           },
                           "parts": [
                             {
@@ -1314,6 +1321,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                         "metadata": {
                           "createdAt": 2024-01-01T00:00:00.001Z,
                           "modelId": "mock-model-id",
+                          "provider": "mock-provider",
                         },
                         "parts": [
                           {
@@ -1458,6 +1466,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                       "format": 2,
                       "metadata": {
                         "modelId": "mock-model-id",
+                        "provider": "mock-provider",
                       },
                       "parts": [
                         {
@@ -1503,6 +1512,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "metadata": {
                       "createdAt": 2024-01-01T00:00:00.001Z,
                       "modelId": "mock-model-id",
+                      "provider": "mock-provider",
                     },
                     "parts": [
                       {
@@ -1551,6 +1561,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                           "format": 2,
                           "metadata": {
                             "modelId": "mock-model-id",
+                            "provider": "mock-provider",
                           },
                           "parts": [
                             {
@@ -1596,6 +1607,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                         "metadata": {
                           "createdAt": 2024-01-01T00:00:00.001Z,
                           "modelId": "mock-model-id",
+                          "provider": "mock-provider",
                         },
                         "parts": [
                           {

--- a/packages/core/src/loop/test-utils/tools.ts
+++ b/packages/core/src/loop/test-utils/tools.ts
@@ -1048,7 +1048,10 @@ export function toolsTests({ loopFn, runId }: { loopFn: typeof loop; runId: stri
         msg => msg.role === 'assistant' && msg.content.parts.some(p => p.type === 'tool-invocation'),
       );
       expect(assistantMsg).toBeDefined();
-      expect(assistantMsg?.content.metadata).toEqual({ modelId: 'claude-code-model' });
+      expect(assistantMsg?.content.metadata).toEqual({
+        modelId: 'claude-code-model',
+        provider: 'mock-provider',
+      });
 
       const parts = assistantMsg!.content.parts;
       expect(parts.map(part => part.type)).toEqual(['text', 'tool-invocation', 'step-start', 'text']);

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -723,6 +723,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       let request: any;
       let rawResponse: any;
       let activeFallbackModelIndex = inputData.fallbackModelIndex || 0;
+      let executedStepModel: string | undefined;
       const maxErrorProcessorRetries = maxProcessorRetries ?? (errorProcessors?.length ? 10 : undefined);
       const { outputStream, callBail, runState, stepTools, stepWorkspace, processAPIErrorRetry } =
         await executeStreamWithFallbackModels<{
@@ -739,6 +740,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         )(async (modelConfig, isLastModel) => {
           activeFallbackModelIndex = models.findIndex(candidate => candidate.id === modelConfig.id);
           const model = modelConfig.model;
+          executedStepModel = model.provider && model.modelId ? `${model.provider}/${model.modelId}` : undefined;
           const modelHeaders = modelConfig.headers;
           // Reset system messages to original before each step execution
           // This ensures that system message modifications in prepareStep/processInputStep/processors
@@ -1290,14 +1292,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           };
         });
 
-      if (currentIteration > 1) {
-        const activeModel = models[activeFallbackModelIndex]?.model;
-        const provider = activeModel?.provider;
-        const modelId = activeModel?.modelId;
-
-        if (provider && modelId) {
-          messageList.enrichLastStepStart(`${provider}/${modelId}`);
-        }
+      if (currentIteration > 1 && executedStepModel) {
+        messageList.enrichLastStepStart(executedStepModel);
       }
 
       // Store modified tools and workspace in _internal so toolCallStep can access them

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -49,6 +49,7 @@ type ProcessOutputStreamOptions<OUTPUT = undefined> = {
   messageList: MessageList;
   outputStream: MastraModelOutput<OUTPUT>;
   runState: AgenticRunState;
+  model?: { provider?: string };
   options?: LoopConfig<OUTPUT>;
   controller: ReadableStreamDefaultController<ChunkType<OUTPUT>>;
   responseFromModel: {
@@ -61,9 +62,22 @@ type ProcessOutputStreamOptions<OUTPUT = undefined> = {
   transportResolver?: () => StreamTransport | undefined;
 };
 
-function buildResponseModelMetadata(runState: AgenticRunState): { metadata: Record<string, unknown> } | undefined {
+function buildResponseModelMetadata(
+  runState: AgenticRunState,
+  model?: { provider?: string },
+): { metadata: Record<string, unknown> } | undefined {
+  const metadata: Record<string, unknown> = {};
   const modelId = runState.state.responseMetadata?.modelId;
-  return modelId ? { metadata: { modelId } } : undefined;
+
+  if (modelId) {
+    metadata.modelId = modelId;
+  }
+
+  if (model?.provider) {
+    metadata.provider = model.provider;
+  }
+
+  return Object.keys(metadata).length > 0 ? { metadata } : undefined;
 }
 
 function flushReasoningBuffer({
@@ -71,11 +85,13 @@ function flushReasoningBuffer({
   messageId,
   messageList,
   runState,
+  model,
 }: {
   buffer: { deltas: string[]; providerMetadata: Record<string, any> | undefined };
   messageId: string;
   messageList: MessageList;
   runState: AgenticRunState;
+  model?: { provider?: string };
 }) {
   const message: MastraDBMessage = {
     id: messageId,
@@ -90,7 +106,7 @@ function flushReasoningBuffer({
           providerMetadata: buffer.providerMetadata,
         },
       ],
-      ...buildResponseModelMetadata(runState),
+      ...buildResponseModelMetadata(runState, model),
     },
     createdAt: new Date(),
   };
@@ -104,6 +120,7 @@ async function processOutputStream<OUTPUT = undefined>({
   messageList,
   outputStream,
   runState,
+  model,
   options,
   controller,
   responseFromModel,
@@ -174,7 +191,7 @@ async function processOutputStream<OUTPUT = undefined>({
                 ...(providerMetadata ? { providerMetadata } : {}),
               },
             ],
-            ...buildResponseModelMetadata(runState),
+            ...buildResponseModelMetadata(runState, model),
           },
           createdAt: new Date(),
         };
@@ -212,6 +229,7 @@ async function processOutputStream<OUTPUT = undefined>({
           messageId,
           messageList,
           runState,
+          model,
         });
       }
 
@@ -345,7 +363,7 @@ async function processOutputStream<OUTPUT = undefined>({
                   providerMetadata: chunk.payload.providerMetadata ?? runState.state.providerOptions,
                 },
               ],
-              ...buildResponseModelMetadata(runState),
+              ...buildResponseModelMetadata(runState, model),
             },
             createdAt: new Date(),
           };
@@ -403,6 +421,7 @@ async function processOutputStream<OUTPUT = undefined>({
           messageId,
           messageList,
           runState,
+          model,
         });
 
         reasoningBuffers.delete(chunk.payload.id);
@@ -436,7 +455,7 @@ async function processOutputStream<OUTPUT = undefined>({
                   ...(chunk.payload.providerMetadata ? { providerMetadata: chunk.payload.providerMetadata } : {}),
                 },
               ],
-              ...buildResponseModelMetadata(runState),
+              ...buildResponseModelMetadata(runState, model),
             },
             createdAt: new Date(),
           };
@@ -464,7 +483,7 @@ async function processOutputStream<OUTPUT = undefined>({
                   },
                 },
               ],
-              ...buildResponseModelMetadata(runState),
+              ...buildResponseModelMetadata(runState, model),
             },
             createdAt: new Date(),
           };
@@ -559,7 +578,7 @@ async function processOutputStream<OUTPUT = undefined>({
           content: {
             format: 2,
             parts: [toolCallPart],
-            ...buildResponseModelMetadata(runState),
+            ...buildResponseModelMetadata(runState, model),
           },
           createdAt: new Date(),
         };
@@ -1126,6 +1145,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               messageId: currentStep.messageId,
               messageList,
               runState,
+              model: currentStep.model,
               options,
               controller,
               responseFromModel: {
@@ -1269,6 +1289,16 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             stepWorkspace: currentStep.workspace,
           };
         });
+
+      if (currentIteration > 1) {
+        const activeModel = models[activeFallbackModelIndex]?.model;
+        const provider = activeModel?.provider;
+        const modelId = activeModel?.modelId;
+
+        if (provider && modelId) {
+          messageList.enrichLastStepStart(`${provider}/${modelId}`);
+        }
+      }
 
       // Store modified tools and workspace in _internal so toolCallStep can access them
       // without going through workflow serialization (which would lose execute functions)

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -966,6 +966,7 @@ https://mastra.ai/en/docs/memory/overview`,
     const result: SerializedObservationalMemoryConfig = {
       scope: om.scope,
       activateAfterIdle: om.activateAfterIdle,
+      activateOnProviderChange: om.activateOnProviderChange,
       shareTokenBudget: om.shareTokenBudget,
       retrieval: om.retrieval,
     };

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -740,6 +740,12 @@ export interface ObservationalMemoryOptions {
   activateAfterIdle?: number | string;
 
   /**
+   * Force-activate buffered observations and reflections when the actor provider/model changes.
+   * Useful when switching between models that do not share prompt caches.
+   */
+  activateOnProviderChange?: boolean;
+
+  /**
    * Share the token budget between messages and observations.
    * When true, the total budget = observation.messageTokens + reflection.observationTokens.
    * - Messages can use more space when observations are small
@@ -1175,6 +1181,9 @@ export type SerializedObservationalMemoryConfig = {
 
   /** Inactivity TTL before forcing buffered observation/reflection activation */
   activateAfterIdle?: number | string;
+
+  /** Force-activate buffered observation/reflection activation when the actor model changes */
+  activateOnProviderChange?: boolean;
 
   /** Share the token budget between messages and observations */
   shareTokenBudget?: boolean;

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -71,6 +71,7 @@ type MemoryObservationalMemoryOptions = Omit<ObservationalMemoryOptions, 'model'
   observation?: ObservationalMemoryConfig['observation'];
   reflection?: ObservationalMemoryConfig['reflection'];
   activateAfterIdle?: ObservationalMemoryConfig['activateAfterIdle'];
+  activateOnProviderChange?: ObservationalMemoryConfig['activateOnProviderChange'];
 };
 
 type MemoryOptions = Omit<MemoryConfigInternal, 'observationalMemory'> & {
@@ -1429,6 +1430,7 @@ ${workingMemory}`;
       scope: omConfig.scope,
       retrieval: omConfig.retrieval,
       activateAfterIdle: omConfig.activateAfterIdle,
+      activateOnProviderChange: omConfig.activateOnProviderChange,
       shareTokenBudget: omConfig.shareTokenBudget,
       model: omConfig.model,
       onIndexObservations,

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -7671,6 +7671,86 @@ describe('Async Buffering Processor Logic', () => {
       expect(finalRecord?.bufferedObservationChunks).toHaveLength(1);
     });
 
+    it('should activate on provider change when threshold messages are loaded from storage', async () => {
+      const storage = createInMemoryStorage();
+      const threadId = 'thread-1';
+      const resourceId = 'resource-1';
+      const om = new ObservationalMemory({
+        storage,
+        scope: 'thread',
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
+        activateOnProviderChange: true,
+        observation: {
+          messageTokens: 30000,
+          bufferTokens: 6000,
+          bufferActivation: 0.7,
+        },
+        reflection: { observationTokens: 20000, bufferActivation: 0.5 },
+      });
+
+      await storage.saveThread({
+        thread: { id: threadId, resourceId, title: 'test', createdAt: new Date(), updatedAt: new Date(), metadata: {} },
+      });
+
+      const record = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await storage.saveMessages({
+        messages: [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [
+                { type: 'text', text: 'First response' },
+                { type: 'step-start', createdAt: Date.now(), model: 'openai/gpt-4o' },
+              ],
+            },
+            type: 'text',
+            createdAt: new Date(),
+            threadId,
+            resourceId,
+          },
+          {
+            id: 'user-1',
+            role: 'user',
+            content: { format: 2, parts: [{ type: 'text', text: 'Hi' }] },
+            type: 'text',
+            createdAt: new Date(),
+            threadId,
+            resourceId,
+          },
+        ] as MastraDBMessage[],
+      });
+
+      await storage.updateBufferedObservations({
+        id: record.id,
+        chunk: {
+          observations: '- Chunk 1',
+          tokenCount: 50,
+          messageIds: ['assistant-1', 'user-1'],
+          messageTokens: 3000,
+          lastObservedAt: new Date('2026-02-05T10:00:00Z'),
+          cycleId: 'cycle-1',
+        },
+      });
+
+      const result = await om.activate({
+        threadId,
+        resourceId,
+        checkThreshold: true,
+        currentModel: { provider: 'cerebras', modelId: 'zai-glm-4.5' },
+      });
+
+      expect(result.activated).toBe(true);
+      expect(result.record?.activeObservations).toContain('Chunk 1');
+    });
+
     it('should not reset lastBufferedBoundary after activation (callers set it)', async () => {
       const storage = createInMemoryStorage();
       const threadId = 'thread-1';

--- a/packages/memory/src/processors/observational-memory/markers.ts
+++ b/packages/memory/src/processors/observational-memory/markers.ts
@@ -207,9 +207,11 @@ export function createActivationMarker(params: {
   threadId: string;
   generationCount: number;
   observations?: string;
-  triggeredBy?: 'threshold' | 'ttl';
+  triggeredBy?: 'threshold' | 'ttl' | 'provider_change';
   lastActivityAt?: number;
   ttlExpiredMs?: number;
+  previousModel?: string;
+  currentModel?: string;
   config: ObservationMarkerConfig;
 }): DataOmActivationPart {
   return {
@@ -230,6 +232,8 @@ export function createActivationMarker(params: {
       triggeredBy: params.triggeredBy,
       lastActivityAt: params.lastActivityAt,
       ttlExpiredMs: params.ttlExpiredMs,
+      previousModel: params.previousModel,
+      currentModel: params.currentModel,
     },
   };
 }

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -63,6 +63,7 @@ export class ObservationStep {
         resourceId,
         checkThreshold: true,
         messages: step0Messages,
+        currentModel: this.turn.actorModelContext,
         writer: this.turn.writer,
         messageList,
       });
@@ -91,6 +92,8 @@ export class ObservationStep {
         observationTokens: obsTokens,
         threadId,
         writer: this.turn.writer,
+        messageList,
+        currentModel: this.turn.actorModelContext,
         requestContext: this.turn.requestContext,
         observabilityContext: this.turn.observabilityContext,
         lastActivityAt: getLastActivityFromMessages(messageList.get.all.db()),
@@ -318,6 +321,7 @@ export class ObservationStep {
         threadId,
         resourceId,
         messages: messageList.get.all.db(),
+        currentModel: this.turn.actorModelContext,
         writer: this.turn.writer,
         messageList,
       });
@@ -333,6 +337,7 @@ export class ObservationStep {
           threadId,
           writer: this.turn.writer,
           messageList,
+          currentModel: this.turn.actorModelContext,
           requestContext: this.turn.requestContext,
           observabilityContext: this.turn.observabilityContext,
           lastActivityAt: getLastActivityFromMessages(messageList.get.all.db()),

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -6,6 +6,7 @@ import type { ObservationalMemoryRecord } from '@mastra/core/storage';
 
 import type { ObservationalMemory } from '../observational-memory';
 import type { MemoryContextProvider } from '../processor';
+import type { ObservationModelContext } from '../types';
 
 import { ObservationStep } from './step';
 import type { ObservationTurnHooks, TurnContext, TurnResult } from './types';
@@ -54,6 +55,9 @@ export class ObservationTurn {
 
   /** Optional observability context for nested OM spans. */
   observabilityContext?: ObservabilityContext;
+
+  /** Current actor model for this step. Updated by the processor before prepare(). */
+  actorModelContext?: ObservationModelContext;
 
   /** Optional processor-provided hooks for turn/step lifecycle integration. */
   readonly hooks?: ObservationTurnHooks;

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -93,6 +93,44 @@ export function getLastActivityFromMessages(messages?: MastraDBMessage[]): numbe
   return undefined;
 }
 
+function formatModelContext(provider?: string, modelId?: string): string | undefined {
+  if (provider && modelId) {
+    return `${provider}/${modelId}`;
+  }
+
+  return modelId;
+}
+
+export function getLastModelFromMessages(messages?: MastraDBMessage[]): string | undefined {
+  if (!messages) return undefined;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message || message.role !== 'assistant' || !message.content || typeof message.content === 'string') {
+      continue;
+    }
+
+    for (let j = message.content.parts.length - 1; j >= 0; j--) {
+      const part = message.content.parts[j];
+      if (part?.type === 'step-start' && typeof part.model === 'string' && part.model.length > 0) {
+        return part.model;
+      }
+    }
+
+    const metadata = message.content.metadata as { provider?: string; modelId?: string } | undefined;
+    const model = formatModelContext(metadata?.provider, metadata?.modelId);
+    if (model) {
+      return model;
+    }
+  }
+
+  return undefined;
+}
+
+export function getCurrentModel(model?: { provider?: string; modelId?: string }): string | undefined {
+  return formatModelContext(model?.provider, model?.modelId);
+}
+
 function parseActivationTTL(value: number | string | undefined, fieldPath: string): number | undefined {
   if (value === undefined) {
     return undefined;
@@ -178,6 +216,7 @@ import type {
   ResolvedReflectionConfig,
   ThresholdRange,
   ObservationMarkerConfig,
+  ObservationModelContext,
 } from './types';
 
 /**
@@ -437,6 +476,7 @@ export class ObservationalMemory {
         ? undefined
         : (config.observation?.bufferActivation ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.bufferActivation),
       activateAfterIdle: parseActivationTTL(config.activateAfterIdle, 'activateAfterIdle'),
+      activateOnProviderChange: config.activateOnProviderChange ?? false,
       blockAfter: asyncBufferingDisabled
         ? undefined
         : resolveBlockAfter(
@@ -469,6 +509,7 @@ export class ObservationalMemory {
         ? undefined
         : (config?.reflection?.bufferActivation ?? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.bufferActivation),
       activateAfterIdle: parseActivationTTL(config.activateAfterIdle, 'activateAfterIdle'),
+      activateOnProviderChange: config.activateOnProviderChange ?? false,
       blockAfter: asyncBufferingDisabled
         ? undefined
         : resolveBlockAfter(
@@ -3036,6 +3077,8 @@ ${formattedMessages}
     checkThreshold?: boolean;
     /** Messages to use for threshold check (in-memory). If omitted, loads from storage. */
     messages?: MastraDBMessage[];
+    /** Current actor model for provider-change activation checks. */
+    currentModel?: ObservationModelContext;
     /** Stream writer for emitting activation markers to the UI. */
     writer?: ProcessorStreamWriter;
     /** MessageList for persisting activation markers on the last assistant message. */
@@ -3075,9 +3118,11 @@ ${formattedMessages}
       return { activated: false, record };
     }
 
-    let activationTriggeredBy: 'threshold' | 'ttl' = 'threshold';
+    let activationTriggeredBy: 'threshold' | 'ttl' | 'provider_change' = 'threshold';
     let activationLastActivityAt: number | undefined;
     let activateAfterIdleExpiredMs: number | undefined;
+    let previousModel: string | undefined;
+    let currentModel: string | undefined;
 
     // Optional threshold guard — skip activation if pending tokens are below threshold
     if (opts.checkThreshold) {
@@ -3095,8 +3140,19 @@ ${formattedMessages}
         activateAfterIdle !== undefined && lastActivityAt !== undefined ? Date.now() - lastActivityAt : undefined;
       const ttlExpired =
         ttlExpiredMs !== undefined && activateAfterIdle !== undefined && ttlExpiredMs >= activateAfterIdle;
+      const actorModel = getCurrentModel(opts.currentModel);
+      const lastModel = getLastModelFromMessages(opts.messages);
+      const providerChanged =
+        this.observationConfig.activateOnProviderChange === true &&
+        actorModel !== undefined &&
+        lastModel !== undefined &&
+        actorModel !== lastModel;
 
-      if (ttlExpired) {
+      if (providerChanged) {
+        activationTriggeredBy = 'provider_change';
+        previousModel = lastModel;
+        currentModel = actorModel;
+      } else if (ttlExpired) {
         activationTriggeredBy = 'ttl';
         activationLastActivityAt = lastActivityAt;
         activateAfterIdleExpiredMs = ttlExpiredMs;
@@ -3187,6 +3243,8 @@ ${formattedMessages}
           triggeredBy: activationTriggeredBy,
           lastActivityAt: activationLastActivityAt,
           ttlExpiredMs: activateAfterIdleExpiredMs,
+          previousModel,
+          currentModel,
           config: this.getObservationMarkerConfig(),
         });
         void opts.writer.custom(activationMarker).catch(() => {});

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -3141,7 +3141,7 @@ ${formattedMessages}
       const ttlExpired =
         ttlExpiredMs !== undefined && activateAfterIdle !== undefined && ttlExpiredMs >= activateAfterIdle;
       const actorModel = getCurrentModel(opts.currentModel);
-      const lastModel = getLastModelFromMessages(opts.messages);
+      const lastModel = getLastModelFromMessages(thresholdMessages);
       const providerChanged =
         this.observationConfig.activateOnProviderChange === true &&
         actorModel !== undefined &&

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -169,6 +169,7 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
       const observabilityContext = getOmObservabilityContext(args);
       state.__omObservabilityContext = observabilityContext;
       this.turn.observabilityContext = observabilityContext;
+      this.turn.actorModelContext = actorModelContext;
 
       // ── Run step preparation (activation, threshold, observation, filtering) ──
       {

--- a/packages/memory/src/processors/observational-memory/reflector-runner.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-runner.ts
@@ -32,12 +32,52 @@ import { withOmTracingSpan } from './tracing';
 import type {
   ObservationDebugEvent,
   ObservationMarkerConfig,
+  ObservationModelContext,
   ObserveHookUsage,
   ObserveHooks,
   ResolvedObservationConfig,
   ResolvedReflectionConfig,
   ThresholdRange,
 } from './types';
+
+function formatModelContext(provider?: string, modelId?: string): string | undefined {
+  if (provider && modelId) {
+    return `${provider}/${modelId}`;
+  }
+
+  return modelId;
+}
+
+function getCurrentModel(model?: ObservationModelContext): string | undefined {
+  return formatModelContext(model?.provider, model?.modelId);
+}
+
+function getLastModelFromMessageList(messageList?: MessageList): string | undefined {
+  const messages = messageList?.get.all.db();
+  if (!messages) return undefined;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message || message.role !== 'assistant' || !message.content || typeof message.content === 'string') {
+      continue;
+    }
+
+    for (let j = message.content.parts.length - 1; j >= 0; j--) {
+      const part = message.content.parts[j];
+      if (part?.type === 'step-start' && typeof part.model === 'string' && part.model.length > 0) {
+        return part.model;
+      }
+    }
+
+    const metadata = message.content.metadata as { provider?: string; modelId?: string } | undefined;
+    const model = formatModelContext(metadata?.provider, metadata?.modelId);
+    if (model) {
+      return model;
+    }
+  }
+
+  return undefined;
+}
 
 type ConcreteReflectionModel = Exclude<ResolvedReflectionConfig['model'], ModelByInputTokens>;
 
@@ -513,9 +553,11 @@ export class ReflectorRunner {
     writer?: ProcessorStreamWriter,
     messageList?: MessageList,
     activationMetadata?: {
-      triggeredBy: 'threshold' | 'ttl';
+      triggeredBy: 'threshold' | 'ttl' | 'provider_change';
       lastActivityAt?: number;
       ttlExpiredMs?: number;
+      previousModel?: string;
+      currentModel?: string;
     },
   ): Promise<boolean> {
     const bufferKey = this.buffering.getReflectionBufferKey(lockKey);
@@ -591,6 +633,8 @@ export class ReflectorRunner {
         triggeredBy: activationMetadata?.triggeredBy,
         lastActivityAt: activationMetadata?.lastActivityAt,
         ttlExpiredMs: activationMetadata?.ttlExpiredMs,
+        previousModel: activationMetadata?.previousModel,
+        currentModel: activationMetadata?.currentModel,
         config: this.getObservationMarkerConfig(freshRecord),
       });
       void writer.custom(activationMarker).catch(() => {});
@@ -619,6 +663,7 @@ export class ReflectorRunner {
     writer?: ProcessorStreamWriter;
     abortSignal?: AbortSignal;
     messageList?: MessageList;
+    currentModel?: ObservationModelContext;
     reflectionHooks?: Pick<ObserveHooks, 'onReflectionStart' | 'onReflectionEnd'>;
     requestContext?: RequestContext;
     observabilityContext?: ObservabilityContext;
@@ -630,6 +675,7 @@ export class ReflectorRunner {
       writer,
       abortSignal,
       messageList,
+      currentModel,
       reflectionHooks,
       requestContext,
       observabilityContext,
@@ -675,15 +721,28 @@ export class ReflectorRunner {
       activateAfterIdle !== undefined && lastActivityAt !== undefined ? Date.now() - lastActivityAt : undefined;
     const ttlExpired =
       ttlExpiredMs !== undefined && activateAfterIdle !== undefined && ttlExpiredMs >= activateAfterIdle;
+    const actorModel = getCurrentModel(currentModel);
+    const lastModel = getLastModelFromMessageList(messageList);
+    const providerChanged =
+      this.reflectionConfig.activateOnProviderChange === true &&
+      actorModel !== undefined &&
+      lastModel !== undefined &&
+      actorModel !== lastModel;
 
-    if (observationTokens < reflectThreshold && !ttlExpired) {
+    if (observationTokens < reflectThreshold && !ttlExpired && !providerChanged) {
       return;
     }
 
     const activationMetadata = {
-      triggeredBy: ttlExpired ? ('ttl' as const) : ('threshold' as const),
+      triggeredBy: providerChanged
+        ? ('provider_change' as const)
+        : ttlExpired
+          ? ('ttl' as const)
+          : ('threshold' as const),
       lastActivityAt: ttlExpired ? lastActivityAt : undefined,
       ttlExpiredMs: ttlExpired ? ttlExpiredMs : undefined,
+      previousModel: providerChanged ? lastModel : undefined,
+      currentModel: providerChanged ? actorModel : undefined,
     };
 
     // ═══════════════════════════════════════════════════════════

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -284,6 +284,11 @@ export interface ObservationMarkerConfig {
   activateAfterIdle?: number;
 }
 
+export interface ObservationModelContext {
+  provider?: string;
+  modelId?: string;
+}
+
 /**
  * Start marker inserted when observation begins.
  * Everything BEFORE this marker will be observed.
@@ -623,14 +628,20 @@ export interface DataOmActivationPart {
     /** The actual observations from activated chunks (for UI display) */
     observations?: string;
 
-    /** Whether activation was triggered by threshold crossing or activateAfterIdle expiry */
-    triggeredBy?: 'threshold' | 'ttl';
+    /** Whether activation was triggered by threshold crossing, activateAfterIdle expiry, or a model/provider change */
+    triggeredBy?: 'threshold' | 'ttl' | 'provider_change';
 
     /** Unix-ms timestamp of the last assistant message part used for TTL checks */
     lastActivityAt?: number;
 
     /** How long activateAfterIdle had been exceeded when activation fired */
     ttlExpiredMs?: number;
+
+    /** Previous assistant model identifier that triggered activation, e.g. openai/gpt-4o */
+    previousModel?: string;
+
+    /** Current actor model identifier that triggered activation, e.g. anthropic/claude-3-7-sonnet */
+    currentModel?: string;
   };
 }
 
@@ -844,6 +855,12 @@ export interface ObservationalMemoryConfig {
    * token threshold has been reached.
    */
   activateAfterIdle?: number | string;
+
+  /**
+   * Force-activate buffered observations and reflections when the actor provider/model changes.
+   * This helps flush prompt-cache-specific memory before switching to a different model.
+   */
+  activateOnProviderChange?: boolean;
 }
 
 /**
@@ -867,6 +884,8 @@ export interface ResolvedObservationConfig {
   bufferActivation?: number;
   /** Time in milliseconds before buffered observations are force-activated based on the last assistant message part timestamp */
   activateAfterIdle?: number;
+  /** Force-activate buffered observations when the actor model/provider changes */
+  activateOnProviderChange?: boolean;
   /** Token threshold above which synchronous observation is forced */
   blockAfter?: number;
   /** Optional token budget for observer context optimization (0 = full truncation, false = disabled) */
@@ -890,6 +909,8 @@ export interface ResolvedReflectionConfig {
   bufferActivation?: number;
   /** Time in milliseconds before buffered reflections are force-activated based on the last assistant message part timestamp */
   activateAfterIdle?: number;
+  /** Force-activate buffered reflections when the actor model/provider changes */
+  activateOnProviderChange?: boolean;
   /** Token threshold above which synchronous reflection is forced */
   blockAfter?: number;
   /** Custom instructions to append to the Reflector's system prompt */


### PR DESCRIPTION
This adds provider/model-change activation for observational memory and wires it through MastraCode.

After this, switching models can immediately activate observations instead of waiting for the next threshold or idle timeout.

```ts
observationalMemory: {
  activateOnProviderChange: true,
}
```

Under the hood, step-start parts now carry the model used for each step, so model changes can be detected across steps, even within a single assistant message. The PR also includes MastraCode TUI updates, docs, and changesets.
<img width="1181" height="551" alt="Screenshot 2026-04-15 at 3 47 39 PM" src="https://github.com/user-attachments/assets/1c88e629-25b1-444b-b8a2-c8885cb5311d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you switch to a different AI model/provider, the system can immediately turn recent buffered observations into active memory so the new model starts with the same compact context—saving tokens and avoiding re-sending large unactivated buffers.

## Overview

Adds provider/model-change activation for Observational Memory and wires it through MastraCode so buffered observations and reflections can be activated immediately when execution moves to a different provider/model (config-gated).

## Key Changes

- New config flag: observationalMemory.activateOnProviderChange?: boolean (default false) — when true, OM activates buffered observations/reflections on provider/model switch.
- Activation logic:
  - Activation triggers now include 'provider_change' in addition to 'threshold' and 'ttl'.
  - Activation metadata and markers carry previousModel and currentModel when triggered by provider change.
  - Helpers added: getLastModelFromMessages and getCurrentModel to derive model context.
- Message/step metadata:
  - step-start parts now optionally include model?: string so model changes can be detected across steps and within a single assistant message.
  - MessageMerger stamps synthetic step-start parts with model metadata when available.
  - MessageList.enrichLastStepStart(model: string): boolean added to annotate the last step-start.
- Observational memory & reflection plumbing:
  - ObservationalMemory.activate and ReflectorRunner.maybeReflect accept currentModel and can trigger activation/reflection when actor model differs from lastModel.
  - Activation marker emission and OM processor forward previousModel/currentModel through events/markers and harness events.
  - ObservationTurn and OM processor state carry actorModelContext for per-step model tracking.
- MastraCode TUI integration:
  - New OM marker type om_activation_provider_change with previousModel/currentModel and UI text "Model changed previous → current, activating observations".
  - Event dispatch and handlers extended to handle triggeredBy: 'provider_change' and forward model info; TUI state tracks activeActivationProviderChangeMarker and clears it during buffering to avoid stale UI.
  - Tests added to validate marker rendering and TUI behavior.
- Execution flow & metadata:
  - LLM execution step threads model context into output processing and enriches last step-start for fallback iterations.
  - Response/DB/UI message metadata now include provider alongside modelId when available (tests/snapshots updated).
- Storage/serialization:
  - Observational memory serialization includes activateOnProviderChange so the flag persists in stored config.
- Docs & changesets:
  - Documentation updated to document activateOnProviderChange and rationale (preserve prompt-cache savings across provider/model switches).
  - Changesets added for mastracode, @mastra/core, and @mastra/memory describing the provider/model-change activation behavior.

## Tests

- New and updated tests/snapshots:
  - OM activation on provider-change integration/unit tests.
  - MessageList step-start enrichment tests.
  - MastraCode TUI OM marker rendering tests.
  - Updated snapshots to include provider metadata where applicable.

## Rationale / Impact

When enabled, activateOnProviderChange ensures switching providers/models immediately activates buffered observations/reflections so the new provider receives a compact, activated context rather than a large raw token window—reducing token waste and preserving prompt-cache savings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->