### PR TITLE
fix(memory): propagate Vertex thought signatures for OM split tool calls

### DIFF
--- a/.changeset/metal-mirrors-design.md
+++ b/.changeset/metal-mirrors-design.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed Observational Memory triggering Gemini Vertex thought signature validation errors when parallel tool calls were stored as separate assistant messages. Tool invocations now receive the last known thought signature so multi-step runs with thinking enabled complete successfully.

--- a/packages/memory/src/processors/observational-memory/__tests__/vertex-thought-signature-om.integration.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/vertex-thought-signature-om.integration.test.ts
@@ -29,7 +29,8 @@ function createStubMemoryProvider(): MemoryContextProvider {
   };
 }
 
-function toolResultPart(
+/** Mirrors OM-split parallel calls: still in `call` before results are merged. */
+function toolInvocationPart(
   callId: string,
   toolName: string,
   providerMetadata?: { vertex?: { thoughtSignature?: string }; google?: { thoughtSignature?: string } },
@@ -37,11 +38,10 @@ function toolResultPart(
   return {
     type: 'tool-invocation',
     toolInvocation: {
-      state: 'result',
+      state: 'call',
       toolCallId: callId,
       toolName,
       args: {},
-      result: { ok: true },
     },
     ...(providerMetadata ? { providerMetadata } : {}),
   } as MastraDBMessage['content']['parts'][number];
@@ -92,7 +92,7 @@ describe('ObservationalMemoryProcessor + Vertex thought signatures (#15294)', ()
       resourceId,
       content: {
         format: 2,
-        parts: [toolResultPart('c1', 'query_data', { vertex: { thoughtSignature: 'sig-from-stream' } })],
+        parts: [toolInvocationPart('c1', 'query_data', { vertex: { thoughtSignature: 'sig-from-stream' } })],
       },
     };
 
@@ -104,7 +104,7 @@ describe('ObservationalMemoryProcessor + Vertex thought signatures (#15294)', ()
       resourceId,
       content: {
         format: 2,
-        parts: [toolResultPart('c2', 'query_data')],
+        parts: [toolInvocationPart('c2', 'query_data')],
       },
     };
 

--- a/packages/memory/src/processors/observational-memory/__tests__/vertex-thought-signature-om.integration.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/vertex-thought-signature-om.integration.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Ensures #15294 fix runs inside processInputStep (not only the standalone helper).
+ * Live Vertex/Gemini is not invoked — credentials are not available in CI.
+ */
+import type { MastraDBMessage } from '@mastra/core/agent';
+import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { ObservationalMemory } from '../observational-memory';
+import { ObservationalMemoryProcessor } from '../processor';
+import type { MemoryContextProvider } from '../processor';
+
+function createInMemoryStorage(): InMemoryMemory {
+  const db = new InMemoryDB();
+  return new InMemoryMemory({ db });
+}
+
+function createStubMemoryProvider(): MemoryContextProvider {
+  return {
+    getContext: vi.fn().mockResolvedValue({
+      systemMessage: undefined,
+      messages: [],
+      hasObservations: false,
+      omRecord: null,
+      continuationMessage: undefined,
+      otherThreadsContext: undefined,
+    }),
+    persistMessages: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function toolResultPart(
+  callId: string,
+  toolName: string,
+  providerMetadata?: { vertex?: { thoughtSignature?: string }; google?: { thoughtSignature?: string } },
+): MastraDBMessage['content']['parts'][number] {
+  return {
+    type: 'tool-invocation',
+    toolInvocation: {
+      state: 'result',
+      toolCallId: callId,
+      toolName,
+      args: {},
+      result: { ok: true },
+    },
+    ...(providerMetadata ? { providerMetadata } : {}),
+  } as MastraDBMessage['content']['parts'][number];
+}
+
+describe('ObservationalMemoryProcessor + Vertex thought signatures (#15294)', () => {
+  const threadId = 'thread-15294';
+  const resourceId = 'resource-15294';
+
+  let om: ObservationalMemory;
+  let processor: ObservationalMemoryProcessor;
+
+  beforeEach(() => {
+    const storage = createInMemoryStorage();
+    om = new ObservationalMemory({
+      storage,
+      observation: { messageTokens: 100_000, model: 'test-model' },
+      reflection: { observationTokens: 100_000, model: 'test-model' },
+      scope: 'thread',
+    });
+    processor = new ObservationalMemoryProcessor(om, createStubMemoryProvider());
+  });
+
+  it('processInputStep propagates thoughtSignature across split assistant tool-invocation messages', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+
+    const messageList = new MessageList({ threadId, resourceId });
+
+    const userMsg: MastraDBMessage = {
+      id: 'u1',
+      role: 'user',
+      content: { format: 2, parts: [{ type: 'text', text: 'Run tools' }] },
+      type: 'text',
+      createdAt: new Date(),
+      threadId,
+      resourceId,
+    };
+
+    const assistantSplitA: MastraDBMessage = {
+      id: 'asst-a',
+      role: 'assistant',
+      createdAt: new Date(),
+      threadId,
+      resourceId,
+      content: {
+        format: 2,
+        parts: [toolResultPart('c1', 'query_data', { vertex: { thoughtSignature: 'sig-from-stream' } })],
+      },
+    };
+
+    const assistantSplitB: MastraDBMessage = {
+      id: 'asst-b',
+      role: 'assistant',
+      createdAt: new Date(),
+      threadId,
+      resourceId,
+      content: {
+        format: 2,
+        parts: [toolResultPart('c2', 'query_data')],
+      },
+    };
+
+    messageList.add(userMsg, 'input');
+    messageList.add(assistantSplitA, 'response');
+    messageList.add(assistantSplitB, 'response');
+
+    await processor.processInputStep({
+      messageList,
+      messages: [userMsg],
+      requestContext,
+      stepNumber: 0,
+      state: {},
+      steps: [],
+      systemMessages: [],
+      model: { provider: 'google.vertex', modelId: 'gemini-3-flash-preview' } as any,
+      retryCount: 0,
+      abort: (() => {
+        throw new Error('aborted');
+      }) as any,
+    });
+
+    const db = messageList.get.all.db();
+    const withSecondCall = db.find(m =>
+      m.content.parts?.some(
+        p =>
+          p.type === 'tool-invocation' &&
+          (p as { toolInvocation?: { toolCallId?: string } }).toolInvocation?.toolCallId === 'c2',
+      ),
+    );
+    expect(withSecondCall).toBeDefined();
+    const part = withSecondCall!.content.parts.find(p => p.type === 'tool-invocation') as {
+      providerMetadata?: { vertex?: { thoughtSignature?: string } };
+    };
+    expect(part.providerMetadata?.vertex?.thoughtSignature).toBe('sig-from-stream');
+  });
+});

--- a/packages/memory/src/processors/observational-memory/__tests__/vertex-thought-signature.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/vertex-thought-signature.test.ts
@@ -81,6 +81,45 @@ describe('propagateVertexThoughtSignaturesToToolInvocations', () => {
     expect(second.providerMetadata?.vertex?.thoughtSignature).toBe('sig-google');
   });
 
+  it('does not copy a thoughtSignature across a user message (new turn boundary)', () => {
+    const messages: MastraDBMessage[] = [
+      {
+        id: 'a1',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [toolPart('c1', 'query_data', { vertex: { thoughtSignature: 'from-earlier-turn' } })],
+        },
+      },
+      {
+        id: 'u1',
+        role: 'user',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Tool results here' }],
+        },
+      },
+      {
+        id: 'a2',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [toolPart('c2', 'query_data')],
+        },
+      },
+    ];
+
+    propagateVertexThoughtSignaturesToToolInvocations(messages);
+
+    const laterPart = messages[2]!.content.parts[0] as {
+      providerMetadata?: { vertex?: { thoughtSignature?: string } };
+    };
+    expect(laterPart.providerMetadata?.vertex?.thoughtSignature).toBeUndefined();
+  });
+
   it('does not overwrite an existing tool-invocation thoughtSignature', () => {
     const messages: MastraDBMessage[] = [
       {

--- a/packages/memory/src/processors/observational-memory/__tests__/vertex-thought-signature.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/vertex-thought-signature.test.ts
@@ -1,0 +1,113 @@
+import type { MastraDBMessage } from '@mastra/core/agent';
+import { describe, expect, it } from 'vitest';
+
+import { propagateVertexThoughtSignaturesToToolInvocations } from '../vertex-thought-signature';
+
+function toolPart(
+  id: string,
+  toolName: string,
+  providerMetadata?: { vertex?: { thoughtSignature?: string }; google?: { thoughtSignature?: string } },
+): MastraDBMessage['content']['parts'][number] {
+  return {
+    type: 'tool-invocation',
+    toolInvocation: {
+      state: 'call',
+      toolCallId: id,
+      toolName,
+      args: {},
+    },
+    ...(providerMetadata ? { providerMetadata } : {}),
+  } as MastraDBMessage['content']['parts'][number];
+}
+
+describe('propagateVertexThoughtSignaturesToToolInvocations', () => {
+  it('copies the prior vertex thoughtSignature onto later parallel tool-invocation parts', () => {
+    const messages: MastraDBMessage[] = [
+      {
+        id: 'a1',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [toolPart('c1', 'query_data', { vertex: { thoughtSignature: 'sig-from-first' } })],
+        },
+      },
+      {
+        id: 'a2',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [toolPart('c2', 'query_data')],
+        },
+      },
+    ];
+
+    propagateVertexThoughtSignaturesToToolInvocations(messages);
+
+    const second = messages[1]!.content.parts[0] as {
+      providerMetadata?: { vertex?: { thoughtSignature?: string } };
+    };
+    expect(second.providerMetadata?.vertex?.thoughtSignature).toBe('sig-from-first');
+  });
+
+  it('uses google namespace thoughtSignature as the source when vertex is absent', () => {
+    const messages: MastraDBMessage[] = [
+      {
+        id: 'a1',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [toolPart('c1', 'query_data', { google: { thoughtSignature: 'sig-google' } })],
+        },
+      },
+      {
+        id: 'a2',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [toolPart('c2', 'query_data')],
+        },
+      },
+    ];
+
+    propagateVertexThoughtSignaturesToToolInvocations(messages);
+
+    const second = messages[1]!.content.parts[0] as {
+      providerMetadata?: { vertex?: { thoughtSignature?: string } };
+    };
+    expect(second.providerMetadata?.vertex?.thoughtSignature).toBe('sig-google');
+  });
+
+  it('does not overwrite an existing tool-invocation thoughtSignature', () => {
+    const messages: MastraDBMessage[] = [
+      {
+        id: 'a1',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [toolPart('c1', 'query_data', { vertex: { thoughtSignature: 'first' } })],
+        },
+      },
+      {
+        id: 'a2',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [toolPart('c2', 'query_data', { vertex: { thoughtSignature: 'second-own' } })],
+        },
+      },
+    ];
+
+    propagateVertexThoughtSignaturesToToolInvocations(messages);
+
+    const second = messages[1]!.content.parts[0] as {
+      providerMetadata?: { vertex?: { thoughtSignature?: string } };
+    };
+    expect(second.providerMetadata?.vertex?.thoughtSignature).toBe('second-own');
+  });
+});

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -247,6 +247,8 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
         // Gemini Vertex validates thought signatures per content block; parallel tool calls
         // only receive a signature on the first part. OM splits calls into separate
         // assistant messages — propagate the last known signature so each block validates.
