### PR TITLE
fix(playground): stop agent editor from crashing when workspace has skills

### DIFF
--- a/packages/playground/src/domains/agents/utils/__tests__/agent-form-mappers.test.ts
+++ b/packages/playground/src/domains/agents/utils/__tests__/agent-form-mappers.test.ts
@@ -11,6 +11,7 @@ import {
   mapScorersToApi,
   buildObservationalMemoryForApi,
   parseObservationalMemoryFromApi,
+  normalizeSkillsFromApi,
 } from '../agent-form-mappers';
 
 // ---------------------------------------------------------------------------
@@ -527,5 +528,43 @@ describe('observational memory round-trip', () => {
     expect(api).toBe(true);
     const parsed = parseObservationalMemoryFromApi(api as any)!;
     expect(parsed.enabled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSkillsFromApi
+// ---------------------------------------------------------------------------
+describe('normalizeSkillsFromApi', () => {
+  it('returns empty record for undefined', () => {
+    expect(normalizeSkillsFromApi(undefined)).toEqual({});
+  });
+
+  it('normalizes a static record of stored skill configs', () => {
+    const input = {
+      docs: { description: 'docs skill', instructions: 'use me', pin: true, strategy: 'always' as const },
+    };
+    expect(normalizeSkillsFromApi(input as any)).toEqual(input);
+  });
+
+  it('merges conditional variants', () => {
+    const input = [
+      { condition: { any: [] }, value: { a: { description: 'A' } } },
+      { condition: { any: [] }, value: { b: { description: 'B' } } },
+    ];
+    expect(normalizeSkillsFromApi(input as any)).toEqual({
+      a: { description: 'A', instructions: undefined, pin: undefined, strategy: undefined },
+      b: { description: 'B', instructions: undefined, pin: undefined, strategy: undefined },
+    });
+  });
+
+  it('does not crash on a SkillMetadata[] (code-agent shape) – returns empty record', () => {
+    // Workspace skills from GET /agents/:id come through as SkillMetadata[].
+    // They do not have `.value`, so the mapper must skip them rather than throw.
+    const skillMetadataArray = [
+      { name: 'docs', description: 'docs skill', path: '/skills/docs' },
+      { name: 'search', description: 'search skill', path: '/skills/search' },
+    ];
+    expect(() => normalizeSkillsFromApi(skillMetadataArray as any)).not.toThrow();
+    expect(normalizeSkillsFromApi(skillMetadataArray as any)).toEqual({});
   });
 });

--- a/packages/playground/src/domains/agents/utils/agent-form-mappers.ts
+++ b/packages/playground/src/domains/agents/utils/agent-form-mappers.ts
@@ -112,6 +112,11 @@ export const normalizeSkillsFromApi = (
   if (Array.isArray(skills)) {
     const result: Record<string, SkillConfig> = {};
     for (const variant of skills) {
+      // Guard against non-variant entries (e.g. a code agent's SkillMetadata[]
+      // accidentally making it into this mapper). Variants must have `.value`.
+      if (!variant || typeof variant !== 'object' || !('value' in variant) || !variant.value) {
+        continue;
+      }
       for (const [key, value] of Object.entries(variant.value)) {
         result[key] = {
           description: value.description,

--- a/packages/playground/src/domains/agents/utils/compute-agent-initial-values.ts
+++ b/packages/playground/src/domains/agents/utils/compute-agent-initial-values.ts
@@ -42,7 +42,11 @@ export function mapAgentResponseToDataSource(agent: GetAgentResponse): AgentData
     tools: agent.tools,
     workflows: agent.workflows,
     agents: agent.agents,
-    skills: agent.skills as AgentDataSource['skills'],
+    // GetAgentResponse.skills is a SkillMetadata[] (activated skills metadata),
+    // not the stored-agent ConditionalField<Record<string, StoredAgentSkillConfig>>.
+    // The edit form only consumes the stored shape, so leave this undefined for
+    // code-agent data sources and let the form initialize skills as empty.
+    skills: undefined,
     workspace: agent.workspaceId ? ({ workspaceId: agent.workspaceId } as AgentDataSource['workspace']) : undefined,
     requestContextSchema,
   };


### PR DESCRIPTION
Opening any agent in Studio's editor crashed with `Cannot convert undefined or null to object` as soon as the agent's workspace exposed one or more `SKILL.md` files. The agent GET response returns skills as a flat `SkillMetadata[]`, but the edit form's mapper assumed every array was a `ConditionalField` variant list and called `Object.entries(variant.value)` on entries with no `value` key.

Before:

```ts
// agent.skills = [{ name, description, license?, path }, ...]
for (const variant of skills) {
  for (const [key, value] of Object.entries(variant.value)) { // crash
    ...
  }
}
```

After:

```ts
for (const variant of skills) {
  if (!variant || typeof variant !== 'object' || !('value' in variant) || !variant.value) continue;
  for (const [key, value] of Object.entries(variant.value)) { ... }
}
```

The code-agent data source no longer forwards `agent.skills` into the stored-skills shape — the editor only consumes the stored `ConditionalField<Record<...>>` form, so code agents now initialize with an empty skills record instead of a malformed array.

Fixes #15517.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The agent editor was crashing whenever someone added a skills file (SKILL.md) to their workspace. The problem was a mismatch between what the server was sending (a simple list of skill information) and what the editor's code was expecting (a different format with special "value" objects). The fix adds safety checks to handle the different format gracefully and prevents the crash from happening.

## Overview

This PR fixes a crash in Studio's agent editor that occurred when an agent's workspace included SKILL.md files. The issue stemmed from a type mismatch: the agent GET response returns skills as a flat `SkillMetadata[]` array, but the editor's form mapper assumed each array entry was a `ConditionalField` variant with a `.value` property, causing a TypeError when calling `Object.entries()` on undefined values.

## Changes Made

**1. Enhanced Skills Normalization** (`agent-form-mappers.ts`)
- Updated `normalizeSkillsFromApi()` to add safety guards before processing variant objects
- Now skips array entries that are not valid variant objects or lack a truthy `.value` property
- Prevents the TypeError that previously crashed the editor

**2. Fixed Agent Data Initialization** (`compute-agent-initial-values.ts`)
- Changed `mapAgentResponseToDataSource()` to set `skills: undefined` instead of forwarding `agent.skills`
- Code-agent-derived data sources now initialize with empty skills, preventing malformed data from being passed to the editor
- Preserves behavior for other field types

**3. Comprehensive Test Coverage** (`agent-form-mappers.test.ts`)
- Added test suite for `normalizeSkillsFromApi()` with four key test cases:
  - Handles `undefined` input (returns empty object)
  - Preserves properly-formatted static skills records
  - Correctly merges conditional field variants
  - Safely handles `SkillMetadata[]` arrays without throwing errors

## Impact

- Prevents the editor crash when workspace contains skills files
- Ensures robust handling of the API response format
- Maintains backward compatibility with stored-agent behavior while protecting code-agent initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->