### PR TITLE
fix(core): deduplicate all OpenAI itemIds to prevent 'Duplicate item found' errors

### DIFF
--- a/.changeset/fix-duplicate-openai-itemids.md
+++ b/.changeset/fix-duplicate-openai-itemids.md
@@ -1,0 +1,24 @@
+---
+"@mastra/core": patch
+---
+
+fix(core): deduplicate all OpenAI itemIds in message sanitization to prevent "Duplicate item found" errors
+
+Extends the existing text-part deduplication in `sanitizeV5UIMessages` to handle all part types
+(reasoning, tool-call, etc.) with OpenAI `providerMetadata.openai.itemId`. Previously, only text
+parts with duplicate `itemId` values were merged. Reasoning parts with duplicate `rs_*` IDs were
+passed through, causing OpenAI to reject requests with "Duplicate item found with id rs_...".
+
+This issue manifests when Observational Memory's async buffering is enabled, as the same response
+parts can appear multiple times in the message history — either within a single message (from merge
+operations) or across multiple non-merged assistant messages loaded from memory.
+
+The fix:
+1. Renames `mergeTextPartsWithDuplicateItemIds` → `deduplicatePartsWithOpenAIItemIds` to reflect
+   broader scope
+2. Text parts still merge by concatenating content (existing behavior)
+3. Non-text parts with duplicate itemIds keep only the first occurrence
+4. Adds cross-message deduplication via `globalSeenItemIds` to catch duplicates spanning
+   multiple assistant messages
+
+Fixes #15617

