### PR TITLE
fix(core): preserve raw usage field in onStepFinish/onFinish callbacks

### DIFF
--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -262,6 +262,67 @@ describe('MastraModelOutput', () => {
       expect(await output.providerMetadata).toEqual(providerMetadata);
     });
 
+    it('should preserve raw usage field in onFinish callback', async () => {
+      const runId = 'test-run';
+      const rawUsage = {
+        inputTokens: { total: 100, noCache: 20, cacheRead: 70, cacheWrite: 10 },
+        outputTokens: { total: 50, text: 40, reasoning: 10 },
+      };
+      let onFinishPayload: any;
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      messageList.add(
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'hello' }] },
+          createdAt: new Date(),
+        },
+        'response',
+      );
+
+      const finishChunk: ChunkType = {
+        type: 'finish',
+        runId,
+        from: ChunkFrom.AGENT,
+        payload: {
+          id: 'finish-1',
+          output: {
+            steps: [],
+            usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150, raw: rawUsage },
+          },
+          stepResult: {
+            reason: 'stop',
+            warnings: [],
+            isContinued: false,
+          },
+          metadata: {},
+          messages: { nonUser: [], all: [] },
+        },
+      } as ChunkType;
+
+      const stream = createChunkStream([createStepFinishChunk(runId), finishChunk]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          onFinish: async payload => {
+            onFinishPayload = payload;
+          },
+        },
+      });
+
+      await output.consumeStream();
+
+      const usage = await output.usage;
+      expect(usage.raw).toEqual(rawUsage);
+      expect(onFinishPayload?.usage?.raw).toEqual(rawUsage);
+    });
+
     it('should propagate arbitrary finish providerMetadata to steps and onFinish', async () => {
       const runId = 'test-run';
       const providerMetadata = {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -801,6 +801,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 ...(self.#usageCount.cachedInputTokens !== undefined && {
                   cachedInputTokens: self.#usageCount.cachedInputTokens,
                 }),
+                ...(self.#usageCount.raw !== undefined && {
+                  raw: self.#usageCount.raw,
+                }),
               };
 
               try {
@@ -1252,6 +1255,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     if (usage.cachedInputTokens !== undefined) {
       this.#usageCount.cachedInputTokens = (this.#usageCount.cachedInputTokens ?? 0) + usage.cachedInputTokens;
     }
+    if (usage.raw !== undefined) {
+      this.#usageCount.raw = usage.raw;
+    }
   }
 
   populateUsageCount(usage: Partial<LanguageModelUsage>) {
@@ -1274,6 +1280,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     }
     if (usage.cachedInputTokens !== undefined && this.#usageCount.cachedInputTokens === undefined) {
       this.#usageCount.cachedInputTokens = usage.cachedInputTokens;
+    }
+    if (usage.raw !== undefined && this.#usageCount.raw === undefined) {
+      this.#usageCount.raw = usage.raw;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #15510

The usage accumulator in `MastraModelOutput` reconstructs the usage object in the `finish` chunk handler but only includes `inputTokens`, `outputTokens`, `totalTokens`, `reasoningTokens`, and `cachedInputTokens` — dropping the `raw` field declared in `LanguageModelUsage`.

## Changes

- **`output.ts`**: Preserve `raw` in both `updateUsageCount` (accumulating) and `populateUsageCount` (first-write) methods, and spread it into the reconstructed usage object in the finish handler.
- **`output.test.ts`**: Add test verifying `raw` is preserved through to `onFinish` callback and `output.usage`.

## Root cause

In the `finish` chunk handler (~line 794), the usage object is rebuilt from `#usageCount` fields but `raw` was never accumulated or spread back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When Mastra was keeping track of how many tokens (units of text) were used during API calls, it was accidentally throwing away some extra details called the `raw` field. This PR fixes that by making sure all the details, including `raw`, are preserved and passed along to your code when the operation finishes. Now you'll get the complete usage information instead of a partial one.

## Changes

### packages/core/src/stream/base/output.ts
Added tracking and propagation of the `usage.raw` field throughout the `MastraModelOutput` lifecycle:
- When building the final `chunk.payload.output.usage`, the `raw` field is now conditionally included if present in internal usage state
- The `updateUsageCount` method now accumulates/sets `#usageCount.raw` when `usage.raw` is provided
- The `populateUsageCount` method now sets `#usageCount.raw` when `usage.raw` is provided and the internal `raw` value is unset

### packages/core/src/stream/base/output.test.ts
Added a new test case that verifies `MastraModelOutput` preserves the `usage.raw` object through the stream lifecycle. The test constructs a finish chunk with raw usage data, runs `consumeStream()`, and asserts that both `output.usage.raw` and the `raw` field in the `onFinish` callback payload match the original raw usage data exactly.

## Issue Fix

Fixes #15510 by ensuring that `onStepFinish` and `onFinish` callbacks receive the complete `LanguageModelUsage` object with the `raw` field intact, not just token counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->