### PR TITLE
feat(client-js,server): expose forEachIndex on workflow resume

### DIFF
--- a/.changeset/legal-tools-cover.md
+++ b/.changeset/legal-tools-cover.md
@@ -1,0 +1,15 @@
+---
+'@mastra/server': minor
+---
+
+Added `forEachIndex` to the workflow resume request body schema. The `/workflows/:workflowId/resume`, `/resume-async`, and `/resume-stream` endpoints (including their agent-builder equivalents) now accept an optional zero-based `forEachIndex` so clients can target a specific iteration of a suspended `.foreach()` step.
+
+```ts
+// POST /workflows/:workflowId/resume
+// body
+{
+  step: 'approve',
+  resumeData: { ok: true },
+  forEachIndex: 1, // resume only the second iteration; others stay suspended
+}
+```

--- a/.changeset/tangy-views-enjoy.md
+++ b/.changeset/tangy-views-enjoy.md
@@ -1,0 +1,16 @@
+---
+'@mastra/client-js': minor
+---
+
+Added `forEachIndex` option to `run.resume()`, `run.resumeAsync()`, and `run.resumeStream()`. Use it to resume a single iteration of a suspended `.foreach()` step while leaving the other iterations suspended.
+
+```ts
+await client
+  .getWorkflow('myWorkflow')
+  .createRun(runId)
+  .resume({
+    step: 'approve',
+    resumeData: { ok: true },
+    forEachIndex: 1, // only resume the second iteration
+  });
+```

--- a/client-sdks/client-js/src/resources/run.ts
+++ b/client-sdks/client-js/src/resources/run.ts
@@ -181,6 +181,7 @@ export class Run extends BaseResource {
     resumeData,
     tracingOptions,
     perStep,
+    forEachIndex,
     ...rest
   }: {
     step?: string | string[];
@@ -188,6 +189,7 @@ export class Run extends BaseResource {
     requestContext?: RequestContext | Record<string, any>;
     tracingOptions?: TracingOptions;
     perStep?: boolean;
+    forEachIndex?: number;
   }): Promise<{ message: string }> {
     const requestContext = parseClientRequestContext(rest.requestContext);
     return this.request(`/workflows/${this.workflowId}/resume?runId=${this.runId}`, {
@@ -198,6 +200,7 @@ export class Run extends BaseResource {
         requestContext,
         tracingOptions,
         perStep,
+        forEachIndex,
       },
     });
   }
@@ -317,6 +320,7 @@ export class Run extends BaseResource {
     requestContext?: RequestContext | Record<string, any>;
     tracingOptions?: TracingOptions;
     perStep?: boolean;
+    forEachIndex?: number;
   }): Promise<WorkflowRunResult> {
     const requestContext = parseClientRequestContext(params.requestContext);
     return this.request<WorkflowRunResult>(`/workflows/${this.workflowId}/resume-async?runId=${this.runId}`, {
@@ -327,6 +331,7 @@ export class Run extends BaseResource {
         requestContext,
         tracingOptions: params.tracingOptions,
         perStep: params.perStep,
+        forEachIndex: params.forEachIndex,
       },
     }).then(deserializeWorkflowError);
   }
@@ -342,6 +347,7 @@ export class Run extends BaseResource {
     requestContext?: RequestContext | Record<string, any>;
     tracingOptions?: TracingOptions;
     perStep?: boolean;
+    forEachIndex?: number;
   }): Promise<globalThis.ReadableStream<StreamVNextChunkType>> {
     const searchParams = new URLSearchParams();
     searchParams.set('runId', this.runId);
@@ -356,6 +362,7 @@ export class Run extends BaseResource {
           requestContext,
           tracingOptions: params.tracingOptions,
           perStep: params.perStep,
+          forEachIndex: params.forEachIndex,
         },
         stream: true,
       },

