### PR TITLE
fix(core): preserve tool execution errors through history reload

### DIFF
--- a/.changeset/fix-tool-error-state-history.md
+++ b/.changeset/fix-tool-error-state-history.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fix tool execution errors being stored as successful results on history reload
+
+When a tool's `execute()` threw an error, the error state was correctly shown during live streaming but was lost when loading from history. The `AIV5Adapter` now correctly handles `output-error` state in `toUIMessage`, `fromUIMessage`, and `fromModelMessage` conversions, preserving `errorText` through save/load cycles.

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter-tool-error.test.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter-tool-error.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from 'vitest';
+
+import type { AIV5Type } from '../types';
+import type { MastraDBMessage } from '../state/types';
+import { AIV5Adapter } from './AIV5Adapter';
+
+describe('AIV5Adapter - tool error handling', () => {
+  describe('toUIMessage - handling output-error state', () => {
+    it('should convert output-error state from toolInvocations array', () => {
+      const dbMsg: MastraDBMessage = {
+        id: 'test-msg',
+        role: 'assistant',
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        content: {
+          format: 2,
+          toolInvocations: [
+            {
+              toolCallId: 'call-123',
+              toolName: 'testTool',
+              args: { input: 'test' },
+              state: 'output-error',
+              errorText: 'Tool execution failed',
+            },
+          ],
+        },
+      };
+
+      const uiMsg = AIV5Adapter.toUIMessage(dbMsg);
+
+      expect(uiMsg.parts).toHaveLength(1);
+      const part = uiMsg.parts[0] as AIV5Type.ToolUIPart;
+      expect(part.type).toBe('tool-testTool');
+      expect(part.toolCallId).toBe('call-123');
+      expect(part.state).toBe('output-error');
+      expect(part.errorText).toBe('Tool execution failed');
+      expect(part).not.toHaveProperty('output');
+    });
+
+    it('should convert output-error state from parts array', () => {
+      const dbMsg: MastraDBMessage = {
+        id: 'test-msg',
+        role: 'assistant',
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                toolCallId: 'call-456',
+                toolName: 'anotherTool',
+                args: { param: 'value' },
+                state: 'output-error',
+                errorText: 'Network error occurred',
+              },
+            },
+          ],
+        },
+      };
+
+      const uiMsg = AIV5Adapter.toUIMessage(dbMsg);
+
+      expect(uiMsg.parts).toHaveLength(1);
+      const part = uiMsg.parts[0] as AIV5Type.ToolUIPart;
+      expect(part.type).toBe('tool-anotherTool');
+      expect(part.toolCallId).toBe('call-456');
+      expect(part.state).toBe('output-error');
+      expect(part.errorText).toBe('Network error occurred');
+      expect(part).not.toHaveProperty('output');
+    });
+
+    it('should handle output-error with empty errorText', () => {
+      const dbMsg: MastraDBMessage = {
+        id: 'test-msg',
+        role: 'assistant',
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                toolCallId: 'call-789',
+                toolName: 'faultyTool',
+                args: {},
+                state: 'output-error',
+              },
+            },
+          ],
+        },
+      };
+
+      const uiMsg = AIV5Adapter.toUIMessage(dbMsg);
+
+      const part = uiMsg.parts[0] as AIV5Type.ToolUIPart;
+      expect(part.state).toBe('output-error');
+      expect(part.errorText).toBe('');
+    });
+  });
+
+  describe('fromModelMessage - handling isError on tool-result', () => {
+    it('should convert tool-result with isError=true to output-error state', () => {
+      const modelMsg: AIV5Type.ModelMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-001',
+            toolName: 'errorTool',
+            input: { data: 'test' },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-001',
+            toolName: 'errorTool',
+            output: 'Error: Something went wrong',
+            isError: true,
+          },
+        ],
+      };
+
+      const dbMsg = AIV5Adapter.fromModelMessage(modelMsg);
+
+      // Check toolInvocations array
+      expect(dbMsg.content.toolInvocations).toHaveLength(1);
+      const inv = dbMsg.content.toolInvocations![0];
+      expect(inv.state).toBe('output-error');
+      expect(inv.errorText).toBe('Error: Something went wrong');
+      expect(inv).not.toHaveProperty('result');
+
+      // Check parts array
+      const toolPart = dbMsg.content.parts.find(
+        p => p.type === 'tool-invocation',
+      ) as Extract<MastraDBMessage['content']['parts'][number], { type: 'tool-invocation' }>;
+      expect(toolPart).toBeDefined();
+      expect(toolPart.toolInvocation.state).toBe('output-error');
+      expect(toolPart.toolInvocation.errorText).toBe('Error: Something went wrong');
+    });
+
+    it('should convert tool-result with isError=false to result state', () => {
+      const modelMsg: AIV5Type.ModelMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-002',
+            toolName: 'successTool',
+            input: { query: 'test' },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-002',
+            toolName: 'successTool',
+            output: { status: 'ok', data: [1, 2, 3] },
+            isError: false,
+          },
+        ],
+      };
+
+      const dbMsg = AIV5Adapter.fromModelMessage(modelMsg);
+
+      const inv = dbMsg.content.toolInvocations![0];
+      expect(inv.state).toBe('result');
+      expect(inv.result).toEqual({ status: 'ok', data: [1, 2, 3] });
+      expect(inv).not.toHaveProperty('errorText');
+    });
+
+    it('should handle tool-result without isError field (undefined)', () => {
+      const modelMsg: AIV5Type.ModelMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-003',
+            toolName: 'normalTool',
+            input: {},
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-003',
+            toolName: 'normalTool',
+            output: 'success',
+          },
+        ],
+      };
+
+      const dbMsg = AIV5Adapter.fromModelMessage(modelMsg);
+
+      const inv = dbMsg.content.toolInvocations![0];
+      expect(inv.state).toBe('result');
+      expect(inv.result).toBe('success');
+    });
+  });
+
+  describe('Round-trip error preservation', () => {
+    it('should preserve error state through save and load cycle', () => {
+      // Simulate live streaming: ModelMessage with isError
+      const streamedMsg: AIV5Type.ModelMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-roundtrip',
+            toolName: 'flakeyTool',
+            input: { retry: false },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-roundtrip',
+            toolName: 'flakeyTool',
+            output: 'Connection timeout',
+            isError: true,
+          },
+        ],
+      };
+
+      // Convert to DB format (as would be stored)
+      const savedMsg = AIV5Adapter.fromModelMessage(streamedMsg);
+
+      // Verify it was saved with error state
+      expect(savedMsg.content.toolInvocations![0].state).toBe('output-error');
+      expect(savedMsg.content.toolInvocations![0].errorText).toBe('Connection timeout');
+
+      // Load from history (DB → UI)
+      const loadedMsg = AIV5Adapter.toUIMessage(savedMsg);
+
+      // Verify error state is preserved in UI format
+      const toolPart = loadedMsg.parts[0] as AIV5Type.ToolUIPart;
+      expect(toolPart.state).toBe('output-error');
+      expect(toolPart.errorText).toBe('Connection timeout');
+      expect(toolPart).not.toHaveProperty('output');
+    });
+
+    it('should not confuse error text with successful output', () => {
+      const streamedMsg: AIV5Type.ModelMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-distinct',
+            toolName: 'distinguishTool',
+            input: {},
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-distinct',
+            toolName: 'distinguishTool',
+            output: 'Error: This is an error message',
+            isError: true,
+          },
+        ],
+      };
+
+      const savedMsg = AIV5Adapter.fromModelMessage(streamedMsg);
+      const loadedMsg = AIV5Adapter.toUIMessage(savedMsg);
+
+      const toolPart = loadedMsg.parts[0] as AIV5Type.ToolUIPart;
+
+      // Should be error state, not success with error text as output
+      expect(toolPart.state).toBe('output-error');
+      expect(toolPart.errorText).toBe('Error: This is an error message');
+
+      // Should NOT have output field
+      expect(toolPart).not.toHaveProperty('output');
+    });
+  });
+});

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
@@ -123,6 +123,14 @@ export class AIV5Adapter {
             input: invocation.args,
             output: invocation.result,
           });
