### PR TITLE
fix(clickhouse): accept ClickHouse Cloud/replicated ReplacingMergeTree variants

### DIFF
--- a/.changeset/fix-playground-trace-import.md
+++ b/.changeset/fix-playground-trace-import.md
@@ -1,5 +1,0 @@
----
-'@mastra/playground': patch
----
-
-Fixed playground trace status to use a local vendor copy of `computeTraceStatus` instead of importing from `@mastra/core/storage`.

--- a/.changeset/little-emus-create.md
+++ b/.changeset/little-emus-create.md
@@ -2,4 +2,4 @@
 '@mastra/clickhouse': patch
 ---
 
-Fixed `ReplacingMergeTree` engine detection on ClickHouse Cloud and replicated clusters. Previously, the observability migration check only accepted the literal `ReplacingMergeTree` engine name, but ClickHouse Cloud silently rewrites it to `SharedReplacingMergeTree` (and self-managed replicated clusters rewrite it to `ReplicatedReplacingMergeTree`). This caused `mastra dev` to repeatedly throw `MIGRATION REQUIRED` on CH Cloud even after `npx mastra migrate` ran successfully. The check now accepts any `*ReplacingMergeTree` variant.
+Fixed `mastra dev` repeatedly reporting `MIGRATION REQUIRED` on ClickHouse Cloud after `mastra migrate` had already run successfully. The observability migration check now recognizes the engine-name variants that ClickHouse Cloud and replicated clusters use in place of `ReplacingMergeTree`.

--- a/.changeset/little-emus-create.md
+++ b/.changeset/little-emus-create.md
@@ -1,0 +1,5 @@
+---
+'@mastra/clickhouse': patch
+---
+
+Fixed `ReplacingMergeTree` engine detection on ClickHouse Cloud and replicated clusters. Previously, the observability migration check only accepted the literal `ReplacingMergeTree` engine name, but ClickHouse Cloud silently rewrites it to `SharedReplacingMergeTree` (and self-managed replicated clusters rewrite it to `ReplicatedReplacingMergeTree`). This caused `mastra dev` to repeatedly throw `MIGRATION REQUIRED` on CH Cloud even after `npx mastra migrate` ran successfully. The check now accepts any `*ReplacingMergeTree` variant.

--- a/stores/clickhouse/src/storage/domains/observability/v-next/migration.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/migration.test.ts
@@ -3,8 +3,30 @@ import type { ClickHouseClient } from '@clickhouse/client';
 import { MastraError } from '@mastra/core/error';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TABLE_LOG_EVENTS, TABLE_METRIC_EVENTS, TABLE_SCORE_EVENTS, TABLE_FEEDBACK_EVENTS } from './ddl';
-import { migrateSignalTables } from './migration';
+import { isReplacingMergeTreeEngine, migrateSignalTables } from './migration';
 import { ObservabilityStorageClickhouseVNext } from '.';
