### PR TITLE
feat(playground-ui): add BrandLoader component

### DIFF
--- a/.changeset/happy-tigers-post.md
+++ b/.changeset/happy-tigers-post.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added BrandLoader, a branded pulse-wave loader component for brand moments like app boot or agent thinking. Complements Spinner, which remains the inline utility loader.

--- a/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.css
+++ b/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.css
@@ -1,0 +1,53 @@
+.brand-loader svg {
+  filter: drop-shadow(0 0 0.7px currentColor);
+  shape-rendering: geometricPrecision;
+}
+.brand-loader circle {
+  fill: currentColor;
+}
+.brand-loader line {
+  stroke: currentColor;
+  stroke-width: 2.8;
+  stroke-linecap: round;
+}
+.brand-loader circle,
+.brand-loader line {
+  animation: brand-loader-pulse 1.8s ease-in-out infinite;
+}
+.brand-loader .brand-loader__b1 {
+  animation-delay: 0s;
+}
+.brand-loader .brand-loader__b2 {
+  animation-delay: 0.09s;
+}
+.brand-loader .brand-loader__ln23 {
+  animation-delay: 0.135s;
+}
+.brand-loader .brand-loader__b3 {
+  animation-delay: 0.18s;
+}
+.brand-loader .brand-loader__ln34 {
+  animation-delay: 0.225s;
+}
+.brand-loader .brand-loader__b4 {
+  animation-delay: 0.27s;
+}
+.brand-loader .brand-loader__ln45 {
+  animation-delay: 0.315s;
+}
+.brand-loader .brand-loader__b5 {
+  animation-delay: 0.36s;
+}
+
+@keyframes brand-loader-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  40% {
+    opacity: 0;
+  }
+  70% {
+    opacity: 1;
+  }
+}

--- a/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.css
+++ b/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.css
@@ -1,41 +1,52 @@
 .brand-loader svg {
-  filter: drop-shadow(0 0 0.7px currentColor);
-  shape-rendering: geometricPrecision;
+  filter: drop-shadow(0 0 0.7px currentcolor);
+  shape-rendering: geometricprecision;
 }
+
 .brand-loader circle {
-  fill: currentColor;
+  fill: currentcolor;
 }
+
 .brand-loader line {
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 2.8;
   stroke-linecap: round;
 }
+
 .brand-loader circle,
 .brand-loader line {
   animation: brand-loader-pulse 1.8s ease-in-out infinite;
 }
