### PR TITLE
chore(langfuse): bump @langfuse/client and @langfuse/otel to ^5.1.0

### DIFF
--- a/.changeset/brown-facts-eat.md
+++ b/.changeset/brown-facts-eat.md
@@ -2,4 +2,4 @@
 '@mastra/langfuse': patch
 ---
 
-Bump @langfuse/client and @langfuse/otel from ^5.0.2 to ^5.1.0 to pick up the latest Langfuse server API spec.
+Improved `@mastra/langfuse` compatibility with the latest Langfuse server API by updating `@langfuse/client` and `@langfuse/otel` to ^5.1.0.

--- a/.changeset/brown-facts-eat.md
+++ b/.changeset/brown-facts-eat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/langfuse': patch
+---
+
+Bump @langfuse/client and @langfuse/otel from ^5.0.2 to ^5.1.0 to pick up the latest Langfuse server API spec.

--- a/observability/langfuse/package.json
+++ b/observability/langfuse/package.json
@@ -31,8 +31,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@langfuse/client": "^5.0.2",
-    "@langfuse/otel": "^5.0.2",
+    "@langfuse/client": "^5.1.0",
+    "@langfuse/otel": "^5.1.0",
     "@mastra/observability": "workspace:*",
     "@mastra/otel-exporter": "workspace:*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1841,11 +1841,11 @@ importers:
   observability/langfuse:
     dependencies:
       '@langfuse/client':
-        specifier: ^5.0.2
-        version: 5.0.2(@opentelemetry/api@1.9.0)
+        specifier: ^5.1.0
+        version: 5.1.0(@opentelemetry/api@1.9.0)
       '@langfuse/otel':
-        specifier: ^5.0.2
-        version: 5.0.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))
+        specifier: ^5.1.0
+        version: 5.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))
       '@mastra/observability':
         specifier: workspace:*
         version: link:../mastra
@@ -11118,18 +11118,18 @@ packages:
     peerDependencies:
       '@langchain/core': '>=0.3.39 <0.4.0'
 
-  '@langfuse/client@5.0.2':
-    resolution: {integrity: sha512-kKlCxtX/q9CLDhzlFuUne+rR4fy0dO25fuqbFsVTRtGly4sJkvhr5+Flu7Az2YpGFLNL0PESBxZtumESjjpYEA==}
+  '@langfuse/client@5.1.0':
+    resolution: {integrity: sha512-czZxxr/9ROaTTjD5vn1qo7WxcGi4zkXGwDvNHgQKrihi6SBBsFapv7v4EtxBhwyXq339C7QyVPWDw55+Cgx9Bg==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
-  '@langfuse/core@5.0.2':
-    resolution: {integrity: sha512-KUFaaxWqZbTfZ2Uh2jNDh6gQfsL7Kxc/4/C4XbwZ/Ip7wZ+CuwuIrs5DupmzC+xWQTNlRWuTzm4OWLO5xvkz8Q==}
+  '@langfuse/core@5.1.0':
+    resolution: {integrity: sha512-yFvC67HBtrY4B3tyzF8+RJaIqK79LBVXtAgtmEc2vhpKauecvSW0zevRnRynFX+ajUHqi9TN7tnD91FJszFLgQ==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
-  '@langfuse/otel@5.0.2':
-    resolution: {integrity: sha512-TClex2HrFU2SByt6lqv2HrKgyprfA2cUpdElhd1yidS6/KSGAkRv7ISASDuGypAD3khZWSy6LdrbF9KXz/s7KQ==}
+  '@langfuse/otel@5.1.0':
+    resolution: {integrity: sha512-pvaXgZHMHqjsRjn+Gs5amrrq61w0Rxz1OChmLr2FfQzlymNl7+MxSXsWBj5dZQlufGbhyG+LT3wdx3MV8aLXHQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -11137,8 +11137,8 @@ packages:
       '@opentelemetry/exporter-trace-otlp-http': '>=0.202.0 <1.0.0'
       '@opentelemetry/sdk-trace-base': ^2.0.1
 
-  '@langfuse/tracing@5.0.2':
-    resolution: {integrity: sha512-m+R0ifDY9eICR3Z7fD+peRlpQoYYeAYpKQzWCkTHKiNyCLNi1Bq/RUjufOMoSE/XEHsgBA+LkWX/ErHSpKQNyw==}
+  '@langfuse/tracing@5.1.0':
+    resolution: {integrity: sha512-ScwYnQzqLZOaMPZkCsWizx139eb02GI8tD5yxs5XVjGNGZxKdw1DfRPTIONSlOhaAYCY9ILGTJdkqAtNTzsbRg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -31342,28 +31342,28 @@ snapshots:
       - encoding
       - ws
 
-  '@langfuse/client@5.0.2(@opentelemetry/api@1.9.0)':
+  '@langfuse/client@5.1.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@langfuse/core': 5.0.2(@opentelemetry/api@1.9.0)
-      '@langfuse/tracing': 5.0.2(@opentelemetry/api@1.9.0)
+      '@langfuse/core': 5.1.0(@opentelemetry/api@1.9.0)
+      '@langfuse/tracing': 5.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
       mustache: 4.2.0
 
-  '@langfuse/core@5.0.2(@opentelemetry/api@1.9.0)':
+  '@langfuse/core@5.1.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@langfuse/otel@5.0.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))':
+  '@langfuse/otel@5.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))':
     dependencies:
-      '@langfuse/core': 5.0.2(@opentelemetry/api@1.9.0)
+      '@langfuse/core': 5.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-http': 0.213.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
 
-  '@langfuse/tracing@5.0.2(@opentelemetry/api@1.9.0)':
+  '@langfuse/tracing@5.1.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@langfuse/core': 5.0.2(@opentelemetry/api@1.9.0)
+      '@langfuse/core': 5.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
 
   '@leichtgewicht/ip-codec@2.0.5': {}


### PR DESCRIPTION
Picks up the Langfuse 5.1.0 API client spec sync (additive, no breaking changes). Verified tests pass and typecheck is clean.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR updates two Langfuse packages the project uses from version 5.0.2 to 5.1.0 so the observability integration stays compatible with the latest Langfuse server API; it's an additive patch with no breaking changes.

## Changes

- **`.changeset/brown-facts-eat.md`**: Added a changeset marking `@mastra/langfuse` as a patch release and noting the dependency bumps for `@langfuse/client` and `@langfuse/otel` to `^5.1.0`.
- **`observability/langfuse/package.json`**: Updated dependencies — `@langfuse/client` and `@langfuse/otel` changed from `^5.0.2` to `^5.1.0`. No other metadata or dependencies modified.

## Quality Assurance

- Tests: verified to pass
- Typechecking: reported clean
- Change type: patch / additive API changes only, no breaking changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->