### PR TITLE
fix(client-js): collect all tool invocations from streamed tool-calls step

### DIFF
--- a/.changeset/fix-client-js-multi-tool-invocations.md
+++ b/.changeset/fix-client-js-multi-tool-invocations.md
@@ -1,0 +1,19 @@
+---
+'@mastra/client-js': patch
+---
+
+fix(client-js): collect all tool invocations from streamed tool-calls step
+
+Previously, `processStreamResponse` and `processStreamResponseLegacy` used
+`reverse().find()` to pick only the last `tool-invocation` part from a
+finished step. When the assistant emitted multiple client tool invocations
+in one step, only one was executed — the rest were silently dropped.
+
+This change:
+- Collects **all** pending tool invocations (state === 'call') from the
+  message parts instead of just the last one
+- Deduplicates by `toolCallId` to prevent reprocessing
+- Executes all matching client tools, patches all results into a single
+  cloned message, then makes **one** recursive continuation call
+- Clears the `toolCalls` array after processing to prevent stale
+  accumulation across continuations

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -1385,15 +1385,28 @@ export class Agent extends BaseResource {
         },
         onFinish: async ({ finishReason, message }) => {
           if (finishReason === 'tool-calls') {
-            const toolCall = [...(message?.parts ?? [])]
-              .reverse()
-              .find(part => part.type === 'tool-invocation')?.toolInvocation;
-            if (toolCall) {
-              toolCalls.push(toolCall);
+            // Collect ALL pending tool invocations from this step (not just the last one)
+            const pendingToolCalls = (message?.parts ?? [])
+              .filter(
+                (part): part is ToolInvocationUIPart =>
+                  part.type === 'tool-invocation' && part.toolInvocation?.state === 'call',
+              )
+              .map(part => part.toolInvocation);
+
+            for (const tc of pendingToolCalls) {
+              if (!toolCalls.some(existing => existing.toolCallId === tc.toolCallId)) {
+                toolCalls.push(tc);
+              }
             }
 
             let shouldExecuteClientTool = false;
-            // Handle tool calls if needed
+
+            // Clone the last message once — all tool results are patched into this single copy
+            const lastMessageRaw = messages[messages.length - 1];
+            const lastMessage: UIMessage | undefined =
+              lastMessageRaw != null ? JSON.parse(JSON.stringify(lastMessageRaw)) : undefined;
+
+            // Execute all pending client tools and patch results into lastMessage
             for (const toolCall of toolCalls) {
               const clientTool = processedParams.clientTools?.[toolCall.toolName] as Tool;
               if (clientTool && clientTool.execute) {
@@ -1411,10 +1424,6 @@ export class Agent extends BaseResource {
                     resourceId,
                   },
                 });
-
-                const lastMessageRaw = messages[messages.length - 1];
-                const lastMessage: UIMessage | undefined =
-                  lastMessageRaw != null ? JSON.parse(JSON.stringify(lastMessageRaw)) : undefined;
 
                 const toolInvocationPart = lastMessage?.parts?.find(
                   part => part.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCall.toolCallId,
@@ -1437,30 +1446,36 @@ export class Agent extends BaseResource {
                   // @ts-expect-error - result property exists when state is 'result'
                   toolInvocation.result = result;
                 }
+              }
+            }
 
-                // Build updated messages for the recursive call
-                // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
-                // When no threadId (stateless), include full conversation history for context
-                const newMessages =
-                  lastMessage != null ? [...messages.filter(m => m.id !== lastMessage.id), lastMessage] : [...messages];
+            // Clear processed tool calls to prevent reprocessing on next continuation
+            toolCalls = [];
 
-                const updatedMessages = threadId
-                  ? newMessages
-                  : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
+            // Make a single recursive call with all tool results patched
+            if (shouldExecuteClientTool) {
+              // Build updated messages for the recursive call
+              // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
+              // When no threadId (stateless), include full conversation history for context
+              const newMessages =
+                lastMessage != null ? [...messages.filter(m => m.id !== lastMessage.id), lastMessage] : [...messages];
 
-                // Recursively call stream with updated messages
-                // This will wait for the recursive stream to complete before continuing
-                try {
-                  await this.processStreamResponse(
-                    {
-                      ...processedParams,
-                      messages: updatedMessages,
-                    },
-                    controller,
-                  );
-                } catch (error) {
-                  console.error('Error processing recursive stream response:', error);
-                }
+              const updatedMessages = threadId
+                ? newMessages
+                : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
+
+              // Recursively call stream with updated messages
+              // This will wait for the recursive stream to complete before continuing
+              try {
+                await this.processStreamResponse(
+                  {
+                    ...processedParams,
+                    messages: updatedMessages,
+                  },
+                  controller,
+                );
+              } catch (error) {
+                console.error('Error processing recursive stream response:', error);
               }
             }
 
@@ -1961,17 +1976,29 @@ export class Agent extends BaseResource {
         },
         onFinish: async ({ finishReason, message }) => {
           if (finishReason === 'tool-calls') {
-            const toolCall = [...(message?.parts ?? [])]
-              .reverse()
-              .find(part => part.type === 'tool-invocation')?.toolInvocation;
-            if (toolCall) {
-              toolCalls.push(toolCall);
+            // Collect ALL pending tool invocations from this step (not just the last one)
+            const pendingToolCalls = (message?.parts ?? [])
+              .filter(
+                (part): part is ToolInvocationUIPart =>
+                  part.type === 'tool-invocation' && part.toolInvocation?.state === 'call',
+              )
+              .map(part => part.toolInvocation);
+
+            for (const tc of pendingToolCalls) {
+              if (!toolCalls.some(existing => existing.toolCallId === tc.toolCallId)) {
+                toolCalls.push(tc);
+              }
             }
 
-            // Handle tool calls if needed
+            // Clone the last message once — all tool results are patched into this single copy
+            const lastMessage: UIMessage = JSON.parse(JSON.stringify(messages[messages.length - 1]));
+            let shouldExecuteClientTool = false;
+
+            // Execute all pending client tools and patch results into lastMessage
             for (const toolCall of toolCalls) {
               const clientTool = processedParams.clientTools?.[toolCall.toolName] as Tool;
               if (clientTool && clientTool.execute) {
+                shouldExecuteClientTool = true;
                 const result = await clientTool.execute(toolCall?.args, {
                   requestContext: processedParams.requestContext as RequestContext,
                   // TODO: Pass proper tracing context when client-js supports tracing
@@ -1985,8 +2012,6 @@ export class Agent extends BaseResource {
                     resourceId,
                   },
                 });
-
-                const lastMessage: UIMessage = JSON.parse(JSON.stringify(messages[messages.length - 1]));
 
                 const toolInvocationPart = lastMessage?.parts?.find(
                   part => part.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCall.toolCallId,
@@ -2027,26 +2052,32 @@ export class Agent extends BaseResource {
                 } finally {
                   writer.releaseLock();
                 }
-
-                // Build updated messages for the recursive call
-                // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
-                // When no threadId (stateless), include full conversation history for context
-                const newMessages = [...messages.filter(m => m.id !== lastMessage.id), lastMessage];
-                const updatedMessages = threadId
-                  ? newMessages
-                  : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
-
-                // Recursively call stream with updated messages
-                this.processStreamResponseLegacy(
-                  {
-                    ...processedParams,
-                    messages: updatedMessages,
-                  },
-                  writable,
-                ).catch(error => {
-                  console.error('Error processing stream response:', error);
-                });
               }
+            }
+
+            // Clear processed tool calls to prevent reprocessing on next continuation
+            toolCalls = [];
+
+            // Make a single recursive call with all tool results patched
+            if (shouldExecuteClientTool) {
+              // Build updated messages for the recursive call
+              // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
+              // When no threadId (stateless), include full conversation history for context
+              const newMessages = [...messages.filter(m => m.id !== lastMessage.id), lastMessage];
+              const updatedMessages = threadId
+                ? newMessages
+                : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
+
+              // Recursively call stream with updated messages
+              this.processStreamResponseLegacy(
+                {
+                  ...processedParams,
+                  messages: updatedMessages,
+                },
+                writable,
+              ).catch(error => {
+                console.error('Error processing stream response:', error);
+              });
             }
           } else {
             setTimeout(() => {

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -1991,7 +1991,9 @@ export class Agent extends BaseResource {
             }
 
             // Clone the last message once — all tool results are patched into this single copy
-            const lastMessage: UIMessage = JSON.parse(JSON.stringify(messages[messages.length - 1]));
+            const lastMessageRaw = messages[messages.length - 1];
+            const lastMessage: UIMessage | undefined =
+              lastMessageRaw != null ? JSON.parse(JSON.stringify(lastMessageRaw)) : undefined;
             let shouldExecuteClientTool = false;
 
             // Execute all pending client tools and patch results into lastMessage
@@ -2063,7 +2065,8 @@ export class Agent extends BaseResource {
               // Build updated messages for the recursive call
               // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
               // When no threadId (stateless), include full conversation history for context
-              const newMessages = [...messages.filter(m => m.id !== lastMessage.id), lastMessage];
+              const newMessages =
+                lastMessage != null ? [...messages.filter(m => m.id !== lastMessage.id), lastMessage] : [...messages];
               const updatedMessages = threadId
                 ? newMessages
                 : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];


### PR DESCRIPTION
## Summary

Fixes #15576

When a streamed step finishes with `finishReason === 'tool-calls'`, the client-side continuation logic in `@mastra/client-js` only collected the **last** `tool-invocation` part from the assistant message (via `reverse().find()`). If the assistant emitted multiple client tool invocations in one step, only one was executed — the rest were silently dropped.

## Changes

Both `processStreamResponse` (v2) and `processStreamResponseLegacy` paths are fixed:

1. **Collect ALL pending tool invocations** — replaced `reverse().find()` with `filter()` to gather all parts where `type === 'tool-invocation' && state === 'call'`
2. **Deduplicate by `toolCallId`** — prevents reprocessing if `onFinish` fires multiple times
3. **Execute all client tools, patch all results into a single cloned message** — previously each tool call cloned the message independently, losing other tools' results
4. **Make ONE recursive continuation call** — instead of recursing per-tool-call (which could cause cascading/duplicate continuations)
5. **Clear `toolCalls` array after processing** — prevents stale accumulation across continuation rounds

## Before vs After

| Behavior | Before | After |
|---|---|---|
| Tool invocations collected per step | 1 (last only) | All pending |
| Recursive calls per step | 1 per tool call | 1 total |
| `toolCalls` array lifecycle | Never cleared (accumulates) | Cleared after processing |
| Message cloning | Per tool call (loses sibling results) | Once (all results patched) |

## Testing

- Type-checked against the codebase (all errors are pre-existing missing monorepo deps, none from this change)
- Changeset included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an AI assistant needed to use multiple tools at once, the client only ran the last tool and dropped the rest. This PR ensures the client runs all requested tools, keeps all their results together, and then continues the conversation correctly.

## Overview

Fixes a bug in `@mastra/client-js` where streamed assistant steps ending with `finishReason === 'tool-calls'` only executed a single (last) `tool-invocation` part. The fix collects all pending tool-invocation parts, deduplicates them, executes each matching client tool exactly once, patches all tool results back into the assistant message, and makes a single continuation call with the fully updated messages.

## Changes

### Modified Files

- client-sdks/client-js/src/resources/agent.ts (+92/-58)
  - In both `processStreamResponse` (v2) and `processStreamResponseLegacy`, replaced the `reverse().find()` single-selection with a `filter()` to collect all `type === 'tool-invocation' && state === 'call'` parts.
  - Deduplicates collected invocations by `toolCallId` to avoid duplicate execution when `onFinish` fires multiple times.
  - Clones the last UI message once and patches all executed tool results into that single clone so sibling results are preserved (previously each tool cloned independently and lost siblings).
  - Executes all client tools, clears the `toolCalls` array after processing to avoid stale accumulation, and makes one recursive continuation call after all tool results are patched (instead of recursing per tool).
  - Added a null guard for `lastMessage` in the legacy streaming path to avoid cloning empty messages.

- .changeset/fix-client-js-multi-tool-invocations.md (+19/-0)
  - New changeset documenting the patch release for the fix.

## Impact

- Multiple tool invocations emitted in a single streamed step are all executed and preserved.
- Tool results from sibling invocations are kept together in the assistant message.
- Continuation logic runs once per aggregated update, preventing duplicate executions and stale tool call accumulation.
- Type-checked against the codebase (remaining errors stem from pre-existing missing monorepo deps).
- Fixes #15576.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->