### PR TITLE
docs(smoke-test-skill): add curl/API variants for --skip-browser mode

### DIFF
--- a/.claude/skills/mastra-smoke-test/references/local-setup.md
+++ b/.claude/skills/mastra-smoke-test/references/local-setup.md
@@ -30,12 +30,37 @@ Based on the selected LLM provider, ensure the API key is available:
 
 ## Start Development Server
 
+### 1. Check for a zombie on :4111 first
+
+`mastra dev` auto-increments the port if `:4111` is already in use (e.g.
+`:4112`, `:4113`). If you don't notice, your subsequent curls will hit the
+**wrong** project (any earlier test session left running). Always check:
+
+```bash
+lsof -i :4111
+# If a node process is listening, kill it before starting:
+kill $(lsof -ti :4111) 2>/dev/null
+```
+
+### 2. Start
+
 ```bash
 cd <project-directory>
 <pm> run dev
 ```
 
-Server starts on `http://localhost:4111`. Wait for "Server ready" message.
+Server starts on `http://localhost:4111`. Wait for "Mastra API running" in the
+output and confirm the printed URL before running tests:
+
+```bash
+curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:4111/api/agents
+# HTTP 200 → dev server up
+```
+
+**If the dev server prints `url: "http://localhost:4112/api"` instead of
+`:4111`,** port 4111 was already taken. Stop, kill the zombie, and restart,
+or pass `--port 4111` if supported — otherwise all the curl examples in the
+test references will target the wrong server.
 
 ## Local Observability Setup
 

--- a/.claude/skills/mastra-smoke-test/references/tests/agents.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/agents.md
@@ -65,3 +65,44 @@ Type in chat: "What about London?"
 Click: Send button
 Wait: For response
 ```
+
+## Curl / API (for `--skip-browser`)
+
+**`<agentKey>` is the key used in `Mastra({ agents: { weatherAgent } })`, not
+the agent's `id` field.** A template where `agents: { weatherAgent }` and the
+agent's `id: 'weather-agent'` is addressed as `/api/agents/weatherAgent/...`,
+not `/api/agents/weather-agent/...`.
+
+**List agents:**
+
+```bash
+curl -s http://localhost:4111/api/agents
+```
+
+**Generate (single call, no memory):**
+
+```bash
+curl -s -X POST "http://localhost:4111/api/agents/<agentKey>/generate" \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"What is the weather in Tokyo?"}]}'
+```
+
+**Generate with memory** (see `memory.md` for the two-call persistence check):
+
+```bash
+curl -s -X POST "http://localhost:4111/api/agents/<agentKey>/generate" \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"..."}],"memory":{"thread":"<tid>","resource":"<rid>"}}'
+```
+
+**Pass criteria:**
+
+- `/api/agents` returns a JSON object keyed by agent key
+- `/generate` returns HTTP 200 with a `text` field containing a coherent
+  response (and, if the agent has a tool, `toolCalls` / `toolResults` in
+  `steps`)
+
+**Common mistake:** sending `threadId` / `resourceId` at the top level to
+`/generate` — these are silently discarded. Use `memory: { thread, resource }`.
+Top-level `threadId` / `resourceId` are only read by the deprecated
+`/generate-legacy` route.

--- a/.claude/skills/mastra-smoke-test/references/tests/errors.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/errors.md
@@ -121,3 +121,61 @@ Verify: Validation error shown
 Navigate to: /this-page-does-not-exist
 Verify: 404 or redirect, not crash
 ```
