### PR TITLE
feat(core): implement discriminated union types for agent `structuredOutput` options

### DIFF
--- a/.changeset/ready-spies-watch.md
+++ b/.changeset/ready-spies-watch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved type safety for agent structured output by implementing a discriminated union.# Please enter your changeset message above this line.

--- a/.changeset/ready-spies-watch.md
+++ b/.changeset/ready-spies-watch.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Improved type safety for agent structured output by implementing a discriminated union.# Please enter your changeset message above this line.
+Improved type safety for agent structured output by implementing a discriminated union.

--- a/.changeset/ready-spies-watch.md
+++ b/.changeset/ready-spies-watch.md
@@ -3,3 +3,13 @@
 ---
 
 Improve structured output option typing so processor-only fields now require a separate structuredOutput.model.
+
+```ts
+await agent.generate('Extract details', {
+  structuredOutput: {
+    model: 'openai/gpt-5-mini',
+    instructions: 'Extract structured details from the prompt',
+    schema: userSchema,
+  },
+});
+```

--- a/.changeset/ready-spies-watch.md
+++ b/.changeset/ready-spies-watch.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Improved type safety for agent structured output by implementing a discriminated union.
+Improve structured output option typing so processor-only fields now require a separate structuredOutput.model.

--- a/packages/core/src/agent/agent-structured-output.test-d.ts
+++ b/packages/core/src/agent/agent-structured-output.test-d.ts
@@ -55,5 +55,28 @@ describe('Agent Structured Output Type Tests', () => {
       providerOptions: { openai: { reasoningEffort: 'low' } },
       schema: z.object({ name: z.string() }),
     };
+
+    // @ts-expect-error - errorStrategy requires model
+    const _opt4: PublicStructuredOutputOptions<{ name: string }> = {
+      errorStrategy: 'warn',
+      schema: z.object({ name: z.string() }),
+    };
+
+    // @ts-expect-error - fallbackValue requires model
+    const _opt5: PublicStructuredOutputOptions<{ name: string }> = {
+      errorStrategy: 'fallback',
+      fallbackValue: { name: 'default' },
+      schema: z.object({ name: z.string() }),
+    };
+  });
+
+  it('should allow fallback fields in Processor Mode', () => {
+    const options: PublicStructuredOutputOptions<{ name: string }> = {
+      model: 'openai/gpt-4o',
+      schema: z.object({ name: z.string() }),
+      errorStrategy: 'fallback',
+      fallbackValue: { name: 'default' },
+    };
+    expectTypeOf(options).toBeObject();
   });
 });

--- a/packages/core/src/agent/agent-structured-output.test-d.ts
+++ b/packages/core/src/agent/agent-structured-output.test-d.ts
@@ -36,7 +36,7 @@ describe('Agent Structured Output Type Tests', () => {
     expectTypeOf(processorOptions).toBeObject();
   });
 
