### PR TITLE
chore(docs): Update Mastra Code

### DIFF
--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -219,8 +219,10 @@ Define reusable prompt templates as markdown files. Mastra Code scans these dire
 | - | - | - |
 | Highest | `.mastracode/commands/` | Project |
 | | `.claude/commands/` | Project (Claude Code compatible) |
+| | `.opencode/command/` | Project (Opencode compatible) |
 | | `~/.mastracode/commands/` | Global |
-| Lowest | `~/.claude/commands/` | Global (Claude Code compatible) |
+| | `~/.claude/commands/` | Global (Claude Code compatible) |
+| Lowest | `~/.opencode/command/` | Global (Opencode compatible) |
 
 Each command file can include YAML frontmatter with `name` and `description` fields:
 

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -13,6 +13,12 @@ Mastra Code is configured through project-level files, global settings, and envi
 
 Mastra Code supports two authentication methods: **API keys** (environment variables) and **OAuth** (provider subscriptions). You can use either or both.
 
+:::note
+
+Use the `/setup` command to interactively configure authentication and models.
+
+:::
+
 ### API keys
 
 The simplest way to get started is to set API key environment variables for the providers you want to use. Mastra Code auto-detects these on startup:
@@ -296,7 +302,7 @@ Configure the scope through:
 
 ### OM model settings
 
-The observer and reflector models default to `google/gemini-2.5-flash`. Override them per-thread through the `/settings` panel or in the harness state.
+The observer and reflector models default to `google/gemini-2.5-flash`. Set them through the `/om` panel or in the harness state.
 
 ### OM thresholds
 
@@ -311,9 +317,9 @@ Mastra Code detects your terminal's color scheme and applies a matching dark or 
 
 ### Detection order
 
-1. `MASTRA_THEME` environment variable — explicit `dark` or `light`
+1. `MASTRA_THEME` environment variable: explicit `dark` or `light`
 1. Persisted setting from `/theme` command (stored in `settings.json`)
-1. OSC 11 query — asks your terminal for its actual background color
+1. OSC 11 query: asks your terminal for its actual background color
 1. `COLORFGBG` environment variable (set by some terminals like iTerm2 and Konsole)
 1. Falls back to dark theme
 

