### PR TITLE
feat(core,mastracode): add --output-format to mastracode headless wit…

### DIFF
--- a/.changeset/eight-carrots-kick.md
+++ b/.changeset/eight-carrots-kick.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added `--output-format` flag to headless mode, accepting `text`, `json`, and `stream-json` for automation and CI use cases. Coexists with all existing headless flags.

--- a/mastracode/src/headless.test.ts
+++ b/mastracode/src/headless.test.ts
@@ -207,6 +207,32 @@ describe('parseHeadlessArgs', () => {
     expect(args.settings).toBeUndefined();
   });
 
+  it('parses --output-format text', () => {
+    const args = parseHeadlessArgs(['node', 'main.js', '-p', 'task', '--output-format', 'text']);
+    expect(args.outputFormat).toBe('text');
+  });
+
+  it('parses --output-format json', () => {
+    const args = parseHeadlessArgs(['node', 'main.js', '-p', 'task', '--output-format', 'json']);
+    expect(args.outputFormat).toBe('json');
+  });
+
+  it('parses --output-format stream-json', () => {
+    const args = parseHeadlessArgs(['node', 'main.js', '-p', 'task', '--output-format', 'stream-json']);
+    expect(args.outputFormat).toBe('stream-json');
+  });
+
+  it('throws on invalid --output-format', () => {
+    expect(() => parseHeadlessArgs(['node', 'main.js', '-p', 'task', '--output-format', 'yaml'])).toThrow(
+      '--output-format must be one of: text, json, stream-json',
+    );
+  });
+
+  it('returns undefined outputFormat when not provided', () => {
+    const args = parseHeadlessArgs(['node', 'main.js', '-p', 'task']);
+    expect(args.outputFormat).toBeUndefined();
+  });
+
   it('parses --clone-thread hyphenated boolean flag', () => {
     const args = parseHeadlessArgs(['node', 'main.js', '-p', 'task', '--clone-thread']);
     expect(args.cloneThread).toBe(true);

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -4,7 +4,7 @@
 import { existsSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 
-import type { Harness, HarnessEvent } from '@mastra/core/harness';
+import type { Harness, HarnessEvent, HarnessMessage } from '@mastra/core/harness';
 
 import { setupDebugLogging } from './utils/debug-log.js';
 import { releaseAllThreadLocks } from './utils/thread-lock.js';
@@ -17,6 +17,7 @@ export interface HeadlessArgs {
   prompt?: string;
   timeout?: number;
   format: 'default' | 'json';
+  outputFormat?: 'text' | 'json' | 'stream-json';
   continue_: boolean;
   model?: string;
   mode?: 'build' | 'plan' | 'fast';
@@ -42,6 +43,7 @@ const headlessOptions = {
   'resource-id': { type: 'string' },
   timeout: { type: 'string' }, // parsed to number after validation
   format: { type: 'string', default: 'default' },
+  'output-format': { type: 'string' },
   model: { type: 'string', short: 'm' },
   mode: { type: 'string' },
   'thinking-level': { type: 'string' },
@@ -49,7 +51,7 @@ const headlessOptions = {
   help: { type: 'boolean', short: 'h', default: false },
 } as const;
 
-/** Parse CLI arguments for headless mode (--prompt, --timeout, --format, --continue, --model, --mode, --thinking-level, --settings). */
+/** Parse CLI arguments for headless mode (--prompt, --timeout, --format, --output-format, --continue, --model, --mode, --thinking-level, --settings). */
 export function parseHeadlessArgs(argv: string[]): HeadlessArgs {
   const { values, positionals } = parseArgs({
     args: argv.slice(2),
@@ -94,6 +96,15 @@ export function parseHeadlessArgs(argv: string[]): HeadlessArgs {
     thinkingLevel = raw as HeadlessArgs['thinkingLevel'];
   }
 
+  let outputFormat: HeadlessArgs['outputFormat'];
+  if (values['output-format'] !== undefined) {
+    const raw = String(values['output-format']);
+    if (raw !== 'text' && raw !== 'json' && raw !== 'stream-json') {
+      throw new Error('--output-format must be one of: text, json, stream-json');
+    }
+    outputFormat = raw;
+  }
+
   const settings = typeof values.settings === 'string' ? values.settings : undefined;
   const thread = typeof values.thread === 'string' ? values.thread : undefined;
   const title = typeof values.title === 'string' ? values.title : undefined;
@@ -108,6 +119,7 @@ export function parseHeadlessArgs(argv: string[]): HeadlessArgs {
     prompt,
     timeout,
     format: format as 'default' | 'json',
+    outputFormat,
     continue_: Boolean(values.continue),
     model,
     mode,
@@ -138,6 +150,7 @@ Headless (non-interactive) mode options:
   --resource-id <id>            Set the resource ID for thread scoping
   --timeout <seconds>           Exit with code 2 if not complete within timeout
   --format <type>               Output format: "default" or "json" (default: "default")
+  --output-format <type>        Automation output: "text", "json", or "stream-json"
   --model, -m <id>              Model override (e.g., "anthropic/claude-sonnet-4-5")
   --mode {build|plan|fast}      Execution mode — defaults to "build" if omitted
   --thinking-level <level>      Thinking level: off, low, medium, high, xhigh
@@ -168,6 +181,8 @@ Examples:
   mastracode --thread abc123 --clone-thread --prompt "Try a different approach"
   mastracode --prompt "Refactor utils" --title "utils-refactor"
   mastracode --prompt "Refactor utils" --format json
+  mastracode --prompt "Run tests and summarize pass/fail counts" --output-format json
+  mastracode --prompt "Find all TODO comments" --output-format stream-json
   mastracode --resource-id my-project --prompt "Fix the bug"
   echo "task description" | mastracode --prompt -
 
@@ -253,6 +268,73 @@ function formatDefault(event: HarnessEvent, ctx: { lastTextLength: number }): vo
   }
 }
 
+interface HeadlessSummary {
+  text: string;
+  finishReason?: string;
+  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  toolCalls: Array<{ id: string; name: string; args: unknown }>;
+  toolResults: Array<{ id: string; name: string; result: unknown; isError: boolean }>;
+  error?: { name: string; message: string; stack?: string };
+  threadId?: string;
+}
+
+function createEmptySummary(): HeadlessSummary {
+  return { text: '', toolCalls: [], toolResults: [] };
+}
+
+function extractAssistantText(message: HarnessMessage): string {
+  return message.content
+    .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+    .map(c => c.text)
+    .join('');
+}
+
+function aggregateIntoSummary(event: HarnessEvent, summary: HeadlessSummary): void {
+  switch (event.type) {
+    case 'message_end':
+      if (event.message.role === 'assistant') {
+        summary.text += extractAssistantText(event.message);
+      }
+      break;
+    case 'tool_start':
+      summary.toolCalls.push({ id: event.toolCallId, name: event.toolName, args: event.args });
+      break;
+    case 'tool_end': {
+      const matching = summary.toolCalls.find(c => c.id === event.toolCallId);
+      summary.toolResults.push({
+        id: event.toolCallId,
+        name: matching?.name ?? '',
+        result: event.result,
+        isError: event.isError,
+      });
+      break;
+    }
+    case 'usage_update':
+      summary.usage = {
+        inputTokens: event.usage.promptTokens,
+        outputTokens: event.usage.completionTokens,
+        totalTokens: event.usage.totalTokens,
+      };
+      break;
+    case 'error':
+      summary.error = {
+        name: event.error.name,
+        message: event.error.message,
+        stack: event.error.stack,
+      };
+      break;
+  }
+}
+
+function finalizeSummary<TState extends Record<string, unknown>>(
+  summary: HeadlessSummary,
+  endEvent: Extract<HarnessEvent, { type: 'agent_end' }>,
+  harness: Harness<TState>,
+): void {
+  summary.finishReason = endEvent.reason;
+  summary.threadId = harness.getCurrentThreadId() ?? undefined;
+}
+
 /** Resolve a thread by ID or title. Tries exact ID match first, then title. */
 async function resolveThread(
   harness: Harness,
@@ -282,10 +364,13 @@ export async function runHeadless<TState extends Record<string, unknown>>(
   args: HeadlessArgs & { prompt: string },
   effectiveDefaults?: Record<string, string>,
 ): Promise<number> {
+  const outputFormat = args.outputFormat;
   const emit =
-    args.format === 'json'
+    outputFormat === 'stream-json' || (!outputFormat && args.format === 'json')
       ? (data: Record<string, unknown>) => process.stdout.write(JSON.stringify(data) + '\n')
       : null;
+  const summary = outputFormat === 'json' ? createEmptySummary() : null;
+  let textBuffer: string | null = outputFormat === 'text' ? '' : null;
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
@@ -372,19 +457,33 @@ export async function runHeadless<TState extends Record<string, unknown>>(
       const result = autoResolve(harness, event);
       if (result.resolved) {
         if (emit) emit(result.json);
-        else process.stderr.write(result.label + '\n');
+        else if (!outputFormat) process.stderr.write(result.label + '\n');
         return;
       }
 
+      // Aggregate into accumulators for text / json modes
+      if (summary) aggregateIntoSummary(event, summary);
+      if (textBuffer !== null && event.type === 'message_end' && event.message.role === 'assistant') {
+        textBuffer += extractAssistantText(event.message);
+      }
+
       if (event.type === 'agent_end') {
-        if (emit) emit({ ...event });
+        if (summary) {
+          finalizeSummary(summary, event, harness);
+          process.stdout.write(JSON.stringify(summary) + '\n');
+        } else if (textBuffer !== null) {
+          process.stdout.write(textBuffer);
+          if (!textBuffer.endsWith('\n')) process.stdout.write('\n');
+        } else if (emit) {
+          emit({ ...event });
+        }
         resolve(resolveExitCode(event.reason));
         return;
       }
 
       if (emit) {
         emit({ ...event });
-      } else {
+      } else if (!outputFormat) {
         formatDefault(event, streamCtx);
       }
     });


### PR DESCRIPTION
…h Harness.streamOnce

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a new `--output-format` flag to the mastracode headless command so users can choose how they get information back — either as plain text, as JSON, or as streaming JSON. This is helpful for tools and scripts that need data in a specific format to work properly.

## Changes

### Core Implementation

**New `--output-format` CLI option** (`headless.ts` and `headless.test.ts`)
- Extended the `HeadlessArgs` interface with an optional `outputFormat` field that accepts three values: `'text'`, `'json'`, or `'stream-json'`
- Added CLI argument parsing and validation that rejects invalid format values with a clear error message
- Updated the `runHeadless()` function to route output differently based on the selected format

### Output Formatting Behavior

- **`stream-json`**: Streams JSON-formatted events to stdout as they occur
- **`json`**: Buffers events internally and emits a single newline-delimited JSON summary at the end, including assistant text, tool calls/results, token usage, and error details
- **`text`**: Buffers events and outputs only the accumulated assistant text at the end
- **Legacy (no flag)**: Preserves the existing behavior of streaming formatted output to stderr

### Supporting Infrastructure

Introduced helper utilities to manage buffered output:
- `HeadlessSummary` type for accumulating event data
- Helper functions (`createEmptySummary`, `extractAssistantText`, `aggregateIntoSummary`, `finalizeSummary`) to build and format the final summary based on the chosen output format

### Testing & Documentation

- Added comprehensive test coverage for the new `--output-format` option, including valid formats, invalid values, and undefined states
- Added a changeset entry documenting the new feature as a minor release, noting that the flag works alongside all existing headless command flags
<!-- end of auto-generated comment: release notes by coderabbit.ai -->