### PR TITLE
feat(create-mastra): ask about enabling Mastra Observe during project bootstrap

### DIFF
--- a/.changeset/observe-prompt-create-mastra.md
+++ b/.changeset/observe-prompt-create-mastra.md
@@ -1,0 +1,10 @@
+---
+'mastra': minor
+'create-mastra': minor
+---
+
+Add "Enable Mastra Observe?" prompt to `create-mastra` and `mastra init`.
+
+When the user opts in, a `MASTRA_CLOUD_ACCESS_TOKEN` placeholder is appended to `.env` along with instructions for minting a token at [cloud.mastra.ai](https://cloud.mastra.ai). The generated project already registers a `CloudExporter`, so pasting the token is all that is needed to start sending traces to the hosted Mastra Studio.
+
+Both commands also accept `--observe` / `--no-observe` flags for non-interactive use.

--- a/packages/cli/src/commands/actions/create-project.ts
+++ b/packages/cli/src/commands/actions/create-project.ts
@@ -18,6 +18,7 @@ interface CreateProjectArgs {
   mcp?: Editor;
   skills?: string[];
   template?: string | boolean;
+  observe?: boolean;
 }
 
 export const createProject = async (projectNameArg: string | undefined, args: CreateProjectArgs) => {
@@ -38,6 +39,7 @@ export const createProject = async (projectNameArg: string | undefined, args: Cr
           mcpServer: args.mcp,
           skills: args.skills,
           template: args.template,
+          observe: args.observe,
         });
         return;
       }
@@ -52,6 +54,7 @@ export const createProject = async (projectNameArg: string | undefined, args: Cr
         mcpServer: args.mcp,
         skills: args.skills,
         template: args.template,
+        observe: args.observe,
       });
     },
     origin,

--- a/packages/cli/src/commands/actions/init-project.ts
+++ b/packages/cli/src/commands/actions/init-project.ts
@@ -16,6 +16,7 @@ interface InitArgs {
   llmApiKey?: string;
   example?: boolean;
   mcp?: Editor;
+  observe?: boolean;
 }
 
 export const initProject = async (args: InitArgs) => {
@@ -41,6 +42,7 @@ export const initProject = async (args: InitArgs) => {
           skills: result?.skills,
           mcpServer: result?.mcpServer,
           versionTag,
+          observe: result?.observe,
         });
         return;
       }
@@ -53,6 +55,7 @@ export const initProject = async (args: InitArgs) => {
           addExample: args.example === false ? false : true,
           mcpServer: args.mcp,
           versionTag,
+          observe: args.observe,
         });
         return;
       }