--- a/docs/src/mastra-code/customization.mdx
+++ b/docs/src/mastra-code/customization.mdx
@@ -66,7 +66,7 @@ const { harness } = createMastraCode({
     {
       id: 'build',
       name: 'Build',
-      defaultModelId: 'anthropic/claude-opus-4-6',
+      defaultModelId: 'anthropic/claude-opus-4-7',
       color: '#7c3aed',
       agent: reviewAgent,
     },

--- a/docs/src/mastra-code/customization.mdx
+++ b/docs/src/mastra-code/customization.mdx
@@ -16,7 +16,7 @@ Import `createMastraCode` to bootstrap Mastra Code in your own application:
 ```typescript title="src/custom-agent.ts"
 import { createMastraCode } from 'mastracode'
 
-const { harness, mcpManager, authStorage } = createMastraCode({
+const { harness, mcpManager, authStorage } = await createMastraCode({
   cwd: '/path/to/project',
   initialState: {
     yolo: false,
@@ -53,7 +53,7 @@ const reviewAgent = new Agent({
   model: 'anthropic/claude-sonnet-4-6',
 })
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   modes: [
     {
       id: 'review',
@@ -96,7 +96,7 @@ const deployTool = createTool({
   },
 })
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   extraTools: { deploy: deployTool },
 })
 ```
@@ -111,7 +111,7 @@ Override the default Explore/Plan/Execute subagents. Each subagent receives its 
 import { createMastraCode } from 'mastracode'
 import { createTool } from '@mastra/core/tools'
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   subagents: [
     {
       id: 'explore',
@@ -138,7 +138,7 @@ Connect to a remote database instead of the default local SQLite:
 ```typescript title="src/custom-storage.ts"
 import { createMastraCode } from 'mastracode'
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   storage: {
     url: 'libsql://my-db.turso.io',
     authToken: 'my-auth-token',
@@ -155,7 +155,7 @@ Replace or extend the default background tasks:
 ```typescript title="src/custom-heartbeats.ts"
 import { createMastraCode } from 'mastracode'
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   heartbeatHandlers: [
     {
       id: 'sync-config',
@@ -201,7 +201,7 @@ Control default behavior through `initialState`:
 ```typescript title="src/custom-state.ts"
 import { createMastraCode } from 'mastracode'
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   initialState: {
     yolo: false,
     thinkingLevel: 'high',

--- a/docs/src/mastra-code/index.mdx
+++ b/docs/src/mastra-code/index.mdx
@@ -60,7 +60,7 @@ Mastra Code requires Node.js 22.13.0 or later.
 
     By default, Mastra Code uses `google/gemini-2.5-flash` for its Observational Memory models. In the next step, you can choose a different model or continue using Gemini Flash. You can later switch this setting with the `/om` command.
 
-    In the last step, choose whether you want to run in "YOLO" mode or not. You're not all set up with Mastra Code!
+    In the last step, choose whether you want to run in "YOLO" mode or not. You're all set up with Mastra Code!
   </StepItem>
 
   <StepItem>

--- a/docs/src/mastra-code/index.mdx
+++ b/docs/src/mastra-code/index.mdx
@@ -7,7 +7,7 @@ packages:
 
 # Mastra Code
 
-Mastra Code is a terminal-based AI coding agent built on Mastra's [Harness](https://mastra.ai/reference/harness/harness-class), [Agent](https://mastra.ai/docs/agents/overview), and [Memory](https://mastra.ai/docs/memory/overview) primitives. It runs in your terminal, connects to 70+ AI models, and provides tools for reading, searching, editing, and executing code.
+Mastra Code is a terminal-based AI coding agent built on Mastra's [Harness](https://mastra.ai/reference/harness/harness-class), [Agent](https://mastra.ai/docs/agents/overview), and [Memory](https://mastra.ai/docs/memory/overview) primitives. It runs in your terminal, connects to thousands of AI models, and provides tools for reading, searching, editing, and executing code.
 
 Mastra Code organizes its capabilities around these areas:
 
@@ -54,9 +54,13 @@ Mastra Code requires Node.js 22.13.0 or later.
   </StepItem>
 
   <StepItem>
-    Set an API key for your preferred provider (e.g. `export ANTHROPIC_API_KEY=sk-ant-...`), or run `/login` to
-    authenticate with an Anthropic or OpenAI subscription. See
-    [Configuration](/configuration#authentication) for all supported providers.
+    On your first startup, Mastra Code starts an onboarding wizard to help you connect and choose your models. You can always rerun this with the `/setup` command.
+
+    In the first step, log in to Anthropic or OpenAI through OAuth. Alternatively, skip this step to later authenticate with an API key. Next, choose models for each mode (you can later switch models with `/models`). When you select a model from the model selector that doesn't have an API key configured, Mastra Code prompts you to enter one.
+
+    By default, Mastra Code uses `google/gemini-2.5-flash` for its Observational Memory models. In the next step, you can choose a different model or continue using Gemini Flash. You can later switch this setting with the `/om` command.
+
+    In the last step, choose whether you want to run in "YOLO" mode or not. You're not all set up with Mastra Code!
   </StepItem>
 
   <StepItem>
@@ -73,15 +77,27 @@ Mastra Code provides built-in slash commands for managing sessions and settings:
 | `/new` | Start a new conversation thread |
 | `/clone` | Clone the current thread (with optional rename) |
 | `/threads` | List all threads for this project |
-| `/models` | Select a different AI model |
-| `/mode` | Switch between Build, Plan, and Fast modes |
-| `/cost` | Show token usage for the current conversation |
-| `/login` | Authenticate with OAuth providers |
-| `/logout` | Log out from a provider |
+| `/thread` | Show current thread info |
+| `/name` | Rename the current thread |
+| `/models` | Switch model pack |
+| `/mode` | Switch or list modes |
+| `/permissions` | Configure tool approval permissions |
 | `/settings` | Open the settings panel |
-| `/theme` | Switch color theme (auto, dark, or light) |
-| `/sandbox` | Add external directories to the allowed path list |
-| `/diff` | Show files modified in the current session |
+| `/om` | Configure Observational Memory |
+| `/skills` | List available skills |
+| `/cost` | Show token usage and costs |
+| `/diff` | Show modified files or git diff |
+| `/sandbox` | Manage sandbox allowed paths |
+| `/review` | Review a GitHub pull request |
+| `/report-issue` | Open or browse mastracode issues |
+| `/login` | Authenticate with OAuth provider |
+| `/logout` | Log out from an OAuth provider |
+| `/setup` | Run the setup wizard |
+| `/theme` | Switch color theme (auto/dark/light) |
+| `/browser` | Configure browser automation |
+| `/update` | Check for and install updates |
+| `/hooks` | Show/reload configured hooks |
+| `/mcp` | Show/reload MCP connections |
 | `/help` | Show available commands |
 | `/exit` | Exit the TUI |
 

--- a/docs/src/mastra-code/reference.mdx
+++ b/docs/src/mastra-code/reference.mdx
@@ -39,7 +39,7 @@ const {
 | `mcpManager` | `MCPManager` | Manager for MCP server connections |
 | `hookManager` | `HookManager` | Manager for lifecycle hooks |
 | `authStorage` | `AuthStorage` | Storage for OAuth credentials |
-| `resolveModel` | `(id: string) => LanguageModel` | Model resolution function |
+| `resolveModel` | `(modelId: string, options?: { thinkingLevel?: ThinkingLevel; remapForCodexOAuth?: boolean; requestContext?: RequestContext }) => ResolvedModel` | Model resolution function |
 | `storageWarning` | `string \| null` | Warning message if storage fallback occurred |
 | `builtinPacks` | `ModePack[]` | Built-in mode packs |
 | `builtinOmPacks` | `OmPack[]` | Built-in Observational Memory packs |
@@ -56,7 +56,7 @@ const {
 | `storage` | `StorageConfig` | Local LibSQL | Database configuration |
 | `initialState` | `Partial<MastraCodeState>` | Default state | Initial harness state values |
 | `heartbeatHandlers` | `HeartbeatHandler[]` | Default handlers | Background task definitions |
-| `resolveModel` | `(id: string) => LanguageModel` | Default resolver | Custom model resolution function |
+| `resolveModel` | `(modelId: string, options?: { thinkingLevel?: ThinkingLevel; remapForCodexOAuth?: boolean; requestContext?: RequestContext }) => ResolvedModel` | Default resolver | Custom model resolution function |
 
 #### `HarnessMode`
 
@@ -150,7 +150,7 @@ The `MastraTUI` class provides the terminal interface. Import it separately to b
 import { createMastraCode } from 'mastracode'
 import { MastraTUI } from 'mastracode/tui'
 
-const { harness, mcpManager, hookManager, authStorage } = createMastraCode()
+const { harness, mcpManager, hookManager, authStorage } = await createMastraCode()
 
 const tui = new MastraTUI({
   harness,
@@ -182,7 +182,7 @@ tui.run()
 ```typescript
 import { createMastraCode } from 'mastracode'
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   cwd: '/path/to/project',
 })
 
@@ -211,7 +211,7 @@ const reviewAgent = new Agent({
   model: 'anthropic/claude-sonnet-4-6',
 })
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   modes: [
     {
       id: 'review',
@@ -244,7 +244,7 @@ const deployTool = createTool({
   },
 })
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   extraTools: { deploy: deployTool },
 })
 ```
@@ -254,7 +254,7 @@ const { harness } = createMastraCode({
 ```typescript
 import { createMastraCode } from 'mastracode'
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   storage: {
     url: 'libsql://my-db.turso.io',
     authToken: process.env.TURSO_AUTH_TOKEN,
@@ -267,7 +267,7 @@ const { harness } = createMastraCode({
 ```typescript
 import { createMastraCode } from 'mastracode'
 
-const { harness } = createMastraCode({
+const { harness } = await createMastraCode({
   initialState: {
     yolo: false,
     permissionRules: {

--- a/docs/src/mastra-code/reference.mdx
+++ b/docs/src/mastra-code/reference.mdx
@@ -12,7 +12,17 @@ The `createMastraCode()` factory function bootstraps Mastra Code and returns a c
 ```typescript
 import { createMastraCode } from 'mastracode'
 
-const { harness, mcpManager, hookManager, authStorage } = createMastraCode(options)
+const {
+  harness,
+  mcpManager,
+  hookManager,
+  authStorage,
+  resolveModel,
+  storageWarning,
+  builtinPacks,
+  builtinOmPacks,
+  effectiveDefaults,
+} = createMastraCode(options)
 ```
 
 ### Parameters
@@ -29,6 +39,11 @@ const { harness, mcpManager, hookManager, authStorage } = createMastraCode(optio
 | `mcpManager` | `MCPManager` | Manager for MCP server connections |
 | `hookManager` | `HookManager` | Manager for lifecycle hooks |
 | `authStorage` | `AuthStorage` | Storage for OAuth credentials |
+| `resolveModel` | `(id: string) => LanguageModel` | Model resolution function |
+| `storageWarning` | `string \| null` | Warning message if storage fallback occurred |
+| `builtinPacks` | `ModePack[]` | Built-in mode packs |
+| `builtinOmPacks` | `OmPack[]` | Built-in Observational Memory packs |
+| `effectiveDefaults` | `object` | Effective default settings after merging |
 
 ### `CreateMastraCodeOptions`
 
@@ -88,7 +103,7 @@ Harness state fields available through `initialState`.
 | Field | Type | Default | Description |
 | - | - | - | - |
 | `yolo` | `boolean` | `true` | Auto-approve all tool calls |
-| `thinkingLevel` | `"off" \| "low" \| "medium" \| "high"` | `"off"` | Extended thinking depth for Anthropic models |
+| `thinkingLevel` | `"off" \| "low" \| "medium" \| "high" \| "xhigh"` | `"off"` | Extended thinking depth for Anthropic models |
 | `smartEditing` | `boolean` | `true` | Use AST-based analysis for code edits |
 | `notifications` | `"bell" \| "system" \| "both" \| "off"` | `"off"` | Alert style when TUI needs attention |
 | `permissionRules` | `PermissionRules` | Default policies | Per-category and per-tool approval policies |

--- a/docs/src/mastra-code/reference.mdx
+++ b/docs/src/mastra-code/reference.mdx
@@ -102,7 +102,7 @@ Harness state fields available through `initialState`.
 
 | Field | Type | Default | Description |
 | - | - | - | - |
-| `yolo` | `boolean` | `true` | Auto-approve all tool calls |
+| `yolo` | `boolean` | `false` | Auto-approve all tool calls |
 | `thinkingLevel` | `"off" \| "low" \| "medium" \| "high" \| "xhigh"` | `"off"` | Extended thinking depth for Anthropic models |
 | `smartEditing` | `boolean` | `true` | Use AST-based analysis for code edits |
 | `notifications` | `"bell" \| "system" \| "both" \| "off"` | `"off"` | Alert style when TUI needs attention |

--- a/docs/src/mastra-code/tools.mdx
+++ b/docs/src/mastra-code/tools.mdx
@@ -17,31 +17,33 @@ Read file contents with line numbers or list directory contents. The agent uses 
 
 - Displays line-numbered output (like `cat -n`) for easy reference.
 - For directories, lists files up to 2 levels deep, excluding hidden items.
-- Supports `view_range` to read specific line ranges in large files.
-- Output is truncated if the file exceeds the token limit. Use `view_range` to read specific sections.
+- Supports `offset` and `limit` to read specific line ranges in large files.
+- Output is truncated if the file exceeds the token limit. Use `offset` and `limit` to read specific sections.
 
 | Parameter | Type | Required | Description |
 | - | - | - | - |
-| `path` | `string` | Yes | Path to the file or directory (relative to project root) |
-| `view_range` | `[number, number]` | No | Line range `[start, end]` to view a section of the file |
+| `path` | `string` | Yes | Path to the file or directory |
+| `encoding` | `string` | No | Encoding to use (default: `utf-8`). Options: `utf-8`, `utf8`, `base64`, `hex`, `binary` |
+| `offset` | `number` | No | Line number to start reading from (1-indexed) |
+| `limit` | `number` | No | Maximum number of lines to read |
+| `showLineNumbers` | `boolean` | No | Whether to prefix each line with its line number (default: `true`) |
 
 ### `string_replace_lsp`
 
 Edit a file by replacing an exact text match with new content. Returns Language Server Protocol (LSP) diagnostics showing any errors or warnings introduced by the edit.
 
 - The agent reads the file first with `view` before editing.
-- `old_str` must be an exact substring of the current file content.
+- `old_string` must be an exact substring of the current file content.
 - Include enough surrounding context to uniquely identify the replacement location.
-- When `new_str` is omitted or empty, the matched text is deleted.
+- Use `replace_all` only when intentionally replacing all occurrences.
 - After editing, TypeScript errors, linting warnings, and other diagnostics are returned automatically.
-- Relative `path` values are resolved against the project root.
 
 | Parameter | Type | Required | Description |
 | - | - | - | - |
-| `path` | `string` | Yes | Path to the file (relative to project root) |
-| `old_str` | `string` | Yes | Exact text to find and replace |
-| `new_str` | `string` | No | Replacement text (omit to delete the matched text) |
-| `start_line` | `number` | No | Line number to narrow the search region |
+| `path` | `string` | Yes | Path to the file |
+| `old_string` | `string` | Yes | Exact text to find and replace. Must be unique in the file |
+| `new_string` | `string` | Yes | Text to replace `old_string` with |
+| `replace_all` | `boolean` | No | If true, replace all occurrences. If false (default), `old_string` must be unique |
 
 ### `ast_smart_edit`
 
@@ -51,20 +53,17 @@ Supported transformations:
 
 - **Pattern-based search and replace**: Find and replace code using AST patterns with `$VARIABLE` placeholders (e.g., replace `console.log($ARG)` with `logger.debug($ARG)`).
 - **Add/remove imports**: Intelligently insert or remove import statements.
-- **Rename functions**: Rename function declarations and all call sites with scope awareness.
-- **Rename variables**: Rename variable declarations and all references.
-- **Selector queries**: Find AST nodes matching a CSS-like selector (e.g., `"FunctionDeclaration"`).
+- **Rename**: Rename all occurrences of an identifier (not scope-aware).
 
 | Parameter | Type | Required | Description |
 | - | - | - | - |
-| `path` | `string` | Yes | File path relative to project root |
+| `path` | `string` | Yes | File path to edit |
 | `pattern` | `string` | No | AST pattern to search for (supports `$VARIABLE` placeholders) |
 | `replacement` | `string` | No | Replacement pattern (can use captured `$VARIABLES`) |
-| `selector` | `string` | No | CSS-like selector for AST nodes |
-| `transform` | `string` | No | Transformation type: `add-import`, `remove-import`, `rename-function`, `rename-variable`, `extract-function`, `inline-variable` |
-| `targetName` | `string` | No | Name of the target element (for rename/remove operations) |
-| `newName` | `string` | No | New name (for rename operations) |
-| `importSpec` | `object` | No | Import specification for `add-import`: `{ module, names, isDefault? }` |
+| `transform` | `string` | No | Transformation type: `add-import`, `remove-import`, `rename` |
+| `targetName` | `string` | No | Required for `remove-import` and `rename`. The current name to target |
+| `newName` | `string` | No | Required for `rename`. The new name to replace `targetName` with |
+| `importSpec` | `object` | No | Required for `add-import`. Specifies the module and names to import: `{ module, names, isDefault? }` |
 
 ### `write_file`
 
@@ -83,33 +82,41 @@ Create a new file or overwrite an existing file entirely.
 
 ### `search_content`
 
-Search file contents using regular expressions. Uses ripgrep when available, falling back to grep.
+Search file contents using regular expressions. Walks the filesystem and returns matching lines with file paths and line numbers.
 
 - Supports full regex syntax (e.g., `"function\\s+\\w+"`, `"import.*from"`).
+- The `path` parameter accepts a plain path (file or directory) or a glob pattern (e.g., `"**/*.ts"`).
 - Respects `.gitignore` automatically in Git repositories.
 - Always preferred over running `grep` or `rg` via `execute_command`.
 
 | Parameter | Type | Required | Description |
 | - | - | - | - |
-| `pattern` | `string` | Yes | Regex pattern to search for in file contents |
-| `path` | `string` | No | Directory or file to search in (relative to project root, defaults to project root) |
-| `glob` | `string` | No | Glob pattern to filter files (e.g., `"*.ts"`, `"*.{js,jsx}"`, `"test/**"`) |
+| `pattern` | `string` | Yes | Regex pattern to search for |
+| `path` | `string` | No | File, directory, or glob pattern to search within (default: `"."`) |
 | `contextLines` | `number` | No | Number of lines to show before and after each match (default: 0) |
-| `maxResults` | `number` | No | Maximum number of matching lines to return (default: 100) |
-| `caseSensitive` | `boolean` | No | Whether the search is case-sensitive (default: true) |
+| `maxCount` | `number` | No | Maximum matches per file (similar to `grep -m`) |
+| `caseSensitive` | `boolean` | No | Whether the search is case-sensitive (default: `true`) |
+| `includeHidden` | `boolean` | No | Include hidden files and directories (default: `false`) |
 
 ### `find_files`
 
-Find files by name pattern using glob matching. Results are sorted by modification time (most recent first).
+List files and directories in the workspace filesystem. Returns a tree-style output that respects `.gitignore`.
 
 - Supports standard glob syntax: `*` (any characters), `**` (any path segments), `?` (single character), `{a,b}` (alternatives).
 - Respects `.gitignore` automatically in Git repositories.
 - Always preferred over running `find` or `ls` via `execute_command`.
+- Omit the `pattern` parameter to list all files — do not pass `pattern: "*"`.
 
 | Parameter | Type | Required | Description |
 | - | - | - | - |
-| `pattern` | `string` | Yes | Glob pattern (e.g., `"**/*.ts"`, `"src/**/*.test.*"`, `"**/package.json"`) |
-| `path` | `string` | No | Directory to search in (relative to project root, defaults to project root) |
+| `path` | `string` | No | Directory path to list (default: `"."`) |
+| `maxDepth` | `number` | No | Maximum depth to descend (default: 2). Similar to `tree -L` |
+| `showHidden` | `boolean` | No | Show hidden files starting with `.` (default: `false`). Similar to `tree -a` |
+| `dirsOnly` | `boolean` | No | List directories only (default: `false`). Similar to `tree -d` |
+| `exclude` | `string` | No | Pattern to exclude (e.g., `"node_modules"`). Similar to `tree -I` |
+| `extension` | `string` | No | Filter by file extension (e.g., `".ts"`). Similar to `tree -P` |
+| `pattern` | `string` or `string[]` | No | Glob pattern(s) to filter files (e.g., `"**/*.ts"`) |
+| `respectGitignore` | `boolean` | No | Respect `.gitignore` in the listed directory (default: `true`) |
 
 ## Shell execution
 


### PR DESCRIPTION
## Description

Make the Mastra Code setup more obvious.

## Related Issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/15609

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR updates Mastra Code's user documentation and examples to make the initial setup, authentication, and model-selection flows obvious and to ensure configured model packs are used instead of requiring a hardcoded Google API key.

---

## Key changes (high-level)
- Prominently recommends running the interactive /setup onboarding (OAuth-first, API-key fallback) so users configure authentication and per-mode models.
- Clarifies that Mastra Code should use configured model packs for memory/requests, addressing the issue where GOOGLE_GENERATIVE_AI_API_KEY was being required when a full pack is configured (fixes #15609).
- Updates documented defaults/state: MastraCodeState.yolo default changed true → false; thinkingLevel adds "xhigh".
- Adds/renames many slash commands and adjusts descriptions to match the onboarding and permission semantics (notable: /setup, /om, /models, /mode, /permissions, /thread, /review, /report-issue, /diff, /sandbox, /mcp, etc.).
- Revises multiple tool parameter contracts and behaviors (view, string_replace_lsp, ast_smart_edit, search_content, find_files).
- Small example and wording updates (async createMastraCode usage, Build mode default model updated to anthropic/claude-opus-4-7, theme detection wording).

---

## Documentation updates by file

- docs/src/mastra-code/configuration.mdx
  - Added instruction to run /setup for interactive auth and model config.
  - Documented Opencode-compatible global/project command dirs (~/.opencode/command/, .opencode/command/).
  - Reference to OM config updated to use the /om panel.
  - Minor theme-detection wording/format tweaks.

- docs/src/mastra-code/customization.mdx
  - Example factory calls changed to use await createMastraCode(...).
  - Build mode example defaultModelId updated from anthropic/claude-opus-4-6 → anthropic/claude-opus-4-7.

- docs/src/mastra-code/index.mdx
  - Reworked onboarding text to an OAuth-first wizard with API-key fallback, per-mode model selection, and clearer flow for model/OM selection.
  - Documented default OM model as google/gemini-2.5-flash (switchable via /om).
  - Expanded and reorganized slash commands list and descriptions to match new semantics and capabilities (added/renamed commands; adjusted permission wording; added /setup).

- docs/src/mastra-code/reference.mdx
  - Documented additional createMastraCode() return properties (resolveModel, storageWarning, builtinPacks, builtinOmPacks, effectiveDefaults).
  - CreateMastraCodeOptions.resolveModel type expanded to accept options (thinkingLevel, remapForCodexOAuth, requestContext).
  - MastraCodeState.yolo default documented as false; thinkingLevel now includes "xhigh".
  - Examples updated to await createMastraCode() and destructure returned properties.

- docs/src/mastra-code/tools.mdx
  - view: view_range → offset/limit; added encoding and showLineNumbers.
  - string_replace_lsp: renamed parameters; removed implicit-delete behavior; added replace_all and clarified uniqueness semantics.
  - ast_smart_edit: removed scope-aware/selector-based renames; standardized transforms and made rename non-scope-aware (renames all occurrences).
  - search_content: implementation description changed to filesystem walk; path accepts globs; maxResults → maxCount; added includeHidden.
  - find_files: changed to tree-style listing respecting .gitignore; pattern now optional; added maxDepth, showHidden, dirsOnly, exclude, extension, respectGitignore.

---

## Other notes
- Documentation-only changes (no exported/public code modified).
- Addresses Issue #15609 by instructing interactive setup and documenting that configured model packs are used for memory/requests, removing the expectation of GOOGLE_GENERATIVE_AI_API_KEY when a full pack is present.
- Files changed: docs/src/mastra-code/configuration.mdx, customization.mdx, index.mdx, reference.mdx, tools.mdx. Total lines changed across files per PR metadata: +94/-48. Estimated review effort: Medium.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->