### PR TITLE
chore(mastracode): bump Anthropic pack defaults to opus-4-7 and sonnet-4-6

### DIFF
--- a/.changeset/petite-corners-sit.md
+++ b/.changeset/petite-corners-sit.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Updated the default Anthropic mode pack models. Users signed in with an Anthropic Max subscription now get `claude-opus-4-7` for `build` and `plan`, and API-key users get `claude-sonnet-4-6` for `build` and `plan`. The `fast` model is unchanged.

--- a/mastracode/src/onboarding/packs.ts
+++ b/mastracode/src/onboarding/packs.ts
@@ -59,7 +59,7 @@ export function getAvailableModePacks(
 
   const openaiCodex = 'openai/gpt-5.4';
   const openaiFast = 'openai/gpt-5.4-mini';
-  const anthropicBuild = access.anthropic === 'oauth' ? 'anthropic/claude-opus-4-6' : 'anthropic/claude-sonnet-4-5';
+  const anthropicBuild = access.anthropic === 'oauth' ? 'anthropic/claude-opus-4-7' : 'anthropic/claude-sonnet-4-6';
 
   if (access.anthropic) {
     packs.push({


### PR DESCRIPTION
Bumps the default Anthropic mode pack models so new onboarders get the latest generation.

- Max (OAuth) users: `build`/`plan` now `anthropic/claude-opus-4-7` (was `claude-opus-4-6`).
- API-key users: `build`/`plan` now `anthropic/claude-sonnet-4-6` (was `claude-sonnet-4-5`).
- `fast` stays on `anthropic/claude-haiku-4-5`.

```ts
// before
const anthropicBuild = access.anthropic === 'oauth' ? 'anthropic/claude-opus-4-6' : 'anthropic/claude-sonnet-4-5';
// after
const anthropicBuild = access.anthropic === 'oauth' ? 'anthropic/claude-opus-4-7' : 'anthropic/claude-sonnet-4-6';
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This update changes which AI models new Mastracode users get by default. If you have Anthropic's Max subscription, you'll now get the newer Claude Opus 4.7 model instead of the older 4.6 version. If you use an API key, you'll get the newer Claude Sonnet 4.6 instead of 4.5. This gives users access to more capable AI models automatically.

## Changes

### Changeset
Added a new changeset file (`.changeset/petite-corners-sit.md`) documenting a patch release for the `mastracode` package.

### Model Pack Defaults
Updated default Anthropic model selections in `mastracode/src/onboarding/packs.ts`:

- **OAuth users** (`anthropic/max` subscription): `build` and `plan` modes now default to `claude-opus-4-7` (upgraded from `claude-opus-4-6`)
- **API key users**: `build` and `plan` modes now default to `claude-sonnet-4-6` (upgraded from `claude-sonnet-4-5`)
- **Fast mode**: Remains unchanged at `claude-haiku-4-5`

The change only affects internal constants within the `getAvailableModePacks` function—no public API declarations were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->