### PR TITLE
docs: mark scorers/weather-scorer.ts as optional in quickstart file listing

### DIFF
--- a/docs/src/content/en/guides/getting-started/quickstart.mdx
+++ b/docs/src/content/en/guides/getting-started/quickstart.mdx
@@ -36,7 +36,7 @@ This creates a new directory for your project with a `src/mastra` folder contain
 - `agents/weather-agent.ts`: A weather agent with a prompt that uses the tool
 - `tools/weather-tool.ts`: A tool to fetch weather for a given location
 - `workflows/weather-workflow.ts`: A workflow that runs the weather agent
-- `scorers/weather-scorer.ts`: A scorer to evaluate the weather agent's responses
+- `scorers/weather-scorer.ts`: A scorer to evaluate the weather agent's responses (only generated if you select **scorers** as a component during setup)
 
 Depending on your choices, you'll also end up with [Mastra Skills](/docs/build-with-ai/skills) or the [MCP Docs Server](/docs/build-with-ai/mcp-docs-server) installed.
 


### PR DESCRIPTION
## Summary

- The quickstart guide lists `scorers/weather-scorer.ts` as part of the generated project structure with no caveat
- This file is **only** created when `scorers` is selected as a component during `create mastra` setup — it is not generated by default
- A user following the quickstart who didn't select scorers will look for the file, not find it, and assume something went wrong
- Added a clarifying note directly to the bullet so the file listing stays accurate

## How to reproduce

```bash
npx create-mastra@latest my-project --example --llm openai --components agents,tools,workflows
ls my-project/src/mastra/
# agents/  index.ts  tools/  workflows/
# no scorers/ directory
```

## Test plan

- Run `create mastra` without selecting scorers — confirm `scorers/weather-scorer.ts` is absent
- Run `create mastra --example --components agents,tools,workflows,scorers` — confirm `scorers/weather-scorer.ts` is still generated correctly
- Read the updated quickstart docs and confirm the file listing is no longer misleading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The quickstart guide listed a file you might not get. This PR adds a short note saying `scorers/weather-scorer.ts` is optional and only created if you pick the scorers component during project setup.

## Changes

**docs/src/content/en/guides/getting-started/quickstart.mdx**

Clarified the quickstart file listing to indicate that `src/mastra/scorers/weather-scorer.ts` is conditionally generated only when the **scorers** component is selected during `npx create-mastra` setup, instead of implying it is always present in the generated project.

This avoids confusion for users who don’t select scorers and therefore won’t see that file in their project.

**Impact**: Documentation only (+1/-1 lines)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->