### PR TITLE
fix(memory): surrogate-safe string truncation prevents Anthropic JSON parse errors

### DIFF
--- a/.changeset/surrogate-safe-truncation.md
+++ b/.changeset/surrogate-safe-truncation.md
@@ -1,0 +1,15 @@
+---
+'@mastra/memory': patch
+---
+
+fix(memory): surrogate-safe string truncation prevents Anthropic JSON parse errors
+
+Observational memory truncation used `str.slice(0, n)` which operates on UTF-16 code units. When the cut lands between a surrogate pair (emoji outside the BMP like 🔥🎭😄), the resulting string contains an unpaired high surrogate. Anthropic's JSON parser strictly validates UTF-16 and rejects the body with "no low surrogate in string".
+
+Fixed by checking whether the last code unit before the cut is a high surrogate (U+D800–U+DBFF) and backing off by one position when it is. Applied to all three truncation sites in the memory package:
+
+- `truncateStringByTokens()` (tool-result-helpers.ts)
+- `maybeTruncate()` (observer-agent.ts)
+- `sanitizeObservationLines()` (observer-agent.ts)
+
+Fixes #15573

--- a/packages/memory/src/processors/observational-memory/__tests__/surrogate-safe-truncation.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/surrogate-safe-truncation.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { truncateStringByTokens } from '../tool-result-helpers';
+import { sanitizeObservationLines } from '../observer-agent';
+
+/**
+ * UTF-16 surrogate pair safety tests.
+ *
+ * Emoji outside the BMP (e.g. 🔥 U+1F525) are encoded as two UTF-16 code
+ * units (a surrogate pair).  Naive `str.slice(0, n)` can split a pair,
+ * leaving an unpaired high surrogate that Anthropic's JSON parser rejects
+ * with "no low surrogate in string".
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/15573
+ */
+
+// 🔥 = U+1F525, encoded as \uD83D\uDD25 in UTF-16 (2 code units, .length === 2)
+const FIRE = '🔥';
+
+describe('truncateStringByTokens – surrogate safety', () => {
+  it('should not produce unpaired surrogates when truncation lands mid-emoji', () => {
+    // Build a string where truncation is likely to land on the emoji
+    const text = 'a'.repeat(50) + FIRE + 'b'.repeat(50);
+    // Force truncation by using a very small token budget
+    const result = truncateStringByTokens(text, 10);
+
+    // Verify no unpaired surrogates: every high surrogate must be followed by a low surrogate
+    for (let i = 0; i < result.length; i++) {
+      const code = result.charCodeAt(i);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        // High surrogate — next must be low surrogate
+        const next = result.charCodeAt(i + 1);
+        expect(next).toBeGreaterThanOrEqual(0xdc00);
+        expect(next).toBeLessThanOrEqual(0xdfff);
+      }
+    }
+
+    // Also verify JSON.stringify doesn't throw
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('should handle strings consisting entirely of surrogate-pair emoji', () => {
+    const text = FIRE.repeat(100);
+    const result = truncateStringByTokens(text, 5);
+
+    // Every character in the truncated portion should be a valid code point
+    for (let i = 0; i < result.length; i++) {
+      const code = result.charCodeAt(i);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = result.charCodeAt(i + 1);
+        expect(next).toBeGreaterThanOrEqual(0xdc00);
+        expect(next).toBeLessThanOrEqual(0xdfff);
+      }
+    }
+  });
+
+  it('should not alter strings that fit within the token budget', () => {
+    const text = `Hello ${FIRE} world`;
+    const result = truncateStringByTokens(text, 1000);
+    expect(result).toBe(text);
+  });
+});
+
+describe('sanitizeObservationLines – surrogate safety', () => {
+  it('should not produce unpaired surrogates when truncating long lines with emoji', () => {
+    // Build a line that exceeds MAX_OBSERVATION_LINE_CHARS (10_000)
+    // Place emoji right at the boundary
+    const line = 'x'.repeat(9999) + FIRE + 'y'.repeat(100);
+    const result = sanitizeObservationLines(line);
+
+    for (let i = 0; i < result.length; i++) {
+      const code = result.charCodeAt(i);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = result.charCodeAt(i + 1);
+        expect(next).toBeGreaterThanOrEqual(0xdc00);
+        expect(next).toBeLessThanOrEqual(0xdfff);
+      }
+    }
+
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+});

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -890,11 +890,26 @@ export function buildObserverHistoryMessage(messages: MastraDBMessage[], options
   } as CoreMessage;
 }
 
+/**
+ * Slice a string without splitting a UTF-16 surrogate pair.
+ * If the cut lands on a high surrogate (U+D800–U+DBFF), back off by one
+ * so the resulting string never contains an unpaired surrogate.
+ */
+function surrogateSafeSlice(str: string, end: number): string {
+  if (end <= 0) return '';
+  if (end >= str.length) return str;
+  const code = str.charCodeAt(end - 1);
+  if (code >= 0xd800 && code <= 0xdbff) {
+    return str.slice(0, end - 1);
+  }
+  return str.slice(0, end);
+}
+
 /** Truncate a string to maxLen characters, appending a note if truncated. */
 function maybeTruncate(str: string, maxLen?: number): string {
   if (!maxLen || str.length <= maxLen) return str;
-  const truncated = str.slice(0, maxLen);
-  const remaining = str.length - maxLen;
+  const truncated = surrogateSafeSlice(str, maxLen);
+  const remaining = str.length - truncated.length;
   return `${truncated}\n... [truncated ${remaining} characters]`;
 }
 
