### PR TITLE
feat(langfuse): map additional Mastra attributes to Langfuse namespace

### DIFF
--- a/.changeset/clean-pans-travel.md
+++ b/.changeset/clean-pans-travel.md
@@ -1,0 +1,9 @@
+---
+'@mastra/langfuse': minor
+---
+
+Added new attribute mappings to the Langfuse exporter so more Mastra attributes are filterable in Langfuse's UI.
+
+**Observation-level metadata** — `gen_ai.agent.id`, `gen_ai.agent.name`, `mastra.span.type`, and `gen_ai.operation.name` are now mapped to `langfuse.observation.metadata.*`, making them top-level filterable keys on each observation. This lets you scope Langfuse evaluators to specific agents or span types.
+
+**Trace-level attributes** — `mastra.metadata.traceName` and `mastra.metadata.version` are now mapped to `langfuse.trace.name` and `langfuse.trace.version`, enabling custom trace names and version-based filtering.

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -63,6 +63,10 @@ vi.mock('@mastra/otel-exporter', () => {
         ...(span.attributes?.completionStartTime
           ? { 'mastra.completion_start_time': span.attributes.completionStartTime.toISOString() }
           : {}),
+        // Pass through entityId/entityName as gen_ai.agent.* (mirrors real SpanConverter behavior)
+        ...(span.entityId ? { 'gen_ai.agent.id': span.entityId } : {}),
+        ...(span.entityName ? { 'gen_ai.agent.name': span.entityName } : {}),
+        ...(span.operationName ? { 'gen_ai.operation.name': span.operationName } : {}),
       },
       spanContext: () => ({ traceId: span.traceId, spanId: span.id }),
     }));
