### PR TITLE
docs: add self-hosted prerequisite callout to CloudExporter page

### DIFF
--- a/docs/src/content/en/docs/mastra-platform/overview.mdx
+++ b/docs/src/content/en/docs/mastra-platform/overview.mdx
@@ -72,3 +72,5 @@ Develop your project locally with [`mastra dev`](/reference/cli/mastra#mastra-de
 Once you're ready to deploy your application to production, use [`mastra studio deploy`](/reference/cli/mastra#mastra-studio-deploy) and [`mastra server deploy`](/reference/cli/mastra#mastra-server-deploy) to push your application to the cloud.
 
 Follow the [Studio deployment guide](/docs/studio/deployment#mastra-platform) and [Server deployment guide](/guides/deployment/mastra-platform) for step-by-step instructions.
+
+If you host your Mastra application on your own infrastructure, you can still send observability data to Studio using the [CloudExporter](/docs/observability/tracing/exporters/cloud).

--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -9,6 +9,16 @@ packages:
 
 The `CloudExporter` sends traces, logs, metrics, scores, and feedback to the Mastra platform. Use it to route observability data from any Mastra app to a hosted project in the Mastra platform.
 
+:::note[Self-hosted or standalone apps]
+
+If you host your Mastra application on your own infrastructure (not on Mastra Platform), you still need a deployed Studio project to view traces, logs, and metrics. `CloudExporter` sends data to a Studio project, so one must exist before you can use it.
+
+1. [Create a Mastra project](/docs/getting-started/manual-install) if you don't have one yet, or use the [quickstart](/guides/getting-started/quickstart) CLI command.
+1. [Deploy Studio](/docs/studio/deployment#mastra-platform) to the Mastra platform with `mastra studio deploy`.
+1. Follow the [quickstart steps below](#quickstart) to create an access token and find your project ID.
+
+:::
+
 ## Version compatibility
 
 - Use `CloudExporter` with `@mastra/observability@1.8.0` or later.

--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -13,7 +13,7 @@ The `CloudExporter` sends traces, logs, metrics, scores, and feedback to the Mas
 
 If you host your Mastra application on your own infrastructure (not on Mastra Platform), you still need a deployed Studio project to view traces, logs, and metrics. `CloudExporter` sends data to a Studio project, so one must exist before you can use it.
 
-1. [Create a Mastra project](/docs/getting-started/manual-install) if you don't have one yet, or use the [quickstart](/guides/getting-started/quickstart) CLI command.
+1. [Create a Mastra project](/guides/getting-started/quickstart) if you don't have one yet.
 1. [Deploy Studio](/docs/studio/deployment#mastra-platform) to the Mastra platform with `mastra studio deploy`.
 1. Follow the [quickstart steps below](#quickstart) to create an access token and find your project ID.
 


### PR DESCRIPTION
Adds a note at the top of the CloudExporter docs page letting self-hosted users know they need a deployed Studio project before they can use CloudExporter. The callout links to the quickstart, Studio deployment, and the quickstart section on the same page for getting the access token and project ID.

Also adds a one-liner to the Mastra Platform overview page linking self-hosted users to the CloudExporter docs from the "Going to production" section.