### PR TITLE
fix(core): pin @vercel/oidc to 3.1.0 as direct dependency

### DIFF
--- a/.changeset/pin-vercel-oidc-core.md
+++ b/.changeset/pin-vercel-oidc-core.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+fix(deps): pin @vercel/oidc to 3.1.0 in @mastra/core
+
+@vercel/oidc 3.2.0 ships a build that breaks when bundled as ESM from CJS
+(emits `__require("path")` stubs that throw "Dynamic require of path is not
+supported" at runtime). Declaring @vercel/oidc as a direct, exact-version
+dependency of @mastra/core forces downstream installs to resolve 3.1.0,
+unblocking E2E and consumer projects.

--- a/package.json
+++ b/package.json
@@ -119,8 +119,7 @@
       "lodash@<=4.17.23": "^4.18.0",
       "prismjs@<1.30.0": "^1.30.0",
       "serialize-javascript@<7.0.5": "^7.0.5",
-      "@tootallnate/once@<3.0.1": "^3.0.1",
-      "@vercel/oidc": "3.1.0"
+      "@tootallnate/once@<3.0.1": "^3.0.1"
     },
     "patchedDependencies": {
       "@changesets/get-dependents-graph": "patches/@changesets__get-dependents-graph.patch",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -257,7 +257,8 @@
     "picomatch": "^4.0.3",
     "radash": "^12.1.1",
     "ws": "^8.20.0",
-    "xxhash-wasm": "^1.1.0"
+    "xxhash-wasm": "^1.1.0",
+    "@vercel/oidc": "3.1.0"
   },
   "peerDependencies": {
     "zod": "^3.25.0 || ^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,6 @@ overrides:
   prismjs@<1.30.0: ^1.30.0
   serialize-javascript@<7.0.5: ^7.0.5
   '@tootallnate/once@<3.0.1': ^3.0.1
-  '@vercel/oidc': 3.1.0
 
 patchedDependencies:
   '@changesets/get-dependents-graph':
@@ -2303,7 +2302,7 @@ importers:
     dependencies:
       '@vitest/eslint-plugin':
         specifier: ^1.6.16
-        version: 1.6.16(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.4)
+        version: 1.6.16(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.5)
       eslint-plugin-import-x:
         specifier: ^4.16.2
         version: 4.16.2(@typescript-eslint/utils@8.58.2(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))
@@ -2328,10 +2327,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.5)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.5)
 
   packages/_external-types:
     dependencies:
@@ -2493,10 +2492,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.5)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.5)
 
   packages/_vendored/ai_v4:
     dependencies:
@@ -2530,10 +2529,10 @@ importers:
         version: 7.0.15
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.5)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.5)
       ai:
         specifier: ^4.3.19
         version: 4.3.19(react@19.2.5)(zod@3.25.76)
@@ -2587,10 +2586,10 @@ importers:
         version: 7.0.15
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.5)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.5)
       ai:
         specifier: ^5.0.154
         version: 5.0.179(zod@4.3.6)
@@ -2651,10 +2650,10 @@ importers:
         version: 7.0.15
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.5)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.4(vitest@4.1.5)
       ai:
         specifier: ^6.0.116
         version: 6.0.168(zod@3.25.76)
@@ -3034,6 +3033,9 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
+      '@vercel/oidc':
+        specifier: 3.1.0
+        version: 3.1.0
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -15994,6 +15996,10 @@ packages:
       '@aws-sdk/credential-provider-web-identity':
         optional: true
 
+  '@vercel/oidc@3.0.5':
+    resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
+    engines: {node: '>= 20'}
+
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
@@ -26035,7 +26041,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.17(zod@4.3.6)
-      '@vercel/oidc': 3.1.0
+      '@vercel/oidc': 3.0.5
       zod: 4.3.6
 
   '@ai-sdk/gateway@2.0.35(zod@4.3.6)':
@@ -37399,6 +37405,8 @@ snapshots:
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.32
 
+  '@vercel/oidc@3.0.5': {}
+
   '@vercel/oidc@3.1.0': {}
 
   '@vercel/oidc@3.2.0': {}
@@ -37600,7 +37608,7 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.4)':
+  '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/utils': 8.58.2(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
@@ -37608,7 +37616,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

`@vercel/oidc` 3.2.0 ships a build that esbuild cannot safely re-bundle as ESM — it emits `__require("path")` stubs that throw `Dynamic require of "path" is not supported` at runtime. This breaks E2E tests and any consumer project that installs `@mastra/core`.

The previous override-based fix (#15601) only pinned `@vercel/oidc` within this monorepo's own lockfile. Consumer installs (and our E2E temp projects) resolve `@vercel/oidc` independently via `@ai-sdk/gateway`'s transitive dep, so they still picked up 3.2.0.

## Fix

- Add `@vercel/oidc` as a direct, exact-version (`3.1.0`) dependency of `@mastra/core` so downstream installs resolve 3.1.0 alongside core.
- Remove the monorepo-only `pnpm.overrides` entry that didn't affect consumers.

## Test plan

- Local `pnpm install` + `pnpm build:lib` on `@mastra/core` ✅
- E2E `no-bundling` (which was failing with the override) should now resolve 3.1.0 in the generated project's install and start cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

A newer version of a library called `@vercel/oidc` (version 3.2.0) breaks when bundled with the Mastra project, so this PR locks the @mastra/core package to use an older working version (3.1.0) instead. By making this version requirement explicit in @mastra/core's own dependencies, anyone who installs Mastra will automatically get the working version, just like specifying which toy goes with which toy set.

## Changes

- **`.changeset/pin-vercel-oidc-core.md`** (new file): Added a changeset entry documenting this patch-level fix for @mastra/core
- **`package.json`**: Removed the monorepo-only `pnpm.overrides` entry for `@vercel/oidc`, which was ineffective for downstream consumers
- **`packages/core/package.json`**: Added `@vercel/oidc@3.1.0` as a direct runtime dependency, ensuring all downstream installations resolve the working version

## Context

The root cause: @vercel/oidc 3.2.0 contains build artifacts that esbuild cannot safely re-bundle, emitting dynamic require stubs (`__require("path")`) that fail at runtime. While a prior monorepo-only override partially addressed the issue, it did not affect consumers installing @mastra/core as a dependency, since transitive resolution could still pull in the broken 3.2.0 through @ai-sdk/gateway. Making @vercel/oidc a direct dependency ensures all downstream projects—E2E test scenarios and consumer applications alike—receive the compatible 3.1.0 version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->