--- a/packages/core/src/agent/message-list/conversion/output-converter-duplicate-itemids.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-duplicate-itemids.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeV5UIMessages } from './output-converter';
+import type { UIMessage } from '@internal/ai-sdk-v5';
+
+/**
+ * Reproduces the "Duplicate item found with id rs_..." error from #15617.
+ *
+ * When Observational Memory's async buffering is enabled, reasoning parts with
+ * the same OpenAI itemId (rs_*) can appear in multiple assistant messages loaded
+ * from memory. The AI SDK converts each into an item_reference, causing OpenAI
+ * to reject the request with a "Duplicate item found" error.
+ */
+describe('sanitizeV5UIMessages — OpenAI itemId deduplication (#15617)', () => {
+  it('should deduplicate reasoning parts with the same rs_* itemId within a single message', () => {
+    const messages: UIMessage[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            reasoning: 'first reasoning',
+            details: [{ type: 'text', text: 'thinking...' }],
+            providerMetadata: { openai: { itemId: 'rs_001' } },
+          } as any,
+          {
+            type: 'text',
+            text: 'Hello',
+          },
+          {
+            type: 'reasoning',
+            reasoning: 'duplicate reasoning',
+            details: [{ type: 'text', text: 'thinking again...' }],
+            providerMetadata: { openai: { itemId: 'rs_001' } },
+          } as any,
+        ],
+        createdAt: new Date(),
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages);
+    expect(result).toHaveLength(1);
+
+    const reasoningParts = result[0]!.parts.filter(p => p.type === 'reasoning');
+    expect(reasoningParts).toHaveLength(1);
+  });
+
+  it('should deduplicate reasoning parts with the same rs_* itemId across messages', () => {
+    const messages: UIMessage[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            reasoning: '',
+            details: [{ type: 'text', text: '' }],
+            providerMetadata: { openai: { itemId: 'rs_abc123' } },
+          } as any,
+          {
+            type: 'text',
+            text: 'Step 1 result',
+            providerMetadata: { openai: { itemId: 'msg_001' } },
+          },
+        ],
+        createdAt: new Date(),
+      },
+      {
+        id: 'msg-2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            reasoning: '',
+            details: [{ type: 'text', text: '' }],
+            providerMetadata: { openai: { itemId: 'rs_abc123' } },
+          } as any,
+          {
+            type: 'text',
+            text: 'Step 2 result',
+            providerMetadata: { openai: { itemId: 'msg_002' } },
+          },
+        ],
+        createdAt: new Date(),
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages);
+
+    // Both messages should still exist
+    expect(result).toHaveLength(2);
+
+    // First message keeps reasoning
+    const msg1Reasoning = result[0]!.parts.filter(p => p.type === 'reasoning');
+    expect(msg1Reasoning).toHaveLength(1);
+
+    // Second message should have reasoning removed (duplicate rs_abc123)
+    const msg2Reasoning = result[1]!.parts.filter(p => p.type === 'reasoning');
+    expect(msg2Reasoning).toHaveLength(0);
+
+    // Text parts with different itemIds should be preserved
+    const msg1Text = result[0]!.parts.filter(p => p.type === 'text');
+    const msg2Text = result[1]!.parts.filter(p => p.type === 'text');
+    expect(msg1Text).toHaveLength(1);
+    expect(msg2Text).toHaveLength(1);
+  });
+
+  it('should still merge text parts with the same itemId within a message', () => {
+    const messages: UIMessage[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'Hello ',
+            providerMetadata: { openai: { itemId: 'msg_001' } },
+          },
+          {
+            type: 'text',
+            text: 'world',
+            providerMetadata: { openai: { itemId: 'msg_001' } },
+          },
+        ],
+        createdAt: new Date(),
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages);
+    expect(result).toHaveLength(1);
+
+    const textParts = result[0]!.parts.filter(p => p.type === 'text');
+    expect(textParts).toHaveLength(1);
+    expect((textParts[0] as any).text).toBe('Hello world');
+  });
+
+  it('should drop text parts with duplicate itemIds across messages', () => {
+    const messages: UIMessage[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'Hello',
+            providerMetadata: { openai: { itemId: 'msg_001' } },
+          },
+        ],
+        createdAt: new Date(),
+      },
+      {
+        id: 'msg-2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'Hello duplicate',
+            providerMetadata: { openai: { itemId: 'msg_001' } },
+          },
+        ],
+        createdAt: new Date(),
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages);
+    // Second message should be filtered out entirely (empty after dedup)
+    expect(result).toHaveLength(1);
+    expect((result[0]!.parts[0] as any).text).toBe('Hello');
+  });
+
+  it('should preserve parts without OpenAI itemIds', () => {
+    const messages: UIMessage[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'no itemId here' },
+          {
+            type: 'reasoning',
+            reasoning: 'also no itemId',
+            details: [{ type: 'text', text: 'thinking' }],
+          } as any,
+        ],
+        createdAt: new Date(),
+      },
+    ];
+
+    const result = sanitizeV5UIMessages(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.parts).toHaveLength(2);
+  });
+});

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -10,54 +10,67 @@ import type { AIV5Type, AIV6Type } from '../types';
 import { ensureAnthropicCompatibleMessages } from '../utils/provider-compat';
 
 /**
- * Merges text parts that share the same OpenAI itemId.
- *
- * When OpenAI streams a response with web search, it interleaves `source` chunks
- * with text-deltas. If the streaming pipeline flushes text on these source chunks,
- * it creates multiple text parts all sharing the same `providerMetadata.openai.itemId`.
- *
- * When these parts are later converted to model messages, each part with an itemId
- * becomes an `item_reference` pointing to the same ID, causing OpenAI to reject
- * the request with: "Duplicate item found with id msg_*"
- *
- * This function merges consecutive text parts with the same itemId into a single part,
- * concatenating their text content and keeping the metadata from the first part.
+ * Extracts the OpenAI itemId from a part's providerMetadata, if present.
  */
