### PR TITLE
fix(cli): forward user bundler options to dev watcher

### DIFF
--- a/.changeset/spicy-ravens-buy.md
+++ b/.changeset/spicy-ravens-buy.md
@@ -1,0 +1,9 @@
+---
+'mastra': patch
+---
+
+Fixed an issue where `mastra dev` ignored user-specified `bundler.externals` (and other bundler options), causing the watcher to fall back to its default preset and fail to bundle certain CommonJS packages (e.g. `tsx`) even when they were listed as externals.
+
+**Before:** `externals` configured in `new Mastra({ bundler: { externals: ["tsx"] } })` was respected by `mastra build` but silently dropped by `mastra dev`.
+
+**After:** `mastra dev` now forwards the user's `externals` and `dynamicPackages` to the watcher, matching the build path.

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -129,5 +129,34 @@ describe('DevBundler', () => {
         await remove(tmpDir);
       }
     });
+
+    it('should forward user-specified externals to the watcher', async () => {
+      // Arrange
+      const devBundler = new DevBundler();
+      vi.spyOn(devBundler as any, 'getUserBundlerOptions').mockResolvedValue({
+        externals: ['tsx'],
+        sourcemap: false,
+        transpilePackages: [],
+      });
+      const { getWatcherInputOptions } = await import('@mastra/deployer/build');
+
+      // Act
+      const tmpDir = '.test-tmp';
+      try {
+        await devBundler.watch('test-entry.js', tmpDir, []);
+
+        // Assert
+        expect(getWatcherInputOptions).toHaveBeenCalledWith(
+          'test-entry.js',
+          'node',
+          expect.any(Object),
+          expect.objectContaining({
+            bundlerOptions: expect.objectContaining({ externals: ['tsx'] }),
+          }),
+        );
+      } finally {
+        await remove(tmpDir);
+      }
+    });
   });
 });

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -73,7 +73,15 @@ export class DevBundler extends Bundler {
       {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
       },
-      { sourcemap: sourcemapEnabled },
+      {
+        sourcemap: sourcemapEnabled,
+        bundlerOptions: {
+          enableSourcemap: sourcemapEnabled,
+          enableEsmShim: true,
+          externals: bundlerOptions?.externals ?? [],
+          dynamicPackages: bundlerOptions?.dynamicPackages,
+        },
+      },
     );
     const toolsInputOptions = await this.listToolsInputOptions(toolsPaths);
 


### PR DESCRIPTION
## Summary

`mastra dev` was silently dropping user-specified `bundler.externals` (and other bundler options), so setting `externals: ["tsx"]` — which `mastra build` honors — had no effect on the dev watcher.

Reported by a user hitting:

> ERROR (Mastra CLI): Mastra wasn't able to bundle "tsx", might be an older commonJS module. Please add `tsx` to your externals.

…even though `tsx` was already in their externals.

## Root cause

`packages/cli/src/commands/dev/DevBundler.ts` read the user's config via `getUserBundlerOptions` but only forwarded `sourcemap` to `getWatcherInputOptions`:

```ts
const bundlerOptions = await this.getUserBundlerOptions(entryFile, outputDirectory);
const sourcemapEnabled = !!bundlerOptions?.sourcemap;

const inputOptions = await getWatcherInputOptions(
  entryFile,
  this.platform,
  { 'process.env.NODE_ENV': ... },
  { sourcemap: sourcemapEnabled }, // ← externals dropped here
);
```

The watcher in `packages/deployer/src/build/watcher.ts` then applied its default `{ externals: true, ... }`, which takes the externals *preset* path in `analyzeBundle` (via `externalsPreset: bundlerOptions?.externals === true`) instead of honoring the user's array.

The build path (`Bundler._bundle` in `packages/deployer/src/bundler/index.ts`) already translates user options into an `internalBundlerOptions` object and passes the full object through — dev just skipped that step. This PR mirrors that translation in the dev path.

## Changes

- `packages/cli/src/commands/dev/DevBundler.ts` — construct `internalBundlerOptions` from the user's config and pass it to `getWatcherInputOptions`, matching the build path.
- `packages/cli/src/commands/dev/DevBundler.test.ts` — regression test that asserts user-specified externals reach the watcher.
- `.changeset/spicy-ravens-buy.md` — patch changeset for `mastra`.

## Test plan

- [x] `pnpm --filter ./packages/cli typecheck` passes
- [x] `pnpm --filter ./packages/cli test src/commands/dev/DevBundler.test.ts` — 3/3 pass, including the new regression test
- [ ] Reporter validates locally (via `pnpm patch mastra`) that their `externals: ["tsx"]` config now works under `mastra dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)