@@ -309,6 +313,71 @@ describe('LangfuseExporter', () => {
       const attrs = processedSpans[0].attributes;
       expect(attrs['langfuse.trace.tags']).toBe(JSON.stringify(['prod', 'v2']));
       expect(attrs['mastra.tags']).toBeUndefined();
+    });
+
+    it('maps traceName metadata to langfuse.trace.name', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(exporter, makeSpan({ metadata: { traceName: 'Weather Agent Run' } }));
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.name']).toBe('Weather Agent Run');
+      expect(attrs['mastra.metadata.traceName']).toBeUndefined();
+    });
+
+    it('maps version metadata to langfuse.trace.version', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(exporter, makeSpan({ metadata: { version: '2.1.0' } }));
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.version']).toBe('2.1.0');
+      expect(attrs['mastra.metadata.version']).toBeUndefined();
+    });
+
+    it('maps gen_ai.agent.id to langfuse.observation.metadata.agentId', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          entityId: 'weather-agent',
+          entityName: 'Weather Agent',
+          operationName: 'chat',
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.observation.metadata.agentId']).toBe('weather-agent');
+      expect(attrs['langfuse.observation.metadata.agentName']).toBe('Weather Agent');
+      expect(attrs['langfuse.observation.metadata.operationName']).toBe('chat');
+      // Original attributes should still be present (not deleted)
+      expect(attrs['gen_ai.agent.id']).toBe('weather-agent');
+    });
+
+    it('maps mastra.span.type to langfuse.observation.metadata.spanType', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(exporter, makeSpan({ type: SpanType.MODEL_GENERATION }));
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.observation.metadata.spanType']).toBe(SpanType.MODEL_GENERATION);
+    });
+
+    it('does not set observation metadata when source attributes are absent', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      // Create a span with no type, entityId, entityName, or operationName
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: undefined as any,
+          entityId: undefined,
+          entityName: undefined,
+          operationName: undefined,
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.observation.metadata.agentId']).toBeUndefined();
+      expect(attrs['langfuse.observation.metadata.agentName']).toBeUndefined();
+      expect(attrs['langfuse.observation.metadata.spanType']).toBeUndefined();
+      expect(attrs['langfuse.observation.metadata.operationName']).toBeUndefined();
     });
 
     it('sets langfuse.environment and langfuse.release on spans', async () => {

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -253,6 +253,34 @@ function mapMastraToLangfuseAttributes(attributes: Record<string, any>, environm
     delete attributes['mastra.tags'];
   }
 
+  // Trace name: mastra.metadata.traceName → langfuse.trace.name
+  if (attributes['mastra.metadata.traceName']) {
+    attributes['langfuse.trace.name'] = attributes['mastra.metadata.traceName'];
+    delete attributes['mastra.metadata.traceName'];
+  }
+
+  // Trace version: mastra.metadata.version → langfuse.trace.version
+  if (attributes['mastra.metadata.version']) {
+    attributes['langfuse.trace.version'] = attributes['mastra.metadata.version'];
+    delete attributes['mastra.metadata.version'];
+  }
+
+  // Observation metadata: map semantic attributes to langfuse.observation.metadata.*
+  // so they become top-level filterable keys on each observation in Langfuse.
+  // @see https://langfuse.com/integrations/native/opentelemetry#how-metadata-mapping-works
+  if (attributes['gen_ai.agent.id']) {
+    attributes['langfuse.observation.metadata.agentId'] = attributes['gen_ai.agent.id'];
+  }
+  if (attributes['gen_ai.agent.name']) {
+    attributes['langfuse.observation.metadata.agentName'] = attributes['gen_ai.agent.name'];
+  }
+  if (attributes['mastra.span.type']) {
+    attributes['langfuse.observation.metadata.spanType'] = attributes['mastra.span.type'];
+  }
+  if (attributes['gen_ai.operation.name']) {
+    attributes['langfuse.observation.metadata.operationName'] = attributes['gen_ai.operation.name'];
+  }
+
   // Input/Output: mastra.*.input/output → langfuse.observation.input/output
   // For gen_ai spans, Langfuse reads gen_ai.input.messages natively.
   // For non-gen_ai spans, we map the first mastra.*.input/output we find.


### PR DESCRIPTION
Maps 6 new Mastra OTel attributes to their Langfuse equivalents so they become filterable in the Langfuse UI and available to evaluators.

`gen_ai.agent.id`, `gen_ai.agent.name`, `mastra.span.type`, and `gen_ai.operation.name` are now mapped to `langfuse.observation.metadata.*`, which makes them top-level filterable keys on each observation. This lets you scope Langfuse evaluators to specific agents or span types — previously these were buried in nested `metadata.attributes` and couldn't be filtered on.

`mastra.metadata.traceName` and `mastra.metadata.version` are now mapped to `langfuse.trace.name` and `langfuse.trace.version` for custom trace names and version filtering.

## Testing

- Unit tests added for all 6 new mappings
- Verified against Langfuse Cloud (hosted) — new attributes appear as filterable metadata in the Langfuse UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes certain properties about your AI operations (like what agent ran, what type of work was done, and version information) visible and filterable in Langfuse's user interface, so you can more easily find and analyze specific traces and operations.

## Overview

This PR extends the Langfuse exporter in `@mastra/langfuse` to map additional Mastra OpenTelemetry attributes to Langfuse-native fields. This makes these attributes filterable in the Langfuse UI and available to evaluators.

## Changes

**Attribute Mappings Added:**

*Observation-level metadata (mapped to `langfuse.observation.metadata.*`):*
- `gen_ai.agent.id` → `langfuse.observation.metadata.agentId`
- `gen_ai.agent.name` → `langfuse.observation.metadata.agentName`
- `mastra.span.type` → `langfuse.observation.metadata.spanType`
- `gen_ai.operation.name` → `langfuse.observation.metadata.operationName`

*Trace-level metadata (mapped directly to trace fields):*
- `mastra.metadata.traceName` → `langfuse.trace.name`
- `mastra.metadata.version` → `langfuse.trace.version`

The mapping function in `tracing.ts` now copies these values to their Langfuse equivalents. For observation metadata, source attributes are preserved; for trace metadata, the original Mastra keys are removed after mapping.

**Test Coverage:**

Added comprehensive test cases in `tracing.test.ts` validating:
- Correct mapping of all six attributes
- Conditional emission (attributes only added when present in source span)
- Preservation of source `gen_ai.*` attributes while adding Langfuse equivalents
- Removal of trace-level Mastra keys after mapping to Langfuse fields

**Package Updates:**

Added a Changeset entry documenting this as a minor version bump for `@mastra/langfuse`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->