### PR TITLE
refactored MODEL_CHUNK 'tool-result' span handling

### DIFF
--- a/.changeset/curly-breads-heal.md
+++ b/.changeset/curly-breads-heal.md
@@ -1,0 +1,15 @@
+---
+'@mastra/observability': minor
+---
+
+Changed `MODEL_CHUNK` `tool-result` span `output` handling.
+
+**What changed**
+
+- `MODEL_CHUNK` spans for `tool-result` now omit `output` for locally executed tools.
+- `TOOL_CALL` remains the canonical span for locally executed tool result payloads.
+- `MODEL_CHUNK` spans for provider-executed `tool-result` chunks still include `output`.
+- `MODEL_CHUNK` metadata still includes `toolCallId`, `toolName`, and `providerExecuted`.
+
+**Why**
+This reduces duplicate tool result payloads in traces without dropping provider-emitted tool results that may not have a matching `TOOL_CALL` span.

--- a/observability/mastra/src/__snapshots__/agent-tool-call-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-tool-call-trace-generate.json
@@ -249,9 +249,6 @@
                       "threadId": "test-thread-id",
                       "toolCallId": "call-calc-1",
                       "toolName": "calculator"
-                    },
-                    "output": {
-                      "result": 8
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/agent-tool-call-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-tool-call-trace.json
@@ -248,9 +248,6 @@
                       "threadId": "test-thread-id",
                       "toolCallId": "call-calc-1",
                       "toolName": "calculator"
-                    },
-                    "output": {
-                      "result": 8
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/agent-workflow-direct-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-direct-trace-generate.json
@@ -297,12 +297,6 @@
                       "runId": "<runId-1>",
                       "toolCallId": "call-workflow-1",
                       "toolName": "workflow-simpleWorkflow"
-                    },
-                    "output": {
-                      "result": {
-                        "output": "test input processed"
-                      },
-                      "runId": "<runId-2>"
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/agent-workflow-direct-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-direct-trace.json
@@ -296,12 +296,6 @@
                       "runId": "<runId-1>",
                       "toolCallId": "call-workflow-1",
                       "toolName": "workflow-simpleWorkflow"
-                    },
-                    "output": {
-                      "result": {
-                        "output": "test input processed"
-                      },
-                      "runId": "<runId-2>"
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/agent-workflow-tool-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-tool-trace-generate.json
@@ -315,11 +315,6 @@
                       "id2": "tacos",
                       "toolCallId": "call-workflow-1",
                       "toolName": "workflowExecutor"
-                    },
-                    "output": {
-                      "result": {
-                        "output": "test input processed"
-                      }
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/agent-workflow-tool-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-tool-trace.json
@@ -314,11 +314,6 @@
                       "id2": "tacos",
                       "toolCallId": "call-workflow-1",
                       "toolName": "workflowExecutor"
-                    },
-                    "output": {
-                      "result": {
-                        "output": "test input processed"
-                      }
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace-generate.json
@@ -257,9 +257,6 @@
                       "runId": "<runId-1>",
                       "toolCallId": "call-calc-1",
                       "toolName": "calculator"
-                    },
-                    "output": {
-                      "result": 8
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace.json
+++ b/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace.json
@@ -256,9 +256,6 @@
                       "runId": "<runId-1>",
                       "toolCallId": "call-calc-1",
                       "toolName": "calculator"
-                    },
-                    "output": {
-                      "result": 8
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/tool-child-spans-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tool-child-spans-trace-generate.json
@@ -255,9 +255,6 @@
                       "runId": "<runId-1>",
                       "toolCallId": "call-child-span-1",
                       "toolName": "childSpanTool"
-                    },
-                    "output": {
-                      "output": "Tool processed: test-data"
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/tool-child-spans-trace.json
+++ b/observability/mastra/src/__snapshots__/tool-child-spans-trace.json
@@ -254,9 +254,6 @@
                       "runId": "<runId-1>",
                       "toolCallId": "call-child-span-1",
                       "toolName": "childSpanTool"
-                    },
-                    "output": {
-                      "output": "Tool processed: test-data"
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/tool-metadata-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tool-metadata-trace-generate.json
@@ -234,9 +234,6 @@
                       "runId": "<runId-1>",
                       "toolCallId": "call-metadata-1",
                       "toolName": "metadataTool"
-                    },
-                    "output": {
-                      "output": "Processed: some data"
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/tool-metadata-trace.json
+++ b/observability/mastra/src/__snapshots__/tool-metadata-trace.json
@@ -233,9 +233,6 @@
                       "runId": "<runId-1>",
                       "toolCallId": "call-metadata-1",
                       "toolName": "metadataTool"
-                    },
-                    "output": {
-                      "output": "Processed: some data"
                     }
                   }
                 }

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -150,13 +150,13 @@ describe('ModelSpanTracker', () => {
       const toolOutputSpans = testExporter.getSpansByName("chunk: 'tool-output'");
       expect(toolOutputSpans).toHaveLength(0);
 
-      // The span should be an event span with the result
+      // The span should be an event span keyed by metadata only
       const span = toolResultSpans[0]!;
       expect(span.isEvent).toBe(true);
       // toolCallId and toolName are in metadata (tool-result specific fields)
       expect(span.metadata).toMatchObject({ toolCallId, toolName });
-      // output contains only the result
-      expect(span.output).toEqual({ text: 'Hello world!' });
+      // output is omitted; TOOL_CALL captures the full result payload
+      expect(span.output).toBeUndefined();
     });
 
     it('should pass through tool-output chunks without creating spans', async () => {
@@ -288,8 +288,8 @@ describe('ModelSpanTracker', () => {
       expect(span.isEvent).toBe(true);
       // toolCallId and toolName are in metadata
       expect(span.metadata).toMatchObject({ toolCallId, toolName });
-      // output contains only the result
-      expect(span.output).toEqual({ output: 'Workflow result', status: 'success' });
+      // output is omitted; TOOL_CALL captures the full result payload
+      expect(span.output).toBeUndefined();
     });
   });
 
