### PR TITLE
fix(ai-sdk): ignore stale approval responses after later user follow-up

### DIFF
--- a/.changeset/quiet-singers-reply.md
+++ b/.changeset/quiet-singers-reply.md
@@ -1,0 +1,5 @@
+---
+"@mastra/ai-sdk": patch
+---
+
+Fix AI SDK v6 approval replay so ordinary user follow-up turns do not resume stale approval responses.

--- a/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
@@ -290,6 +290,31 @@ describe('extractV6NativeApproval', () => {
     expect(result?.runId).toBe('new-run');
     expect(result?.resumeData.approved).toBe(false);
   });
+
+  it('ignores earlier approval responses once a later user follow-up exists', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'msg-1',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'old-call',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: `old-run${APPROVAL_ID_SEPARATOR}old-call`, approved: true },
+          },
+        ],
+      },
+      {
+        role: 'user' as const,
+        id: 'msg-2',
+        parts: [{ type: 'text', text: 'What happened?' }],
+      },
+    ];
+
+    expect(extractV6NativeApproval(messages as any)).toBeNull();
+  });
 });
 
 describe('handleChatStream v6 native approve() resume flow', () => {

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -37,17 +37,11 @@ import type {
 export function extractV6NativeApproval(
   messages: V6UIMessage[],
 ): { resumeData: Record<string, unknown>; runId: string } | null {
-  // Find the last trailing assistant message — stop as soon as we see one.
-  let lastAssistantMsg: V6UIMessage | undefined;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i]!;
-    if (message.role === 'assistant') {
-      lastAssistantMsg = message;
-      break;
-    }
-  }
-
-  if (!lastAssistantMsg) return null;
+  // Only inspect the actual trailing message. If a user has already sent a
+  // follow-up turn after an approval response, we must treat that as a normal
+  // chat submission rather than replaying the stale approval response.
+  const lastAssistantMsg = messages.at(-1);
+  if (!lastAssistantMsg || lastAssistantMsg.role !== 'assistant') return null;
 
   for (const part of lastAssistantMsg.parts ?? []) {
     if (!isToolUIPart(part) || part.state !== 'approval-responded') continue;


### PR DESCRIPTION
## Description

This is a narrow follow-up to #15345.

`extractV6NativeApproval()` is documented as inspecting only the trailing assistant message so older approval responses are not re-processed. In practice it still walked backward to the first assistant message it could find, which allowed an earlier `approval-responded` part to be reused after a later ordinary user follow-up.

That means a normal chat turn could be misrouted into `resumeStream()` with stale approval state.

Before:

```ts
messages = [assistant(approval-responded), user("What happened?")]
// extractV6NativeApproval(messages) => { runId: 'run-123', resumeData: { approved: true } }
```

After:

```ts
messages = [assistant(approval-responded), user("What happened?")]
// extractV6NativeApproval(messages) => null
```

The fix keeps approval extraction scoped to the actual trailing assistant message and adds regression coverage for the follow-up-turn case.

## Related Issue(s)

Fixes #15479

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
