### PR TITLE
fix(mastracode): resolve API keys from stored slot and env vars

### DIFF
--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -1,4 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
 import type { LanguageModelV1 } from '@ai-sdk/provider';
 import type { MastraLanguageModel } from '@mastra/core/agent';
 import type { HarnessRequestContext } from '@mastra/core/harness';
@@ -36,9 +37,22 @@ export function resolveModel(modelId: string): LanguageModelV1 | MastraLanguageM
       name: 'moonshotai.anthropicv1',
     })(modelId.substring('moonshotai/'.length));
   } else if (isAnthropicModel) {
-    return opencodeClaudeMaxProvider(modelId.substring(`anthropic/`.length));
-  } else if (isOpenAIModel && authStorage.isLoggedIn('openai-codex')) {
-    return openaiCodexProvider(modelId.substring(`openai/`.length));
+    const bareModelId = modelId.substring('anthropic/'.length);
+    const apiKey = authStorage.getStoredApiKey('anthropic') ?? process.env.ANTHROPIC_API_KEY;
+    if (apiKey) {
+      return createAnthropic({ apiKey })(bareModelId);
+    }
+    return opencodeClaudeMaxProvider(bareModelId);
+  } else if (isOpenAIModel) {
+    const bareModelId = modelId.substring('openai/'.length);
+    if (authStorage.isLoggedIn('openai-codex')) {
+      return openaiCodexProvider(bareModelId);
+    }
+    const apiKey = authStorage.getStoredApiKey('openai-codex') ?? process.env.OPENAI_API_KEY;
+    if (apiKey) {
+      return createOpenAI({ apiKey }).chat(bareModelId);
+    }
+    return new ModelRouterLanguageModel(modelId);
   } else {
     return new ModelRouterLanguageModel(modelId);
   }


### PR DESCRIPTION
## Problem

`resolveModel` always routes `anthropic/*` models to `opencodeClaudeMaxProvider` (OAuth path) with no API key fallback. Users who have a stored API key (via `authStorage.setStoredApiKey`) or `ANTHROPIC_API_KEY` environment variable get:

```
Not logged in to Anthropic. Run /login first.
```

...even though valid API key credentials exist. This forces all Anthropic users through the OAuth flow, which is unnecessary when a direct API key is available.

The same issue exists for OpenAI — if a user has an API key but isn't logged in via OAuth, the model falls through to the generic `ModelRouterLanguageModel` instead of using the key directly.

## Fix

Check `authStorage.getStoredApiKey()` and `process.env` before falling back to OAuth/gateway:

**Anthropic**: stored API key or `ANTHROPIC_API_KEY` env → `createAnthropic({ apiKey })`. Otherwise → `opencodeClaudeMaxProvider` (OAuth).

**OpenAI**: OAuth logged in → `openaiCodexProvider`. Otherwise stored API key or `OPENAI_API_KEY` env → `createOpenAI({ apiKey })`. Otherwise → `ModelRouterLanguageModel` (gateway).

## Context

We hit this while integrating mastracode into an Electron app (Superset Desktop). The app stores API keys via `authStorage.setStoredApiKey("anthropic", key)` from a Settings UI. These keys were invisible to `resolveModel` because it only checked the main credential slot (`authStorage.get("anthropic")`), which is reserved for OAuth credentials set by `authStorage.login()`.

The `getStoredApiKey` / `setStoredApiKey` API exists specifically for API keys that should persist independently of the OAuth lifecycle, but `resolveModel` wasn't consulting it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI SDK support for improved model handling
  * Enhanced API key configuration with fallback options for both OpenAI and Anthropic models
  * API keys can now be sourced from authentication storage or environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->