### PR TITLE
feat(core): load_tool accepts array of toolNames (closes #15414)

### DIFF
--- a/.changeset/fruity-yaks-jump.md
+++ b/.changeset/fruity-yaks-jump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Enhanced load_tool to accept an array of tool names, enabling bulk tool loading in a single call. Returns 'loaded', 'notFound', and 'alreadyLoaded' arrays for clearer response shape.

--- a/packages/core/src/processors/processors/tool-search.test.ts
+++ b/packages/core/src/processors/processors/tool-search.test.ts
@@ -535,6 +535,124 @@ describe('ToolSearchProcessor', () => {
       const toolKeys = Object.keys(result2.tools || {}).filter(k => k === 'weather');
       expect(toolKeys.length).toBe(1);
     });
+
+    it('should load multiple tools at once via toolNames array', async () => {
+      const processor = new ToolSearchProcessor({
+        tools: {
+          weather: createMockTool('weather', 'Get weather'),
+          calendar: createMockTool('calendar', 'Manage calendar'),
+          email: createMockTool('email', 'Send email'),
+        },
+      });
+
+      const args = createMockArgs('thread-multi');
+      const result = await processor.processInputStep(args);
+      const loadTool = result.tools?.load_tool;
+
+      const loadResult = await loadTool!.execute?.({ toolNames: ['weather', 'calendar'] }, undefined);
+
+      expect(loadResult.success).toBe(true);
+      expect(loadResult.loaded).toEqual(expect.arrayContaining(['weather', 'calendar']));
+      expect(loadResult.loadedCount).toBe(2);
+      expect(loadResult.notFound).toBeUndefined();
+      expect(loadResult.alreadyLoaded).toBeUndefined();
+
+      // Verify both are actually loaded
+      const args2 = createMockArgs('thread-multi');
+      const result2 = await processor.processInputStep(args2);
+      expect(result2.tools?.weather).toBeDefined();
+      expect(result2.tools?.calendar).toBeDefined();
+      expect(result2.tools?.email).toBeUndefined();
+    });
+
+    it('should return clear error for empty toolNames array', async () => {
+      const processor = new ToolSearchProcessor({
+        tools: {
+          weather: createMockTool('weather', 'Get weather'),
+        },
+      });
+
+      const args = createMockArgs('thread-empty');
+      const result = await processor.processInputStep(args);
+      const loadTool = result.tools?.load_tool;
+
+      const loadResult = await loadTool!.execute?.({ toolNames: [] }, undefined);
+
+      expect(loadResult.success).toBe(false);
+      expect(loadResult.message).toBe('toolNames array must not be empty.');
+    });
+
+    it('should report not-found tools in multi-load response', async () => {
+      const processor = new ToolSearchProcessor({
+        tools: {
+          weather: createMockTool('weather', 'Get weather'),
+        },
+      });
+
+      const args = createMockArgs('thread-multi');
+      const result = await processor.processInputStep(args);
+      const loadTool = result.tools?.load_tool;
+
+      const loadResult = await loadTool!.execute?.({ toolNames: ['weather', 'nonexistent', 'calendar'] }, undefined);
+
+      // Partial load (some found, some not): success=false since not all requested tools are available
+      expect(loadResult.success).toBe(false);
+      expect(loadResult.loaded).toEqual(['weather']);
+      expect(loadResult.notFound).toEqual(['nonexistent', 'calendar']);
+      expect(loadResult.loadedCount).toBe(1);
+    });
+
+    it('should report already-loaded tools in multi-load response', async () => {
+      const processor = new ToolSearchProcessor({
+        tools: {
+          weather: createMockTool('weather', 'Get weather'),
+          calendar: createMockTool('calendar', 'Manage calendar'),
+        },
+      });
+
+      const args1 = createMockArgs('thread-multi');
+      const result1 = await processor.processInputStep(args1);
+      const loadTool1 = result1.tools?.load_tool;
+      await loadTool1!.execute?.({ toolName: 'weather' }, undefined);
+
+      // Try loading weather again alongside calendar
+      const args2 = createMockArgs('thread-multi');
+      const result2 = await processor.processInputStep(args2);
+      const loadTool2 = result2.tools?.load_tool;
+
+      const loadResult = await loadTool2!.execute?.({ toolNames: ['weather', 'calendar'] }, undefined);
+
+      expect(loadResult.success).toBe(true);
+      expect(loadResult.loaded).toEqual(['calendar']);
+      expect(loadResult.alreadyLoaded).toEqual(['weather']);
+      expect(loadResult.loadedCount).toBe(1);
+    });
+
+    it('should return success=true when all requested tools are already loaded', async () => {
+      const processor = new ToolSearchProcessor({
+        tools: {
+          weather: createMockTool('weather', 'Get weather'),
+          calendar: createMockTool('calendar', 'Manage calendar'),
+        },
+      });
+
+      const args1 = createMockArgs('thread-multi');
+      const result1 = await processor.processInputStep(args1);
+      const loadTool1 = result1.tools?.load_tool;
+      await loadTool1!.execute?.({ toolNames: ['weather', 'calendar'] }, undefined);
+
+      // All already loaded — should be success even though nothing new was loaded
+      const args2 = createMockArgs('thread-multi');
+      const result2 = await processor.processInputStep(args2);
+      const loadTool2 = result2.tools?.load_tool;
+
+      const loadResult = await loadTool2!.execute?.({ toolNames: ['weather', 'calendar'] }, undefined);
+
+      expect(loadResult.success).toBe(true);
+      expect(loadResult.loaded).toBeUndefined();
+      expect(loadResult.alreadyLoaded).toEqual(['weather', 'calendar']);
+      expect(loadResult.notFound).toBeUndefined();
+    });
   });
 
   describe('processInputStep integration', () => {

--- a/packages/core/src/processors/processors/tool-search.test.ts
+++ b/packages/core/src/processors/processors/tool-search.test.ts
@@ -653,6 +653,46 @@ describe('ToolSearchProcessor', () => {
       expect(loadResult.alreadyLoaded).toEqual(['weather', 'calendar']);
       expect(loadResult.notFound).toBeUndefined();
     });
+
+    it('should merge and deduplicate when both toolName and toolNames are provided', async () => {
+      const processor = new ToolSearchProcessor({
+        tools: {
+          weather: createMockTool('weather', 'Get weather'),
+          calendar: createMockTool('calendar', 'Manage calendar'),
+        },
+      });
+
+      const args = createMockArgs('thread-merge');
+      const result = await processor.processInputStep(args);
+      const loadTool = result.tools?.load_tool;
+
+      // toolName 'weather' should be merged with toolNames ['calendar']
+      const loadResult = await loadTool!.execute?.({ toolName: 'weather', toolNames: ['calendar'] }, undefined);
+
+      expect(loadResult.success).toBe(true);
+      // weather from toolName, calendar from toolNames — both deduplicated
+      expect(loadResult.loaded).toEqual(expect.arrayContaining(['weather', 'calendar']));
+      expect(loadResult.loadedCount).toBe(2);
+    });
+
+    it('should deduplicate duplicate names within toolNames array', async () => {
+      const processor = new ToolSearchProcessor({
+        tools: {
+          weather: createMockTool('weather', 'Get weather'),
+        },
+      });
+
+      const args = createMockArgs('thread-dedup');
+      const result = await processor.processInputStep(args);
+      const loadTool = result.tools?.load_tool;
+
+      // Duplicate 'weather' entries should only load once
+      const loadResult = await loadTool!.execute?.({ toolNames: ['weather', 'weather'] }, undefined);
+
+      expect(loadResult.success).toBe(true);
+      expect(loadResult.loaded).toEqual(['weather']);
+      expect(loadResult.loadedCount).toBe(1);
+    });
   });
 
   describe('processInputStep integration', () => {

--- a/packages/core/src/processors/processors/tool-search.ts
+++ b/packages/core/src/processors/processors/tool-search.ts
@@ -390,64 +390,119 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     const loadTool = createTool({
       id: 'load_tool',
       description:
-        'Load a specific tool into your context. ' +
-        'Call this after finding a tool with search_tools. ' +
-        'Once loaded, the tool will be available for use. ' +
-        'Args: toolName - The exact name of the tool to load (from search results).',
+        'Load one or more tools into your context. ' +
+        'Call this after finding tools with search_tools. ' +
+        'Once loaded, tools will be available for use. ' +
+        'Pass a single toolName or an array of toolNames to load multiple tools at once.',
       inputSchema: z.object({
-        toolName: z.string().describe('The exact name of the tool to load (from search results)'),
+        toolName: z.string().optional().describe('The exact name of a tool to load (from search results)'),
+        toolNames: z
+          .array(z.string())
+          .optional()
+          .describe('Array of exact tool names to load in one call (from search results)'),
       }),
       outputSchema: z.object({
         success: z.boolean(),
         message: z.string(),
+        loadedCount: z.number().optional(),
         toolName: z.string().optional(),
+        loaded: z.array(z.string()).optional(),
+        notFound: z.array(z.string()).optional(),
+        alreadyLoaded: z.array(z.string()).optional(),
       }),
-      execute: async ({ toolName }) => {
-        // Check if tool exists
-        const matchingTool = this.allTools[toolName] ?? Object.values(this.allTools).find(tool => tool.id === toolName);
-
-        if (!matchingTool) {
-          // Generate suggestions for similar tool names
-          const availableToolNames = Object.keys(this.allTools).concat(
-            Object.values(this.allTools)
-              .map(t => t.id)
-              .filter(id => !this.allTools[id]),
-          );
-          const suggestions = availableToolNames.filter(
-            name =>
-              name.toLowerCase().includes(toolName.toLowerCase()) ||
-              toolName.toLowerCase().includes(name.toLowerCase()),
-          );
-
-          let message = `Tool "${toolName}" not found.`;
-          if (suggestions.length > 0) {
-            message += ` Did you mean: ${suggestions.slice(0, 3).join(', ')}?`;
-          } else {
-            message += ' Use search_tools to find available tools.';
-          }
-
+      execute: async ({ toolName, toolNames }) => {
+        // Determine which tools to load
+        let toLoad: string[];
+        const toolNamesProvided = toolNames !== undefined;
+        if (toolNamesProvided && toolNames!.length === 0) {
           return {
             success: false,
-            message,
+            message: 'toolNames array must not be empty.',
+          };
+        }
+        if (toolNamesProvided && toolNames!.length > 0) {
+          // Merge toolName into toolNames if both provided, then dedupe
+          const base: string[] = [...toolNames!];
+          if (toolName) base.push(toolName);
+          toLoad = Array.from(new Set(base));
+        } else if (toolName) {
+          toLoad = [toolName];
+        } else {
+          return {
+            success: false,
+            message: 'You must provide either toolName (string) or toolNames (array) to load.',
           };
         }
 
-        // Check if already loaded (thread-scoped)
-        if (loadedToolNames.has(toolName)) {
+        const notFound: string[] = [];
+        const alreadyLoaded: string[] = [];
+        const loaded: string[] = [];
+
+        for (const name of toLoad) {
+          // Check if tool exists
+          const matchingTool = this.allTools[name] ?? Object.values(this.allTools).find(tool => tool.id === name);
+
+          if (!matchingTool) {
+            notFound.push(name);
+            continue;
+          }
+
+          // Check if already loaded (thread-scoped)
+          if (loadedToolNames.has(name)) {
+            alreadyLoaded.push(name);
+            continue;
+          }
+
+          // Load the tool (thread-scoped)
+          loadedToolNames.add(name);
+          loaded.push(name);
+        }
+
+        // Build response based on how many tools were requested
+        // Only use single-tool backward-compatible shape when using the legacy toolName param
+        if (toLoad.length === 1 && !toolNamesProvided) {
+          // Single-tool response (backward compatible shape)
+          if (notFound.length > 0) {
+            const name = toLoad[0]!;
+            const availableToolNames = Object.keys(this.allTools);
+            const suggestions = availableToolNames.filter(
+              n => n.toLowerCase().includes(name.toLowerCase()) || name.toLowerCase().includes(n.toLowerCase()),
+            );
+            let message = `Tool "${name}" not found.`;
+            if (suggestions.length > 0) {
+              message += ` Did you mean: ${suggestions.slice(0, 3).join(', ')}?`;
+            } else {
+              message += ' Use search_tools to find available tools.';
+            }
+            return { success: false, message, toolName: name };
+          }
+          if (alreadyLoaded.length > 0) {
+            return {
+              success: true,
+              message: `Tool "${alreadyLoaded[0]}" is already loaded and available.`,
+              toolName: alreadyLoaded[0],
+            };
+          }
           return {
             success: true,
-            message: `Tool "${toolName}" is already loaded and available.`,
-            toolName,
+            message: `Tool "${loaded[0]}" loaded successfully. It will be available on your next turn.`,
+            toolName: loaded[0],
           };
         }
 
-        // Load the tool (thread-scoped)
-        loadedToolNames.add(toolName);
+        // Multi-tool response
+        const parts: string[] = [];
+        if (loaded.length > 0) parts.push(`Loaded: ${loaded.join(', ')}`);
+        if (alreadyLoaded.length > 0) parts.push(`Already loaded: ${alreadyLoaded.join(', ')}`);
+        if (notFound.length > 0) parts.push(`Not found: ${notFound.join(', ')}`);
 
         return {
-          success: true,
-          message: `Tool "${toolName}" loaded successfully. It will be available on your next turn.`,
-          toolName,
+          success: notFound.length === 0,
+          message: parts.join(' | '),
+          loadedCount: loaded.length,
+          loaded: loaded.length > 0 ? loaded : undefined,
+          notFound: notFound.length > 0 ? notFound : undefined,
+          alreadyLoaded: alreadyLoaded.length > 0 ? alreadyLoaded : undefined,
         };
       },
     });

--- a/packages/core/src/processors/processors/tool-search.ts
+++ b/packages/core/src/processors/processors/tool-search.ts
@@ -343,7 +343,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
     // Add system instruction about the meta-tools
     messageList.addSystem(
       'To discover available tools, call search_tools with a keyword query. ' +
-        'To add a tool to the conversation, call load_tool with the tool name. ' +
+        'To add one or more tools to the conversation, call load_tool with a toolName or toolNames array. ' +
         'Tools must be loaded before they can be used.',
     );
 
@@ -381,7 +381,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
 
         return {
           results,
-          message: `Found ${results.length} tool(s). Use load_tool with the exact tool name to make it available.`,
+          message: `Found ${results.length} tool(s). Use load_tool with an exact toolName or a toolNames array to make them available.`,
         };
       },
     });
@@ -492,7 +492,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
 
         // Multi-tool response
         const parts: string[] = [];
-        if (loaded.length > 0) parts.push(`Loaded: ${loaded.join(', ')}`);
+        if (loaded.length > 0) parts.push(`Loaded: ${loaded.join(', ')} — available on your next turn`);
         if (alreadyLoaded.length > 0) parts.push(`Already loaded: ${alreadyLoaded.join(', ')}`);
         if (notFound.length > 0) parts.push(`Not found: ${notFound.join(', ')}`);
 

--- a/packages/core/src/processors/processors/tool-search.ts
+++ b/packages/core/src/processors/processors/tool-search.ts
@@ -414,7 +414,7 @@ export class ToolSearchProcessor implements Processor<'tool-search'> {
         // Determine which tools to load
         let toLoad: string[];
         const toolNamesProvided = toolNames !== undefined;
-        if (toolNamesProvided && toolNames!.length === 0) {
+        if (toolNamesProvided && toolNames!.length === 0 && !toolName) {
           return {
             success: false,
             message: 'toolNames array must not be empty.',


### PR DESCRIPTION
## Summary

Extends `ToolSearchProcessor.load_tool` to accept either a single `toolName` (string) or an array of `toolNames` (string[]), allowing agents to load multiple tools in a single call instead of N sequential calls.

## Changes

- **`inputSchema`**: `toolName: string` is now optional; added `toolNames: string[]` as an alternative
- **`outputSchema`**: added `loadedCount`, `toolNames`, `notFound`, `alreadyLoaded` fields for multi-tool responses
- **Backward compatible**: single-tool response shape (`toolName`, `success`, `message`) preserved when passing one `toolName`
- **Multi-tool response**: aggregates results — `Loaded`, `Already loaded`, `Not found` — in a single message

## Motivation

When an agent needs 5 tools, it currently must call `load_tool` 5 times sequentially. This adds latency and token overhead. With `toolNames: ["toolA", "toolB", "toolC"]`, the agent can load all three in one round-trip.

## Closes

Closes #15414

---

Author: WadeY <1015513736@qq.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
You can now tell load_tool to load many tools at once by giving it a list of names, so agents can load multiple tools in one request instead of calling it many times.

## Overview
ToolSearchProcessor.load_tool now accepts either the legacy single `toolName` (string) or a new `toolNames` (string[]) array. Single-tool calls remain backward compatible; array calls return an aggregated multi-tool response that reports which tools were newly loaded, which were already loaded, and which were not found.

## Key Changes
- Input schema
  - `toolName` made optional; added `toolNames?: string[]`.
  - Requests must supply at least one of `toolName`/`toolNames`. Passing an empty `toolNames` returns the explicit error "toolNames array must not be empty."
  - When both `toolName` and `toolNames` are provided, they are merged and deduplicated; if `toolNames` is an empty array and `toolName` is present, it falls through to the legacy single-tool behavior.
- Output schema
  - Legacy single-string calls preserve the original response shape ({ toolName, success, message }).
  - Array/multi-tool calls return a multi-tool shape with `loaded` (renamed from input-style `toolNames`), `alreadyLoaded`, `notFound`, `loadedCount`, `success` (false if any requested tool was not found), and a combined `message`.
  - Multi-tool calls where all requested tools were already loaded return `success: true`.
- Behavior
  - Normalizes and deduplicates requested names; merges `toolName` into `toolNames` when both provided.
  - Classifies each requested name as `notFound`, `alreadyLoaded` (thread-scoped `loadedToolNames`), or newly `loaded` (added to thread state).
  - Aggregates results for multi-tool responses; preserves legacy behavior when the single `toolName` param is used (guard ensures legacy single-tool response shape is returned only for that invocation style).
  - Thread-scoped loaded tools state managed with TTL and test helpers to clear state.
- Backward compatibility
  - Preserved for callers using the single `toolName` string; callers using `toolNames` always receive the multi-tool response format.

## Tests & Changeset
- Tests: added comprehensive unit tests for multi-tool behavior: full success, partial not-found, already-loaded (including all-already-loaded), empty-array error (exact message asserted), dedupe within `toolNames`, and merge/dedupe when both `toolName` and `toolNames` are provided. Author reports final test run with 47 tests passing.
- Changeset: .changeset/fruity-yaks-jump.md added with a minor bump for @mastra/core documenting the new bulk-load capability and the `loaded`/`notFound`/`alreadyLoaded` response arrays.

## Motivation
Reduce latency and token overhead by allowing agents to request and load multiple tools in a single operation.

## Files changed (high level)
- packages/core/src/processors/processors/tool-search.ts — implementation & schema updates (+96/-41)
- packages/core/src/processors/processors/tool-search.test.ts — new multi-tool tests (+158/-0)
- .changeset/fruity-yaks-jump.md — changeset entry (+5)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->