### PR TITLE
fix langfuse tests when running locally

### DIFF
--- a/observability/langfuse/src/tracing.config.test.ts
+++ b/observability/langfuse/src/tracing.config.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { LangfuseExporter, LANGFUSE_DEFAULT_BASE_URL } from './tracing';
 
 // Track constructor args to verify config is passed correctly
 const processorArgs: any[] = [];
+const originalLangfuseBaseUrl = process.env.LANGFUSE_BASE_URL;
 
 vi.mock('@langfuse/otel', () => {
   class MockLangfuseSpanProcessor {
@@ -37,6 +38,12 @@ vi.mock('@mastra/otel-exporter', () => {
 describe('LangfuseExporterConfig', () => {
   beforeEach(() => {
     processorArgs.length = 0;
+    delete process.env.LANGFUSE_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (originalLangfuseBaseUrl === undefined) delete process.env.LANGFUSE_BASE_URL;
+    else process.env.LANGFUSE_BASE_URL = originalLangfuseBaseUrl;
   });
 
   it('uses default base URL when none provided', () => {

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -31,6 +31,13 @@ const mockScoreCreate = vi.fn();
 const mockClientFlush = vi.fn().mockResolvedValue(undefined);
 const mockClientShutdown = vi.fn().mockResolvedValue(undefined);
 const clientConstructorArgs: any[] = [];
+const originalLangfuseEnv = {
+  publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+  secretKey: process.env.LANGFUSE_SECRET_KEY,
+  baseUrl: process.env.LANGFUSE_BASE_URL,
+  environment: process.env.LANGFUSE_TRACING_ENVIRONMENT,
+  release: process.env.LANGFUSE_RELEASE,
+};
 
 vi.mock('@langfuse/client', () => {
   class MockLangfuseClient {
@@ -112,6 +119,11 @@ describe('LangfuseExporter', () => {
     mockShutdown.mockClear();
     mockClientFlush.mockClear();
     mockClientShutdown.mockClear();
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.LANGFUSE_TRACING_ENVIRONMENT;
+    delete process.env.LANGFUSE_RELEASE;
   });
 
   afterEach(async () => {
@@ -119,6 +131,17 @@ describe('LangfuseExporter', () => {
       await exporter.shutdown();
       exporter = undefined;
     }
+
+    if (originalLangfuseEnv.publicKey === undefined) delete process.env.LANGFUSE_PUBLIC_KEY;
+    else process.env.LANGFUSE_PUBLIC_KEY = originalLangfuseEnv.publicKey;
+    if (originalLangfuseEnv.secretKey === undefined) delete process.env.LANGFUSE_SECRET_KEY;
+    else process.env.LANGFUSE_SECRET_KEY = originalLangfuseEnv.secretKey;
+    if (originalLangfuseEnv.baseUrl === undefined) delete process.env.LANGFUSE_BASE_URL;
+    else process.env.LANGFUSE_BASE_URL = originalLangfuseEnv.baseUrl;
+    if (originalLangfuseEnv.environment === undefined) delete process.env.LANGFUSE_TRACING_ENVIRONMENT;
+    else process.env.LANGFUSE_TRACING_ENVIRONMENT = originalLangfuseEnv.environment;
+    if (originalLangfuseEnv.release === undefined) delete process.env.LANGFUSE_RELEASE;
+    else process.env.LANGFUSE_RELEASE = originalLangfuseEnv.release;
   });
 
   describe('configuration', () => {


### PR DESCRIPTION
## Description

fix langfuse tests when running locally

no changeset required

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR fixes Langfuse tests so they don't interfere with each other when running on your computer. Just like cleaning up your toys after playtime, the tests now remember what environment settings were there before the test ran and put them back afterward, preventing one test from accidentally affecting another.

## Changes

### observability/langfuse/src/tracing.config.test.ts
Added proper environment variable cleanup to prevent test isolation issues. The test now:
- Captures the `LANGFUSE_BASE_URL` environment variable before each test
- Clears it before the test runs
- Restores the original value (or removes it if it wasn't set) after each test

**Lines changed: +8/-1**

### observability/langfuse/src/tracing.test.ts
Extended environment cleanup to handle all Langfuse-related environment variables. The test now:
- Snapshots the existing `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, `LANGFUSE_TRACING_ENVIRONMENT`, and `LANGFUSE_RELEASE` variables before each test
- Deletes all these variables to prevent cross-test contamination
- Restores the original values (or removes the variables if they were previously unset) after each test

**Lines changed: +23/-0**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->