### PR TITLE
fix(core): prevent dataset experiment hang on workflow targets

### DIFF
--- a/.changeset/seven-books-peel.md
+++ b/.changeset/seven-books-peel.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed `dataset.startExperiment({ targetType: 'workflow', targetId })` hanging forever. Internally, the target resolver returned a workflow from an async function, but workflows expose a `.then(step)` builder method that makes them look like a thenable to JavaScript. The promise machinery then tried to unwrap the workflow and never settled. The resolver now returns a non-thenable wrapper so workflow experiments complete normally, honour `itemTimeout`, and surface failures. Fixes #15453.
+Fixed `dataset.startExperiment` hanging forever when `targetType` is `'workflow'`. Workflow experiments now complete normally, honour `itemTimeout`, and surface failures. Fixes #15453.

--- a/.changeset/seven-books-peel.md
+++ b/.changeset/seven-books-peel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `dataset.startExperiment({ targetType: 'workflow', targetId })` hanging forever. Internally, the target resolver returned a workflow from an async function, but workflows expose a `.then(step)` builder method that makes them look like a thenable to JavaScript. The promise machinery then tried to unwrap the workflow and never settled. The resolver now returns a non-thenable wrapper so workflow experiments complete normally, honour `itemTimeout`, and surface failures. Fixes #15453.

--- a/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { z } from 'zod';
 import type { MastraScorer } from '../../../evals/base';
 import type { Mastra } from '../../../mastra';
 import { RequestContext } from '../../../request-context';
@@ -6,6 +7,7 @@ import type { MastraCompositeStore, StorageDomains } from '../../../storage/base
 import { DatasetsInMemory } from '../../../storage/domains/datasets/inmemory';
 import { ExperimentsInMemory } from '../../../storage/domains/experiments/inmemory';
 import { InMemoryDB } from '../../../storage/domains/inmemory-db';
+import { createStep, createWorkflow } from '../../../workflows';
 import { runExperiment } from '../index';
 
 // Mock agent that returns predictable output
@@ -403,6 +405,46 @@ describe('runExperiment', () => {
       expect(result.succeededCount).toBe(2);
       expect(mockWorkflow.createRun).toHaveBeenCalledTimes(2);
     });
