### PR TITLE
fix(memory): avoid lone UTF-16 surrogates when truncating observer text

### DIFF
--- a/.changeset/twelve-lemons-peel.md
+++ b/.changeset/twelve-lemons-peel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observer agent truncation that could cut UTF-16 surrogate pairs in half when formatting messages, tool results, or observation lines with emoji or other astral-plane characters. This produced lone surrogates that strict JSON parsers (including Anthropic's) reject with errors like `no low surrogate in string`, causing observer runs to fail.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1402,6 +1402,39 @@ describe('Observer Agent Helpers', () => {
       expect(formatted).toContain('[truncated ~');
       expect(formatted).not.toContain('x'.repeat(200));
     });
+
+    // Regression test for https://github.com/mastra-ai/mastra/issues/15573
+    // Anthropic rejects bodies containing lone UTF-16 surrogates with
+    // `The request body is not valid JSON: no low surrogate in string`.
+    // Truncating via `str.slice(0, maxLen)` can cut between the high and low
+    // surrogate of a non-BMP character (e.g. emoji like 🔥 U+1F525), leaving a
+    // lone high surrogate in the <other-conversation> blocks we inject into
+    // the actor's context.
+    it('should not leave lone UTF-16 surrogates when truncating emoji across maxPartLength boundary', () => {
+      // Place an emoji (surrogate pair) such that maxPartLength lands between
+      // its high and low surrogate code units.
+      const prefix = 'a'.repeat(9);
+      const emoji = '🔥'; // length 2 in UTF-16
+      const suffix = 'tail content that will be truncated';
+      const text = prefix + emoji + suffix;
+
+      const msg = createTestMessage(text, 'user');
+      // Cut in the middle of the emoji's surrogate pair (after prefix + high surrogate).
+      const formatted = formatMessagesForObserver([msg], { maxPartLength: prefix.length + 1 });
+
+      // JSON.stringify is what the AI SDK / Anthropic client uses to serialize
+      // the request body. A lone surrogate survives stringification and is
+      // what Anthropic's server-side parser rejects.
+      const serialized = JSON.stringify({ content: formatted });
+
+      const loneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+      const loneLowSurrogate = /(^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+      expect(loneHighSurrogate.test(formatted)).toBe(false);
+      expect(loneLowSurrogate.test(formatted)).toBe(false);
+      // Belt-and-suspenders: the serialized form must also be free of lone surrogates.
+      expect(loneHighSurrogate.test(serialized)).toBe(false);
+      expect(loneLowSurrogate.test(serialized)).toBe(false);
+    });
   });
 
   describe('buildObserverHistoryMessage', () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -113,6 +113,7 @@ import {
 } from '../reflector-agent';
 import { resolveRetentionFloor } from '../thresholds';
 import { TokenCounter } from '../token-counter';
+import { formatToolResultForObserver } from '../tool-result-helpers';
 
 // =============================================================================
 // Test Helpers
@@ -1432,6 +1433,28 @@ describe('Observer Agent Helpers', () => {
       expect(loneHighSurrogate.test(formatted)).toBe(false);
       expect(loneLowSurrogate.test(formatted)).toBe(false);
       // Belt-and-suspenders: the serialized form must also be free of lone surrogates.
+      expect(loneHighSurrogate.test(serialized)).toBe(false);
+      expect(loneLowSurrogate.test(serialized)).toBe(false);
+    });
+
+    it('should not leave lone UTF-16 surrogates when truncating tool results with emoji', () => {
+      // Regression for the same surrogate issue, but via the tool-result path.
+      // formatToolResultForObserver serializes the value, then truncateStringByTokens
+      // performs a binary-search slice. A large tool result containing an emoji at
+      // the token boundary must not produce a lone surrogate.
+      const prefix = 'b'.repeat(20);
+      const emoji = '🔥'; // U+1F525 surrogate pair
+      const suffix = ' '.repeat(1000); // spaces are cheap in tokens so binary search lands near length
+      const toolResult = { summary: prefix + emoji + suffix };
+
+      // Force a very low token limit so truncation is guaranteed.
+      const formatted = formatToolResultForObserver(toolResult, { maxTokens: 10 });
+      const serialized = JSON.stringify({ content: formatted });
+
+      const loneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+      const loneLowSurrogate = /(^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+      expect(loneHighSurrogate.test(formatted)).toBe(false);
+      expect(loneLowSurrogate.test(formatted)).toBe(false);
       expect(loneHighSurrogate.test(serialized)).toBe(false);
       expect(loneLowSurrogate.test(serialized)).toBe(false);
     });

--- a/packages/memory/src/processors/observational-memory/__tests__/string-utils.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/string-utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+
+import { safeSlice } from '../string-utils';
+
+describe('safeSlice', () => {
+  it('returns the whole string when end >= str.length', () => {
+    expect(safeSlice('hello', 10)).toBe('hello');
+    expect(safeSlice('hello', 5)).toBe('hello');
+  });
+
+  it('returns empty string when end <= 0', () => {
+    expect(safeSlice('hello', 0)).toBe('');
+    expect(safeSlice('hello', -1)).toBe('');
+  });
+
+  it('handles ASCII strings like normal slice', () => {
+    expect(safeSlice('abcdef', 3)).toBe('abc');
+    expect(safeSlice('abcdef', 1)).toBe('a');
+  });
+
+  it('backs off by one when end lands immediately after a high surrogate', () => {
+    const prefix = 'a'.repeat(9);
+    const emoji = '\uD83D\uDD25'; // 🔥 (high surrogate + low surrogate)
+    const str = prefix + emoji;
+
+    // end = 10 slices through the emoji's high surrogate at index 9.
+    // safeSlice should back off to end = 9, dropping the entire surrogate pair.
+    expect(safeSlice(str, 10)).toBe(prefix);
+  });
+
+  it('does not back off when end lands after a low surrogate', () => {
+    const prefix = 'a'.repeat(9);
+    const emoji = '\uD83D\uDD25'; // 🔥
+    const str = prefix + emoji;
+
+    // end = 11 lands after the low surrogate at index 10.
+    expect(safeSlice(str, 11)).toBe(prefix + emoji);
+  });
+
+  it('does not back off when end lands after a non-surrogate BMP character', () => {
+    const str = 'abc🔥def';
+    // indexes: 0='a', 1='b', 2='c', 3=high surrogate, 4=low surrogate, 5='d', 6='e', 7='f'
+    expect(safeSlice(str, 3)).toBe('abc'); // end on high surrogate → back off
+    expect(safeSlice(str, 4)).toBe('abc'); // end on low surrogate → back off (high at 3)
+    expect(safeSlice(str, 5)).toBe('abc🔥'); // end on 'd' (not a surrogate)
+    expect(safeSlice(str, 6)).toBe('abc🔥d'); // end on 'e' (not a surrogate)
+  });
+
+  it('handles multiple surrogate pairs correctly', () => {
+    const str = '🔥a🔥b🔥';
+    // indices: 0=high,1=low,2=a,3=high,4=low,5=b,6=high,7=low
+    expect(safeSlice(str, 1)).toBe(''); // backs off from first high surrogate
+    expect(safeSlice(str, 3)).toBe('🔥a');
+    expect(safeSlice(str, 4)).toBe('🔥a'); // backs off from second high surrogate
+    expect(safeSlice(str, 6)).toBe('🔥a🔥b');
+    expect(safeSlice(str, 7)).toBe('🔥a🔥b'); // backs off from third high surrogate
+  });
+
+  it('handles a string that starts with a high surrogate', () => {
+    const str = '\uD83D\uDD25hello';
+    expect(safeSlice(str, 1)).toBe('');
+    expect(safeSlice(str, 2)).toBe('🔥');
+  });
+
+  it('handles an empty string', () => {
+    expect(safeSlice('', 0)).toBe('');
+    expect(safeSlice('', 5)).toBe('');
+  });
+});

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -3,6 +3,7 @@ import type { CoreMessage } from '@mastra/core/llm';
 
 import { stripEphemeralAnchorIds } from './anchor-ids';
 import { isTemporalGapMarker } from './date-utils';
+import { safeSlice } from './string-utils';
 import {
   DEFAULT_OBSERVER_TOOL_RESULT_MAX_TOKENS,
   formatToolResultForObserver,
@@ -927,8 +928,8 @@ export function buildObserverHistoryMessage(messages: MastraDBMessage[], options
 /** Truncate a string to maxLen characters, appending a note if truncated. */
 function maybeTruncate(str: string, maxLen?: number): string {
   if (!maxLen || str.length <= maxLen) return str;
-  const truncated = str.slice(0, maxLen);
-  const remaining = str.length - maxLen;
+  const truncated = safeSlice(str, maxLen);
+  const remaining = str.length - truncated.length;
   return `${truncated}\n... [truncated ${remaining} characters]`;
 }
 
@@ -1375,7 +1376,7 @@ export function sanitizeObservationLines(observations: string): string {
   let changed = false;
   for (let i = 0; i < lines.length; i++) {
     if (lines[i]!.length > MAX_OBSERVATION_LINE_CHARS) {
-      lines[i] = lines[i]!.slice(0, MAX_OBSERVATION_LINE_CHARS) + ' … [truncated]';
+      lines[i] = safeSlice(lines[i]!, MAX_OBSERVATION_LINE_CHARS) + ' … [truncated]';
       changed = true;
     }
   }

--- a/packages/memory/src/processors/observational-memory/string-utils.ts
+++ b/packages/memory/src/processors/observational-memory/string-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Slice a string up to `end` UTF-16 code units without splitting a surrogate
+ * pair. If `end` would land immediately after a lone high surrogate
+ * (U+D800..U+DBFF), the slice backs off by one code unit so the pair is
+ * dropped as a whole.
+ *
+ * Lone UTF-16 surrogates are rejected by strict JSON parsers (e.g. Anthropic's
+ * with `no low surrogate in string`), so any truncation of observer-facing
+ * text that could cut an emoji/astral codepoint in half must go through this
+ * helper.
+ */
+export function safeSlice(str: string, end: number): string {
+  if (end <= 0) return '';
+  if (end >= str.length) return str;
+  const code = str.charCodeAt(end - 1);
+  const safeEnd = code >= 0xd800 && code <= 0xdbff ? end - 1 : end;
+  return str.slice(0, safeEnd);
+}

--- a/packages/memory/src/processors/observational-memory/tool-result-helpers.ts
+++ b/packages/memory/src/processors/observational-memory/tool-result-helpers.ts
@@ -1,5 +1,7 @@
 import { estimateTokenCount } from 'tokenx';
 
+import { safeSlice } from './string-utils';
+
 const ENCRYPTED_CONTENT_KEY = 'encryptedContent';
 const ENCRYPTED_CONTENT_REDACTION_THRESHOLD = 256;
 
@@ -91,7 +93,7 @@ export function truncateStringByTokens(text: string, maxTokens: number): string 
   }
 
   const buildCandidate = (sliceEnd: number) => {
-    const visible = text.slice(0, sliceEnd);
+    const visible = safeSlice(text, sliceEnd);
     return `${visible}\n... [truncated ~${totalTokens - estimateTokenCount(visible)} tokens]`;
   };
 


### PR DESCRIPTION
Fixes #15573.

Observer agent truncation sliced strings by UTF-16 code units, which could cut an emoji (or any astral-plane character) in half and leave a lone high surrogate behind. Strict JSON parsers reject that — Anthropic's surfaces it as `no low surrogate in string` — and the observer run fails.

Added a shared `safeSlice` helper that backs off one code unit when the slice would end on a lone high surrogate, and routed the three truncation sites through it: `maybeTruncate`, `sanitizeObservationLines`, and `truncateStringByTokens`.

Before:

```ts
// maxPartLength lands between an emoji's surrogates
const truncated = str.slice(0, maxLen); // ends with 0xD83D alone
JSON.stringify(truncated); // produces invalid JSON for strict parsers
```

After:

```ts
const truncated = safeSlice(str, maxLen); // backs off onto the code-point boundary, no lone surrogates
```

Includes a regression test that constructs a string where `maxPartLength` lands between an emoji's surrogates and asserts the formatted output contains no lone surrogates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Imagine you're reading a message and you need to cut it short because it's too long. Some characters (like emojis) are made of two special pieces instead of one. This PR fixes a bug where the code was cutting right in the middle of those two-piece characters, leaving a broken half that could break JSON parsing. The fix uses a smart cutter that never splits those characters.

---

## Summary

This PR fixes an issue in the observational memory code where truncation could split UTF-16 surrogate pairs (e.g., emojis), producing lone high surrogates that strict JSON parsers reject (error: "no low surrogate in string"), causing Anthropic requests to fail with 400s.

### Root cause
Truncation used UTF-16 code-unit slicing (String.prototype.slice) which can cut between a high and low surrogate, leaving an invalid lone surrogate in strings embedded in JSON.

### Solution
Introduce safeSlice(str, end) which, when a proposed slice end would leave a lone high surrogate, backs off one code unit to avoid producing an unmatched surrogate. Replace direct code-unit slicing with safeSlice at the three truncation sites:
- maybeTruncate() in observer-agent.ts
- sanitizeObservationLines() in observer-agent.ts
- truncateStringByTokens() in tool-result-helpers.ts

### Tests
- Added unit tests for safeSlice covering boundary cases and surrogate-pair behavior (packages/.../__tests__/string-utils.test.ts).
- Added regression tests that exercise formatting/truncation paths where maxPartLength or maxTokens lands between an emoji’s surrogates, asserting neither the formatted string nor JSON.stringify(...) contains lone surrogates (observational-memory.test.ts).

### Files changed (high level)
- Added safeSlice exported from packages/memory/src/processors/observational-memory/string-utils.ts
- Updated truncation logic in packages/memory/src/processors/observational-memory/observer-agent.ts and tool-result-helpers.ts to use safeSlice
- Added/updated tests in packages/memory/src/processors/observational-memory/__tests__ to cover the fix
- Added a changeset entry .changeset/twelve-lemons-peel.md documenting the patch release for @mastra/memory

This ensures observational text remains valid JSON for strict parsers and prevents intermittent Anthropic request failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->