+        // In-place mutation is intentional: the same MastraDBMessage objects must be
+        // updated for the upcoming model request (see vertex-thought-signature.ts).
         propagateVertexThoughtSignaturesToToolInvocations(messageList.get.all.db());
 
         // ── Repro capture (processor-specific) ──────────────

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -10,6 +10,7 @@ import type { ObservationTurn } from './observation-turn/index';
 import type { ObservationalMemory } from './observational-memory';
 import { isOmReproCaptureEnabled, safeCaptureJson, writeProcessInputStepReproCapture } from './repro-capture';
 import type { TokenCounterModelContext } from './token-counter';
+import { propagateVertexThoughtSignaturesToToolInvocations } from './vertex-thought-signature';
 
 /** Subset of Memory that the processor needs — avoids circular imports. */
 export interface MemoryContextProvider {
@@ -242,6 +243,11 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
           .getStorage()
           .setPendingMessageTokens(freshRecord.id, finalTotalPending)
           .catch(() => {});
+
+        // Gemini Vertex validates thought signatures per content block; parallel tool calls
+        // only receive a signature on the first part. OM splits calls into separate
+        // assistant messages — propagate the last known signature so each block validates.
+        propagateVertexThoughtSignaturesToToolInvocations(messageList.get.all.db());
 
         // ── Repro capture (processor-specific) ──────────────
         if (reproCaptureEnabled) {

--- a/packages/memory/src/processors/observational-memory/vertex-thought-signature.ts
+++ b/packages/memory/src/processors/observational-memory/vertex-thought-signature.ts
@@ -36,12 +36,26 @@ function writeVertexThoughtSignature(part: PartWithProviderMetadata, signature: 
  * signature are rejected (400). Copy the most recent prior signature onto
  * `tool-invocation` parts that are missing one so the reconstructed history validates.
  *
+ * Only assistant messages are updated. `lastKnown` resets on each `user` message so
+ * signatures from an earlier model turn are not applied after tool results or a new
+ * user message.
+ *
+ * Mutates message objects in place so the same list the agent sends to the model is
+ * updated; copying would detach edits from `MessageList` storage.
+ *
  * @see https://github.com/mastra-ai/mastra/issues/15294
  */
 export function propagateVertexThoughtSignaturesToToolInvocations(messages: MastraDBMessage[]): void {
   let lastKnown: string | undefined;
 
   for (const msg of messages) {
+    if (msg.role === 'user') {
+      lastKnown = undefined;
+    }
+    if (msg.role !== 'assistant') {
+      continue;
+    }
+
     const parts = msg.content?.parts;
     if (!parts?.length) continue;
 

--- a/packages/memory/src/processors/observational-memory/vertex-thought-signature.ts
+++ b/packages/memory/src/processors/observational-memory/vertex-thought-signature.ts
@@ -1,0 +1,68 @@
+import type { MastraDBMessage } from '@mastra/core/agent';
+
+type PartWithProviderMetadata = {
+  type: string;
+  providerMetadata?: {
+    vertex?: { thoughtSignature?: string };
+    google?: { thoughtSignature?: string };
+    [key: string]: unknown;
+  };
+};
+
+function readThoughtSignatureFromPart(part: PartWithProviderMetadata): string | undefined {
+  const meta = part.providerMetadata;
+  if (!meta) return undefined;
+  return meta.vertex?.thoughtSignature ?? meta.google?.thoughtSignature;
+}
+
+function toolInvocationHasThoughtSignature(part: PartWithProviderMetadata): boolean {
+  return !!readThoughtSignatureFromPart(part);
+}
+
+function writeVertexThoughtSignature(part: PartWithProviderMetadata, signature: string): void {
+  if (!part.providerMetadata) {
+    part.providerMetadata = {};
+  }
+  if (!part.providerMetadata.vertex) {
+    part.providerMetadata.vertex = {};
+  }
+  part.providerMetadata.vertex.thoughtSignature = signature;
+}
+
+/**
+ * Gemini (Vertex) streaming often emits `thoughtSignature` only on the first parallel
+ * tool call. Observational Memory splits assistant tool calls into separate messages, so
+ * each becomes its own API content block — blocks where every function call lacks a
+ * signature are rejected (400). Copy the most recent prior signature onto
+ * `tool-invocation` parts that are missing one so the reconstructed history validates.
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/15294
+ */
+export function propagateVertexThoughtSignaturesToToolInvocations(messages: MastraDBMessage[]): void {
+  let lastKnown: string | undefined;
+
+  for (const msg of messages) {
+    const parts = msg.content?.parts;
+    if (!parts?.length) continue;
+
+    for (const part of parts) {
+      const typed = part as PartWithProviderMetadata;
+      const sig = readThoughtSignatureFromPart(typed);
+      if (sig) {
+        lastKnown = sig;
+      }
+
+      if (typed.type !== 'tool-invocation') {
+        continue;
+      }
+
+      if (toolInvocationHasThoughtSignature(typed)) {
+        continue;
+      }
+
+      if (lastKnown) {
+        writeVertexThoughtSignature(typed, lastKnown);
+      }
+    }
+  }
+}


### PR DESCRIPTION

## Description

Observational Memory can split parallel Gemini tool calls into separate assistant messages. Vertex only attaches a `thought_signature` to the first call in a batch, so when those calls end up in different blocks the API rejects the next request. After each OM input step we now reuse the last signature we saw and attach it to any tool-invocation parts that are still missing one, so the history stays valid for thinking mode.

## Related Issue(s)

Fixes #15294

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Observational Memory sometimes splits multiple tool calls into separate assistant messages but Gemini only gives a special "thought signature" to the first one; later pieces get rejected. This PR copies the last-seen thought signature onto subsequent assistant tool-invocation parts (until a new user message), so Vertex accepts split parallel calls.

## Overview
Fixes a bug where Observational Memory (OM) reconstruction of Gemini/Vertex streaming could produce assistant content blocks for parallel tool-invocations that lack the required Vertex `thought_signature`, causing Vertex 400 validation errors (issue #15294). The fix propagates the most recently observed thought signature across assistant message parts within the same assistant turn so multi-step parallel tool-call workflows validate correctly.

## Changes
- Added propagateVertexThoughtSignaturesToToolInvocations(messages: MastraDBMessage[]) in packages/memory/src/processors/observational-memory/vertex-thought-signature.ts.
  - Scans messages, resets its last-known signature on every user message, records signatures from assistant parts (Vertex then Google fallback), and writes the last-known signature into tool-invocation parts that lack one (mutating messages in place).
- Invoke propagation inside ObservationalMemoryProcessor.processInputStep (packages/memory/src/processors/observational-memory/processor.ts) immediately after persisting token counts and before repro-capture/other repro logic so OM-updated message objects include signatures before further processing.
- Added tests:
  - Unit tests (vertex-thought-signature.test.ts) covering propagation behavior, Google fallback, respecting user-turn boundaries (no cross-turn propagation), and not overwriting existing signatures.
  - Integration test (vertex-thought-signature-om.integration.test.ts) asserting processInputStep performs propagation on OM-split assistant messages.
- Changeset entry (.changeset/metal-mirrors-design.md) bumping @mastra/memory patch with a short note describing the fix.

## Impact
Resolves #15294 — Observational Memory no longer produces Vertex validation errors for multi-step parallel tool calls on Gemini models. Classified as a bug fix; includes tests proving the behavior.

## Notes
- The propagation deliberately stops at user message boundaries (scope limited to assistant-run segments following user turns).
- Documentation was not updated in this PR; some reviewer comments (coderabbit) were not fully addressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->