### PR TITLE
refactor(playground-ui): harmonize DS surfaces and dedupe dropdown menu item classes

### DIFF
--- a/.changeset/wacky-chairs-march.md
+++ b/.changeset/wacky-chairs-march.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved visual consistency across Chip, DropdownMenu, Notification, Popover, and toast components — unified radius and border scale. Deduplicated dropdown menu item classes and added max-height scroll handling for long menus.

--- a/packages/playground-ui/src/ds/components/Chip/chip.tsx
+++ b/packages/playground-ui/src/ds/components/Chip/chip.tsx
@@ -3,26 +3,38 @@ import React from 'react';
 import { cn } from '@/lib/utils';
 
 const sizeClasses = {
-  small: 'text-[11px]   pt-[5px] pb-[4px]',
-  default: 'text-[12px] pt-[5px] pb-[4px] ',
-  large: 'text-[13px]   pt-[5px] pb-[4px] ',
+  small: 'text-[10.5px]   pt-[5px] pb-[4px]',
+  default: 'text-[11.5px] pt-[5px] pb-[4px] ',
+  large: 'text-[12.5px]   pt-[5px] pb-[4px] ',
 };
 
 const bgColorClasses = {
-  gray: { bright: 'bg-neutral-700', muted: 'bg-neutral-700/80' },
-  red: { bright: 'bg-red-900', muted: 'bg-red-900/80' },
-  orange: { bright: 'bg-yellow-900', muted: 'bg-yellow-900/80' },
-  blue: { bright: 'bg-blue-800', muted: 'bg-blue-800/80' },
-  green: { bright: 'bg-green-900', muted: 'bg-green-900/80' },
-  purple: { bright: 'bg-purple-900', muted: 'bg-purple-900/80' },
-  yellow: { bright: 'bg-yellow-700', muted: 'bg-yellow-700/80' },
-  cyan: { bright: 'bg-cyan-900', muted: 'bg-cyan-900/80' },
-  pink: { bright: 'bg-pink-900', muted: 'bg-pink-900/80' },
+  gray: {
+    bright: 'bg-neutral-500/30',
+    muted: 'bg-neutral-500/10',
+  },
+  red: { bright: 'bg-red-500/30', muted: 'bg-red-500/10' },
+  orange: {
+    bright: 'bg-orange-500/30',
+    muted: 'bg-orange-500/10',
+  },
+  blue: { bright: 'bg-blue-500/30', muted: 'bg-blue-500/10' },
+  green: { bright: 'bg-green-500/30', muted: 'bg-green-500/10' },
+  purple: {
+    bright: 'bg-purple-500/30',
+    muted: 'bg-purple-500/10',
+  },
+  yellow: {
+    bright: 'bg-yellow-500/30',
+    muted: 'bg-yellow-500/10',
+  },
+  cyan: { bright: 'bg-cyan-500/30', muted: 'bg-cyan-500/10' },
+  pink: { bright: 'bg-pink-500/30', muted: 'bg-pink-500/10' },
 };
 
 const txtIntensityClasses = {
-  bright: 'text-neutral4',
-  muted: 'text-neutral3',
+  bright: 'text-neutral4/90',
+  muted: 'text-neutral3/90',
 };
 
 export interface ChipProps extends React.HTMLAttributes<HTMLSpanElement> {
@@ -43,7 +55,7 @@ export const Chip = ({
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-md uppercase px-[0.5em] gap-[0.4em] tracking-wide font-normal',
+        'inline-flex items-center rounded-lg uppercase px-1.5 gap-[0.4em] tracking-wide font-normal',
         // general styles for svg icons within the chip
         '[&>svg]:w-[1em] [&>svg]:h-[1em] [&>svg]:translate-y-[-0.02em] [&>svg]:mx-[-0.2em]',
         // if the chip has only one child and it's an svg, make it fully opaque

--- a/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.stories.tsx
@@ -236,6 +236,40 @@ export const WithSubMenu: Story = {
   ),
 };
 
+export const WithManyItems: Story = {
+  render: () => {
+    const items = Array.from({ length: 40 }, (_, i) => `Item ${i + 1}`);
+    const subItems = Array.from({ length: 30 }, (_, i) => `Sub item ${i + 1}`);
+
+    return (
+      <DropdownMenu>
+        <DropdownMenu.Trigger asChild>
+          <Button variant="outline">Open long menu</Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content className="w-56">
+          <DropdownMenu.Label>Many items</DropdownMenu.Label>
+          <DropdownMenu.Separator />
+          {items.map(label => (
+            <DropdownMenu.Item key={label}>{label}</DropdownMenu.Item>
+          ))}
+          <DropdownMenu.Separator />
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger>
+              <UserPlus />
+              <span>Nested (many)</span>
+            </DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent>
+              {subItems.map(label => (
+                <DropdownMenu.Item key={label}>{label}</DropdownMenu.Item>
+              ))}
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    );
+  },
+};
+
 export const WithDisabledItems: Story = {
   render: () => (
     <DropdownMenu>

--- a/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.tsx
+++ b/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.tsx
@@ -13,18 +13,16 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
+const itemClass = cn(
+  'relative flex cursor-pointer select-none items-center gap-3 rounded-lg px-3 py-1.5 text-sm transition-colors text-neutral4 dark:hover:text-white dark:focus:text-white hover:text-neutral6 focus:text-neutral6 hover:bg-surface4 focus:bg-surface4 active:bg-surface5 data-disabled:pointer-events-none data-disabled:opacity-50 [&>span]:truncate [&_svg]:size-4 [&_svg]:shrink-0 focus-visible:outline-hidden focus-visible:ring-0',
+  '[&>svg]:w-[1.1em] [&>svg]:h-[1.1em] [&>svg]:opacity-50 [&>svg]:mx-[-.25em] [&:hover>svg]:opacity-100',
+);
+
 const DropdownMenuTrigger = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      'cursor-pointer focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-white/30 focus-visible:rounded-sm',
-      className,
-    )}
-    {...props}
-  >
+  <DropdownMenuPrimitive.Trigger ref={ref} className={cn('cursor-pointer', className)} {...props}>
     {children}
   </DropdownMenuPrimitive.Trigger>
 ));
