### PR TITLE
feat: add tanstack-start server adapter

### DIFF
--- a/.changeset/odd-cats-cheer.md
+++ b/.changeset/odd-cats-cheer.md
@@ -1,0 +1,7 @@
+---
+'@mastra/tanstack-start': minor
+---
+
+Added a new TanStack Start server adapter package for Mastra.
+
+It provides a `MastraServer` wrapper around the Hono adapter with `createRequestHandler()` and `createRouteHandlers()` helpers so TanStack Start catch-all server routes can forward requests to Mastra with minimal setup.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4961,6 +4961,55 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
 
+  server-adapters/tanstack-start:
+    dependencies:
+      '@mastra/hono':
+        specifier: workspace:*
+        version: link:../hono
+      '@mastra/server':
+        specifier: workspace:*
+        version: link:../../packages/server
+      '@tanstack/react-router':
+        specifier: '>=1.0.0'
+        version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    devDependencies:
+      '@hono/node-server':
+        specifier: ^1.19.11
+        version: 1.19.14(hono@4.12.14)
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/server-adapter-test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      eslint:
+        specifier: ^10.2.1
+        version: 10.2.1(jiti@2.6.1)
+      hono:
+        specifier: ^4.12.8
+        version: 4.12.14
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+
   stores/_test-utils:
     dependencies:
       vitest:
@@ -14906,6 +14955,10 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tanstack/history@1.161.6':
+    resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
+    engines: {node: '>=20.19'}
+
   '@tanstack/query-core@5.90.20':
     resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
 
@@ -14913,6 +14966,19 @@ packages:
     resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-router@1.168.23':
