### PR TITLE
fix(playground): alias TraceStatus import for traces

### DIFF
--- a/packages/playground/src/domains/agents/components/agent-traces-panel.tsx
+++ b/packages/playground/src/domains/agents/components/agent-traces-panel.tsx
@@ -1,4 +1,4 @@
-import { TraceStatus } from '@mastra/core/storage';
+import { TraceStatus } from '@internal-temp/core/index';
 import type { ListTracesResponse, SpanRecord } from '@mastra/core/storage';
 import {
   Button,
@@ -426,7 +426,7 @@ export function AgentTracesPanel({
     refetchInterval: query => (is403ForbiddenError(query.state.error) ? false : 3000),
   });
 
-  const traces: TraceSpan[] = tracesData ?? [];
+  const traces = useMemo<TraceSpan[]>(() => tracesData ?? [], [tracesData]);
 
   // Client-side search filter
   const filteredTraces = useMemo(() => {
@@ -676,7 +676,7 @@ export function AgentTracesPanel({
           setDialogIsOpen(true);
         },
       }),
-    [displayTraces, selectedTraceId],
+    [buildTraceUrl, displayTraces, navigate, selectedTraceId],
   );
 
   const toPreviousTrace = useMemo(
@@ -690,7 +690,7 @@ export function AgentTracesPanel({
           setDialogIsOpen(true);
         },
       }),
-    [displayTraces, selectedTraceId],
+    [buildTraceUrl, displayTraces, navigate, selectedTraceId],
   );
 
   const gridColumns = scorerActive ? GRID_COLUMNS_WITH_SCORE : GRID_COLUMNS;

--- a/packages/playground/src/domains/agents/hooks/use-agent-traces-filters.ts
+++ b/packages/playground/src/domains/agents/hooks/use-agent-traces-filters.ts
@@ -1,5 +1,5 @@
+import type { TraceStatus } from '@internal-temp/core/index';
 import { EntityType } from '@mastra/core/observability';
-import type { TraceStatus } from '@mastra/core/storage';
 import { useState, useCallback, useMemo } from 'react';
 
 export type AgentTracesFilterState = {

--- a/packages/playground/src/vendor/@mastra/core/index.ts
+++ b/packages/playground/src/vendor/@mastra/core/index.ts
@@ -1,0 +1,7 @@
+// this is temporary
+/** Derived status of a trace, computed from the root span's error and endedAt fields. */
+export enum TraceStatus {
+  SUCCESS = 'success',
+  ERROR = 'error',
+  RUNNING = 'running',
+}

--- a/packages/playground/tsconfig.app.json
+++ b/packages/playground/tsconfig.app.json
@@ -21,7 +21,8 @@
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@internal-temp/*": ["./src/vendor/@mastra/*"]
     },
     "types": ["node", "vite/client"]
   },

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -11,7 +11,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@internal-temp/*": ["./src/vendor/@mastra/*"]
     }
   }
 }

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -216,6 +216,7 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),
+        '@internal-temp': path.resolve(__dirname, './src/vendor/@mastra'),
       },
     },
     build: {


### PR DESCRIPTION
This keeps the traces panel and filters using `TraceStatus` after the storage import path change by routing those imports through a temporary internal alias in the playground app.

Before, the playground imported `TraceStatus` from `@mastra/core/storage`. After this change, it imports the enum from `@internal-temp/core/index` and resolves that alias through the playground tsconfig and Vite config.

I also ran `pnpm --filter ./packages/playground build`. A direct `pnpm exec tsc -p packages/playground/tsconfig.app.json --noEmit` still reports existing unrelated playground type errors outside this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR is like moving a toy from a big toy box into your pocket so you can use it without carrying the whole toy box around. The playground was importing a status type from the main storage code, but now it uses a local copy instead, so everything loads faster and cleaner.

## Overview

The playground's traces panel and filters were importing `TraceStatus` from `@mastra/core/storage`, which created an unnecessary dependency. This change introduces a temporary internal alias `@internal-temp/core` that resolves to vendored copies of needed types within the playground's own codebase, allowing the playground to import `TraceStatus` from `@internal-temp/core/index` instead.

## Changes

**Import path updates:**
- `packages/playground/src/domains/agents/components/agent-traces-panel.tsx`: Updated `TraceStatus` import from `@mastra/core/storage` to `@internal-temp/core/index`
- `packages/playground/src/domains/agents/hooks/use-agent-traces-filters.ts`: Updated `TraceStatus` type import to `@internal-temp/core/index`

**Vendored enum:**
- `packages/playground/src/vendor/@mastra/core/index.ts`: New file exporting a minimal `TraceStatus` enum with three string-valued members (`SUCCESS = 'success'`, `ERROR = 'error'`, `RUNNING = 'running'`)

**Module resolution configuration:**
- `packages/playground/tsconfig.json` and `packages/playground/tsconfig.app.json`: Added path alias `@internal-temp/*` → `./src/vendor/@mastra/*`
- `packages/playground/vite.config.ts`: Added Vite resolve alias mapping `@internal-temp` to `./src/vendor/@mastra`

**React hook optimization:**
- `agent-traces-panel.tsx`: Added `useMemo` for `traces` derivation and updated dependency arrays for `toNextTrace` and `toPreviousTrace` hooks to include `buildTraceUrl` and `navigate`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->