--- a/client-sdks/client-js/src/resources/workflow.test.ts
+++ b/client-sdks/client-js/src/resources/workflow.test.ts
@@ -17,6 +17,10 @@ describe('Workflow (fetch-mocked)', () => {
       if (url.includes('/start-async')) return Promise.resolve(createJsonResponse({ result: 'started-async' }));
       if (url.includes('/resume?runId=')) return Promise.resolve(createJsonResponse({ message: 'resumed' }));
       if (url.includes('/resume-async')) return Promise.resolve(createJsonResponse({ result: 'resumed-async' }));
+      if (url.includes('/resume-stream?')) {
+        const body = Workflow.createRecordStream([{ type: 'result', payload: { ok: true } }]);
+        return Promise.resolve(new Response(body as unknown as ReadableStream, { status: 200 }));
+      }
       if (url.includes('/stream?')) {
         const body = Workflow.createRecordStream([
           { type: 'log', payload: { msg: 'hello' } },
@@ -142,6 +146,36 @@ describe('Workflow (fetch-mocked)', () => {
     const options = call[1];
     const body = JSON.parse(options.body);
     expect(body.tracingOptions).toEqual(tracingOptions);
+  });
+
+  it('forwards forEachIndex when resuming workflow run synchronously', async () => {
+    const run = await wf.createRun();
+    await run.resume({ step: 's1', forEachIndex: 2 });
+
+    const call = fetchMock.mock.calls.find((args: any[]) => String(args[0]).includes('/resume?runId='));
+    expect(call).toBeTruthy();
+    const body = JSON.parse(call[1].body);
+    expect(body.forEachIndex).toBe(2);
+  });
+
+  it('forwards forEachIndex when resuming workflow run asynchronously', async () => {
+    const run = await wf.createRun();
+    await run.resumeAsync({ step: 's1', forEachIndex: 3 });
+
+    const call = fetchMock.mock.calls.find((args: any[]) => String(args[0]).includes('/resume-async'));
+    expect(call).toBeTruthy();
+    const body = JSON.parse(call[1].body);
+    expect(body.forEachIndex).toBe(3);
+  });
+
+  it('forwards forEachIndex when resuming workflow run as a stream', async () => {
+    const run = await wf.createRun();
+    await run.resumeStream({ step: 's1', forEachIndex: 4 });
+
+    const call = fetchMock.mock.calls.find((args: any[]) => String(args[0]).includes('/resume-stream?'));
+    expect(call).toBeTruthy();
+    const body = JSON.parse(call[1].body);
+    expect(body.forEachIndex).toBe(4);
   });
 });
 

--- a/docs/src/content/en/reference/client-js/workflows.mdx
+++ b/docs/src/content/en/reference/client-js/workflows.mdx
@@ -147,6 +147,18 @@ await run.resume({
 })
 ```
 
+When a [`.foreach()`](/reference/workflows/workflow-methods/foreach) step suspends across multiple iterations, pass `forEachIndex` to resume one iteration at a time. Iterations you don't target remain suspended.
+
+```typescript
+await run.resume({
+  step: 'approve',
+  resumeData: { ok: true },
+  forEachIndex: 1,
+})
+```
+
+`forEachIndex` is also supported by `resumeAsync()` and `resumeStream()`.
+
 ### `cancel()`
 
 Cancel a running workflow:

--- a/docs/src/content/en/reference/client-js/workflows.mdx
+++ b/docs/src/content/en/reference/client-js/workflows.mdx
@@ -147,13 +147,13 @@ await run.resume({
 })
 ```
 
-When a [`.foreach()`](/reference/workflows/workflow-methods/foreach) step suspends across multiple iterations, pass `forEachIndex` to resume one iteration at a time. Iterations you don't target remain suspended.
+When a [`.foreach()`](/reference/workflows/workflow-methods/foreach) step suspends across multiple iterations, pass `forEachIndex` (zero-based; `0` targets the first iteration) to resume one iteration at a time. Iterations you don't target remain suspended.
 
 ```typescript
 await run.resume({
   step: 'approve',
   resumeData: { ok: true },
-  forEachIndex: 1,
+  forEachIndex: 1, // resumes the second iteration
 })
 ```
 

--- a/docs/src/content/en/reference/streaming/workflows/resumeStream.mdx
+++ b/docs/src/content/en/reference/streaming/workflows/resumeStream.mdx
@@ -54,6 +54,13 @@ if (result!.status === 'suspended') {
     isOptional: true,
   },
   {
+    name: 'forEachIndex',
+    type: 'number',
+    description:
+      'Target a specific iteration of a suspended `.foreach()` step. Pass the zero-based index of the iteration to resume; other iterations remain suspended. Omit to resume all suspended iterations of the step with the same `resumeData`.',
+    isOptional: true,
+  },
+  {
     name: 'tracingOptions',
     type: 'TracingOptions',
     isOptional: true,

--- a/docs/src/content/en/reference/workflows/run-methods/resume.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/resume.mdx
@@ -53,6 +53,13 @@ if (result.status === 'suspended') {
     isOptional: true,
   },
   {
+    name: 'forEachIndex',
+    type: 'number',
+    description:
+      'Target a specific iteration of a suspended `.foreach()` step. Pass the zero-based index of the iteration you want to resume; other iterations remain suspended. Omit this field to resume all suspended iterations of the step with the same `resumeData`.',
+    isOptional: true,
+  },
+  {
     name: 'tracingContext',
     type: 'TracingContext',
     isOptional: true,
@@ -197,6 +204,28 @@ if (result.status === 'suspended') {
 When exactly one step is suspended, you can omit the `step` parameter and the workflow will automatically resume that step. For workflows with multiple suspended steps, you must explicitly specify which step to resume.
 
 :::
+
+### Resuming a single [`.foreach()`](../workflow-methods/foreach) iteration
+
+When a [`.foreach()`](../workflow-methods/foreach) step suspends across multiple iterations, use `forEachIndex` to resume one iteration at a time with different `resumeData`. Iterations you don't pass remain suspended until you resume them.
+
+```typescript
+// Resume only the second iteration (index 1) with its own data
+await run.resume({
+  step: 'approve',
+  resumeData: { ok: true },
+  forEachIndex: 1,
+})
+
+// Later, resume the first iteration with different data
+await run.resume({
+  step: 'approve',
+  resumeData: { ok: false },
+  forEachIndex: 0,
+})
+```
+
+If `forEachIndex` is omitted, every suspended iteration of the step is resumed with the same `resumeData`.
 
 ## Related
 

--- a/docs/src/content/en/reference/workflows/run-methods/resume.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/resume.mdx
@@ -207,7 +207,7 @@ When exactly one step is suspended, you can omit the `step` parameter and the wo
 
 ### Resuming a single [`.foreach()`](../workflow-methods/foreach) iteration
 
-When a [`.foreach()`](../workflow-methods/foreach) step suspends across multiple iterations, use `forEachIndex` to resume one iteration at a time with different `resumeData`. Iterations you don't pass remain suspended until you resume them.
+When a [`.foreach()`](../workflow-methods/foreach) step suspends across multiple iterations, use `forEachIndex` (zero-based) to resume one iteration at a time with different `resumeData`. Iterations not targeted by `forEachIndex` remain suspended until resumed.
 
 ```typescript
 // Resume only the second iteration (index 1) with its own data

--- a/docs/src/content/en/reference/workflows/workflow-methods/foreach.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/foreach.mdx
@@ -174,6 +174,19 @@ Each progress event payload contains:
 ]}
 />
 
+### Resuming a single iteration
+
+When a step inside `.foreach()` suspends, each iteration suspends independently. Pass `forEachIndex` to [`run.resume()`](../run-methods/resume) to resume one iteration at a time with its own `resumeData`. Omitting `forEachIndex` resumes every suspended iteration with the same data.
+
+```typescript
+await run.resume({
+  step: 'approve',
+  resumeData: { ok: true },
+  forEachIndex: 1,
+})
+```
+
 ## Related
 
 - [Looping with foreach](/docs/workflows/control-flow#looping-with-foreach)
+- [run.resume()](../run-methods/resume)

--- a/packages/server/src/server/handlers/workflows.test.ts
+++ b/packages/server/src/server/handlers/workflows.test.ts
@@ -992,5 +992,35 @@ describe('vNext Workflow Handlers', () => {
       expect(capturedOptions.requestContext).toBeDefined();
       expect(capturedOptions.requestContext.get('custom-key')).toBe('resume-async-value');
     });
+
+    it('RESUME_ASYNC_WORKFLOW_ROUTE should pass forEachIndex to run.resume()', async () => {
+      // Create and start a run that will suspend
+      const run = await reusableWorkflow.createRun({ runId: 'test-run-foreach-index' });
+      await run.start({ inputData: {} });
+
+      // Wait for it to suspend
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Spy on the resume method to capture options
+      let capturedOptions: any;
+      const originalResume = run.resume.bind(run);
+      vi.spyOn(run, 'resume').mockImplementation((options: any) => {
+        capturedOptions = options;
+        return originalResume(options);
+      });
+
+      vi.spyOn(reusableWorkflow, 'createRun').mockResolvedValue(run);
+
+      await RESUME_ASYNC_WORKFLOW_ROUTE.handler({
+        ...createTestServerContext({ mastra: mockMastra }),
+        workflowId: 'reusable-workflow',
+        runId: 'test-run-foreach-index',
+        step: 'test-step',
+        resumeData: {},
+        forEachIndex: 2,
+      } as any);
+
+      expect(capturedOptions.forEachIndex).toBe(2);
+    });
   });
 });

--- a/packages/server/src/server/schemas/workflows.ts
+++ b/packages/server/src/server/schemas/workflows.ts
@@ -140,6 +140,7 @@ export const resumeBodySchema = z.object({
   requestContext: z.record(z.string(), z.unknown()).optional(),
   tracingOptions: tracingOptionsSchema.optional(),
   perStep: z.boolean().optional(),
+  forEachIndex: z.number().int().nonnegative().optional(),
 });
 
 /**


### PR DESCRIPTION
Core already supports resuming a single iteration of a suspended `.foreach()` step via `forEachIndex`, but the option wasn't reachable from the HTTP API or the client SDK. This wires it through `@mastra/server`'s resume schemas and `@mastra/client-js`'s `run.resume()`, `resumeAsync()`, and `resumeStream()`, plus updates the reference docs.

```ts
await client
  .getWorkflow('myWorkflow')
  .createRun(runId)
  .resume({
    step: 'approve',
    resumeData: { ok: true },
    forEachIndex: 1, // only resume the second iteration; others stay suspended
  });
```

Tested with new unit tests in client-js (resume / resumeAsync / resumeStream forward the field) and a server handler test that asserts the field reaches `run.resume()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets you resume just one paused iteration of a workflow loop instead of resuming every paused iteration. It's like telling the system "resume the person in line at position 2" rather than "resume everyone in line."

## Changes

Adds a new optional forEachIndex option to resume a specific zero-based iteration of a suspended .foreach() step; non-targeted iterations remain suspended.

### Client SDK Updates
- @mastra/client-js: add optional forEachIndex?: number to:
  - Run.resume()
  - Run.resumeAsync()
  - Run.resumeStream()
- The value is forwarded in the POST body so the server can resume only the specified iteration.

### Server-Side Changes
- @mastra/server: resumeBodySchema extended to accept optional forEachIndex: z.number().int().nonnegative().
- Applies to resume endpoints: /workflows/:workflowId/resume, /resume-async, and /resume-stream.
- RESUME_ASYNC_WORKFLOW_ROUTE handler forwards forEachIndex into run.resume() options.

### Tests
- Client tests assert run.resume(), run.resumeAsync(), and run.resumeStream() serialize and forward forEachIndex.
- Server handler test verifies forEachIndex reaches run.resume().

### Documentation
- Docs updated to document forEachIndex (zero-based), show examples (e.g., forEachIndex: 1 to resume the second iteration), and clarify that omitting forEachIndex resumes all suspended iterations with the same resumeData.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->