-.brand-loader .brand-loader__b1 {
+
+.brand-loader .brand-loader-b1 {
   animation-delay: 0s;
 }
-.brand-loader .brand-loader__b2 {
+
+.brand-loader .brand-loader-b2 {
   animation-delay: 0.09s;
 }
-.brand-loader .brand-loader__ln23 {
+
+.brand-loader .brand-loader-ln23 {
   animation-delay: 0.135s;
 }
-.brand-loader .brand-loader__b3 {
+
+.brand-loader .brand-loader-b3 {
   animation-delay: 0.18s;
 }
-.brand-loader .brand-loader__ln34 {
+
+.brand-loader .brand-loader-ln34 {
   animation-delay: 0.225s;
 }
-.brand-loader .brand-loader__b4 {
+
+.brand-loader .brand-loader-b4 {
   animation-delay: 0.27s;
 }
-.brand-loader .brand-loader__ln45 {
+
+.brand-loader .brand-loader-ln45 {
   animation-delay: 0.315s;
 }
-.brand-loader .brand-loader__b5 {
+
+.brand-loader .brand-loader-b5 {
   animation-delay: 0.36s;
 }
 
@@ -44,9 +55,11 @@
   100% {
     opacity: 1;
   }
+
   40% {
     opacity: 0;
   }
+
   70% {
     opacity: 1;
   }

--- a/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.stories.tsx
+++ b/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { BrandLoader } from './brand-loader';
+
+const meta: Meta<typeof BrandLoader> = {
+  title: 'Elements/BrandLoader',
+  component: BrandLoader,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'radio' },
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BrandLoader>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Small: Story = {
+  args: { size: 'sm' },
+};
+
+export const Medium: Story = {
+  args: { size: 'md' },
+};
+
+export const Large: Story = {
+  args: { size: 'lg' },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-8">
+      <BrandLoader size="sm" />
+      <BrandLoader size="md" />
+      <BrandLoader size="lg" />
+    </div>
+  ),
+};
+
+export const OnSurface: Story = {
+  render: () => (
+    <div className="flex h-64 w-96 items-center justify-center rounded-lg bg-surface2">
+      <BrandLoader size="lg" />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.tsx
+++ b/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.tsx
@@ -17,7 +17,8 @@ const sizeClasses = {
 };
 
 function BrandLoader({ className, size = 'md', 'aria-label': ariaLabel = 'Loading' }: BrandLoaderProps) {
-  const filterId = useId();
+  const reactId = useId();
+  const filterId = `brand-loader-${reactId.replace(/[^a-zA-Z0-9_-]/g, '')}`;
 
   return (
     <div
@@ -38,14 +39,14 @@ function BrandLoader({ className, size = 'md', 'aria-label': ariaLabel = 'Loadin
           </filter>
         </defs>
         <g filter={`url(#${filterId})`}>
-          <line className="brand-loader__ln23" x1="10.4" y1="4.5" x2="16.8" y2="16.2" />
-          <line className="brand-loader__ln34" x1="16.8" y1="16.2" x2="23.2" y2="4.5" />
-          <line className="brand-loader__ln45" x1="23.2" y1="4.5" x2="29.5" y2="16.2" />
-          <circle className="brand-loader__b1" cx="4.5" cy="16.2" r="4.5" />
-          <circle className="brand-loader__b2" cx="10.4" cy="4.5" r="4.5" />
-          <circle className="brand-loader__b3" cx="16.8" cy="16.2" r="4.5" />
-          <circle className="brand-loader__b4" cx="23.2" cy="4.5" r="4.5" />
-          <circle className="brand-loader__b5" cx="29.5" cy="16.2" r="4.5" />
+          <line className="brand-loader-ln23" x1="10.4" y1="4.5" x2="16.8" y2="16.2" />
+          <line className="brand-loader-ln34" x1="16.8" y1="16.2" x2="23.2" y2="4.5" />
+          <line className="brand-loader-ln45" x1="23.2" y1="4.5" x2="29.5" y2="16.2" />
+          <circle className="brand-loader-b1" cx="4.5" cy="16.2" r="4.5" />
+          <circle className="brand-loader-b2" cx="10.4" cy="4.5" r="4.5" />
+          <circle className="brand-loader-b3" cx="16.8" cy="16.2" r="4.5" />
+          <circle className="brand-loader-b4" cx="23.2" cy="4.5" r="4.5" />
+          <circle className="brand-loader-b5" cx="29.5" cy="16.2" r="4.5" />
         </g>
       </svg>
     </div>

--- a/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.tsx
+++ b/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.tsx
@@ -1,0 +1,55 @@
+import { useId } from 'react';
+
+import { cn } from '@/lib/utils';
+
+import './brand-loader.css';
+
+export type BrandLoaderProps = {
+  className?: string;
+  size?: 'sm' | 'md' | 'lg';
+  'aria-label'?: string;
+};
+
+const sizeClasses = {
+  sm: 'w-6',
+  md: 'w-10',
+  lg: 'w-16',
+};
+
+function BrandLoader({ className, size = 'md', 'aria-label': ariaLabel = 'Loading' }: BrandLoaderProps) {
+  const filterId = useId();
+
+  return (
+    <div
+      role="status"
+      aria-label={ariaLabel}
+      className={cn('brand-loader inline-block text-neutral6', sizeClasses[size], className)}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 34 21"
+        className="block w-full h-auto overflow-visible"
+        aria-hidden="true"
+      >
+        <defs>
+          <filter id={filterId}>
+            <feGaussianBlur in="SourceGraphic" stdDeviation="0.55" />
+            <feColorMatrix values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -7" />
+          </filter>
+        </defs>
+        <g filter={`url(#${filterId})`}>
+          <line className="brand-loader__ln23" x1="10.4" y1="4.5" x2="16.8" y2="16.2" />
+          <line className="brand-loader__ln34" x1="16.8" y1="16.2" x2="23.2" y2="4.5" />
+          <line className="brand-loader__ln45" x1="23.2" y1="4.5" x2="29.5" y2="16.2" />
+          <circle className="brand-loader__b1" cx="4.5" cy="16.2" r="4.5" />
+          <circle className="brand-loader__b2" cx="10.4" cy="4.5" r="4.5" />
+          <circle className="brand-loader__b3" cx="16.8" cy="16.2" r="4.5" />
+          <circle className="brand-loader__b4" cx="23.2" cy="4.5" r="4.5" />
+          <circle className="brand-loader__b5" cx="29.5" cy="16.2" r="4.5" />
+        </g>
+      </svg>
+    </div>
+  );
+}
+
+export { BrandLoader };

--- a/packages/playground-ui/src/ds/components/BrandLoader/index.ts
+++ b/packages/playground-ui/src/ds/components/BrandLoader/index.ts
@@ -1,0 +1,1 @@
+export * from './brand-loader';

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -48,6 +48,7 @@ export * from './ds/components/Select';
 export * from './ds/components/Skeleton';
 export * from './ds/components/Slider';
 export * from './ds/components/Spinner';
+export * from './ds/components/BrandLoader';
 export * from './ds/components/Switch';
 export * from './ds/components/Tooltip';
 export * from './ds/components/Truncate';

--- a/packages/playground-ui/src/vite-env.d.ts
+++ b/packages/playground-ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';


### PR DESCRIPTION
## Summary
- Adds `BrandLoader` — a branded pulse-wave SVG loader to `@mastra/playground-ui` design system.
- Sits alongside `Spinner`: use `BrandLoader` for brand moments (app boot, agent thinking, splash); keep `Spinner` for inline utility (buttons, table rows).
- `currentColor`-themed (defaults to `text-neutral6` so it auto-flips in light/dark). `size`: `sm` (24px) / `md` (40px, default) / `lg` (64px).
- Goo SVG filter + small drop-shadow halo + `shape-rendering: geometricPrecision` for soft, non-sharp edges at every size.
- CSS is colocated at `brand-loader.css` and side-effect imported from the component module, so the rules only ship when `BrandLoader` is actually imported — not globally via `index.css`.
- `useId()` scopes the goo `<filter>` id per instance to avoid collisions when multiple loaders render on the same page.

<img width="670" height="450" alt="CleanShot 2026-04-18 at 14 10 47" src="https://github.com/user-attachments/assets/b107f793-eb95-481f-a254-6c076487e092" />

## Test plan
- [ ] `pnpm --filter @mastra/playground-ui storybook` → `Elements/BrandLoader` — verify Default, Small, Medium, Large, AllSizes, OnSurface.
- [ ] Toggle light/dark theme in Storybook; confirm color flips (white on dark, near-black on light).
- [ ] Render multiple instances on one page; confirm goo filter doesn't collide.
- [ ] Inspect built CSS: `brand-loader` rules absent when BrandLoader not imported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a new, branded pulsing loader animation called BrandLoader to the Mastra UI library. It's a soft, gooey pulse of connected dots used for prominent brand moments (app boot, agent thinking, splash), auto-adjusts to light/dark themes, and comes in three sizes.

## Summary of Changes

### New Component: BrandLoader
- Adds `BrandLoader` component (packages/playground-ui/src/ds/components/BrandLoader/brand-loader.tsx).
  - Props: `size?: 'sm' | 'md' | 'lg'` (default `md`), `className?`, `'aria-label'?: string` (default `"Loading"`).
  - Renders a semantic `<div role="status">` wrapping an SVG of animated circles and connecting lines.
  - Uses React `useId()` to generate a sanitized, per-instance SVG filter id (avoids collisions when multiple instances render).
  - The component imports `brand-loader.css` as a side-effect so styles only ship when the component is imported.

### Styling & Animation
- New stylesheet `brand-loader.css` implements:
  - Goo SVG filter (feGaussianBlur + feColorMatrix) applied via per-instance filter id.
  - Small drop-shadow halo using `currentcolor`.
  - `shape-rendering: geometricPrecision` for consistent soft edges.
  - Elements themed with `currentcolor` (defaults to `text-neutral6`), enabling automatic light/dark flipping.
  - Staggered infinite `brand-loader-pulse` keyframe animation on circles and lines to create a wave-like pulse.
- Sizes mapped to tailwind-width classes: `sm` = 24px (w-6), `md` = 40px (w-10), `lg` = 64px (w-16).

### Exports & Integration
- Added module entry `packages/playground-ui/src/ds/components/BrandLoader/index.ts` (re-exports).
- Publicly re-exported from package entry (`packages/playground-ui/src/index.ts`).
- Added `declare module '*.css';` in vite-env.d.ts to allow CSS imports.

### Storybook
- Adds Stories: `Elements/BrandLoader` with `Default`, `Small`, `Medium`, `Large`, `AllSizes`, and `OnSurface` demonstrations (`brand-loader.stories.tsx`).

### Release Notes
- Changeset added (.changeset/happy-tigers-post.md) — bumps @mastra/playground-ui minor and announces BrandLoader for brand moments, clarifies Spinner remains for inline utility use.

### Accessibility & Behavior Notes
- Accessible role `status` and customizable `aria-label`.
- CSS import strategy and per-instance filter IDs ensure minimal bundle impact and avoid visual collisions when multiple loaders render.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->