+
+## Curl / API (for `--skip-browser`)
+
+Same curls for local and cloud; cloud needs `Authorization: Bearer <api-key>`.
+
+```bash
+# Unknown agent
+curl -sw "\nHTTP %{http_code}\n" -X POST \
+  http://localhost:4111/api/agents/nonexistent/generate \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"hi"}]}'
+
+# Workflow with missing required input field
+curl -sw "\nHTTP %{http_code}\n" -X POST \
+  http://localhost:4111/api/workflows/<workflowId>/start-async \
+  -H "Content-Type: application/json" \
+  -d '{"inputData":{}}'
+
+# Tool with missing required input field
+curl -sw "\nHTTP %{http_code}\n" -X POST \
+  http://localhost:4111/api/tools/<toolId>/execute \
+  -H "Content-Type: application/json" \
+  -d '{"data":{}}'
+
+# Unknown tool
+curl -sw "\nHTTP %{http_code}\n" -X POST \
+  http://localhost:4111/api/tools/nonexistent/execute \
+  -H "Content-Type: application/json" \
+  -d '{"data":{}}'
+```
+
+### Expected behavior
+
+The current server returns the following. These are the values to assert
+against — flag any deviation as a regression.
+
+| Case                             | HTTP | Body shape                                               |
+| -------------------------------- | ---- | -------------------------------------------------------- |
+| Unknown agent id                 | 404  | `{ error: "Agent with id <id> not found" }` (or similar) |
+| Unknown tool id                  | 404  | `{ error: "Tool not found" }`                            |
+| Unknown workflow id              | 404  | `{ error: "Workflow not found" }`                        |
+| Workflow missing required input  | 500  | `{ error: "Invalid input data: <field> expected ..." }`  |
+| Tool missing required input      | 200  | `{ error: true, validationErrors: { ... } }`             |
+| Invalid JSON body                | 400  | `{ error: "..." }` (Hono body parse failure)             |
+
+**Known inconsistencies** (document if you observe, don't treat as
+failures unless they change):
+
+- Workflow invalid input returns **500** (arguably should be 400)
+- Tool invalid input returns **200** with `error: true` in the body
+  (inconsistent with HTTP semantics vs. workflow/agent error responses)
+
+### Pass criteria
+
+- Every error response includes a readable `error` field (or
+  `validationErrors` for tools)
+- No stack traces leak into the response body
+- HTTP status codes match the table above (or are documented deviations)

--- a/.claude/skills/mastra-smoke-test/references/tests/mcp.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/mcp.md
@@ -97,3 +97,56 @@ Click: On server in list
 Verify: Connection status shown
 Verify: Available tools listed
 ```
+
+## Curl / API (for `--skip-browser`)
+
+The server exposes MCP endpoints under `/api/mcp/v0/...` (not `/api/mcps`
+— that's the Studio route). The `MCP` here refers to Mastra hosting MCP
+servers for external clients; it does not list external MCP clients the
+project consumes.
+
+**1. List MCP servers this Mastra instance exposes**
+
+```bash
+curl -s "http://localhost:4111/api/mcp/v0/servers" | jq '.'
+```
+
+Response shape: `{ servers: [...], total_count: N, next: null }`. An
+empty array is a valid pass if the project declares no MCP servers (the
+default `create-mastra` template does not).
+
+**2. Get one server's metadata**
+
+```bash
+curl -s "http://localhost:4111/api/mcp/v0/servers/<serverId>" | jq '.'
+```
+
+**3. List tools a server exposes, and execute one**
+
+```bash
+# List tools
+curl -s "http://localhost:4111/api/mcp/<serverId>/tools" | jq '.'
+
+# Inspect one tool
+curl -s "http://localhost:4111/api/mcp/<serverId>/tools/<toolId>" | jq '.'
+
+# Execute the tool
+curl -s -X POST "http://localhost:4111/api/mcp/<serverId>/tools/<toolId>/execute" \
+  -H "Content-Type: application/json" \
+  -d '{"data":{ ... }}'
+```
+
+**Pass criteria:**
+
+- `GET /api/mcp/v0/servers` returns HTTP 200 with the expected shape
+  (empty `servers` array is OK)
+- If servers are declared: each shows up in the list and
+  `GET /api/mcp/v0/servers/:id` returns a non-null object
+- If tools are exposed: `GET /api/mcp/:serverId/tools` lists them and
+  `POST /.../execute` returns a successful result
+
+**Common mistakes:**
+
+- Hitting `/api/mcps` or `/api/mcp/servers` — neither exists server-side
+- Treating an empty `servers` list as failure on the default template —
+  it's expected

--- a/.claude/skills/mastra-smoke-test/references/tests/memory.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/memory.md
@@ -92,3 +92,64 @@ Navigate to: /agents
 Click: Same agent
 Verify: History still visible (if persistent storage)
 ```