+
+    // Regression test for issue #15453: a real Workflow is thenable (has a `.then`
+    // builder method). Returning one from an async resolver caused Promise
+    // unwrapping to hang forever. Uses a real createWorkflow instance rather than
+    // a plain mock so the thenable behaviour is exercised.
+    it('runs against a real workflow instance without hanging', async () => {
+      const inputSchema = z.object({ prompt: z.string() });
+      const outputSchema = z.object({ text: z.string() });
+
+      const echoStep = createStep({
+        id: 'echo',
+        inputSchema,
+        outputSchema,
+        execute: async ({ inputData }) => ({ text: `echo:${inputData.prompt}` }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'real-echo-wf',
+        inputSchema,
+        outputSchema,
+      })
+        .then(echoStep)
+        .commit();
+
+      (mastra.getWorkflowById as ReturnType<typeof vi.fn>).mockReturnValue(workflow);
+      (mastra.getWorkflow as ReturnType<typeof vi.fn>).mockReturnValue(workflow);
+
+      const result = await runExperiment(mastra, {
+        datasetId,
+        targetType: 'workflow',
+        targetId: 'real-echo-wf',
+        itemTimeout: 5_000,
+      });
+
+      expect(result.status).toBe('completed');
+      expect(result.succeededCount).toBe(2);
+      expect(result.failedCount).toBe(0);
+      const outputs = result.results.map(r => r.output);
+      expect(outputs).toEqual(expect.arrayContaining([{ text: 'echo:Hello' }, { text: 'echo:Goodbye' }]));
+    }, 10_000);
   });
 
   describe('scorer target', () => {

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -198,10 +198,11 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
       };
     } else if (targetType && targetId) {
       // Registry-based target path (existing)
-      const target = await resolveTarget(mastra, targetType, targetId, agentVersion);
-      if (!target) {
+      const resolved = await resolveTarget(mastra, targetType, targetId, agentVersion);
+      if (!resolved) {
         throw new Error(`Target not found: ${targetType}/${targetId}`);
       }
+      const { target } = resolved;
       execFn = (item, itemSignal) => {
         // Merge global request context with per-item request context (item takes precedence)
         const mergedRequestContext =
@@ -467,16 +468,19 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
  * Resolve a target from Mastra's registries by type and ID.
  * When `agentVersion` is provided for an agent target, the returned agent
  * will have the versioned config applied (via `applyStoredOverrides`).
+ *
+ * The result is wrapped in `{ target }` because `Workflow` has a `.then`
+ * method for step chaining, which makes it thenable. Returning a thenable
+ * from an async function causes the Promise machinery to attempt to unwrap
+ * it, which hangs forever since the builder `.then` never invokes its
+ * callbacks. Wrapping in a plain object avoids the unwrap.
  */
 async function resolveTarget(
   mastra: Mastra,
   targetType: string,
   targetId: string,
   agentVersion?: string,
-): Promise<Target | null> {
-  // NOTE: Workflow is thenable, so we must never return one directly from an
-  // async function — TypeScript would try to unwrap it.  We collect into a
-  // local variable and return once at the end.
+): Promise<{ target: Target } | null> {
   let resolved: Target | null = null;
 
   switch (targetType) {
@@ -526,5 +530,5 @@ async function resolveTarget(
       break;
   }
 
-  return resolved;
+  return resolved ? { target: resolved } : null;
 }

--- a/packages/core/src/server/server.test-d.ts
+++ b/packages/core/src/server/server.test-d.ts
@@ -2,8 +2,8 @@ import { describe, expectTypeOf, it } from 'vitest';
 import type { RequestContext } from '../request-context';
 import type { MastraAuthProvider } from './auth';
 import { CompositeAuth } from './composite-auth';
-import { registerApiRoute } from './index';
 import { SimpleAuth } from './simple-auth';
+import { registerApiRoute } from './index';
 
 /**
  * Type tests for registerApiRoute


### PR DESCRIPTION
## Description

`dataset.startExperiment({ targetType: 'workflow', targetId })` hung forever because `resolveTarget` is an `async` function and a `Workflow` is thenable (it exposes a `.then(step)` builder for chaining). When the async resolver returned the workflow, JavaScript's promise machinery invoked `.then(resolve, reject)` on it to unwrap — but the builder `.then` never calls those callbacks, so the outer promise never settled.

Regression introduced in #15317, which made `resolveTarget` async to support agent version pinning.

- Wrap the resolved target in a plain `{ target }` object so the Promise machinery cannot treat it as a thenable.
- Update the single call site in `runExperiment` to destructure the wrapper.
- Replace the misleading inline NOTE with a docstring that explains *why* the wrapper exists.
- Add a regression test that builds a real `createWorkflow().then(step).commit()` instance (the prior test used a plain mock without `.then`, which is why CI didn't catch the hang).

## Related Issue(s)

Fixes #15453

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Running an experiment that targeted a workflow could hang forever because workflow objects expose a .then builder that confused Promise resolution. The fix wraps the workflow in a plain object ({ target }) so JavaScript won't try to "unwrap" it, preventing the hang.

---

## Summary of Changes

This PR fixes a hang in dataset.startExperiment() when the targetType is "workflow". The hang occurred because resolveTarget returned a Workflow instance directly; as an async return value, Promises treated that instance as a thenable and called its .then builder, which never invoked the provided resolve/reject callbacks—leaving the outer promise pending.

### Root Cause
An async resolveTarget returned a Workflow instance (which implements a .then builder). Promise resolution attempted to treat the Workflow as a thenable, invoking its builder and stalling, so workflow.createRun was never called and the experiment never settled.

### Solution
- resolveTarget now returns a plain wrapper object { target } (or null) instead of the Target instance directly, preventing it from being recognized as a thenable.
- runExperiment updated to use the wrapper and destructure const { target } = resolved before calling executeTarget.
- Replaced a misleading inline NOTE with a docstring explaining why the wrapper is required.
- Added a regression test that constructs a real workflow via createWorkflow().then(step).commit() (previous test used a mock without .then and missed the hang).

### Files Changed
1. .changeset/seven-books-peel.md — Changeset documenting the patch and referencing Fixes #15453.
2. packages/core/src/datasets/experiment/index.ts — resolveTarget now returns `{ target } | null`; runExperiment updated to destructure and use the wrapped target.
3. packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts — Added regression test that builds a real committed workflow (with .then) and verifies runExperiment completes and produces expected outputs.
4. packages/core/src/server/server.test-d.ts — minor import ordering change (no behavioral impact).

### Behavior Impact
- Before: startExperiment({ targetType: 'workflow', targetId }) could hang indefinitely; workflow.createRun was never invoked; itemTimeout didn't fire.
- After: workflow-targeted experiments complete normally; runs start as expected; itemTimeout and failure propagation work correctly.

### Testing
- Added regression test asserting experiment completes (status: completed), with expected succeeded/failed counts and outputs. The test uses a real workflow instance (created via createWorkflow().then(...).commit()) and includes a 10s timeout.

Type: Bug fix (non-breaking)  
Related: Fixes #15453
<!-- end of auto-generated comment: release notes by coderabbit.ai -->