### PR TITLE
fix: handle invalid URL in getFileContentType catch block

### DIFF
--- a/.changeset/fix-playground-ui-file-content-type.md
+++ b/.changeset/fix-playground-ui-file-content-type.md
@@ -1,0 +1,12 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fix unhandled `TypeError` in `getFileContentType` when the URL is relative
+or malformed. The `catch` block now falls back to inferring the MIME type
+from the raw string's file extension and strips query/hash fragments so
+inputs like `/files/report.pdf`, `https://x.dev/a.pdf?token=1`, and
+`/files/report.pdf#page=2` all resolve to `application/pdf` instead of
+rejecting.
+
+Closes #15432.

--- a/packages/playground-ui/src/lib/file/__tests__/contentTypeFromUrl.test.ts
+++ b/packages/playground-ui/src/lib/file/__tests__/contentTypeFromUrl.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getFileContentType } from '../contentTypeFromUrl';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getFileContentType', () => {
+  it('returns the content-type header when the HEAD request succeeds', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers({
+          'content-type': 'image/png',
+        }),
+      }),
+    );
+
+    await expect(getFileContentType('https://example.com/image.png')).resolves.toBe('image/png');
+  });
+
+  it('falls back to the absolute URL pathname when the HEAD request is not ok', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        headers: new Headers(),
+      }),
+    );
+
+    await expect(getFileContentType('https://example.com/files/report.pdf')).resolves.toBe('application/pdf');
+  });
+
+  it('falls back to the absolute URL pathname when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    await expect(getFileContentType('https://example.com/files/report.pdf')).resolves.toBe('application/pdf');
+  });
+
+  it('returns a MIME type for a relative path when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    await expect(getFileContentType('/files/report.pdf')).resolves.toBe('application/pdf');
+  });
+
+  it('returns undefined for a malformed string when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    await expect(getFileContentType('not a url')).resolves.toBeUndefined();
+  });
+
+  it('strips query strings from the raw fallback extension', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    await expect(getFileContentType('https://x.dev/a.pdf?token=1')).resolves.toBe('application/pdf');
+  });
+
+  it('strips hash fragments from the raw fallback extension', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    await expect(getFileContentType('/files/report.pdf#page=2')).resolves.toBe('application/pdf');
+  });
+
+  it('normalizes uppercase extensions in the fallback path', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    await expect(getFileContentType('/FOO.PDF')).resolves.toBe('application/pdf');
+  });
+
+  it('returns undefined for an unknown extension in the fallback path', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    await expect(getFileContentType('/thing.xyz')).resolves.toBeUndefined();
+  });
+});

--- a/packages/playground-ui/src/lib/file/contentTypeFromUrl.ts
+++ b/packages/playground-ui/src/lib/file/contentTypeFromUrl.ts
@@ -28,7 +28,7 @@ export const getFileContentType = async (url: string) => {
     } catch {
       // url is not a valid absolute URL (e.g. a relative path) — extract
       // extension from the raw string so we still return a useful MIME type.
-      const extension = url.split('.').pop()?.split('?')[0];
+      const extension = url.split('.').pop()?.split(/[?#]/)[0];
       if (!extension) return undefined;
       return EXTENSION_TO_MIME[extension.toLowerCase()];
     }

--- a/packages/playground-ui/src/lib/file/contentTypeFromUrl.ts
+++ b/packages/playground-ui/src/lib/file/contentTypeFromUrl.ts
@@ -18,13 +18,20 @@ export const getFileContentType = async (url: string) => {
 
     return contentType;
   } catch {
-    const urlObject = new URL(url);
-    const pathname = urlObject.pathname;
-
-    const extension = pathname.split('.').pop();
-    if (!extension) return undefined;
-    const lowerCaseExtension = extension.toLowerCase();
-
-    return EXTENSION_TO_MIME[lowerCaseExtension];
+    // fetch failed — try to infer content type from the file extension
+    try {
+      const urlObject = new URL(url);
+      const pathname = urlObject.pathname;
+      const extension = pathname.split('.').pop();
+      if (!extension) return undefined;
+      return EXTENSION_TO_MIME[extension.toLowerCase()];
+    } catch {
+      // url is not a valid absolute URL (e.g. a relative path) — extract
+      // extension from the raw string so we still return a useful MIME type.
+      const extension = url.split('.').pop()?.split('?')[0];
+      if (!extension) return undefined;
+      return EXTENSION_TO_MIME[extension.toLowerCase()];
+    }
   }
 };
+

--- a/packages/playground-ui/src/lib/file/contentTypeFromUrl.ts
+++ b/packages/playground-ui/src/lib/file/contentTypeFromUrl.ts
@@ -34,4 +34,3 @@ export const getFileContentType = async (url: string) => {
     }
   }
 };