@@ -38,15 +36,13 @@ const DropdownMenuSubTrigger = React.forwardRef<
 >(({ className, inset, children, ...props }, ref) => (
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
-    className={cn(
-      'hover:bg-surface4 focus:bg-surface4 active:bg-surface5 data-[state=open]:bg-surface4 flex cursor-default select-none items-center rounded-md px-2 py-1.5 text-sm transition-colors text-neutral4 dark:hover:text-white dark:focus:text-white hover:text-neutral6 focus:text-neutral6 focus-visible:outline-hidden focus-visible:ring-0',
-      inset && 'pl-8',
-      className,
-    )}
+    className={cn(itemClass, 'data-[state=open]:bg-surface4', inset && 'pl-8', className)}
     {...props}
   >
     {children}
-    <ChevronDown className="ml-auto -rotate-90" />
+    <span className="ml-auto pl-2">
+      <ChevronDown className="-rotate-90 opacity-50" />
+    </span>
   </DropdownMenuPrimitive.SubTrigger>
 ));
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
@@ -55,14 +51,16 @@ const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'bg-surface3 backdrop-blur-xl data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 min-w-32 overflow-auto overflow-x-hidden rounded-lg',
-      className,
-    )}
-    {...props}
-  />
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        'bg-surface3 backdrop-blur-xl data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 min-w-44 max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))] overflow-x-hidden overflow-y-auto rounded-xl border-2 border-border1/50 p-1 shadow-md',
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
 ));
 DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
 
@@ -78,7 +76,7 @@ const DropdownMenuContent = React.forwardRef<
         ref={ref}
         sideOffset={sideOffset}
         className={cn(
-          'bg-surface3 data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 backdrop-blur-xl text-neutral4 z-50 min-w-32 overflow-auto rounded-lg p-2 shadow-md',
+          'bg-surface3 data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 backdrop-blur-xl text-neutral4 z-50 min-w-44 max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))] overflow-x-hidden overflow-y-auto rounded-xl border-2 border-border1/50 p-1 shadow-md',
           className,
         )}
         {...props}
