### PR TITLE
test(redis): use shared client acceptance and domain factories

### DIFF
--- a/stores/redis/src/storage/index.test.ts
+++ b/stores/redis/src/storage/index.test.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from 'node:crypto';
-import { createTestSuite, createConfigValidationTests } from '@internal/storage-test-utils';
+import {
+  createTestSuite,
+  createConfigValidationTests,
+  createClientAcceptanceTests,
+  createDomainDirectTests,
+} from '@internal/storage-test-utils';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type { MemoryStorage } from '@mastra/core/storage';
 import { createClient } from 'redis';
@@ -94,44 +99,34 @@ createConfigValidationTests({
   ],
 });
 
-// Pre-configured client acceptance tests
-describe('RedisStore client acceptance tests', () => {
-  it('should accept a pre-configured client', async () => {
-    const client = await createTestClient();
-    const store = new RedisStore({
-      id: 'redis-client-test',
-      client,
-    });
+// Pre-configured client acceptance + domain direct tests (shared across redis-family stores)
+let sharedClient: RedisClient;
 
-    expect(store).toBeDefined();
-    expect(store.name).toBe('Redis');
-
-    await client.quit();
-  });
+beforeAll(async () => {
+  sharedClient = await createTestClient();
 });
 
-// Domain-level pre-configured client tests
-describe('Redis domain direct tests', () => {
-  it('should allow memory domain with pre-configured client', async () => {
-    const client = await createTestClient();
-    const memoryDomain = new StoreMemoryRedis({ client });
-    expect(memoryDomain).toBeDefined();
-    await client.quit();
-  });
+afterAll(async () => {
+  if (sharedClient.isOpen) {
+    await sharedClient.quit();
+  }
+});
 
-  it('should allow workflows domain with pre-configured client', async () => {
-    const client = await createTestClient();
-    const workflowsDomain = new WorkflowsRedis({ client });
-    expect(workflowsDomain).toBeDefined();
-    await client.quit();
-  });
+createClientAcceptanceTests({
+  storeName: 'RedisStore',
+  expectedStoreName: 'Redis',
+  createStoreWithClient: () =>
+    new RedisStore({
+      id: 'redis-client-test',
+      client: sharedClient,
+    }),
+});
 
-  it('should allow scores domain with pre-configured client', async () => {
-    const client = await createTestClient();
-    const scoresDomain = new ScoresRedis({ client });
-    expect(scoresDomain).toBeDefined();
-    await client.quit();
-  });
+createDomainDirectTests({
+  storeName: 'Redis',
+  createMemoryDomain: () => new StoreMemoryRedis({ client: sharedClient }),
+  createWorkflowsDomain: () => new WorkflowsRedis({ client: sharedClient }),
+  createScoresDomain: () => new ScoresRedis({ client: sharedClient }),
 });
 
 // Additional Redis-specific tests


### PR DESCRIPTION
The redis adapter was duplicating the client-acceptance and domain-direct tests that upstash already consumes from `@internal/storage-test-utils`. Switched redis to the same shared factories so the two redis-family stores stay in lockstep.

Redis-specific tests (connection options, `getClient`, msg-idx scan avoidance, ordering regressions) stay inline because they assert adapter-internal behavior.

One small wrinkle: node-redis' `connect()` is async, so I pre-connect a shared client in `beforeAll` and close it in `afterAll` — the sync `createStoreWithClient`/`createMemoryDomain` factories close over it.

Before:

```ts
describe('RedisStore client acceptance tests', () => {
  it('should accept a pre-configured client', async () => {
    const client = await createTestClient();
    const store = new RedisStore({ id: 'redis-client-test', client });
    expect(store.name).toBe('Redis');
    await client.quit();
  });
});

describe('Redis domain direct tests', () => {
  it('should allow memory domain with pre-configured client', async () => {
    const client = await createTestClient();
    const memoryDomain = new StoreMemoryRedis({ client });
    expect(memoryDomain).toBeDefined();
    await client.quit();
  });
  // ...repeats for workflows, scores
});
```

After:

```ts
let sharedClient: RedisClient;
beforeAll(async () => { sharedClient = await createTestClient(); });
afterAll(async () => { if (sharedClient.isOpen) await sharedClient.quit(); });

createClientAcceptanceTests({
  storeName: 'RedisStore',
  expectedStoreName: 'Redis',
  createStoreWithClient: () => new RedisStore({ id: 'redis-client-test', client: sharedClient }),
});

createDomainDirectTests({
  storeName: 'Redis',
  createMemoryDomain: () => new StoreMemoryRedis({ client: sharedClient }),
  createWorkflowsDomain: () => new WorkflowsRedis({ client: sharedClient }),
  createScoresDomain: () => new ScoresRedis({ client: sharedClient }),
});
```

All 192 tests pass (243 skipped, unchanged); typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR cleans up duplicate test code for Redis by reusing shared testing tools that other adapters already use. Instead of writing the same tests over and over, the Redis tests now borrow pre-made test templates that do the same checks, keeping all adapters consistent. The PR also optimizes by using one shared database connection for all tests instead of creating a new one for each test.

## Summary of changes

The PR refactors the Redis adapter test suite (`stores/redis/src/storage/index.test.ts`) to eliminate code duplication by adopting shared test generators from `@internal/storage-test-utils`.

**Test infrastructure changes:**
- Introduces a single `sharedClient` initialized once in `beforeAll` and cleaned up in `afterAll` (closing only when the client is open)
- Replaces hand-rolled "client acceptance" describe/it blocks with `createClientAcceptanceTests`, which runs via a `createStoreWithClient` factory callback
- Replaces hand-rolled "domain direct" describe/it blocks with `createDomainDirectTests`, using factory callbacks to instantiate memory, workflows, and scores domains with the shared client

**Redis-specific tests retained:**
- Adapter-internal behavior assertions remain inline (connection options, getClient, message-index scan avoidance, ordering regressions)

**Code metrics:**
- Lines changed: +29/-34
- Test results: 192 tests passed, 243 skipped (unchanged)
- Type checking: clean

This aligns the Redis adapter test structure with the upstash adapter, improving consistency across the codebase while reducing maintenance burden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->