### PR TITLE
docs: use https:// for Turso CLI dump URL in Cloud migration guide

### DIFF
--- a/docs/src/content/en/guides/migrations/mastra-cloud.mdx
+++ b/docs/src/content/en/guides/migrations/mastra-cloud.mdx
@@ -115,10 +115,10 @@ If you prefer to work from the command line, or need to script the export, you c
   <StepItem>
     Export the database to a SQL dump.
 
-    Set the credentials provided by support (or use the dashboard values if you already copied them earlier) as environment variables, then dump the database to a local file:
+    Set the credentials provided by support (or use the dashboard values if you already copied them earlier) as environment variables, then dump the database to a local file. If you copied the URL from the dashboard, swap the `libsql://` scheme for `https://` — the Turso CLI expects the HTTPS form when passing the URL with an auth token.
 
     ```bash
-    export MASTRA_STORAGE_URL="libsql://<db-name>-<org>.turso.io"
+    export MASTRA_STORAGE_URL="https://<db-name>-<org>.turso.io"
     export MASTRA_STORAGE_AUTH_TOKEN="<token-from-dashboard-or-support>"
 
     turso db shell "$MASTRA_STORAGE_URL?authToken=$MASTRA_STORAGE_AUTH_TOKEN" ".dump" > mastra-cloud-dump.sql


### PR DESCRIPTION
The Turso CLI rejects the `libsql://` scheme when a URL is passed with `?authToken=...` for `turso db shell`. The Mastra Cloud dashboard exposes the connection string as `libsql://...`, so the guide now tells users to swap it to `https://` for the one-time dump and uses `https://` in the example env var.

Before:

```bash
export MASTRA_STORAGE_URL="libsql://<db-name>-<org>.turso.io"
turso db shell "$MASTRA_STORAGE_URL?authToken=$MASTRA_STORAGE_AUTH_TOKEN" ".dump" > mastra-cloud-dump.sql
```

After:

```bash
export MASTRA_STORAGE_URL="https://<db-name>-<org>.turso.io"
turso db shell "$MASTRA_STORAGE_URL?authToken=$MASTRA_STORAGE_AUTH_TOKEN" ".dump" > mastra-cloud-dump.sql
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The documentation was telling people to use a wrong format (`libsql://`) when setting up a database connection for migrating from Mastra Cloud. The Turso database tool rejects this format when you add a security token to the URL. The fix updates the guide to use the correct format (`https://`) that actually works.

## Summary

Updated the Mastra Cloud migration guide to correct the database connection URL scheme used in the Turso CLI export command. The guide now instructs users to use `https://` instead of `libsql://` for the `MASTRA_STORAGE_URL` environment variable when performing a one-time database dump, as the Turso CLI rejects the `libsql://` scheme when an authentication token is appended to the URL.

**Files Changed:**
- `docs/src/content/en/guides/migrations/mastra-cloud.mdx`

**Changes:**
- Updated example export command from `export MASTRA_STORAGE_URL="libsql://<db-name>-<org>.turso.io"` to `export MASTRA_STORAGE_URL="https://<db-name>-<org>.turso.io"`
- Added clarifying text in the "Export the database to a SQL dump" step: "If you copied the URL from the dashboard, swap the `libsql://` scheme for `https://` — the Turso CLI expects the HTTPS form when passing the URL with an auth token."
- The corresponding Turso CLI dump command example reflects the new HTTPS scheme

**Impact:**
Documentation-only change with no impact on code functionality. Improves accuracy and usability of migration instructions for users exporting from Mastra Cloud.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->