+    resolution: {integrity: sha512-+GblieDnutG6oipJJPNtRJjrWF8QTZEG/l0532+BngFkVK48oHNOcvIkSoAFYftK1egAwM7KBxXsb0Ou+X6/MQ==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@tanstack/react-table@8.21.3':
     resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
@@ -14926,6 +14992,14 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.168.15':
+    resolution: {integrity: sha512-Wr0424NDtD8fT/uALobMZ9DdcfsTyXtW5IPR++7zvW8/7RaIOeaqXpVDId8ywaGtqPWLWOfaUg2zUtYtukoXYA==}
+    engines: {node: '>=20.19'}
+    hasBin: true
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
@@ -17383,6 +17457,9 @@ packages:
         optional: true
       react:
         optional: true
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
@@ -19875,6 +19952,10 @@ packages:
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isbot@5.1.39:
+    resolution: {integrity: sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -23507,6 +23588,16 @@ packages:
   serialize-javascript@7.0.5:
     resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
+
+  seroval-plugins@1.5.2:
+    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.2:
+    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+    engines: {node: '>=10'}
 
   serve-handler@6.1.7:
     resolution: {integrity: sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==}
@@ -35957,6 +36048,8 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@tanstack/history@1.161.6': {}
+
   '@tanstack/query-core@5.90.20': {}
 
   '@tanstack/react-query@5.90.21(react@18.3.1)':
@@ -35969,6 +36062,22 @@ snapshots:
       '@tanstack/query-core': 5.90.20
       react: 19.2.5
 
+  '@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.168.15
+      isbot: 5.1.39
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   '@tanstack/react-table@8.21.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/table-core': 8.21.3
@@ -35980,6 +36089,15 @@ snapshots:
       '@tanstack/virtual-core': 3.13.23
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/router-core@1.168.15':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      cookie-es: 3.1.1
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
+
+  '@tanstack/store@0.9.3': {}
 
   '@tanstack/table-core@8.21.3': {}
 
@@ -38859,6 +38977,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  cookie-es@3.1.1: {}
 
   cookie-signature@1.0.6: {}
 
@@ -41963,6 +42083,8 @@ snapshots:
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
+
+  isbot@5.1.39: {}
 
   isexe@2.0.0: {}
 
@@ -46741,6 +46863,12 @@ snapshots:
       type-fest: 0.13.1
 
   serialize-javascript@7.0.5: {}
+
+  seroval-plugins@1.5.2(seroval@1.5.2):
+    dependencies:
+      seroval: 1.5.2
+
+  seroval@1.5.2: {}
 
   serve-handler@6.1.7:
     dependencies:

--- a/server-adapters/tanstack-start/.gitignore
+++ b/server-adapters/tanstack-start/.gitignore
@@ -1,0 +1,3 @@
+.env
+dist/
+node_modules/

--- a/server-adapters/tanstack-start/CHANGELOG.md
+++ b/server-adapters/tanstack-start/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @mastra/tanstack-start
+
+## 1.0.0-alpha.0
+
+### Patch Changes
+
+- Initial release.

--- a/server-adapters/tanstack-start/README.md
+++ b/server-adapters/tanstack-start/README.md
@@ -1,0 +1,59 @@
+# @mastra/tanstack-start
+
+TanStack Start server adapter for Mastra.
+
+This adapter wraps `@mastra/hono` and gives you handlers that plug directly into TanStack Start server routes.
+
+## Installation
+
+```bash
+npm install @mastra/tanstack-start
+```
+
+## Usage
+
+```typescript
+// src/server/mastra-app.ts
+import { MastraServer } from '@mastra/tanstack-start';
+import { mastra } from './mastra';
+
+const server = new MastraServer({ mastra });
+await server.init();
+
+export { server };
+```
+
+```typescript
+// src/routes/api/$.ts
+import { createFileRoute } from '@tanstack/react-router';
+import { server } from '../../server/mastra-app';
+
+export const Route = createFileRoute('/api/$')({
+  server: {
+    handlers: server.createRouteHandlers(),
+  },
+});
+```
+
+If you only want to handle a subset of methods:
+
+```typescript
+const handlers = server.createRouteHandlers(['GET', 'POST']);
+```
+
+## Why this adapter
+
+- No manual per-method wiring in TanStack Start route files
+- Keeps Mastra setup aligned with existing Hono adapter behavior
+- Works with catch-all server routes such as `/api/$`
+
+## Tested capabilities
+
+The adapter test suite covers:
+
+- Core Mastra route integration via TanStack Start-style request forwarding
+- `createRouteHandlers()` and `createRequestHandler()` behavior
+- MCP registry and MCP transport routes
+- Auth helper middleware and RBAC permission enforcement
+- HTTP request logging behavior
+- Malformed JSON handling and server resiliency

--- a/server-adapters/tanstack-start/eslint.config.js
+++ b/server-adapters/tanstack-start/eslint.config.js
@@ -1,0 +1,11 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...config.map(conf => ({
+    ...conf,
+    ignores: [...(conf.ignores || []), '**/vitest.perf.config.ts', '**/performance-test.ts'],
+  })),
+];

--- a/server-adapters/tanstack-start/lint-staged.config.js
+++ b/server-adapters/tanstack-start/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['eslint --fix', 'prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/server-adapters/tanstack-start/package.json
+++ b/server-adapters/tanstack-start/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@mastra/tanstack-start",
+  "version": "1.0.0-alpha.0",
+  "description": "Mastra TanStack Start adapter for server routes",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build --watch",
+    "test": "vitest run",
+    "lint": "eslint ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@mastra/hono": "workspace:*",
+    "@mastra/server": "workspace:*"
+  },
+  "devDependencies": {
+    "@hono/node-server": "^1.19.11",
+    "@internal/lint": "workspace:*",
+    "@internal/server-adapter-test-utils": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.19.15",
+    "eslint": "^10.2.1",
+    "hono": "^4.12.8",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@tanstack/react-router": ">=1.0.0"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "server-adapters/tanstack-start"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  }
+}

--- a/server-adapters/tanstack-start/src/__tests__/auth-middleware.test.ts
+++ b/server-adapters/tanstack-start/src/__tests__/auth-middleware.test.ts
@@ -1,0 +1,44 @@
+import { Mastra } from '@mastra/core';
+import { describe, expect, it } from 'vitest';
+import { createAuthMiddleware, MastraServer } from '../index';
+
+function createMastraWithAuth() {
+  const mastra = new Mastra({ logger: false });
+  const originalGetServer = mastra.getServer.bind(mastra);
+
+  mastra.getServer = () =>
+    ({
+      ...originalGetServer(),
+      auth: {
+        authenticateToken: async (token: string) =>
+          token === 'valid-token' ? { id: 'user-1', email: 'user@example.com' } : null,
+        authorize: async () => true,
+      },
+    }) as any;
+
+  return mastra;
+}
+
+describe('TanStack Start auth middleware helper', () => {
+  it('protects raw routes outside Mastra route registration', async () => {
+    const mastra = createMastraWithAuth();
+    const adapter = new MastraServer({ mastra });
+    const app = adapter.app;
+
+    adapter.registerContextMiddleware();
+
+    app.get('/custom/protected', createAuthMiddleware({ mastra }), c => {
+      const user = c.get('requestContext').get('user') as { id: string };
+      return c.json({ userId: user.id });
+    });
+
+    const unauthenticated = await app.request('http://localhost/custom/protected');
+    expect(unauthenticated.status).toBe(401);
+
+    const authenticated = await app.request('http://localhost/custom/protected', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(authenticated.status).toBe(200);
+    await expect(authenticated.json()).resolves.toEqual({ userId: 'user-1' });
+  });
+});

--- a/server-adapters/tanstack-start/src/__tests__/http-logging.test.ts
+++ b/server-adapters/tanstack-start/src/__tests__/http-logging.test.ts
@@ -1,0 +1,47 @@
+import { createHttpLoggingTestSuite } from '@internal/server-adapter-test-utils';
+import { Hono } from 'hono';
+import { describe } from 'vitest';
+import { MastraServer } from '../index';
+
+describe('TanStack Start Server Adapter', () => {
+  createHttpLoggingTestSuite({
+    suiteName: 'TanStack Start HTTP Logging',
+    createApp: () => new Hono(),
+    setupAdapter: async (_app, mastra) => {
+      const adapter = new MastraServer({ app: _app as any, mastra });
+      return { adapter, app: adapter.app };
+    },
+    addRoute: async (app, method, path, handler) => {
+      const routeHandler = async (c: any) => {
+        const result = await handler(c);
+        if (result.status) return c.json(result.body || {}, result.status);
+        return c.json(result);
+      };
+
+      switch (method) {
+        case 'GET':
+          app.get(path, routeHandler);
+          break;
+        case 'POST':
+          app.post(path, routeHandler);
+          break;
+        case 'PUT':
+          app.put(path, routeHandler);
+          break;
+        case 'DELETE':
+          app.delete(path, routeHandler);
+          break;
+      }
+    },
+    executeRequest: async (app, method, url, options = {}) => {
+      const response = await app.request(
+        new Request(url, {
+          method,
+          headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+          ...(options.body ? { body: options.body } : {}),
+        }),
+      );
+      return { status: response.status };
+    },
+  });
+});

--- a/server-adapters/tanstack-start/src/__tests__/malformed-json.test.ts
+++ b/server-adapters/tanstack-start/src/__tests__/malformed-json.test.ts
@@ -1,0 +1,48 @@
+import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
+import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MastraServer } from '../index';
+
+describe('Malformed JSON Body Handling', () => {
+  let context: AdapterTestContext;
+  let adapter: MastraServer;
+
+  beforeEach(async () => {
+    context = await createDefaultTestContext();
+    adapter = new MastraServer({
+      mastra: context.mastra,
+      tools: context.tools,
+      taskStore: context.taskStore,
+    });
+    await adapter.init();
+  });
+
+  it('returns 400 for malformed json payload', async () => {
+    const response = await adapter.app.request(
+      new Request('http://localhost/api/agents/test-agent/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"messages": [{"role": "user", "content": "hel',
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('continues serving valid requests after malformed json', async () => {
+    const malformed = await adapter.app.request(
+      new Request('http://localhost/api/agents/test-agent/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{invalid json here',
+      }),
+    );
+    expect(malformed.status).toBe(400);
+
+    const valid = await adapter.app.request(
+      new Request('http://localhost/api/agents', {
+        method: 'GET',
+      }),
+    );
+    expect(valid.status).toBe(200);
+  });
+});

--- a/server-adapters/tanstack-start/src/__tests__/mcp-routes.test.ts
+++ b/server-adapters/tanstack-start/src/__tests__/mcp-routes.test.ts
@@ -1,0 +1,46 @@
+import { createMCPRouteTestSuite } from '@internal/server-adapter-test-utils';
+import type { AdapterTestContext, HttpRequest, HttpResponse } from '@internal/server-adapter-test-utils';
+import { describe } from 'vitest';
+import { MastraServer } from '../index';
+
+describe('TanStack Start MCP Registry Routes Integration', () => {
+  createMCPRouteTestSuite({
+    suiteName: 'TanStack Start Adapter',
+    setupAdapter: async (context: AdapterTestContext) => {
+      const adapter = new MastraServer({
+        mastra: context.mastra,
+        taskStore: context.taskStore,
+        customRouteAuthConfig: context.customRouteAuthConfig,
+      });
+      await adapter.init();
+      return { app: adapter.app, adapter };
+    },
+    executeHttpRequest: async (app, request: HttpRequest): Promise<HttpResponse> => {
+      let url = `http://localhost${request.path}`;
+      if (request.query) {
+        const queryParams = new URLSearchParams();
+        Object.entries(request.query).forEach(([key, value]) => {
+          if (Array.isArray(value)) value.forEach(v => queryParams.append(key, String(v)));
+          else queryParams.append(key, String(value));
+        });
+        const queryString = queryParams.toString();
+        if (queryString) url += `?${queryString}`;
+      }
+
+      const response = await app.request(
+        new Request(url, {
+          method: request.method,
+          headers: { 'Content-Type': 'application/json', ...(request.headers || {}) },
+          body: request.body ? JSON.stringify(request.body) : undefined,
+        }),
+      );
+
+      return {
+        status: response.status,
+        type: 'json',
+        data: await response.json(),
+        headers: Object.fromEntries(response.headers.entries()),
+      };
+    },
+  });
+});

--- a/server-adapters/tanstack-start/src/__tests__/mcp-transport.test.ts
+++ b/server-adapters/tanstack-start/src/__tests__/mcp-transport.test.ts
@@ -1,0 +1,23 @@
+import { serve } from '@hono/node-server';
+import { createMCPTransportTestSuite } from '@internal/server-adapter-test-utils';
+import type { Mastra } from '@mastra/core/mastra';
+import { describe } from 'vitest';
+import { MastraServer } from '../index';
+
+describe('TanStack Start MCP Transport Routes Integration', () => {
+  createMCPTransportTestSuite({
+    suiteName: 'TanStack Start Adapter',
+    createServer: async (mastra: Mastra) => {
+      const adapter = new MastraServer({ mastra });
+      await adapter.init();
+
+      const server = serve({ fetch: adapter.app.fetch, port: 0 });
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Failed to get server address');
+      }
+
+      return { server, port: address.port };
+    },
+  });
+});

--- a/server-adapters/tanstack-start/src/__tests__/rbac-permissions.test.ts
+++ b/server-adapters/tanstack-start/src/__tests__/rbac-permissions.test.ts
@@ -1,0 +1,88 @@
+import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
+import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
+import type { ServerRoute } from '@mastra/server/server-adapter';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MastraServer } from '../index';
+
+const ROLE_PERMISSIONS: Record<string, string[]> = {
+  admin: ['*'],
+  member: ['agents:read', 'workflows:*', 'tools:read', 'tools:execute'],
+  viewer: ['agents:read', 'workflows:read'],
+  _default: [],
+};
+
+function createProtectedRoute(permission: string): ServerRoute<any, any, any> {
+  return {
+    method: 'GET',
+    path: `/api/test/${permission.replace(':', '-')}`,
+    responseType: 'json',
+    requiresPermission: permission,
+    handler: async () => ({ success: true, permission }),
+  };
+}
+
+function createMockAuthConfig() {
+  return {
+    authenticateToken: async (token: string) => {
+      if (!token) return null;
+      const permissions = ROLE_PERMISSIONS[token];
+      if (!permissions) return null;
+      return { id: `user_${token}`, role: token };
+    },
+    authorize: async () => true,
+  };
+}
+
+function createMockRBACProvider() {
+  return {
+    getPermissions: async (user: { role: string }) => ROLE_PERMISSIONS[user.role] || [],
+    getRoles: async (user: { role: string }) => [user.role],
+  };
+}
+
+async function setupAuthAdapter(context: AdapterTestContext) {
+  const originalGetServer = context.mastra.getServer.bind(context.mastra);
+  context.mastra.getServer = () => ({
+    ...originalGetServer(),
+    auth: createMockAuthConfig(),
+    rbac: createMockRBACProvider(),
+  });
+
+  const adapter = new MastraServer({ mastra: context.mastra });
+  adapter.registerContextMiddleware();
+  adapter.registerAuthMiddleware();
+  return adapter;
+}
+
+describe('RBAC Permission Enforcement', () => {
+  let context: AdapterTestContext;
+
+  beforeEach(async () => {
+    context = await createDefaultTestContext();
+  });
+
+  it('returns 401 for unauthenticated request', async () => {
+    const adapter = await setupAuthAdapter(context);
+    await adapter.registerRoute(adapter.app, createProtectedRoute('agents:read'), { prefix: '' });
+    const response = await adapter.app.request('http://localhost/api/test/agents-read');
+    expect(response.status).toBe(401);
+  });
+
+  it('allows admin via wildcard permission', async () => {
+    const adapter = await setupAuthAdapter(context);
+    await adapter.registerRoute(adapter.app, createProtectedRoute('agents:execute'), { prefix: '' });
+    const response = await adapter.app.request('http://localhost/api/test/agents-execute', {
+      headers: { Authorization: 'Bearer admin' },
+    });
+    expect(response.status).toBe(200);
+  });
+
+  it('denies viewer for execute permission', async () => {
+    const adapter = await setupAuthAdapter(context);
+    await adapter.registerRoute(adapter.app, createProtectedRoute('agents:execute'), { prefix: '' });
+    const response = await adapter.app.request('http://localhost/api/test/agents-execute', {
+      headers: { Authorization: 'Bearer viewer' },
+    });
+    expect(response.status).toBe(403);
+  });
+});

--- a/server-adapters/tanstack-start/src/__tests__/server-app-access.test.ts
+++ b/server-adapters/tanstack-start/src/__tests__/server-app-access.test.ts
@@ -1,0 +1,32 @@
+import { Mastra } from '@mastra/core/mastra';
+import { describe, expect, it } from 'vitest';
+import { MastraServer } from '../index';
+
+describe('MastraServer (TanStack Start) - Server App Access', () => {
+  it('returns app passed to constructor', () => {
+    const mastra = new Mastra({ logger: false });
+    const adapter = new MastraServer({ mastra });
+
+    const app = adapter.getApp();
+    expect(app).toBe(adapter.app);
+  });
+
+  it('registers adapter with Mastra instance', () => {
+    const mastra = new Mastra({ logger: false });
+    const adapter = new MastraServer({ mastra });
+
+    expect(mastra.getMastraServer()).toBeDefined();
+    expect(mastra.getServerApp()).toBe(adapter.app);
+  });
+
+  it('supports forwarding requests through createRequestHandler', async () => {
+    const mastra = new Mastra({ logger: false });
+    const adapter = new MastraServer({ mastra });
+
+    await adapter.init();
+    const handler = adapter.createRequestHandler();
+    const response = await handler({ request: new Request('http://localhost/api/agents') });
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/server-adapters/tanstack-start/src/__tests__/tanstack-start-adapter.test.ts
+++ b/server-adapters/tanstack-start/src/__tests__/tanstack-start-adapter.test.ts
@@ -1,0 +1,86 @@
+import type {
+  AdapterTestContext,
+  AdapterSetupOptions,
+  HttpRequest,
+  HttpResponse,
+} from '@internal/server-adapter-test-utils';
+import { createRouteAdapterTestSuite, createDefaultTestContext } from '@internal/server-adapter-test-utils';
+import { describe, expect, it } from 'vitest';
+import { MastraServer } from '../index';
+
+describe('TanStack Start Server Adapter', () => {
+  createRouteAdapterTestSuite({
+    suiteName: 'TanStack Start Adapter Integration Tests',
+
+    setupAdapter: async (context: AdapterTestContext, options?: AdapterSetupOptions) => {
+      const adapter = new MastraServer({
+        mastra: context.mastra,
+        tools: context.tools,
+        taskStore: context.taskStore,
+        customRouteAuthConfig: context.customRouteAuthConfig,
+        prefix: options?.prefix,
+      });
+
+      await adapter.init();
+      return { adapter, app: adapter.app };
+    },
+
+    executeHttpRequest: async (app, httpRequest: HttpRequest): Promise<HttpResponse> => {
+      let url = `http://localhost${httpRequest.path}`;
+      if (httpRequest.query) {
+        const queryParams = new URLSearchParams();
+        Object.entries(httpRequest.query).forEach(([key, value]) => {
+          if (Array.isArray(value)) value.forEach(v => queryParams.append(key, String(v)));
+          else queryParams.append(key, String(value));
+        });
+        const queryString = queryParams.toString();
+        if (queryString) url += `?${queryString}`;
+      }
+
+      const response = await app.request(
+        new Request(url, {
+          method: httpRequest.method,
+          headers: { 'Content-Type': 'application/json', ...(httpRequest.headers || {}) },
+          body: httpRequest.body ? JSON.stringify(httpRequest.body) : undefined,
+        }),
+      );
+
+      const headers = Object.fromEntries(response.headers.entries());
+      const contentType = response.headers.get('content-type') || '';
+      const isStream =
+        contentType.includes('text/plain') ||
+        contentType.includes('text/event-stream') ||
+        response.headers.get('transfer-encoding') === 'chunked';
+
+      if (isStream) {
+        return { status: response.status, type: 'stream', stream: response.body, headers };
+      }
+      let data: unknown;
+      try {
+        data = await response.json();
+      } catch {
+        data = await response.text();
+      }
+      return { status: response.status, type: 'json', data, headers };
+    },
+  });
+
+  it('creates full handlers map for TanStack Start route files', async () => {
+    const context = await createDefaultTestContext();
+    const adapter = new MastraServer({ mastra: context.mastra });
+    await adapter.init();
+
+    const handlers = adapter.createRouteHandlers();
+    expect(Object.keys(handlers).sort()).toEqual(['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT']);
+  });
+
+  it('forwards request via createRequestHandler', async () => {
+    const context = await createDefaultTestContext();
+    const adapter = new MastraServer({ mastra: context.mastra });
+    await adapter.init();
+
+    const serve = adapter.createRequestHandler();
+    const response = await serve({ request: new Request('http://localhost/api/agents', { method: 'GET' }) });
+    expect(response.status).toBe(200);
+  });
+});

--- a/server-adapters/tanstack-start/src/index.ts
+++ b/server-adapters/tanstack-start/src/index.ts
@@ -1,0 +1,121 @@
+import type { ToolsInput } from '@mastra/core/agent';
+import type { Mastra } from '@mastra/core/mastra';
+import { MastraServer as HonoMastraServer } from '@mastra/hono';
+import type { HonoApp } from '@mastra/hono';
+import type { InMemoryTaskStore } from '@mastra/server/a2a/store';
+import type { BodyLimitOptions, MCPOptions, StreamOptions } from '@mastra/server/server-adapter';
+import { Hono } from 'hono';
+export { createAuthMiddleware } from '@mastra/hono';
+export type { HonoAuthMiddlewareOptions } from '@mastra/hono';
+
+export type TanstackStartMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD';
+
+export type TanstackStartHandler = (args: { request: Request }) => Response | Promise<Response>;
+
+export type TanstackStartHandlers = Record<TanstackStartMethod, TanstackStartHandler>;
+
+const DEFAULT_TANSTACK_START_METHODS: readonly TanstackStartMethod[] = [
+  'GET',
+  'POST',
+  'PUT',
+  'DELETE',
+  'PATCH',
+  'OPTIONS',
+  'HEAD',
+];
+
+/**
+ * Minimal app interface required to serve Mastra through TanStack Start server route handlers.
+ */
+export interface TanstackStartApp extends HonoApp {
+  fetch(request: Request): Response | Promise<Response>;
+}
+
+export interface MastraTanstackStartServerOptions {
+  /**
+   * Optional preconfigured Hono-compatible app.
+   * If omitted, a new Hono app is created.
+   */
+  app?: TanstackStartApp;
+  mastra: Mastra;
+  bodyLimitOptions?: BodyLimitOptions;
+  tools?: ToolsInput;
+  prefix?: string;
+  openapiPath?: string;
+  taskStore?: InMemoryTaskStore;
+  customRouteAuthConfig?: Map<string, boolean>;
+  streamOptions?: StreamOptions;
+  mcpOptions?: MCPOptions;
+}
+
+/**
+ * TanStack Start server adapter that wires Mastra routes into a Hono app and
+ * exposes request handlers compatible with `createFileRoute(...).server.handlers`.
+ */
+export class MastraServer {
+  readonly app: TanstackStartApp;
+  private readonly honoServer: HonoMastraServer;
+
+  constructor({ app, ...options }: MastraTanstackStartServerOptions) {
+    const resolvedApp = (app ?? new Hono()) as TanstackStartApp;
+    this.app = resolvedApp;
+    this.honoServer = new HonoMastraServer({
+      ...options,
+      app: resolvedApp,
+    });
+  }
+
+  async init(): Promise<void> {
+    await this.honoServer.init();
+  }
+
+  get mastra() {
+    return (this.honoServer as any).mastra;
+  }
+
+  get logger() {
+    return (this.honoServer as any).logger;
+  }
+
+  getApp<TApp = TanstackStartApp>(): TApp {
+    return this.honoServer.getApp<TApp>();
+  }
+
+  createContextMiddleware() {
+    return this.honoServer.createContextMiddleware();
+  }
+
+  registerContextMiddleware(): void {
+    this.honoServer.registerContextMiddleware();
+  }
+
+  registerAuthMiddleware(): void {
+    this.honoServer.registerAuthMiddleware();
+  }
+
+  registerHttpLoggingMiddleware(): void {
+    this.honoServer.registerHttpLoggingMiddleware();
+  }
+
+  async registerRoute(
+    ...args: Parameters<HonoMastraServer['registerRoute']>
+  ): ReturnType<HonoMastraServer['registerRoute']> {
+    return this.honoServer.registerRoute(...args);
+  }
+
+  /**
+   * Creates a single request handler function for TanStack Start server routes.
+   */
+  createRequestHandler(): TanstackStartHandler {
+    return ({ request }) => this.app.fetch(request);
+  }
+
+  /**
+   * Creates an HTTP method map that can be directly assigned to
+   * `createFileRoute(...).server.handlers`.
+   */
+  createRouteHandlers(methods: readonly TanstackStartMethod[] = DEFAULT_TANSTACK_START_METHODS): TanstackStartHandlers {
+    const handler = this.createRequestHandler();
+    return Object.fromEntries(methods.map(method => [method, handler])) as TanstackStartHandlers;
+  }
+}

--- a/server-adapters/tanstack-start/tsconfig.build.json
+++ b/server-adapters/tanstack-start/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+}

--- a/server-adapters/tanstack-start/tsconfig.json
+++ b/server-adapters/tanstack-start/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/server-adapters/tanstack-start/tsup.config.ts
+++ b/server-adapters/tanstack-start/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/server-adapters/tanstack-start/vitest.config.ts
+++ b/server-adapters/tanstack-start/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:server-adapters/tanstack-start',
+    isolate: false,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Description

First pass at supporting tanstack-start with a server adapter.

## Related Issue(s)

https://github.com/mastra-ai/mastra/issues/15580

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a new adapter that lets TanStack Start (a web routing framework) work with Mastra (an AI agent framework). It's like a translator between the two frameworks, so when a TanStack Start app receives a request, it can pass it to Mastra to handle AI-related tasks.

## Overview

This PR introduces a complete TanStack Start server adapter package (`@mastra/tanstack-start`) that enables seamless integration between TanStack Start applications and the Mastra AI framework. The adapter wraps the existing Hono adapter and provides TanStack Start-compatible request handlers for server-side routing.

## Key Changes

### Core Implementation
- **`src/index.ts`**: Main adapter module that exports:
  - `MastraServer` class: wraps the underlying Hono-based server and provides lifecycle methods (`init()`, `getApp()`)
  - Helper methods for creating request handlers (`createRequestHandler()`) and route handlers (`createRouteHandlers()`) compatible with TanStack Start
  - TypeScript types for TanStack Start HTTP methods and handler signatures
  - Re-exports authentication middleware from `@mastra/hono`

### Configuration & Build Setup
- **`package.json`**: Package manifest with ESM/CJS dual export support, dependencies on `@mastra/hono` and `@mastra/server`, and build scripts
- **Build configuration**: `tsup.config.ts`, `tsconfig.json`, `tsconfig.build.json` for TypeScript compilation
- **Linting/formatting**: `eslint.config.js`, `lint-staged.config.js` for code quality
- **Testing**: `vitest.config.ts` for test runner configuration

### Testing Coverage
Comprehensive test suite covering:
- **Route integration** (`tanstack-start-adapter.test.ts`): validates route creation and HTTP method handling
- **Auth middleware** (`auth-middleware.test.ts`): tests authentication with token validation and RBAC
- **RBAC permissions** (`rbac-permissions.test.ts`): permission enforcement and role-based access control
- **HTTP logging** (`http-logging.test.ts`): request/response logging functionality
- **MCP integration** (`mcp-routes.test.ts`, `mcp-transport.test.ts`): Model Context Protocol registry and transport routes
- **Server resilience** (`malformed-json.test.ts`): graceful handling of malformed JSON requests
- **Server access** (`server-app-access.test.ts`): app exposure and adapter registration

### Documentation
- **`README.md`**: Complete guide including installation, basic usage, route configuration examples, and tested capabilities
- **`CHANGELOG.md`**: Version 1.0.0-alpha.0 release notes
- **`.changeset/`**: Changesets entry documenting the minor version bump

## Implementation Details

The `MastraServer` class serves as the primary integration point, providing:
- Middleware registration for context, authentication, and HTTP logging
- Request handler creation for TanStack Start catch-all routes
- Route handler maps supporting GET, POST, PUT, DELETE, PATCH, OPTIONS, and HEAD methods
- Full integration with Mastra's authentication, RBAC, and MCP capabilities

The adapter is designed to work with TanStack Start's file-based routing system via `createFileRoute()` and route handlers, enabling straightforward integration of AI agent functionality into TanStack Start applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->