@@ -65,6 +68,7 @@ export const initProject = async (args: InitArgs) => {
         llmApiKey: args.llmApiKey,
         mcpServer: args.mcp,
         versionTag,
+        observe: args.observe,
       });
       return;
     },

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -31,6 +31,7 @@ export const create = async (args: {
   skills?: string[];
   template?: string | boolean;
   analytics?: PosthogAnalytics;
+  observe?: boolean;
 }) => {
   if (args.template !== undefined) {
     await createFromTemplate({
@@ -59,6 +60,7 @@ export const create = async (args: {
     llmApiKey: args?.llmApiKey,
     skills: args?.skills,
     mcpServer: args?.mcpServer,
+    observe: args?.observe,
     needsInteractive,
   });
 
@@ -89,6 +91,7 @@ export const create = async (args: {
       skills: result?.skills || args.skills,
       mcpServer: result?.mcpServer || args.mcpServer,
       versionTag: args.createVersionTag,
+      observe: args.observe ?? result?.observe,
     });
     postCreate({ projectName });
     return;
@@ -123,6 +126,7 @@ export const create = async (args: {
     skills: args.skills,
     mcpServer: args.mcpServer,
     versionTag: args.createVersionTag,
+    observe: args.observe,
   });
 
   postCreate({ projectName });

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -164,6 +164,7 @@ export const createMastraProject = async ({
   llmApiKey,
   skills,
   mcpServer,
+  observe,
   needsInteractive,
 }: {
   projectName?: string;
@@ -173,6 +174,7 @@ export const createMastraProject = async ({
   llmApiKey?: string;
   skills?: string[];
   mcpServer?: string;
+  observe?: boolean;
   needsInteractive?: boolean;
 }) => {
   p.intro(color.inverse(' Mastra Create '));
@@ -207,6 +209,7 @@ export const createMastraProject = async ({
         llmApiKey: llmApiKey !== undefined,
         skills: skills !== undefined && skills.length > 0,
         mcpServer: mcpServer !== undefined,
+        observe: observe !== undefined,
         directory: true,
         gitInit: skipGitInit,
       },

--- a/packages/cli/src/commands/init/init.test.ts
+++ b/packages/cli/src/commands/init/init.test.ts
@@ -15,6 +15,7 @@ vi.mock('./utils', () => ({
   createMastraDir: vi.fn(),
   writeCodeSample: vi.fn(),
   checkDependencies: vi.fn(),
+  writeObserveEnv: vi.fn(),
 }));
 
 vi.mock('../../utils/logger', () => ({
@@ -195,6 +196,48 @@ describe('CLI', () => {
 
   //   expect(fs.existsSync('/mock')).toBe(false);
   // });
+
+  test('calls writeObserveEnv when observe is true', async () => {
+    vi.spyOn(utils, 'createMastraDir').mockImplementation(async directory => {
+      const dirPath = `${directory}/mastra`;
+      fs.mkdirSync(dirPath, { recursive: true });
+      return { ok: true, dirPath };
+    });
+
+    const mockWriteObserveEnv = vi.spyOn(utils, 'writeObserveEnv');
+
+    await init({
+      directory: '/mock',
+      components: ['agents'],
+      addExample: false,
+      llmProvider: 'openai',
+      llmApiKey: 'sk-...',
+      observe: true,
+    });
+
+    expect(mockWriteObserveEnv).toHaveBeenCalled();
+  });
+
+  test('does not call writeObserveEnv when observe is false or undefined', async () => {
+    vi.spyOn(utils, 'createMastraDir').mockImplementation(async directory => {
+      const dirPath = `${directory}/mastra`;
+      fs.mkdirSync(dirPath, { recursive: true });
+      return { ok: true, dirPath };
+    });
+
+    const mockWriteObserveEnv = vi.spyOn(utils, 'writeObserveEnv');
+
+    await init({
+      directory: '/mock',
+      components: ['agents'],
+      addExample: false,
+      llmProvider: 'openai',
+      llmApiKey: 'sk-...',
+      observe: false,
+    });
+
+    expect(mockWriteObserveEnv).not.toHaveBeenCalled();
+  });
 
   test('stops initialization if mastra is already setup', async () => {
     fs.mkdirSync('/mock/mastra', { recursive: true });

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -16,6 +16,7 @@ import {
   writeClaudeMarkdown,
   writeCodeSample,
   writeIndexFile,
+  writeObserveEnv,
 } from './utils';
 import type { Component, LLMProvider } from './utils';
 
@@ -31,6 +32,7 @@ export const init = async ({
   mcpServer,
   versionTag,
   initGit = false,
+  observe,
 }: {
   directory?: string;
   components: Component[];
@@ -41,6 +43,7 @@ export const init = async ({
   mcpServer?: Editor;
   versionTag?: string;
   initGit?: boolean;
+  observe?: boolean;
 }) => {
   s.start('Initializing Mastra');
   const packageVersionTag = versionTag ? `@${versionTag}` : '';
@@ -178,6 +181,27 @@ export const init = async ({
         s.stop('Git repository initialized');
       } catch {
         s.stop();
+      }
+    }
+
+    // TODO(PLTFRM-861/862): Once the create-project and mint-token APIs ship,
+    // sign the user in, create a project, and pass the real token here instead
+    // of writing a placeholder.
+    if (observe) {
+      try {
+        await writeObserveEnv();
+        p.note(
+          `${color.green('Mastra Observe enabled.')}
+
+  1. Visit ${color.cyan('https://cloud.mastra.ai')} to create a project and mint an access token.
+  2. Paste the token into ${color.cyan('MASTRA_CLOUD_ACCESS_TOKEN')} in your ${color.cyan('.env')} file.`,
+        );
+      } catch (error) {
+        console.warn(
+          color.yellow(
+            `\nWarning: Failed to write Mastra Observe env entry: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          ),
+        );
       }
     }
 

--- a/packages/cli/src/commands/init/utils.test.ts
+++ b/packages/cli/src/commands/init/utils.test.ts
@@ -1,0 +1,50 @@
+import { fs, vol } from 'memfs';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('node:fs/promises', async () => {
+  const memfs = await import('memfs');
+  return {
+    ...memfs.fs.promises,
+    default: memfs.fs.promises,
+  };
+});
+
+const { writeObserveEnv } = await import('./utils');
+
+describe('writeObserveEnv', () => {
+  const cwd = '/mock-project';
+
+  beforeEach(() => {
+    vol.reset();
+    fs.mkdirSync(cwd, { recursive: true });
+    vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+  });
+
+  test('appends placeholder MASTRA_CLOUD_ACCESS_TOKEN to .env', async () => {
+    fs.writeFileSync(`${cwd}/.env`, 'EXISTING=1\n');
+
+    await writeObserveEnv();
+
+    const contents = fs.readFileSync(`${cwd}/.env`, 'utf-8') as string;
+    expect(contents).toContain('EXISTING=1');
+    expect(contents).toContain('# Mastra Observe');
+    expect(contents).toContain('MASTRA_CLOUD_ACCESS_TOKEN=');
+    expect(contents).not.toMatch(/MASTRA_CLOUD_ACCESS_TOKEN=\S/);
+  });
+
+  test('writes a real token when one is provided', async () => {
+    fs.writeFileSync(`${cwd}/.env`, '');
+
+    await writeObserveEnv({ token: 'tok_abc123' });
+
+    const contents = fs.readFileSync(`${cwd}/.env`, 'utf-8') as string;
+    expect(contents).toContain('MASTRA_CLOUD_ACCESS_TOKEN=tok_abc123');
+  });
+
+  test('creates the .env file if it does not exist', async () => {
+    await writeObserveEnv();
+
+    const contents = fs.readFileSync(`${cwd}/.env`, 'utf-8') as string;
+    expect(contents).toContain('MASTRA_CLOUD_ACCESS_TOKEN=');
+  });
+});

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -627,6 +627,31 @@ export const writeAPIKey = async ({ provider, apiKey }: { provider: LLMProvider;
   const escapedApiKey = shellQuote.quote([apiKey ? apiKey : 'your-api-key']);
   await exec(`echo ${escapedKey}=${escapedApiKey} >> ${envFileName}`);
 };
+
+/**
+ * Append a Mastra Observe `MASTRA_CLOUD_ACCESS_TOKEN` entry to the project's
+ * `.env` file.
+ *
+ * The generated `src/mastra/index.ts` template already registers a
+ * `CloudExporter` which no-ops unless `MASTRA_CLOUD_ACCESS_TOKEN` is set, so
+ * enabling Observe is a pure env-var concern from the scaffolder's side.
+ *
+ * TODO(PLTFRM-861/862): Once the create-project and mint-token APIs are
+ * available, sign the user in, create a project, and write the real token
+ * here instead of a placeholder.
+ */
+export const writeObserveEnv = async ({ token }: { token?: string } = {}) => {
+  const envFilePath = path.join(process.cwd(), '.env');
+  const lines = [
+    '',
+    '# Mastra Observe — https://cloud.mastra.ai',
+    '# Create a project and paste your access token below to send traces to',
+    '# the hosted Mastra Studio.',
+    `MASTRA_CLOUD_ACCESS_TOKEN=${token ?? ''}`,
+    '',
+  ];
+  await fs.appendFile(envFilePath, lines.join('\n'));
+};
 export const createMastraDir = async (directory: string): Promise<{ ok: true; dirPath: string } | { ok: false }> => {
   let dir = directory
     .trim()
@@ -679,6 +704,7 @@ interface InteractivePromptArgs {
     gitInit?: boolean;
     skills?: boolean;
     mcpServer?: boolean;
+    observe?: boolean;
   };
 }
 
@@ -729,6 +755,21 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
           });
         }
         return undefined;
+      },
+      observe: async () => {
+        if (skip?.observe) return undefined;
+
+        const choice = await p.select({
+          message: 'Enable Mastra Observe? (observability for your agents, workflows, and tools — free tier available)',
+          options: [
+            { value: 'yes', label: 'Yes, enable Mastra Observe', hint: 'recommended' },
+            { value: 'no', label: 'No thanks' },
+          ],
+          initialValue: 'yes',
+        });
+
+        if (p.isCancel(choice)) return undefined;
+        return choice === 'yes';
       },
       configureMastraToolingForAgents: async () => {
         if (skip?.skills && skip?.mcpServer) return { skills: undefined, mcpServer: undefined };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -97,6 +97,8 @@ program
     '--template [template-name]',
     'Create project from a template (use template name, public GitHub URL, or leave blank to select from list)',
   )
+  .option('--observe', 'Enable Mastra Observe (writes MASTRA_CLOUD_ACCESS_TOKEN placeholder to .env)')
+  .option('--no-observe', 'Do not enable Mastra Observe')
   .action(createProject);
 
 program
@@ -118,6 +120,8 @@ program
     'MCP Server for code editor (cursor, cursor-global, windsurf, vscode, antigravity)',
     parseMcp,
   )
+  .option('--observe', 'Enable Mastra Observe (writes MASTRA_CLOUD_ACCESS_TOKEN placeholder to .env)')
+  .option('--no-observe', 'Do not enable Mastra Observe')
   .action(initProject);
 
 program

--- a/packages/create-mastra/src/index.ts
+++ b/packages/create-mastra/src/index.ts
@@ -52,6 +52,8 @@ program
     '--template [template-name]',
     'Create project from a template (use template name, public GitHub URL, or leave blank to select from list)',
   )
+  .option('--observe', 'Enable Mastra Observe (writes MASTRA_CLOUD_ACCESS_TOKEN placeholder to .env)')
+  .option('--no-observe', 'Do not enable Mastra Observe')
   .action(async (projectNameArg, args) => {
     // TODO(major): Remove args.projectName in favor of projectNameArg
     const projectName = projectNameArg || args.projectName;
@@ -69,6 +71,7 @@ program
         directory: 'src/',
         template: args.template,
         analytics,
+        observe: args.observe,
       });
       return;
     }
@@ -85,6 +88,7 @@ program
       mcpServer: args.mcp,
       template: args.template,
       analytics,
+      observe: args.observe,
     });
   });
 


### PR DESCRIPTION
## Summary

Both `mastra init` and `create-mastra` now ask "Do you want to enable Mastra Observe?" during interactive onboarding. If the user answers yes, the generated \`.env\` gets a \`MASTRA_CLOUD_ACCESS_TOKEN=\` entry and the CLI prints a pointer to https://cloud.mastra.ai so the user can mint a token.

The existing generated \`src/mastra/index.ts\` already registers a \`CloudExporter\` that no-ops when the env var is empty, so enabling Observe is a pure env-var concern for now.

Also adds \`--observe\` / \`--no-observe\` flags to both commands so the prompt can be suppressed in non-interactive flows.

## Test plan

- \`pnpm --filter ./packages/cli typecheck\` — clean
- \`pnpm --filter ./packages/cli test -- src/commands/init/\` — 285/285, including the new \`writeObserveEnv\` tests (appends to existing \`.env\`, writes real token, creates \`.env\` when missing)
- \`pnpm --filter ./packages/cli test -- src/commands/create/\` — 285/285, no regressions
- \`pnpm build:cli\` — succeeds
- \`pnpm --filter ./packages/create-mastra build\` — succeeds
- Manual: run \`create-mastra\` interactively, choose yes, confirm \`.env\` contains the entry and the prompt appears