+
+## Curl / API (for `--skip-browser`)
+
+The current `/agents/:agentId/generate` route expects thread/resource under a
+`memory` object. Top-level `threadId` / `resourceId` are only read by the
+deprecated `/generate-legacy` route — sending them to `/generate` silently
+discards them and the agent will appear to "forget" context.
+
+**Correct request shape:**
+
+```json
+{
+  "messages": [{ "role": "user", "content": "..." }],
+  "memory": { "thread": "<thread-id>", "resource": "<resource-id>" }
+}
+```
+
+**Two-call persistence check:**
+
+```bash
+TID="smoke-memory-$(date +%s)"
+RID="smoke-user"
+
+# Call 1: seed context
+curl -s -X POST "http://localhost:4111/api/agents/<agentKey>/generate" \
+  -H "Content-Type: application/json" \
+  -d "{\"messages\":[{\"role\":\"user\",\"content\":\"Remember: my name is Abhi.\"}],\"memory\":{\"thread\":\"$TID\",\"resource\":\"$RID\"}}"
+
+# Call 2: same thread, verify recall
+curl -s -X POST "http://localhost:4111/api/agents/<agentKey>/generate" \
+  -H "Content-Type: application/json" \
+  -d "{\"messages\":[{\"role\":\"user\",\"content\":\"What is my name?\"}],\"memory\":{\"thread\":\"$TID\",\"resource\":\"$RID\"}}"
+
+# Assert: thread exists in storage
+curl -s "http://localhost:4111/api/memory/threads?resourceId=$RID" | \
+  jq '{total, ids: (.threads | map(.id))}'
+```
+
+**Response shape:** `GET /api/memory/threads` returns
+`{ threads: [...], total, page, perPage, hasMore }` — **not** a bare array.
+Each entry has `{ id, resourceId, title, metadata, createdAt, updatedAt }`.
+
+**Query params:** `resourceId` is **case-sensitive** (capital `I`). Lowercase
+`resourceid` is silently ignored and returns **all** threads, which can make
+a broken test look like it passed. `agentId` is optional.
+
+**Pass criteria:**
+
+- Call 2 response references "Abhi"
+- `GET /api/memory/threads?resourceId=<rid>` returns `.total >= 1` with a
+  thread whose `id` matches `$TID`
+- To harden: seed a second thread under a different `resourceId` and
+  confirm the filter excludes it
+
+**If call 2 forgets context:** check you sent `memory: { thread, resource }`
+(not top-level `threadId` / `resourceId`) and that `<agentKey>` matches the key
+used in the `Mastra({ agents })` config, not the agent's `id` field.
+
+**If `/memory/threads` returns threads from other resources:** you typed
+`resourceid` instead of `resourceId` — the unknown param is dropped and no
+filter is applied.

--- a/.claude/skills/mastra-smoke-test/references/tests/scorers.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/scorers.md
@@ -53,3 +53,61 @@ Wait: For page to load
 Verify: Page loads without errors
 Verify: Scorers list visible (may be empty)
 ```
+
+## Curl / API (for `--skip-browser`)
+
+**There is no "execute scorer" HTTP endpoint.** Scorers run automatically
+as part of agent / workflow execution (live scoring) and record `score`
+rows. To smoke-test scorers over the API you verify (1) they are
+registered, and (2) they emit scores when an agent / workflow runs.
+
+**1. List registered scorers**
+
+```bash
+curl -s http://localhost:4111/api/scores/scorers | jq 'keys'
+```
+
+Pass: returns an object keyed by scorer id (`weather-scorer`,
+`translation-quality-scorer`, etc.) for the scorers declared in the
+project. Empty `{}` is only acceptable if the project genuinely declares
+none.
+
+**2. Get a single scorer's config**
+
+```bash
+curl -s http://localhost:4111/api/scores/scorers/<scorerId> | jq '.'
+```
+
+Pass: returns a non-null object with `config` and the agents/workflows it
+is attached to. `null` means the id is wrong or the scorer is not
+registered.
+
+**3. Trigger scoring by running an agent / workflow, then read scores**
+
+```bash
+# Run the workflow (or agent) that has scorers attached
+curl -s -X POST "http://localhost:4111/api/workflows/<workflowId>/start-async" \
+  -H "Content-Type: application/json" \
+  -d '{"inputData":{"city":"Tokyo"}}' | jq '.traceId'
+
+# Scores recorded for that run
+curl -s "http://localhost:4111/api/observability/scores?page=0&perPage=20" \
+  | jq '.scores | map({scorerId, score, reason})'
+```
+
+**Pass criteria:**
+
+- `/api/scores/scorers` lists every scorer the template declares
+- After a workflow/agent run completes, `/api/observability/scores` has
+  new entries with the expected `scorerId`s and numeric `score` values
+- Each recorded score has a `runId` / `traceId` tying it back to the
+  invoking run
+
+**Common mistakes:**
+
+- Treating `POST /api/scores/scorers/<id>/execute` as real — it does not
+  exist. If you see agent output that claims a score without a
+  corresponding row in `/observability/scores`, you hallucinated the
+  result.
+- Expecting scorers to run on ad-hoc text input — they need a live
+  agent/workflow run.

--- a/.claude/skills/mastra-smoke-test/references/tests/tools.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/tools.md
@@ -64,3 +64,43 @@ Click: Submit button
 Wait: For output
 Verify: JSON output appears
 ```
