### PR TITLE
fix(core): handle missing agent stream error payloads

### DIFF
--- a/.changeset/smooth-hairs-move.md
+++ b/.changeset/smooth-hairs-move.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent stream errors when providers end a stream without an error payload.

--- a/packages/core/src/agent/__tests__/save-and-errors.test.ts
+++ b/packages/core/src/agent/__tests__/save-and-errors.test.ts
@@ -3,6 +3,9 @@ import { APICallError } from '@internal/ai-sdk-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
+import { MastraError } from '../../error';
+import type { IMastraLogger } from '../../logger';
+import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
 import { createTool } from '../../tools';
 import { Agent } from '../agent';
@@ -1883,6 +1886,92 @@ describe('AGENT_RUN span must be ended on LLM errors', () => {
       expect(agentRunSpan).toBeDefined();
       expect(agentRunSpan.error).toHaveBeenCalled();
       expect(agentRunSpan.error.mock.calls[0][0]).toMatchObject({ endSpan: true });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('should synthesize a MastraError when the stream finishes with finishReason error but no error payload', async () => {
+    const { spy, getAgentRunSpan } = await mockGetOrCreateSpan();
+
+    try {
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn().mockReturnValue(new Map()),
+        listLogs: vi.fn().mockResolvedValue({ logs: [], total: 0, page: 1, perPage: 10, hasMore: false }),
+        listLogsByRunId: vi.fn().mockResolvedValue({ logs: [], total: 0, page: 1, perPage: 10, hasMore: false }),
+      } satisfies IMastraLogger;
+      const mastra = new Mastra({ logger });
+
+      const errorFinishModel = new MockLanguageModelV2({
+        doGenerate: async () => ({
+          content: [],
+          finishReason: 'error',
+          usage: { inputTokens: 10, outputTokens: 0, totalTokens: 10 },
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        }),
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'gemini-2.5-flash',
+              timestamp: new Date(0),
+            },
+            {
+              type: 'finish',
+              finishReason: 'error',
+              usage: { inputTokens: 10, outputTokens: 0, totalTokens: 10 },
+            },
+          ]),
+        }),
+      });
+
+      const agent = new Agent({
+        id: 'test-finish-reason-error-without-payload',
+        name: 'Test Finish Reason Error Without Payload',
+        model: errorFinishModel,
+        instructions: 'You are a helpful assistant.',
+        mastra,
+      });
+
+      const output = await agent.stream('Hello', { modelSettings: { maxRetries: 0 } });
+
+      await output.consumeStream();
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      const agentRunSpan = getAgentRunSpan();
+      expect(agentRunSpan).toBeDefined();
+      expect(agentRunSpan.error).toHaveBeenCalled();
+      expect(agentRunSpan.error.mock.calls[0][0]).toMatchObject({ endSpan: true });
+      expect(agentRunSpan.error.mock.calls[0][0].error).toBeInstanceOf(MastraError);
+      expect(agentRunSpan.error.mock.calls[0][0].error.message).toBe(
+        'Agent stream finished with finishReason "error" but no error payload was provided',
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        'Error in agent stream',
+        expect.objectContaining({
+          error: expect.any(MastraError),
+          modelId: 'mock-model-id',
+          provider: 'mock-provider',
+          runId: expect.any(String),
+        }),
+      );
+      const loggedError = (logger.error as ReturnType<typeof vi.fn>).mock.calls[0][1]?.error;
+      expect(loggedError).toBeInstanceOf(MastraError);
+      expect(loggedError).not.toBeUndefined();
+      expect(loggedError.message).toBe(
+        'Agent stream finished with finishReason "error" but no error payload was provided',
+      );
     } finally {
       spy.mockRestore();
     }

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -231,36 +231,44 @@ export function createMapResultsStep<OUTPUT = undefined>({
           if (payload.finishReason === 'error') {
             const provider = payload.model?.provider;
             const modelId = payload.model?.modelId;
-            const isUpstreamError = APICallError.isInstance(payload.error);
-
-            if (isUpstreamError) {
-              capabilities.logger.error('Upstream LLM API error', {
-                error: payload.error,
-                runId,
-                ...(provider && { provider }),
-                ...(modelId && { modelId }),
-              });
-            } else {
-              capabilities.logger.error('Error in agent stream', {
-                error: payload.error,
-                runId,
-                ...(provider && { provider }),
-                ...(modelId && { modelId }),
-              });
-            }
-
             const error =
               payload.error instanceof Error
                 ? payload.error
                 : new MastraError(
                     {
                       id: 'AGENT_STREAM_ERROR',
+                      text:
+                        payload.error == null
+                          ? 'Agent stream finished with finishReason "error" but no error payload was provided'
+                          : undefined,
                       domain: ErrorDomain.AGENT,
                       category: ErrorCategory.SYSTEM,
-                      details: { runId },
+                      details: {
+                        runId,
+                        ...(provider && { provider }),
+                        ...(modelId && { modelId }),
+                      },
                     },
                     payload.error,
                   );
+            const isUpstreamError = APICallError.isInstance(error);
+
+            if (isUpstreamError) {
+              capabilities.logger.error('Upstream LLM API error', {
+                error,
+                runId,
+                ...(provider && { provider }),
+                ...(modelId && { modelId }),
+              });
+            } else {
+              capabilities.logger.error('Error in agent stream', {
+                error,
+                runId,
+                ...(provider && { provider }),
+                ...(modelId && { modelId }),
+              });
+            }
+
             // End the AGENT_RUN span so the trace is exported.
             // Without this, the span is orphaned and exporters that wait
             // for the root span to end (e.g. Datadog) never emit the trace.


### PR DESCRIPTION
Fixes #14879.

When a provider ends an agent stream with `finishReason: "error"` but no error payload, we now synthesize a `MastraError` and send it through the normal agent error path.

Before:
```ts
finishReason: "error"
error: undefined
```

After:
```ts
finishReason: "error"
error: new MastraError(...)
```

This keeps agent error logging and AGENT_RUN shutdown consistent for affected providers.

Test plan: `pnpm --filter @mastra/core test:unit src/agent/__tests__/save-and-errors.test.ts` and `pnpm --filter ./packages/core check`