### PR TITLE
fix(core): resolve server type-test lint ordering

### DIFF
--- a/.changeset/polite-jars-start.md
+++ b/.changeset/polite-jars-start.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed an import order lint error in a core server type test.

--- a/packages/core/src/server/server.test-d.ts
+++ b/packages/core/src/server/server.test-d.ts
@@ -2,8 +2,8 @@ import { describe, expectTypeOf, it } from 'vitest';
 import type { RequestContext } from '../request-context';
 import type { MastraAuthProvider } from './auth';
 import { CompositeAuth } from './composite-auth';
-import { registerApiRoute } from './index';
 import { SimpleAuth } from './simple-auth';
+import { registerApiRoute } from './index';
 
 /**
  * Type tests for registerApiRoute


### PR DESCRIPTION
This fixes the import ordering in `packages/core/src/server/server.test-d.ts` so `@mastra/core` lint passes again.

I verified it with `pnpm --filter ./packages/core lint` and a full `pnpm lint` from the repo root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

The PR fixes the order of some import statements in a test file because the linter (a tool that checks code style) was complaining about them being in the wrong order. It's like reorganizing your bookshelf so books are arranged correctly—the books are the same, just rearranged to follow the rules.

## Changes

- **Import reordering in test file**: Reordered import statements in `packages/core/src/server/server.test-d.ts` to comply with the `@mastra/core` lint rule, moving `registerApiRoute` to appear after `SimpleAuth`
- **Changeset entry**: Added `.changeset/polite-jars-start.md` documenting a patch release for `@mastra/core` with the import-order lint fix

## Verification

The changes were validated by running:
- Focused lint on the core package: `pnpm --filter ./packages/core lint`
- Full repository lint: `pnpm lint`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->