### PR TITLE
fix(core): propagate tracingContext through built-in subagent tool

### DIFF
--- a/.changeset/eager-regions-taste.md
+++ b/.changeset/eager-regions-taste.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed subagent traces being orphaned from the parent agent's trace when the built-in `subagent` tool is invoked from inside an agent run. Subagent spans now nest correctly under the parent agent's trace in observability backends like Langfuse. Fixes #15461.

--- a/.changeset/eager-regions-taste.md
+++ b/.changeset/eager-regions-taste.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed subagent traces being orphaned from the parent agent's trace when the built-in `subagent` tool is invoked from inside an agent run. Subagent spans now nest correctly under the parent agent's trace in observability backends like Langfuse. Fixes #15461.
+Fixed Harness subagent tracing so delegated runs keep the parent tracing context and show up in the same trace in observability exporters. Fixes #15461.

--- a/packages/core/src/harness/subagent-tool.test.ts
+++ b/packages/core/src/harness/subagent-tool.test.ts
@@ -241,6 +241,63 @@ describe('createSubagentTool requestContext forwarding', () => {
   });
 });
 
+describe('createSubagentTool tracingContext forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('forwards tracingContext to subagent.stream() when provided', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('done'));
+
+    const tool = createSubagentTool({
+      subagents,
+      resolveModel,
+      fallbackModelId: 'test-model',
+    });
+
+    const mockSpan = { spanContext: () => ({ traceId: 'abc', spanId: 'def' }) };
+    const tracingContext = { currentSpan: mockSpan } as any;
+
+    const requestContext = new RequestContext();
+    requestContext.set('harness', { emitEvent: vi.fn() });
+
+    await (tool as any).execute(
+      { agentType: 'explore', task: 'Investigate' },
+      { requestContext, tracingContext, agent: { toolCallId: 'tc-trace-1' } },
+    );
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    const streamOpts = mockStream.mock.calls[0]![1];
+    expect(streamOpts.tracingContext).toBe(tracingContext);
+  });
+
+  it('does not include tracingContext when not provided', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('done'));
+
+    const tool = createSubagentTool({
+      subagents,
+      resolveModel,
+      fallbackModelId: 'test-model',
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('harness', { emitEvent: vi.fn() });
+
+    await (tool as any).execute(
+      { agentType: 'explore', task: 'Investigate' },
+      { requestContext, agent: { toolCallId: 'tc-trace-2' } },
+    );
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    const streamOpts = mockStream.mock.calls[0]![1];
+    expect(streamOpts).not.toHaveProperty('tracingContext');
+  });
+});
+
 describe('createSubagentTool workspace propagation', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -464,6 +464,7 @@ Use this tool when:
           abortSignal,
           requireToolApproval: false,
           requestContext: subagentRequestContext,
+          ...(context?.tracingContext && { tracingContext: context.tracingContext }),
           // When allowedWorkspaceTools is set, hide workspace tools not in
           // the list. Non-workspace tools always pass through.
           prepareStep:


### PR DESCRIPTION
## Description

The built-in `subagent` tool dropped the parent agent run's `tracingContext` when invoking the inner subagent, causing the subagent's `agent_run`, `invoke_agent`, and `model_step` spans to surface as a separate orphan trace in observability backends (Langfuse, etc.) instead of nesting under the parent. This PR forwards the tool's `tracingContext` to `subagent.stream()` so the full call tree stays linked in a single trace.

- Forward `context.tracingContext` to `subagent.stream()` in `createSubagentTool`, mirroring the existing pattern used elsewhere in `harness.ts`
- Add unit tests in `subagent-tool.test.ts` covering both the forwarded and the absent `tracingContext` cases
- Verified end-to-end against Langfuse Cloud: with the fix, the parent agent run trace contains the nested `invoke_agent → chat → model_step → model_chunk` chain; without it, those spans are orphaned to a separate root trace

## Before
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/e8db707f-e64f-47ec-ac09-97893ead2d05" />

## After
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/45420798-4049-4b41-88f9-251c9ec4b2d4" />

## Related Issue(s)

Fixes #15461

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a parent agent asked a smaller agent to do work, the system that records the whole process lost the connection between them. This change makes sure the child agent keeps the parent's tracing information so the whole process appears together in monitoring tools.

## Overview

Fixes a bug where the built-in subagent tool omitted the parent agent run's tracingContext when invoking a nested subagent, causing child spans (agent_run, invoke_agent, model_step) to become orphaned in observability backends (e.g., Langfuse, OTel).

## Changes

- packages/core/src/harness/tools.ts
  - createSubagentTool now conditionally forwards context.tracingContext into subagent.stream(...) alongside other forwarded options (abortSignal, requireToolApproval, requestContext, prepareStep).
- packages/core/src/harness/subagent-tool.test.ts
  - Added tests verifying that tracingContext is forwarded when present and omitted entirely when not present.
  - Includes beforeEach/afterEach hooks to manage mocks.
- .changeset/eager-regions-taste.md
  - New changeset entry to release a patch for @mastra/core documenting the fix.

## Verification

- Unit tests added to cover both presence and absence of tracingContext.
- End-to-end verification against Langfuse Cloud shows the nested invoke_agent → chat → model_step → model_chunk chain is now nested under the parent agent_run instead of appearing as an orphan trace.

## Impact

Restores expected parent→child trace relationships for ephemeral subagent activity in OTel exporters. Fixes issue #15461. Classified as a bug fix with tests added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->