### PR TITLE
simplified procesor span input & output

### DIFF
--- a/.changeset/wide-lamps-grab.md
+++ b/.changeset/wide-lamps-grab.md
@@ -2,12 +2,4 @@
 '@mastra/core': minor
 ---
 
-Improved `PROCESSOR_RUN` spans to record hook-specific input and changed output instead of broad internal processor state. Processor traces now keep replayable `messages` and `systemMessages`, summarize model and tool configuration, omit `messageList` instances, raw stream chunk payloads, and model usage, and only include output message arrays when a processor actually changed them.
-
-**If you consume traces**
-
-Update any dashboards or parsers that depend on the previous `PROCESSOR_RUN` payload shape. Some fields are now summarized, omitted, or only present when changed.
-
-**Example**
-
-A `processInputStep` span now records a normalized model summary with `modelId`, `provider`, and `specificationVersion`, and a summarized tools list with `id`, `name`, and `description` instead of the full step configuration.
+Processor traces now store hook-specific inputs and only include changed outputs, reducing payload size while keeping traces more replayable. If you consume `PROCESSOR_RUN` payloads directly, update any dashboards or parsers that depend on the previous shape.

--- a/.changeset/wide-lamps-grab.md
+++ b/.changeset/wide-lamps-grab.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+---
+
+Improved `PROCESSOR_RUN` spans to record hook-specific input and changed output instead of broad internal processor state. Processor traces now keep replayable `messages` and `systemMessages`, summarize model and tool configuration, omit `messageList` instances, raw stream chunk payloads, and model usage, and only include output message arrays when a processor actually changed them.
+
+**If you consume traces**
+
+Update any dashboards or parsers that depend on the previous `PROCESSOR_RUN` payload shape. Some fields are now summarized, omitted, or only present when changed.
+
+**Example**
+
+A `processInputStep` span now records a normalized model summary with `modelId`, `provider`, and `specificationVersion`, and a summarized tools list with `id`, `name`, and `description` instead of the full step configuration.