@@ -92,15 +90,7 @@ const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex cursor-pointer select-none items-center gap-3 rounded-md px-2 py-1.5 text-sm transition-colors text-neutral4 dark:hover:text-white dark:focus:text-white hover:text-neutral6 focus:text-neutral6 hover:bg-surface4 focus:bg-surface4 active:bg-surface5 data-disabled:pointer-events-none data-disabled:opacity-50 [&>span]:truncate [&_svg]:size-4 [&_svg]:shrink-0 focus-visible:outline-hidden focus-visible:ring-0',
-      '[&>svg]:w-[1.1em] [&>svg]:h-[1.1em] [&>svg]:opacity-50 [&>svg]:mx-[-.25em] [&:hover>svg]:opacity-100',
-      className,
-    )}
-    {...props}
-  />
+  <DropdownMenuPrimitive.Item ref={ref} className={cn(itemClass, className)} {...props} />
 ));
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
@@ -165,11 +155,7 @@ const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator
-    ref={ref}
-    className={cn('dark:bg-white/10 bg-black/10 -mx-1 my-1 h-px', className)}
-    {...props}
-  />
+  <DropdownMenuPrimitive.Separator ref={ref} className={cn('bg-border1/50 -mx-1.5 my-1 h-0.5', className)} {...props} />
 ));
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 

