### PR TITLE
feat(cli): 

### DIFF
--- a/.changeset/mighty-emus-rest.md
+++ b/.changeset/mighty-emus-rest.md
@@ -2,8 +2,4 @@
 'mastra': patch
 ---
 
-Improved deploy env file handling for `mastra deploy` and `mastra studio deploy`:
-
-- **Single env file selection.** Deploy now uses one env file instead of merging multiple files together. When multiple `.env` files exist, you'll be prompted to choose which one to deploy.
-- **Added `--env-file` flag.** Specify exactly which env file to use (e.g. `--env-file .env.staging` or `--env-file config/prod.env`). Accepts any file path, not just `.env*` files.
-- **Non-interactive mode requires `--env-file` when ambiguous.** In CI (`--yes` or `MASTRA_API_TOKEN`), deploy requires `--env-file` when multiple env files exist instead of silently picking one. A single env file is auto-selected.
+Improved env file handling for `mastra server deploy` and `mastra studio deploy`. Deploy now selects a single env file instead of silently merging multiple files. When multiple `.env` files exist, you are prompted to choose one. Added `--env-file` to specify the file directly (e.g. `--env-file .env.staging`), which is required in non-interactive mode when multiple env files are present.

--- a/.changeset/mighty-emus-rest.md
+++ b/.changeset/mighty-emus-rest.md
@@ -2,7 +2,8 @@
 'mastra': patch
 ---
 
-Improved deploy env file handling with two changes:
+Improved deploy env file handling for `mastra deploy` and `mastra studio deploy`:
 
-- **Added `--env-file` flag** to `mastra deploy` and `mastra studio deploy`. Lets you specify exactly which env file to use (e.g. `--env-file .env.staging` or `--env-file config/prod.env`).
-- **Fixed ambiguous env file selection in CI.** When multiple `.env` files exist in non-interactive mode (`--yes` or `MASTRA_API_TOKEN`), deploy now requires `--env-file` instead of silently picking one.
+- **Single env file selection.** Deploy now uses one env file instead of merging multiple files together. When multiple `.env` files exist, you'll be prompted to choose which one to deploy.
+- **Added `--env-file` flag.** Specify exactly which env file to use (e.g. `--env-file .env.staging` or `--env-file config/prod.env`). Accepts any file path, not just `.env*` files.
+- **Non-interactive mode requires `--env-file` when ambiguous.** In CI (`--yes` or `MASTRA_API_TOKEN`), deploy requires `--env-file` when multiple env files exist instead of silently picking one. A single env file is auto-selected.

--- a/.changeset/mighty-emus-rest.md
+++ b/.changeset/mighty-emus-rest.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed deploy env file selection feedback in the CLI. Deploy now shows a single prompt and confirms which env file will be uploaded.

--- a/.changeset/mighty-emus-rest.md
+++ b/.changeset/mighty-emus-rest.md
@@ -2,4 +2,7 @@
 'mastra': patch
 ---
 
-Fixed deploy env file selection feedback in the CLI. Deploy now shows a single prompt and confirms which env file will be uploaded.
+Improved deploy env file handling with two changes:
+
+- **Added `--env-file` flag** to `mastra deploy` and `mastra studio deploy`. Lets you specify exactly which env file to use (e.g. `--env-file .env.staging` or `--env-file config/prod.env`).
+- **Fixed ambiguous env file selection in CI.** When multiple `.env` files exist in non-interactive mode (`--yes` or `MASTRA_API_TOKEN`), deploy now requires `--env-file` instead of silently picking one.

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -181,6 +181,28 @@ describe('readEnvVars (server deploy)', () => {
     expect(prompts.select).not.toHaveBeenCalled();
   });
 