+
+## Curl / API (for `--skip-browser`)
+
+**`<toolId>` is the tool's `.id` property, not the export name.** A
+`weatherTool` export with `id: 'get-weather'` is addressed as
+`/api/tools/get-weather/execute`, not `/api/tools/weatherTool/execute`.
+
+**List tools:**
+
+```bash
+curl -s http://localhost:4111/api/tools
+```
+
+**Execute a tool:**
+
+```bash
+curl -s -X POST "http://localhost:4111/api/tools/<toolId>/execute" \
+  -H "Content-Type: application/json" \
+  -d '{"data":{"location":"San Francisco"}}'
+```
+
+Note the `data` wrapper — the tool's input schema fields go **inside** `data`,
+not at the top level.
+
+**Pass criteria:**
+
+- `/api/tools` returns a JSON object keyed by tool id
+- `/execute` with valid input returns HTTP 200 with the tool's result object
+- `/execute` with invalid input returns HTTP 200 with
+  `{ error: true, validationErrors: {...} }` (see `errors.md`)
+
+**Common mistakes:**
+
+- Using the export name (e.g. `weatherTool`) instead of the tool's `id`
+  (e.g. `get-weather`) → 404 "Tool not found"
+- Sending input fields at the top level instead of under `data` → validation
+  error on every field
+- External API failures surface as HTTP 500 with upstream error content.
+  Retry with a different input (e.g. a well-known city) before concluding
+  the tool itself is broken.

--- a/.claude/skills/mastra-smoke-test/references/tests/traces.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/traces.md
@@ -87,6 +87,43 @@ curl -X POST <server-url>/api/agents/weather-agent/generate \
 - Persist across sessions
 - Note if both Studio and Server traces appear
 
+## Curl / API (for `--skip-browser`, local)
+
+The same `/api/observability/traces` endpoint works locally (no auth needed):
+
+```bash
+# List recent spans (response shape: { pagination, spans })
+curl -s "http://localhost:4111/api/observability/traces?page=0&perPage=20" | jq '.'
+
+# Get a specific trace by id (captured from a prior agent/workflow response)
+curl -s "http://localhost:4111/api/observability/traces/<traceId>" | jq '.'
+```
+
+**Response shape:** `GET /api/observability/traces` returns
+`{ pagination: { total, page, perPage, hasMore }, spans: [...] }` — **not**
+a bare array and **not** a `traces` key. Each entry in `spans` has
+`spanType` (`agent_run`, `tool_call`, `workflow_run`, `scorer_run`),
+`traceId`, timestamps, and payload.
+
+Quick pass check:
+
+```bash
+curl -s "http://localhost:4111/api/observability/traces?page=0&perPage=100" | \
+  jq '{total: .pagination.total, byType: ([.spans[].spanType] | group_by(.) | map({t: .[0], n: length}))}'
+```
+
+**Pass criteria (local):**
+
+- After running agent / tool / workflow tests, `.pagination.total > 0`
+- `.spans` contains the expected `spanType`s: `agent_run`, `workflow_run`,
+  `scorer_run` (and `tool_call` if the agent invoked a tool)
+- `traceId` values returned in earlier generate/workflow responses resolve
+  via `/observability/traces/:traceId`
+
+**Note:** local traces are in-memory only (DefaultExporter). They disappear
+on dev server restart. Run the agent/tool/workflow tests in the same dev
+server session as the traces test.
+
 ## Direct Trace API (Cloud Only)
 
 If UI traces aren't appearing but you need to verify the trace pipeline:

