### PR TITLE
fix(core): wait for suspended streams before resume

### DIFF
--- a/.changeset/cold-lines-sell.md
+++ b/.changeset/cold-lines-sell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed harness suspension resumes and MastraGateway env-dependent tests.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -83,6 +83,7 @@ export class Harness<TState = {}> {
     | null = null;
   private pendingApprovalToolName: string | null = null;
   private pendingSuspensionRunId: string | null = null;
+  private pendingSuspensionSettled: Promise<unknown> | null = null;
   private pendingSuspensionToolCallId: string | null = null;
   private pendingQuestions = new Map<string, (answer: HarnessQuestionAnswer) => void>();
   private pendingPlanApprovals = new Map<
@@ -1374,6 +1375,10 @@ export class Harness<TState = {}> {
       );
       const streamResult = await this.processStream(response, requestContext);
 
+      if (streamResult.suspended) {
+        this.pendingSuspensionSettled = response.finishReason;
+      }
+
       if (this.currentOperationId === operationId) {
         const reason = streamResult.suspended ? 'suspended' : this.abortRequested ? 'aborted' : 'complete';
         this.emit({ type: 'agent_end', reason });
@@ -2421,6 +2426,11 @@ export class Harness<TState = {}> {
 
     if (!this.abortController) {
       this.abortController = new AbortController();
+    }
+
+    if (this.pendingSuspensionSettled) {
+      await this.pendingSuspensionSettled;
+      this.pendingSuspensionSettled = null;
     }
 
     const requestContext = await this.buildRequestContext(requestContextInput);

--- a/packages/core/src/llm/model/gateways/mastra.test.ts
+++ b/packages/core/src/llm/model/gateways/mastra.test.ts
@@ -1,8 +1,12 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MastraGateway } from './mastra.js';
 
 describe('MastraGateway', () => {
+  beforeEach(() => {
+    delete process.env.MASTRA_GATEWAY_API_KEY;
+  });
+
   afterEach(() => {
     delete process.env.MASTRA_GATEWAY_API_KEY;
     vi.restoreAllMocks();


### PR DESCRIPTION
This waits for a suspended harness stream to finish settling before resumeStream runs, so the workflow snapshot is persisted before resume tries to load it. It also clears the MastraGateway API key before each test so the gateway spec doesn't depend on whatever is set in the shell.

Before:


After:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're pausing a task, and before it's fully saved, you try to resume it—that could cause problems. This PR makes sure everything is completely saved and settled before resuming. It also cleans up test environments so they don't accidentally use leftover settings from the system.

## Changes Overview

### Harness Suspension/Resume Race Condition Fix
Modified `packages/core/src/harness/harness.ts` to prevent a race condition when resuming suspended streams:
- Added a `pendingSuspensionSettled` instance field to track the completion promise of a suspended stream
- When a stream suspends, the settlement promise is now captured instead of discarded
- Before `resumeStream` executes, it now awaits this pending settlement promise to ensure the workflow snapshot is fully persisted before attempting to resume
- The promise is cleared after awaiting

### Test Environment Isolation
Updated `packages/core/src/llm/model/gateways/mastra.test.ts` to improve test isolation:
- Added a `beforeEach` hook that clears `process.env.MASTRA_GATEWAY_API_KEY` before each test runs
- Combined with existing `afterEach` cleanup, this ensures the gateway tests don't depend on or inherit environment variables from the system

### Changeset Entry
Added `.changeset/cold-lines-sell.md` documenting a patch version bump for `@mastra/core` with release notes covering the harness suspension fix and test environment improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->