+
+describe('isReplacingMergeTreeEngine', () => {
+  it('accepts plain ReplacingMergeTree', () => {
+    expect(isReplacingMergeTreeEngine('ReplacingMergeTree')).toBe(true);
+  });
+
+  it('accepts SharedReplacingMergeTree (ClickHouse Cloud rewrite)', () => {
+    expect(isReplacingMergeTreeEngine('SharedReplacingMergeTree')).toBe(true);
+  });
+
+  it('accepts ReplicatedReplacingMergeTree (self-managed replicated clusters)', () => {
+    expect(isReplacingMergeTreeEngine('ReplicatedReplacingMergeTree')).toBe(true);
+  });
+
+  it('rejects non-replacing engines', () => {
+    expect(isReplacingMergeTreeEngine('MergeTree')).toBe(false);
+    expect(isReplacingMergeTreeEngine('SharedMergeTree')).toBe(false);
+    expect(isReplacingMergeTreeEngine('AggregatingMergeTree')).toBe(false);
+    expect(isReplacingMergeTreeEngine('Log')).toBe(false);
+    expect(isReplacingMergeTreeEngine('')).toBe(false);
+  });
+});
 
 /** Wraps a client so that INSERT commands throw — used to exercise rollback. */
 function clientThatFailsOnInsert(real: ClickHouseClient): ClickHouseClient {

--- a/stores/clickhouse/src/storage/domains/observability/v-next/migration.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/migration.ts
@@ -38,6 +38,13 @@ const SIGNAL_MIGRATIONS: SignalMigration[] = [
   { table: TABLE_FEEDBACK_EVENTS, createDDL: FEEDBACK_EVENTS_DDL, idColumn: 'feedbackId' },
 ];
 
+// ClickHouse Cloud silently rewrites `ReplacingMergeTree` to `SharedReplacingMergeTree`,
+// and self-managed replicated clusters rewrite it to `ReplicatedReplacingMergeTree`.
+// All three share dedup-on-merge semantics, so treat them as already-migrated.
+export function isReplacingMergeTreeEngine(engine: string): boolean {
+  return engine.endsWith('ReplacingMergeTree');
+}
+
 async function getTableEngine(client: ClickHouseClient, table: string): Promise<string | null> {
   const result = await client.query({
     query: `SELECT engine FROM system.tables WHERE database = currentDatabase() AND name = {table:String}`,
@@ -81,7 +88,7 @@ export async function checkSignalTablesMigrationStatus(client: ClickHouseClient)
 
   for (const { table, idColumn } of SIGNAL_MIGRATIONS) {
     const engine = await getTableEngine(client, table);
-    if (!engine || engine === 'ReplacingMergeTree') {
+    if (!engine || isReplacingMergeTreeEngine(engine)) {
       continue;
     }
 
@@ -103,7 +110,7 @@ export async function checkSignalTablesMigrationStatus(client: ClickHouseClient)
 export async function migrateSignalTables(client: ClickHouseClient, logger?: IMastraLogger): Promise<void> {
   for (const { table, createDDL, idColumn } of SIGNAL_MIGRATIONS) {
     const engine = await getTableEngine(client, table);
-    if (!engine || engine === 'ReplacingMergeTree') continue;
+    if (!engine || isReplacingMergeTreeEngine(engine)) continue;
 
     logger?.info?.(`Migrating ${table} from ${engine} to ReplacingMergeTree with ${idColumn} column`);
 


### PR DESCRIPTION
## Summary

- `mastra dev` on ClickHouse Cloud repeatedly throws `MIGRATION_REQUIRED_SIGNAL_TABLES` even immediately after `npx mastra migrate` runs successfully.
- Root cause: ClickHouse Cloud silently rewrites `ReplacingMergeTree` into `SharedReplacingMergeTree`, and self-managed replicated clusters rewrite it into `ReplicatedReplacingMergeTree`. The observability signal-tables migration check compared engine names with exact equality (`engine === 'ReplacingMergeTree'`), so on Cloud the freshly-migrated tables were re-flagged as legacy on the next init — an infinite migration loop.
- Fix: introduce `isReplacingMergeTreeEngine()` that accepts any `*ReplacingMergeTree` engine name, and use it in both `checkSignalTablesMigrationStatus` and `migrateSignalTables`.

## Repro

1. Point a local Mastra project at a ClickHouse Cloud instance.
2. Run `npx mastra migrate` — it completes successfully.
3. Run `mastra dev` — throws:

```
MastraError:
===========================================================================
MIGRATION REQUIRED: ClickHouse observability signal tables need signal IDs
===========================================================================

  - mastra_metric_events (SharedReplacingMergeTree)
  - mastra_log_events (SharedReplacingMergeTree)
  - mastra_score_events (SharedReplacingMergeTree)
  - mastra_feedback_events (SharedReplacingMergeTree)
```

Note the listed engines: these are *already* `SharedReplacingMergeTree` (the Cloud equivalent of `ReplacingMergeTree`) — they are structurally correct, the check just didn't recognize the Cloud engine name.

## Test plan

- [x] New unit tests cover `ReplacingMergeTree`, `SharedReplacingMergeTree`, `ReplicatedReplacingMergeTree`, plus negative cases (`MergeTree`, `SharedMergeTree`, `AggregatingMergeTree`, `Log`, empty string).
- [x] `npx tsc --noEmit -p tsconfig.build.json` — no new errors in migration files.
- [x] `npx vitest run src/storage/domains/observability/v-next/migration.test.ts -t "isReplacingMergeTreeEngine"` — 4 passed.
- [ ] Reviewer to confirm the fix on a ClickHouse Cloud instance (the CI docker-compose test harness runs self-hosted CH, which reproduces `ReplacingMergeTree` literally and so doesn't hit the Cloud-rewrite path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The cloud automatically renames certain ClickHouse table engines, and the old check only recognized one exact name, so it kept asking to migrate tables that were already migrated. This PR teaches the check to recognize all renamed variants so it stops asking repeatedly.

## Summary of changes

Three files were modified to fix ClickHouse engine detection for migrated signal tables:

- .changeset/little-emus-create.md
  - Adds a patch changeset for @mastra/clickhouse documenting the fix for ReplacingMergeTree engine detection on ClickHouse Cloud and replicated clusters.

- stores/clickhouse/src/storage/domains/observability/v-next/migration.ts
  - Added exported helper function isReplacingMergeTreeEngine(engine: string): boolean that treats any engine name ending with "ReplacingMergeTree" (e.g., SharedReplacingMergeTree, ReplicatedReplacingMergeTree) as already migrated.
  - Updated checkSignalTablesMigrationStatus and migrateSignalTables to use the new helper instead of an exact equality check for "ReplacingMergeTree", preventing Cloud/replicated variants from being incorrectly flagged for migration.

- stores/clickhouse/src/storage/domains/observability/v-next/migration.test.ts
  - Added tests for isReplacingMergeTreeEngine covering positive cases (ReplacingReplacingMergeTree, SharedReplacingMergeTree, ReplicatedReplacingMergeTree) and negative cases (MergeTree, SharedMergeTree, AggregatingMergeTree, Log, empty string).

## Problem addressed

Running npx mastra migrate against ClickHouse Cloud produced temp tables with ENGINE=ReplacingMergeTree, but ClickHouse Cloud rewrites this to SharedReplacingMergeTree (and replicated clusters use ReplicatedReplacingMergeTree). The prior logic only accepted the exact "ReplacingMergeTree" string, causing mastra dev to repeatedly report MIGRATION_REQUIRED_SIGNAL_TABLES and loop. This change recognizes the Cloud/replicated engine name variants as already migrated and stops the repeated migration prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->