-


### PR DESCRIPTION
## Summary

Fixes #15432

The `getFileContentType` function in `packages/playground-ui/src/lib/file/contentTypeFromUrl.ts` has an unhandled `TypeError` path in its `catch` block.

## Problem

When `fetch()` fails and `url` is not a valid absolute URL, `new URL(url)` in the catch block throws a `TypeError` that escapes the function entirely:

```typescript
catch {
  const urlObject = new URL(url);  // ← throws TypeError for relative paths!
  const pathname = urlObject.pathname;
  ...
}
```

**Repro:**
```typescript
await getFileContentType('/relative/path/to/file.pdf');
// → Unhandled TypeError: Failed to construct 'URL': Invalid URL
```

Relative paths (`/files/report.pdf`) and malformed strings are realistic inputs in the playground UI.

## Fix

Wrap the URL construction in an inner try-catch and fall back to extracting the extension directly from the raw string:

```typescript
catch {
  try {
    const urlObject = new URL(url);
    const pathname = urlObject.pathname;
    const extension = pathname.split('.').pop();
    if (!extension) return undefined;
    return EXTENSION_TO_MIME[extension.toLowerCase()];
  } catch {
    // url is not a valid absolute URL — extract extension from raw string
    const extension = url.split('.').pop()?.split('?')[0];
    if (!extension) return undefined;
    return EXTENSION_TO_MIME[extension.toLowerCase()];
  }
}
```

## Testing

- Valid absolute URL: works as before
- Relative URL like `/files/report.pdf`: now returns `application/pdf` instead of throwing
- Malformed URL: returns `undefined` gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When the app can't download a file to check its type, it now safely guesses the file type from the filename instead of crashing. If the filename is weird or malformed, it returns "unknown" (undefined) instead of throwing an error.

## Summary

This PR fixes an unhandled TypeError in packages/playground-ui/src/lib/file/contentTypeFromUrl.ts by adding a robust two-step fallback for inferring MIME types when fetch() fails or the Content-Type header is missing.

### What Changed

- getFileContentType now uses a safe fallback sequence:
  1. Try parsing the input with new URL(url) and extract the extension from pathname (lowercased) to map via EXTENSION_TO_MIME.
  2. If URL parsing throws (relative or malformed inputs), strip query/hash from the raw string, extract the trailing file extension, lowercase it, and map via EXTENSION_TO_MIME.
  3. Return undefined if no usable extension is found.
- Prevents rethrowing from new URL(url) in the catch block and avoids unhandled promise rejections.

### Tests & Release Note

- Adds Vitest coverage for:
  - Successful HEAD responses with content-type header
  - Non-OK HEAD responses and fetch rejections
  - Fallback resolution from absolute and relative paths (including query/hash stripping and uppercase extensions)
  - Malformed strings returning undefined
- Includes a changeset to publish a patch release for @mastra/playground-ui.

### Files Changed

- packages/playground-ui/src/lib/file/contentTypeFromUrl.ts (+15/-8)
- packages/playground-ui/src/lib/file/__tests__/contentTypeFromUrl.test.ts (new tests)
- .changeset/fix-playground-ui-file-content-type.md (changeset)

### Effect

- Preserves existing behavior for absolute URLs.
- Correctly resolves MIME types for relative paths (e.g., /files/report.pdf → application/pdf).
- Returns undefined for malformed inputs instead of throwing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->