### PR TITLE
fix(deps): pin @vercel/oidc to 3.1.0 to unblock E2E

### DIFF
--- a/.claude/skills/mastra-smoke-test/references/tests/errors.md
+++ b/.claude/skills/mastra-smoke-test/references/tests/errors.md
@@ -157,14 +157,14 @@ curl -sw "\nHTTP %{http_code}\n" -X POST \
 The current server returns the following. These are the values to assert
 against — flag any deviation as a regression.
 
-| Case                             | HTTP | Body shape                                               |
-| -------------------------------- | ---- | -------------------------------------------------------- |
-| Unknown agent id                 | 404  | `{ error: "Agent with id <id> not found" }` (or similar) |
-| Unknown tool id                  | 404  | `{ error: "Tool not found" }`                            |
-| Unknown workflow id              | 404  | `{ error: "Workflow not found" }`                        |
-| Workflow missing required input  | 500  | `{ error: "Invalid input data: <field> expected ..." }`  |
-| Tool missing required input      | 200  | `{ error: true, validationErrors: { ... } }`             |
-| Invalid JSON body                | 400  | `{ error: "..." }` (Hono body parse failure)             |
+| Case                            | HTTP | Body shape                                               |
+| ------------------------------- | ---- | -------------------------------------------------------- |
+| Unknown agent id                | 404  | `{ error: "Agent with id <id> not found" }` (or similar) |
+| Unknown tool id                 | 404  | `{ error: "Tool not found" }`                            |
+| Unknown workflow id             | 404  | `{ error: "Workflow not found" }`                        |
+| Workflow missing required input | 500  | `{ error: "Invalid input data: <field> expected ..." }`  |
+| Tool missing required input     | 200  | `{ error: true, validationErrors: { ... } }`             |
+| Invalid JSON body               | 400  | `{ error: "..." }` (Hono body parse failure)             |
 
 **Known inconsistencies** (document if you observe, don't treat as
 failures unless they change):

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
       "lodash@<=4.17.23": "^4.18.0",
       "prismjs@<1.30.0": "^1.30.0",
       "serialize-javascript@<7.0.5": "^7.0.5",
-      "@tootallnate/once@<3.0.1": "^3.0.1"
+      "@tootallnate/once@<3.0.1": "^3.0.1",
+      "@vercel/oidc": "3.1.0"
     },
     "patchedDependencies": {
       "@changesets/get-dependents-graph": "patches/@changesets__get-dependents-graph.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,7 @@ overrides:
   prismjs@<1.30.0: ^1.30.0
   serialize-javascript@<7.0.5: ^7.0.5
   '@tootallnate/once@<3.0.1': ^3.0.1
+  '@vercel/oidc': 3.1.0
 
 patchedDependencies:
   '@changesets/get-dependents-graph':
@@ -15993,10 +15994,6 @@ packages:
       '@aws-sdk/credential-provider-web-identity':
         optional: true
 
-  '@vercel/oidc@3.0.5':
-    resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
-    engines: {node: '>= 20'}
-
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
@@ -26038,7 +26035,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.17(zod@4.3.6)
-      '@vercel/oidc': 3.0.5
+      '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
   '@ai-sdk/gateway@2.0.35(zod@4.3.6)':
@@ -37401,8 +37398,6 @@ snapshots:
   '@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.32)':
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.32
-
-  '@vercel/oidc@3.0.5': {}
 
   '@vercel/oidc@3.1.0': {}
 


### PR DESCRIPTION
## What

Pin `@vercel/oidc` to `3.1.0` via `pnpm.overrides` in the root `package.json`.

## Why

Lockfile maintenance PR #15598 bumped `@vercel/oidc` from 3.1.0 → 3.2.0. Version 3.2.0 changed its bundled output in a way that interacts badly with esbuild's CJS-in-ESM inlining: `require("path")` calls inside the package get wrapped in `__require` stubs during tsup bundling of `@internal/ai-v6` (where `@vercel/oidc` is pulled in transitively via `@ai-sdk/gateway`), and those stubs throw `Dynamic require of "path" is not supported` at runtime.

This broke create-mastra E2E tests starting around 01:14 UTC on Apr 22, immediately after #15598 merged.

Version 3.1.0 was used in the repo for ~2.5 months without issue.

## How

Added a pnpm override: `"@vercel/oidc": "3.1.0"`. Lockfile regenerated — all references now resolve to 3.1.0.

## Follow-up

A proper fix (externalize `@vercel/oidc` in `@internal/ai-v6` and `@mastra/core` tsup configs plus the deployer's rollup externals) should follow so future 3.2.x+ bumps don't re-trigger this. Tracking separately.

## Test plan

- [x] Lockfile regenerated cleanly with `pnpm install --lockfile-only`
- [x] All `@vercel/oidc` entries in `pnpm-lock.yaml` pinned to 3.1.0
- [ ] E2E create-mastra passes in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes broken end-to-end tests by forcing a problematic package back to the previous working version. A recent upgrade of @vercel/oidc to 3.2.0 caused bundling/runtime errors, so we pin it to 3.1.0 to restore stability.

## Changes

- Added "pnpm.overrides": { "@vercel/oidc": "3.1.0" } to the root package.json.
- Regenerated pnpm-lock.yaml so all references to @vercel/oidc resolve to 3.1.0.
- Minor documentation formatting tweak in .claude/skills/mastra-smoke-test/references/tests/errors.md (table spacing).

## Motivation

A lockfile maintenance PR upgraded @vercel/oidc from 3.1.0 → 3.2.0. Version 3.2.0 changed its bundled output such that esbuild's CJS-in-ESM inlining produces __require stubs around require("path") during tsup bundling of @internal/ai-v6 (transitively pulled in via @ai-sdk/gateway). Those stubs throw "Dynamic require of \"path\" is not supported" at runtime, causing create-mastra E2E tests to fail starting ~2026-04-22T01:14Z. 3.1.0 was previously used without issue for ~2.5 months.

## Test plan

- Lockfile regenerated with pnpm install --lockfile-only (checked).
- Verified all @vercel/oidc entries in pnpm-lock.yaml point to 3.1.0 (checked).
- E2E create-mastra CI run pending to confirm fix.

## Follow-up

Plan to externalize @vercel/oidc in tsup configs for @internal/ai-v6 and @mastra/core and add deployer rollup externals to prevent regressions from future 3.2.x+ releases; tracked separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->