### PR TITLE
feat(mastracode): normalize Fireworks and generic model IDs in TUI status line

### DIFF
--- a/.changeset/two-bikes-start.md
+++ b/.changeset/two-bikes-start.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved model ID display in the Mastra Code TUI status line. Fireworks model IDs are now shown in compact form (e.g. fireworks/kimi-k2.6 instead of the full fireworks-ai/accounts/fireworks/models/... path). Version separators in model names are also normalized (e.g. kimi-k2p6 is displayed as kimi-k2.6).

--- a/mastracode/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/src/tui/__tests__/status-line.test.ts
@@ -131,4 +131,54 @@ describe('updateStatusLine', () => {
     expect(rendered).toContain('mastra/claude-opus-4.6');
     expect(rendered).not.toContain('anthropic/claude-opus-4.6');
   });
+
+  it('rewrites fireworks-ai long paths and kimi version separator at full width', () => {
+    const state = createState();
+    state.harness.getFullModelId.mockReturnValue('fireworks-ai/accounts/fireworks/models/kimi-k2p6');
+    process.stdout.columns = 200;
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('fireworks/kimi-k2.6');
+    expect(rendered).not.toContain('fireworks-ai/accounts/fireworks/models/');
+    expect(rendered).not.toContain('kimi-k2p6');
+  });
+
+  it('rewrites fireworks-ai long paths and kimi version separator when compacted', () => {
+    const state = createState();
+    state.harness.getFullModelId.mockReturnValue('fireworks-ai/accounts/fireworks/models/kimi-k2p6');
+    process.stdout.columns = 25;
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('fireworks/kimi-k2.6');
+    expect(rendered).not.toContain('fireworks-ai/accounts/fireworks/models/');
+    expect(rendered).not.toContain('kimi-k2p6');
+  });
+
+  it('rewrites kimi version separator for non-fireworks models', () => {
+    const state = createState();
+    state.harness.getFullModelId.mockReturnValue('moonshot/kimi-k1p5');
+    process.stdout.columns = 200;
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('kimi-k1.5');
+    expect(rendered).not.toContain('kimi-k1p5');
+  });
+
+  it('rewrites minimax-m2p7 version separator', () => {
+    const state = createState();
+    state.harness.getFullModelId.mockReturnValue('fireworks-ai/accounts/fireworks/models/minimax-m2p7');
+    process.stdout.columns = 200;
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('fireworks/minimax-m2.7');
+    expect(rendered).not.toContain('minimax-m2p7');
+  });
 });

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -88,12 +88,18 @@ export function updateStatusLine(state: TUIState): void {
 
   // --- Collect raw data ---
   // Show OM model when observing/reflecting, otherwise main model
-  const fullModelId =
+  const rawModelId =
     (showOMMode
       ? isObserving
         ? state.harness.getObserverModelId()
         : state.harness.getReflectorModelId()
       : state.harness.getFullModelId()) ?? '';
+  // Rewrite Fireworks AI long paths: fireworks-ai/accounts/fireworks/models/<name> → fireworks/<name>
+  let fullModelId = rawModelId.startsWith('fireworks-ai/accounts/fireworks/models/')
+    ? 'fireworks/' + rawModelId.slice('fireworks-ai/accounts/fireworks/models/'.length)
+    : rawModelId;
+  // Rewrite version separators where 'p' stands for '.': e.g. kimi-k2p6 → kimi-k2.6, minimax-m2p7 → minimax-m2.7
+  fullModelId = fullModelId.replace(/\b([a-z]+-[a-z])(\d+)p(\d+)\b/g, '$1$2.$3');
   const compactModelId = (modelId: string): string => {
     const parts = modelId.split('/');
     if (parts.length >= 3) {


### PR DESCRIPTION
Before, Fireworks model IDs took up the whole status bar:

```
fireworks-ai/accounts/fireworks/models/kimi-k2p6
```

Now they're compact and readable:

```
fireworks/kimi-k2.6
```

Same for other model families that use `p` as a version separator (like `minimax-m2p7` → `minimax-m2.7`). The rewrite happens before the compact/full width logic so it works everywhere consistently.

Added tests for the new behavior — all passing.

before

<img width="630" height="134" alt="Screenshot 2026-04-22 at 10 20 02 AM" src="https://github.com/user-attachments/assets/938419ac-a75c-458a-9a17-e54a91ad53ab" />

after

<img width="337" height="95" alt="Screenshot 2026-04-22 at 10 20 05 AM" src="https://github.com/user-attachments/assets/9d15d856-52af-4ed4-9c6e-35928afcd6aa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the names of AI models look cleaner and shorter when displayed in Mastra Code. Instead of showing super long names like `fireworks-ai/accounts/fireworks/models/kimi-k2p6`, it displays a simpler version like `fireworks/kimi-k2.6`. It also fixes how version numbers look by replacing `p` (the letter p) with a dot (like `.`) so `kimi-k2p6` becomes `kimi-k2.6`.

## Changes

### Status Line Model ID Normalization

The `updateStatusLine` function in `mastracode/src/tui/status-line.ts` now applies two normalization transformations to model IDs before rendering:

1. **Fireworks Path Simplification**: Long Fireworks model paths like `fireworks-ai/accounts/fireworks/models/kimi-k2p6` are rewritten to a compact form `fireworks/kimi-k2.6`
2. **Version Separator Normalization**: Version separators using `p` are converted to dots across all model families (e.g., `kimi-k2p6` → `kimi-k2.6`, `minimax-m2p7` → `minimax-m2.7`)

These rewrites are applied before the compact/full width display logic, ensuring consistency across all rendering modes.

### Test Coverage

Four new unit tests added to `mastracode/src/tui/__tests__/status-line.test.ts`:
- Two tests verify Fireworks model ID normalization under both full terminal width (200 columns) and compact width (25 columns) scenarios
- One test confirms non-Fireworks models also receive version separator normalization (e.g., `moonshot/kimi-k1p5` → `moonshot/kimi-k1.5`)
- Tests validate that normalized forms appear in rendered output while original long paths do not

### Package Release

Added changeset entry `.changeset/two-bikes-start.md` marking a patch release for the `mastracode` package documenting the status-line model ID normalization feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->