### PR TITLE
fix(cli): stabilize deploy-upload retry tests

### DIFF
--- a/.changeset/every-lemons-relax.md
+++ b/.changeset/every-lemons-relax.md
@@ -1,5 +1,0 @@
----
-'mastra': patch
----
-
-Fixed flaky unit tests for deploy upload retry by decoupling token refresh from module-level mocks.

--- a/.changeset/every-lemons-relax.md
+++ b/.changeset/every-lemons-relax.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed flaky unit tests for deploy upload retry by decoupling token refresh from module-level mocks.

--- a/packages/cli/src/utils/deploy-upload.test.ts
+++ b/packages/cli/src/utils/deploy-upload.test.ts
@@ -1,15 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../commands/auth/client.js', () => ({
-  createApiClient: vi.fn(token => ({ _token: token })),
-}));
-
-vi.mock('../commands/auth/credentials.js', () => ({
-  getToken: vi.fn().mockResolvedValue('refreshed-token'),
-}));
-
-import { createApiClient } from '../commands/auth/client.js';
-import { getToken } from '../commands/auth/credentials.js';
 import { bestEffortCancel, confirmUploadWithRetry } from './deploy-upload.js';
 
 const ok = () => Promise.resolve({ error: undefined, response: { status: 200 } });
@@ -17,7 +7,7 @@ const fail = (status: number) => Promise.resolve({ error: { detail: 'err' }, res
 const networkError = () =>
   Promise.reject(Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNRESET' } }));
 
-beforeEach(() => vi.resetAllMocks());
+beforeEach(() => vi.clearAllMocks());
 afterEach(() => vi.useRealTimers());
 
 // ─── bestEffortCancel ──────────────────────────────────────────────
@@ -88,22 +78,21 @@ describe('confirmUploadWithRetry', () => {
 
   it('refreshes token on 401 before retry', async () => {
     vi.useFakeTimers();
-    vi.mocked(getToken).mockResolvedValue('fresh-tok');
-    vi.mocked(createApiClient).mockReturnValue({ _token: 'fresh' } as any);
+    const refreshClient = vi.fn().mockResolvedValue({ _token: 'fresh' } as any);
 
     const post = vi
       .fn()
       .mockImplementationOnce(() => fail(401))
       .mockImplementationOnce(ok);
 
-    const p = confirmUploadWithRetry({ ...baseOpts(), postUploadComplete: post });
+    const p = confirmUploadWithRetry({ ...baseOpts(), postUploadComplete: post, refreshClient });
     // Flush microtasks so the first attempt completes before advancing timers
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(1000);
     await p;
 
-    expect(getToken).toHaveBeenCalledTimes(1);
-    expect(createApiClient).toHaveBeenCalledWith('fresh-tok', 'org-1');
+    expect(refreshClient).toHaveBeenCalledTimes(1);
+    expect(refreshClient).toHaveBeenCalledWith('org-1');
     // Second call uses refreshed client
     expect(post.mock.calls[1]![0]).toEqual({ _token: 'fresh' });
   });
@@ -130,12 +119,12 @@ describe('confirmUploadWithRetry', () => {
   });
 
   it('cancels and throws when token refresh fails', async () => {
-    vi.mocked(getToken).mockRejectedValue(new Error('no refresh token'));
+    const refreshClient = vi.fn().mockRejectedValue(new Error('no refresh token'));
     const post = vi.fn().mockImplementation(() => fail(401));
 
-    await expect(confirmUploadWithRetry({ ...baseOpts(), maxRetries: 1, postUploadComplete: post })).rejects.toThrow(
-      'no refresh token',
-    );
+    await expect(
+      confirmUploadWithRetry({ ...baseOpts(), maxRetries: 1, postUploadComplete: post, refreshClient }),
+    ).rejects.toThrow('no refresh token');
 
     expect(cancelDeploy).toHaveBeenCalledTimes(1);
     expect(post).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/utils/deploy-upload.ts
+++ b/packages/cli/src/utils/deploy-upload.ts
@@ -38,8 +38,16 @@ export async function confirmUploadWithRetry(opts: {
   client: ApiClient;
   orgId: string;
   maxRetries?: number;
+  /** Override for testing — refresh the client with a new token. */
+  refreshClient?: (orgId: string) => Promise<ApiClient>;
 }): Promise<void> {
-  const { postUploadComplete, cancelDeploy, orgId, maxRetries = 3 } = opts;
+  const {
+    postUploadComplete,
+    cancelDeploy,
+    orgId,
+    maxRetries = 3,
+    refreshClient = async (o: string) => createApiClient(await getToken(), o),
+  } = opts;
   let lastError: Error | undefined;
   let currentClient = opts.client;
 
@@ -79,8 +87,7 @@ export async function confirmUploadWithRetry(opts: {
     // On 401, refresh the token before retrying
     if (status === 401) {
       try {
-        const freshToken = await getToken();
-        currentClient = createApiClient(freshToken, orgId);
+        currentClient = await refreshClient(orgId);
       } catch (refreshError) {
         lastError = refreshError instanceof Error ? refreshError : new Error('Failed to refresh authentication token');
         break;


### PR DESCRIPTION
Two unit tests in `deploy-upload.test.ts` were flaking in sharded CI (most recently https://github.com/mastra-ai/mastra/actions/runs/24749117119). They leaned on `vi.mock('../commands/auth/credentials.js')` to stub `getToken`, but with the CLI's `isolate: false` vitest config and multiple test files mocking the same module, the mock didn't reliably bind to the `getToken` actually imported by `deploy-upload.ts`. Result: `getToken` was either never called or didn't reject as expected.

Fix is to stop mocking at the module level and instead inject a `refreshClient` function into `confirmUploadWithRetry`. Production behavior is unchanged — the default still does `createApiClient(await getToken(), orgId)`.

Before:

```ts
vi.mock('../commands/auth/credentials.js', () => ({
  getToken: vi.fn().mockResolvedValue('refreshed-token'),
}));
// ...
vi.mocked(getToken).mockRejectedValue(new Error('no refresh token'));
```

After:

```ts
const refreshClient = vi.fn().mockRejectedValue(new Error('no refresh token'));
await confirmUploadWithRetry({ ...baseOpts(), postUploadComplete: post, refreshClient });
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes tests that were randomly failing in the CI pipeline. The issue was that the tests were trying to fake out a function using a global "mock" system, but when multiple tests ran in parallel, the fake didn't always work. The fix was to pass in a fake function directly where it's needed instead of relying on the global mock system.

## Summary

This PR stabilizes flaky unit tests in `deploy-upload.test.ts` by refactoring the token refresh testing approach to use dependency injection instead of module-level mocks.

### Problem

Tests for `confirmUploadWithRetry` relied on module-level `vi.mock` to stub out the `getToken` function from `../commands/auth/credentials.js`. In sharded CI environments with Vitest configured to use `isolate: false`, multiple test files mocking the same module caused the mock to not reliably bind to the imported `getToken`, resulting in tests intermittently failing.

### Solution

- Added an optional `refreshClient?: (orgId: string) => Promise<ApiClient>` parameter to `confirmUploadWithRetry` options
- Tests now inject a mock `refreshClient` function directly instead of relying on module-level mocks
- When `refreshClient` is not provided in production, `confirmUploadWithRetry` defaults to the original behavior of calling `createApiClient(await getToken(), orgId)`
- Updated test assertions to verify `refreshClient` is called with the correct org ID and that the refreshed client's token is used for retries

### Changes

- **packages/cli/src/utils/deploy-upload.ts**: Added optional `refreshClient` parameter with fallback to default token refresh logic
- **packages/cli/src/utils/deploy-upload.test.ts**: Removed module-level mocks for `createApiClient` and `getToken`; updated 401-refresh and refresh-failure tests to inject mock `refreshClient`; changed test setup from `vi.resetAllMocks()` to `vi.clearAllMocks()`
- **.changeset/every-lemons-relax.md**: Added changelog entry for patch release documenting the test flakiness fix

### Impact

Production behavior is unchanged. Tests are now more reliable and explicit about their dependencies, improving maintainability in parallel test execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->