### PR TITLE
fix(playground): use local vendor copy for trace status

### DIFF
--- a/.changeset/fix-playground-trace-import.md
+++ b/.changeset/fix-playground-trace-import.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground': patch
+---
+
+Fixed playground trace status to use a local vendor copy of `computeTraceStatus` instead of importing from `@mastra/core/storage`.

--- a/packages/playground/src/domains/traces/components/trace-keys-and-values.tsx
+++ b/packages/playground/src/domains/traces/components/trace-keys-and-values.tsx
@@ -1,4 +1,4 @@
-import { computeTraceStatus, TraceStatus } from '@mastra/core/storage';
+import { computeTraceStatus, TraceStatus } from '@internal-temp/core/index';
 import { DataKeysAndValues } from '@mastra/playground-ui';
 import { format } from 'date-fns';
 

--- a/packages/playground/src/vendor/@mastra/core/index.ts
+++ b/packages/playground/src/vendor/@mastra/core/index.ts
@@ -5,3 +5,15 @@ export enum TraceStatus {
   ERROR = 'error',
   RUNNING = 'running',
 }
+
+/**
+ * Computes the trace status from a root span's error and endedAt fields.
+ * - ERROR: if error is present (regardless of endedAt)
+ * - RUNNING: if endedAt is null/undefined and no error
+ * - SUCCESS: if endedAt is present and no error
+ */
+export function computeTraceStatus(span: { error?: unknown; endedAt?: Date | string | null }): TraceStatus {
+  if (span.error != null) return TraceStatus.ERROR;
+  if (span.endedAt == null) return TraceStatus.RUNNING;
+  return TraceStatus.SUCCESS;
+}


### PR DESCRIPTION
The playground was importing `computeTraceStatus` and `TraceStatus` directly from `@mastra/core/storage`. This switches to a local vendor copy that already existed in the playground, just needed the function added.

```diff
-import { computeTraceStatus, TraceStatus } from '@mastra/core/storage';
+import { computeTraceStatus, TraceStatus } from '@internal-temp/core/index';
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes the playground by making it use a copy of code that lives locally in the playground folder instead of trying to get it from somewhere else. Specifically, the playground needed a function to figure out the status of a trace (whether it's still running, finished successfully, or had an error), so now it uses a local copy of that function rather than importing it from a shared library.

## Changes

### Import Updates
- Updated `packages/playground/src/domains/traces/components/trace-keys-and-values.tsx` to import `computeTraceStatus` and `TraceStatus` from the local vendor path `@internal-temp/core/index` instead of from `@mastra/core/storage`.

### Local Vendor Addition
- Added the `computeTraceStatus` function to `packages/playground/src/vendor/@mastra/core/index.ts`. This function determines the status of a trace based on a root span's `error` and `endedAt` fields:
  - Returns `TraceStatus.ERROR` if the span has an error (takes precedence)
  - Returns `TraceStatus.RUNNING` if the span has no end date and no error
  - Returns `TraceStatus.SUCCESS` if the span has ended and has no error

### Release Documentation
- Added a changeset entry (`.changeset/fix-playground-trace-import.md`) documenting a patch version bump for `@mastra/playground` with the change description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->