### PR TITLE
fix(core): clarify resumeStream no-snapshot errors

### DIFF
--- a/.changeset/puny-goats-smell.md
+++ b/.changeset/puny-goats-smell.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Improved error message when `resumeStream()` or `resumeGenerate()` cannot find a suspended run snapshot. Instead of the cryptic "No snapshot found for this workflow run: agentic-loop <runId>", the agent now throws an actionable `AGENT_RESUME_NO_SNAPSHOT_FOUND` error that explains whether storage is missing or the runId is invalid, and suggests remediation steps.
+Fixed resume errors for suspended agent runs: `resumeStream()` and `resumeGenerate()` now return a clear message when storage is missing or the `runId` is invalid.

--- a/.changeset/puny-goats-smell.md
+++ b/.changeset/puny-goats-smell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved error message when `resumeStream()` or `resumeGenerate()` cannot find a suspended run snapshot. Instead of the cryptic "No snapshot found for this workflow run: agentic-loop <runId>", the agent now throws an actionable `AGENT_RESUME_NO_SNAPSHOT_FOUND` error that explains whether storage is missing or the runId is invalid, and suggests remediation steps.

--- a/packages/core/src/agent/__tests__/resume-stream-no-snapshot.test.ts
+++ b/packages/core/src/agent/__tests__/resume-stream-no-snapshot.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { Agent } from '../agent';
+import { MockLanguageModelV2 } from './mock-model';
+
+/**
+ * Tests for the AGENT_RESUME_NO_SNAPSHOT_FOUND error.
+ *
+ * These verify that resumeStream / resumeGenerate throw an actionable error
+ * when no agentic-loop snapshot can be loaded, rather than the cryptic
+ * "No snapshot found for this workflow run: agentic-loop <runId>" from the
+ * workflow engine.
+ *
+ * For the full suspend → resume happy-path tests, see issues:
+ *  - https://github.com/mastra-ai/mastra/issues/10389
+ *  - https://github.com/mastra-ai/mastra/issues/14663
+ */
+
+function createMockModel() {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    }),
+  });
+}
+
+describe('resumeStream / resumeGenerate — no snapshot found', () => {
+  describe('resumeStream', () => {
+    it('throws AGENT_RESUME_NO_SNAPSHOT_FOUND when no storage is configured', async () => {
+      const agent = new Agent({
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel() as any,
+      });
+
+      // No Mastra instance → no storage → no snapshot
+      await expect(agent.resumeStream({ approved: true }, { runId: 'some-run-id' })).rejects.toThrow(
+        expect.objectContaining({
+          id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+          message: expect.stringContaining('some-run-id'),
+        }),
+      );
+    });
+
+    it('throws AGENT_RESUME_NO_SNAPSHOT_FOUND when storage exists but runId is unknown', async () => {
+      const mockModel = createMockModel();
+      const agent = new Agent({
+        name: 'test-agent',
+        instructions: 'test',
+        model: mockModel as any,
+      });
+
+      const mastra = new Mastra({
+        agents: { 'test-agent': agent },
+        storage: new InMemoryStore(),
+        logger: false,
+      });
+
+      const registeredAgent = mastra.getAgent('test-agent');
+
+      await expect(registeredAgent.resumeStream({ approved: true }, { runId: 'does-not-exist' })).rejects.toThrow(
+        expect.objectContaining({
+          id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+          message: expect.stringContaining('does-not-exist'),
+        }),
+      );
+    });
+
+    it('error message mentions missing storage when Mastra has no storage', async () => {
+      const agent = new Agent({
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel() as any,
+      });
+
+      const mastra = new Mastra({
+        agents: { 'test-agent': agent },
+        logger: false,
+        // no storage
+      });
+
+      const registeredAgent = mastra.getAgent('test-agent');
+
+      await expect(registeredAgent.resumeStream({ approved: true }, { runId: 'abc' })).rejects.toThrow(
+        expect.objectContaining({
+          id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+          message: expect.stringContaining('storage'),
+        }),
+      );
+    });
+  });
+
+  describe('resumeGenerate', () => {
+    it('throws AGENT_RESUME_NO_SNAPSHOT_FOUND when no storage is configured', async () => {
+      const agent = new Agent({
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel() as any,
+      });
+
+      await expect(agent.resumeGenerate({ approved: true }, { runId: 'some-run-id' })).rejects.toThrow(
+        expect.objectContaining({
+          id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+          message: expect.stringContaining('some-run-id'),
+        }),
+      );
+    });
+
+    it('throws AGENT_RESUME_NO_SNAPSHOT_FOUND when storage exists but runId is unknown', async () => {
+      const mockModel = createMockModel();
+      const agent = new Agent({
+        name: 'test-agent',
+        instructions: 'test',
+        model: mockModel as any,
+      });
+
+      const mastra = new Mastra({
+        agents: { 'test-agent': agent },
+        storage: new InMemoryStore(),
+        logger: false,
+      });
+
+      const registeredAgent = mastra.getAgent('test-agent');
+
+      await expect(registeredAgent.resumeGenerate({ approved: true }, { runId: 'does-not-exist' })).rejects.toThrow(
+        expect.objectContaining({
+          id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+          message: expect.stringContaining('does-not-exist'),
+        }),
+      );
+    });
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4709,6 +4709,41 @@ export class Agent<
   }
 
   /**
+   * Loads the agentic-loop workflow snapshot for resume, or throws an actionable error.
+   * Used by resumeStream and resumeGenerate to fail fast at the agent boundary.
+   * @internal
+   */
+  async #loadAgenticLoopSnapshotOrThrow({ runId, method }: { runId: string; method: string }) {
+    const workflowsStore = await this.#mastra?.getStorage()?.getStore('workflows');
+    const existingSnapshot = await workflowsStore?.loadWorkflowSnapshot({
+      workflowName: 'agentic-loop',
+      runId,
+    });
+
+    if (!existingSnapshot) {
+      const hasStorage = !!workflowsStore;
+      throw new MastraError({
+        id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text:
+          `Agent "${this.name}" ${method}() could not find a suspended run for runId "${runId}". ` +
+          (hasStorage
+            ? `The run may have already completed, never suspended, or the runId is invalid. `
+            : `No storage is configured on this Mastra instance, so workflow snapshots cannot be persisted. Register the agent on a Mastra instance with persistent storage (e.g. PostgreSQL, LibSQL). `) +
+          `Ensure you are calling ${method}() only with a runId from a currently-suspended run.`,
+        details: {
+          runId,
+          agentName: this.name,
+          hasStorage,
+        },
+      });
+    }
+
+    return existingSnapshot;
+  }
+
+  /**
    * Executes the agent call, handling tools, memory, and streaming.
    * @internal
    */
@@ -5640,11 +5675,8 @@ export class Agent<
       });
     }
 