@@ -350,18 +350,18 @@ describe('ModelSpanTracker', () => {
       const toolResultSpans = testExporter.getSpansByName("chunk: 'tool-result'");
       expect(toolResultSpans).toHaveLength(1);
 
-      // The span should be an event span with the result (args stripped)
+      // The span should be an event span keyed by metadata only
       const span = toolResultSpans[0]!;
       expect(span.isEvent).toBe(true);
       // toolCallId and toolName are in metadata
       expect(span.metadata).toMatchObject({ toolCallId, toolName });
-      // output contains only the result
-      expect(span.output).toEqual({ text: 'Streamed content' });
+      // output is omitted; TOOL_CALL captures the full result payload
+      expect(span.output).toBeUndefined();
     });
   });
 
-  describe('tool-result args removal', () => {
-    it('should remove args from tool-result output for non-streaming tools', async () => {
+  describe('tool-result payload policy', () => {
+    it('should omit tool-result output for locally executed tools', async () => {
       const modelSpan = tracing.startSpan({
         type: SpanType.MODEL_GENERATION,
         name: 'test-generation',
@@ -396,13 +396,53 @@ describe('ModelSpanTracker', () => {
       expect(toolResultSpans).toHaveLength(1);
 
       const span = toolResultSpans[0]!;
-      // args should not be in the output or metadata
-      expect(span.output).not.toHaveProperty('args');
+      // args should not be in metadata and output is omitted entirely
       expect(span.metadata).not.toHaveProperty('args');
       // toolCallId and toolName should be in metadata
       expect(span.metadata).toMatchObject({ toolCallId, toolName });
-      // output contains only the result
-      expect(span.output).toEqual({ output: 'tool result' });
+      // output is omitted; TOOL_CALL captures the full result payload
+      expect(span.output).toBeUndefined();
+    });
+
+    it('should keep tool-result output for provider-executed tools', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const toolCallId = 'call_provider123';
+      const toolName = 'web_search';
+      const result = { output: 'provider result' };
+      const chunks = [
+        { type: 'step-start', payload: { messageId: 'msg-1' } },
+        {
+          type: 'tool-result',
+          payload: {
+            args: { query: 'mastra' },
+            toolCallId,
+            toolName,
+            providerExecuted: true,
+            result,
+          },
+        },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+
+      modelSpan.end();
+
+      const toolResultSpans = testExporter.getSpansByName("chunk: 'tool-result'");
+      expect(toolResultSpans).toHaveLength(1);
+
+      const span = toolResultSpans[0]!;
+      expect(span.metadata).not.toHaveProperty('args');
+      expect(span.metadata).toMatchObject({ toolCallId, toolName, providerExecuted: true });
+      expect(span.output).toEqual(result);
     });
   });
 
@@ -488,15 +528,15 @@ describe('ModelSpanTracker', () => {
         toolCallId: 'call_agent1',
         toolName: 'agent-first',
       });
-      // output contains only the result
-      expect(agent1Span!.output).toEqual({ text: 'Agent1: Hello' });
+      // output is omitted; TOOL_CALL captures the full result payload
+      expect(agent1Span!.output).toBeUndefined();
 
       expect(agent2Span).toBeDefined();
       expect(agent2Span!.metadata).toMatchObject({
         toolCallId: 'call_agent2',
         toolName: 'agent-second',
       });
-      expect(agent2Span!.output).toEqual({ text: 'Agent2: World' });
+      expect(agent2Span!.output).toBeUndefined();
     });
   });
 

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -721,7 +721,9 @@ export class ModelSpanTracker {
                 dynamic,
                 providerExecuted,
                 providerMetadata,
-                // Output - the actual result
+                // Keep provider-executed results on MODEL_CHUNK because they come
+                // from the model/provider stream and may not have a sibling TOOL_CALL span.
+                // For locally executed tools, the canonical payload lives on TOOL_CALL.
                 result,
                 // Stripped - redundant (already on TOOL_CALL span input)
                 args: _args,
@@ -734,7 +736,7 @@ export class ModelSpanTracker {
               if (providerExecuted !== undefined) metadata.providerExecuted = providerExecuted;
               if (providerMetadata !== undefined) metadata.providerMetadata = providerMetadata;
 
-              this.#createEventSpan(chunk.type, result, { metadata });
+              this.#createEventSpan(chunk.type, providerExecuted ? result : undefined, { metadata });
               break;
             }
 


### PR DESCRIPTION
## Description

**What changed**

- `MODEL_CHUNK` spans for `tool-result` now omit `output` for locally executed tools.
- `TOOL_CALL` remains the canonical span for locally executed tool result payloads.
- `MODEL_CHUNK` spans for provider-executed `tool-result` chunks still include `output`.

**Why**
This reduces duplicate tool result payloads in traces without dropping provider-emitted tool results that may not have a matching `TOOL_CALL` span.


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The change stops duplicating tool results in traces by removing the result payload from one of the two places it was being recorded for locally run tools, while still keeping the payload when the tool was run by an external provider.

## What Changed

- MODEL_CHUNK spans for chunkType 'tool-result' now omit the output field for locally executed tools; the TOOL_CALL span remains the canonical source for locally produced tool result payloads.
- If providerExecuted is true (provider-executed tools), MODEL_CHUNK 'tool-result' spans continue to include output (since provider-emitted results may lack a matching TOOL_CALL span).
- Span metadata still includes toolCallId, toolName, and providerExecuted; args is not included in metadata.
- Tests and snapshots updated to reflect the new policy.

## Files Modified

1. .changeset/curly-breads-heal.md — new changeset describing the behavior change for @mastra/observability.
2. observability/mastra/src/model-tracing.ts — ModelSpanTracker now conditionally sets event span output to result only when providerExecuted is truthy.
3. observability/mastra/src/model-tracing.test.ts — test assertions and cases updated to require span.output to be undefined for locally executed tool-result chunks and present when providerExecuted: true; snapshots updated accordingly.

## Rationale

Reduces duplicate tool result payloads in traces for locally executed tools while preserving provider-emitted tool results that might not have a corresponding TOOL_CALL span.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->