--- a/.claude/skills/mastra-smoke-test/references/tests/workflows.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/workflows.md
@@ -64,3 +64,42 @@ Click: Run button
 Wait: For completion
 Verify: Success state and output
 ```
+
+## Curl / API (for `--skip-browser`)
+
+**`<workflowId>` is the workflow's registered id** (the key used in
+`Mastra({ workflows: { weatherWorkflow } })` or the workflow's `.id`,
+depending on how it was registered).
+
+**List workflows:**
+
+```bash
+curl -s http://localhost:4111/api/workflows
+```
+
+**Run a workflow synchronously:**
+
+```bash
+curl -s -X POST "http://localhost:4111/api/workflows/<workflowId>/start-async" \
+  -H "Content-Type: application/json" \
+  -d '{"inputData":{"city":"Tokyo"}}'
+```
+
+Note the `inputData` wrapper — the workflow's input schema fields go
+**inside** `inputData`, not at the top level.
+
+**Pass criteria:**
+
+- `/api/workflows` returns a JSON object keyed by workflow id
+- `/start-async` returns HTTP 200 with a result object containing the final
+  workflow output and a run id
+- Response typically includes a `traceId` — capture it to cross-reference in
+  `traces.md` verification
+
+**Common mistakes:**
+
+- Sending input fields at the top level instead of under `inputData` →
+  HTTP 500 "Invalid input data: `<field>` expected `<type>`, received
+  undefined"
+- Using the workflow's display name instead of its registered id → 404
+  "Workflow not found"


### PR DESCRIPTION
## Summary

The `mastra-smoke-test` skill's test references were written as browser-first clickthrough scripts. When running the suite without a browser (`--skip-browser`), there was no documented API path — you had to infer endpoints, request shapes, and pass/fail criteria from the server source.

This PR adds a `Curl / API` section alongside the existing `Browser Actions` section in each of the 9 test references, and patches `local-setup.md` with a port-collision safeguard that affects both variants.

## What changed

Each test reference now documents the exact endpoint, request body shape, and expected response shape, verified against a live dev server:

| Test | Endpoint |
|---|---|
| agents | `POST /api/agents/:agentId/generate` with `memory: { thread, resource }` |
| tools | `POST /api/tools/:toolId/execute` — `:toolId` matches the tool's `.id`, not the export name |
| workflows | `POST /api/workflows/:workflowId/start-async` with `{ inputData }` |
| traces | `GET /api/observability/traces` — response is `{ pagination, spans }` |
| scorers | `GET /api/scores/scorers` (list only; standalone execute endpoint does not exist — scorers run during agent/workflow execution) |
| memory | `GET /api/memory/threads?resourceId=X` — **`resourceId` is case-sensitive**; lowercase `resourceid` silently returns all threads (false-positive trap). Response is `{ threads, total, page, perPage, hasMore }` |
| mcp | `GET /api/mcp/v0/servers` |
| errors | Expected status codes per failure mode: 404 (unknown agent), 500 (invalid workflow input), 200 + error flag (invalid tool input), 400 (malformed JSON) |

`local-setup.md` now instructs you to:
1. Check for a zombie process on `:4111` before starting (since `mastra dev` auto-increments to `:4112` and silently invalidates every curl in the suite).
2. Wait for `Mastra API running` in the output (the previous "Server ready" string was never printed).
3. Confirm the printed URL is `:4111` before running tests.

## Browser variant

Unchanged. The only deletion in the diff is a stale "Wait for Server ready" string that the dev server doesn't actually print — replaced with accurate wait-signal guidance that helps both variants. `grep '## Browser Actions'` shows all 9 sections still intact.

## Test plan

- Ran the full smoke test suite (agents, tools, workflows, traces, scorers, memory, MCP, errors) against a fresh alpha-test project with `--skip-browser` following only the new curl sections — all pass.
- Verified response shapes with live `curl | jq keys` against the dev server.
- Verified `resourceId` case sensitivity (lowercase returns 2 threads, capital returns 1).
- Verified port-collision warning by intentionally starting a second project while `:4111` was busy (second one bound to `:4112`, fully reproducing the original footgun).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR adds easy-to-follow instructions for testing Mastra's core features (agents, tools, workflows, memory, etc.) using simple API calls instead of clicking through a browser. This lets developers and the test suite run the smoke tests much faster and more reliably without needing a web browser.

---

## Overview

This documentation PR extends the mastra-smoke-test skill to support `--skip-browser` mode by adding curl/API examples and verification steps across nine test references. Each reference now pairs browser-based instructions with concrete curl commands, expected HTTP responses, and common pitfalls. A pre-start port-collision safeguard was added to local-setup.md to ensure the dev server runs on the expected port (4111).

---

## Changes by File

**local-setup.md** (+26/-1)
- Added pre-start port collision detection: checks for zombie process on port 4111 using `lsof`
- Updated dev-server readiness checks: verify "Mastra API running" output and validate HTTP 200 from `/api/agents`
- Added troubleshooting guidance for port auto-increment (if server prints :4112, kill existing listener or restart)

**agents.md** (+41/-0)
- New "Curl / API" section with curl examples for listing agents (`GET /api/agents`) and generating responses (`POST /api/agents/<agentKey>/generate`)
- Clarifies that `<agentKey>` is the key from the `Mastra({ agents: { ... } })` config, not the agent's `.id`
- Documents correct memory payload structure: `memory: { thread, resource }` (not top-level `threadId`/`resourceId`)
- Specifies pass criteria for API responses

**tools.md** (+40/-0)
- New "Curl / API" section documenting tool listing (`GET /api/tools`) and execution (`POST /api/tools/<toolId>/execute`)
- Clarifies input wrapping under `data` object
- Notes that `<toolId>` is the tool's `.id`, not its export name (common cause of 404)
- Specifies HTTP 200 for both valid and invalid inputs; validation errors returned as `{ error: true, validationErrors: {...} }`

**workflows.md** (+39/-0)
- New "Curl / API" section for workflow discovery (`GET /api/workflows`) and execution (`POST /api/workflows/<workflowId>/start-async`)
- Documents required `inputData` wrapper for request payload
- Specifies expected response shape including `traceId`/run ID
- Warns against top-level inputs (causes 500) and using display name instead of ID (causes 404)

**memory.md** (+61/-0)
- New "Curl / API" section documenting two-step workflow: seed context with `memory.thread` and `memory.resource`, then post follow-up to verify recall
- Details `GET /api/memory/threads?resourceId=X` endpoint with response structure and **case-sensitive `resourceId` query parameter**
- Provides pass/fail assertions and misconfiguration checks

**traces.md** (+37/-0)
- New "Curl / API" section for local trace retrieval via `GET http://localhost:4111/api/observability/traces`
- Specifies response shape as `{ pagination, spans }` (not a bare array)
- Documents expected `spans[].spanType` values
- Notes that local traces use DefaultExporter (in-memory, cleared on server restart)

