### PR TITLE
test(memory): fix other-conversation test to match getOtherThreadsContext filtering

### DIFF
--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -6144,7 +6144,7 @@ describe('Reflection with Thread Attribution', () => {
 // =============================================================================
 
 describe('Resource Scope: other-conversation blocks after observation', () => {
-  it('should include other thread messages in context even after those threads have been observed', async () => {
+  it('includes only unobserved sibling-thread messages as other-conversation blocks', async () => {
     const { MessageList } = await import('@mastra/core/agent');
     const { RequestContext } = await import('@mastra/core/di');
 
@@ -6153,7 +6153,7 @@ describe('Resource Scope: other-conversation blocks after observation', () => {
     const threadAId = 'thread-A';
     const threadBId = 'thread-B';
 
-    // Thread A's messages were created at 09:01-09:02, observed at 09:02
+    // Thread A's early messages were observed at 09:02; later messages were added post-observation.
     const threadAObservedAt = new Date('2025-01-01T09:02:00Z');
 
     // Create Thread A with per-thread lastObservedAt in metadata (simulating completed observation)
@@ -6165,7 +6165,7 @@ describe('Resource Scope: other-conversation blocks after observation', () => {
         createdAt: new Date('2025-01-01T09:00:00Z'),
         updatedAt: new Date('2025-01-01T09:00:00Z'),
         metadata: {
-          __om: { lastObservedAt: threadAObservedAt.toISOString() },
+          mastra: { om: { lastObservedAt: threadAObservedAt.toISOString() } },
         },
       },
     });
@@ -6182,7 +6182,7 @@ describe('Resource Scope: other-conversation blocks after observation', () => {
       },
     });
 
-    // Add messages to Thread A (already observed)
+    // Add messages to Thread A: two already-observed + one added after observation.
     await storage.saveMessages({
       messages: [
         {
@@ -6200,6 +6200,18 @@ describe('Resource Scope: other-conversation blocks after observation', () => {
           content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'Blue is a great color!' }] },
           type: 'text',
           createdAt: new Date('2025-01-01T09:02:00Z'),
+          threadId: threadAId,
+          resourceId,
+        },
+        {
+          id: 'msg-a-3',
+          role: 'user' as const,
+          content: {
+            format: 2 as const,
+            parts: [{ type: 'text' as const, text: 'Actually I also like green' }],
+          },
+          type: 'text',
+          createdAt: new Date('2025-01-01T09:45:00Z'),
           threadId: threadAId,
           resourceId,
         },
@@ -6309,12 +6321,14 @@ describe('Resource Scope: other-conversation blocks after observation', () => {
       `<thread id="thread-A">\n- 🔴 User is debugging observational memory prompt ordering\n</thread>`,
     );
 
-    // KEY ASSERTION: Thread A's messages should appear as <other-conversation> blocks
-    // even though Thread A was already observed (its messages are older than resource-level lastObservedAt).
-    // The agent on Thread B needs to see Thread A's raw conversation to have full context.
+    // KEY ASSERTION: Thread A's already-observed messages (≤ lastObservedAt) should NOT
+    // re-appear as raw <other-conversation> blocks — they are already represented in the
+    // <observations> block. Only Thread A messages created AFTER lastObservedAt should
+    // surface as unobserved other-conversation context.
     expect(omContent).toContain('other-conversation');
-    expect(omContent).toContain('My favorite color is blue');
-    expect(omContent).toContain('Blue is a great color!');
+    expect(omContent).toContain('Actually I also like green');
+    expect(omContent).not.toContain('My favorite color is blue');
+    expect(omContent).not.toContain('Blue is a great color!');
 
     // Thread B's messages should NOT be in <other-conversation> blocks (it's the active thread)
     expect(omContent).not.toContain('Hello from thread B!');


### PR DESCRIPTION
## Summary

Fixes a failing unit test in `packages/memory` exposed by #15269.

The test `Resource Scope: other-conversation blocks after observation` was asserting pre-#15269 behavior where `getOtherThreadsContext()` re-loaded already-observed sibling messages into the active thread's context with no date filter. It only passed because the test set thread metadata under the key `__om` instead of the correct `mastra.om`, which caused `getThreadOMMetadata()` to return `undefined` and skip date filtering entirely.

After #15269 added the record-level `lastObservedAt` fallback, sibling-thread messages at or before `lastObservedAt` are correctly filtered out — matching the intent described in the linked issue #15265 ("apply date filtering for ALL threads") and the complementary fallback test in `observational-memory-api.test.ts`.

## Changes

- Use the correct metadata shape (`metadata.mastra.om.lastObservedAt`)
- Add a post-observation Thread A message to the test fixture
- Assert already-observed Thread A messages do **not** re-appear as raw `<other-conversation>` blocks (they live in the `<observations>` block)
- Assert the one newer Thread A message (after `lastObservedAt`) **does** appear as an `<other-conversation>` block

## Test plan

- `pnpm --filter ./packages/memory exec vitest run src/processors/observational-memory/__tests__/observational-memory.test.ts -t "other-conversation blocks after observation"` — passes
- `pnpm --filter ./packages/memory exec vitest run src/processors/observational-memory` — 790 pass, 0 fail
- `pnpm --filter ./packages/memory check` — clean

No production code changes; test-only fix, so no changeset required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR fixes a test that checks whether a system correctly filters out old messages from other conversations. The test was using the wrong instructions to check when messages were last seen, so it wasn't actually testing what it should. The fix corrects those instructions and adds a new message to verify that only recently-created messages from other conversations show up (while old ones that were already seen don't reappear).

## Details

### Summary of Changes

Updated the "Resource Scope: other-conversation blocks after observation" test in the memory package to correctly validate filtering behavior:

- **Corrected metadata structure**: Changed from incorrect shape `__om: { lastObservedAt: ... }` to the correct `metadata.mastra.om.lastObservedAt`
- **Enhanced fixture data**: Added a new message (`msg-a-3`) in Thread A with a `createdAt` timestamp after the observation boundary
- **Refined test assertions**: 
  - Verified that the post-observation Thread A message appears in `<other-conversation>` blocks
  - Verified that pre-observation Thread A messages are filtered out and do not reappear (they're already represented in `<observations>`)

### Context

This test fix addresses a regression introduced by PR #15269, which added record-level `lastObservedAt` fallback filtering. With the correct metadata structure now in place, the test properly validates that sibling-thread messages at or before the `lastObservedAt` cursor are correctly excluded from `<other-conversation>` blocks, while newer messages are included.

### Scope

Test-only changes; no modifications to exported or public APIs. The fix ensures the test accurately validates the intended filtering behavior without changing any production code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->