### PR TITLE
fix(otel-bridge): return undefined for invalid span contexts

### DIFF
--- a/.changeset/good-sides-doubt.md
+++ b/.changeset/good-sides-doubt.md
@@ -1,0 +1,17 @@
+---
+'@mastra/otel-bridge': patch
+---
+
+Fixed OtelBridge returning invalid all-zero span and trace IDs when no OpenTelemetry SDK is registered.
+
+**What was broken**
+
+`@mastra/otel-bridge` declares `@opentelemetry/sdk-node` as an optional peer dependency, so it is expected to work without an SDK wired up. In that case the OTEL API hands back a no-op tracer whose span contexts carry all-zero IDs. The bridge was forwarding those IDs to Mastra's core spans instead of falling through to the default ID generator.
+
+The result: every span collapsed onto the same `spanId="0000000000000000"`, downstream exporters like Braintrust silently dropped traces, and `TrackingExporter`'s parent-matching queue kept rescheduling via `setImmediate` looking for a parent that could never resolve — pegging CPU at 100%.
+
+**The fix**
+
+The bridge now checks `isSpanContextValid` on the OTEL span context and returns `undefined` when it is the no-op all-zero context, letting `DefaultSpan` generate its own valid IDs. The same guard is applied when resolving parent span IDs.
+
+Fixes #15589.

--- a/.changeset/good-sides-doubt.md
+++ b/.changeset/good-sides-doubt.md
@@ -2,16 +2,4 @@
 '@mastra/otel-bridge': patch
 ---
 
-Fixed OtelBridge returning invalid all-zero span and trace IDs when no OpenTelemetry SDK is registered.
-
-**What was broken**
-
-`@mastra/otel-bridge` declares `@opentelemetry/sdk-node` as an optional peer dependency, so it is expected to work without an SDK wired up. In that case the OTEL API hands back a no-op tracer whose span contexts carry all-zero IDs. The bridge was forwarding those IDs to Mastra's core spans instead of falling through to the default ID generator.
-
-The result: every span collapsed onto the same `spanId="0000000000000000"`, downstream exporters like Braintrust silently dropped traces, and `TrackingExporter`'s parent-matching queue kept rescheduling via `setImmediate` looking for a parent that could never resolve — pegging CPU at 100%.
-
-**The fix**
-
-The bridge now checks `isSpanContextValid` on the OTEL span context and returns `undefined` when it is the no-op all-zero context, letting `DefaultSpan` generate its own valid IDs. The same guard is applied when resolving parent span IDs.
-
-Fixes #15589.
+Return `undefined` from `OtelBridge.createSpan` when no OpenTelemetry SDK is registered, so core generates valid span/trace IDs instead of reusing the OTEL no-op all-zero IDs. This prevents downstream trace exporters from dropping spans and stops the infinite-loop CPU spike in parent-matching. Fixes #15589.

--- a/observability/otel-bridge/src/bridge.test.ts
+++ b/observability/otel-bridge/src/bridge.test.ts
@@ -138,10 +138,11 @@ describe('OtelBridge', () => {
         bridge.shutdown();
       });
 
