### PR TITLE
docs: add Doubleword as a model provider

### DIFF
--- a/.changeset/add-doubleword-provider.md
+++ b/.changeset/add-doubleword-provider.md
@@ -1,0 +1,5 @@
+---
+"mastra-docs": patch
+---
+
+docs: add Doubleword as a model provider

--- a/docs/src/content/en/models/providers/doubleword.mdx
+++ b/docs/src/content/en/models/providers/doubleword.mdx
@@ -1,0 +1,76 @@
+---
+title: "Doubleword"
+description: "Use Doubleword's AI model gateway with Mastra via the Vercel AI SDK provider."
+---
+
+# Doubleword
+
+[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API.
+
+Use the [`@doubleword/vercel-ai`](https://www.npmjs.com/package/@doubleword/vercel-ai) package to integrate with Mastra.
+
+## Setup
+
+Set up your environment variable:
+
+```bash
+export DOUBLEWORD_API_KEY="your-api-key"
+```
+
+## Usage with Mastra
+
+```typescript
+import { Agent } from "@mastra/core/agent";
+import { createDoubleword } from "@doubleword/vercel-ai";
+
+const doubleword = createDoubleword();
+
+const agent = new Agent({
+  name: "my-agent",
+  instructions: "You are a helpful assistant.",
+  model: doubleword("Qwen/Qwen3.5-397B-A17B-FP8"),
+});
+
+const result = await agent.generate("Say hello.");
+console.log(result.text);
+```
+
+## Batch processing
+
+For background workloads where latency is not critical, use `createDoublewordBatch` to transparently route requests through the Batch API at reduced cost:
+
+```typescript
+import { Agent } from "@mastra/core/agent";
+import { createDoublewordBatch } from "@doubleword/vercel-ai";
+
+const doubleword = createDoublewordBatch();
+
+const agent = new Agent({
+  name: "my-agent",
+  instructions: "You are a helpful assistant.",
+  model: doubleword("Qwen/Qwen3.5-397B-A17B-FP8"),
+});
+
+const result = await agent.generate("Summarize this document.");
+console.log(result.text);
+await doubleword.close();
+```
+
+## Custom base URL
+
+If you're running a self-hosted Doubleword Control Layer, pass a custom base URL:
+
+```typescript
+import { createDoubleword } from "@doubleword/vercel-ai";
+
+const doubleword = createDoubleword({
+  baseURL: "https://your-instance.example.com/ai/v1",
+  apiKey: "your-api-key",
+});
+```
+
+## Links
+
+- [Doubleword documentation](https://docs.doubleword.ai)
+- [Available models](https://docs.doubleword.ai/inference-api/models)
+- [@doubleword/vercel-ai on npm](https://www.npmjs.com/package/@doubleword/vercel-ai)

--- a/docs/src/content/en/models/providers/index.mdx
+++ b/docs/src/content/en/models/providers/index.mdx
@@ -133,6 +133,11 @@ Direct access to individual AI model providers. Each provider offers unique mode
       href="/models/providers/deepinfra"
       logo="https://models.dev/logos/deepinfra.svg"
     />    <CardGridItem
+      title="Doubleword"
+      description="AI model gateway"
+      href="/models/providers/doubleword"
+      logo="https://doubleword.ai/logo.svg"
+    />    <CardGridItem
       title="DigitalOcean"
       description="46 models"
       href="/models/providers/digitalocean"

--- a/docs/src/content/en/models/sidebars.js
+++ b/docs/src/content/en/models/sidebars.js
@@ -203,6 +203,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'providers/doubleword',
+          label: 'Doubleword',
+        },
+        {
+          type: 'doc',
           id: 'providers/digitalocean',
           label: 'DigitalOcean',
         },


### PR DESCRIPTION
## Summary

- Add Doubleword provider documentation page with installation, setup, and usage examples
- Add Doubleword to the providers sidebar navigation and index page
- Includes examples for both real-time and batch processing via `@doubleword/vercel-ai`

[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing across multiple inference providers. It offers a [Vercel AI SDK provider](https://www.npmjs.com/package/@doubleword/vercel-ai) that integrates directly with Mastra agents, along with batch processing support for up to 90% cost savings.

## Test plan

- [ ] Verify the provider page renders correctly at `/models/providers/doubleword`
- [ ] Verify Doubleword appears in the providers index page
- [ ] Verify Doubleword appears in the sidebar navigation
- [ ] Verify all external links are valid

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a simple how-to page showing how to use Doubleword with Mastra so developers can route model requests through one gateway and save costs when processing many requests at once.

---

## Changes

**New Documentation Files Added:**

- **`docs/src/content/en/models/providers/doubleword.mdx`** (+76 lines)
  - Introduces Doubleword as an OpenAI-compatible AI model gateway and the `@doubleword/vercel-ai` integration.
  - Documents installation and environment setup via `DOUBLEWORD_API_KEY`.
  - Shows TypeScript examples for using `createDoubleword()` with Mastra agents (streaming and non-streaming: `agent.stream`, `agent.generate`).
  - Adds batch processing examples using `createDoublewordBatch()` (notes up to ~90% cost savings) and demonstrates closing the batch provider (`doubleword.close()`).
  - Documents optional custom `baseURL`/`apiKey` configuration for self-hosted Doubleword Control Layer instances.
  - External links: https://doubleword.ai, https://docs.doubleword.ai, https://github.com/doublewordai/vercel-doubleword

- **`docs/src/content/en/models/providers/index.mdx`** (+5 lines)
  - Added a `CardGridItem` for Doubleword (title, description, href, logo).

- **`docs/src/content/en/models/sidebars.js`** (+5 lines)
  - Inserted a sidebar doc entry `providers/doubleword` (label: "Doubleword") in the Providers category (placed after `providers/deepinfra`).

- **`.changeset/add-doubleword-provider.md`** (+5 lines)
  - Adds a changeset marking a patch for `mastra-docs` with the description "docs: add Doubleword as a model provider".

**Totals:** +91/-0 lines

**Impact:** Documentation-only; no code or public API changes. Estimated review effort: Low.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->