### PR TITLE
chore(security): add Dependabot config to exclude e2e-tests from version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+
+# Dependabot configuration for mastra-ai/mastra.
+#
+# Scope of this initial config: only exclude `e2e-tests/**` from Dependabot
+# version-update PRs. These are private, non-shipped harnesses that regenerate
+# their lockfiles per-test-run; updating them produces churn with no security
+# impact on shipped code.
+#
+# Note: `exclude-paths` only suppresses Dependabot PRs. It does NOT close
+# existing security alerts for those manifests — those are dismissed via the
+# GitHub API (see PR body for context).
+#
+# Other non-shipped manifests (observability/_examples, examples/,
+# packages/*/integration-tests, packages/_vendored) will be handled in
+# follow-up PRs once this baseline config is validated.
+
+updates:
+  # Root monorepo (pnpm workspace). This covers every workspace package
+  # listed in pnpm-workspace.yaml — the actual shipped code.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    exclude-paths:
+      # Non-shipped e2e test harnesses. Each has its own lockfile that is
+      # regenerated per-test-run; Dependabot PRs against them are pure noise.
+      - e2e-tests/**
+
+  # Standalone npm project used by maintainers for issue triage automation.
+  - package-ecosystem: npm
+    directory: /scripts/gh-issue-triage
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - area/scripts
+
+  # Keep GitHub Actions workflow pins current.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - area/ci


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` that tells Dependabot to skip `e2e-tests/**` when proposing version updates for the root pnpm workspace.

## Why

The `e2e-tests/*` packages each carry their own `pnpm-lock.yaml` because they run as standalone projects that verify Mastra's install/build/publish flow end to end. They are marked `private: true`, are never published, and their lockfiles are regenerated per test run.

Previously Dependabot scanned every one of those lockfiles as an independent manifest and opened a version-update PR for every transitive vulnerability it found. None of that code ships to users, so the PRs were pure maintenance churn.

## What this PR does

- Adds `.github/dependabot.yml` with one npm ecosystem entry for the root workspace that uses `exclude-paths: [e2e-tests/**]`.
- Also registers the standalone `scripts/gh-issue-triage` project and GitHub Actions for routine updates.

## What this PR does NOT do

- Does not touch `observability/_examples/**`, `examples/**`, `packages/*/integration-tests/**`, or `packages/_vendored/**`. Those are intentionally deferred to follow-up PRs once this baseline is validated.
- Does not change runtime dependencies, versions, or lockfiles.

## Alert cleanup

Security alerts that were open against `e2e-tests/**` manifests have been dismissed via the Dependabot API with `reason=not_used` and a per-alert comment explaining the rationale (private manifest, not shipped, suppressed via `exclude-paths`).

Before: 274 open alerts
After: 88 open alerts (dropped 186 from e2e manifests)

## Test plan

- YAML is syntactically valid (`version: 2` schema).
- `exclude-paths` glob syntax matches GitHub's documented format.
- No runtime code or lockfiles changed — no build/test impact.
- Remaining 88 alerts will be reviewed and either fixed, dismissed, or suppressed in follow-up PRs.

---

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR teaches a tool called Dependabot to stop bothering the team about updates for test files in the `e2e-tests` folder, since those tests never get released to users anyway. Instead of ignoring hundreds of fake security warnings, the team can now focus on the updates that actually matter.

## Summary

Added a new `.github/dependabot.yml` configuration file to configure Dependabot for automated dependency update management across the repository. The configuration implements three update rules:

1. **Root workspace npm dependencies** (`/`): Checks weekly for npm updates with a maximum of 10 open PRs, excludes `e2e-tests/**` from version update proposals, and applies a `dependencies` label
2. **Standalone scripts project** (`/scripts/gh-issue-triage`): Checks weekly for npm updates with a maximum of 5 open PRs and applies appropriate labels
3. **GitHub Actions workflows** (`/`): Checks weekly for action version pins with a maximum of 5 open PRs and applies a `ci` label

The exclusion of `e2e-tests/**` significantly reduces noise from dependency update proposals, since these directories maintain standalone projects with private visibility (`private: true`), regenerated lockfiles per test run, and are never published to users. As a result, 186 previously-open Dependabot alerts for e2e-test dependencies were dismissed via the Dependabot API with a `not_used` reason, reducing the total open alert count from 274 to 88.

This change improves signal-to-noise ratio for legitimate security concerns while establishing a baseline automation pattern for future expansions to other non-production directories.

**Changes made:**
- Added 51 lines to `.github/dependabot.yml` (new file)

**Out of scope:** Future follow-ups will handle `observability/_examples/**`, `examples/**`, `packages/*/integration-tests/**`, and `packages/_vendored/**`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->