+        } else if (invocation.state === 'output-error') {
+          parts.push({
+            type: `tool-${invocation.toolName}`,
+            toolCallId: invocation.toolCallId,
+            state: 'output-error',
+            input: invocation.args,
+            errorText: invocation.errorText || '',
+          });
         } else {
           parts.push({
             type: `tool-${invocation.toolName}`,
@@ -174,6 +182,16 @@ export class AIV5Adapter {
               input: inv.args,
               output: inv.result,
               state: 'output-available',
+              callProviderMetadata: mergeMastraCreatedAt(part.providerMetadata, part.createdAt),
+              providerExecuted: (part as { providerExecuted?: boolean }).providerExecuted,
+            } satisfies AIV5Type.ToolUIPart);
+          } else if (inv.state === 'output-error') {
+            parts.push({
+              type: `tool-${inv.toolName}`,
+              toolCallId: inv.toolCallId,
+              input: inv.args,
+              state: 'output-error',
+              errorText: inv.errorText || '',
               callProviderMetadata: mergeMastraCreatedAt(part.providerMetadata, part.createdAt),
               providerExecuted: (part as { providerExecuted?: boolean }).providerExecuted,
             } satisfies AIV5Type.ToolUIPart);
@@ -361,6 +379,15 @@ export class AIV5Adapter {
             state: 'result',
           } satisfies NonNullable<MastraDBMessage['content']['toolInvocations']>[0];
         }
+        if (p.state === 'output-error') {
+          return {
+            args: p.input,
+            toolCallId: p.toolCallId,
+            toolName,
+            state: 'output-error',
+            errorText: p.errorText || '',
+          } satisfies NonNullable<MastraDBMessage['content']['toolInvocations']>[0];
+        }
         return {
           args: p.input,
           toolCallId: p.toolCallId,
@@ -409,6 +436,20 @@ export class AIV5Adapter {
                     ? (p.output as { value: unknown }).value
                     : p.output,
                 state: 'result' as const,
+              },
+              providerMetadata: callProviderMetadata,
+              createdAt: getMastraCreatedAt(callProviderMetadata),
+            } satisfies ToolInvocationUIPart & { providerMetadata?: AIV5Type.ProviderMetadata; createdAt?: number };
+          }
+          if (p.state === 'output-error') {
+            return {
+              type: 'tool-invocation' as const,
+              toolInvocation: {
+                toolCallId: p.toolCallId,
+                toolName,
+                args: p.input,
+                state: 'output-error' as const,
+                errorText: p.errorText || '',
               },
               providerMetadata: callProviderMetadata,
               createdAt: getMastraCreatedAt(callProviderMetadata),
@@ -623,11 +664,16 @@ export class AIV5Adapter {
         );
 
         const updateMatchingCallInvocationResult = (toolResultPart: AIV5Type.ToolResultPart, matchingCall: any) => {
-          matchingCall.state = 'result';
-          matchingCall.result =
-            typeof toolResultPart.output === 'object' && toolResultPart.output && 'value' in toolResultPart.output
-              ? toolResultPart.output.value
-              : toolResultPart.output;
+          if (toolResultPart.isError === true) {
+            matchingCall.state = 'output-error';
+            matchingCall.errorText = String(toolResultPart.output);
+          } else {
+            matchingCall.state = 'result';
+            matchingCall.result =
+              typeof toolResultPart.output === 'object' && toolResultPart.output && 'value' in toolResultPart.output
+                ? toolResultPart.output.value
+                : toolResultPart.output;
+          }
         };
 
         if (matchingCall) {


### PR DESCRIPTION
## Summary

Fixes #15569 — Tool execution errors were stored as successful results and lost on history reload.

## Problem

When a tool's `execute()` throws an error:
- ✅ During live streaming: correctly shows `state: 'output-error'` with `errorText`
- ❌ **Bug**: When loaded from history via `toAISdkV5Messages()`, appears as successful (`state: 'output-available'` with error string as `output`)

## Root Cause

The `AIV5Adapter` had three gaps in error state handling:

1. **`toUIMessage()`**: Only checked `state === 'result'`, missing `'output-error'` — fell through to the else branch which treated it as a call/streaming state
2. **`fromModelMessage()`**: `updateMatchingCallInvocationResult()` always set `state: 'result'`, ignoring the `isError` flag on `ToolResultPart`
3. **`fromUIMessage()`**: Similar to #1, didn't preserve `output-error` state when converting UI messages back to DB format

## Fix

- **`toUIMessage()`**: Added `output-error` branch in both toolInvocations and parts handling, emitting `errorText` instead of `output`
- **`fromModelMessage()`**: Check `isError` on tool-result parts; when true, set `state: 'output-error'` with `errorText` instead of `state: 'result'`
- **`fromUIMessage()`**: Preserve `output-error` state in both conversion paths (toolInvocations array and V2 parts)

All changes follow the existing V6 adapter pattern (lines 442-448, 579-585).

## Tests

Added `AIV5Adapter-tool-error.test.ts` covering:
- `toUIMessage` converts `output-error` state correctly from both toolInvocations and parts
- `fromModelMessage` handles `isError=true` on tool-result parts
- Round-trip preservation: error stored → loaded from history → still shows as error
- Edge cases: empty errorText, missing isError field

## Changeset

Included — `@mastra/core` patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When tools fail during execution, the errors now stay labeled as errors instead of getting mixed up with successful results. This way, when you reload the conversation history, the errors show up correctly as errors rather than appearing like the tool worked but returned an error message.

## Overview

This PR fixes issue #15569 by ensuring tool execution errors are properly preserved through history reloads. The problem occurred when tool invocations that threw errors during execution were stored with an `output-error` state during live streaming, but appeared as successful results when messages were later loaded from history. The root cause was in the `AIV5Adapter` message conversion logic, which didn't properly handle the `output-error` state.

## Changes

### Changeset
- Added a patch-level changeset for `@mastra/core` documenting the tool error state preservation fix.

### AIV5Adapter Enhancements (`AIV5Adapter.ts`)
The adapter now correctly handles `output-error` state across all conversion paths:

- **`toUIMessage()`**: Added handling for `output-error` state when converting tool invocations from the database. Tool invocations with `state: 'output-error'` now produce UI parts with `state: 'output-error'` and include `errorText` (defaulting to empty string if not present).

- **`fromModelMessage()`**: Updated to check the `isError` flag on `ToolResultPart`. When `isError === true`, it sets the matching tool invocation to `state: 'output-error'` with `errorText` derived from the output, instead of always setting `state: 'result'`.

- **`fromUIMessage()`**: Extended to preserve `output-error` state when converting UI parts back to database format, creating `MastraDB` tool invocation entries with the appropriate error state and `errorText`.

### Test Coverage (`AIV5Adapter-tool-error.test.ts`)
A comprehensive test suite validates:

- **State conversion**: `toUIMessage()` correctly converts DB tool invocations with `output-error` state to UI parts with `errorText`.
- **Error flag handling**: `fromModelMessage()` properly respects the `isError` flag and sets the appropriate state.
- **Round-trip preservation**: Error state and `errorText` survive a complete `fromModelMessage` → `toUIMessage` conversion cycle without being misinterpreted as successful output.
- **Edge cases**: Proper handling of missing or empty `errorText` values, and behavior when the `isError` flag is absent.

## Result

Tool execution errors are now consistently preserved through save/load cycles. Live streaming errors and history-loaded errors now have parity, ensuring users see the correct error state whether a conversation is being streamed in real-time or loaded from history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->