### PR TITLE
fix(core): propagate tracingContext to subagent stream to fix nested OTel spans

### DIFF
--- a/.changeset/fix-subagent-tracingcontext.md
+++ b/.changeset/fix-subagent-tracingcontext.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed `tracingContext` not being propagated to subagent's `stream()` call in `createSubagentTool`. This caused all nested spans from subagents to be missing in Langfuse and other OTel exporters, breaking the expected parent → child relationship in trace UIs. Fixes #15461

--- a/packages/core/src/harness/subagent-tool.test.ts
+++ b/packages/core/src/harness/subagent-tool.test.ts
@@ -239,6 +239,48 @@ describe('createSubagentTool requestContext forwarding', () => {
     expect(streamCall[1].requestContext).toBeInstanceOf(RequestContext);
     expect(result.isError).toBe(false);
   });
+
+  it('forwards tracingContext to subagent.stream when provided', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('result text'));
+
+    const tool = createSubagentTool({
+      subagents,
+      resolveModel,
+      fallbackModelId: 'test-model',
+    });
+
+    const mockSpan = { spanContext: () => ({ traceId: 'abc', spanId: 'def' }) };
+    const tracingContext = { currentSpan: mockSpan as any };
+
+    await (tool as any).execute(
+      { agentType: 'explore', task: 'Explore with tracing' },
+      { agent: { toolCallId: 'tc-tracing-1' }, tracingContext },
+    );
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    const streamOpts = mockStream.mock.calls[0]![1];
+    expect(streamOpts).toHaveProperty('tracingContext');
+    expect(streamOpts.tracingContext).toBe(tracingContext);
+  });
+
+  it('does not include tracingContext in subagent.stream when not provided', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('result text'));
+
+    const tool = createSubagentTool({
+      subagents,
+      resolveModel,
+      fallbackModelId: 'test-model',
+    });
+
+    await (tool as any).execute(
+      { agentType: 'explore', task: 'Explore without tracing' },
+      { agent: { toolCallId: 'tc-tracing-2' } },
+    );
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    const streamOpts = mockStream.mock.calls[0]![1];
+    expect(streamOpts).not.toHaveProperty('tracingContext');
+  });
 });
 
 describe('createSubagentTool workspace propagation', () => {

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -464,6 +464,7 @@ Use this tool when:
           abortSignal,
           requireToolApproval: false,
           requestContext: subagentRequestContext,
+          ...(context?.tracingContext && { tracingContext: context.tracingContext }),
           // When allowedWorkspaceTools is set, hide workspace tools not in
           // the list. Non-workspace tools always pass through.
           prepareStep:


### PR DESCRIPTION
Fixes #15461

## Problem

When a Harness agent delegates work to a subagent via the built-in `subagent` tool, the `tracingContext` is not forwarded to the ephemeral subagent's `stream()` call. This causes all nested spans from subagents to be missing in Langfuse and other OTel exporters, breaking the expected parent → child trace relationship.

The `createSubagentTool.execute` in `packages/core/src/harness/tools.ts` forwarded `requestContext`, `abortSignal`, and other contextual fields, but omitted `tracingContext`.

## Solution

Add `...(context?.tracingContext && { tracingContext: context.tracingContext })` to the `subagent.stream()` call, matching the same conditional-spread pattern used in `harness.ts` `sendMessage()` for the parent agent's stream call.

## Testing

Added two unit tests to `subagent-tool.test.ts`:
- Verifies `tracingContext` is forwarded to `subagent.stream()` when provided in the tool execution context
- Verifies `tracingContext` is NOT included when not provided (no spurious property injection)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Summary
When a parent AI agent asks a helper agent (subagent) to do something, it needs to pass along trace/tracking information so you can see all the work happening. This PR fixes the code to actually pass that information along, which restores visibility of the subagent's actions in monitoring tools like Langfuse.

## Overview
Fixes issue #15461 where OpenTelemetry tracing context was not propagated to subagents, causing nested spans to be missing from exporters like Langfuse and breaking parent→child trace relationships in distributed tracing.

## Changes Made

**Core Fix**
- Modified `createSubagentTool` in `packages/core/src/harness/tools.ts` to conditionally propagate `tracingContext` to the subagent's `stream()` call via: `...(context?.tracingContext && { tracingContext: context.tracingContext })`
- This matches the existing pattern used for the parent agent's `sendMessage()` call

**Tests**
- Added two unit tests in `packages/core/src/harness/subagent-tool.test.ts` to verify:
  1. `tracingContext` is correctly forwarded when provided in the tool execution context
  2. `tracingContext` is not included in options when not provided

**Documentation**
- Added a changeset entry for `@mastra/core` (patch) documenting the fix and referencing issue #15461

## Impact
Restores nested tracing visibility for subagent spans in OpenTelemetry exporters, allowing distributed tracing of parent→child agent relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->