-      it('should produce unique IDs across multiple createSpan calls', () => {
-        // With the bug, every span shares spanId "0000000000000000" and
-        // traceId "00...00", which is what causes TrackingExporter to
-        // infinite-loop trying to match children to parents.
+      it('should consistently return undefined across multiple createSpan calls', () => {
+        // With the bug, every span shared spanId "0000000000000000" and
+        // traceId "00...00", which is what caused TrackingExporter to
+        // infinite-loop trying to match children to parents. The fix makes
+        // every call return undefined so core generates unique IDs itself.
         const bridge = new OtelBridge();
 
         const options: CreateSpanOptions<SpanType.AGENT_RUN> = {
@@ -153,10 +154,8 @@ describe('OtelBridge', () => {
         const a = bridge.createSpan(options);
         const b = bridge.createSpan(options);
 
-        // If the bridge returns IDs at all, they must be unique per span.
-        if (a && b) {
-          expect(a.spanId).not.toBe(b.spanId);
-        }
+        expect(a).toBeUndefined();
+        expect(b).toBeUndefined();
 
         bridge.shutdown();
       });

--- a/observability/otel-bridge/src/bridge.test.ts
+++ b/observability/otel-bridge/src/bridge.test.ts
@@ -9,10 +9,32 @@
 
 import type { CreateSpanOptions } from '@mastra/core/observability';
 import { SpanType } from '@mastra/core/observability';
-import { describe, expect, it } from 'vitest';
+import { isSpanContextValid, trace } from '@opentelemetry/api';
+import { tracing } from '@opentelemetry/sdk-node';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { OtelBridge } from './bridge.js';
 
+// OTEL invalid (no-op) IDs, returned when no SDK / tracer provider is registered
+const INVALID_SPAN_ID = '0000000000000000';
+const INVALID_TRACE_ID = '00000000000000000000000000000000';
+
 describe('OtelBridge', () => {
+  // Register a real (in-memory) tracer provider for tests that need the bridge
+  // to produce valid span contexts. Without this, the OTEL API falls back to a
+  // no-op tracer whose spans carry all-zero IDs (see issue #15589 regression
+  // tests below).
+  let tracerProvider: tracing.BasicTracerProvider;
+
+  beforeAll(() => {
+    tracerProvider = new tracing.BasicTracerProvider();
+    trace.setGlobalTracerProvider(tracerProvider);
+  });
+
+  afterAll(async () => {
+    await tracerProvider.shutdown();
+    trace.disable();
+  });
+
   describe('createSpan', () => {
     it('should return spanIds with valid format when creating root span', () => {
       const bridge = new OtelBridge();
@@ -31,6 +53,10 @@ describe('OtelBridge', () => {
       // OTEL span IDs are 16 hex chars, trace IDs are 32 hex chars
       expect(result?.spanId).toMatch(/^[0-9a-f]{16}$/);
       expect(result?.traceId).toMatch(/^[0-9a-f]{32}$/);
+      // The all-zero IDs also match the hex regex above, so assert explicitly
+      // that we got a valid (non-no-op) span context.
+      expect(result?.spanId).not.toBe(INVALID_SPAN_ID);
+      expect(result?.traceId).not.toBe(INVALID_TRACE_ID);
 
       bridge.shutdown();
     });
@@ -44,6 +70,96 @@ describe('OtelBridge', () => {
       expect(result).toBeUndefined();
 
       bridge.shutdown();
+    });
+
+    // Regression tests for https://github.com/mastra-ai/mastra/issues/15589
+    //
+    // When no OTEL SDK / tracer provider is registered, `trace.getTracer(...)`
+    // returns a no-op tracer whose spans have INVALID_SPAN_ID / INVALID_TRACE_ID.
+    // The bridge must NOT hand those zero IDs back to core — doing so causes all
+    // spans to collapse onto the same ID, which breaks TrackingExporter's
+    // parent-matching queue and pegs CPU at ~100% via setImmediate reschedules.
+    describe('when no OTEL SDK is registered', () => {
+      // Tear down the suite-level provider so the OTEL API falls back to its
+      // no-op tracer, exactly reproducing a user who forgot to wire up sdk-node.
+      beforeAll(() => {
+        trace.disable();
+      });
+
+      afterAll(() => {
+        trace.setGlobalTracerProvider(tracerProvider);
+      });
+
+      it('should return undefined (not zero IDs) so core can generate valid IDs', () => {
+        // In this test environment, no SDK / tracer provider is registered,
+        // so the OTEL API is in its no-op state. This mirrors a real user
+        // who configures OtelBridge without also wiring up @opentelemetry/sdk-node.
+        const bridge = new OtelBridge();
+
+        const options: CreateSpanOptions<SpanType.AGENT_RUN> = {
+          type: SpanType.AGENT_RUN,
+          name: 'test-agent',
+          attributes: { agentId: 'test' },
+        };
+
+        const result = bridge.createSpan(options);
+
+        // Expected: bridge detects invalid span context and returns undefined,
+        // letting DefaultSpan fall through to its own ID generator.
+        expect(result).toBeUndefined();
+
+        bridge.shutdown();
+      });
+
+      it('should not return the invalid (all-zero) OTEL span/trace IDs', () => {
+        const bridge = new OtelBridge();
+
+        const options: CreateSpanOptions<SpanType.AGENT_RUN> = {
+          type: SpanType.AGENT_RUN,
+          name: 'test-agent',
+          attributes: { agentId: 'test' },
+        };
+
+        const result = bridge.createSpan(options);
+
+        // If the bridge does return something, it must be a valid span context.
+        if (result) {
+          expect(result.spanId).not.toBe(INVALID_SPAN_ID);
+          expect(result.traceId).not.toBe(INVALID_TRACE_ID);
+          expect(
+            isSpanContextValid({
+              spanId: result.spanId,
+              traceId: result.traceId,
+              traceFlags: 0,
+            }),
+          ).toBe(true);
+        }
+
+        bridge.shutdown();
+      });
+
+      it('should produce unique IDs across multiple createSpan calls', () => {
+        // With the bug, every span shares spanId "0000000000000000" and
+        // traceId "00...00", which is what causes TrackingExporter to
+        // infinite-loop trying to match children to parents.
+        const bridge = new OtelBridge();
+
+        const options: CreateSpanOptions<SpanType.AGENT_RUN> = {
+          type: SpanType.AGENT_RUN,
+          name: 'test-agent',
+          attributes: { agentId: 'test' },
+        };
+
+        const a = bridge.createSpan(options);
+        const b = bridge.createSpan(options);
+
+        // If the bridge returns IDs at all, they must be unique per span.
+        if (a && b) {
+          expect(a.spanId).not.toBe(b.spanId);
+        }
+
+        bridge.shutdown();
+      });
     });
   });
 

--- a/observability/otel-bridge/src/bridge.ts
+++ b/observability/otel-bridge/src/bridge.ts
@@ -23,7 +23,7 @@ import type {
 import { TracingEventType } from '@mastra/core/observability';
 import { BaseExporter, getExternalParentId } from '@mastra/observability';
 import { SpanConverter, getSpanKind } from '@mastra/otel-exporter';
-import { trace as otelTrace, context as otelContext } from '@opentelemetry/api';
+import { trace as otelTrace, context as otelContext, isSpanContextValid } from '@opentelemetry/api';
 import type { Span as OtelSpan, Context as OtelContext } from '@opentelemetry/api';
 
 /**
@@ -129,6 +129,15 @@ export class OtelBridge extends BaseExporter implements ObservabilityBridge {
 
       // Get OTEL span identifiers
       const otelSpanContext = otelSpan.spanContext();
+
+      // If no OTEL SDK is registered, the global tracer returns a non-recording
+      // span with an invalid span context (all-zero span/trace IDs). Returning
+      // those IDs would collide across every Mastra span and break downstream
+      // exporters. Bail out so DefaultSpan falls through to its own ID generator.
+      if (!isSpanContextValid(otelSpanContext)) {
+        return undefined;
+      }
+
       const spanId = otelSpanContext.spanId;
       const traceId = otelSpanContext.traceId;
 
@@ -137,7 +146,9 @@ export class OtelBridge extends BaseExporter implements ObservabilityBridge {
 
       // Get parentSpanId from parent context if available
       const parentSpan = otelTrace.getSpan(parentOtelContext);
-      const parentSpanId = parentSpan?.spanContext().spanId;
+      const parentSpanContext = parentSpan?.spanContext();
+      const parentSpanId =
+        parentSpanContext && isSpanContextValid(parentSpanContext) ? parentSpanContext.spanId : undefined;
 
       this.logger.debug(
         `[OtelBridge.createSpan] Created span [spanId=${spanId}] [traceId=${traceId}] ` +

--- a/observability/otel-bridge/src/bridge.ts
+++ b/observability/otel-bridge/src/bridge.ts
@@ -135,6 +135,9 @@ export class OtelBridge extends BaseExporter implements ObservabilityBridge {
       // those IDs would collide across every Mastra span and break downstream
       // exporters. Bail out so DefaultSpan falls through to its own ID generator.
       if (!isSpanContextValid(otelSpanContext)) {
+        // End the span we just started so its lifecycle stays clean on
+        // providers that do track non-recording spans.
+        otelSpan.end();
         return undefined;
       }
 


### PR DESCRIPTION
Fixes #15589.

`@mastra/otel-bridge` lists `@opentelemetry/sdk-node` as an optional peer dependency, so it should work when the user hasn't wired up an OTEL SDK. It didn't. When no SDK is registered, `trace.getTracer()` returns a no-op tracer whose spans have all-zero IDs, and the bridge was handing those IDs straight back to core. Every Mastra span collided on `spanId=0`, downstream exporters like Braintrust dropped traces, and TrackingExporter's parent-matching queue spun at 100% CPU via `setImmediate` reschedules.

The fix adds an `isSpanContextValid` check so the bridge bails out in that case and lets `DefaultSpan` generate its own valid IDs.

Before:
```ts
const otelSpanContext = otelSpan.spanContext();
const spanId = otelSpanContext.spanId;   // "0000000000000000" with no SDK
const traceId = otelSpanContext.traceId; // "00000000000000000000000000000000"
return { spanId, traceId, parentSpanId };
```

After:
```ts
const otelSpanContext = otelSpan.spanContext();
if (!isSpanContextValid(otelSpanContext)) {
  return undefined; // DefaultSpan will generate valid IDs
}
const spanId = otelSpanContext.spanId;
const traceId = otelSpanContext.traceId;
return { spanId, traceId, parentSpanId };
```

Added three regression tests for the no-SDK path and wired the existing suite to register a real `BasicTracerProvider` (instead of silently relying on the broken no-op IDs). 14/14 tests pass, tsc/lint/build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When OpenTelemetry isn't set up, it handed out fake all-zero IDs that made every trace look identical. This change detects those invalid OTEL span contexts, stops using them, and lets Mastra generate real unique IDs.

## Overview

Fixes a bug in @mastra/otel-bridge where the OTEL no-op tracer (used when no SDK/tracer provider is registered) produced invalid all-zero span/trace IDs that were propagated into Mastra. That caused downstream exporters to drop spans and made TrackingExporter repeatedly re-queue parent-resolution work, pegging CPU.

## Solution

- OtelBridge.createSpan validates OTEL span contexts using isSpanContextValid(otelSpan.spanContext()).
  - If the OTEL span context is invalid (all-zero/non-recording), the bridge ends the OTEL span and returns undefined so Mastra's DefaultSpan generates its own valid IDs.
  - Parent span resolution only uses parentSpanContext.spanId when the parent context exists and is valid; otherwise parentSpanId is undefined.

## Changes

- observability/otel-bridge/src/bridge.ts
  - Import and use isSpanContextValid.
  - After starting an OTEL span, validate its spanContext; end and return undefined on invalid contexts.
  - Guard parentSpanId derivation with isSpanContextValid.
  - Store OTEL spans in otelSpanMap only for valid contexts.

- observability/otel-bridge/src/bridge.test.ts
  - Register a BasicTracerProvider for tests that require a real SDK; tear it down for no-SDK regression tests.
  - Add regression tests for the "no OTEL SDK registered" path asserting createSpan returns undefined (and, if a value is returned, that it is valid and non-zero).
  - Add assertions ensuring returned IDs match OTEL hex formats and are not the all-zero IDs.

- .changeset
  - Added patch documenting the behavioral fix.

## Testing

- Added regression tests covering the no-SDK path; test suite is wired to register a BasicTracerProvider for other tests.
- Local results: 14/14 tests pass; tsc, lint, and build are clean.

## Notes

- Prevents duplicate zero IDs from reaching exporters (e.g., BraintrustExporter, TrackingExporter), eliminating parent-resolution failures and CPU spin from repeated setImmediate rescheduling.
- Consider optionally surfacing an init-time warning when no tracer provider is registered (not implemented here).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->