--- a/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.tsx
+++ b/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.tsx
@@ -100,10 +100,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 >(({ className, children, checked, ...props }, ref) => (
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
-    className={cn(
-      'hover:bg-surface4 focus:bg-surface4 active:bg-surface5 dark:hover:text-white dark:focus:text-white hover:text-neutral6 focus:text-neutral6 relative flex w-full cursor-pointer select-none items-center gap-4 rounded-md px-2 py-1.5 text-sm transition-colors text-neutral4 data-disabled:pointer-events-none data-disabled:opacity-50 focus-visible:outline-hidden focus-visible:ring-0',
-      className,
-    )}
+    className={cn(itemClass, 'w-full gap-4 px-2', className)}
     checked={checked}
     {...props}
   >

--- a/packages/playground-ui/src/ds/components/Notification/notification.tsx
+++ b/packages/playground-ui/src/ds/components/Notification/notification.tsx
@@ -55,7 +55,7 @@ export function Notification({
 
   const typeStyles = {
     info: 'bg-surface4 border-border1',
-    error: 'bg-accent2Darker border-accent2/30',
+    error: 'bg-accent2Darker border-accent2/20',
     success: 'bg-accent1Darker border-accent1/30',
     warning: 'bg-accent6Darker border-accent6/30',
   };
@@ -70,7 +70,7 @@ export function Notification({
   return (
     <div
       className={cn(
-        'grid grid-cols-[auto_1fr_auto] gap-3 rounded-lg border p-4 text-ui-md text-neutral4 items-start',
+        'grid grid-cols-[auto_1fr_auto] gap-3 rounded-xl border py-2.5 px-3.5 text-ui-md text-neutral4 items-start',
         'shadow-card',
         transitions.all,
         isAnimatingOut

--- a/packages/playground-ui/src/ds/components/Popover/popover.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.tsx
@@ -18,7 +18,7 @@ const PopoverContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         'z-50 w-72 rounded-xl border-2 border-border1/50 bg-surface3 text-neutral5 shadow-md focus-visible:outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className && /\bp-\S+/.test(className) ? false : `py-3.5 px-3`,
+        className && /\bp[trblxy]?-\S+/.test(className) ? false : `py-3.5 px-3`,
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Popover/popover.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.tsx
@@ -17,8 +17,8 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-md border border-border1 bg-surface3 text-neutral5 shadow-md focus-visible:outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className && /\bp-\S+/.test(className) ? false : `p-4`,
+        'z-50 w-72 rounded-xl border-2 border-border1/50 bg-surface3 text-neutral5 shadow-md focus-visible:outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className && /\bp-\S+/.test(className) ? false : `py-3.5 px-3`,
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/lib/toast.tsx
+++ b/packages/playground-ui/src/lib/toast.tsx
@@ -21,7 +21,7 @@ const defaultOptions: ExternalToast = {
   unstyled: true,
   classNames: {
     toast:
-      'bg-surface3 w-full h-auto rounded-lg gap-2 border border-border1 px-3 py-2 flex items-center justify-between pointer-events-auto shadow-card :data-content:flex-1',
+      'bg-surface3 w-full h-auto rounded-xl gap-2 border border-border1 px-3 py-2 flex items-center justify-between pointer-events-auto shadow-card :data-content:flex-1',
     title: 'text-xs font-medium text-neutral5',
     description: 'text-xs text-neutral3',
     cancelButton:


### PR DESCRIPTION
## Description

Visual polish across a handful of design-system surfaces plus a small refactor of `DropdownMenu`. No API changes, no new dependencies.

**Chip**

Unified color scale — switched from mixed `bg-X-700/800/900` solids to a consistent `bg-X-500/30` (bright) and `bg-X-500/10` (muted) across all hues. Nudged type sizes down 0.5px, added slight transparency to text tones, bumped radius to `rounded-lg`.

```tsx
// before
<Chip color="blue" intensity="bright" />   // bg-blue-800 + text-neutral4
// after
<Chip color="blue" intensity="bright" />   // bg-blue-500/30 + text-neutral4/90
```

**DropdownMenu**

- Extracted `itemClass` shared between `Item` and `SubTrigger` (removes ~7 duplicated classes).
- Portal-wrapped `SubContent` and added `max-h: min(20rem, --radix-dropdown-menu-content-available-height)` so long menus scroll cleanly — added a `WithManyItems` Storybook story covering this.
- Upgraded surface to `rounded-xl` + `border-2 border-border1/50` to match the rest of the DS.
- Refined separator (`bg-border1/50`, `h-0.5`).

**Notification / Popover / toast**

Radius bumped to `rounded-xl`, `border-2 border-border1/50` where relevant, padding retuned for a slightly tighter feel. Error border opacity softened on `Notification`.

## Related Issue(s)

N/A — design polish pass.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable) — changeset added, no user-facing docs impacted
- [ ] I have added tests that prove my fix is effective or that my feature works — visual changes; added `WithManyItems` story for the scroll behavior
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<img width="1893" height="1197" alt="CleanShot 2026-04-16 at 15 22 27" src="https://github.com/user-attachments/assets/89c5b9b5-b7fb-46c9-a63c-01ab0807195e" />
<img width="1893" height="855" alt="CleanShot 2026-04-16 at 15 23 15" src="https://github.com/user-attachments/assets/f86093a1-0527-4b8a-92ed-d93eba53661d" />

## ELI5
This PR gives several UI pieces a small visual makeover to make them look more consistent (rounder corners, softer borders, tighter spacing) and cleans up dropdown menu code so menu items share the same styling and very long menus scroll properly.

## Changes Overview

### Changeset
- Added a `patch` changeset for `@mastra/playground-ui` documenting visual consistency updates across multiple components and deduplication of dropdown menu classes.

### Chip Component
- Reduced font sizes by 0.5px for small/default/large.
- Switched to translucent 500-based backgrounds: bright `bg-X-500/30`, muted `bg-X-500/10`.
- Applied slight text transparency (`text-neutral4/90`, `text-neutral3/90`).
- Increased border radius from `rounded-md` to `rounded-lg`.
- Adjusted horizontal padding from `px-[0.5em]` to `px-1.5`.

### DropdownMenu Component
- Extracted a shared `itemClass` and applied it to Item, CheckboxItem (with w-full/gap-4/px-2 overrides), and SubTrigger to remove duplicated classes and unify hover/focus/disabled and radius behavior.
- Portal-wrapped `SubContent` and added max-height `max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))]` with `overflow-y-auto` so long menus scroll.
- Upgraded surfaces to `rounded-xl` with `border-2 border-border1/50` and tightened padding (`p-1`), refined separator to `bg-border1/50 h-0.5`.
- Adjusted SubTrigger chevron layout and icon opacity/spacing.
- Increased content min-width and applied consistent max-height/overflow/padding model for Content and SubContent.
- Added Storybook story `WithManyItems` demonstrating long menus (40 top-level + 30 nested items).

### Notification Component
- Increased radius to `rounded-xl`.
- Tightened padding from `p-4` to `py-2.5 px-3.5`.
- Softened error border opacity from `border-accent2/30` to `border-accent2/20`.

### Popover Component
- Updated content surface from `rounded-md border` to `rounded-xl border-2 border-border1/50`.
- Improved padding fallback detection to respect directional padding utilities (`px-*/py-*/pt-*/...`) and changed default padding from `p-4` to `py-3.5 px-3` when no padding utility is provided.

### Toast Component
- Updated default toast container radius from `rounded-lg` to `rounded-xl` (and adjusted classNames accordingly).

## Impact
- Visual consistency across surfaces (rounded-xl / rounded-lg where appropriate, border-2 border-border1/50, refined paddings and text opacities).
- Code quality: dropdown menu item classes deduplicated via shared `itemClass`.
- UX: long dropdown menus now scroll within a capped max-height; Storybook verifies behavior.
- No API or prop changes; no new dependencies. Tests: Storybook coverage for long dropdowns; no unit tests added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->