### PR TITLE
fix(cli): deploy to existing Observe project instead of always creating new

### DIFF
--- a/.changeset/pltfrm-866-deploy-to-existing-project.md
+++ b/.changeset/pltfrm-866-deploy-to-existing-project.md
@@ -1,0 +1,14 @@
+---
+'mastra': patch
+---
+
+`mastra studio deploy` and `mastra server deploy` now prompt you to pick from existing projects in the selected organization instead of silently matching by `package.json` name or always creating a new project.
+
+**What changed**
+
+- When existing projects are found, both commands show an interactive selector listing them (plus a "Create new project" option).
+- `--project <id-or-slug>` still bypasses the selector for non-interactive use.
+- `-y/--yes` auto-accepts only when there is exactly one project whose name or slug matches the local `package.json` name; otherwise it errors asking you to pass `--project`.
+- Projects saved in `.mastra-project.json` for the same organization are still auto-matched (no prompt).
+
+This fixes deploys accidentally creating duplicate projects or targeting the wrong existing project when the local package name happened to collide.

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -164,6 +164,86 @@ describe('serverDeployAction', () => {
     await expect(serverDeployAction(undefined, {})).resolves.toBeUndefined();
   });
 
+  it('prompts the user with a selector when existing projects are found', async () => {
+    vi.resetModules();
+
+    const { loadProjectConfig } = await import('../studio/project-config.js');
+    vi.mocked(loadProjectConfig).mockResolvedValue(null);
+
+    const platform = await import('./platform-api.js');
+    vi.mocked(platform.fetchServerProjects).mockResolvedValue([
+      { id: 'proj-a', name: 'Daniel', slug: 'daniel', organizationId: 'org-1' } as never,
+      { id: 'proj-b', name: 'Other', slug: 'other', organizationId: 'org-1' } as never,
+    ]);
+
+    const prompts = await import('@clack/prompts');
+    vi.mocked(prompts.select).mockResolvedValueOnce('proj-a' as never);
+    vi.mocked(prompts.confirm).mockResolvedValueOnce(false as never);
+
+    const { serverDeployAction } = await import('./deploy.js');
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('__exit__');
+    });
+
+    await expect(serverDeployAction(undefined, {})).rejects.toThrow();
+
+    expect(prompts.select).toHaveBeenCalledTimes(1);
+    const selectArgs = vi.mocked(prompts.select).mock.calls[0]![0] as {
+      options: Array<{ value: string; label: string }>;
+    };
+    expect(selectArgs.options.map(o => o.value)).toEqual(['proj-a', 'proj-b', '__create_new__']);
+    expect(platform.createServerProject).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+  });
+
+  it('--project <slug> bypasses the selector when it matches an existing project', async () => {
+    vi.resetModules();
+
+    const { loadProjectConfig } = await import('../studio/project-config.js');
+    vi.mocked(loadProjectConfig).mockResolvedValue(null);
+
+    const platform = await import('./platform-api.js');
+    vi.mocked(platform.fetchServerProjects).mockResolvedValue([
+      { id: 'proj-a', name: 'Daniel', slug: 'daniel', organizationId: 'org-1' } as never,
+      { id: 'proj-b', name: 'Other', slug: 'other', organizationId: 'org-1' } as never,
+    ]);
+
+    const prompts = await import('@clack/prompts');
+    vi.mocked(prompts.confirm).mockResolvedValueOnce(false as never);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('__exit__');
+    });
+
+    const { serverDeployAction } = await import('./deploy.js');
+    await expect(serverDeployAction(undefined, { project: 'daniel' })).rejects.toThrow();
+
+    expect(prompts.select).not.toHaveBeenCalled();
+    expect(platform.createServerProject).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+  });
+
+  it('auto-accept with multiple projects and no name match throws a helpful error', async () => {
+    vi.resetModules();
+
+    const { loadProjectConfig } = await import('../studio/project-config.js');
+    vi.mocked(loadProjectConfig).mockResolvedValue(null);
+
+    const platform = await import('./platform-api.js');
+    vi.mocked(platform.fetchServerProjects).mockResolvedValue([
+      { id: 'proj-a', name: 'Daniel', slug: 'daniel', organizationId: 'org-1' } as never,
+      { id: 'proj-b', name: 'Other', slug: 'other', organizationId: 'org-1' } as never,
+    ]);
+
+    const { serverDeployAction } = await import('./deploy.js');
+
+    await expect(serverDeployAction(undefined, { yes: true })).rejects.toThrow(/Pass --project/);
+    expect(platform.createServerProject).not.toHaveBeenCalled();
+  });
+
   it('uses project config in headless mode without fetching orgs', async () => {
     process.env.MASTRA_API_TOKEN = 'headless-token';
     vi.resetModules();

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -156,6 +156,7 @@ async function resolveProject(
   projectConfig: { projectId?: string; projectName?: string; projectSlug?: string; organizationId?: string } | null,
   flagProject?: string,
   defaultName?: string | null,
+  autoAccept?: boolean,
 ): Promise<{ projectId: string; projectName: string; projectSlug: string }> {
   const envProjectId = process.env.MASTRA_PROJECT_ID;
   if (envProjectId) {
@@ -179,16 +180,46 @@ async function resolveProject(
     };
   }
 
-  // Check if a project already exists matching the package name before creating
   const name = defaultName;
   if (!name) {
     throw new Error('Could not determine project name from package.json. Use --project to specify one.');
   }
 
   const existing = await fetchServerProjects(token, orgId);
-  const match = existing.find(proj => proj.name === name || proj.slug === name);
-  if (match) {
-    return { projectId: match.id, projectName: match.name, projectSlug: match.slug ?? match.name };
+  const nameMatches = existing.filter(proj => proj.name === name || proj.slug === name);
+
+  if (existing.length > 0) {
+    if (autoAccept) {
+      // Non-interactive: only safe to auto-pick when exactly one project matches by name/slug.
+      if (nameMatches.length === 1) {
+        const m = nameMatches[0]!;
+        return { projectId: m.id, projectName: m.name, projectSlug: m.slug ?? m.name };
+      }
+      throw new Error(
+        `Found ${existing.length} existing project(s) in this organization. Pass --project <id-or-slug> to select one, or re-run without --yes to choose interactively.`,
+      );
+    }
+
+    const CREATE_NEW = '__create_new__';
+    const initialValue = nameMatches.length === 1 ? nameMatches[0]!.id : existing[0]!.id;
+    const selected = await p.select({
+      message: 'Select a project to deploy to',
+      initialValue,
+      options: [
+        ...existing.map(proj => ({ value: proj.id, label: `${proj.name} (${proj.id})` })),
+        { value: CREATE_NEW, label: `＋ Create new project "${name}"` },
+      ],
+    });
+
+    if (p.isCancel(selected)) {
+      p.cancel('Deploy cancelled.');
+      process.exit(0);
+    }
+
+    if (selected !== CREATE_NEW) {
+      const match = existing.find(proj => proj.id === selected)!;
+      return { projectId: match.id, projectName: match.name, projectSlug: match.slug ?? match.name };
+    }
   }
 
   const project = await createServerProject(token, orgId, name);
@@ -241,6 +272,7 @@ export async function serverDeployAction(
     projectConfig,
     opts.project,
     packageName,
+    autoAccept,
   );
 
   // Step 5: Confirmation

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -64,6 +64,14 @@ describe('getMastraVersion', () => {
 });
 
 // Mock all external dependencies
+vi.mock('node:child_process', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    execSync: vi.fn().mockReturnValue('my-app'),
+  };
+});
+
 vi.mock('@clack/prompts', () => ({
   intro: vi.fn(),
   log: { step: vi.fn(), info: vi.fn(), success: vi.fn(), warn: vi.fn() },
@@ -199,5 +207,114 @@ describe('deployAction', () => {
     await expect(deployAction(undefined, {})).rejects.toThrow(
       'MASTRA_ORG_ID and MASTRA_PROJECT_ID are required when MASTRA_API_TOKEN is set',
     );
+  });
+});
+
+describe('resolveProject (studio)', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+
+    const cp = await import('node:child_process');
+    vi.mocked(cp.execSync).mockReturnValue('my-app');
+
+    const credentials = await import('../auth/credentials.js');
+    vi.mocked(credentials.getToken).mockResolvedValue('test-token');
+    vi.mocked(credentials.getCurrentOrgId).mockResolvedValue('org-1');
+
+    const api = await import('../auth/api.js');
+    vi.mocked(api.fetchOrgs).mockResolvedValue([
+      { id: 'org-1', name: 'Test Org', role: 'admin', isCurrent: true } as unknown as Awaited<
+        ReturnType<typeof api.fetchOrgs>
+      >[number],
+    ]);
+
+    const projectConfig = await import('./project-config.js');
+    vi.mocked(projectConfig.loadProjectConfig).mockResolvedValue(null);
+    vi.mocked(projectConfig.saveProjectConfig).mockResolvedValue(undefined);
+
+    const prompts = await import('@clack/prompts');
+    vi.mocked(prompts.isCancel).mockReturnValue(false);
+    vi.mocked(prompts.confirm).mockResolvedValue(false as never);
+  });
+
+  it('prompts the user with a selector when existing projects are found', async () => {
+    const platform = await import('./platform-api.js');
+    vi.mocked(platform.fetchProjects).mockResolvedValue([
+      { id: 'proj-a', name: 'Daniel', slug: 'daniel' } as never,
+      { id: 'proj-b', name: 'Other', slug: 'other' } as never,
+    ]);
+
+    const prompts = await import('@clack/prompts');
+    // User picks an existing project — then cancels the confirm step so the test stops before build
+    vi.mocked(prompts.select).mockResolvedValueOnce('proj-a' as never);
+    vi.mocked(prompts.confirm).mockResolvedValueOnce(false as never);
+
+    const { deployAction } = await import('./deploy.js');
+    // Confirm=false triggers process.exit(0), so guard it
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('__exit__');
+    });
+
+    await expect(deployAction(undefined, {})).rejects.toThrow();
+
+    expect(prompts.select).toHaveBeenCalledTimes(1);
+    const selectArgs = vi.mocked(prompts.select).mock.calls[0]![0] as {
+      options: Array<{ value: string; label: string }>;
+      initialValue?: string;
+    };
+    expect(selectArgs.options.map(o => o.value)).toEqual(['proj-a', 'proj-b', '__create_new__']);
+
+    exitSpy.mockRestore();
+  });
+
+  it('--project <slug> bypasses the selector when it matches an existing project', async () => {
+    const platform = await import('./platform-api.js');
+    vi.mocked(platform.fetchProjects).mockResolvedValue([
+      { id: 'proj-a', name: 'Daniel', slug: 'daniel' } as never,
+      { id: 'proj-b', name: 'Other', slug: 'other' } as never,
+    ]);
+
+    const prompts = await import('@clack/prompts');
+    vi.mocked(prompts.confirm).mockResolvedValueOnce(false as never);
+
+    const { deployAction } = await import('./deploy.js');
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('__exit__');
+    });
+
+    await expect(deployAction(undefined, { project: 'daniel' })).rejects.toThrow();
+
+    expect(prompts.select).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+  });
+
+  it('auto-accept with multiple projects and no name match throws a helpful error', async () => {
+    const platform = await import('./platform-api.js');
+    vi.mocked(platform.fetchProjects).mockResolvedValue([
+      { id: 'proj-a', name: 'Daniel', slug: 'daniel' } as never,
+      { id: 'proj-b', name: 'Other', slug: 'other' } as never,
+    ]);
+
+    const { deployAction } = await import('./deploy.js');
+
+    await expect(deployAction(undefined, { yes: true })).rejects.toThrow(/Pass --project .* to select one/);
+  });
+
+  it('auto-accept with exactly one name match picks that project without prompting', async () => {
+    const platform = await import('./platform-api.js');
+    vi.mocked(platform.fetchProjects).mockResolvedValue([
+      { id: 'proj-a', name: 'my-app', slug: 'my-app' } as never,
+      { id: 'proj-b', name: 'Other', slug: 'other' } as never,
+    ]);
+
+    const prompts = await import('@clack/prompts');
+
+    const { deployAction } = await import('./deploy.js');
+
+    // Will eventually fail when it reaches build; we just care it doesn't hit the "Pass --project" error
+    await expect(deployAction(undefined, { yes: true })).rejects.not.toThrow(/Pass --project/);
+
+    expect(prompts.select).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -195,6 +195,7 @@ async function resolveProject(
   projectConfig: { projectId?: string; projectName?: string; projectSlug?: string; organizationId?: string } | null,
   flagProject?: string,
   defaultName?: string | null,
+  autoAccept?: boolean,
 ): Promise<ProjectResolution> {
   // 0. MASTRA_PROJECT_ID env var (CI/CD headless path)
   const envProjectId = process.env.MASTRA_PROJECT_ID;
@@ -222,7 +223,52 @@ async function resolveProject(
     };
   }
 
-  // 3. No existing project — return the name so caller can create after confirmation
+  // 3. Consult the list of existing projects in this org before defaulting to create-new.
+  const projects = await fetchProjects(token, orgId);
+  const nameMatches = defaultName
+    ? projects.filter(proj => proj.name === defaultName || proj.slug === defaultName)
+    : [];
+
+  if (projects.length > 0) {
+    if (autoAccept) {
+      // Non-interactive: only safe to auto-pick when there is exactly one
+      // project whose name/slug matches the package.json name.
+      if (nameMatches.length === 1) {
+        const m = nameMatches[0]!;
+        return { existing: true, projectId: m.id, projectName: m.name, projectSlug: m.slug ?? m.name };
+      }
+      throw new Error(
+        `Found ${projects.length} existing project(s) in this organization. Pass --project <id-or-slug> to select one, or re-run without --yes to choose interactively.`,
+      );
+    }
+
+    const CREATE_NEW = '__create_new__';
+    const initialValue = nameMatches.length === 1 ? nameMatches[0]!.id : projects[0]!.id;
+    const selected = await p.select({
+      message: 'Select a project to deploy to',
+      initialValue,
+      options: [
+        ...projects.map(proj => ({
+          value: proj.id,
+          label: `${proj.name} (${proj.id})`,
+        })),
+        { value: CREATE_NEW, label: defaultName ? `＋ Create new project "${defaultName}"` : '＋ Create new project' },
+      ],
+    });
+
+    if (p.isCancel(selected)) {
+      p.cancel('Deploy cancelled.');
+      process.exit(0);
+    }
+
+    if (selected !== CREATE_NEW) {
+      const match = projects.find(proj => proj.id === selected)!;
+      return { existing: true, projectId: match.id, projectName: match.name, projectSlug: match.slug ?? match.name };
+    }
+    // fall through to create-new flow
+  }
+
+  // 4. No existing project (or user chose "Create new") — return the name so caller can create after confirmation.
   const name = defaultName;
   if (!name) {
     throw new Error('Could not determine project name from package.json. Use --project to specify one.');
@@ -263,7 +309,7 @@ export async function deployAction(
   const { orgId, orgName } = await resolveOrg(token, projectConfig, opts.org);
 
   // Step 4: Resolve project (does NOT create yet — waits for confirmation)
-  const resolution = await resolveProject(token, orgId, projectConfig, opts.project, packageName);
+  const resolution = await resolveProject(token, orgId, projectConfig, opts.project, packageName, autoAccept);
 
   let projectId: string;
   let projectName: string;


### PR DESCRIPTION
Closes [PLTFRM-866](https://linear.app/kepler-crm/issue/PLTFRM-866).

## Summary

Both `mastra studio deploy` and `mastra server deploy` now let users pick an existing Observe project instead of always creating a new one.

- `mastra studio deploy` previously always proposed creating a brand new project named after the local `package.json`.
- `mastra server deploy` looked up projects but silently matched by name/slug — which could target the wrong project on collision.

Both commands now, in order:

1. Honor `MASTRA_PROJECT_ID`, `--project <id-or-slug>`, and `.mastra-project.json` same-org auto-match (unchanged).
2. Fall back to a `@clack/prompts` selector listing every project in the org. Initial selection defaults to any project whose name/slug matches the local `package.json`.
3. `-y/--yes` mode auto-selects only when there is exactly one name/slug match; otherwise fails with a clear instruction to pass `--project <id-or-slug>`.

The "create new project" flow now runs only when the user picks "Create new project" in the selector (or when the org has zero projects and `-y` is passed with a valid name).

Headless deploys using `MASTRA_API_TOKEN` still require `MASTRA_ORG_ID + MASTRA_PROJECT_ID` (unchanged).

## Test plan

- \`pnpm --filter ./packages/cli typecheck\` — clean
- \`pnpm test:cli\` — 287/287 including the new selector / \`--project\` / auto-accept tests on both commands
- Manual: deploy an unconfigured project into an existing Observe project with and without \`--project\` and \`-y\`