--- a/observability/mastra/src/__snapshots__/agent-processors-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace-generate.json
@@ -60,54 +60,6 @@
               "runId": "<runId-1>"
             },
             "input": {
-              "phase": "input",
-              "messageCount": 1
-            },
-            "output": {
-              "phase": "input",
-              "messageList": {
-                "messages": [
-                  {
-                    "role": "user",
-                    "content": [
-                      {
-                        "type": "text",
-                        "text": "  Hello! How are you?  "
-                      }
-                    ]
-                  }
-                ],
-                "systemMessages": [
-                  {
-                    "role": "system",
-                    "content": "You are a helpful assistant"
-                  }
-                ]
-              },
-              "systemMessages": [
-                {
-                  "role": "system",
-                  "content": "You are a helpful assistant"
-                }
-              ],
-              "state": {},
-              "processorStates": {
-                "__type": "Map",
-                "__map_entries": [
-                  [
-                    "string",
-                    "validator",
-                    {
-                      "inputAccumulatedText": "",
-                      "outputAccumulatedText": "",
-                      "outputChunkCount": 0,
-                      "customState": {},
-                      "streamParts": []
-                    }
-                  ]
-                ]
-              },
-              "retryCount": 0,
               "messages": [
                 {
                   "id": "<id-1>",
@@ -125,8 +77,16 @@
                     "content": "  Hello! How are you?  "
                   }
                 }
-              ]
-            }
+              ],
+              "systemMessages": [
+                {
+                  "role": "system",
+                  "content": "You are a helpful assistant"
+                }
+              ],
+              "retryCount": 0
+            },
+            "output": {}
           },
           "children": [
             {
@@ -448,153 +408,9 @@
               "runId": "<runId-1>"
             },
             "input": {
-              "phase": "outputResult",
-              "messageCount": 1
-            },
-            "output": {
-              "phase": "outputResult",
-              "messageList": {
-                "messages": [
-                  {
-                    "role": "user",
-                    "content": [
-                      {
-                        "type": "text",
-                        "text": "  Hello! How are you?  "
-                      }
-                    ]
-                  },
-                  {
-                    "role": "assistant",
-                    "content": [
-                      {
-                        "type": "text",
-                        "text": "Mock V2 generate response",
-                        "createdAt": "<date>"
-                      }
-                    ]
-                  }
-                ],
-                "systemMessages": [
-                  {
-                    "role": "system",
-                    "content": "You are a helpful assistant"
-                  }
-                ]
-              },
-              "state": {},
-              "processorStates": {
-                "__type": "Map",
-                "__map_entries": [
-                  [
-                    "string",
-                    "validator",
-                    {
-                      "inputAccumulatedText": "",
-                      "outputAccumulatedText": "",
-                      "outputChunkCount": 0,
-                      "customState": {},
-                      "streamParts": []
-                    }
-                  ],
-                  [
-                    "string",
-                    "test-agent-output-processor",
-                    {
-                      "inputAccumulatedText": "Mock V2 generate response",
-                      "outputAccumulatedText": "Mock V2 generate response",
-                      "outputChunkCount": 5,
-                      "customState": {},
-                      "streamParts": [
-                        {
-                          "type": "response-metadata",
-                          "runId": "<runId-1>",
-                          "from": "AGENT",
-                          "payload": {
-                            "type": "response-metadata",
-                            "id": "<id-2>",
-                            "modelId": "mock-model-id"
-                          }
-                        },
-                        {
-                          "type": "text-start",
-                          "runId": "<runId-1>",
-                          "from": "AGENT",
-                          "payload": {
-                            "id": "msg_<msg-1>"
-                          }
-                        },
-                        {
-                          "type": "text-delta",
-                          "runId": "<runId-1>",
-                          "from": "AGENT",
-                          "payload": {
-                            "id": "msg_<msg-1>",
-                            "text": "Mock V2 generate response"
-                          }
-                        },
-                        {
-                          "type": "text-end",
-                          "runId": "<runId-1>",
-                          "from": "AGENT",
-                          "payload": {
-                            "type": "text-end",
-                            "id": "msg_<msg-1>"
-                          }
-                        },
-                        {
-                          "type": "finish",
-                          "runId": "<runId-1>",
-                          "from": "AGENT",
-                          "payload": {
-                            "stepResult": {
-                              "reason": "stop"
-                            },
-                            "output": {
-                              "usage": {
-                                "inputTokens": 15,
-                                "outputTokens": 25,
-                                "totalTokens": 40
-                              }
-                            },
-                            "metadata": {},
-                            "messages": {
-                              "all": [],
-                              "user": [],
-                              "nonUser": []
-                            },
-                            "type": "finish"
-                          }
-                        }
-                      ]
-                    }
-                  ],
-                  [
-                    "string",
-                    "summarizer",
-                    {
-                      "inputAccumulatedText": "",
-                      "outputAccumulatedText": "",
-                      "outputChunkCount": 0,
-                      "customState": {},
-                      "streamParts": []
-                    }
-                  ]
-                ]
-              },
-              "result": {
-                "text": "Mock V2 generate response",
-                "usage": {
-                  "inputTokens": 15,
-                  "outputTokens": 25,
-                  "totalTokens": 40
-                },
-                "finishReason": "stop"
-              },
-              "retryCount": 0,
               "messages": [
                 {
-                  "id": "<id-3>",
+                  "id": "<id-2>",
                   "role": "assistant",
                   "content": {
                     "format": 2,
@@ -613,8 +429,15 @@
                   },
                   "createdAt": "<date>"
                 }
-              ]
-            }
+              ],
+              "result": {
+                "text": "Mock V2 generate response",
+                "finishReason": "stop",
+                "stepCount": 1
+              },
+              "retryCount": 0
+            },
+            "output": {}
           },
           "children": [
             {

--- a/observability/mastra/src/__snapshots__/agent-processors-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace.json
@@ -60,54 +60,6 @@
               "runId": "<runId-1>"
             },
             "input": {
-              "phase": "input",
-              "messageCount": 1
-            },
-            "output": {
-              "phase": "input",
-              "messageList": {
-                "messages": [
-                  {
-                    "role": "user",
-                    "content": [
-                      {
-                        "type": "text",
-                        "text": "  Hello! How are you?  "
-                      }
-                    ]
-                  }
-                ],
-                "systemMessages": [
-                  {
-                    "role": "system",
-                    "content": "You are a helpful assistant"
-                  }
-                ]
-              },
-              "systemMessages": [
-                {
-                  "role": "system",
-                  "content": "You are a helpful assistant"
-                }
-              ],
-              "state": {},
-              "processorStates": {
-                "__type": "Map",
-                "__map_entries": [
-                  [
-                    "string",
-                    "validator",
-                    {
-                      "inputAccumulatedText": "",
-                      "outputAccumulatedText": "",
-                      "outputChunkCount": 0,
-                      "customState": {},
-                      "streamParts": []
-                    }
-                  ]
-                ]
-              },
-              "retryCount": 0,
               "messages": [
                 {
                   "id": "<id-1>",
@@ -125,8 +77,16 @@
                     "content": "  Hello! How are you?  "
                   }
                 }
-              ]
-            }
+              ],
+              "systemMessages": [
+                {
+                  "role": "system",
+                  "content": "You are a helpful assistant"
+                }
+              ],
+              "retryCount": 0
+            },
+            "output": {}
           },
           "children": [
             {
@@ -447,136 +407,9 @@
               "runId": "<runId-1>"
             },
             "input": {
-              "phase": "outputResult",
-              "messageCount": 1
-            },
-            "output": {
-              "phase": "outputResult",
-              "messageList": {
-                "messages": [
-                  {
-                    "role": "user",
-                    "content": [
-                      {
-                        "type": "text",
-                        "text": "  Hello! How are you?  "
-                      }
-                    ]
-                  },
-                  {
-                    "role": "assistant",
-                    "content": [
-                      {
-                        "type": "text",
-                        "text": "Mock V2 stream response",
-                        "createdAt": "<date>"
-                      }
-                    ]
-                  }
-                ],
-                "systemMessages": [
-                  {
-                    "role": "system",
-                    "content": "You are a helpful assistant"
-                  }
-                ]
-              },
-              "state": {},
-              "processorStates": {
-                "__type": "Map",
-                "__map_entries": [
-                  [
-                    "string",
-                    "validator",
-                    {
-                      "inputAccumulatedText": "",
-                      "outputAccumulatedText": "",
-                      "outputChunkCount": 0,
-                      "customState": {},
-                      "streamParts": []
-                    }
-                  ],
-                  [
-                    "string",
-                    "test-agent-output-processor",
-                    {
-                      "inputAccumulatedText": "Mock V2 stream response",
-                      "outputAccumulatedText": "Mock V2 stream response",
-                      "outputChunkCount": 3,
-                      "customState": {},
-                      "streamParts": [
-                        {
-                          "type": "response-metadata",
-                          "runId": "<runId-1>",
-                          "from": "AGENT",
-                          "payload": {
-                            "type": "response-metadata",
-                            "id": "<id-2>",
-                            "modelId": "mock-model-id"
-                          }
-                        },
-                        {
-                          "type": "text-delta",
-                          "runId": "<runId-1>",
-                          "from": "AGENT",
-                          "payload": {
-                            "id": "<id-2>",
-                            "text": "Mock V2 stream response"
-                          }
-                        },
-                        {
-                          "type": "finish",
-                          "runId": "<runId-1>",
-                          "from": "AGENT",
-                          "payload": {
-                            "stepResult": {
-                              "reason": "stop"
-                            },
-                            "output": {
-                              "usage": {
-                                "inputTokens": 15,
-                                "outputTokens": 25,
-                                "totalTokens": 40
-                              }
-                            },
-                            "metadata": {},
-                            "messages": {
-                              "all": [],
-                              "user": [],
-                              "nonUser": []
-                            },
-                            "type": "finish"
-                          }
-                        }
-                      ]
-                    }
-                  ],
-                  [
-                    "string",
-                    "summarizer",
-                    {
-                      "inputAccumulatedText": "",
-                      "outputAccumulatedText": "",
-                      "outputChunkCount": 0,
-                      "customState": {},
-                      "streamParts": []
-                    }
-                  ]
-                ]
-              },
-              "result": {
-                "text": "Mock V2 stream response",
-                "usage": {
-                  "inputTokens": 15,
-                  "outputTokens": 25,
-                  "totalTokens": 40
-                },
-                "finishReason": "stop"
-              },
-              "retryCount": 0,
               "messages": [
                 {
-                  "id": "<id-3>",
+                  "id": "<id-2>",
                   "role": "assistant",
                   "content": {
                     "format": 2,
@@ -595,8 +428,15 @@
                   },
                   "createdAt": "<date>"
                 }
-              ]
-            }
+              ],
+              "result": {
+                "text": "Mock V2 stream response",
+                "finishReason": "stop",
+                "stepCount": 1
+              },
+              "retryCount": 0
+            },
+            "output": {}
           },
           "children": [
             {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -1,6 +1,6 @@
 import type { StepResult } from '@internal/ai-sdk-v5';
-import type { MastraDBMessage } from '../agent/message-list';
-import { MessageList } from '../agent/message-list';
+import type { MastraDBMessage, MessageInput } from '../agent/message-list';
+import { MessageList, messagesAreEqual } from '../agent/message-list';
 import { TripWire } from '../agent/trip-wire';
 import type { TripWireOptions } from '../agent/trip-wire';
 import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../agent/utils';
@@ -13,6 +13,13 @@ import type { RequestContext } from '../request-context';
 import type { ChunkType } from '../stream';
 import type { MastraModelOutput } from '../stream/base/output';
 import type { LanguageModelUsage } from '../stream/types';
+import {
+  summarizeActiveToolsForSpan,
+  summarizeProcessorModelForSpan,
+  summarizeProcessorResultForSpan,
+  summarizeProcessorToolsForSpan,
+  summarizeToolChoiceForSpan,
+} from './span-payload';
 import type { ProcessorStepOutput } from './step-schema';
 import { isMaybeClaude46, TrailingAssistantGuard } from './trailing-assistant-guard';
 import { isProcessorWorkflow } from './index';
@@ -113,6 +120,108 @@ export class ProcessorState<OUTPUT = undefined> {
  * Union type for processor or workflow that can be used as a processor
  */
 type ProcessorOrWorkflow = Processor | ProcessorWorkflow;
+
+function areProcessorMessageArraysEqual(before: unknown[] | undefined, after: unknown[] | undefined): boolean {
+  if (before === after) {
+    return true;
+  }
+
+  if (!before || !after) {
+    return before === after;
+  }
+
+  return (
+    before.length === after.length &&
+    before.every((message, index) => messagesAreEqual(message as MessageInput, after[index] as MessageInput))
+  );
+}
+
+function buildProcessInputStepSpanInput(args: {
+  messages: MastraDBMessage[];
+  systemMessages: unknown[];
+  stepNumber: number;
+  messageId?: string;
+  retryCount: number;
+  model: unknown;
+  tools?: unknown;
+  toolChoice?: unknown;
+  activeTools?: unknown;
+}) {
+  const summarizedModel = summarizeProcessorModelForSpan(args.model);
+  const summarizedTools = summarizeProcessorToolsForSpan(args.tools);
+  const summarizedToolChoice = summarizeToolChoiceForSpan(args.toolChoice, args.tools);
+  const summarizedActiveTools = summarizeActiveToolsForSpan(args.activeTools, args.tools);
+
+  return {
+    messages: args.messages,
+    systemMessages: args.systemMessages,
+    stepNumber: args.stepNumber,
+    ...(args.messageId ? { messageId: args.messageId } : {}),
+    retryCount: args.retryCount,
+    ...(summarizedModel ? { model: summarizedModel } : {}),
+    ...(summarizedTools ? { tools: summarizedTools } : {}),
+    ...(summarizedToolChoice ? { toolChoice: summarizedToolChoice } : {}),
+    ...(summarizedActiveTools ? { activeTools: summarizedActiveTools } : {}),
+  };
+}
+
+function buildProcessInputStepSpanOutput(args: {
+  result: RunProcessInputStepResult;
+  beforeStepInput: Pick<RunProcessInputStepResult, 'messageId' | 'model' | 'tools' | 'toolChoice' | 'activeTools'>;
+  afterStepInput: RunProcessInputStepResult;
+  beforeMessages: MastraDBMessage[];
+  beforeSystemMessages: unknown[];
+  messages: MastraDBMessage[];
+  systemMessages: unknown[];
+}) {
+  const output: Record<string, unknown> = {};
+
+  if (!areProcessorMessageArraysEqual(args.beforeMessages, args.messages)) {
+    output.messages = args.messages;
+  }
+
+  if (!areProcessorMessageArraysEqual(args.beforeSystemMessages, args.systemMessages)) {
+    output.systemMessages = args.systemMessages;
+  }
+
+  if (args.afterStepInput.messageId !== args.beforeStepInput.messageId) {
+    output.messageId = args.afterStepInput.messageId;
+  }
+
+  if (args.result.model !== undefined || args.afterStepInput.model !== args.beforeStepInput.model) {
+    const model = summarizeProcessorModelForSpan(args.afterStepInput.model);
+    if (model) {
+      output.model = model;
+    }
+  }
+
+  if (args.result.tools !== undefined || args.afterStepInput.tools !== args.beforeStepInput.tools) {
+    const tools = summarizeProcessorToolsForSpan(args.afterStepInput.tools);
+    if (tools) {
+      output.tools = tools;
+    }
+  }
+
+  if (args.result.toolChoice !== undefined || args.afterStepInput.toolChoice !== args.beforeStepInput.toolChoice) {
+    const toolChoice = summarizeToolChoiceForSpan(args.afterStepInput.toolChoice, args.afterStepInput.tools);
+    if (toolChoice) {
+      output.toolChoice = toolChoice;
+    }
+  }
+
+  if (args.result.activeTools !== undefined || args.afterStepInput.activeTools !== args.beforeStepInput.activeTools) {
+    const activeTools = summarizeActiveToolsForSpan(args.afterStepInput.activeTools, args.afterStepInput.tools);
+    if (activeTools) {
+      output.activeTools = activeTools;
+    }
+  }
+
+  if (args.result.retryCount !== undefined) {
+    output.retryCount = args.result.retryCount;
+  }
+
+  return output;
+}
 
 export class ProcessorRunner {
   public readonly inputProcessors: ProcessorOrWorkflow[];
@@ -299,6 +408,15 @@ export class ProcessorRunner {
         continue;
       }
 
+      const defaultResult: OutputResult = {
+        text: '',
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        finishReason: 'unknown',
+        steps: [],
+      };
+      const outputMessagesBefore = processableMessages;
+      const outputSystemMessagesBefore = messageList.getAllSystemMessages();
+      const summarizedResult = summarizeProcessorResultForSpan(result ?? defaultResult);
       const currentSpan = observabilityContext?.tracingContext?.currentSpan;
       const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
       const processorSpan = parentSpan?.createChildSpan({
@@ -311,7 +429,10 @@ export class ProcessorRunner {
           processorExecutor: 'legacy',
           processorIndex: index,
         },
-        input: processableMessages,
+        input: {
+          messages: processableMessages,
+          ...(summarizedResult ? { result: summarizedResult } : {}),
+        },
       });
 
       // Start recording MessageList mutations for this processor
@@ -320,13 +441,6 @@ export class ProcessorRunner {
       try {
         // Get per-processor state that persists across all method calls within this request
         const processorState = this.getProcessorState(processor.id);
-
-        const defaultResult: OutputResult = {
-          text: '',
-          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-          finishReason: 'unknown',
-          steps: [],
-        };
 
         const processResult = await processMethod({
           messages: processableMessages,
@@ -373,7 +487,14 @@ export class ProcessorRunner {
         }
 
         processorSpan?.end({
-          output: processableMessages,
+          output: {
+            ...(!areProcessorMessageArraysEqual(outputMessagesBefore, processableMessages)
+              ? { messages: processableMessages }
+              : {}),
+            ...(!areProcessorMessageArraysEqual(outputSystemMessagesBefore, messageList.getAllSystemMessages())
+              ? { systemMessages: messageList.getAllSystemMessages() }
+              : {}),
+          },
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
         });
       } catch (error) {
@@ -686,6 +807,9 @@ export class ProcessorRunner {
         continue;
       }
 
+      const currentSystemMessages = messageList.getAllSystemMessages();
+      const inputMessagesBefore = processableMessages;
+      const inputSystemMessagesBefore = currentSystemMessages;
       const currentSpan = observabilityContext?.tracingContext?.currentSpan;
       const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
       const processorSpan = parentSpan?.createChildSpan({
@@ -698,16 +822,16 @@ export class ProcessorRunner {
           processorExecutor: 'legacy',
           processorIndex: index,
         },
-        input: processableMessages,
+        input: {
+          messages: processableMessages,
+          systemMessages: currentSystemMessages,
+        },
       });
 
       // Start recording MessageList mutations for this processor
       messageList.startRecording();
 
       try {
-        // Get all system messages to pass to the processor
-        const currentSystemMessages = messageList.getAllSystemMessages();
-
         // Get per-processor state that persists across all method calls within this request
         const processorState = this.getProcessorState(processor.id);
 
@@ -825,7 +949,14 @@ export class ProcessorRunner {
         }
 
         processorSpan?.end({
-          output: processableMessages,
+          output: {
+            ...(!areProcessorMessageArraysEqual(inputMessagesBefore, processableMessages)
+              ? { messages: processableMessages }
+              : {}),
+            ...(!areProcessorMessageArraysEqual(inputSystemMessagesBefore, messageList.getAllSystemMessages())
+              ? { systemMessages: messageList.getAllSystemMessages() }
+              : {}),
+          },
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
         });
       } catch (error) {
@@ -974,14 +1105,17 @@ export class ProcessorRunner {
           processorExecutor: 'legacy',
           processorIndex: index,
         },
-        input: {
-          ...inputData,
-          model: {
-            id: inputData.model.modelId,
-            provider: inputData.model.provider,
-            specificationVersion: inputData.model.specificationVersion,
-          },
-        },
+        input: buildProcessInputStepSpanInput({
+          messages: inputData.messages,
+          systemMessages: inputData.systemMessages,
+          stepNumber: inputData.stepNumber,
+          messageId: inputData.messageId,
+          retryCount: args.retryCount ?? 0,
+          model: inputData.model,
+          tools: inputData.tools,
+          toolChoice: inputData.toolChoice,
+          activeTools: inputData.activeTools,
+        }),
       });
 
       // Start recording MessageList mutations for this processor
@@ -990,6 +1124,13 @@ export class ProcessorRunner {
       try {
         // Get per-processor state that persists across all method calls within this request
         const processorState = this.getProcessorState(processor.id);
+        const beforeStepInput = {
+          messageId: inputData.messageId,
+          model: inputData.model,
+          tools: inputData.tools,
+          toolChoice: inputData.toolChoice,
+          activeTools: inputData.activeTools,
+        };
 
         const processMethodArgs = {
           messageList,
@@ -1032,18 +1173,15 @@ export class ProcessorRunner {
         const mutations = messageList.stopRecording();
 
         processorSpan?.end({
-          output: {
-            ...stepInput,
+          output: buildProcessInputStepSpanOutput({
+            result,
+            beforeStepInput,
+            afterStepInput: stepInput,
+            beforeMessages: inputData.messages,
+            beforeSystemMessages: inputData.systemMessages,
             messages: messageList.get.all.db(),
             systemMessages: messageList.getAllSystemMessages(),
-            model: stepInput.model
-              ? {
-                  modelId: stepInput.model.modelId,
-                  provider: stepInput.model.provider,
-                  specificationVersion: stepInput.model.specificationVersion,
-                }
-              : undefined,
-          },
+          }),
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
         });
       } catch (error) {
@@ -1180,6 +1318,12 @@ export class ProcessorRunner {
         throw new TripWire(reason || `Tripwire triggered by ${processor.id}`, options, processor.id);
       };
 
+      const currentSystemMessages = messageList.getAllSystemMessages();
+      const defaultUsage: LanguageModelUsage = {
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      };
       const currentSpan = observabilityContext.tracingContext?.currentSpan;
       const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
       const processorSpan = parentSpan?.createChildSpan({
@@ -1192,24 +1336,23 @@ export class ProcessorRunner {
           processorExecutor: 'legacy',
           processorIndex: index,
         },
-        input: { messages: processableMessages, stepNumber, finishReason, toolCalls, text },
+        input: {
+          messages: processableMessages,
+          systemMessages: currentSystemMessages,
+          stepNumber,
+          ...(finishReason !== undefined ? { finishReason } : {}),
+          ...(toolCalls !== undefined ? { toolCalls } : {}),
+          ...(text !== undefined ? { text } : {}),
+        },
       });
 
       // Start recording MessageList mutations for this processor
       messageList.startRecording();
 
-      // Get all system messages to pass to the processor
-      const currentSystemMessages = messageList.getAllSystemMessages();
-
       // Get or create processor state (persists across steps within a request)
       const processorState = this.getProcessorState(processor.id);
 
       try {
-        const defaultUsage: LanguageModelUsage = {
-          inputTokens: undefined,
-          outputTokens: undefined,
-          totalTokens: undefined,
-        };
         const result = await processMethod({
           messages: processableMessages,
           messageList,
@@ -1267,7 +1410,14 @@ export class ProcessorRunner {
         }
 
         processorSpan?.end({
-          output: messageList.get.all.db(),
+          output: {
+            ...(!areProcessorMessageArraysEqual(processableMessages, messageList.get.all.db())
+              ? { messages: messageList.get.all.db() }
+              : {}),
+            ...(!areProcessorMessageArraysEqual(currentSystemMessages, messageList.getAllSystemMessages())
+              ? { systemMessages: messageList.getAllSystemMessages() }
+              : {}),
+          },
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
         });
       } catch (error) {
@@ -1344,6 +1494,7 @@ export class ProcessorRunner {
         throw new TripWire(reason || `Tripwire triggered by ${processor.id}`, options, processor.id);
       };
 
+      const processableMessages: MastraDBMessage[] = messageList.get.all.db();
       const currentSpan = observabilityContext.tracingContext?.currentSpan;
       const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
       const processorSpan = parentSpan?.createChildSpan({
@@ -1356,13 +1507,17 @@ export class ProcessorRunner {
           processorExecutor: 'legacy',
           processorIndex: index,
         },
-        input: { error: error instanceof Error ? error.message : String(error), stepNumber },
+        input: {
+          messages: processableMessages,
+          error: error instanceof Error ? error.message : String(error),
+          stepNumber,
+          ...(args.messageId ? { messageId: args.messageId } : {}),
+          retryCount,
+        },
       });
 
       // Start recording MessageList mutations for this processor
       messageList.startRecording();
-
-      const processableMessages: MastraDBMessage[] = messageList.get.all.db();
 
       // Get or create processor state (persists across steps within a request)
       const processorState = this.getProcessorState(processor.id);

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -202,14 +202,22 @@ function buildProcessInputStepSpanOutput(args: {
     }
   }
 
-  if (args.result.toolChoice !== undefined || args.afterStepInput.toolChoice !== args.beforeStepInput.toolChoice) {
+  if (
+    args.result.toolChoice !== undefined ||
+    args.afterStepInput.toolChoice !== args.beforeStepInput.toolChoice ||
+    args.afterStepInput.tools !== args.beforeStepInput.tools
+  ) {
     const toolChoice = summarizeToolChoiceForSpan(args.afterStepInput.toolChoice, args.afterStepInput.tools);
     if (toolChoice) {
       output.toolChoice = toolChoice;
     }
   }
 
-  if (args.result.activeTools !== undefined || args.afterStepInput.activeTools !== args.beforeStepInput.activeTools) {
+  if (
+    args.result.activeTools !== undefined ||
+    args.afterStepInput.activeTools !== args.beforeStepInput.activeTools ||
+    args.afterStepInput.tools !== args.beforeStepInput.tools
+  ) {
     const activeTools = summarizeActiveToolsForSpan(args.afterStepInput.activeTools, args.afterStepInput.tools);
     if (activeTools) {
       output.activeTools = activeTools;
@@ -408,15 +416,15 @@ export class ProcessorRunner {
         continue;
       }
 
+      const outputMessagesBefore = processableMessages;
+      const outputSystemMessagesBefore = messageList.getAllSystemMessages();
       const defaultResult: OutputResult = {
         text: '',
         usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
         finishReason: 'unknown',
         steps: [],
       };
-      const outputMessagesBefore = processableMessages;
-      const outputSystemMessagesBefore = messageList.getAllSystemMessages();
-      const summarizedResult = summarizeProcessorResultForSpan(result ?? defaultResult);
+      const summarizedResult = result ? summarizeProcessorResultForSpan(result) : undefined;
       const currentSpan = observabilityContext?.tracingContext?.currentSpan;
       const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
       const processorSpan = parentSpan?.createChildSpan({
@@ -1498,6 +1506,7 @@ export class ProcessorRunner {
       const processableMessages: MastraDBMessage[] = messageList.get.all.db();
       const systemMessagesBefore = messageList.getAllSystemMessages();
       const messageIdBefore = args.messageId;
+      let messageIdAfter = args.messageId;
       const currentSpan = observabilityContext.tracingContext?.currentSpan;
       const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
       const processorSpan = parentSpan?.createChildSpan({
@@ -1542,7 +1551,11 @@ export class ProcessorRunner {
           messageId: args.messageId,
           ...(args.rotateResponseMessageId
             ? {
-                rotateResponseMessageId: args.rotateResponseMessageId,
+                rotateResponseMessageId: () => {
+                  const nextMessageId = args.rotateResponseMessageId!();
+                  messageIdAfter = nextMessageId;
+                  return nextMessageId;
+                },
               }
             : {}),
         });
@@ -1551,8 +1564,6 @@ export class ProcessorRunner {
         const mutations = messageList.stopRecording();
         const messagesAfter = messageList.get.all.db();
         const systemMessagesAfter = messageList.getAllSystemMessages();
-        const messageIdAfter = args.messageId;
-
         const output: Record<string, unknown> = {
           retry: result?.retry ?? false,
         };

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -432,6 +432,7 @@ export class ProcessorRunner {
         input: {
           messages: processableMessages,
           ...(summarizedResult ? { result: summarizedResult } : {}),
+          retryCount,
         },
       });
 
@@ -1495,6 +1496,8 @@ export class ProcessorRunner {
       };
 
       const processableMessages: MastraDBMessage[] = messageList.get.all.db();
+      const systemMessagesBefore = messageList.getAllSystemMessages();
+      const messageIdBefore = args.messageId;
       const currentSpan = observabilityContext.tracingContext?.currentSpan;
       const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
       const processorSpan = parentSpan?.createChildSpan({
@@ -1546,9 +1549,28 @@ export class ProcessorRunner {
 
         // Stop recording and get mutations for this processor
         const mutations = messageList.stopRecording();
+        const messagesAfter = messageList.get.all.db();
+        const systemMessagesAfter = messageList.getAllSystemMessages();
+        const messageIdAfter = args.messageId;
+
+        const output: Record<string, unknown> = {
+          retry: result?.retry ?? false,
+        };
+
+        if (!areProcessorMessageArraysEqual(processableMessages, messagesAfter)) {
+          output.messages = messagesAfter;
+        }
+
+        if (!areProcessorMessageArraysEqual(systemMessagesBefore, systemMessagesAfter)) {
+          output.systemMessages = systemMessagesAfter;
+        }
+
+        if (messageIdAfter !== messageIdBefore) {
+          output.messageId = messageIdAfter;
+        }
 
         processorSpan?.end({
-          output: { retry: result?.retry ?? false },
+          output,
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
         });
 

--- a/packages/core/src/processors/span-payload.test.ts
+++ b/packages/core/src/processors/span-payload.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  summarizeActiveToolsForSpan,
+  summarizeProcessorModelForSpan,
+  summarizeProcessorResultForSpan,
+  summarizeProcessorToolsForSpan,
+  summarizeToolChoiceForSpan,
+} from './span-payload';
+
+describe('processor span summaries', () => {
+  it('summarizes models to the standard safe shape', () => {
+    expect(
+      summarizeProcessorModelForSpan({
+        modelId: 'gpt-test',
+        provider: 'openai',
+        specificationVersion: 'v2',
+        apiKey: 'secret',
+      }),
+    ).toEqual({
+      modelId: 'gpt-test',
+      provider: 'openai',
+      specificationVersion: 'v2',
+    });
+
+    expect(
+      summarizeProcessorModelForSpan({
+        id: 'legacy-model',
+        provider: 'anthropic',
+        specificationVersion: 'v1',
+      }),
+    ).toEqual({
+      modelId: 'legacy-model',
+      provider: 'anthropic',
+      specificationVersion: 'v1',
+    });
+  });
+
+  it('summarizes tools and active tools with ids and names', () => {
+    const tools = {
+      weather: {
+        id: 'weather-tool',
+        name: 'Weather Tool',
+        description: 'Checks the weather',
+        client: { token: 'secret' },
+      },
+      search: {
+        description: 'Searches the web',
+      },
+    };
+
+    expect(summarizeProcessorToolsForSpan(tools)).toEqual([
+      {
+        id: 'weather-tool',
+        name: 'Weather Tool',
+        description: 'Checks the weather',
+      },
+      {
+        id: 'search',
+        name: 'search',
+        description: 'Searches the web',
+      },
+    ]);
+
+    expect(summarizeActiveToolsForSpan(['weather-tool', 'search'], tools)).toEqual([
+      {
+        id: 'weather-tool',
+        name: 'Weather Tool',
+      },
+      {
+        id: 'search',
+        name: 'search',
+      },
+    ]);
+  });
+
+  it('normalizes toolChoice to a stable object shape', () => {
+    const tools = {
+      weather: {
+        id: 'weather-tool',
+        name: 'Weather Tool',
+      },
+    };
+
+    expect(summarizeToolChoiceForSpan('auto', tools)).toEqual({ type: 'auto' });
+    expect(summarizeToolChoiceForSpan({ type: 'tool', toolName: 'weather-tool' }, tools)).toEqual({
+      type: 'tool',
+      tool: {
+        id: 'weather-tool',
+        name: 'Weather Tool',
+      },
+    });
+  });
+
+  it('summarizes output results without carrying raw step arrays', () => {
+    expect(
+      summarizeProcessorResultForSpan({
+        text: 'done',
+        finishReason: 'stop',
+        toolCalls: [{ toolName: 'weather' }],
+        steps: [{ text: 'step 1' }, { text: 'step 2' }],
+        providerOptions: { headers: { Authorization: 'Bearer secret' } },
+      }),
+    ).toEqual({
+      text: 'done',
+      finishReason: 'stop',
+      toolCalls: [{ toolName: 'weather' }],
+      stepCount: 2,
+    });
+  });
+});

--- a/packages/core/src/processors/span-payload.test.ts
+++ b/packages/core/src/processors/span-payload.test.ts
@@ -83,6 +83,9 @@ describe('processor span summaries', () => {
         name: 'search',
       },
     ]);
+
+    expect(summarizeProcessorToolsForSpan({})).toEqual([]);
+    expect(summarizeActiveToolsForSpan([], tools)).toEqual([]);
   });
 
   it('normalizes toolChoice to a stable object shape', () => {

--- a/packages/core/src/processors/span-payload.test.ts
+++ b/packages/core/src/processors/span-payload.test.ts
@@ -72,6 +72,17 @@ describe('processor span summaries', () => {
         name: 'search',
       },
     ]);
+
+    expect(summarizeActiveToolsForSpan(['weather', 'search'], tools)).toEqual([
+      {
+        id: 'weather-tool',
+        name: 'Weather Tool',
+      },
+      {
+        id: 'search',
+        name: 'search',
+      },
+    ]);
   });
 
   it('normalizes toolChoice to a stable object shape', () => {
@@ -84,6 +95,13 @@ describe('processor span summaries', () => {
 
     expect(summarizeToolChoiceForSpan('auto', tools)).toEqual({ type: 'auto' });
     expect(summarizeToolChoiceForSpan({ type: 'tool', toolName: 'weather-tool' }, tools)).toEqual({
+      type: 'tool',
+      tool: {
+        id: 'weather-tool',
+        name: 'Weather Tool',
+      },
+    });
+    expect(summarizeToolChoiceForSpan({ type: 'tool', toolName: 'weather' }, tools)).toEqual({
       type: 'tool',
       tool: {
         id: 'weather-tool',

--- a/packages/core/src/processors/span-payload.ts
+++ b/packages/core/src/processors/span-payload.ts
@@ -1,0 +1,170 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+type ProcessorToolSummary = {
+  id: string;
+  name: string;
+  description?: string;
+};
+
+type ActiveToolSummary = {
+  id: string;
+  name: string;
+};
+
+function summarizeProcessorToolEntry(key: string, value: unknown): ProcessorToolSummary {
+  if (!isPlainObject(value)) {
+    return {
+      id: key,
+      name: key,
+    };
+  }
+
+  const id = readString(value.id) ?? key;
+  const name = readString(value.name) ?? id;
+  const description = readString(value.description);
+
+  return {
+    id,
+    name,
+    ...(description !== undefined ? { description } : {}),
+  };
+}
+
+export function summarizeProcessorModelForSpan(value: unknown):
+  | {
+      modelId?: string;
+      provider?: string;
+      specificationVersion?: string;
+    }
+  | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const modelId = readString(value.modelId) ?? readString(value.id);
+  const provider = readString(value.provider);
+  const specificationVersion = readString(value.specificationVersion);
+
+  if (modelId === undefined && provider === undefined && specificationVersion === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...(modelId !== undefined ? { modelId } : {}),
+    ...(provider !== undefined ? { provider } : {}),
+    ...(specificationVersion !== undefined ? { specificationVersion } : {}),
+  };
+}
+
+export function summarizeProcessorToolsForSpan(tools: unknown): ProcessorToolSummary[] | undefined {
+  if (!isPlainObject(tools)) {
+    return undefined;
+  }
+
+  const summaries = Object.entries(tools).map(([key, value]) => summarizeProcessorToolEntry(key, value));
+  return summaries.length > 0 ? summaries : undefined;
+}
+
+export function summarizeActiveToolsForSpan(activeTools: unknown, tools?: unknown): ActiveToolSummary[] | undefined {
+  if (!Array.isArray(activeTools)) {
+    return undefined;
+  }
+
+  const toolSummaries = summarizeProcessorToolsForSpan(tools) ?? [];
+  const summaries = activeTools
+    .map(tool => {
+      const toolKey = readString(tool);
+      if (toolKey === undefined) {
+        return undefined;
+      }
+
+      const match = toolSummaries.find(summary => summary.id === toolKey || summary.name === toolKey);
+      return {
+        id: match?.id ?? toolKey,
+        name: match?.name ?? toolKey,
+      };
+    })
+    .filter((tool): tool is ActiveToolSummary => tool !== undefined);
+
+  return summaries.length > 0 ? summaries : undefined;
+}
+
+export function summarizeToolChoiceForSpan(
+  toolChoice: unknown,
+  tools?: unknown,
+):
+  | {
+      type: string;
+      tool?: ActiveToolSummary;
+    }
+  | undefined {
+  if (typeof toolChoice === 'string') {
+    return { type: toolChoice };
+  }
+
+  if (!isPlainObject(toolChoice)) {
+    return undefined;
+  }
+
+  const type = readString(toolChoice.type);
+  if (type === undefined) {
+    return undefined;
+  }
+
+  if (type !== 'tool') {
+    return { type };
+  }
+
+  const toolKey = readString(toolChoice.toolName) ?? readString(toolChoice.toolId);
+  if (toolKey === undefined) {
+    return { type };
+  }
+
+  const tool = summarizeActiveToolsForSpan([toolKey], tools)?.[0];
+  return {
+    type,
+    ...(tool ? { tool } : {}),
+  };
+}
+
+export function summarizeProcessorResultForSpan(value: unknown): Record<string, unknown> | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const projected: Record<string, unknown> = {};
+  for (const key of [
+    'text',
+    'object',
+    'finishReason',
+    'toolCalls',
+    'toolResults',
+    'warnings',
+    'files',
+    'sources',
+    'reasoning',
+    'reasoningText',
+    'tripwire',
+  ] as const) {
+    if (value[key] !== undefined) {
+      projected[key] = value[key];
+    }
+  }
+
+  if (Array.isArray(value.steps)) {
+    projected.stepCount = value.steps.length;
+  }
+
+  return Object.keys(projected).length > 0 ? projected : undefined;
+}

--- a/packages/core/src/processors/span-payload.ts
+++ b/packages/core/src/processors/span-payload.ts
@@ -76,12 +76,30 @@ export function summarizeProcessorToolsForSpan(tools: unknown): ProcessorToolSum
   return summaries.length > 0 ? summaries : undefined;
 }
 
+function summarizeProcessorToolRegistry(
+  tools: unknown,
+): Array<{ registryKey: string; summary: ProcessorToolSummary }> | undefined {
+  if (!isPlainObject(tools)) {
+    return undefined;
+  }
+
+  const summaries = summarizeProcessorToolsForSpan(tools);
+  if (!summaries) {
+    return undefined;
+  }
+
+  return Object.keys(tools).map((registryKey, index) => ({
+    registryKey,
+    summary: summaries[index]!,
+  }));
+}
+
 export function summarizeActiveToolsForSpan(activeTools: unknown, tools?: unknown): ActiveToolSummary[] | undefined {
   if (!Array.isArray(activeTools)) {
     return undefined;
   }
 
-  const toolSummaries = summarizeProcessorToolsForSpan(tools) ?? [];
+  const toolRegistry = summarizeProcessorToolRegistry(tools) ?? [];
   const summaries = activeTools
     .map(tool => {
       const toolKey = readString(tool);
@@ -89,10 +107,13 @@ export function summarizeActiveToolsForSpan(activeTools: unknown, tools?: unknow
         return undefined;
       }
 
-      const match = toolSummaries.find(summary => summary.id === toolKey || summary.name === toolKey);
+      const match = toolRegistry.find(
+        candidate =>
+          candidate.summary.id === toolKey || candidate.summary.name === toolKey || candidate.registryKey === toolKey,
+      );
       return {
-        id: match?.id ?? toolKey,
-        name: match?.name ?? toolKey,
+        id: match?.summary.id ?? toolKey,
+        name: match?.summary.name ?? toolKey,
       };
     })
     .filter((tool): tool is ActiveToolSummary => tool !== undefined);
@@ -131,10 +152,22 @@ export function summarizeToolChoiceForSpan(
     return { type };
   }
 
-  const tool = summarizeActiveToolsForSpan([toolKey], tools)?.[0];
+  const toolRegistry = summarizeProcessorToolRegistry(tools) ?? [];
+  const match = toolRegistry.find(
+    candidate =>
+      candidate.summary.id === toolKey || candidate.summary.name === toolKey || candidate.registryKey === toolKey,
+  );
+
   return {
     type,
-    ...(tool ? { tool } : {}),
+    ...(match
+      ? {
+          tool: {
+            id: match.summary.id,
+            name: match.summary.name,
+          },
+        }
+      : {}),
   };
 }
 

--- a/packages/core/src/processors/span-payload.ts
+++ b/packages/core/src/processors/span-payload.ts
@@ -157,17 +157,20 @@ export function summarizeToolChoiceForSpan(
     candidate =>
       candidate.summary.id === toolKey || candidate.summary.name === toolKey || candidate.registryKey === toolKey,
   );
+  const fallbackToolId = readString(toolChoice.toolId) ?? toolKey;
+  const fallbackToolName = readString(toolChoice.toolName) ?? toolKey;
 
   return {
     type,
-    ...(match
+    tool: match
       ? {
-          tool: {
-            id: match.summary.id,
-            name: match.summary.name,
-          },
+          id: match.summary.id,
+          name: match.summary.name,
         }
-      : {}),
+      : {
+          id: fallbackToolId,
+          name: fallbackToolName,
+        },
   };
 }
 

--- a/packages/core/src/processors/span-payload.ts
+++ b/packages/core/src/processors/span-payload.ts
@@ -72,8 +72,7 @@ export function summarizeProcessorToolsForSpan(tools: unknown): ProcessorToolSum
     return undefined;
   }
 
-  const summaries = Object.entries(tools).map(([key, value]) => summarizeProcessorToolEntry(key, value));
-  return summaries.length > 0 ? summaries : undefined;
+  return Object.entries(tools).map(([key, value]) => summarizeProcessorToolEntry(key, value));
 }
 
 function summarizeProcessorToolRegistry(
@@ -94,6 +93,16 @@ function summarizeProcessorToolRegistry(
   }));
 }
 
+function resolveToolInRegistry(
+  toolRegistry: Array<{ registryKey: string; summary: ProcessorToolSummary }>,
+  toolKey: string,
+) {
+  return toolRegistry.find(
+    candidate =>
+      candidate.summary.id === toolKey || candidate.summary.name === toolKey || candidate.registryKey === toolKey,
+  );
+}
+
 export function summarizeActiveToolsForSpan(activeTools: unknown, tools?: unknown): ActiveToolSummary[] | undefined {
   if (!Array.isArray(activeTools)) {
     return undefined;
@@ -107,10 +116,7 @@ export function summarizeActiveToolsForSpan(activeTools: unknown, tools?: unknow
         return undefined;
       }
 
-      const match = toolRegistry.find(
-        candidate =>
-          candidate.summary.id === toolKey || candidate.summary.name === toolKey || candidate.registryKey === toolKey,
-      );
+      const match = resolveToolInRegistry(toolRegistry, toolKey);
       return {
         id: match?.summary.id ?? toolKey,
         name: match?.summary.name ?? toolKey,
@@ -118,7 +124,7 @@ export function summarizeActiveToolsForSpan(activeTools: unknown, tools?: unknow
     })
     .filter((tool): tool is ActiveToolSummary => tool !== undefined);
 
-  return summaries.length > 0 ? summaries : undefined;
+  return summaries;
 }
 
 export function summarizeToolChoiceForSpan(
@@ -153,10 +159,7 @@ export function summarizeToolChoiceForSpan(
   }
 
   const toolRegistry = summarizeProcessorToolRegistry(tools) ?? [];
-  const match = toolRegistry.find(
-    candidate =>
-      candidate.summary.id === toolKey || candidate.summary.name === toolKey || candidate.registryKey === toolKey,
-  );
+  const match = resolveToolInRegistry(toolRegistry, toolKey);
   const fallbackToolId = readString(toolChoice.toolId) ?? toolKey;
   const fallbackToolName = readString(toolChoice.toolName) ?? toolKey;
 

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -4,7 +4,8 @@ import type { CoreMessage } from '@internal/ai-sdk-v4';
 import { z } from 'zod/v4';
 import { Agent } from '../../agent';
 import type { MastraDBMessage } from '../../agent';
-import { MessageList } from '../../agent/message-list';
+import { MessageList, messagesAreEqual } from '../../agent/message-list';
+import type { MessageInput } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
 import { isSupportedLanguageModel } from '../../agent/utils';
 import { RequestContext } from '../../di';
@@ -17,6 +18,13 @@ import type { ObservabilityContext } from '../../observability';
 import { executeWithContext } from '../../observability/utils';
 import type { OutputResult, Processor } from '../../processors';
 import { ProcessorRunner, ProcessorState, ProcessorStepOutputSchema, ProcessorStepSchema } from '../../processors';
+import {
+  summarizeActiveToolsForSpan,
+  summarizeProcessorModelForSpan,
+  summarizeProcessorResultForSpan,
+  summarizeProcessorToolsForSpan,
+  summarizeToolChoiceForSpan,
+} from '../../processors/span-payload';
 import type { ProcessorStepOutput } from '../../processors/step-schema';
 import { toStandardSchema } from '../../schema';
 import type { InferPublicSchema, InferStandardSchemaOutput, PublicSchema, StandardSchemaWithJSON } from '../../schema';
@@ -147,6 +155,21 @@ function isProcessor(obj: unknown): obj is Processor {
       typeof (obj as any).processOutputStream === 'function' ||
       typeof (obj as any).processOutputResult === 'function' ||
       typeof (obj as any).processOutputStep === 'function')
+  );
+}
+
+function areProcessorMessageArraysEqual(before: unknown[] | undefined, after: unknown[] | undefined): boolean {
+  if (before === after) {
+    return true;
+  }
+
+  if (!before || !after) {
+    return before === after;
+  }
+
+  return (
+    before.length === after.length &&
+    before.every((message, index) => messagesAreEqual(message as MessageInput, after[index] as MessageInput))
   );
 }
 
@@ -764,6 +787,7 @@ function createStepFromProcessor<TProcessorId extends string>(
       const abort = (reason?: string, options?: { retry?: boolean; metadata?: unknown }): never => {
         throw new TripWire(reason || `Tripwire triggered by ${processor.id}`, options, processor.id);
       };
+      const initialMessageId = messageId;
       let currentMessageId = messageId;
       const rotateCurrentResponseMessageId = rotateResponseMessageId
         ? () => {
@@ -771,6 +795,152 @@ function createStepFromProcessor<TProcessorId extends string>(
             return currentMessageId;
           }
         : undefined;
+      const defaultOutputResult: OutputResult = {
+        text: '',
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        finishReason: 'unknown',
+        steps: [],
+      };
+
+      const buildProcessorSpanInput = () => {
+        switch (phase) {
+          case 'input':
+            return {
+              messages: (messages as MastraDBMessage[]) ?? [],
+              ...(systemMessages ? { systemMessages } : {}),
+              ...(retryCount !== undefined ? { retryCount } : {}),
+            };
+          case 'inputStep': {
+            const summarizedModel = summarizeProcessorModelForSpan(model);
+            const summarizedTools = summarizeProcessorToolsForSpan(tools);
+            const summarizedToolChoice = summarizeToolChoiceForSpan(toolChoice, tools);
+            const summarizedActiveTools = summarizeActiveToolsForSpan(activeTools, tools);
+
+            return {
+              messages: (messages as MastraDBMessage[]) ?? [],
+              ...(systemMessages ? { systemMessages } : {}),
+              ...(stepNumber !== undefined ? { stepNumber } : {}),
+              ...(currentMessageId ? { messageId: currentMessageId } : {}),
+              ...(retryCount !== undefined ? { retryCount } : {}),
+              ...(summarizedModel ? { model: summarizedModel } : {}),
+              ...(summarizedTools ? { tools: summarizedTools } : {}),
+              ...(summarizedToolChoice ? { toolChoice: summarizedToolChoice } : {}),
+              ...(summarizedActiveTools ? { activeTools: summarizedActiveTools } : {}),
+            };
+          }
+          case 'outputResult': {
+            const summarizedResult = summarizeProcessorResultForSpan(outputResult ?? defaultOutputResult);
+
+            return {
+              messages: (messages as MastraDBMessage[]) ?? [],
+              ...(summarizedResult ? { result: summarizedResult } : {}),
+              ...(retryCount !== undefined ? { retryCount } : {}),
+            };
+          }
+          case 'outputStep':
+            return {
+              messages: (messages as MastraDBMessage[]) ?? [],
+              ...(systemMessages ? { systemMessages } : {}),
+              ...(stepNumber !== undefined ? { stepNumber } : {}),
+              ...(finishReason !== undefined ? { finishReason } : {}),
+              ...(text !== undefined ? { text } : {}),
+              ...(toolCalls !== undefined ? { toolCalls } : {}),
+              ...(retryCount !== undefined ? { retryCount } : {}),
+            };
+          default:
+            return undefined;
+        }
+      };
+
+      const buildProcessorSpanOutput = (result: unknown) => {
+        if (result === null || typeof result !== 'object' || Array.isArray(result)) {
+          return result;
+        }
+
+        const payload = result as Record<string, unknown>;
+        switch (phase) {
+          case 'input':
+            return {
+              ...(Array.isArray(payload.messages) &&
+              !areProcessorMessageArraysEqual(messages as unknown[] | undefined, payload.messages)
+                ? { messages: payload.messages }
+                : {}),
+              ...(Array.isArray(payload.systemMessages) &&
+              !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
+                ? { systemMessages: payload.systemMessages }
+                : {}),
+            };
+          case 'inputStep': {
+            const output: Record<string, unknown> = {};
+
+            if (
+              Array.isArray(payload.messages) &&
+              !areProcessorMessageArraysEqual(messages as unknown[] | undefined, payload.messages)
+            ) {
+              output.messages = payload.messages;
+            }
+
+            if (
+              Array.isArray(payload.systemMessages) &&
+              !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
+            ) {
+              output.systemMessages = payload.systemMessages;
+            }
+
+            if (payload.messageId !== undefined && payload.messageId !== initialMessageId) {
+              output.messageId = payload.messageId;
+            }
+
+            if (payload.model !== undefined && payload.model !== model) {
+              const summarizedModel = summarizeProcessorModelForSpan(payload.model);
+              if (summarizedModel) {
+                output.model = summarizedModel;
+              }
+            }
+
+            if (payload.tools !== undefined && payload.tools !== tools) {
+              const summarizedTools = summarizeProcessorToolsForSpan(payload.tools);
+              if (summarizedTools) {
+                output.tools = summarizedTools;
+              }
+            }
+
+            if (payload.toolChoice !== undefined && payload.toolChoice !== toolChoice) {
+              const summarizedToolChoice = summarizeToolChoiceForSpan(payload.toolChoice, payload.tools ?? tools);
+              if (summarizedToolChoice) {
+                output.toolChoice = summarizedToolChoice;
+              }
+            }
+
+            if (payload.activeTools !== undefined && payload.activeTools !== activeTools) {
+              const summarizedActiveTools = summarizeActiveToolsForSpan(payload.activeTools, payload.tools ?? tools);
+              if (summarizedActiveTools) {
+                output.activeTools = summarizedActiveTools;
+              }
+            }
+
+            if (payload.retryCount !== undefined && payload.retryCount !== retryCount) {
+              output.retryCount = payload.retryCount;
+            }
+
+            return output;
+          }
+          case 'outputResult':
+          case 'outputStep':
+            return {
+              ...(Array.isArray(payload.messages) &&
+              !areProcessorMessageArraysEqual(messages as unknown[] | undefined, payload.messages)
+                ? { messages: payload.messages }
+                : {}),
+              ...(Array.isArray(payload.systemMessages) &&
+              !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
+                ? { systemMessages: payload.systemMessages }
+                : {}),
+            };
+          default:
+            return undefined;
+        }
+      };
 
       // Early return if processor doesn't implement this phase - no span created
       // This prevents empty spans for phases the processor doesn't handle
@@ -799,7 +969,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               entityType: getProcessorEntityType(phase),
               entityId: processor.id,
               entityName: processor.name ?? processor.id,
-              input: { phase, messageCount: messages?.length },
+              input: buildProcessorSpanInput(),
               attributes: {
                 processorExecutor: 'workflow',
                 // Read processorIndex from processor (set in combineProcessorsIntoWorkflow)
@@ -885,7 +1055,7 @@ function createStepFromProcessor<TProcessorId extends string>(
       const executePhaseWithSpan = async <T>(fn: () => Promise<T>): Promise<T> => {
         try {
           const result = await executeWithContext({ span: processorSpan, fn });
-          processorSpan?.end({ output: result });
+          processorSpan?.end({ output: buildProcessorSpanOutput(result) });
           return result;
         } catch (error) {
           // TripWire errors should end span but bubble up to halt the workflow
@@ -1055,22 +1225,12 @@ function createStepFromProcessor<TProcessorId extends string>(
                   entityType: EntityType.OUTPUT_PROCESSOR,
                   entityId: processor.id,
                   entityName: processor.name ?? processor.id,
-                  input: { phase, streamParts: [] },
                   attributes: {
                     processorExecutor: 'workflow',
                     processorIndex: processor.processorIndex,
                   },
                 });
                 mutableState[spanKey] = processorSpan;
-              }
-
-              // Update span with current chunk data
-              if (processorSpan) {
-                processorSpan.input = {
-                  phase,
-                  streamParts: streamParts ?? [],
-                  totalChunks: (streamParts ?? []).length,
-                };
               }
 
               // Create observability context with processor span for internal agent calls
@@ -1093,7 +1253,7 @@ function createStepFromProcessor<TProcessorId extends string>(
 
                 // End span on finish chunk
                 if (part && (part as ChunkType).type === 'finish') {
-                  processorSpan?.end({ output: result });
+                  processorSpan?.end({ output: { totalChunks: (streamParts ?? []).length } });
                   delete mutableState[spanKey];
                 }
               } catch (error) {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -5,7 +5,8 @@ import { z } from 'zod/v4';
 import type { MastraPrimitives } from '../action';
 import { Agent } from '../agent';
 import type { AgentExecutionOptions, AgentStreamOptions, MastraDBMessage } from '../agent';
-import { MessageList } from '../agent/message-list';
+import { MessageList, messagesAreEqual } from '../agent/message-list';
+import type { MessageInput } from '../agent/message-list';
 import { TripWire } from '../agent/trip-wire';
 import { MastraBase } from '../base';
 import { RequestContext } from '../di';
@@ -28,6 +29,13 @@ import {
 import { executeWithContext } from '../observability/utils';
 import { ProcessorRunner, ProcessorState } from '../processors';
 import type { OutputResult, Processor, ProcessorStreamWriter } from '../processors';
+import {
+  summarizeActiveToolsForSpan,
+  summarizeProcessorModelForSpan,
+  summarizeProcessorResultForSpan,
+  summarizeProcessorToolsForSpan,
+  summarizeToolChoiceForSpan,
+} from '../processors/span-payload';
 import { ProcessorStepOutputSchema, ProcessorStepInputSchema } from '../processors/step-schema';
 import type { ProcessorStepInput, ProcessorStepOutput } from '../processors/step-schema';
 import { toStandardSchema } from '../schema';
@@ -146,6 +154,21 @@ function isStepParams(input: unknown): input is StepParams<any, any, any, any, a
     'execute' in input &&
     !(input instanceof Agent) &&
     !(input instanceof Tool)
+  );
+}
+
+function areProcessorMessageArraysEqual(before: unknown[] | undefined, after: unknown[] | undefined): boolean {
+  if (before === after) {
+    return true;
+  }
+
+  if (!before || !after) {
+    return before === after;
+  }
+
+  return (
+    before.length === after.length &&
+    before.every((message, index) => messagesAreEqual(message as MessageInput, after[index] as MessageInput))
   );
 }
 
@@ -724,6 +747,7 @@ function createStepFromProcessor<TProcessorId extends string>(
       const abort = (reason?: string, options?: { retry?: boolean; metadata?: unknown }): never => {
         throw new TripWire(reason || `Tripwire triggered by ${processor.id}`, options, processor.id);
       };
+      const initialMessageId = messageId;
       let currentMessageId = messageId;
       const rotateCurrentResponseMessageId = rotateResponseMessageId
         ? () => {
@@ -731,6 +755,152 @@ function createStepFromProcessor<TProcessorId extends string>(
             return currentMessageId;
           }
         : undefined;
+      const defaultOutputResult: OutputResult = {
+        text: '',
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        finishReason: 'unknown',
+        steps: [],
+      };
+
+      const buildProcessorSpanInput = () => {
+        switch (phase) {
+          case 'input':
+            return {
+              messages: (messages as MastraDBMessage[]) ?? [],
+              ...(systemMessages ? { systemMessages } : {}),
+              ...(retryCount !== undefined ? { retryCount } : {}),
+            };
+          case 'inputStep': {
+            const summarizedModel = summarizeProcessorModelForSpan(model);
+            const summarizedTools = summarizeProcessorToolsForSpan(tools);
+            const summarizedToolChoice = summarizeToolChoiceForSpan(toolChoice, tools);
+            const summarizedActiveTools = summarizeActiveToolsForSpan(activeTools, tools);
+
+            return {
+              messages: (messages as MastraDBMessage[]) ?? [],
+              ...(systemMessages ? { systemMessages } : {}),
+              ...(stepNumber !== undefined ? { stepNumber } : {}),
+              ...(currentMessageId ? { messageId: currentMessageId } : {}),
+              ...(retryCount !== undefined ? { retryCount } : {}),
+              ...(summarizedModel ? { model: summarizedModel } : {}),
+              ...(summarizedTools ? { tools: summarizedTools } : {}),
+              ...(summarizedToolChoice ? { toolChoice: summarizedToolChoice } : {}),
+              ...(summarizedActiveTools ? { activeTools: summarizedActiveTools } : {}),
+            };
+          }
+          case 'outputResult': {
+            const summarizedResult = summarizeProcessorResultForSpan(outputResult ?? defaultOutputResult);
+
+            return {
+              messages: (messages as MastraDBMessage[]) ?? [],
+              ...(summarizedResult ? { result: summarizedResult } : {}),
+              ...(retryCount !== undefined ? { retryCount } : {}),
+            };
+          }
+          case 'outputStep':
+            return {
+              messages: (messages as MastraDBMessage[]) ?? [],
+              ...(systemMessages ? { systemMessages } : {}),
+              ...(stepNumber !== undefined ? { stepNumber } : {}),
+              ...(finishReason !== undefined ? { finishReason } : {}),
+              ...(text !== undefined ? { text } : {}),
+              ...(toolCalls !== undefined ? { toolCalls } : {}),
+              ...(retryCount !== undefined ? { retryCount } : {}),
+            };
+          default:
+            return undefined;
+        }
+      };
+
+      const buildProcessorSpanOutput = (result: unknown) => {
+        if (result === null || typeof result !== 'object' || Array.isArray(result)) {
+          return result;
+        }
+
+        const payload = result as Record<string, unknown>;
+        switch (phase) {
+          case 'input':
+            return {
+              ...(Array.isArray(payload.messages) &&
+              !areProcessorMessageArraysEqual(messages as unknown[] | undefined, payload.messages)
+                ? { messages: payload.messages }
+                : {}),
+              ...(Array.isArray(payload.systemMessages) &&
+              !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
+                ? { systemMessages: payload.systemMessages }
+                : {}),
+            };
+          case 'inputStep': {
+            const output: Record<string, unknown> = {};
+
+            if (
+              Array.isArray(payload.messages) &&
+              !areProcessorMessageArraysEqual(messages as unknown[] | undefined, payload.messages)
+            ) {
+              output.messages = payload.messages;
+            }
+
+            if (
+              Array.isArray(payload.systemMessages) &&
+              !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
+            ) {
+              output.systemMessages = payload.systemMessages;
+            }
+
+            if (payload.messageId !== undefined && payload.messageId !== initialMessageId) {
+              output.messageId = payload.messageId;
+            }
+
+            if (payload.model !== undefined && payload.model !== model) {
+              const summarizedModel = summarizeProcessorModelForSpan(payload.model);
+              if (summarizedModel) {
+                output.model = summarizedModel;
+              }
+            }
+
+            if (payload.tools !== undefined && payload.tools !== tools) {
+              const summarizedTools = summarizeProcessorToolsForSpan(payload.tools);
+              if (summarizedTools) {
+                output.tools = summarizedTools;
+              }
+            }
+
+            if (payload.toolChoice !== undefined && payload.toolChoice !== toolChoice) {
+              const summarizedToolChoice = summarizeToolChoiceForSpan(payload.toolChoice, payload.tools ?? tools);
+              if (summarizedToolChoice) {
+                output.toolChoice = summarizedToolChoice;
+              }
+            }
+
+            if (payload.activeTools !== undefined && payload.activeTools !== activeTools) {
+              const summarizedActiveTools = summarizeActiveToolsForSpan(payload.activeTools, payload.tools ?? tools);
+              if (summarizedActiveTools) {
+                output.activeTools = summarizedActiveTools;
+              }
+            }
+
+            if (payload.retryCount !== undefined && payload.retryCount !== retryCount) {
+              output.retryCount = payload.retryCount;
+            }
+
+            return output;
+          }
+          case 'outputResult':
+          case 'outputStep':
+            return {
+              ...(Array.isArray(payload.messages) &&
+              !areProcessorMessageArraysEqual(messages as unknown[] | undefined, payload.messages)
+                ? { messages: payload.messages }
+                : {}),
+              ...(Array.isArray(payload.systemMessages) &&
+              !areProcessorMessageArraysEqual(systemMessages as unknown[] | undefined, payload.systemMessages)
+                ? { systemMessages: payload.systemMessages }
+                : {}),
+            };
+          default:
+            return undefined;
+        }
+      };
 
       // Early return if processor doesn't implement this phase - no span created
       // This prevents empty spans for phases the processor doesn't handle
@@ -759,7 +929,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               entityType: getProcessorEntityType(phase),
               entityId: processor.id,
               entityName: processor.name ?? processor.id,
-              input: { phase, messageCount: messages?.length },
+              input: buildProcessorSpanInput(),
               attributes: {
                 processorExecutor: 'workflow',
                 // Read processorIndex from processor (set in combineProcessorsIntoWorkflow)
@@ -858,7 +1028,7 @@ function createStepFromProcessor<TProcessorId extends string>(
       const executePhaseWithSpan = async <T>(fn: () => Promise<T>): Promise<T> => {
         try {
           const result = await executeWithContext({ span: processorSpan, fn });
-          processorSpan?.end({ output: result });
+          processorSpan?.end({ output: buildProcessorSpanOutput(result) });
           return result;
         } catch (error) {
           // TripWire errors should end span but bubble up to halt the workflow
@@ -1038,21 +1208,12 @@ function createStepFromProcessor<TProcessorId extends string>(
                   entityType: EntityType.OUTPUT_PROCESSOR,
                   entityId: processor.id,
                   entityName: processor.name ?? processor.id,
-                  input: { phase, totalChunks: 0 },
                   attributes: {
                     processorExecutor: 'workflow',
                     processorIndex: processor.processorIndex,
                   },
                 });
                 mutableState[spanKey] = processorSpan;
-              }
-
-              // Update span with current chunk data
-              if (processorSpan) {
-                processorSpan.input = {
-                  phase,
-                  totalChunks: (streamParts ?? []).length,
-                };
               }
 
               // Create observability context with processor span for internal agent calls


### PR DESCRIPTION
## Description

Improved `PROCESSOR_RUN` spans to record hook-specific input and changed output instead of broad internal processor state. Processor traces now keep replayable `messages` and `systemMessages`, summarize model and tool configuration, omit `messageList` instances, raw stream chunk payloads, and model usage, and only include output message arrays when a processor actually changed them.

## Related Issue(s)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes processor traces much smaller and clearer by recording only the exact inputs each processor hook sees and only the outputs that actually changed, instead of dumping large internal state snapshots. Traces remain replayable while avoiding verbose or sensitive data.

## Overview
Processor span payloads for PROCESSOR_RUN were refactored to emit phase-specific, minimal inputs and concise outputs that include only deltas. Model/tool configuration and processor results are summarized; heavy internals (messageList instances, raw stream chunk payloads, and usage data) are omitted. Message arrays (messages/systemMessages) are included in traces only when they actually differ.

## Key Changes

- New summarizer helpers
  - Added packages/core/src/processors/span-payload.ts with:
    - summarizeProcessorModelForSpan — returns { modelId?, provider?, specificationVersion? } | undefined
    - summarizeProcessorToolsForSpan — maps tools to { id, name, description? }[] | undefined
    - summarizeActiveToolsForSpan — resolves active tool IDs to { id, name }[] (returns [] when empty)
    - summarizeToolChoiceForSpan — normalizes toolChoice into { type, tool? } | undefined
    - summarizeProcessorResultForSpan — allowlists result fields, replaces raw steps with stepCount, and returns undefined when empty

- Span construction & diffs
  - Replaced generic span inputs with phase-aware builders (buildProcessorSpanInput / buildProcessorSpanOutput) across runner.ts, workflow.ts, and evented/workflow.ts.
  - Introduced areProcessorMessageArraysEqual (using messagesAreEqual) to avoid emitting unchanged messages/systemMessages.
  - Span outputs now emit only changed fields (deltas): messageId rotations, retryCount changes, model/tools/toolChoice/activeTools summaries, and summarized result deltas.
  - Removed per-chunk incremental span input updates for outputStream; outputStream spans now end with a single summarized output (e.g., totalChunks).

- Error and result handling
  - runProcessAPIError, runProcessInputStep, runInputProcessors, and runOutputProcessors now record richer but summarized inputs (messages, systemMessages, error/context, summarized model/tools/toolChoice, retryCount, stepNumber, optional messageId).
  - Outputs for these paths use conditional diffs and summarized processor results (via summarizeProcessorResultForSpan) instead of full raw objects.
  - A defaultOutputResult baseline is used to ensure consistent summarization when outputResult is absent.

- Tests & snapshots
  - Added packages/core/src/processors/span-payload.test.ts validating model/tool/result/toolChoice summarization, active tool resolution, and step-count behavior.
  - Updated observability snapshots (observability/mastra/src/__snapshots__/*.json) to reflect reduced span payloads and summarized results.

## Implementation details
- Traces preserve replayable arrays (messages/systemMessages) only when relevant, but avoid serializing messageList objects, stream chunk payloads, and model usage.
- Summaries intentionally exclude sensitive/verbose fields (e.g., apiKey, full model config) and normalize legacy/current shapes (modelId vs id).
- Centralized helpers produce stable, small, and consistent span payloads.

## Tests
- New Vitest suite verifies summarizers and edge cases: omission of sensitive fields, deriving tool id/name defaults from registry keys, normalization of toolChoice inputs, resolving active tools, and replacing detailed steps with stepCount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->