+  it('fails when the selected env file disappears before it can be read', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env', isFile: () => true },
+      { name: '.env.staging', isFile: () => true },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(prompts.select).mockResolvedValue('.env.staging');
+    vi.mocked(readFile).mockImplementation(async path => {
+      if (String(path).endsWith('.env.staging')) {
+        const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        throw err;
+      }
+
+      return 'BASE_ONLY=1';
+    });
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project')).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('fails when no deploy env file exists', async () => {
     const { readdir } = await import('node:fs/promises');
     vi.mocked(readdir).mockResolvedValue([] as Awaited<ReturnType<typeof readdir>>);

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -157,19 +157,30 @@ describe('readEnvVars (server deploy)', () => {
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });
 
-  it('defaults to .env.production in auto-accept mode when it exists', async () => {
-    const { readdir, readFile } = await import('node:fs/promises');
-    const prompts = await import('@clack/prompts');
+  it('throws in auto-accept mode when multiple env files exist and no --env-file specified', async () => {
+    const { readdir } = await import('node:fs/promises');
     vi.mocked(readdir).mockResolvedValue([
       { name: '.env.staging', isFile: () => true, isSymbolicLink: () => false },
       { name: '.env', isFile: () => true, isSymbolicLink: () => false },
       { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
     ] as unknown as Awaited<ReturnType<typeof readdir>>);
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { autoAccept: true })).rejects.toThrow(
+      'Multiple env files found: .env, .env.production, .env.staging. Use --env-file to specify which one to deploy.',
+    );
+  });
+
+  it('auto-selects the only env file in auto-accept mode without prompting', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
-      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
       if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
-      if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
     });
@@ -218,17 +229,11 @@ describe('readEnvVars (server deploy)', () => {
   });
 
   it('uses the requested env file without prompting', async () => {
-    const { readdir, readFile } = await import('node:fs/promises');
+    const { access, readFile } = await import('node:fs/promises');
     const prompts = await import('@clack/prompts');
-    vi.mocked(readdir).mockResolvedValue([
-      { name: '.env', isFile: () => true },
-      { name: '.env.staging', isFile: () => true },
-      { name: '.env.production', isFile: () => true },
-    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(access).mockResolvedValue(undefined);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
-      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
-      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
       if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
@@ -244,17 +249,34 @@ describe('readEnvVars (server deploy)', () => {
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });
 
-  it('fails when the requested env file is not available', async () => {
-    const { readdir } = await import('node:fs/promises');
-    vi.mocked(readdir).mockResolvedValue([
-      { name: '.env', isFile: () => true },
-      { name: '.env.production', isFile: () => true },
-    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+  it('accepts a non-.env-prefixed file when explicitly requested', async () => {
+    const { access, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(access).mockResolvedValue(undefined);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('config/prod.env')) return 'SECRET=abc';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { envFile: 'config/prod.env' })).resolves.toEqual({
+      SECRET: 'abc',
+    });
+    expect(prompts.select).not.toHaveBeenCalled();
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: config/prod.env');
+  });
+
+  it('fails when the requested env file does not exist on disk', async () => {
+    const { access } = await import('node:fs/promises');
+    vi.mocked(access).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
 
     const { readEnvVars } = await import('./deploy.js');
 
     await expect(readEnvVars('/project', { envFile: '.env.staging' })).rejects.toThrow(
-      'Env file not found for deploy: .env.staging. Available files: .env, .env.production',
+      'Env file not found: .env.staging',
     );
   });
 
@@ -293,6 +315,11 @@ describe('readEnvVars (server deploy)', () => {
 });
 
 describe('serverDeployAction', () => {
+  beforeEach(async () => {
+    const { access } = await import('node:fs/promises');
+    vi.mocked(access).mockResolvedValue(undefined);
+  });
+
   afterEach(() => {
     vi.resetModules();
   });

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -148,11 +148,11 @@ describe('readEnvVars (server deploy)', () => {
     expect(prompts.select).toHaveBeenCalledWith({
       message: 'Choose env file to deploy',
       options: [
-        { value: '.env.production', label: '.env.production' },
         { value: '.env', label: '.env' },
+        { value: '.env.production', label: '.env.production' },
         { value: '.env.staging', label: '.env.staging' },
       ],
-      initialValue: '.env.production',
+      initialValue: '.env',
     });
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -161,9 +161,9 @@ describe('readEnvVars (server deploy)', () => {
     const { readdir, readFile } = await import('node:fs/promises');
     const prompts = await import('@clack/prompts');
     vi.mocked(readdir).mockResolvedValue([
-      { name: '.env.staging', isFile: () => true },
-      { name: '.env', isFile: () => true },
-      { name: '.env.production', isFile: () => true },
+      { name: '.env.staging', isFile: () => true, isSymbolicLink: () => false },
+      { name: '.env', isFile: () => true, isSymbolicLink: () => false },
+      { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
     ] as unknown as Awaited<ReturnType<typeof readdir>>);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
@@ -182,6 +182,39 @@ describe('readEnvVars (server deploy)', () => {
     });
     expect(prompts.select).not.toHaveBeenCalled();
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.production');
+  });
+
+  it('includes symlinked env files when discovering deploy env files', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env', isFile: () => false, isSymbolicLink: () => true },
+      { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
+      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+    vi.mocked(prompts.select).mockResolvedValue('.env');
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project')).resolves.toEqual({
+      SHARED: 'base',
+      BASE_ONLY: '1',
+    });
+    expect(prompts.select).toHaveBeenCalledWith({
+      message: 'Choose env file to deploy',
+      options: [
+        { value: '.env', label: '.env' },
+        { value: '.env.production', label: '.env.production' },
+      ],
+      initialValue: '.env.production',
+    });
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env');
   });
 
   it('fails when the selected env file disappears before it can be read', async () => {

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -217,6 +217,47 @@ describe('readEnvVars (server deploy)', () => {
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env');
   });
 
+  it('uses the requested env file without prompting', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env', isFile: () => true },
+      { name: '.env.staging', isFile: () => true },
+      { name: '.env.production', isFile: () => true },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
+      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
+      if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { envFile: '.env.staging' })).resolves.toEqual({
+      SHARED: 'staging',
+      STAGING_ONLY: '1',
+    });
+    expect(prompts.select).not.toHaveBeenCalled();
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
+  });
+
+  it('fails when the requested env file is not available', async () => {
+    const { readdir } = await import('node:fs/promises');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env', isFile: () => true },
+      { name: '.env.production', isFile: () => true },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { envFile: '.env.staging' })).rejects.toThrow(
+      'Env file not found for deploy: .env.staging. Available files: .env, .env.production',
+    );
+  });
+
   it('fails when the selected env file disappears before it can be read', async () => {
     const { readdir, readFile } = await import('node:fs/promises');
     const prompts = await import('@clack/prompts');

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -152,21 +152,23 @@ describe('readEnvVars (server deploy)', () => {
         { value: '.env.production', label: '.env.production' },
         { value: '.env.staging', label: '.env.staging' },
       ],
-      initialValue: '.env',
+      initialValue: '.env.production',
     });
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });
 
-  it('defaults to the first discovered env file in auto-accept mode when multiple files exist', async () => {
+  it('defaults to .env.production in auto-accept mode when it exists', async () => {
     const { readdir, readFile } = await import('node:fs/promises');
     const prompts = await import('@clack/prompts');
     vi.mocked(readdir).mockResolvedValue([
       { name: '.env.staging', isFile: () => true },
       { name: '.env', isFile: () => true },
+      { name: '.env.production', isFile: () => true },
     ] as unknown as Awaited<ReturnType<typeof readdir>>);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
       if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
+      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
       if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
@@ -175,10 +177,11 @@ describe('readEnvVars (server deploy)', () => {
     const { readEnvVars } = await import('./deploy.js');
 
     await expect(readEnvVars('/project', { autoAccept: true })).resolves.toEqual({
-      SHARED: 'base',
-      BASE_ONLY: '1',
+      SHARED: 'prod',
+      PROD_ONLY: '1',
     });
     expect(prompts.select).not.toHaveBeenCalled();
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.production');
   });
 
   it('fails when the selected env file disappears before it can be read', async () => {

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -25,8 +25,9 @@ vi.mock('node:fs/promises', () => ({
   rm: vi.fn().mockResolvedValue(undefined),
   stat: vi.fn().mockResolvedValue({ size: 1024 }),
   access: vi.fn().mockResolvedValue(undefined),
+  readdir: vi.fn().mockResolvedValue([]),
   readFile: vi.fn(async (path: string) => {
-    if (path.endsWith('.env') || path.endsWith('.env.local') || path.endsWith('.env.production')) {
+    if (String(path).includes('/.env')) {
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
     }
@@ -119,6 +120,79 @@ describe('parseEnvFile (server deploy)', () => {
   });
 });
 
+describe('readEnvVars (server deploy)', () => {
+  it('prompts for which env file to deploy when multiple files exist', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env.production', isFile: () => true },
+      { name: '.env', isFile: () => true },
+      { name: '.env.staging', isFile: () => true },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
+      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
+      if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+    vi.mocked(prompts.select).mockResolvedValue('.env.staging');
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project')).resolves.toEqual({
+      SHARED: 'staging',
+      STAGING_ONLY: '1',
+    });
+    expect(prompts.select).toHaveBeenCalledWith({
+      message: 'Choose env file to deploy',
+      options: [
+        { value: '.env.production', label: '.env.production' },
+        { value: '.env', label: '.env' },
+        { value: '.env.staging', label: '.env.staging' },
+      ],
+      initialValue: '.env.production',
+    });
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
+  });
+
+  it('defaults to the first discovered env file in auto-accept mode when multiple files exist', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env.staging', isFile: () => true },
+      { name: '.env', isFile: () => true },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
+      if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { autoAccept: true })).resolves.toEqual({
+      SHARED: 'base',
+      BASE_ONLY: '1',
+    });
+    expect(prompts.select).not.toHaveBeenCalled();
+  });
+
+  it('fails when no deploy env file exists', async () => {
+    const { readdir } = await import('node:fs/promises');
+    vi.mocked(readdir).mockResolvedValue([] as Awaited<ReturnType<typeof readdir>>);
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project')).rejects.toThrow(
+      'No env file found for deploy. Add a .env or .env.* file before deploying.',
+    );
+  });
+});
+
 describe('serverDeployAction', () => {
   afterEach(() => {
     vi.resetModules();
@@ -151,7 +225,15 @@ describe('serverDeployAction', () => {
     process.env.MASTRA_API_TOKEN = 'headless-token';
     vi.resetModules();
 
+    const { readdir, readFile } = await import('node:fs/promises');
     const { loadProjectConfig } = await import('../studio/project-config.js');
+    vi.mocked(readdir).mockResolvedValue([{ name: '.env', isFile: () => true }] as unknown as Awaited<
+      ReturnType<typeof readdir>
+    >);
+    vi.mocked(readFile).mockImplementation(async path => {
+      if (String(path).endsWith('.env')) return 'API_KEY=test';
+      return Buffer.from('zip-data');
+    });
     vi.mocked(loadProjectConfig).mockResolvedValue({
       organizationId: 'org-1',
       projectId: 'proj-1',
@@ -168,9 +250,17 @@ describe('serverDeployAction', () => {
     process.env.MASTRA_API_TOKEN = 'headless-token';
     vi.resetModules();
 
+    const { readdir, readFile } = await import('node:fs/promises');
     const { loadProjectConfig } = await import('../studio/project-config.js');
     const { fetchOrgs } = await import('../auth/api.js');
 
+    vi.mocked(readdir).mockResolvedValue([{ name: '.env', isFile: () => true }] as unknown as Awaited<
+      ReturnType<typeof readdir>
+    >);
+    vi.mocked(readFile).mockImplementation(async path => {
+      if (String(path).endsWith('.env')) return 'API_KEY=test';
+      return Buffer.from('zip-data');
+    });
     vi.mocked(loadProjectConfig).mockResolvedValue({
       organizationId: 'org-1',
       projectId: 'proj-1',

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -87,7 +87,8 @@ export async function readEnvVars(
     throw new Error('No env file found for deploy. Add a .env or .env.* file before deploying.');
   }
 
-  let selectedEnvFile = availableDeployEnvFiles[0]!;
+  let selectedEnvFile =
+    availableDeployEnvFiles.find(envFile => envFile === '.env.production') ?? availableDeployEnvFiles[0]!;
 
   if (availableDeployEnvFiles.length > 1) {
     if (!options.autoAccept) {

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -68,17 +68,6 @@ export function parseEnvFile(content: string): Record<string, string> {
   return vars;
 }
 
-async function readOptionalEnvFile(projectDir: string, envFile: string): Promise<string | null> {
-  try {
-    return await readFile(join(projectDir, envFile), 'utf-8');
-  } catch (err: unknown) {
-    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return null;
-    }
-    throw err;
-  }
-}
-
 async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
   const entries = await readdir(projectDir, { withFileTypes: true });
 
@@ -119,7 +108,7 @@ export async function readEnvVars(
 
   p.log.step(`Using env file: ${selectedEnvFile}`);
 
-  return parseEnvFile((await readOptionalEnvFile(projectDir, selectedEnvFile)) ?? '');
+  return parseEnvFile(await readFile(join(projectDir, selectedEnvFile), 'utf-8'));
 }
 
 /* ------------------------------------------------------------------ */

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -85,13 +85,7 @@ async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
   return entries
     .filter(entry => entry.isFile() && (entry.name === '.env' || entry.name.startsWith('.env.')))
     .map(entry => entry.name)
-    .sort((a, b) => {
-      if (a === '.env.production') return -1;
-      if (b === '.env.production') return 1;
-      if (a === '.env') return -1;
-      if (b === '.env') return 1;
-      return a.localeCompare(b);
-    });
+    .sort((a, b) => a.localeCompare(b));
 }
 
 export async function readEnvVars(

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -81,7 +81,7 @@ async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
 
 export async function readEnvVars(
   projectDir: string,
-  options: { autoAccept?: boolean } = {},
+  options: { autoAccept?: boolean; envFile?: string } = {},
 ): Promise<Record<string, string>> {
   const availableDeployEnvFiles = await getDeployEnvFiles(projectDir);
 
@@ -89,23 +89,33 @@ export async function readEnvVars(
     throw new Error('No env file found for deploy. Add a .env or .env.* file before deploying.');
   }
 
-  let selectedEnvFile =
-    availableDeployEnvFiles.find(envFile => envFile === '.env.production') ?? availableDeployEnvFiles[0]!;
+  let selectedEnvFile = options.envFile;
 
-  if (availableDeployEnvFiles.length > 1) {
-    if (!options.autoAccept) {
-      const selected = await p.select({
-        message: 'Choose env file to deploy',
-        options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
-        initialValue: selectedEnvFile,
-      });
+  if (selectedEnvFile) {
+    if (!availableDeployEnvFiles.includes(selectedEnvFile)) {
+      throw new Error(
+        `Env file not found for deploy: ${selectedEnvFile}. Available files: ${availableDeployEnvFiles.join(', ')}`,
+      );
+    }
+  } else {
+    selectedEnvFile =
+      availableDeployEnvFiles.find(envFile => envFile === '.env.production') ?? availableDeployEnvFiles[0]!;
 
-      if (p.isCancel(selected)) {
-        p.cancel('Deploy cancelled.');
-        process.exit(0);
+    if (availableDeployEnvFiles.length > 1) {
+      if (!options.autoAccept) {
+        const selected = await p.select({
+          message: 'Choose env file to deploy',
+          options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
+          initialValue: selectedEnvFile,
+        });
+
+        if (p.isCancel(selected)) {
+          p.cancel('Deploy cancelled.');
+          process.exit(0);
+        }
+
+        selectedEnvFile = selected as string;
       }
-
-      selectedEnvFile = selected as string;
     }
   }
 
@@ -233,7 +243,15 @@ async function resolveProject(
 
 export async function serverDeployAction(
   dir: string | undefined,
-  opts: { org?: string; project?: string; yes?: boolean; config?: string; skipBuild?: boolean; debug?: boolean },
+  opts: {
+    org?: string;
+    project?: string;
+    yes?: boolean;
+    config?: string;
+    skipBuild?: boolean;
+    debug?: boolean;
+    envFile?: string;
+  },
 ) {
   const targetDir = resolve(dir || process.cwd());
   const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);
@@ -336,7 +354,7 @@ export async function serverDeployAction(
   s.stop(`Created ${sizeLabel} archive`);
 
   s.start('Reading environment variables...');
-  const envVars = await readEnvVars(targetDir, { autoAccept });
+  const envVars = await readEnvVars(targetDir, { autoAccept, envFile: opts.envFile });
   const envCount = Object.keys(envVars).length;
   if (envCount > 0) {
     s.stop(`Found ${envCount} env var(s)`);

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -72,7 +72,9 @@ async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
   const entries = await readdir(projectDir, { withFileTypes: true });
 
   return entries
-    .filter(entry => entry.isFile() && (entry.name === '.env' || entry.name.startsWith('.env.')))
+    .filter(
+      entry => (entry.isFile() || entry.isSymbolicLink()) && (entry.name === '.env' || entry.name.startsWith('.env.')),
+    )
     .map(entry => entry.name)
     .sort((a, b) => a.localeCompare(b));
 }

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { createWriteStream } from 'node:fs';
-import { mkdir, rm, stat, access, readFile } from 'node:fs/promises';
+import { mkdir, rm, stat, access, readFile, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import * as p from '@clack/prompts';
@@ -68,18 +68,64 @@ export function parseEnvFile(content: string): Record<string, string> {
   return vars;
 }
 
-async function readEnvVars(projectDir: string): Promise<Record<string, string>> {
-  const vars: Record<string, string> = {};
-  for (const envFile of ['.env', '.env.local', '.env.production']) {
-    try {
-      const content = await readFile(join(projectDir, envFile), 'utf-8');
-      Object.assign(vars, parseEnvFile(content));
-    } catch (err: unknown) {
-      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') continue;
-      throw err;
+async function readOptionalEnvFile(projectDir: string, envFile: string): Promise<string | null> {
+  try {
+    return await readFile(join(projectDir, envFile), 'utf-8');
+  } catch (err: unknown) {
+    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
+  const entries = await readdir(projectDir, { withFileTypes: true });
+
+  return entries
+    .filter(entry => entry.isFile() && (entry.name === '.env' || entry.name.startsWith('.env.')))
+    .map(entry => entry.name)
+    .sort((a, b) => {
+      if (a === '.env.production') return -1;
+      if (b === '.env.production') return 1;
+      if (a === '.env') return -1;
+      if (b === '.env') return 1;
+      return a.localeCompare(b);
+    });
+}
+
+export async function readEnvVars(
+  projectDir: string,
+  options: { autoAccept?: boolean } = {},
+): Promise<Record<string, string>> {
+  const availableDeployEnvFiles = await getDeployEnvFiles(projectDir);
+
+  if (availableDeployEnvFiles.length === 0) {
+    throw new Error('No env file found for deploy. Add a .env or .env.* file before deploying.');
+  }
+
+  let selectedEnvFile = availableDeployEnvFiles[0]!;
+
+  if (availableDeployEnvFiles.length > 1) {
+    if (!options.autoAccept) {
+      const selected = await p.select({
+        message: 'Choose env file to deploy',
+        options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
+        initialValue: selectedEnvFile,
+      });
+
+      if (p.isCancel(selected)) {
+        p.cancel('Deploy cancelled.');
+        process.exit(0);
+      }
+
+      selectedEnvFile = selected as string;
     }
   }
-  return vars;
+
+  p.log.step(`Using env file: ${selectedEnvFile}`);
+
+  return parseEnvFile((await readOptionalEnvFile(projectDir, selectedEnvFile)) ?? '');
 }
 
 /* ------------------------------------------------------------------ */
@@ -304,7 +350,7 @@ export async function serverDeployAction(
   s.stop(`Created ${sizeLabel} archive`);
 
   s.start('Reading environment variables...');
-  const envVars = await readEnvVars(targetDir);
+  const envVars = await readEnvVars(targetDir, { autoAccept });
   const envCount = Object.keys(envVars).length;
   if (envCount > 0) {
     s.stop(`Found ${envCount} env var(s)`);

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -83,40 +83,48 @@ export async function readEnvVars(
   projectDir: string,
   options: { autoAccept?: boolean; envFile?: string } = {},
 ): Promise<Record<string, string>> {
+  // When an explicit env file is provided, trust the user — read it directly.
+  if (options.envFile) {
+    const filePath = join(projectDir, options.envFile);
+    try {
+      await access(filePath);
+    } catch {
+      throw new Error(`Env file not found: ${options.envFile}`);
+    }
+    p.log.step(`Using env file: ${options.envFile}`);
+    return parseEnvFile(await readFile(filePath, 'utf-8'));
+  }
+
   const availableDeployEnvFiles = await getDeployEnvFiles(projectDir);
 
   if (availableDeployEnvFiles.length === 0) {
     throw new Error('No env file found for deploy. Add a .env or .env.* file before deploying.');
   }
 
-  let selectedEnvFile = options.envFile;
+  let selectedEnvFile: string;
 
-  if (selectedEnvFile) {
-    if (!availableDeployEnvFiles.includes(selectedEnvFile)) {
-      throw new Error(
-        `Env file not found for deploy: ${selectedEnvFile}. Available files: ${availableDeployEnvFiles.join(', ')}`,
-      );
-    }
+  if (availableDeployEnvFiles.length === 1) {
+    selectedEnvFile = availableDeployEnvFiles[0]!;
+  } else if (options.autoAccept) {
+    throw new Error(
+      `Multiple env files found: ${availableDeployEnvFiles.join(', ')}. Use --env-file to specify which one to deploy.`,
+    );
   } else {
-    selectedEnvFile =
+    const defaultFile =
       availableDeployEnvFiles.find(envFile => envFile === '.env.production') ?? availableDeployEnvFiles[0]!;
 
-    if (availableDeployEnvFiles.length > 1) {
-      if (!options.autoAccept) {
-        const selected = await p.select({
-          message: 'Choose env file to deploy',
-          options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
-          initialValue: selectedEnvFile,
-        });
+    const selected = await p.select({
+      message: 'Choose env file to deploy',
+      options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
+      initialValue: defaultFile,
+    });
 
-        if (p.isCancel(selected)) {
-          p.cancel('Deploy cancelled.');
-          process.exit(0);
-        }
-
-        selectedEnvFile = selected as string;
-      }
+    if (p.isCancel(selected)) {
+      p.cancel('Deploy cancelled.');
+      process.exit(0);
     }
+
+    selectedEnvFile = selected as string;
   }
 
   p.log.step(`Using env file: ${selectedEnvFile}`);

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -292,6 +292,47 @@ describe('readEnvVars', () => {
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env');
   });
 
+  it('uses the requested env file without prompting', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env', isFile: () => true },
+      { name: '.env.staging', isFile: () => true },
+      { name: '.env.production', isFile: () => true },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
+      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
+      if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { envFile: '.env.staging' })).resolves.toEqual({
+      SHARED: 'staging',
+      STAGING_ONLY: '1',
+    });
+    expect(prompts.select).not.toHaveBeenCalled();
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
+  });
+
+  it('fails when the requested env file is not available', async () => {
+    const { readdir } = await import('node:fs/promises');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env', isFile: () => true },
+      { name: '.env.production', isFile: () => true },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { envFile: '.env.staging' })).rejects.toThrow(
+      'Env file not found for deploy: .env.staging. Available files: .env, .env.production',
+    );
+  });
+
   it('fails when the selected env file disappears before it can be read', async () => {
     const { readdir, readFile } = await import('node:fs/promises');
     const prompts = await import('@clack/prompts');

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -236,9 +236,9 @@ describe('readEnvVars', () => {
     const { readdir, readFile } = await import('node:fs/promises');
     const prompts = await import('@clack/prompts');
     vi.mocked(readdir).mockResolvedValue([
-      { name: '.env.staging', isFile: () => true },
-      { name: '.env', isFile: () => true },
-      { name: '.env.production', isFile: () => true },
+      { name: '.env.staging', isFile: () => true, isSymbolicLink: () => false },
+      { name: '.env', isFile: () => true, isSymbolicLink: () => false },
+      { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
     ] as unknown as Awaited<ReturnType<typeof readdir>>);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
@@ -257,6 +257,39 @@ describe('readEnvVars', () => {
     });
     expect(prompts.select).not.toHaveBeenCalled();
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.production');
+  });
+
+  it('includes symlinked env files when discovering deploy env files', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env', isFile: () => false, isSymbolicLink: () => true },
+      { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
+      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+    vi.mocked(prompts.select).mockResolvedValue('.env');
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project')).resolves.toEqual({
+      SHARED: 'base',
+      BASE_ONLY: '1',
+    });
+    expect(prompts.select).toHaveBeenCalledWith({
+      message: 'Choose env file to deploy',
+      options: [
+        { value: '.env', label: '.env' },
+        { value: '.env.production', label: '.env.production' },
+      ],
+      initialValue: '.env.production',
+    });
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env');
   });
 
   it('fails when the selected env file disappears before it can be read', async () => {

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -79,6 +79,26 @@ vi.mock('archiver', () => ({
   default: vi.fn(),
 }));
 
+vi.mock('node:fs/promises', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    rm: vi.fn().mockResolvedValue(undefined),
+    stat: vi.fn().mockResolvedValue({ size: 1024 }),
+    access: vi.fn().mockResolvedValue(undefined),
+    readdir: vi.fn().mockResolvedValue([]),
+    readFile: vi.fn(async (path: string) => {
+      const filePath = String(path);
+      if (filePath.includes('/.env')) {
+        const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        throw err;
+      }
+      return (actual.readFile as (path: string) => Promise<string>)(path);
+    }),
+  };
+});
+
 vi.mock('../auth/credentials.js', () => ({
   getToken: vi.fn().mockResolvedValue('test-token'),
   getCurrentOrgId: vi.fn().mockResolvedValue('org-1'),
@@ -172,6 +192,79 @@ describe('parseEnvFile', () => {
 
     const result = parseEnvFile('export FOO=bar\nexport BAZ="qux"');
     expect(result).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+});
+
+describe('readEnvVars', () => {
+  it('prompts for which env file to deploy when multiple files exist', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env.production', isFile: () => true },
+      { name: '.env', isFile: () => true },
+      { name: '.env.staging', isFile: () => true },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
+      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
+      if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+    vi.mocked(prompts.select).mockResolvedValue('.env.staging');
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project')).resolves.toEqual({
+      SHARED: 'staging',
+      STAGING_ONLY: '1',
+    });
+    expect(prompts.select).toHaveBeenCalledWith({
+      message: 'Choose env file to deploy',
+      options: [
+        { value: '.env.production', label: '.env.production' },
+        { value: '.env', label: '.env' },
+        { value: '.env.staging', label: '.env.staging' },
+      ],
+      initialValue: '.env.production',
+    });
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
+  });
+
+  it('defaults to the first discovered env file in auto-accept mode when multiple files exist', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env.staging', isFile: () => true },
+      { name: '.env', isFile: () => true },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
+      if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { autoAccept: true })).resolves.toEqual({
+      SHARED: 'base',
+      BASE_ONLY: '1',
+    });
+    expect(prompts.select).not.toHaveBeenCalled();
+  });
+
+  it('fails when no deploy env file exists', async () => {
+    const { readdir } = await import('node:fs/promises');
+    vi.mocked(readdir).mockResolvedValue([] as Awaited<ReturnType<typeof readdir>>);
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project')).rejects.toThrow(
+      'No env file found for deploy. Add a .env or .env.* file before deploying.',
+    );
   });
 });
 

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -232,19 +232,30 @@ describe('readEnvVars', () => {
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });
 
-  it('defaults to .env.production in auto-accept mode when it exists', async () => {
-    const { readdir, readFile } = await import('node:fs/promises');
-    const prompts = await import('@clack/prompts');
+  it('throws in auto-accept mode when multiple env files exist and no --env-file specified', async () => {
+    const { readdir } = await import('node:fs/promises');
     vi.mocked(readdir).mockResolvedValue([
       { name: '.env.staging', isFile: () => true, isSymbolicLink: () => false },
       { name: '.env', isFile: () => true, isSymbolicLink: () => false },
       { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
     ] as unknown as Awaited<ReturnType<typeof readdir>>);
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { autoAccept: true })).rejects.toThrow(
+      'Multiple env files found: .env, .env.production, .env.staging. Use --env-file to specify which one to deploy.',
+    );
+  });
+
+  it('auto-selects the only env file in auto-accept mode without prompting', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
-      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
       if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
-      if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
     });
@@ -293,17 +304,11 @@ describe('readEnvVars', () => {
   });
 
   it('uses the requested env file without prompting', async () => {
-    const { readdir, readFile } = await import('node:fs/promises');
+    const { access, readFile } = await import('node:fs/promises');
     const prompts = await import('@clack/prompts');
-    vi.mocked(readdir).mockResolvedValue([
-      { name: '.env', isFile: () => true },
-      { name: '.env.staging', isFile: () => true },
-      { name: '.env.production', isFile: () => true },
-    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(access).mockResolvedValue(undefined);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
-      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
-      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
       if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
@@ -319,17 +324,34 @@ describe('readEnvVars', () => {
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });
 
-  it('fails when the requested env file is not available', async () => {
-    const { readdir } = await import('node:fs/promises');
-    vi.mocked(readdir).mockResolvedValue([
-      { name: '.env', isFile: () => true },
-      { name: '.env.production', isFile: () => true },
-    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+  it('accepts a non-.env-prefixed file when explicitly requested', async () => {
+    const { access, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(access).mockResolvedValue(undefined);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('config/prod.env')) return 'SECRET=abc';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { envFile: 'config/prod.env' })).resolves.toEqual({
+      SECRET: 'abc',
+    });
+    expect(prompts.select).not.toHaveBeenCalled();
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: config/prod.env');
+  });
+
+  it('fails when the requested env file does not exist on disk', async () => {
+    const { access } = await import('node:fs/promises');
+    vi.mocked(access).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
 
     const { readEnvVars } = await import('./deploy.js');
 
     await expect(readEnvVars('/project', { envFile: '.env.staging' })).rejects.toThrow(
-      'Env file not found for deploy: .env.staging. Available files: .env, .env.production',
+      'Env file not found: .env.staging',
     );
   });
 

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -223,11 +223,11 @@ describe('readEnvVars', () => {
     expect(prompts.select).toHaveBeenCalledWith({
       message: 'Choose env file to deploy',
       options: [
-        { value: '.env.production', label: '.env.production' },
         { value: '.env', label: '.env' },
+        { value: '.env.production', label: '.env.production' },
         { value: '.env.staging', label: '.env.staging' },
       ],
-      initialValue: '.env.production',
+      initialValue: '.env',
     });
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -227,21 +227,23 @@ describe('readEnvVars', () => {
         { value: '.env.production', label: '.env.production' },
         { value: '.env.staging', label: '.env.staging' },
       ],
-      initialValue: '.env',
+      initialValue: '.env.production',
     });
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });
 
-  it('defaults to the first discovered env file in auto-accept mode when multiple files exist', async () => {
+  it('defaults to .env.production in auto-accept mode when it exists', async () => {
     const { readdir, readFile } = await import('node:fs/promises');
     const prompts = await import('@clack/prompts');
     vi.mocked(readdir).mockResolvedValue([
       { name: '.env.staging', isFile: () => true },
       { name: '.env', isFile: () => true },
+      { name: '.env.production', isFile: () => true },
     ] as unknown as Awaited<ReturnType<typeof readdir>>);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
       if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
+      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
       if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
@@ -250,10 +252,11 @@ describe('readEnvVars', () => {
     const { readEnvVars } = await import('./deploy.js');
 
     await expect(readEnvVars('/project', { autoAccept: true })).resolves.toEqual({
-      SHARED: 'base',
-      BASE_ONLY: '1',
+      SHARED: 'prod',
+      PROD_ONLY: '1',
     });
     expect(prompts.select).not.toHaveBeenCalled();
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.production');
   });
 
   it('fails when the selected env file disappears before it can be read', async () => {

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -256,6 +256,28 @@ describe('readEnvVars', () => {
     expect(prompts.select).not.toHaveBeenCalled();
   });
 
+  it('fails when the selected env file disappears before it can be read', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env', isFile: () => true },
+      { name: '.env.staging', isFile: () => true },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(prompts.select).mockResolvedValue('.env.staging');
+    vi.mocked(readFile).mockImplementation(async path => {
+      if (String(path).endsWith('.env.staging')) {
+        const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        throw err;
+      }
+
+      return 'BASE_ONLY=1';
+    });
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project')).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('fails when no deploy env file exists', async () => {
     const { readdir } = await import('node:fs/promises');
     vi.mocked(readdir).mockResolvedValue([] as Awaited<ReturnType<typeof readdir>>);

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -111,40 +111,48 @@ export async function readEnvVars(
   projectDir: string,
   options: { autoAccept?: boolean; envFile?: string } = {},
 ): Promise<Record<string, string>> {
+  // When an explicit env file is provided, trust the user — read it directly.
+  if (options.envFile) {
+    const filePath = join(projectDir, options.envFile);
+    try {
+      await access(filePath);
+    } catch {
+      throw new Error(`Env file not found: ${options.envFile}`);
+    }
+    p.log.step(`Using env file: ${options.envFile}`);
+    return parseEnvFile(await readFile(filePath, 'utf-8'));
+  }
+
   const availableDeployEnvFiles = await getDeployEnvFiles(projectDir);
 
   if (availableDeployEnvFiles.length === 0) {
     throw new Error('No env file found for deploy. Add a .env or .env.* file before deploying.');
   }
 
-  let selectedEnvFile = options.envFile;
+  let selectedEnvFile: string;
 
-  if (selectedEnvFile) {
-    if (!availableDeployEnvFiles.includes(selectedEnvFile)) {
-      throw new Error(
-        `Env file not found for deploy: ${selectedEnvFile}. Available files: ${availableDeployEnvFiles.join(', ')}`,
-      );
-    }
+  if (availableDeployEnvFiles.length === 1) {
+    selectedEnvFile = availableDeployEnvFiles[0]!;
+  } else if (options.autoAccept) {
+    throw new Error(
+      `Multiple env files found: ${availableDeployEnvFiles.join(', ')}. Use --env-file to specify which one to deploy.`,
+    );
   } else {
-    selectedEnvFile =
+    const defaultFile =
       availableDeployEnvFiles.find(envFile => envFile === '.env.production') ?? availableDeployEnvFiles[0]!;
 
-    if (availableDeployEnvFiles.length > 1) {
-      if (!options.autoAccept) {
-        const selected = await p.select({
-          message: 'Choose env file to deploy',
-          options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
-          initialValue: selectedEnvFile,
-        });
+    const selected = await p.select({
+      message: 'Choose env file to deploy',
+      options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
+      initialValue: defaultFile,
+    });
 
-        if (p.isCancel(selected)) {
-          p.cancel('Deploy cancelled.');
-          process.exit(0);
-        }
-
-        selectedEnvFile = selected as string;
-      }
+    if (p.isCancel(selected)) {
+      p.cancel('Deploy cancelled.');
+      process.exit(0);
     }
+
+    selectedEnvFile = selected as string;
   }
 
   p.log.step(`Using env file: ${selectedEnvFile}`);

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -113,13 +113,7 @@ async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
   return entries
     .filter(entry => entry.isFile() && (entry.name === '.env' || entry.name.startsWith('.env.')))
     .map(entry => entry.name)
-    .sort((a, b) => {
-      if (a === '.env.production') return -1;
-      if (b === '.env.production') return 1;
-      if (a === '.env') return -1;
-      if (b === '.env') return 1;
-      return a.localeCompare(b);
-    });
+    .sort((a, b) => a.localeCompare(b));
 }
 
 export async function readEnvVars(

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -109,7 +109,7 @@ async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
 
 export async function readEnvVars(
   projectDir: string,
-  options: { autoAccept?: boolean } = {},
+  options: { autoAccept?: boolean; envFile?: string } = {},
 ): Promise<Record<string, string>> {
   const availableDeployEnvFiles = await getDeployEnvFiles(projectDir);
 
@@ -117,23 +117,33 @@ export async function readEnvVars(
     throw new Error('No env file found for deploy. Add a .env or .env.* file before deploying.');
   }
 
-  let selectedEnvFile =
-    availableDeployEnvFiles.find(envFile => envFile === '.env.production') ?? availableDeployEnvFiles[0]!;
+  let selectedEnvFile = options.envFile;
 
-  if (availableDeployEnvFiles.length > 1) {
-    if (!options.autoAccept) {
-      const selected = await p.select({
-        message: 'Choose env file to deploy',
-        options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
-        initialValue: selectedEnvFile,
-      });
+  if (selectedEnvFile) {
+    if (!availableDeployEnvFiles.includes(selectedEnvFile)) {
+      throw new Error(
+        `Env file not found for deploy: ${selectedEnvFile}. Available files: ${availableDeployEnvFiles.join(', ')}`,
+      );
+    }
+  } else {
+    selectedEnvFile =
+      availableDeployEnvFiles.find(envFile => envFile === '.env.production') ?? availableDeployEnvFiles[0]!;
 
-      if (p.isCancel(selected)) {
-        p.cancel('Deploy cancelled.');
-        process.exit(0);
+    if (availableDeployEnvFiles.length > 1) {
+      if (!options.autoAccept) {
+        const selected = await p.select({
+          message: 'Choose env file to deploy',
+          options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
+          initialValue: selectedEnvFile,
+        });
+
+        if (p.isCancel(selected)) {
+          p.cancel('Deploy cancelled.');
+          process.exit(0);
+        }
+
+        selectedEnvFile = selected as string;
       }
-
-      selectedEnvFile = selected as string;
     }
   }
 
@@ -269,7 +279,15 @@ async function resolveProject(
 
 export async function deployAction(
   dir: string | undefined,
-  opts: { org?: string; project?: string; yes?: boolean; config?: string; skipBuild?: boolean; debug?: boolean },
+  opts: {
+    org?: string;
+    project?: string;
+    yes?: boolean;
+    config?: string;
+    skipBuild?: boolean;
+    debug?: boolean;
+    envFile?: string;
+  },
 ) {
   const targetDir = resolve(dir || process.cwd());
   const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);
@@ -403,7 +421,7 @@ export async function deployAction(
   s.stop(`Created ${sizeLabel} archive (${elapsed(performance.now() - t)})`);
 
   s.start('Reading environment variables...');
-  const envVars = await readEnvVars(targetDir, { autoAccept });
+  const envVars = await readEnvVars(targetDir, { autoAccept, envFile: opts.envFile });
   const envCount = Object.keys(envVars).length;
   if (envCount > 0) {
     s.stop(`Found ${envCount} env var(s)`);

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -96,17 +96,6 @@ export function parseEnvFile(content: string): Record<string, string> {
   return vars;
 }
 
-async function readOptionalEnvFile(projectDir: string, envFile: string): Promise<string | null> {
-  try {
-    return await readFile(join(projectDir, envFile), 'utf-8');
-  } catch (err: unknown) {
-    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return null;
-    }
-    throw err;
-  }
-}
-
 async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
   const entries = await readdir(projectDir, { withFileTypes: true });
 
@@ -147,7 +136,7 @@ export async function readEnvVars(
 
   p.log.step(`Using env file: ${selectedEnvFile}`);
 
-  return parseEnvFile((await readOptionalEnvFile(projectDir, selectedEnvFile)) ?? '');
+  return parseEnvFile(await readFile(join(projectDir, selectedEnvFile), 'utf-8'));
 }
 
 /* ------------------------------------------------------------------ */

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { createWriteStream, readFileSync } from 'node:fs';
-import { mkdir, rm, stat, access, readFile } from 'node:fs/promises';
+import { mkdir, rm, stat, access, readFile, readdir } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -96,18 +96,64 @@ export function parseEnvFile(content: string): Record<string, string> {
   return vars;
 }
 
-async function readEnvVars(projectDir: string): Promise<Record<string, string>> {
-  const vars: Record<string, string> = {};
-  for (const envFile of ['.env.production', '.env.local', '.env']) {
-    try {
-      const content = await readFile(join(projectDir, envFile), 'utf-8');
-      Object.assign(vars, parseEnvFile(content));
-    } catch (err: unknown) {
-      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') continue;
-      throw err;
+async function readOptionalEnvFile(projectDir: string, envFile: string): Promise<string | null> {
+  try {
+    return await readFile(join(projectDir, envFile), 'utf-8');
+  } catch (err: unknown) {
+    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
+  const entries = await readdir(projectDir, { withFileTypes: true });
+
+  return entries
+    .filter(entry => entry.isFile() && (entry.name === '.env' || entry.name.startsWith('.env.')))
+    .map(entry => entry.name)
+    .sort((a, b) => {
+      if (a === '.env.production') return -1;
+      if (b === '.env.production') return 1;
+      if (a === '.env') return -1;
+      if (b === '.env') return 1;
+      return a.localeCompare(b);
+    });
+}
+
+export async function readEnvVars(
+  projectDir: string,
+  options: { autoAccept?: boolean } = {},
+): Promise<Record<string, string>> {
+  const availableDeployEnvFiles = await getDeployEnvFiles(projectDir);
+
+  if (availableDeployEnvFiles.length === 0) {
+    throw new Error('No env file found for deploy. Add a .env or .env.* file before deploying.');
+  }
+
+  let selectedEnvFile = availableDeployEnvFiles[0]!;
+
+  if (availableDeployEnvFiles.length > 1) {
+    if (!options.autoAccept) {
+      const selected = await p.select({
+        message: 'Choose env file to deploy',
+        options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
+        initialValue: selectedEnvFile,
+      });
+
+      if (p.isCancel(selected)) {
+        p.cancel('Deploy cancelled.');
+        process.exit(0);
+      }
+
+      selectedEnvFile = selected as string;
     }
   }
-  return vars;
+
+  p.log.step(`Using env file: ${selectedEnvFile}`);
+
+  return parseEnvFile((await readOptionalEnvFile(projectDir, selectedEnvFile)) ?? '');
 }
 
 /* ------------------------------------------------------------------ */
@@ -371,7 +417,7 @@ export async function deployAction(
   s.stop(`Created ${sizeLabel} archive (${elapsed(performance.now() - t)})`);
 
   s.start('Reading environment variables...');
-  const envVars = await readEnvVars(targetDir);
+  const envVars = await readEnvVars(targetDir, { autoAccept });
   const envCount = Object.keys(envVars).length;
   if (envCount > 0) {
     s.stop(`Found ${envCount} env var(s)`);

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -115,7 +115,8 @@ export async function readEnvVars(
     throw new Error('No env file found for deploy. Add a .env or .env.* file before deploying.');
   }
 
-  let selectedEnvFile = availableDeployEnvFiles[0]!;
+  let selectedEnvFile =
+    availableDeployEnvFiles.find(envFile => envFile === '.env.production') ?? availableDeployEnvFiles[0]!;
 
   if (availableDeployEnvFiles.length > 1) {
     if (!options.autoAccept) {

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -100,7 +100,9 @@ async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
   const entries = await readdir(projectDir, { withFileTypes: true });
 
   return entries
-    .filter(entry => entry.isFile() && (entry.name === '.env' || entry.name.startsWith('.env.')))
+    .filter(
+      entry => (entry.isFile() || entry.isSymbolicLink()) && (entry.name === '.env' || entry.name.startsWith('.env.')),
+    )
     .map(entry => entry.name)
     .sort((a, b) => a.localeCompare(b));
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -192,6 +192,7 @@ const deployCommand = studioCommand
   .option('--project <id>', 'Project ID')
   .option('-y, --yes', 'Auto-accept defaults without confirmation')
   .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
+  .option('--env-file <file>', 'Env file to deploy (for example: .env.production)')
   .option('--skip-build', 'Skip the build step and use existing .mastra/output')
   .option('--debug', 'Enable debug logs', false)
   .action(wrapAction(deployAction));
@@ -269,6 +270,7 @@ serverCommand
   .option('--project <id>', 'Project ID')
   .option('-y, --yes', 'Auto-accept defaults without confirmation')
   .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
+  .option('--env-file <file>', 'Env file to deploy (for example: .env.production)')
   .option('--skip-build', 'Skip the build step and deploy the existing .mastra/output directory')
   .option('--debug', 'Enable debug logs', false)
   .action(wrapAction(serverDeployAction));


### PR DESCRIPTION
## Description
This updates CLI deploys to discover `.env` and `.env.*` files in the project, default to `.env.production` when auto-accept is enabled, and prompt you to choose the file to upload when multiple env files are available. It also logs the selected file before upload and fails with a clear error when no deploy env file exists.

**Before**: deploys used a fixed env file order
**After** : you can pick from the env files found in the project the CLI confirms which env file will be uploaded deploy fails with a clear error if no `.env` or `.env.*` file exists.


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

The CLI deploy now finds environment files in your project (like .env and .env.*), makes you pick exactly one to upload (or auto-selects .env.production with --yes), and stops with a clear error if none are found.

## Overview

This change replaces the previous hard-coded, multi-file merging behavior with discovery of `.env` and `.env.*` files and selection of exactly one deploy env file. Behavior:
- Discover and deterministically sort `.env` and `.env.*` (including symlinks).
- If none exist, fail with a clear error.
- If multiple exist and auto-accept is disabled, prompt the user to choose; cancelling prints "Deploy cancelled." and exits.
- If auto-accept/--yes is enabled, default to `.env.production` when present; otherwise choose the first discovered file.
- Log which env file will be used and parse only that file (no merging).
- Treat ENOENT when reading the selected file as an error (do not treat as missing/skip).

One CodeRabbit comment remains unaddressed.

## Implementation changes

- packages/cli/src/commands/server/deploy.ts and packages/cli/src/commands/studio/deploy.ts
  - readEnvVars(projectDir, options?: { autoAccept?: boolean }) updated to:
    - Discover `.env` and `.env.*` files (includes symlinks), sort them, require ≥1 candidate.
    - Default to `.env.production` when autoAccept is true and present.
    - Prompt to select when multiple exist and autoAccept is false; exit on cancel.
    - Log the selected file and parse only that file; propagate read errors (ENOENT).
  - New helper getDeployEnvFiles(projectDir): Promise<string[]> added.
  - Deploy actions updated to pass autoAccept (opts.yes) through to readEnvVars.
  - Removed previous hard-coded env-file precedence and multi-file merging.

- .changeset/mighty-emus-rest.md
  - Adds changelog metadata documenting the UX change.

- Commit note: fix(cli): allow symlinked deploy env files — ensures symlinked `.env` files are accepted during discovery.

## Tests

- packages/cli/src/commands/server/deploy.test.ts and packages/cli/src/commands/studio/deploy.test.ts
  - Added/updated tests that mock node:fs/promises (readdir/readFile) to cover:
    - Interactive selection: verifies prompts.select usage, initial selection, and "Using env file" logging.
    - autoAccept mode: verifies `.env.production` is chosen without prompting.
    - Symlinked env files are included in discovery.
    - Selected-file missing: verifies readFile ENOENT is propagated as an error.
    - No env files: verifies explicit error when none are found.
  - Headless-mode tests updated to mock discovery/read so deploy proceeds with expected env values.

## Type of change

New feature (non-breaking)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->