### PR TITLE
fix(server): suppress noisy log when background tasks are not enabled

### DIFF
--- a/.changeset/flat-humans-turn.md
+++ b/.changeset/flat-humans-turn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed noisy 'Background task manager not available' error log in studio when background tasks are not enabled. The list endpoint now returns an empty list, the get-by-id endpoint returns 404, and the SSE stream endpoint returns an empty stream that closes on disconnect — instead of throwing an HTTP 400 that gets logged as an error.

--- a/packages/server/src/server/handlers/background-tasks.test.ts
+++ b/packages/server/src/server/handlers/background-tasks.test.ts
@@ -141,16 +141,16 @@ describe('Background Tasks handlers', () => {
       expect(result.total).toBe(5);
     });
 
-    it('throws when background task manager is not available', async () => {
+    it('returns an empty list when background task manager is not available', async () => {
       const noTasksMastra = new Mastra({ logger: false, storage, backgroundTasks: { enabled: false } });
 
-      await expect(
-        LIST_BACKGROUND_TASKS_ROUTE.handler({
-          mastra: noTasksMastra,
-          requestContext: {} as any,
-          abortSignal: new AbortController().signal,
-        } as any),
-      ).rejects.toThrow(HTTPException);
+      const result = await LIST_BACKGROUND_TASKS_ROUTE.handler({
+        mastra: noTasksMastra,
+        requestContext: {} as any,
+        abortSignal: new AbortController().signal,
+      } as any);
+
+      expect(result).toEqual({ tasks: [], total: 0 });
     });
   });
 
@@ -185,7 +185,7 @@ describe('Background Tasks handlers', () => {
       ).rejects.toThrow(HTTPException);
     });
 
-    it('throws when background task manager is not available', async () => {
+    it('throws 404 when background task manager is not available', async () => {
       const noTasksMastra = new Mastra({ logger: false, storage, backgroundTasks: { enabled: false } });
 
       await expect(
@@ -313,16 +313,22 @@ describe('Background Tasks handlers', () => {
       abortController.abort();
     });
 
-    it('throws when background task manager is not available', async () => {
+    it('returns an empty stream that closes on abort when background task manager is not available', async () => {
       const noTasksMastra = new Mastra({ logger: false, storage, backgroundTasks: { enabled: false } });
+      const abortController = new AbortController();
 
-      await expect(
-        BACKGROUND_TASK_STREAM_ROUTE.handler({
-          mastra: noTasksMastra,
-          abortSignal: new AbortController().signal,
-          requestContext: {} as any,
-        } as any),
-      ).rejects.toThrow(HTTPException);
+      const result = await BACKGROUND_TASK_STREAM_ROUTE.handler({
+        mastra: noTasksMastra,
+        abortSignal: abortController.signal,
+        requestContext: {} as any,
+      } as any);
+
+      expect(result).toBeInstanceOf(ReadableStream);
+
+      const reader = (result as ReadableStream).getReader();
+      abortController.abort();
+      const { done } = await reader.read();
+      expect(done).toBe(true);
     });
   });
 });

--- a/packages/server/src/server/handlers/background-tasks.ts
+++ b/packages/server/src/server/handlers/background-tasks.ts
@@ -22,7 +22,21 @@ export const BACKGROUND_TASK_STREAM_ROUTE = createRoute({
   handler: async ({ mastra, agentId, runId, threadId, resourceId, abortSignal }) => {
     const bgManager = mastra.backgroundTaskManager;
     if (!bgManager) {
-      throw new HTTPException(400, { message: 'Background task manager not available' });
+      // Background tasks are not enabled — return an empty stream that stays
+      // open until the client disconnects. This avoids spamming the logs with
+      // false-positive errors when clients (e.g. the studio UI) optimistically
+      // subscribe to the stream.
+      return new ReadableStream({
+        start(controller) {
+          abortSignal?.addEventListener('abort', () => {
+            try {
+              controller.close();
+            } catch {
+              // Already closed
+            }
+          });
+        },
+      });
     }
 
     return bgManager.stream({ agentId, runId, threadId, resourceId, abortSignal });
@@ -41,7 +55,8 @@ export const LIST_BACKGROUND_TASKS_ROUTE = createRoute({
   handler: async ({ mastra, ...params }) => {
     const bgManager = mastra.backgroundTaskManager;
     if (!bgManager) {
-      throw new HTTPException(400, { message: 'Background task manager not available' });
+      // Background tasks not enabled — there are no tasks to return.
+      return { tasks: [], total: 0 };
     }
 
     return bgManager.listTasks(params);
@@ -60,7 +75,8 @@ export const GET_BACKGROUND_TASK_ROUTE = createRoute({
   handler: async ({ mastra, backgroundTaskId }) => {
     const bgManager = mastra.backgroundTaskManager;
     if (!bgManager) {
-      throw new HTTPException(400, { message: 'Background task manager not available' });
+      // Background tasks not enabled — the task can't exist.
+      throw new HTTPException(404, { message: 'Background task not found' });
     }
 
     const task = await bgManager.getTask(backgroundTaskId);


### PR DESCRIPTION
The studio UI optimistically subscribes to `/background-tasks/stream` on mount. When users haven't enabled `backgroundTasks` in their Mastra config, the handler threw HTTP 400, which the server adapter logged as `Error calling handler` — visible noise for users who never opted into the feature.

Now the handlers gracefully no-op when the manager isn't available: list returns `{ tasks: [], total: 0 }`, get-by-id returns 404 (the task can't exist), and stream returns an empty `ReadableStream` that closes on client disconnect.

Before:
```
ERROR Error calling handler
  path: '/background-tasks/stream'
  method: 'GET'
  error: { message: 'Background task manager not available', ... }
```

After: silent — the SSE connection stays open with no events until the client disconnects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the Studio tries to check for background tasks on startup but they're turned off in the config, the server used to complain loudly with error messages. This PR makes the server silently pretend that background tasks exist but are empty instead, which stops all the noise.

## Changes

### Problem
The Studio UI automatically attempts to connect to the background tasks stream endpoint (`/background-tasks/stream`) when it loads. If background tasks are not enabled in the Mastra configuration, the server handlers previously rejected these requests with HTTP 400 errors, which were logged as errors on the server. This produced noisy, unnecessary log entries that appeared even though the situation was expected and not actually an error.

### Solution
The background task handlers now gracefully degrade when the background task manager is unavailable, instead of throwing errors:

- **List endpoint** (`/background-tasks`): Returns an empty result `{ tasks: [], total: 0 }` instead of HTTP 400
- **Get by ID endpoint** (`/background-tasks/:id`): Returns HTTP 404 (task not found) instead of HTTP 400 (manager unavailable)
- **Stream endpoint** (`/background-tasks/stream`): Returns an open, empty `ReadableStream` that gracefully closes when the client disconnects, instead of HTTP 400

### Implementation Details
The handler implementations in `packages/server/src/server/handlers/background-tasks.ts` now check if the background task manager is available and return appropriate empty/404 responses instead of throwing exceptions. The stream endpoint specifically returns an SSE-compatible `ReadableStream` that respects the `abortSignal` provided by the client.

The corresponding tests have been updated to verify these new graceful behaviors rather than expecting exceptions.

### Impact
- Eliminates noisy HTTP 400 error logs when background tasks are disabled
- The SSE connection remains open silently until the client disconnects
- Better experience for users with background tasks disabled in their configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->