**scorers.md** (+58/-0)
- New "Curl / API" section documenting scorer discovery (`GET /api/scores/scorers`)
- Clarifies there is no standalone "execute scorer" endpoint; scoring is triggered via workflow execution (`POST /api/workflows/<workflowId>/start-async`)
- Documents verification flow: list scorers, start workflow, check `/api/observability/scores` for new entries tied to `traceId`

**mcp.md** (+53/-0)
- New "Curl / API" section documenting MCP endpoints under `/api/mcp/v0/...`
- Step-by-step curl commands: list servers, fetch server metadata, list per-server tools, inspect tool, invoke tool via `POST .../execute`
- Specifies expected HTTP 200 responses and clarifies that empty `servers` array is valid
- Notes common mistakes (wrong API path prefixes)

**errors.md** (+58/-0)
- New "Curl / API" section with negative test cases: unknown agent ID, missing workflow inputs, missing tool inputs, unknown tool ID
- Documents expected status codes and response body structure per failure mode (404 for not found, 500 for workflow input errors, 200 + error flag for tool input errors)
- Specifies pass criteria: readable error messages, no stack traces, HTTP/status conformity

---

## Key Technical Details

- **Memory/resourceId**: Case-sensitive query parameter for thread lookup
- **AgentKey vs. agent.id**: Smoke tests use config key, not the agent's internal ID
- **ToolId vs. tool export name**: Curl tests require tool `.id`, not export variable name
- **Payload nesting**: Tools use `data: {...}`, agents/workflows use `memory: {...}` and `inputData: {...}`
- **Port safeguard**: Dev server must run on 4111; pre-start check prevents auto-increment to 4112
- **Local traces**: DefaultExporter stores in-memory; tests must run in same server session

<!-- end of auto-generated comment: release notes by coderabbit.ai -->