-function mergeTextPartsWithDuplicateItemIds<T extends { type: string }>(parts: T[]): T[] {
+function getItemId(part: { providerMetadata?: Record<string, unknown> }): string | undefined {
+  const openai = (part.providerMetadata as Record<string, unknown> | undefined)?.openai as
+    | Record<string, unknown>
+    | undefined;
+  return openai?.itemId as string | undefined;
+}
+
+/**
+ * Deduplicates parts that share the same OpenAI itemId.
+ *
+ * Text parts with the same itemId are merged by concatenating their text content.
+ * Non-text parts (reasoning, tool-call, etc.) with duplicate itemIds are dropped
+ * (only the first occurrence is kept).
+ *
+ * This prevents OpenAI from rejecting requests with:
+ *   "Duplicate item found with id msg_*" (text parts)
+ *   "Duplicate item found with id rs_*"  (reasoning parts)
+ *
+ * The reasoning duplication can occur when Observational Memory's async buffering
+ * causes the same response parts to appear multiple times in the message history.
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/15617
+ */
+function deduplicatePartsWithOpenAIItemIds<T extends { type: string }>(parts: T[]): T[] {
   const result: T[] = [];
+  const seenItemIds = new Set<string>();
 
   for (const part of parts) {
-    // Only process text parts with OpenAI itemId
-    if (part.type !== 'text') {
-      result.push(part);
-      continue;
-    }
+    const itemId = getItemId(part as T & { providerMetadata?: Record<string, unknown> });
 
-    const textPart = part as T & { text: string; providerMetadata?: Record<string, unknown> };
-    const itemId = (textPart.providerMetadata?.openai as Record<string, unknown> | undefined)?.itemId as
-      | string
-      | undefined;
     if (!itemId) {
       result.push(part);
       continue;
     }
 
-    // Find an existing text part in result with the same itemId
-    const existingIndex = result.findIndex(p => {
-      if (p.type !== 'text') return false;
-      const existingTextPart = p as T & { providerMetadata?: Record<string, unknown> };
-      const existingItemId = (existingTextPart.providerMetadata?.openai as Record<string, unknown> | undefined)?.itemId;
-      return existingItemId === itemId;
-    });
+    if (part.type === 'text') {
+      // Text parts: merge by concatenating text content
+      const existingIndex = result.findIndex(p => {
+        if (p.type !== 'text') return false;
+        return getItemId(p as T & { providerMetadata?: Record<string, unknown> }) === itemId;
+      });
 
-    if (existingIndex !== -1) {
-      // Merge: concatenate text into the existing part
-      const existing = result[existingIndex] as T & { text: string };
-      result[existingIndex] = {
-        ...existing,
-        text: existing.text + textPart.text,
-      };
+      if (existingIndex !== -1) {
+        const existing = result[existingIndex] as T & { text: string };
+        const textPart = part as T & { text: string };
+        result[existingIndex] = {
+          ...existing,
+          text: existing.text + textPart.text,
+        };
+      } else {
+        seenItemIds.add(itemId);
+        result.push(part);
+      }
     } else {
+      // Non-text parts (reasoning, tool-call, etc.): keep first occurrence only
+      if (seenItemIds.has(itemId)) {
+        continue;
+      }
+      seenItemIds.add(itemId);
       result.push(part);
     }
   }
@@ -108,6 +121,13 @@ export function sanitizeV5UIMessages(
   messages: AIV5Type.UIMessage[],
   filterIncompleteToolCalls = false,
 ): AIV5Type.UIMessage[] {
+  // Track OpenAI itemIds across ALL messages to deduplicate reasoning/tool-call parts
+  // that appear in multiple assistant messages (e.g., when memory loads non-merged messages).
+  // Without this, the AI SDK generates duplicate item_reference entries for the same rs_*/fc_* ID,
+  // causing OpenAI to reject with "Duplicate item found with id ...".
+  // @see https://github.com/mastra-ai/mastra/issues/15617
+  const globalSeenItemIds = new Set<string>();
+
   const msgs = messages
     .map(m => {
       if (m.parts.length === 0) return false;
@@ -158,14 +178,27 @@ export function sanitizeV5UIMessages(
 
       if (!safeParts.length) return false;
 
-      // Merge text parts with duplicate OpenAI itemIds to prevent "Duplicate item found" errors.
-      // This can happen when streaming flushes text multiple times for the same response
-      // (e.g., when source citations are interleaved with text-deltas).
-      const mergedParts = mergeTextPartsWithDuplicateItemIds(safeParts);
+      // Deduplicate parts with duplicate OpenAI itemIds within this message.
+      // Text parts are merged by concatenating; non-text parts keep only the first occurrence.
+      const mergedParts = deduplicatePartsWithOpenAIItemIds(safeParts);
+
+      // Cross-message deduplication: remove non-text parts whose OpenAI itemId
+      // was already seen in a previous message. Text parts with duplicate cross-message
+      // itemIds are also dropped (not merged across messages) to prevent duplicate
+      // item_reference entries in the Responses API input.
+      const crossDedupedParts = mergedParts.filter(part => {
+        const itemId = getItemId(part as typeof part & { providerMetadata?: Record<string, unknown> });
+        if (!itemId) return true;
+        if (globalSeenItemIds.has(itemId)) return false;
+        globalSeenItemIds.add(itemId);
+        return true;
+      });
+
+      if (!crossDedupedParts.length) return false;
 
       const sanitized = {
         ...m,
-        parts: mergedParts.map(part => {
+        parts: crossDedupedParts.map(part => {
           if (AIV5.isToolUIPart(part) && part.state === 'output-available') {
             return {
               ...part,


### PR DESCRIPTION
## Summary

Fixes #15617 — "Duplicate item found with id rs_..." when Observational Memory buffering is enabled.

## Problem

`sanitizeV5UIMessages` only deduplicated **text** parts with duplicate `providerMetadata.openai.itemId` values. Non-text parts (reasoning, tool-call) were passed through unchanged. When Observational Memory's async buffering causes the same response parts to appear multiple times in the message history — either within a single message or across multiple non-merged assistant messages loaded from memory — reasoning parts with duplicate `rs_*` IDs are converted to duplicate `item_reference` entries by the AI SDK, causing OpenAI to reject the request.

Setting `bufferTokens: false` (synchronous mode) avoids the duplication, which is why it works as a workaround.

## Fix

1. **Renamed** `mergeTextPartsWithDuplicateItemIds` → `deduplicatePartsWithOpenAIItemIds` to reflect broader scope
2. **Text parts**: still merge by concatenating content (existing behavior preserved)
3. **Non-text parts** (reasoning, tool-call, etc.): keep only the first occurrence of each `itemId`, drop duplicates
4. **Cross-message deduplication**: added `globalSeenItemIds` tracking across all messages in `sanitizeV5UIMessages` to catch duplicates spanning multiple assistant messages (common when memory loads non-merged messages)

## Testing

- Added test suite covering:
  - Within-message reasoning dedup (same `rs_*` ID in one message)
  - Cross-message reasoning dedup (same `rs_*` ID across two assistant messages)
  - Text merge behavior preserved (same `msg_*` ID concatenates text)
  - Cross-message text dedup (duplicate text itemIds across messages)
  - Parts without itemIds are unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When OpenAI gets a request with duplicate item IDs (like the same reasoning part mentioned twice), it rejects the request. A memory feature sometimes caused the same message parts to appear multiple times, triggering this error. This fix removes the duplicates before sending the request, so OpenAI gets a clean request without repeats.

## Summary

This PR fixes OpenAI API errors ("Duplicate item found with id rs_*") that occur when Observational Memory buffering is enabled. The root cause is that duplicate response parts—particularly reasoning parts with identical OpenAI `itemId` values—were being included in requests sent to the API, which rejects duplicates.

### Changes

**Core deduplication logic** (`output-converter.ts`):
- Renamed `mergeTextPartsWithDuplicateItemIds` to `deduplicatePartsWithOpenAIItemIds` to reflect broader scope
- **Within-message deduplication**: For parts with duplicate `providerMetadata.openai.itemId` values:
  - Text parts are merged by concatenating their content (preserves existing behavior)
  - Non-text parts (reasoning, tool-call, etc.) are deduplicated by keeping only the first occurrence
- **Cross-message deduplication**: Added `globalSeenItemIds` tracking in `sanitizeV5UIMessages` to prevent duplicate itemIds from appearing across multiple assistant messages, which commonly occurs when memory loads include non-merged messages
- Parts without OpenAI `itemId` metadata are unaffected by deduplication

**Test coverage** (`output-converter-duplicate-itemids.test.ts`):
- Within-message reasoning deduplication (rs_* IDs collapse to a single reasoning part)
- Cross-message reasoning deduplication (later messages' duplicates are filtered out)
- Text merge behavior preserved (duplicate text parts concatenate within a message)
- Cross-message text deduplication (duplicate text parts across messages trigger filtering)
- Parts without itemIds remain unaffected

### Impact

Eliminates the "Duplicate item found" error without requiring users to disable asynchronous memory buffering (previously a workaround via `observationalMemory.option.bufferTokens: false`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->