### PR TITLE
fix(mastracode): check stored API key slot and env vars in key resolution

### DIFF
--- a/.changeset/fix-api-key-resolution.md
+++ b/.changeset/fix-api-key-resolution.md
@@ -1,0 +1,7 @@
+---
+'mastracode': patch
+---
+
+Fix API key resolution to check stored key slot and env vars.
+
+`getAnthropicApiKey()` and `getOpenAIApiKey()` now check `authStorage.getStoredApiKey()` and `process.env` in addition to the main credential slot. Fixes API keys becoming invisible to `resolveModel` after OAuth connect/disconnect cycles.

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -84,28 +84,31 @@ export function remapOpenAIModelForCodexOAuth(modelId: string): string {
 }
 
 /**
- * Resolve the Anthropic API key from stored credentials.
- * Returns the key if available, undefined otherwise.
+ * Resolve the Anthropic API key.
+ * Main slot → dedicated apikey: slot → env var.
  */
 export function getAnthropicApiKey(): string | undefined {
-  // Check stored API key credential (set via /apikey or UI prompt)
   const storedCred = authStorage.get('anthropic');
   if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
     return storedCred.key.trim();
   }
-  return undefined;
+  const dedicatedKey = authStorage.getStoredApiKey('anthropic')?.trim();
+  if (dedicatedKey) return dedicatedKey;
+  return process.env.ANTHROPIC_API_KEY?.trim() || undefined;
 }
 
 /**
- * Resolve the OpenAI API key from stored credentials.
- * Returns the key if available, undefined otherwise.
+ * Resolve the OpenAI API key.
+ * Main slot → dedicated apikey: slot → env var.
  */
 export function getOpenAIApiKey(): string | undefined {
   const storedCred = authStorage.get('openai-codex');
   if (storedCred?.type === 'api_key' && storedCred.key.trim().length > 0) {
     return storedCred.key.trim();
   }
-  return undefined;
+  const dedicatedKey = authStorage.getStoredApiKey('openai-codex')?.trim();
+  if (dedicatedKey) return dedicatedKey;
+  return process.env.OPENAI_API_KEY?.trim() || undefined;
 }
 
 /**


### PR DESCRIPTION
Fixes #15484

`getAnthropicApiKey()` and `getOpenAIApiKey()` only check `authStorage.get()` (main credential slot). They miss keys in `authStorage.getStoredApiKey()` and `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` env vars.

This breaks when OAuth overwrites the main slot then gets disconnected — the API key in the dedicated slot is invisible to `resolveModel`, which falls through to OAuth and throws "Not logged in."

Both functions now check: main slot → `getStoredApiKey()` → env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR fixes a problem where API keys for Anthropic and OpenAI would become unavailable in the mastracode application. The fix teaches the app to look for API keys in three places instead of just one: the main settings storage, a dedicated API key storage location, and environment variables. This helps users who save API keys through the Settings UI or set them up in containers/CI environments.

## Changes

### mastracode/src/agents/model.ts
Updated `getAnthropicApiKey()` and `getOpenAIApiKey()` to implement a three-level fallback chain for API key resolution:

1. Check the main credential slot (`authStorage.get('anthropic')` / `authStorage.get('openai-codex')`)
2. Check the dedicated stored API key slot via `authStorage.getStoredApiKey(<providerId>)`
3. Fall back to environment variables (`process.env.ANTHROPIC_API_KEY` / `process.env.OPENAI_API_KEY`)

All retrieved keys are trimmed before being returned. This prevents `resolveModel` from incorrectly falling back to OAuth authentication after OAuth connect/disconnect cycles that clear the main credential slot.

### .changeset/fix-api-key-resolution.md
Added a Changesets entry documenting the patch release for the `mastracode` package with notes on the updated API key resolution behavior.

## Why This Matters
- **Persisted API keys**: Keys saved via the Settings UI (using `authStorage.setStoredApiKey()`) are no longer lost after OAuth operations
- **Environment variable support**: CI/container/development environments can now provide API keys through standard environment variables
- **Prevents authentication errors**: Fixes the "Not logged in" error that occurred when API keys became unavailable after OAuth lifecycle changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->