### PR TITLE
fix(tavily): make @tavily/core a direct dependency of @mastra/tavily

### DIFF
--- a/.changeset/tavily-core-runtime-dependency.md
+++ b/.changeset/tavily-core-runtime-dependency.md
@@ -1,0 +1,5 @@
+---
+"@mastra/tavily": patch
+---
+
+Moved `@tavily/core` from `peerDependencies` to `dependencies`. The Tavily SDK is an internal implementation detail of this package (imported directly from `client.ts` at runtime), not a user-provided pluggable dependency like `@mastra/core` or `zod`. Declaring it as a peer dep required every consumer — including transitive consumers such as globally-installed CLIs — to install `@tavily/core` themselves, which caused `ERR_MODULE_NOT_FOUND: Cannot find package '@tavily/core'` at runtime. It is now installed automatically alongside `@mastra/tavily`.

--- a/.changeset/tavily-core-runtime-dependency.md
+++ b/.changeset/tavily-core-runtime-dependency.md
@@ -2,4 +2,4 @@
 "@mastra/tavily": patch
 ---
 
-Moved `@tavily/core` from `peerDependencies` to `dependencies`. The Tavily SDK is an internal implementation detail of this package (imported directly from `client.ts` at runtime), not a user-provided pluggable dependency like `@mastra/core` or `zod`. Declaring it as a peer dep required every consumer — including transitive consumers such as globally-installed CLIs — to install `@tavily/core` themselves, which caused `ERR_MODULE_NOT_FOUND: Cannot find package '@tavily/core'` at runtime. It is now installed automatically alongside `@mastra/tavily`.
+Fixed runtime `ERR_MODULE_NOT_FOUND` for `@tavily/core` by making it a direct dependency. Consumers no longer need to install `@tavily/core` manually.

--- a/integrations/tavily/package.json
+++ b/integrations/tavily/package.json
@@ -48,16 +48,17 @@
   "engines": {
     "node": ">=22.13.0"
   },
+  "dependencies": {
+    "@tavily/core": "^0.7.2"
+  },
   "peerDependencies": {
     "@mastra/core": ">=1.0.0-0 <2.0.0-0",
-    "@tavily/core": ">=0.7.0",
     "zod": ">=3.0.0 || >=4.0.0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
-    "@tavily/core": "^0.7.2",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
     "vitest": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1460,6 +1460,10 @@ importers:
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   integrations/tavily:
+    dependencies:
+      '@tavily/core':
+        specifier: ^0.7.2
+        version: 0.7.2
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -1470,9 +1474,6 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@tavily/core':
-        specifier: ^0.7.2
-        version: 0.7.2
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)


### PR DESCRIPTION
## Summary

Fixes `ERR_MODULE_NOT_FOUND: Cannot find package '@tavily/core'` when using `@mastra/tavily` (surfaced via the globally-installed `mastracode` CLI, which depends on it).

`@mastra/tavily` declared `@tavily/core` as a `peerDependency`, but `@tavily/core` is the actual Tavily SDK that `client.ts` imports at runtime — it's an internal implementation detail, not a user-provided pluggable dep like `@mastra/core` or `zod`.

npm (and other package managers) do **not** auto-install peer dependencies of transitive dependencies, and this is especially true for globally-installed packages. So any consumer of `@mastra/tavily` that didn't *also* explicitly install `@tavily/core` would hit the missing-module error the first time the tool touched its client.

## Change

Moved `@tavily/core` from `peerDependencies` → `dependencies` in `integrations/tavily/package.json`. It now installs automatically alongside `@mastra/tavily`.

`@mastra/core` and `zod` remain peer dependencies (those *are* shared across the Mastra ecosystem and should use the consumer's version).

## Test plan

- `pnpm install` — clean
- `pnpm --filter @mastra/tavily build:lib` — clean, dist unchanged (still externalizes `@tavily/core`)
- `pnpm --filter @mastra/tavily test` — all 31 tests pass
- Verified `@tavily/core` resolves from `integrations/tavily/node_modules/`

Changeset included (`@mastra/tavily` patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

@mastra/tavily needed @tavily/core to run but didn’t install it automatically for users, causing "package not found" errors. This PR makes @tavily/core install with @mastra/tavily so consumers no longer hit that error.

## Problem

Consumers (including transitive/global users like the mastracode CLI) could get ERR_MODULE_NOT_FOUND for '@tavily/core' because it was declared as a peerDependency while @mastra/tavily imports it at runtime. Package managers do not auto-install peer dependencies for transitive/global installs, so the runtime SDK was missing unless manually installed.

## Changes

- integrations/tavily/package.json
  - Moved "@tavily/core" from peerDependencies/devDependencies into dependencies at "^0.7.2".
  - Left "@mastra/core" and "zod" as peerDependencies.

- .changeset/tavily-core-runtime-dependency.md
  - Added a changeset declaring a patch release for @mastra/tavily describing the fix.

No public APIs or exported code changed.

## Testing

- Clean pnpm install completed.
- pnpm --filter @mastra/tavily build:lib (clean) — dist unchanged; @tavily/core still externalized in build.
- pnpm --filter @mastra/tavily test — 31 tests passed.
- Verified @tavily/core resolves from integrations/tavily/node_modules/.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->