### PR TITLE
fix(redis): use patch bump for initial @mastra/redis release

### DIFF
--- a/.changeset/witty-cloths-eat.md
+++ b/.changeset/witty-cloths-eat.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/redis': minor
+'@mastra/redis': patch
 ---
 
 Add Redis storage provider


### PR DESCRIPTION
## Summary

`@mastra/redis` is a newly-added storage package that has not yet been published to npm. Its `package.json` is set to `1.0.0` and a pending changeset was marked as `minor`, which would cause the first release to publish as `1.1.0` — skipping `1.0.x` entirely and implying a significant feature addition when it is simply the initial release.

This PR changes the changeset from `minor` to `patch` so the first published version is `1.0.1`, matching the pattern used by other storage packages that are currently at `1.0.1` (`@mastra/astra`, `@mastra/chroma`, `@mastra/opensearch`, `@mastra/pinecone`, `@mastra/turbopuffer`).

## Test plan

- [x] Verified `@mastra/redis` is not yet on npm (`npm view @mastra/redis` returns 404)
- [x] Confirmed current `stores/redis/package.json` version is `1.0.0`
- [x] Only the changeset bump type changed; no code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes how the @mastra/redis package will be numbered when it's first released. Instead of jumping from 1.0.0 to 1.1.0 (a medium update), it will go to 1.0.1 (a tiny update) to match the numbering style of other similar packages.

## Summary

Updates the changeset configuration for the newly-added @mastra/redis package, changing the release bump type from `minor` to `patch`. This ensures the initial npm publication will be version 1.0.1 rather than 1.1.0, aligning with the versioning scheme used by other storage packages in the monorepo (@mastra/astra, @mastra/chroma, @mastra/opensearch, @mastra/pinecone, @mastra/turbopuffer).

## Changes

- **`.changeset/witty-cloths-eat.md`**: Modified version bump type from `minor` to `patch`

No code changes were made; only the changeset configuration was updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->