### PR TITLE
fix(server): forward requestContext through approve/decline tool-call REST handlers

### DIFF
--- a/.changeset/fix-approve-tool-call-request-context.md
+++ b/.changeset/fix-approve-tool-call-request-context.md
@@ -1,0 +1,7 @@
+---
+'@mastra/server': patch
+---
+
+Forward `requestContext` from the `/approve-tool-call`, `/decline-tool-call`, `/approve-tool-call-generate` and `/decline-tool-call-generate` REST handlers to `agent.approveToolCall(...)` / `declineToolCall(...)` / `approveToolCallGenerate(...)` / `declineToolCallGenerate(...)`.
+
+Previously `requestContext` was destructured from the handler arguments but never passed through. On resume, `dynamicInstructions` ran with `requestContext: undefined`, so any value placed on the per-request `RequestContext` by upstream middleware (or by `body.requestContext` auto-merge) was lost for the rest of the turn. Agents whose prompt assembly depends on request-scoped data (e.g. read-only state from the frontend) produced blank or placeholder responses after the user approved a HITL tool call. Other agent entry points (`stream`, `generate`) already forwarded `requestContext` correctly; this brings the approval routes in line.

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -1453,6 +1453,7 @@ export const APPROVE_TOOL_CALL_ROUTE = createRoute({
 
       const streamResult = await agent.approveToolCall({
         ...params,
+        requestContext,
         abortSignal,
       });
 
@@ -1497,6 +1498,7 @@ export const DECLINE_TOOL_CALL_ROUTE = createRoute({
 
       const streamResult = await agent.declineToolCall({
         ...params,
+        requestContext,
         abortSignal,
       });
 
@@ -1540,6 +1542,7 @@ export const APPROVE_TOOL_CALL_GENERATE_ROUTE = createRoute({
 
       const result = await agent.approveToolCallGenerate({
         ...params,
+        requestContext,
         abortSignal,
       });
 
@@ -1583,6 +1586,7 @@ export const DECLINE_TOOL_CALL_GENERATE_ROUTE = createRoute({
 
       const result = await agent.declineToolCallGenerate({
         ...params,
+        requestContext,
         abortSignal,
       });
 


### PR DESCRIPTION
## Description

The four REST handlers in `packages/server/src/server/handlers/agents.ts`:

- `POST /agents/:agentId/approve-tool-call`
- `POST /agents/:agentId/decline-tool-call`
- `POST /agents/:agentId/approve-tool-call-generate`
- `POST /agents/:agentId/decline-tool-call-generate`

destructure `requestContext` from the handler args (to extract version options via `extractVersionOptions(requestContext)`) but never forward it to `agent.approveToolCall(...)` / `declineToolCall(...)` / their `*Generate` variants. Other agent entry points (`stream`, `generate`) pass `requestContext` through the options object; the approval routes diverge from that convention.

### Impact

On resume, `dynamicInstructions` runs with `requestContext: undefined`. Any value placed on the per-request `RequestContext` — whether by upstream middleware or via `body.requestContext` auto-merge — is lost for the rest of the turn. Agents whose prompt assembly depends on request-scoped data (for example, read-only state synced from the frontend) render blank or placeholder responses after the user approves a HITL tool call.

We observed this in production at [Colar.ai](https://colar.ai): 100% of approve-tool-call resumes were producing a placeholder system prompt (``"Agente X inicializando."``) because our `dynamicInstructions` falls back to that string when `readOnly` from `requestContext` is `null`. We shipped a pnpm patch adding `requestContext,` to each handler invocation as an interim fix, and this PR upstreams it.

### Fix

Add `requestContext` to the options object passed into the four agent methods (one-line change per handler, 4 handlers total).

```diff
 const streamResult = await agent.approveToolCall({
   ...params,
+  requestContext,
   abortSignal,
 });
```

…and the analogous change for `declineToolCall`, `approveToolCallGenerate`, `declineToolCallGenerate`.

## Related Issue(s)

None filed — opening this PR directly per the "Do you want to open a Pull Request" section of `CONTRIBUTING.md`. Happy to split out a bug report if maintainers prefer.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable) — no user-facing docs affected; `requestContext` is already documented as part of `AgentExecutionOptions`.
- [ ] I have added tests that prove my fix is effective or that my feature works — I did not find existing handler-level tests for these four routes in `packages/server`. Happy to add one if maintainers point me at the right harness / pattern to follow.
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When a user approves or declines a tool action, the server was dropping per-request information (like request-specific flags or middleware-provided data) before resuming the agent. This PR ensures that information is passed along so the agent continues the turn with the correct request context.

## Changes
- Forwarded `requestContext` into the options object for four REST handlers in packages/server/src/server/handlers/agents.ts:
  - POST /agents/:agentId/approve-tool-call
  - POST /agents/:agentId/decline-tool-call
  - POST /agents/:agentId/approve-tool-call-generate
  - POST /agents/:agentId/decline-tool-call-generate
- Each handler now calls the corresponding agent method with `{ ...params, requestContext, abortSignal }`.

## Problem Solved
Handlers previously destructured `requestContext` to compute version options but did not pass it to agent methods. That caused per-request RequestContext data to be lost during resume (e.g., dynamic instructions ran with `requestContext` undefined), leading to incorrect prompts in production (reported by Colar.ai).

## Implementation
One-line changes in each of the four handlers to include `requestContext` in the agent call arguments.

## Supporting Changes
Added a changeset entry for @mastra/server (patch) documenting the fix.

## Type
Bug fix
<!-- end of auto-generated comment: release notes by coderabbit.ai -->