@@ -1341,7 +1356,7 @@ export function sanitizeObservationLines(observations: string): string {
   let changed = false;
   for (let i = 0; i < lines.length; i++) {
     if (lines[i]!.length > MAX_OBSERVATION_LINE_CHARS) {
-      lines[i] = lines[i]!.slice(0, MAX_OBSERVATION_LINE_CHARS) + ' … [truncated]';
+      lines[i] = surrogateSafeSlice(lines[i]!, MAX_OBSERVATION_LINE_CHARS) + ' … [truncated]';
       changed = true;
     }
   }

--- a/packages/memory/src/processors/observational-memory/tool-result-helpers.ts
+++ b/packages/memory/src/processors/observational-memory/tool-result-helpers.ts
@@ -80,6 +80,22 @@ export function resolveToolResultValue(
   };
 }
 
+/**
+ * Slice a string without splitting a UTF-16 surrogate pair.
+ * If the cut lands on a high surrogate (U+D800–U+DBFF), back off by one
+ * so the resulting string never contains an unpaired surrogate.
+ */
+function surrogateSafeSlice(str: string, end: number): string {
+  if (end <= 0) return '';
+  if (end >= str.length) return str;
+  const code = str.charCodeAt(end - 1);
+  // High surrogate range: 0xD800–0xDBFF
+  if (code >= 0xd800 && code <= 0xdbff) {
+    return str.slice(0, end - 1);
+  }
+  return str.slice(0, end);
+}
+
 export function truncateStringByTokens(text: string, maxTokens: number): string {
   if (!text || maxTokens <= 0) {
     return '';
@@ -91,7 +107,7 @@ export function truncateStringByTokens(text: string, maxTokens: number): string 
   }
 
   const buildCandidate = (sliceEnd: number) => {
-    const visible = text.slice(0, sliceEnd);
+    const visible = surrogateSafeSlice(text, sliceEnd);
     return `${visible}\n... [truncated ~${totalTokens - estimateTokenCount(visible)} tokens]`;
   };
 


### PR DESCRIPTION
## Summary

Observational memory truncation uses `str.slice(0, n)` which operates on UTF-16 code units. When the cut lands between a surrogate pair (emoji outside the BMP like 🔥🎭😄), the resulting string contains an unpaired high surrogate. Anthropic's JSON parser strictly validates UTF-16 and rejects the body with `no low surrogate in string`.

## Fix

Added a `surrogateSafeSlice()` helper that checks whether the last code unit before the cut is a high surrogate (U+D800–U+DBFF) and backs off by one position when it is. Applied to all three truncation sites in the memory package:

- `truncateStringByTokens()` in `tool-result-helpers.ts` — binary-search token truncation
- `maybeTruncate()` in `observer-agent.ts` — character-limit truncation
- `sanitizeObservationLines()` in `observer-agent.ts` — per-line length guard

## Tests

Added 4 test cases covering:
- Truncation landing mid-emoji in mixed text
- Strings consisting entirely of surrogate-pair emoji
- Passthrough when text fits within budget
- Per-line sanitization with emoji at the boundary

All tests pass locally (`vitest run`).

Closes #15573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a bug where cutting text at certain positions could accidentally split emoji characters in half, creating broken data that Anthropic's parser rejects. The fix checks if we're about to cut in the middle of an emoji and moves the cut point back one position to keep them whole.

## Overview

This PR addresses issue #15573 by implementing surrogate-safe string truncation across the memory package. The issue occurred because UTF-16 encodes characters outside the Basic Multilingual Plane (like many emoji) using surrogate pairs—two code units that must stay together. When truncation using `slice(0, n)` cut at the wrong position, it could leave an unpaired high surrogate, which Anthropic's strict JSON parser rejects with a "no low surrogate in string" error.

## Changes

### Core Fix: Surrogate-Safe Truncation

A new helper function `surrogateSafeSlice(str, end)` was added to both `tool-result-helpers.ts` and `observer-agent.ts`. This function detects when a truncation boundary falls immediately after a high surrogate code unit (U+D800–U+DBFF) and automatically backs off by one position to preserve the surrogate pair.

### Applied Locations

- **`truncateStringByTokens()` in `tool-result-helpers.ts`**: Binary-search token truncation now uses `surrogateSafeSlice` instead of the unsafe `slice()` operation.
- **`maybeTruncate()` in `observer-agent.ts`**: Character-limit truncation updated to use `surrogateSafeSlice` with corrected remaining character count calculation.
- **`sanitizeObservationLines()` in `observer-agent.ts`**: Per-line length guard now truncates overlong lines using `surrogateSafeSlice` before appending the ellipsis marker.

### Tests

A new test file `surrogate-safe-truncation.test.ts` was added with four test cases:
- Truncation within mixed text containing emoji at the boundary
- Truncation of strings composed entirely of surrogate-pair emoji
- Passthrough behavior when text fits within the token budget
- Per-line sanitization with emoji at length boundaries

All tests validate that truncated output contains no unpaired surrogates and can be safely JSON-stringified.

### Changeset

A changeset entry (`.changeset/surrogate-safe-truncation.md`) was added marking a patch release for `@mastra/memory` with the bugfix description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->