### PR TITLE
fix(core): handle missing execution context in channel webhooks

### DIFF
--- a/.changeset/flat-tires-turn.md
+++ b/.changeset/flat-tires-turn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed channel webhook handling in Node.js when no execution context is available.

--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -116,6 +116,34 @@ describe('AgentChannels', () => {
         expect(route.requiresAuth).toBe(false);
       }
     });
+
+    it('handles Hono contexts without ExecutionContext without throwing', async () => {
+      const webhookFn = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+      (agentChannels as any).initPromise = Promise.resolve();
+      (agentChannels as any).chat = { webhooks: { slack: webhookFn } };
+
+      const slackRoute = agentChannels.getWebhookRoutes().find(route => route.path.endsWith('/slack/webhook')) as any;
+      expect(slackRoute).toBeDefined();
+
+      const handler = await slackRoute.createHandler({} as any);
+      const request = new Request('http://localhost/api/agents/test-agent/channels/slack/webhook', {
+        method: 'POST',
+        body: JSON.stringify({ type: 'url_verification', challenge: 'abc' }),
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const ctx = {
+        req: { raw: request },
+        json: (body: unknown, status?: number) => new Response(JSON.stringify(body), { status: status ?? 200 }),
+        get executionCtx() {
+          throw new Error('This context has no ExecutionContext');
+        },
+      } as any;
+
+      await expect(handler(ctx)).resolves.toBeInstanceOf(Response);
+      expect(webhookFn).toHaveBeenCalledTimes(1);
+      expect(webhookFn).toHaveBeenCalledWith(request, undefined);
+    });
   });
 
   describe('sdk getter', () => {

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -718,7 +718,13 @@ export class AgentChannels {
 
             // Pass platform execution context (e.g. Vercel/Cloudflare waitUntil)
             // to the Chat SDK so background processing survives serverless responses.
-            const execCtx = c.executionCtx as { waitUntil?: (p: Promise<unknown>) => void } | undefined;
+            // Hono's `executionCtx` getter throws in Node.js when no ExecutionContext exists.
+            let execCtx: { waitUntil?: (p: Promise<unknown>) => void } | undefined;
+            try {
+              execCtx = c.executionCtx as { waitUntil?: (p: Promise<unknown>) => void } | undefined;
+            } catch {
+              execCtx = undefined;
+            }
             const waitUntilFn = execCtx?.waitUntil?.bind(execCtx);
             return webhookHandler(c.req.raw, waitUntilFn ? { waitUntil: waitUntilFn } : undefined);
           };


### PR DESCRIPTION
This guards channel webhook handling when Hono's `executionCtx` getter throws in Node.js, so Slack webhook verification and other channel webhooks no longer fail with a 500 during `mastra dev`.

Before:
`const execCtx = c.executionCtx`

After:
`let execCtx; try { execCtx = c.executionCtx } catch {}`

Also adds a regression test for a throwing `executionCtx` getter and a changeset.

Fixes #15427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation
Imagine you're trying to read a book from a shelf, but sometimes the shelf is empty in certain rooms. Instead of just reaching for the book and falling when it's not there, this fix carefully checks first whether the book is on the shelf before trying to grab it. That way, Slack webhooks work properly in Node.js environments where that "shelf" (execution context) doesn't exist.

## Overview
This PR fixes a critical issue where Slack channel webhooks return HTTP 500 errors in Node.js environments during `mastra dev`, preventing Slack Event Subscriptions from verifying the webhook URL and receiving events.

## Root Cause
Hono's `c.executionCtx` getter throws an error in Node.js when no execution context is available, causing the webhook handler to crash unexpectedly.

## Changes Made

**Core Fix** (`packages/core/src/channels/agent-channels.ts`):
- Wrapped `c.executionCtx` access in a try/catch block to safely handle the error
- If the getter throws, `execCtx` defaults to `undefined`
- Preserved existing logic: conditionally binds `waitUntil` and passes it to the webhook handler only when execution context is available

**Test Coverage** (`packages/core/src/channels/__tests__/agent-channels.test.ts`):
- Added regression test that verifies webhook route handlers work when the Hono context's `executionCtx` getter throws
- Test confirms the handler resolves to a valid Response and invokes the underlying Slack webhook function with the correct parameters

**Changeset** (`.changeset/flat-tires-turn.md`):
- Marked `@mastra/core` for a patch release documenting the channel webhook fix for Node.js environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->