### PR TITLE
feat(playground-ui): add Logo component

### DIFF
--- a/.changeset/rare-carrots-glow.md
+++ b/.changeset/rare-carrots-glow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added new Logo component to the playground-ui design system. Supports two sizes (sm, md), uses currentcolor for theming, and includes an optional outline-on-hover animation that respects prefers-reduced-motion.

--- a/.changeset/rare-carrots-glow.md
+++ b/.changeset/rare-carrots-glow.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': minor
 ---
 
-Added new Logo component to the playground-ui design system. Supports two sizes (sm, md), uses currentcolor for theming, and includes an optional outline-on-hover animation that respects prefers-reduced-motion.
+Added new Logo component to the playground-ui design system. Supports two sizes (sm, md), uses currentColor for theming, and includes an optional outline-on-hover animation that respects prefers-reduced-motion.

--- a/packages/playground-ui/src/ds/components/Logo/index.ts
+++ b/packages/playground-ui/src/ds/components/Logo/index.ts
@@ -1,1 +1,2 @@
 export * from './MastraLogo';
+export * from './logo';

--- a/packages/playground-ui/src/ds/components/Logo/logo.css
+++ b/packages/playground-ui/src/ds/components/Logo/logo.css
@@ -1,0 +1,63 @@
+.logo svg {
+  shape-rendering: geometricprecision;
+  overflow: visible;
+}
+
+.logo .logo-fill {
+  fill: currentcolor;
+  transition: fill-opacity 320ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Inner stroke: clipPath clips the stroke to the shape so only the inside
+   half renders — reads as a line drawn inside, not a border around. */
+.logo .logo-stroke {
+  fill: none;
+  stroke: currentcolor;
+  stroke-width: 0;
+  transition: stroke-width 320ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.logo-animate-on-hover .logo-fill {
+  animation: logo-fill-cycle 1500ms cubic-bezier(0.4, 0, 0.2, 1) 1;
+}
+
+.logo-animate-on-hover .logo-stroke {
+  animation: logo-stroke-cycle 1500ms cubic-bezier(0.4, 0, 0.2, 1) 1;
+}
+
+@keyframes logo-fill-cycle {
+  0% {
+    fill-opacity: 1;
+  }
+  23.3% {
+    fill-opacity: 0;
+  }
+  43.3% {
+    fill-opacity: 0;
+  }
+  100% {
+    fill-opacity: 1;
+  }
+}
+
+@keyframes logo-stroke-cycle {
+  0% {
+    stroke-width: 0;
+  }
+  23.3% {
+    stroke-width: 2;
+  }
+  43.3% {
+    stroke-width: 2;
+  }
+  100% {
+    stroke-width: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .logo .logo-fill,
+  .logo .logo-stroke {
+    transition: none;
+  }
+}

--- a/packages/playground-ui/src/ds/components/Logo/logo.css
+++ b/packages/playground-ui/src/ds/components/Logo/logo.css
@@ -65,5 +65,6 @@
   .logo .logo-fill,
   .logo .logo-stroke {
     transition: none;
+    animation: none;
   }
 }

--- a/packages/playground-ui/src/ds/components/Logo/logo.css
+++ b/packages/playground-ui/src/ds/components/Logo/logo.css
@@ -29,12 +29,15 @@
   0% {
     fill-opacity: 1;
   }
+
   23.3% {
     fill-opacity: 0;
   }
+
   43.3% {
     fill-opacity: 0;
   }
+
   100% {
     fill-opacity: 1;
   }
@@ -44,12 +47,15 @@
   0% {
     stroke-width: 0;
   }
+
   23.3% {
     stroke-width: 2;
   }
+
   43.3% {
     stroke-width: 2;
   }
+
   100% {
     stroke-width: 0;
   }

--- a/packages/playground-ui/src/ds/components/Logo/logo.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Logo/logo.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Logo } from './logo';
+
+const meta: Meta<typeof Logo> = {
+  title: 'Elements/Logo',
+  component: Logo,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'radio' },
+      options: ['sm', 'md'],
+    },
+    animateOnHover: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Logo>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const OutlineOnHover: Story = {
+  args: { animateOnHover: true, size: 'md' },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-8">
+      <Logo size="sm" animateOnHover />
+      <Logo size="md" animateOnHover />
+    </div>
+  ),
+};
+
+export const OnSurface: Story = {
+  render: () => (
+    <div className="flex h-64 w-96 items-center justify-center rounded-lg bg-surface2">
+      <Logo size="md" animateOnHover />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Logo/logo.tsx
+++ b/packages/playground-ui/src/ds/components/Logo/logo.tsx
@@ -1,0 +1,63 @@
+import { useId, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+import './logo.css';
+
+const PATH_D =
+  'M4.49805 11.6934C6.98237 11.6934 8.99609 13.7081 8.99609 16.1924C8.9959 18.6765 6.98225 20.6904 4.49805 20.6904C2.01394 20.6903 0.000196352 18.6765 0 16.1924C0 13.7081 2.01382 11.6935 4.49805 11.6934ZM10.3867 0C12.8709 0 14.8846 2.01388 14.8848 4.49805C14.8848 4.8377 14.847 5.16846 14.7755 5.48643C14.4618 6.88139 14.1953 8.4633 14.9928 9.65L16.2575 11.5319C16.3363 11.6491 16.4727 11.7115 16.6137 11.703C16.7369 11.6957 16.8525 11.6343 16.9214 11.5318L18.1876 9.64717C18.9772 8.47198 18.7236 6.90783 18.4205 5.52484C18.3523 5.21392 18.3164 4.89094 18.3164 4.55957C18.3167 2.07546 20.3313 0.0615234 22.8154 0.0615234C25.2994 0.0617476 27.3132 2.0756 27.3135 4.55957C27.3135 4.93883 27.2665 5.30712 27.178 5.65896C26.8547 6.94441 26.5817 8.37932 27.2446 9.52714L28.459 11.6301C28.4819 11.6697 28.5245 11.6934 28.5703 11.6934C31.0545 11.6935 33.0684 13.7081 33.0684 16.1924C33.0682 18.6765 31.0544 20.6903 28.5703 20.6904C26.0861 20.6904 24.0725 18.6765 24.0723 16.1924C24.0723 15.8049 24.1212 15.4288 24.2133 15.0701C24.5458 13.7746 24.8298 12.3251 24.1609 11.1668L23.0044 9.16384C22.9656 9.09659 22.8931 9.05859 22.8154 9.05859C22.7983 9.05859 22.7824 9.06614 22.7728 9.08033L21.4896 10.9895C20.686 12.1851 20.9622 13.781 21.284 15.1851C21.3582 15.5089 21.3975 15.8461 21.3975 16.1924C21.3973 18.6764 19.3834 20.6902 16.8994 20.6904C14.4152 20.6904 12.4006 18.6765 12.4004 16.1924C12.4004 15.932 12.4226 15.6768 12.4651 15.4286C12.6859 14.14 12.8459 12.7122 12.1167 11.6271L11.2419 10.3253C10.6829 9.49347 9.71913 9.05932 8.78286 8.70188C7.0906 8.05584 5.88867 6.41734 5.88867 4.49805C5.88886 2.0139 7.90254 3.29835e-05 10.3867 0Z';
+
+export type LogoProps = {
+  className?: string;
+  size?: 'sm' | 'md';
+  animateOnHover?: boolean;
+  'aria-label'?: string;
+};
+
+const sizeClasses = {
+  sm: 'w-6',
+  md: 'w-10',
+};
+
+function Logo({ className, size = 'md', animateOnHover = false, 'aria-label': ariaLabel = 'Mastra' }: LogoProps) {
+  const reactId = useId();
+  const clipId = `logo-clip-${reactId.replace(/[^a-zA-Z0-9_-]/g, '')}`;
+  const [playing, setPlaying] = useState(false);
+
+  const handleMouseEnter = animateOnHover ? () => setPlaying(true) : undefined;
+  const handleAnimationEnd = animateOnHover && playing ? () => setPlaying(false) : undefined;
+
+  return (
+    <div
+      role="img"
+      aria-label={ariaLabel}
+      onMouseEnter={handleMouseEnter}
+      onAnimationEnd={handleAnimationEnd}
+      className={cn(
+        'logo inline-block text-neutral6',
+        sizeClasses[size],
+        animateOnHover && playing && 'logo-animate-on-hover',
+        className,
+      )}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 34 21"
+        fill="none"
+        className="logo-svg block w-full h-auto"
+        aria-hidden="true"
+      >
+        <defs>
+          <clipPath id={clipId}>
+            <path d={PATH_D} />
+          </clipPath>
+        </defs>
+
+        <path className="logo-fill" d={PATH_D} />
+        <path className="logo-stroke" d={PATH_D} clipPath={`url(#${clipId})`} />
+      </svg>
+    </div>
+  );
+}
+
+export { Logo };

--- a/packages/playground-ui/src/ds/components/Logo/logo.tsx
+++ b/packages/playground-ui/src/ds/components/Logo/logo.tsx
@@ -1,3 +1,4 @@
+import type { AnimationEvent } from 'react';
 import { useId, useState } from 'react';
 
 import { cn } from '@/lib/utils';
@@ -35,7 +36,13 @@ function Logo({ className, size = 'md', animateOnHover = false, 'aria-label': ar
         setPlaying(true);
       }
     : undefined;
-  const handleAnimationEnd = animateOnHover && playing ? () => setPlaying(false) : undefined;
+  const handleAnimationEnd =
+    animateOnHover && playing
+      ? (e: AnimationEvent<HTMLDivElement>) => {
+          if (e.animationName !== 'logo-stroke-cycle') return;
+          setPlaying(false);
+        }
+      : undefined;
 
   return (
     <div

--- a/packages/playground-ui/src/ds/components/Logo/logo.tsx
+++ b/packages/playground-ui/src/ds/components/Logo/logo.tsx
@@ -19,12 +19,22 @@ const sizeClasses = {
   md: 'w-10',
 };
 
+function prefersReducedMotion() {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
 function Logo({ className, size = 'md', animateOnHover = false, 'aria-label': ariaLabel = 'Mastra' }: LogoProps) {
   const reactId = useId();
   const clipId = `logo-clip-${reactId.replace(/[^a-zA-Z0-9_-]/g, '')}`;
   const [playing, setPlaying] = useState(false);
 
-  const handleMouseEnter = animateOnHover ? () => setPlaying(true) : undefined;
+  const handleMouseEnter = animateOnHover
+    ? () => {
+        if (prefersReducedMotion()) return;
+        setPlaying(true);
+      }
+    : undefined;
   const handleAnimationEnd = animateOnHover && playing ? () => setPlaying(false) : undefined;
 
   return (


### PR DESCRIPTION
## Summary
- New `Logo` component in `packages/playground-ui/src/ds/components/Logo`
- Two sizes (`sm`, `md`), uses `currentcolor` for theming
- Optional `animateOnHover` outline-stroke animation; respects `prefers-reduced-motion`
- Storybook stories: `Default`, `OutlineOnHover`, `AllSizes`, `OnSurface`

<img width="416" height="260" alt="CleanShot 2026-04-20 at 09 12 50" src="https://github.com/user-attachments/assets/3bde6de5-a24e-4946-ba8c-81e4e954018b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a new Logo component so the app can show a reusable, theme-aware Mastra logo in two sizes, with an optional hover outline animation that respects users' reduced-motion preferences.

## Changes Overview

### New Logo Component
Adds a new Logo component at packages/playground-ui/src/ds/components/Logo/ with implementation, styles, stories, and a changeset.

### Component Features
- Props: className?, size ('sm' | 'md', default 'md'), animateOnHover? (default false), 'aria-label'? (default 'Mastra').
- Sizes: `sm` (w-6) and `md` (w-10).
- Theming: Uses `currentColor` so the logo inherits color from its context.
- Accessibility:
  - Container uses role="img" with aria-label.
  - SVG uses aria-hidden and generates sanitized per-instance clipPath IDs via useId.
- Animation:
  - Optional outline-on-hover animation (1500ms keyframe sequence) that toggles fill opacity and stroke-width to produce an outline draw effect.
  - Animation playback state managed with React hooks.
  - Respects prefers-reduced-motion: when user prefers reduced motion, animation is disabled entirely and playing state is not set.
  - onAnimationEnd filters by animation name to avoid clearing playing state prematurely when multiple child animations fire.

### Styling
- New logo.css defines fill and stroke layers, keyframes (logo-fill-cycle and logo-stroke-cycle), transitions, hover-triggered animation class, and a media query to disable animations/transitions for prefers-reduced-motion.

### Storybook
Adds logo.stories.tsx with four stories and controls:
- Default — basic render.
- OutlineOnHover — animateOnHover true, md size.
- AllSizes — shows sm and md together.
- OnSurface — logo on a surface background for contrast.
ArgTypes configured for size (radio) and animateOnHover (boolean).

### Module Exports
index.ts in the Logo folder now re-exports the Logo implementation (export * from './logo') alongside existing MastraLogo exports.

### Changeset & Versioning
Adds a changeset (.changeset/rare-carrots-glow.md) documenting a minor bump for @mastra/playground-ui. The changeset copy was adjusted to capitalize "currentColor".

### Commits / Fixes
- style: formatting for keyframe stops to satisfy stylelint.
- fix: fully respect prefers-reduced-motion (disable animation and skip setting playing state).
- fix: filter onAnimationEnd by animation name to avoid premature state clearing.
- docs: capitalize "currentColor" in the changeset entry.

### Test Plan
- Run Storybook for @mastra/playground-ui and verify the four Logo stories render correctly.
- Toggle OS reduced-motion preference to confirm animations are suppressed when appropriate.
- Verify Storybook controls for `size` and `animateOnHover` behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->