### PR TITLE
fix(core): allow providers with narrower TUser in CompositeAuth

### DIFF
--- a/.changeset/auth-provider-variance.md
+++ b/.changeset/auth-provider-variance.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix TUser variance on `MastraAuthProvider` so providers with a narrower `TUser` (e.g. `SimpleAuth<MyUser>`, `MastraAuthClerk`) can be passed to `new CompositeAuth([...])` without a cast.
+Fixed `CompositeAuth` types so typed auth providers, such as `SimpleAuth<MyUser>` or `MastraAuthClerk`, can be combined without casts.

--- a/.changeset/auth-provider-variance.md
+++ b/.changeset/auth-provider-variance.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix TUser variance on `MastraAuthProvider` so providers with a narrower `TUser` (e.g. `SimpleAuth<MyUser>`, `MastraAuthClerk`) can be passed to `new CompositeAuth([...])` without a cast.

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -5,7 +5,7 @@ import type { MastraAuthConfig } from './types';
 export interface MastraAuthProviderOptions<TUser = unknown> {
   name?: string;
   authorizeUser?: (user: TUser, request: HonoRequest) => Promise<boolean> | boolean;
-  mapUserToResourceId?: (user: TUser) => string | undefined | null;
+  mapUserToResourceId?(user: TUser): string | undefined | null;
   /**
    * Protected paths for the auth provider
    */
@@ -19,7 +19,7 @@ export interface MastraAuthProviderOptions<TUser = unknown> {
 export abstract class MastraAuthProvider<TUser = unknown> extends MastraBase {
   public protected?: MastraAuthConfig['protected'];
   public public?: MastraAuthConfig['public'];
-  public mapUserToResourceId?: (user: TUser) => string | undefined | null;
+  public mapUserToResourceId?(user: TUser): string | undefined | null;
 
   constructor(options?: MastraAuthProviderOptions<TUser>) {
     super({ component: 'AUTH', name: options?.name });

--- a/packages/core/src/server/server.test-d.ts
+++ b/packages/core/src/server/server.test-d.ts
@@ -1,6 +1,9 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import type { RequestContext } from '../request-context';
+import type { MastraAuthProvider } from './auth';
+import { CompositeAuth } from './composite-auth';
 import { registerApiRoute } from './index';
+import { SimpleAuth } from './simple-auth';
 
 /**
  * Type tests for registerApiRoute
@@ -59,5 +62,26 @@ describe('registerApiRoute Type Tests', () => {
         },
       });
     });
+  });
+});
+
+/**
+ * Regression test: CompositeAuth must accept providers whose TUser is narrower
+ * than unknown. When mapUserToResourceId is declared in property position on
+ * MastraAuthProvider<TUser>, strict contravariance rejects such providers
+ * even though the runtime contract is compatible.
+ */
+describe('CompositeAuth TUser variance', () => {
+  it('accepts SimpleAuth providers with a narrower TUser generic', () => {
+    interface CustomUser {
+      sub: string;
+    }
+
+    const typed = new SimpleAuth<CustomUser>({
+      tokens: { example: { sub: '1' } },
+    });
+
+    const _assignable: MastraAuthProvider<unknown> = typed;
+    new CompositeAuth([typed]);
   });
 });

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -58,7 +58,7 @@ export type MastraAuthConfig<TUser = unknown> = {
    * When provided, the returned value is set as `MASTRA_RESOURCE_ID_KEY` on the request context
    * after successful authentication, enabling per-user memory isolation.
    */
-  mapUserToResourceId?: (user: TUser) => string | undefined | null;
+  mapUserToResourceId?(user: TUser): string | undefined | null;
 
   /**
    * Authorization function for the server


### PR DESCRIPTION
## TL;DR

If you use `CompositeAuth` with typed auth providers (`SimpleAuth<MyUser>`, `MastraAuthClerk`, etc.) in a project with TypeScript `strict` mode, you currently have to cast to get past a compile error. This PR makes it work out of the box — type-only change, no runtime behavior change.

## Description

`MastraAuthProvider<TUser>.mapUserToResourceId` is declared in property position, which TypeScript treats as strictly contravariant. Any subclass with a narrower `TUser` — `SimpleAuth<MyUser>`, `MastraAuthClerk<JwtPayload>` — fails to assign to the `MastraAuthProvider[]` parameter of `new CompositeAuth(...)` under `strict`/`strictFunctionTypes`.

### Reproduction

```ts
import { CompositeAuth, SimpleAuth } from '@mastra/core/server';
import { MastraAuthClerk } from '@mastra/auth-clerk';

interface MyUser { sub: string }

const clerk = new MastraAuthClerk();
const simple = new SimpleAuth<MyUser>({ tokens: { x: { sub: '1' } } });

// TS2322: Type 'SimpleAuth<MyUser>' is not assignable to type 'MastraAuthProvider<unknown>'.
//   Types of property 'mapUserToResourceId' are incompatible.
new CompositeAuth([simple, clerk]);
```

### Fix

Switch the three declaration sites (`auth.ts` class, `auth.ts` options interface, `types.ts` config type) from property position to method shorthand. Method declarations get bivariant parameter checking and lift the restriction. No runtime change — `CompositeAuth`'s own constructor already assigns through this field and continues to type-check after the switch.

### Added

A type-level regression test in `server.test-d.ts` that asserts `CompositeAuth` accepts a `SimpleAuth` with a narrower `TUser`. Verified it fails with the current `main` declaration and passes with the fix.

### Scope

Limited to `mapUserToResourceId` (the site triggered by `CompositeAuth`). `authorizeUser` and `authorize` have the same shape and could be switched similarly if a narrow-`TUser` user reports an equivalent error.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable) — no doc changes needed
- [x] I have added tests that prove my fix is effective
- [ ] I have addressed all Coderabbit comments on this PR — will do if any come up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you have different types of security guards (auth providers) with different uniforms (TUser types). The code previously required them all to wear exactly the same uniform to work together. This PR changes the rules slightly so guards with more specific uniforms can still work as a team, fixing a TypeScript error that appeared when trying to combine them.

## Overview

This PR fixes a TypeScript typing issue in `CompositeAuth` that prevented combining typed auth providers with narrower `TUser` implementations. The fix converts `mapUserToResourceId` declarations from property syntax to method shorthand syntax across multiple files, enabling proper bivariant parameter checking in TypeScript's strict mode.

## Changes

### Core Changes
- **Method signature conversion**: Updated `mapUserToResourceId` declarations from arrow-function property style (`mapUserToResourceId?: (user: TUser) => ...`) to method shorthand style (`mapUserToResourceId?(user: TUser): ...`) in:
  - `packages/core/src/server/auth.ts` — `MastraAuthProviderOptions<TUser>` interface and `MastraAuthProvider<TUser>` class
  - `packages/core/src/server/types.ts` — `MastraAuthConfig<TUser>` type definition

### Testing
- **Type regression test**: Added type-level tests in `packages/core/src/server/server.test-d.ts` asserting that `SimpleAuth<CustomUser>` can be assigned to `MastraAuthProvider<unknown>` and passed to `new CompositeAuth([typed])`

### Release
- **Changeset**: Added `.changeset/auth-provider-variance.md` documenting a patch-level fix to `@mastra/core`

## Technical Details

The issue stems from TypeScript's contravariance treatment of function properties. Method declarations receive bivariant parameter checking, allowing providers with narrower `TUser` types (e.g., `SimpleAuth<MyUser>`, `MastraAuthClerk<JwtPayload>`) to be combined in `CompositeAuth` without type errors. This is a type-only change with no runtime behavior modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->