### PR TITLE
Add Regolo.AI as provider

### DIFF
--- a/packages/core/src/llm/model/provider-registry.json
+++ b/packages/core/src/llm/model/provider-registry.json
@@ -171,7 +171,7 @@
         "llama-3.1-8b-instruct",
         "llama-3.3-70b-instruct",
         "mistral-nemo-instruct-2407",
-        "mistral-small-3.2-24b-instruct-2506",
+        "mistral-small-3.2",
         "pixtral-12b-2409",
         "qwen3-235b-a22b-instruct-2507",
         "qwen3-coder-30b-a3b-instruct",
@@ -800,17 +800,16 @@
       "name": "Regolo.ai",
       "models": [
         "MiniMax-M2.5",
-        "qwen3.5-122b-a10b",
-        "mistral-small-4-119b-2603",
+        "mistral-small-4-119b",
         "gpt-oss-120b",
-        "apertus-70b-2509",
+        "apertus-70b",
         "gpt-oss-20b",
         "llama-3.1-8b-instruct",
-        "mistral-small-3.2-24b-instruct-2506",
+        "mistral-small-3.2",
         "llama-3.3-70b-instruct",
         "qwen3.5-9b",
         "qwen3-coder-next",
-        "qwen3.5-35b-a3b"
+        "qwen3.5-122b"
       ],
       "docUrl": "https://docs.regolo.ai",
       "gateway": "models.dev"
@@ -3494,7 +3493,7 @@
         "meta-llama-3_3-70b-instruct",
         "mistral-7b-instruct-v0.3",
         "mistral-nemo-instruct-2407",
-        "mistral-small-3.2-24b-instruct-2506",
+        "mistral-small-3.2",
         "qwen2.5-vl-72b-instruct",
         "qwen3-32b",
         "qwen3-coder-30b-a3b-instruct"
@@ -4782,7 +4781,7 @@
       "llama-3.1-8b-instruct",
       "llama-3.3-70b-instruct",
       "mistral-nemo-instruct-2407",
-      "mistral-small-3.2-24b-instruct-2506",
+      "mistral-small-3.2",
       "pixtral-12b-2409",
       "qwen3-235b-a22b-instruct-2507",
       "qwen3-coder-30b-a3b-instruct",
@@ -5405,17 +5404,16 @@
     ],
     "regolo": [
         "MiniMax-M2.5",
-        "qwen3.5-122b-a10b",
-        "mistral-small-4-119b-2603",
+        "qwen3.5-122b",
+        "mistral-small-4-119b",
         "gpt-oss-120b",
-        "apertus-70b-2509",
+        "apertus-70b",
         "gpt-oss-20b",
         "llama-3.1-8b-instruct",
-        "mistral-small-3.2-24b-instruct-2506",
+        "mistral-small-3.2",
         "llama-3.3-70b-instruct",
         "qwen3.5-9b",
-        "qwen3-coder-next",
-        "qwen3.5-35b-a3b"
+        "qwen3-coder-next"
     ],
     "siliconflow-cn": [
       "ByteDance-Seed/Seed-OSS-36B-Instruct",
@@ -7545,7 +7543,7 @@
       "meta-llama-3_3-70b-instruct",
       "mistral-7b-instruct-v0.3",
       "mistral-nemo-instruct-2407",
-      "mistral-small-3.2-24b-instruct-2506",
+      "mistral-small-3.2",
       "qwen2.5-vl-72b-instruct",
       "qwen3-32b",
       "qwen3-coder-30b-a3b-instruct"

--- a/packages/core/src/llm/model/provider-registry.json
+++ b/packages/core/src/llm/model/provider-registry.json
@@ -793,6 +793,28 @@
       "docUrl": "https://abacus.ai/help/api",
       "gateway": "models.dev"
     },
+    "regolo": {
+      "url": "https://api.regolo.ai/v1",
+      "apiKeyEnvVar": "REGOLO_API_KEY",
+      "apiKeyHeader": "Authorization",
+      "name": "Regolo.ai",
+      "models": [
+        "MiniMax-M2.5",
+        "qwen3.5-122b-a10b",
+        "mistral-small-4-119b-2603",
+        "gpt-oss-120b",
+        "apertus-70b-2509",
+        "gpt-oss-20b",
+        "llama-3.1-8b-instruct",
+        "mistral-small-3.2-24b-instruct-2506",
+        "llama-3.3-70b-instruct",
+        "qwen3.5-9b",
+        "qwen3-coder-next",
+        "qwen3.5-35b-a3b"
+      ],
+      "docUrl": "https://docs.regolo.ai",
+      "gateway": "models.dev"
+    },
     "perplexity-agent": {
       "url": "https://api.perplexity.ai/v1",
       "apiKeyEnvVar": "PERPLEXITY_API_KEY",

--- a/packages/core/src/llm/model/provider-registry.json
+++ b/packages/core/src/llm/model/provider-registry.json
@@ -5403,6 +5403,20 @@
       "perplexity/sonar",
       "xai/grok-4-1-fast-non-reasoning"
     ],
+    "regolo": [
+        "MiniMax-M2.5",
+        "qwen3.5-122b-a10b",
+        "mistral-small-4-119b-2603",
+        "gpt-oss-120b",
+        "apertus-70b-2509",
+        "gpt-oss-20b",
+        "llama-3.1-8b-instruct",
+        "mistral-small-3.2-24b-instruct-2506",
+        "llama-3.3-70b-instruct",
+        "qwen3.5-9b",
+        "qwen3-coder-next",
+        "qwen3.5-35b-a3b"
+    ],
     "siliconflow-cn": [
       "ByteDance-Seed/Seed-OSS-36B-Instruct",
       "Kwaipilot/KAT-Dev",


### PR DESCRIPTION
## Description

Adding Regolo.Ai as provider for AI/

## Related Issue(s)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5 Explanation

This PR adds Regolo.ai as a new AI provider so the platform can call Regolo's API and offer its models to users.

Changes

- Registered a new provider entry "regolo" in packages/core/src/llm/model/provider-registry.json with:
  - url: "https://api.regolo.ai/v1"
  - apiKeyEnvVar: "REGOLO_API_KEY"
  - apiKeyHeader: "Authorization"
  - name: "Regolo.ai"
  - docUrl: "https://docs.regolo.ai"
  - gateway: "models.dev"
  - models (11):
    - MiniMax-M2.5
    - mistral-small-4-119b
    - gpt-oss-120b
    - apertus-70b
    - gpt-oss-20b
    - llama-3.1-8b-instruct
    - mistral-small-3.2
    - llama-3.3-70b-instruct
    - qwen3.5-9b
    - qwen3-coder-next
    - qwen3.5-122b
- Added top-level models.regolo listing the same Regolo model IDs.
- Replaced model ID "mistral-small-3.2-24b-instruct-2506" with "mistral-small-3.2" in provider/model declarations (notably for Scaleway and OVHcloud entries).
- File modified: packages/core/src/llm/model/provider-registry.json (+38 / -4).
- Commit summary: single commit "feat(fallback): detect".

Notes

- PR classified as a new feature / non-breaking change.
- Documentation updates, tests, and CodeRabbit comments remain unaddressed (checklist items unchecked).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->