-  // These should fail if uncommented or tested with @ts-expect-error
+  // Negative cases: processor-only fields must be rejected when `model` is missing
   it('should NOT allow processor fields without model', () => {
     // @ts-expect-error - instructions requires model
     const _opt1: PublicStructuredOutputOptions<{ name: string }> = {

--- a/packages/core/src/agent/agent-structured-output.test-d.ts
+++ b/packages/core/src/agent/agent-structured-output.test-d.ts
@@ -1,0 +1,59 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod/v4';
+import type { IMastraLogger } from '../logger';
+import type { PublicStructuredOutputOptions } from './types';
+
+describe('Agent Structured Output Type Tests', () => {
+  it('should allow schema only (Direct Mode)', () => {
+    const options: PublicStructuredOutputOptions<{ name: string }> = {
+      schema: z.object({ name: z.string() }),
+    };
+    expectTypeOf(options).toBeObject();
+  });
+
+  it('should allow model and instructions (Processor Mode)', () => {
+    const options: PublicStructuredOutputOptions<{ name: string }> = {
+      model: 'openai/gpt-4o',
+      instructions: 'Give me a name',
+      schema: z.object({ name: z.string() }),
+    };
+    expectTypeOf(options).toBeObject();
+  });
+
+  it('should allow common fields in both modes', () => {
+    const directOptions: PublicStructuredOutputOptions<{ name: string }> = {
+      schema: z.object({ name: z.string() }),
+      jsonPromptInjection: true,
+    };
+
+    const processorOptions: PublicStructuredOutputOptions<{ name: string }> = {
+      model: 'openai/gpt-4o',
+      schema: z.object({ name: z.string() }),
+      jsonPromptInjection: true,
+    };
+
+    expectTypeOf(directOptions).toBeObject();
+    expectTypeOf(processorOptions).toBeObject();
+  });
+
+  // These should fail if uncommented or tested with @ts-expect-error
+  it('should NOT allow processor fields without model', () => {
+    // @ts-expect-error - instructions requires model
+    const _opt1: PublicStructuredOutputOptions<{ name: string }> = {
+      instructions: 'Give me a name',
+      schema: z.object({ name: z.string() }),
+    };
+
+    // @ts-expect-error - logger requires model
+    const _opt2: PublicStructuredOutputOptions<{ name: string }> = {
+      logger: {} as unknown as IMastraLogger,
+      schema: z.object({ name: z.string() }),
+    };
+
+    // @ts-expect-error - providerOptions requires model
+    const _opt3: PublicStructuredOutputOptions<{ name: string }> = {
+      providerOptions: { openai: { reasoningEffort: 'low' } },
+      schema: z.object({ name: z.string() }),
+    };
+  });
+});

--- a/packages/core/src/agent/agent-structured-output.test-d.ts
+++ b/packages/core/src/agent/agent-structured-output.test-d.ts
@@ -1,82 +1,187 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod/v4';
 import type { IMastraLogger } from '../logger';
-import type { PublicStructuredOutputOptions } from './types';
+import { Agent } from './agent';
 
-describe('Agent Structured Output Type Tests', () => {
-  it('should allow schema only (Direct Mode)', () => {
-    const options: PublicStructuredOutputOptions<{ name: string }> = {
-      schema: z.object({ name: z.string() }),
-    };
-    expectTypeOf(options).toBeObject();
+describe('Agent Structured Output Call-Site Type Tests', () => {
+  const agent = new Agent({
+    id: 'test-agent',
+    name: 'test-agent',
+    instructions: 'Test instructions',
+    model: 'openai/gpt-4o',
   });
 
-  it('should allow model and instructions (Processor Mode)', () => {
-    const options: PublicStructuredOutputOptions<{ name: string }> = {
-      model: 'openai/gpt-4o',
-      instructions: 'Give me a name',
-      schema: z.object({ name: z.string() }),
-    };
-    expectTypeOf(options).toBeObject();
+  const schema = z.object({ name: z.string() });
+
+  describe('agent.generate()', () => {
+    it('should allow schema only (Direct Mode)', () => {
+      const res = agent.generate('prompt', {
+        structuredOutput: {
+          schema,
+        },
+      });
+      expectTypeOf(res).resolves.toHaveProperty('object');
+    });
+
+    it('should allow model and instructions (Processor Mode)', () => {
+      const res = agent.generate('prompt', {
+        structuredOutput: {
+          model: 'openai/gpt-4o',
+          instructions: 'Give me a name',
+          schema,
+        },
+      });
+      expectTypeOf(res).resolves.toHaveProperty('object');
+    });
+
+    it('should allow errorStrategy and fallbackValue in Direct Mode (Common Fields)', () => {
+      const res1 = agent.generate('prompt', {
+        structuredOutput: {
+          schema,
+          errorStrategy: 'warn',
+        },
+      });
+      const res2 = agent.generate('prompt', {
+        structuredOutput: {
+          schema,
+          errorStrategy: 'fallback',
+          fallbackValue: { name: 'default' },
+        },
+      });
+      expectTypeOf(res1).resolves.toHaveProperty('object');
+      expectTypeOf(res2).resolves.toHaveProperty('object');
+    });
+
+    it('should allow errorStrategy and fallbackValue in Processor Mode', () => {
+      const res = agent.generate('prompt', {
+        structuredOutput: {
+          model: 'openai/gpt-4o',
+          schema,
+          errorStrategy: 'fallback',
+          fallbackValue: { name: 'default' },
+        },
+      });
+      expectTypeOf(res).resolves.toHaveProperty('object');
+    });
+
+    it('should NOT allow processor-only fields without model', () => {
+      void agent.generate('prompt', {
+        // @ts-expect-error - instructions requires model
+        structuredOutput: {
+          instructions: 'Give me a name',
+          schema,
+        },
+      });
+
+      void agent.generate('prompt', {
+        // @ts-expect-error - logger requires model
+        structuredOutput: {
+          logger: {} as unknown as IMastraLogger,
+          schema,
+        },
+      });
+
+      void agent.generate('prompt', {
+        // @ts-expect-error - providerOptions requires model
+        structuredOutput: {
+          providerOptions: { openai: { reasoningEffort: 'low' } },
+          schema,
+        },
+      });
+
+      void agent.generate('prompt', {
+        // @ts-expect-error - useAgent requires model
+        structuredOutput: {
+          useAgent: true,
+          schema,
+        },
+      });
+    });
   });
 
-  it('should allow common fields in both modes', () => {
-    const directOptions: PublicStructuredOutputOptions<{ name: string }> = {
-      schema: z.object({ name: z.string() }),
-      jsonPromptInjection: true,
-    };
+  describe('agent.stream()', () => {
+    it('should allow schema only (Direct Mode)', () => {
+      const res = agent.stream('prompt', {
+        structuredOutput: {
+          schema,
+        },
+      });
+      expectTypeOf(res).resolves.toHaveProperty('object');
+    });
 
-    const processorOptions: PublicStructuredOutputOptions<{ name: string }> = {
-      model: 'openai/gpt-4o',
-      schema: z.object({ name: z.string() }),
-      jsonPromptInjection: true,
-    };
+    it('should allow model and instructions (Processor Mode)', () => {
+      const res = agent.stream('prompt', {
+        structuredOutput: {
+          model: 'openai/gpt-4o',
+          instructions: 'Give me a name',
+          schema,
+        },
+      });
+      expectTypeOf(res).resolves.toHaveProperty('object');
+    });
 
-    expectTypeOf(directOptions).toBeObject();
-    expectTypeOf(processorOptions).toBeObject();
-  });
+    it('should allow errorStrategy and fallbackValue in Direct Mode (Common Fields)', () => {
+      const res1 = agent.stream('prompt', {
+        structuredOutput: {
+          schema,
+          errorStrategy: 'warn',
+        },
+      });
+      const res2 = agent.stream('prompt', {
+        structuredOutput: {
+          schema,
+          errorStrategy: 'fallback',
+          fallbackValue: { name: 'default' },
+        },
+      });
+      expectTypeOf(res1).resolves.toHaveProperty('object');
+      expectTypeOf(res2).resolves.toHaveProperty('object');
+    });
 
-  // Negative cases: processor-only fields must be rejected when `model` is missing
-  it('should NOT allow processor fields without model', () => {
-    // @ts-expect-error - instructions requires model
-    const _opt1: PublicStructuredOutputOptions<{ name: string }> = {
-      instructions: 'Give me a name',
-      schema: z.object({ name: z.string() }),
-    };
+    it('should allow errorStrategy and fallbackValue in Processor Mode', () => {
+      const res = agent.stream('prompt', {
+        structuredOutput: {
+          model: 'openai/gpt-4o',
+          schema,
+          errorStrategy: 'fallback',
+          fallbackValue: { name: 'default' },
+        },
+      });
+      expectTypeOf(res).resolves.toHaveProperty('object');
+    });
 
-    // @ts-expect-error - logger requires model
-    const _opt2: PublicStructuredOutputOptions<{ name: string }> = {
-      logger: {} as unknown as IMastraLogger,
-      schema: z.object({ name: z.string() }),
-    };
+    it('should NOT allow processor-only fields without model', () => {
+      void agent.stream('prompt', {
+        // @ts-expect-error - instructions requires model
+        structuredOutput: {
+          instructions: 'Give me a name',
+          schema,
+        },
+      });
 
-    // @ts-expect-error - providerOptions requires model
-    const _opt3: PublicStructuredOutputOptions<{ name: string }> = {
-      providerOptions: { openai: { reasoningEffort: 'low' } },
-      schema: z.object({ name: z.string() }),
-    };
+      void agent.stream('prompt', {
+        // @ts-expect-error - logger requires model
+        structuredOutput: {
+          logger: {} as unknown as IMastraLogger,
+          schema,
+        },
+      });
 
-    // @ts-expect-error - errorStrategy requires model
-    const _opt4: PublicStructuredOutputOptions<{ name: string }> = {
-      errorStrategy: 'warn',
-      schema: z.object({ name: z.string() }),
-    };
+      void agent.stream('prompt', {
+        // @ts-expect-error - providerOptions requires model
+        structuredOutput: {
+          providerOptions: { openai: { reasoningEffort: 'low' } },
+          schema,
+        },
+      });
 
-    // @ts-expect-error - fallbackValue requires model
-    const _opt5: PublicStructuredOutputOptions<{ name: string }> = {
-      errorStrategy: 'fallback',
-      fallbackValue: { name: 'default' },
-      schema: z.object({ name: z.string() }),
-    };
-  });
-
-  it('should allow fallback fields in Processor Mode', () => {
-    const options: PublicStructuredOutputOptions<{ name: string }> = {
-      model: 'openai/gpt-4o',
-      schema: z.object({ name: z.string() }),
-      errorStrategy: 'fallback',
-      fallbackValue: { name: 'default' },
-    };
-    expectTypeOf(options).toBeObject();
+      void agent.stream('prompt', {
+        // @ts-expect-error - useAgent requires model
+        structuredOutput: {
+          useAgent: true,
+          schema,
+        },
+      });
+    });
   });
 });

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -91,23 +91,23 @@ export type StructuredOutputCommonFields<SCHEMA = unknown> = {
 export type StructuredOutputProcessorFields<MODEL, OUTPUT = {}, SCHEMA = unknown> = {
   /**
    * Model to use for the internal structuring agent.
-   * @required Providing this enables **Two-Stage Processing**: the main agent generates text, and this model converts that text into JSON.
+   * @remarks Providing this enables **Two-Stage Processing**: the main agent generates text, and this model converts that text into JSON.
    */
   model: MODEL;
   /**
    * Custom instructions for the structuring agent.
-   * @requires **model** must be provided to use this field.
+   * @remarks **model** must be provided to use this field.
    * If using native LLM structuring (no separate model), include these instructions in the main prompt/instructions instead.
    */
   instructions?: string;
   /**
    * Optional logger instance for structured logging.
-   * @requires **model** must be provided to use this field.
+   * @remarks **model** must be provided to use this field.
    */
   logger?: IMastraLogger;
   /**
    * Provider-specific options for the structuring agent.
-   * @requires **model** must be provided to use this field.
+   * @remarks **model** must be provided to use this field.
    */
   providerOptions?: ProviderOptions;
 } & StructuredOutputCommonFields<SCHEMA> &

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -89,38 +89,42 @@ export type StructuredOutputCommonFields<SCHEMA = unknown> = {
 };
 
 export type StructuredOutputProcessorFields<MODEL, OUTPUT = {}, SCHEMA = unknown> = {
-  /** Model to use for the internal structuring agent. When provided, enables two-stage processing where the main agent generates text and a separate structuring agent converts it to JSON. */
+  /**
+   * Model to use for the internal structuring agent.
+   * @required Providing this enables **Two-Stage Processing**: the main agent generates text, and this model converts that text into JSON.
+   */
   model: MODEL;
   /**
    * Custom instructions for the structuring agent.
-   * If not provided, will generate instructions based on the schema.
+   * @requires **model** must be provided to use this field.
+   * If using native LLM structuring (no separate model), include these instructions in the main prompt/instructions instead.
    */
   instructions?: string;
   /**
-   * Optional logger instance for structured logging
+   * Optional logger instance for structured logging.
+   * @requires **model** must be provided to use this field.
    */
   logger?: IMastraLogger;
   /**
-   * Provider-specific options passed to the internal structuring agent.
-   * Use this to control model behavior like reasoning effort for thinking models.
-   *
-   * @example
-   * ```ts
-   * providerOptions: {
-   *   openai: { reasoningEffort: 'low' }
-   * }
-   * ```
+   * Provider-specific options for the structuring agent.
+   * @requires **model** must be provided to use this field.
    */
   providerOptions?: ProviderOptions;
 } & StructuredOutputCommonFields<SCHEMA> &
   FallbackFields<OUTPUT>;
 
 export type StructuredOutputDirectFields<SCHEMA = unknown> = {
+  /** @internal Not allowed in Direct Mode */
   model?: never;
+  /** @internal Not allowed in Direct Mode. Use main agent instructions instead. */
   instructions?: never;
+  /** @internal Not allowed in Direct Mode */
   logger?: never;
+  /** @internal Not allowed in Direct Mode */
   providerOptions?: never;
+  /** @internal Not allowed in Direct Mode */
   errorStrategy?: never;
+  /** @internal Not allowed in Direct Mode */
   fallbackValue?: never;
 } & StructuredOutputCommonFields<SCHEMA>;
 

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -78,25 +78,28 @@ type FallbackFields<OUTPUT = undefined> =
   | { errorStrategy?: 'strict' | 'warn'; fallbackValue?: never }
   | { errorStrategy: 'fallback'; fallbackValue: OUTPUT };
 
-export type StructuredOutputOptionsBase<OUTPUT = {}> = {
-  /** Model to use for the internal structuring agent. If not provided, falls back to the agent's model */
-  model?: MastraModelConfig;
+/** Fields available in both direct and processor modes */
+export type StructuredOutputCommonFields<SCHEMA = unknown> = {
+  /**
+   * Whether to use system prompt injection instead of native response format to coerce the LLM to respond with json text if the LLM does not natively support structured outputs.
+   */
+  jsonPromptInjection?: boolean;
+  /** Validation schema to validate the output against */
+  schema: SCHEMA;
+};
+
+export type StructuredOutputProcessorFields<MODEL, OUTPUT = {}, SCHEMA = unknown> = {
+  /** Model to use for the internal structuring agent. When provided, enables two-stage processing where the main agent generates text and a separate structuring agent converts it to JSON. */
+  model: MODEL;
   /**
    * Custom instructions for the structuring agent.
    * If not provided, will generate instructions based on the schema.
    */
   instructions?: string;
-
-  /**
-   * Whether to use system prompt injection instead of native response format to coerce the LLM to respond with json text if the LLM does not natively support structured outputs.
-   */
-  jsonPromptInjection?: boolean;
-
   /**
    * Optional logger instance for structured logging
    */
   logger?: IMastraLogger;
-
   /**
    * Provider-specific options passed to the internal structuring agent.
    * Use this to control model behavior like reasoning effort for thinking models.
@@ -109,22 +112,39 @@ export type StructuredOutputOptionsBase<OUTPUT = {}> = {
    * ```
    */
   providerOptions?: ProviderOptions;
-} & FallbackFields<OUTPUT>;
+} & StructuredOutputCommonFields<SCHEMA> &
+  FallbackFields<OUTPUT>;
 
-export type StructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<OUTPUT> & {
-  /** Zod schema to validate the output against */
-  schema: StandardSchemaWithJSON<OUTPUT>;
-};
+export type StructuredOutputDirectFields<SCHEMA = unknown> = {
+  model?: never;
+  instructions?: never;
+  logger?: never;
+  providerOptions?: never;
+  errorStrategy?: never;
+  fallbackValue?: never;
+} & StructuredOutputCommonFields<SCHEMA>;
 
-export type PublicStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<OUTPUT> & {
-  schema: PublicSchema<OUTPUT>;
-};
+export type StructuredOutputOptionsBase<MODEL, OUTPUT = {}, SCHEMA = unknown> =
+  | StructuredOutputProcessorFields<MODEL, OUTPUT, SCHEMA>
+  | StructuredOutputDirectFields<SCHEMA>;
 
-export type SerializableStructuredOutputOptions<OUTPUT = {}> = Omit<StructuredOutputOptionsBase<OUTPUT>, 'model'> & {
-  model?: ModelRouterModelId | OpenAICompatibleConfig;
-  /** JSON Schema to validate the output against */
-  schema: JSONSchema7;
-};
+export type StructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<
+  MastraModelConfig,
+  OUTPUT,
+  StandardSchemaWithJSON<OUTPUT>
+>;
+
+export type PublicStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<
+  MastraModelConfig,
+  OUTPUT,
+  PublicSchema<OUTPUT>
+>;
+
+export type SerializableStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<
+  ModelRouterModelId | OpenAICompatibleConfig,
+  OUTPUT,
+  JSONSchema7
+>;
 
 /**
  * Provide options while creating an agent.

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -401,7 +401,7 @@ export type StructuredOutputProcessorFields<MODEL, OUTPUT = {}, SCHEMA = unknown
   model: MODEL;
   /**
    * Custom instructions for the structuring agent.
-   * @remarks Processor-mode only. **model** must be provided to use this field.
+   * @remarks Processor-mode only. Requires `structuredOutput.model`.
    * If using native LLM structuring (no separate model), include these instructions in the main prompt/instructions instead.
    */
   instructions?: string;
@@ -409,17 +409,17 @@ export type StructuredOutputProcessorFields<MODEL, OUTPUT = {}, SCHEMA = unknown
    * When true and `model` is also provided, reuse the parent agent for the separate
    * structuring pass. If a thread is available, Mastra attaches read-only memory so
    * the structuring model has full conversation context.
-   * @remarks Processor-mode only. **model** must be provided to use this field.
+   * @remarks Processor-mode only. Requires `structuredOutput.model`.
    */
   useAgent?: boolean;
   /**
    * Optional logger instance for structured logging.
-   * @remarks Processor-mode only. **model** must be provided to use this field.
+   * @remarks Processor-mode only. Requires `structuredOutput.model`.
    */
   logger?: IMastraLogger;
   /**
    * Provider-specific options passed to the internal structuring agent.
-   * @remarks Processor-mode only. **model** must be provided to use this field.
+   * @remarks Processor-mode only. Requires `structuredOutput.model`.
    * Use this to control model behavior like reasoning effort for thinking models.
    *
    * @example

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -378,22 +378,8 @@ type FallbackFields<OUTPUT = undefined> =
   | { errorStrategy?: 'strict' | 'warn'; fallbackValue?: never }
   | { errorStrategy: 'fallback'; fallbackValue: OUTPUT };
 
-export type StructuredOutputOptionsBase<OUTPUT = {}> = {
-  /** Model to use for the internal structuring agent. If not provided, falls back to the agent's model */
-  model?: MastraModelConfig;
-  /**
-   * Custom instructions for the structuring agent.
-   * If not provided, will generate instructions based on the schema.
-   */
-  instructions?: string;
-
-  /**
-   * When true and `model` is also provided, reuse the parent agent for the separate
-   * structuring pass. If a thread is available, Mastra attaches read-only memory so
-   * the structuring model has full conversation context.
-   */
-  useAgent?: boolean;
-
+/** Fields available in both direct and processor modes */
+export type StructuredOutputCommonFields<SCHEMA = unknown, OUTPUT = {}> = {
   /**
    * Whether to use prompt injection instead of native response format to coerce the LLM to respond with JSON text.
    * true and 'system' inject JSON instructions into the leading system message.
@@ -402,14 +388,38 @@ export type StructuredOutputOptionsBase<OUTPUT = {}> = {
    * false or omitted uses the provider's native response format.
    */
   jsonPromptInjection?: boolean | 'system' | 'inline' | 'auto';
+  /** Validation schema to validate the output against */
+  schema: SCHEMA;
+} & FallbackFields<OUTPUT>;
 
+/** Fields available only when using Processor Mode (when structuredOutput.model is provided) */
+export type StructuredOutputProcessorFields<MODEL, OUTPUT = {}, SCHEMA = unknown> = {
   /**
-   * Optional logger instance for structured logging
+   * Model to use for the internal structuring agent.
+   * @remarks Providing this enables **Two-Stage Processing**: the main agent generates text, and this model converts that text into JSON.
+   */
+  model: MODEL;
+  /**
+   * Custom instructions for the structuring agent.
+   * @remarks Processor-mode only. **model** must be provided to use this field.
+   * If using native LLM structuring (no separate model), include these instructions in the main prompt/instructions instead.
+   */
+  instructions?: string;
+  /**
+   * When true and `model` is also provided, reuse the parent agent for the separate
+   * structuring pass. If a thread is available, Mastra attaches read-only memory so
+   * the structuring model has full conversation context.
+   * @remarks Processor-mode only. **model** must be provided to use this field.
+   */
+  useAgent?: boolean;
+  /**
+   * Optional logger instance for structured logging.
+   * @remarks Processor-mode only. **model** must be provided to use this field.
    */
   logger?: IMastraLogger;
-
   /**
    * Provider-specific options passed to the internal structuring agent.
+   * @remarks Processor-mode only. **model** must be provided to use this field.
    * Use this to control model behavior like reasoning effort for thinking models.
    *
    * @example
@@ -420,22 +430,43 @@ export type StructuredOutputOptionsBase<OUTPUT = {}> = {
    * ```
    */
   providerOptions?: ProviderOptions;
-} & FallbackFields<OUTPUT>;
+} & StructuredOutputCommonFields<SCHEMA, OUTPUT>;
 
-export type StructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<OUTPUT> & {
-  /** Zod schema to validate the output against */
-  schema: StandardSchemaWithJSON<OUTPUT>;
-};
+/** Fields available when using Direct Mode (without structuredOutput.model) */
+export type StructuredOutputDirectFields<SCHEMA = unknown, OUTPUT = {}> = {
+  /** @internal Not allowed in Direct Mode */
+  model?: never;
+  /** @internal Not allowed in Direct Mode. Use main agent instructions instead. */
+  instructions?: never;
+  /** @internal Not allowed in Direct Mode */
+  useAgent?: never;
+  /** @internal Not allowed in Direct Mode */
+  logger?: never;
+  /** @internal Not allowed in Direct Mode */
+  providerOptions?: never;
+} & StructuredOutputCommonFields<SCHEMA, OUTPUT>;
 
-export type PublicStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<OUTPUT> & {
-  schema: PublicSchema<OUTPUT>;
-};
+export type StructuredOutputOptionsBase<MODEL, OUTPUT = {}, SCHEMA = unknown> =
+  | StructuredOutputProcessorFields<MODEL, OUTPUT, SCHEMA>
+  | StructuredOutputDirectFields<SCHEMA, OUTPUT>;
 
-export type SerializableStructuredOutputOptions<OUTPUT = {}> = Omit<StructuredOutputOptionsBase<OUTPUT>, 'model'> & {
-  model?: ModelRouterModelId | OpenAICompatibleConfig;
-  /** JSON Schema to validate the output against */
-  schema: JSONSchema7;
-};
+export type StructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<
+  MastraModelConfig,
+  OUTPUT,
+  StandardSchemaWithJSON<OUTPUT>
+>;
+
+export type PublicStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<
+  MastraModelConfig,
+  OUTPUT,
+  PublicSchema<OUTPUT>
+>;
+
+export type SerializableStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<
+  ModelRouterModelId | OpenAICompatibleConfig,
+  OUTPUT,
+  JSONSchema7
+>;
 
 /**
  * Provide options while creating an agent.

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -361,22 +361,8 @@ type FallbackFields<OUTPUT = undefined> =
   | { errorStrategy?: 'strict' | 'warn'; fallbackValue?: never }
   | { errorStrategy: 'fallback'; fallbackValue: OUTPUT };
 
-export type StructuredOutputOptionsBase<OUTPUT = {}> = {
-  /** Model to use for the internal structuring agent. If not provided, falls back to the agent's model */
-  model?: MastraModelConfig;
-  /**
-   * Custom instructions for the structuring agent.
-   * If not provided, will generate instructions based on the schema.
-   */
-  instructions?: string;
-
-  /**
-   * When true and `model` is also provided, reuse the parent agent for the separate
-   * structuring pass. If a thread is available, Mastra attaches read-only memory so
-   * the structuring model has full conversation context.
-   */
-  useAgent?: boolean;
-
+/** Fields available in both direct and processor modes */
+export type StructuredOutputCommonFields<SCHEMA = unknown, OUTPUT = {}> = {
   /**
    * Whether to use prompt injection instead of native response format to coerce the LLM to respond with JSON text.
    * true and 'system' inject JSON instructions into the leading system message.
@@ -385,14 +371,38 @@ export type StructuredOutputOptionsBase<OUTPUT = {}> = {
    * false or omitted uses the provider's native response format.
    */
   jsonPromptInjection?: boolean | 'system' | 'inline' | 'auto';
+  /** Validation schema to validate the output against */
+  schema: SCHEMA;
+} & FallbackFields<OUTPUT>;
 
+/** Fields available only when using Processor Mode (when structuredOutput.model is provided) */
+export type StructuredOutputProcessorFields<MODEL, OUTPUT = {}, SCHEMA = unknown> = {
   /**
-   * Optional logger instance for structured logging
+   * Model to use for the internal structuring agent.
+   * @remarks Providing this enables **Two-Stage Processing**: the main agent generates text, and this model converts that text into JSON.
+   */
+  model: MODEL;
+  /**
+   * Custom instructions for the structuring agent.
+   * @remarks Processor-mode only. **model** must be provided to use this field.
+   * If using native LLM structuring (no separate model), include these instructions in the main prompt/instructions instead.
+   */
+  instructions?: string;
+  /**
+   * When true and `model` is also provided, reuse the parent agent for the separate
+   * structuring pass. If a thread is available, Mastra attaches read-only memory so
+   * the structuring model has full conversation context.
+   * @remarks Processor-mode only. **model** must be provided to use this field.
+   */
+  useAgent?: boolean;
+  /**
+   * Optional logger instance for structured logging.
+   * @remarks Processor-mode only. **model** must be provided to use this field.
    */
   logger?: IMastraLogger;
-
   /**
    * Provider-specific options passed to the internal structuring agent.
+   * @remarks Processor-mode only. **model** must be provided to use this field.
    * Use this to control model behavior like reasoning effort for thinking models.
    *
    * @example
@@ -403,22 +413,43 @@ export type StructuredOutputOptionsBase<OUTPUT = {}> = {
    * ```
    */
   providerOptions?: ProviderOptions;
-} & FallbackFields<OUTPUT>;
+} & StructuredOutputCommonFields<SCHEMA, OUTPUT>;
 
-export type StructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<OUTPUT> & {
-  /** Zod schema to validate the output against */
-  schema: StandardSchemaWithJSON<OUTPUT>;
-};
+/** Fields available when using Direct Mode (without structuredOutput.model) */
+export type StructuredOutputDirectFields<SCHEMA = unknown, OUTPUT = {}> = {
+  /** @internal Not allowed in Direct Mode */
+  model?: never;
+  /** @internal Not allowed in Direct Mode. Use main agent instructions instead. */
+  instructions?: never;
+  /** @internal Not allowed in Direct Mode */
+  useAgent?: never;
+  /** @internal Not allowed in Direct Mode */
+  logger?: never;
+  /** @internal Not allowed in Direct Mode */
+  providerOptions?: never;
+} & StructuredOutputCommonFields<SCHEMA, OUTPUT>;
 
-export type PublicStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<OUTPUT> & {
-  schema: PublicSchema<OUTPUT>;
-};
+export type StructuredOutputOptionsBase<MODEL, OUTPUT = {}, SCHEMA = unknown> =
+  | StructuredOutputProcessorFields<MODEL, OUTPUT, SCHEMA>
+  | StructuredOutputDirectFields<SCHEMA, OUTPUT>;
 
-export type SerializableStructuredOutputOptions<OUTPUT = {}> = Omit<StructuredOutputOptionsBase<OUTPUT>, 'model'> & {
-  model?: ModelRouterModelId | OpenAICompatibleConfig;
-  /** JSON Schema to validate the output against */
-  schema: JSONSchema7;
-};
+export type StructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<
+  MastraModelConfig,
+  OUTPUT,
+  StandardSchemaWithJSON<OUTPUT>
+>;
+
+export type PublicStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<
+  MastraModelConfig,
+  OUTPUT,
+  PublicSchema<OUTPUT>
+>;
+
+export type SerializableStructuredOutputOptions<OUTPUT = {}> = StructuredOutputOptionsBase<
+  ModelRouterModelId | OpenAICompatibleConfig,
+  OUTPUT,
+  JSONSchema7
+>;
 
 /**
  * Provide options while creating an agent.

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -384,7 +384,7 @@ export type StructuredOutputProcessorFields<MODEL, OUTPUT = {}, SCHEMA = unknown
   model: MODEL;
   /**
    * Custom instructions for the structuring agent.
-   * @remarks Processor-mode only. **model** must be provided to use this field.
+   * @remarks Processor-mode only. Requires `structuredOutput.model`.
    * If using native LLM structuring (no separate model), include these instructions in the main prompt/instructions instead.
    */
   instructions?: string;
@@ -392,17 +392,17 @@ export type StructuredOutputProcessorFields<MODEL, OUTPUT = {}, SCHEMA = unknown
    * When true and `model` is also provided, reuse the parent agent for the separate
    * structuring pass. If a thread is available, Mastra attaches read-only memory so
    * the structuring model has full conversation context.
-   * @remarks Processor-mode only. **model** must be provided to use this field.
+   * @remarks Processor-mode only. Requires `structuredOutput.model`.
    */
   useAgent?: boolean;
   /**
    * Optional logger instance for structured logging.
-   * @remarks Processor-mode only. **model** must be provided to use this field.
+   * @remarks Processor-mode only. Requires `structuredOutput.model`.
    */
   logger?: IMastraLogger;
   /**
    * Provider-specific options passed to the internal structuring agent.
-   * @remarks Processor-mode only. **model** must be provided to use this field.
+   * @remarks Processor-mode only. Requires `structuredOutput.model`.
    * Use this to control model behavior like reasoning effort for thinking models.
    *
    * @example


### PR DESCRIPTION
fixes: #14552

## Description

This PR introduces discriminated union types for the `structuredOutput` options on the `Agent` class config. 
This ensures that certain fields (e.g., `instructions`, `logger`, and `providerOptions`) are only available when a separate structuring `model` is provided.

>  i.e. these options are only available in the **Processor Mode** (i.e. two-stage structuring) and not in **Direct Mode** (native LLM-structuring). Up until now, these options were silently ignored in Direct Mode, which was confusing for devs.

## Changes
- Refactored `StructuredOutputOptionsBase` into:
  - `StructuredOutputProcessorFields` - enabled when `model` is provided (allows `instructions`, `logger`, `providerOptions`, `errorStrategy`, and `fallbackValue`)
  - `StructuredOutputDirectFields` - used when `model` is omitted (disallows the processor-only fields)
  - `StructuredOutputCommonFields` - for shared fields like `jsonPromptInjection` and `schema`
- Added explicit JSDocs to explain the difference between Direct & Processor modes in the IDE on hover
- Added comprehensive type tests in [`agent-structured-output.test-d.ts`](https://github.com/mastra-ai/mastra/compare/main...BeeBombshell:mastra:feat/structured-output-union-types?expand=1#diff-13925af0bf71a6e64b8d53c08d18f7b222b0f15f70421bcc3effb4f647c3cd71)

### Screenshots
(manual testing in the project - defining an agent execution with a mixed config)
<img width="1915" height="1288" alt="image" src="https://github.com/user-attachments/assets/0ca5f825-e44e-4c8f-bc83-efc2ee6f6d10" />
<img width="2352" height="1291" alt="image" src="https://github.com/user-attachments/assets/2c60c004-85db-4a40-9d2f-c767b2625585" />


## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes TypeScript separate direct structured output from processor-based structured output. Processor-only options now require a separate `model`, so invalid options produce compile-time errors instead of being ignored.

## Changes Overview

### Type System Refactor

- Replaces the flat `StructuredOutputOptionsBase` type with Direct Mode and Processor Mode union types.
- Requires `model` for processor-only fields, including `instructions`, `useAgent`, `logger`, `providerOptions`, `errorStrategy`, and `fallbackValue`.
- Keeps shared fields, such as `schema` and `jsonPromptInjection`, available in both modes.
- Updates `StructuredOutputOptions`, `PublicStructuredOutputOptions`, and `SerializableStructuredOutputOptions`.
- Preserves router and OpenAI-compatible model types for serializable processor mode.

### Documentation

- Adds JSDoc for Direct Mode and Processor Mode.
- Documents that processor-only fields require a separate `model`.

### Tests

- Adds declaration tests for `agent.generate()` and `agent.stream()`.
- Verifies valid Direct Mode and Processor Mode configurations.
- Verifies that processor-only fields fail type checks without `model`.
- Covers `errorStrategy` and `fallbackValue` combinations.

### Changelog

- Adds a patch changeset for `@mastra/core`.

## Impact

The new types catch invalid structured output configurations at compile time. This change does not alter runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->