### PR TITLE
fix(core): forward resourceId to nested workflow runs

### DIFF
--- a/.changeset/fix-nested-workflow-resource-id.md
+++ b/.changeset/fix-nested-workflow-resource-id.md
@@ -1,0 +1,16 @@
+---
+"@mastra/core": patch
+---
+
+Fixed nested workflows dropping `resourceId` when executed as a step of a parent workflow. Child workflow snapshots now preserve the parent run's resource association, so tenant-scoped persistence works end-to-end. Closes [#15246](https://github.com/mastra-ai/mastra/issues/15246).
+
+```ts
+const run = await parent.createRun({
+  runId: 'run-1',
+  resourceId: 'workspace-1',
+});
+
+await run.start({ inputData: { ok: true } });
+// Before: child snapshots persisted with resourceId: undefined
+// After:  child snapshots persisted with resourceId: 'workspace-1'
+```

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -618,4 +618,59 @@ describe('Workflow (Default Engine Specifics)', () => {
       expect('tracingContext' in (snapshot ?? {})).toBe(true);
     });
   });
+
+  describe('Nested workflow resourceId propagation (issue #15246)', () => {
+    it('persists the parent run resourceId on nested child workflow snapshots', async () => {
+      const storage = new MockStore();
+      const mastra = new Mastra({ logger: false, storage });
+
+      const childStep = createStep({
+        id: 'child-step',
+        inputSchema: z.object({ value: z.string() }),
+        outputSchema: z.object({ echoed: z.string() }),
+        execute: async ({ inputData }) => ({ echoed: inputData.value }),
+      });
+
+      const childWorkflow = createWorkflow({
+        id: 'nested-resource-id-child',
+        inputSchema: z.object({ value: z.string() }),
+        outputSchema: z.object({ echoed: z.string() }),
+        steps: [childStep],
+      })
+        .then(childStep)
+        .commit();
+
+      const parentWorkflow = createWorkflow({
+        id: 'nested-resource-id-parent',
+        inputSchema: z.object({ value: z.string() }),
+        outputSchema: z.object({ echoed: z.string() }),
+        steps: [childWorkflow],
+      })
+        .then(childWorkflow)
+        .commit();
+
+      parentWorkflow.__registerMastra(mastra);
+
+      const run = await parentWorkflow.createRun({ resourceId: 'workspace-1' });
+      const result = await run.start({ inputData: { value: 'hello' } });
+
+      expect(result.status).toBe('success');
+
+      const workflowsStore = await storage.getStore('workflows');
+
+      const parentRuns = await workflowsStore?.listWorkflowRuns({
+        workflowName: 'nested-resource-id-parent',
+        resourceId: 'workspace-1',
+      });
+      expect(parentRuns?.runs.length).toBe(1);
+      expect(parentRuns?.runs[0]?.resourceId).toBe('workspace-1');
+
+      const childRuns = await workflowsStore?.listWorkflowRuns({
+        workflowName: 'nested-resource-id-child',
+      });
+      expect(childRuns?.runs.length).toBe(1);
+      // Regression guard for #15246: child workflow snapshots must inherit the parent's resourceId.
+      expect(childRuns?.runs[0]?.resourceId).toBe('workspace-1');
+    });
+  });
 });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2195,6 +2195,7 @@ export class Workflow<
   // To run a workflow use `.createRun` and then `.start` or `.resume`
   async execute({
     runId,
+    resourceId,
     inputData,
     resumeData,
     state,
@@ -2217,6 +2218,7 @@ export class Workflow<
     ...rest
   }: {
     runId?: string;
+    resourceId?: string;
     inputData: TInput;
     resumeData?: unknown;
     state: TState;
@@ -2276,7 +2278,11 @@ export class Workflow<
 
     const isTimeTravel = !!(timeTravel && timeTravel.steps.length > 0);
 
-    const run = isResume ? await this.createRun({ runId: resume.runId }) : await this.createRun({ runId });
+    // Forward the parent run's resourceId into the nested run so that
+    // child workflow snapshots preserve the tenant/resource association.
+    const run = isResume
+      ? await this.createRun({ runId: resume.runId, resourceId })
+      : await this.createRun({ runId, resourceId });
     const nestedAbortCb = () => {
       abort();
     };


### PR DESCRIPTION
Nested workflows ran as a step of a parent workflow were losing the parent's `resourceId` when creating their internal run. That meant child snapshots got persisted with `resourceId: undefined`, breaking tenant/resource association for anyone relying on it.

`Workflow.execute()` now forwards the incoming `resourceId` to the nested `createRun()` call on both the fresh-start and resume paths.

```ts
const run = await parent.createRun({
  runId: 'run-1',
  resourceId: 'workspace-1',
});

await run.start({ inputData: { ok: true } });
// Before: child snapshots persisted with resourceId: undefined
// After:  child snapshots persisted with resourceId: 'workspace-1'
```

Closes #15246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When a parent workflow creates child workflows (nested workflows), the parent had a "resource ID" label that says which workspace/tenant it belongs to. Before this fix, the child workflows weren't getting that label passed down, causing them to lose track of which workspace they belonged to. This PR fixes it by making sure the parent passes its resource ID label to all child workflows so they stay properly associated with the same workspace.

---

## Changes

### Changeset
Added `@mastra/core` patch release documentation describing the fix for nested workflow resource ID propagation. The changeset confirms that nested workflows executed as steps within a parent workflow will now preserve the parent run's resource association during snapshot persistence.

### Test Coverage
Added a comprehensive test suite `Nested workflow resourceId propagation (issue #15246)` under the Default Engine tests that:
- Creates a parent workflow containing a nested child workflow
- Executes the parent workflow with an explicit `resourceId` (`workspace-1`)
- Verifies both the parent run AND the child workflow run's snapshot are persisted with the correct `resourceId: workspace-1`
- Guards against regressions where nested children would lose the resource association

### Core Implementation
Updated `Workflow.execute()` in `packages/core/src/workflows/workflow.ts` to:
- Accept an optional `resourceId` parameter in its destructured arguments
- Forward the `resourceId` to `createRun()` calls on both the fresh-start path (`this.createRun({ runId, resourceId })`) and the resume path (`this.createRun({ runId: resume.runId, resourceId })`)
- Include an inline comment explaining that the `resourceId` is forwarded to preserve tenant/resource association in nested run snapshots

### Impact
This ensures that when a parent workflow with a specific `resourceId` invokes nested child workflows, the child snapshots inherit and persist with the parent's `resourceId` instead of becoming `undefined`, maintaining proper tenant-scoped persistence throughout the entire workflow hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->