### PR TITLE
fix(cli): Hide internal log on dev

### DIFF
--- a/.changeset/small-otters-take.md
+++ b/.changeset/small-otters-take.md
@@ -1,0 +1,6 @@
+---
+'@mastra/agent-builder': patch
+'mastra': patch
+---
+
+Hide internal log during `mastra dev` startup (that was previously already hidden but got exposed again by a recent change)

--- a/packages/agent-builder/src/defaults.ts
+++ b/packages/agent-builder/src/defaults.ts
@@ -1243,7 +1243,7 @@ export const mastra = new Mastra({
           const lines = output.split('\n').filter((line: string) => line.trim());
           stdoutLines.push(...lines);
 
-          if (output.includes('Mastra API running on ')) {
+          if (output.includes('Mastra API running')) {
             clearTimeout(timeout);
             resolve({
               success: true,

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -165,11 +165,7 @@ const startServer = async (
     if (currentServerProcess.stdout) {
       currentServerProcess.stdout.on('data', (data: Buffer) => {
         const output = data.toString();
-        if (
-          !output.includes('Studio available') &&
-          !output.includes('👨‍💻') &&
-          !output.includes('Mastra API running on ')
-        ) {
+        if (!output.includes('Studio available') && !output.includes('👨‍💻') && !output.includes('Mastra API running')) {
           process.stdout.write(output);
         }
       });
@@ -178,11 +174,7 @@ const startServer = async (
     if (currentServerProcess.stderr) {
       currentServerProcess.stderr.on('data', (data: Buffer) => {
         const output = data.toString();
-        if (
-          !output.includes('Studio available') &&
-          !output.includes('👨‍💻') &&
-          !output.includes('Mastra API running on ')
-        ) {
+        if (!output.includes('Studio available') && !output.includes('👨‍💻') && !output.includes('Mastra API running')) {
           process.stderr.write(output);
         }
       });


### PR DESCRIPTION
## Description

A recent commit changed `API Running on` to `API Running` which made these checks not work, leaking the log

Before/After:

<img width="1039" height="747" alt="image" src="https://github.com/user-attachments/assets/2708b9f1-9b30-4ee4-8afc-bfdcde6f5525" />

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR hides an internal log message that appears when starting the Mastra development server. A recent change made the log filter too specific, which caused the log to start showing up again when it shouldn't. This PR broadens the filter to catch the log message and hide it like it's supposed to.

## Overview

This patch release addresses a logging issue in the `mastra dev` command where internal server startup logs were being exposed to users. The fix simplifies log filtering by matching a broader substring pattern to ensure these internal messages are properly hidden from the CLI output.

## Changes

**packages/cli/src/commands/dev/dev.ts**
- Broadened the log filtering condition for both stdout and stderr handlers
- Changed substring match from `"Mastra API running on "` to `"Mastra API running"`
- This ensures internal server startup logs are filtered out regardless of the specific URL format
- Maintains filtering of other internal messages like `"Studio available"` and `"👨‍💻"`

**packages/agent-builder/src/defaults.ts**
- Updated server startup detection logic to resolve when output contains `"Mastra API running"` instead of `"Mastra API running on "`
- Makes the startup signal detection consistent with the broader filtering approach

**.changeset/small-otters-take.md**
- Documents this as a patch release for both `@mastra/agent-builder` and `mastra`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->