### PR TITLE
fix(core): re-stamp MODEL_GENERATION span when fallback model takes over

### DIFF
--- a/.changeset/slick-goats-cover.md
+++ b/.changeset/slick-goats-cover.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed fallback model attribution in observability traces. When an agent switched to a fallback model after the primary failed, exporters like Langfuse still labelled the generation with the primary model, causing usage and cost to be misattributed or dropped. The MODEL_GENERATION span is now re-stamped with the active fallback model so traces reflect the model that actually served the response.
+Fixed fallback model attribution in agent traces. When an agent fell back after the primary model failed, token usage and cost were reported against the primary model instead of the fallback that actually served the response (e.g. in Langfuse). Fixes #13547.

--- a/.changeset/slick-goats-cover.md
+++ b/.changeset/slick-goats-cover.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed fallback model attribution in observability traces. When an agent switched to a fallback model after the primary failed, exporters like Langfuse still labelled the generation with the primary model, causing usage and cost to be misattributed or dropped. The MODEL_GENERATION span is now re-stamped with the active fallback model so traces reflect the model that actually served the response.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -735,4 +735,115 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     expect(secondModelStream).toHaveBeenCalledTimes(2);
     expect(firstModelStream).toHaveBeenCalledTimes(1);
   });
+
+  it('re-stamps MODEL_GENERATION span attributes when a fallback model takes over', async () => {
+    const primaryStream = vi.fn(async () => {
+      throw new APICallError({
+        message: 'primary down',
+        url: 'https://primary.example.com/v1/messages',
+        requestBodyValues: {},
+        statusCode: 503,
+        isRetryable: true,
+      });
+    });
+    const secondaryStream = vi.fn(async () => ({
+      stream: convertArrayToReadableStream([
+        {
+          type: 'response-metadata',
+          id: 'resp-secondary',
+          modelId: 'secondary-model',
+          timestamp: new Date(0),
+        },
+        {
+          type: 'text-delta',
+          textDelta: 'from secondary',
+        },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: testUsage,
+        },
+      ]),
+      request: {},
+      response: { headers: undefined },
+      warnings: [],
+    }));
+
+    const modelSpanTracker = {
+      getTracingContext: vi.fn(() => ({})),
+      reportGenerationError: vi.fn(),
+      endGeneration: vi.fn(),
+      updateGeneration: vi.fn(),
+      wrapStream: vi.fn(<T>(stream: T) => stream),
+      startStep: vi.fn(),
+    };
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      modelSpanTracker: modelSpanTracker as any,
+      models: [
+        {
+          id: 'primary-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'primary-provider',
+            modelId: 'primary-model',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream: primaryStream,
+          } as any,
+        },
+        {
+          id: 'secondary-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'secondary-provider',
+            modelId: 'secondary-model',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream: secondaryStream,
+          } as any,
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+        threadId: 'thread-123',
+        resourceId: 'resource-456',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<{}>);
+
+    const input = createIterationInput();
+    input.stepResult.isContinued = false;
+
+    await llmExecutionStep.execute(createExecuteParams(input));
+
+    expect(primaryStream).toHaveBeenCalledTimes(1);
+    expect(secondaryStream).toHaveBeenCalledTimes(1);
+    expect(modelSpanTracker.updateGeneration).toHaveBeenCalledWith({
+      name: `llm: 'secondary-model'`,
+      attributes: {
+        model: 'secondary-model',
+        provider: 'secondary-provider',
+      },
+    });
+  });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -742,6 +742,19 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           activeFallbackModelIndex = models.findIndex(candidate => candidate.id === modelConfig.id);
           const model = modelConfig.model;
           const modelHeaders = modelConfig.headers;
+
+          // Re-stamp MODEL_GENERATION span with the fallback model so that downstream
+          // exporters (Langfuse, etc.) attribute usage and cost to the model that
+          // actually served the request instead of the first model in the list.
+          if (modelSpanTracker && activeFallbackModelIndex > 0) {
+            modelSpanTracker.updateGeneration({
+              name: `llm: '${model.modelId}'`,
+              attributes: {
+                model: model.modelId,
+                provider: model.provider,
+              },
+            });
+          }
           // Reset system messages to original before each step execution
           // This ensures that system message modifications in prepareStep/processInputStep/processors
           // don't persist across steps - each step starts fresh with original system messages


### PR DESCRIPTION
## Description

Fixes fallback model attribution in observability traces. When an agent's primary model failed and the fallback model served the response, the `MODEL_GENERATION` span kept the primary
model's `model` and `provider` attributes, so exporters like Langfuse attributed usage and cost to the wrong (failed) model or dropped them entirely.

## Before
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/28900c25-7403-4f35-ad09-34529247f85f" />

## After
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/6244ef59-4b7d-4eef-912a-33060433444b" />

## Related Issue(s)

Fixes #13547

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Imagine you ask a friend for help, but they can't and a backup friend does it. When someone asks who helped, you should say the backup friend. This PR ensures the system records the backup model when the main model fails, so usage and cost are attributed to the model that actually answered.

## Summary

This PR fixes fallback model attribution in observability traces: when an agent's primary model fails and a fallback model serves the response, the MODEL_GENERATION span is re-stamped with the fallback model's modelId and provider so exporters (e.g., Langfuse) attribute usage and cost to the correct model.

Key changes:
- Implementation (packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts): inside executeStreamWithFallbackModels, call modelSpanTracker.updateGeneration() when a fallback model (activeFallbackModelIndex > 0) is selected to re-stamp the MODEL_GENERATION span with the active model's name, model, and provider attributes.
- Test (packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts): added test "re-stamps MODEL_GENERATION span attributes when a fallback model takes over" which mocks modelSpanTracker, forces the primary model to throw, runs a successful secondary model, and asserts updateGeneration is called with the secondary model's attributes.
- Release notes (.changeset/slick-goats-cover.md): added a changeset describing the patch release and observability fix.

Design note:
- The change reuses the existing update pattern used for processor-driven model swaps, implemented in Mastra core so downstream exporters (Langfuse, Datadog, Arize, otel-exporter) automatically receive corrected attribution.

Related: fixes #13547
<!-- end of auto-generated comment: release notes by coderabbit.ai -->