### PR TITLE
fix(core): coordinate parallel suspend in evented workflow engine

### DIFF
--- a/.changeset/spicy-nights-fail.md
+++ b/.changeset/spicy-nights-fail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed evented workflow parallel and conditional runs so suspend completes only after sibling branches finish, and suspended step lists match persisted state.

--- a/packages/core/src/storage/domains/workflows/inmemory.ts
+++ b/packages/core/src/storage/domains/workflows/inmemory.ts
@@ -46,9 +46,10 @@ export class WorkflowsInMemory extends WorkflowsStorage {
   }): Promise<Record<string, StepResult<any, any, any, any>>> {
     const key = this.getWorkflowKey(params.workflowName, params.runId);
     const previous = this.workflowResultUpdateChains.get(key) ?? Promise.resolve();
-    const current = previous.then(() => this.mergeWorkflowResultUpdate(params)) as Promise<
-      Record<string, StepResult<any, any, any, any>>
-    >;
+    // Swallow prior rejections so one failed merge cannot skip subsequent branches' merges.
+    const current = Promise.resolve(previous)
+      .catch(() => undefined)
+      .then(() => this.mergeWorkflowResultUpdate(params));
     this.workflowResultUpdateChains.set(key, current);
     return current.finally(() => {
       if (this.workflowResultUpdateChains.get(key) === current) {

--- a/packages/core/src/storage/domains/workflows/inmemory.ts
+++ b/packages/core/src/storage/domains/workflows/inmemory.ts
@@ -14,6 +14,12 @@ import { WorkflowsStorage } from './base';
 export class WorkflowsInMemory extends WorkflowsStorage {
   private db: InMemoryDB;
 
+  /**
+   * Serializes `updateWorkflowResults` for the same workflow run so parallel branches
+   * cannot read a stale snapshot and drop another branch's step result.
+   */
+  private workflowResultUpdateChains = new Map<string, Promise<unknown>>();
+
   constructor({ db }: { db: InMemoryDB }) {
     super();
     this.db = db;
@@ -31,7 +37,27 @@ export class WorkflowsInMemory extends WorkflowsStorage {
     return `${workflowName}-${runId}`;
   }
 
-  async updateWorkflowResults({
+  async updateWorkflowResults(params: {
+    workflowName: string;
+    runId: string;
+    stepId: string;
+    result: StepResult<any, any, any, any>;
+    requestContext: Record<string, any>;
+  }): Promise<Record<string, StepResult<any, any, any, any>>> {
+    const key = this.getWorkflowKey(params.workflowName, params.runId);
+    const previous = this.workflowResultUpdateChains.get(key) ?? Promise.resolve();
+    const current = previous.then(() => this.mergeWorkflowResultUpdate(params)) as Promise<
+      Record<string, StepResult<any, any, any, any>>
+    >;
+    this.workflowResultUpdateChains.set(key, current);
+    return current.finally(() => {
+      if (this.workflowResultUpdateChains.get(key) === current) {
+        this.workflowResultUpdateChains.delete(key);
+      }
+    }) as Promise<Record<string, StepResult<any, any, any, any>>>;
+  }
+
+  private mergeWorkflowResultUpdate({
     workflowName,
     runId,
     stepId,
@@ -43,7 +69,7 @@ export class WorkflowsInMemory extends WorkflowsStorage {
     stepId: string;
     result: StepResult<any, any, any, any>;
     requestContext: Record<string, any>;
-  }): Promise<Record<string, StepResult<any, any, any, any>>> {
+  }): Record<string, StepResult<any, any, any, any>> {
     const key = this.getWorkflowKey(workflowName, runId);
     const run = this.db.workflows.get(key);
 

--- a/packages/core/src/workflows/evented/evented-workflow.test.ts
+++ b/packages/core/src/workflows/evented/evented-workflow.test.ts
@@ -78,9 +78,8 @@ createWorkflowTestSuite({
     abortStatus: true,
     abortDuringStep: true,
 
-    // Suspend/resume - parallel suspend has race condition (each step publishes workflow.suspend independently)
-    resumeParallelMulti: true,
-    resumeMultiSuspendError: true,
+    resumeParallelMulti: false,
+    resumeMultiSuspendError: false,
     resumeBranchingStatus: true,
     // Suspend/resume - still failing (loop/foreach coordination, nested input propagation)
     resumeLoopInput: true,

--- a/packages/core/src/workflows/evented/execution-engine.ts
+++ b/packages/core/src/workflows/evented/execution-engine.ts
@@ -189,6 +189,22 @@ export class EventedExecutionEngine extends ExecutionEngine {
     // Wait for workflow to complete
     const resultData: any = await resultPromise;
 
+    // Multi-branch suspend: pub/sub payload can omit sibling step rows; merge persisted snapshot
+    // so `suspended` / `steps` match storage (same guarantee as default engine).
+    if (resultData?.prevResult?.status === 'suspended' && resultData.stepResults) {
+      const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
+      const snap = await workflowsStore?.loadWorkflowSnapshot({
+        workflowName: params.workflowId,
+        runId: params.runId,
+      });
+      if (snap?.context && typeof snap.context === 'object') {
+        resultData.stepResults = {
+          ...(snap.context as Record<string, unknown>),
+          ...resultData.stepResults,
+        };
+      }
+    }
+
     // Extract state from resultData (stored in stepResults.__state)
     const finalState = resultData.state ?? resultData.stepResults?.__state ?? params.initialState ?? {};
 

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -409,7 +409,8 @@ export class WorkflowEventProcessor extends EventProcessor {
     // Extract final state from stepResults or args
     const finalState = resolveCurrentState({ stepResults, state });
 
-    // TODO: if there are still active paths don't end the workflow yet
+    // Multi-branch suspend coordination: processWorkflowStepEnd defers workflow.suspend until
+    // sibling branches are terminal; fan-in emits suspend when siblings include mixed success+suspend.
     // handle nested workflow
     if (parentWorkflow) {
       await this.mastra.pubsub.publish('workflows', {
@@ -1621,15 +1622,48 @@ export class WorkflowEventProcessor extends EventProcessor {
 
       return;
     } else if (prevResult.status === 'suspended') {
-      const suspendedPaths: Record<string, number[]> = {};
-      const suspendedStep = getStep(workflow, executionPath);
-      if (suspendedStep) {
-        suspendedPaths[suspendedStep.id] = executionPath;
+      const parentEntry = executionPath.length >= 2 ? workflow.stepGraph[executionPath[0]!] : undefined;
+
+      // Parallel / conditional: do not emit workflow.suspend until every sibling branch has
+      // reached a terminal step result in storage (matches default engine; avoids incomplete
+      // `suspended` metadata when the first branch suspends before siblings persist).
+      if (parentEntry && (parentEntry.type === 'parallel' || parentEntry.type === 'conditional')) {
+        for (const branch of parentEntry.steps) {
+          if (!isExecutableStep(branch)) {
+            continue;
+          }
+          const sr = stepResults[branch.step.id];
+          if (!sr || !['success', 'skipped', 'suspended', 'failed'].includes(sr.status)) {
+            return;
+          }
+        }
       }
 
-      // Extract resume labels from suspend payload metadata
-      const resumeLabels: Record<string, { stepId: string; foreachIndex?: number }> =
+      const suspendedPaths: Record<string, number[]> = {};
+      let resumeLabels: Record<string, { stepId: string; foreachIndex?: number }> =
         prevResult.suspendPayload?.__workflow_meta?.resumeLabels ?? {};
+
+      if (parentEntry && (parentEntry.type === 'parallel' || parentEntry.type === 'conditional')) {
+        for (let i = 0; i < parentEntry.steps.length; i++) {
+          const branch = parentEntry.steps[i];
+          if (branch?.type !== 'step') continue;
+          const sid = branch.step.id;
+          const sr = stepResults[sid] as { status?: string; suspendPayload?: any } | undefined;
+          if (sr?.status === 'suspended') {
+            suspendedPaths[sid] = [executionPath[0]!, i];
+            const labels = sr.suspendPayload?.__workflow_meta?.resumeLabels;
+            if (labels && typeof labels === 'object') {
+              resumeLabels = { ...resumeLabels, ...labels };
+            }
+          }
+        }
+      }
+      if (Object.keys(suspendedPaths).length === 0) {
+        const suspendedStep = getStep(workflow, executionPath);
+        if (suspendedStep) {
+          suspendedPaths[suspendedStep.id] = executionPath;
+        }
+      }
 
       // Check shouldPersistSnapshot option - default to true if not specified
       const shouldPersist =
@@ -1758,13 +1792,112 @@ export class WorkflowEventProcessor extends EventProcessor {
         });
       }
     } else if ((step?.type === 'parallel' || step?.type === 'conditional') && executionPath.length > 1) {
+      const execBranches = step.steps.filter(s => isExecutableStep(s));
+      const allSiblingTerminal = execBranches.every(b => {
+        const res = stepResults?.[b.step.id];
+        return res && ['success', 'skipped', 'suspended', 'failed'].includes(res.status);
+      });
+      if (!allSiblingTerminal) {
+        return;
+      }
+
+      const anySuspended = execBranches.some(b => stepResults[b.step.id]?.status === 'suspended');
+      if (anySuspended) {
+        const suspendedBranch = execBranches.find(b => stepResults[b.step.id]?.status === 'suspended')!;
+        const suspendedPrev = stepResults[suspendedBranch.step.id] as StepResult<any, any, any, any>;
+        const branchIdx = step.steps.findIndex(b => isExecutableStep(b) && b.step.id === suspendedBranch.step.id);
+        const suspendExecutionPath = branchIdx >= 0 ? [executionPath[0]!, branchIdx] : executionPath;
+
+        const suspendedPaths: Record<string, number[]> = {};
+        let resumeLabels: Record<string, { stepId: string; foreachIndex?: number }> =
+          suspendedPrev.suspendPayload?.__workflow_meta?.resumeLabels ?? {};
+
+        for (let i = 0; i < step.steps.length; i++) {
+          const branch = step.steps[i];
+          if (branch?.type !== 'step') {
+            continue;
+          }
+          const sid = branch.step.id;
+          const sr = stepResults[sid] as { status?: string; suspendPayload?: any } | undefined;
+          if (sr?.status === 'suspended') {
+            suspendedPaths[sid] = [executionPath[0]!, i];
+            const labels = sr.suspendPayload?.__workflow_meta?.resumeLabels;
+            if (labels && typeof labels === 'object') {
+              resumeLabels = { ...resumeLabels, ...labels };
+            }
+          }
+        }
+
+        const shouldPersistSuspend =
+          workflow?.options?.shouldPersistSnapshot?.({
+            stepResults: stepResults ?? {},
+            workflowStatus: 'suspended',
+          }) ?? true;
+
+        if (shouldPersistSuspend) {
+          await workflowsStore?.updateWorkflowResults({
+            workflowName: workflow.id,
+            runId,
+            stepId: '__state',
+            result: currentState as any,
+            requestContext,
+          });
+
+          await workflowsStore?.updateWorkflowState({
+            workflowName: workflowId,
+            runId,
+            opts: {
+              status: 'suspended',
+              result: suspendedPrev,
+              suspendedPaths,
+              resumeLabels,
+            },
+          });
+        }
+
+        await this.mastra.pubsub.publish('workflows', {
+          type: 'workflow.suspend',
+          runId,
+          data: {
+            workflowId,
+            runId,
+            executionPath: suspendExecutionPath,
+            resumeSteps,
+            parentWorkflow,
+            stepResults,
+            prevResult: suspendedPrev,
+            activeSteps,
+            requestContext,
+            timeTravel,
+            state: currentState,
+            outputOptions,
+          },
+        });
+
+        await this.mastra.pubsub.publish(`workflow.events.v2.${runId}`, {
+          type: 'watch',
+          runId,
+          data: {
+            type: 'workflow-step-suspended',
+            payload: {
+              id: suspendedBranch.step.id,
+              ...suspendedPrev,
+              suspendedAt: Date.now(),
+              suspendPayload: suspendedPrev.suspendPayload,
+            },
+          },
+        });
+
+        return;
+      }
+
       let skippedCount = 0;
       const allResults: Record<string, any> = step.steps.reduce(
-        (acc, step) => {
-          if (isExecutableStep(step)) {
-            const res = stepResults?.[step.step.id];
+        (acc, st) => {
+          if (isExecutableStep(st)) {
+            const res = stepResults?.[st.step.id];
             if (res && res.status === 'success') {
-              acc[step.step.id] = res?.output;
+              acc[st.step.id] = res?.output;
               // @ts-expect-error - skipped status not in type
             } else if (res?.status === 'skipped') {
               skippedCount++;
@@ -1777,7 +1910,7 @@ export class WorkflowEventProcessor extends EventProcessor {
       );
 
       const keys = Object.keys(allResults);
-      if (keys.length + skippedCount < step.steps.length) {
+      if (keys.length + skippedCount < execBranches.length) {
         return;
       }
 

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1918,10 +1918,6 @@ export class EventedRun<
 
     const resumePath = snapshot.suspendedPaths?.[steps[0]!] as any;
 
-    console.dir(
-      { resume: { requestContextObj: snapshot.requestContext, requestContext: params.requestContext } },
-      { depth: null },
-    );
     // Start with the snapshot's request context (old values)
     const requestContextObj = snapshot.requestContext ?? {};
     const requestContext = new RequestContext();


### PR DESCRIPTION
## Description

Evented workflow engine: when parallel or conditional branches call `suspend()`, completion and `workflows-finish` now align with the default engine. We **defer** emitting `workflow.suspend` until every sibling branch has a **terminal** step result in storage, **fan in** correctly when some branches succeed and others suspend (so the run does not stall), **merge** the persisted workflow snapshot into the execution result when status is `suspended`, and **serialize** in-memory `updateWorkflowResults` per run so parallel branches cannot overwrite each other’s snapshot rows. Shared suspend/resume tests `resumeParallelMulti` and `resumeMultiSuspendError` are enabled for the evented suite. Removes stray `console.dir` debug logging in `EventedRun.resume`.

## Related Issue(s)

Fixes #15481  

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable) — *N/A: internal engine behavior, no public API doc change*
- [x] I have added tests that prove my fix is effective or that my feature works *(shared suite + unskipped cases)*
- [ ] I have addressed all Coderabbit comments on this PR *(after it opens)*



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When multiple branches run at the same time and some pause, the evented workflow engine used to let each branch announce the pause independently, causing races and mismatched state. This PR coordinates those pauses so the engine waits for sibling branches to reach terminal states, then emits a single, correct suspend and preserves the persisted snapshot so resumes behave consistently.

## Changes Overview

### Changeset
- Added `.changeset/spicy-nights-fail.md` to document a patch release for `@mastra/core` fixing evented workflow suspend behavior in parallel/conditional branches.

### Core Suspend Coordination
packages/core/src/workflows/evented/workflow-event-processor/index.ts (+145/-12)
- Coordinate suspend emission across sibling branches in parallel/conditional flows.
- When a step result is `suspended`, derive the parent branch and wait until all executable siblings are in a terminal state (`success`, `skipped`, `suspended`, `failed`) before proceeding.
- Aggregate `suspendedPaths` and merge `resumeLabels` from suspended siblings.
- If any sibling is suspended once all executable siblings are terminal, persist `__state`, update workflow status to `suspended`, publish `workflow.suspend`, and emit a `workflow-step-suspended` watch event, returning early to avoid finishing logic.
- Narrow the “all results ready” gate to compare against executable branch count rather than total step count.

### Snapshot Merging for Suspended Runs
packages/core/src/workflows/evented/execution-engine.ts (+16/-0)
- After completion, when the workflow status is `suspended`, load the persisted workflow snapshot and merge its `context` into `resultData.stepResults` (with in-memory step results taking precedence) so the emitted suspended payload matches stored state.

### Serialized Workflow Result Updates
packages/core/src/storage/domains/workflows/inmemory.ts (+29/-2)
- Serialize in-memory `updateWorkflowResults` calls per run using a `workflowResultUpdateChains` map keyed by `workflowName-runId`.
- Factored merge logic into a private `mergeWorkflowResultUpdate(...)` helper and chain updates to prevent concurrent branch updates from clobbering each other’s snapshot rows or being disrupted by prior chain rejections.

### Test Coverage
packages/core/src/workflows/evented/evented-workflow.test.ts (+2/-3)
- Enabled previously skipped evented tests `resumeParallelMulti` and `resumeMultiSuspendError` so the evented suite now runs parallel multi-suspend/resume scenarios and aligns with the default engine.

### Code Cleanup
packages/core/src/workflows/evented/workflow.ts (-4)
- Removed stray `console.dir` debug logging from `EventedRun.resume()`.

### Notes
- Marked as a bug fix and test update; references issue #15481.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->