-    const workflowsStore = await this.#mastra?.getStorage()?.getStore('workflows');
-    const existingSnapshot = await workflowsStore?.loadWorkflowSnapshot({
-      workflowName: 'agentic-loop',
-      runId: streamOptions?.runId ?? '',
-    });
+    const runId = streamOptions?.runId ?? '';
+    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
 
     const result = await this.#execute({
       ...mergedStreamOptions,
@@ -5768,11 +5800,8 @@ export class Agent<
       });
     }
 
-    const workflowsStore = await this.#mastra?.getStorage()?.getStore('workflows');
-    const existingSnapshot = await workflowsStore?.loadWorkflowSnapshot({
-      workflowName: 'agentic-loop',
-      runId: options?.runId ?? '',
-    });
+    const runId = options?.runId ?? '';
+    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeGenerate' });
 
     const result = await this.#execute({
       ...mergedOptions,


### PR DESCRIPTION
This improves the error you get from `agent.resumeStream()` and `agent.resumeGenerate()` when the `agentic-loop` snapshot cannot be loaded.

Before, this bubbled up as:
`No snapshot found for this workflow run: agentic-loop <runId>`

Now the agent fails earlier with `AGENT_RESUME_NO_SNAPSHOT_FOUND`, including the `runId`, whether storage is configured, and a clearer explanation of what likely happened (missing storage, stale/invalid `runId`, or a run that already completed / never suspended).

This does not fix the full multi-step suspension behavior in #14875, but it does improve one of the main failure modes reported there by replacing the cryptic snapshot error with something actionable.

It also adds focused tests for the no-storage and unknown-`runId` cases, plus the changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

If an AI agent tries to continue a paused task but can't find the saved state, this PR makes the agent give a clear, helpful error instead of a confusing low-level message so you know whether storage is missing or the runId is wrong.

## What Changed

**Error Message Improvement**
- Replaces the cryptic workflow error with a structured error: id = `AGENT_RESUME_NO_SNAPSHOT_FOUND`.
- The error includes the `runId`, whether storage is configured, and a short explanation of likely causes (no storage, stale/invalid `runId`, or a run that already completed/never suspended).

**Code Changes**
- Added private helper Agent.#loadAgenticLoopSnapshotOrThrow({ runId, method }) to load the `agentic-loop` snapshot and throw the new MastraError when missing.
- Refactored resumeStream() and resumeGenerate() to call the helper and “fail fast” at the agent boundary instead of letting a downstream workflow-level snapshot lookup produce an opaque error.

**Tests**
- New tests in packages/core/src/agent/__tests__/resume-stream-no-snapshot.test.ts covering:
  - resume when no storage is configured (asserts error id and message mentions storage and runId),
  - resume with storage configured but an unknown runId (asserts error id and runId in message),
  - structured assertions that the thrown error contains id `AGENT_RESUME_NO_SNAPSHOT_FOUND`.

**Release**
- Adds a patch changeset for @mastra/core.

**Scope**
- This fixes the primary failure mode for missing snapshots but does not implement full multi-step suspension/resume behavior described in issue #14875.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->