### PR TITLE
fix(cli): throw on ambiguous env file in CI, trust explicit --env-file

### DIFF
--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -157,19 +157,30 @@ describe('readEnvVars (server deploy)', () => {
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });
 
-  it('defaults to .env.production in auto-accept mode when it exists', async () => {
-    const { readdir, readFile } = await import('node:fs/promises');
-    const prompts = await import('@clack/prompts');
+  it('throws in auto-accept mode when multiple env files exist and no --env-file specified', async () => {
+    const { readdir } = await import('node:fs/promises');
     vi.mocked(readdir).mockResolvedValue([
       { name: '.env.staging', isFile: () => true, isSymbolicLink: () => false },
       { name: '.env', isFile: () => true, isSymbolicLink: () => false },
       { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
     ] as unknown as Awaited<ReturnType<typeof readdir>>);
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { autoAccept: true })).rejects.toThrow(
+      'Multiple env files found: .env, .env.production, .env.staging. Use --env-file to specify which one to deploy.',
+    );
+  });
+
+  it('auto-selects the only env file in auto-accept mode without prompting', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
-      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
       if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
-      if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
     });
@@ -218,17 +229,11 @@ describe('readEnvVars (server deploy)', () => {
   });
 
   it('uses the requested env file without prompting', async () => {
-    const { readdir, readFile } = await import('node:fs/promises');
+    const { access, readFile } = await import('node:fs/promises');
     const prompts = await import('@clack/prompts');
-    vi.mocked(readdir).mockResolvedValue([
-      { name: '.env', isFile: () => true },
-      { name: '.env.staging', isFile: () => true },
-      { name: '.env.production', isFile: () => true },
-    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(access).mockResolvedValue(undefined);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
-      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
-      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
       if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
@@ -244,17 +249,34 @@ describe('readEnvVars (server deploy)', () => {
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });
 
-  it('fails when the requested env file is not available', async () => {
-    const { readdir } = await import('node:fs/promises');
-    vi.mocked(readdir).mockResolvedValue([
-      { name: '.env', isFile: () => true },
-      { name: '.env.production', isFile: () => true },
-    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+  it('accepts a non-.env-prefixed file when explicitly requested', async () => {
+    const { access, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(access).mockResolvedValue(undefined);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('config/prod.env')) return 'SECRET=abc';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { envFile: 'config/prod.env' })).resolves.toEqual({
+      SECRET: 'abc',
+    });
+    expect(prompts.select).not.toHaveBeenCalled();
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: config/prod.env');
+  });
+
+  it('fails when the requested env file does not exist on disk', async () => {
+    const { access } = await import('node:fs/promises');
+    vi.mocked(access).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
 
     const { readEnvVars } = await import('./deploy.js');
 
     await expect(readEnvVars('/project', { envFile: '.env.staging' })).rejects.toThrow(
-      'Env file not found for deploy: .env.staging. Available files: .env, .env.production',
+      'Env file not found: .env.staging',
     );
   });
 
@@ -293,6 +315,11 @@ describe('readEnvVars (server deploy)', () => {
 });
 
 describe('serverDeployAction', () => {
+  beforeEach(async () => {
+    const { access } = await import('node:fs/promises');
+    vi.mocked(access).mockResolvedValue(undefined);
+  });
+
   afterEach(() => {
     vi.resetModules();
   });

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -83,40 +83,48 @@ export async function readEnvVars(
   projectDir: string,
   options: { autoAccept?: boolean; envFile?: string } = {},
 ): Promise<Record<string, string>> {
+  // When an explicit env file is provided, trust the user — read it directly.
+  if (options.envFile) {
+    const filePath = join(projectDir, options.envFile);
+    try {
+      await access(filePath);
+    } catch {
+      throw new Error(`Env file not found: ${options.envFile}`);
+    }
+    p.log.step(`Using env file: ${options.envFile}`);
+    return parseEnvFile(await readFile(filePath, 'utf-8'));
+  }
+
   const availableDeployEnvFiles = await getDeployEnvFiles(projectDir);
 
   if (availableDeployEnvFiles.length === 0) {
     throw new Error('No env file found for deploy. Add a .env or .env.* file before deploying.');
   }
 
-  let selectedEnvFile = options.envFile;
+  let selectedEnvFile: string;
 
-  if (selectedEnvFile) {
-    if (!availableDeployEnvFiles.includes(selectedEnvFile)) {
-      throw new Error(
-        `Env file not found for deploy: ${selectedEnvFile}. Available files: ${availableDeployEnvFiles.join(', ')}`,
-      );
-    }
+  if (availableDeployEnvFiles.length === 1) {
+    selectedEnvFile = availableDeployEnvFiles[0]!;
+  } else if (options.autoAccept) {
+    throw new Error(
+      `Multiple env files found: ${availableDeployEnvFiles.join(', ')}. Use --env-file to specify which one to deploy.`,
+    );
   } else {
-    selectedEnvFile =
+    const defaultFile =
       availableDeployEnvFiles.find(envFile => envFile === '.env.production') ?? availableDeployEnvFiles[0]!;
 
-    if (availableDeployEnvFiles.length > 1) {
-      if (!options.autoAccept) {
-        const selected = await p.select({
-          message: 'Choose env file to deploy',
-          options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
-          initialValue: selectedEnvFile,
-        });
+    const selected = await p.select({
+      message: 'Choose env file to deploy',
+      options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
+      initialValue: defaultFile,
+    });
 
-        if (p.isCancel(selected)) {
-          p.cancel('Deploy cancelled.');
-          process.exit(0);
-        }
-
-        selectedEnvFile = selected as string;
-      }
+    if (p.isCancel(selected)) {
+      p.cancel('Deploy cancelled.');
+      process.exit(0);
     }
+
+    selectedEnvFile = selected as string;
   }
 
   p.log.step(`Using env file: ${selectedEnvFile}`);

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -232,19 +232,30 @@ describe('readEnvVars', () => {
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });
 
-  it('defaults to .env.production in auto-accept mode when it exists', async () => {
-    const { readdir, readFile } = await import('node:fs/promises');
-    const prompts = await import('@clack/prompts');
+  it('throws in auto-accept mode when multiple env files exist and no --env-file specified', async () => {
+    const { readdir } = await import('node:fs/promises');
     vi.mocked(readdir).mockResolvedValue([
       { name: '.env.staging', isFile: () => true, isSymbolicLink: () => false },
       { name: '.env', isFile: () => true, isSymbolicLink: () => false },
       { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
     ] as unknown as Awaited<ReturnType<typeof readdir>>);
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { autoAccept: true })).rejects.toThrow(
+      'Multiple env files found: .env, .env.production, .env.staging. Use --env-file to specify which one to deploy.',
+    );
+  });
+
+  it('auto-selects the only env file in auto-accept mode without prompting', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(readdir).mockResolvedValue([
+      { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
+    ] as unknown as Awaited<ReturnType<typeof readdir>>);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
-      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
       if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
-      if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
     });
@@ -293,17 +304,11 @@ describe('readEnvVars', () => {
   });
 
   it('uses the requested env file without prompting', async () => {
-    const { readdir, readFile } = await import('node:fs/promises');
+    const { access, readFile } = await import('node:fs/promises');
     const prompts = await import('@clack/prompts');
-    vi.mocked(readdir).mockResolvedValue([
-      { name: '.env', isFile: () => true },
-      { name: '.env.staging', isFile: () => true },
-      { name: '.env.production', isFile: () => true },
-    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.mocked(access).mockResolvedValue(undefined);
     vi.mocked(readFile).mockImplementation(async path => {
       const filePath = String(path);
-      if (filePath.endsWith('.env')) return 'SHARED=base\nBASE_ONLY=1';
-      if (filePath.endsWith('.env.production')) return 'SHARED=prod\nPROD_ONLY=1';
       if (filePath.endsWith('.env.staging')) return 'SHARED=staging\nSTAGING_ONLY=1';
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       throw err;
@@ -319,17 +324,34 @@ describe('readEnvVars', () => {
     expect(prompts.log.step).toHaveBeenCalledWith('Using env file: .env.staging');
   });
 
-  it('fails when the requested env file is not available', async () => {
-    const { readdir } = await import('node:fs/promises');
-    vi.mocked(readdir).mockResolvedValue([
-      { name: '.env', isFile: () => true },
-      { name: '.env.production', isFile: () => true },
-    ] as unknown as Awaited<ReturnType<typeof readdir>>);
+  it('accepts a non-.env-prefixed file when explicitly requested', async () => {
+    const { access, readFile } = await import('node:fs/promises');
+    const prompts = await import('@clack/prompts');
+    vi.mocked(access).mockResolvedValue(undefined);
+    vi.mocked(readFile).mockImplementation(async path => {
+      const filePath = String(path);
+      if (filePath.endsWith('config/prod.env')) return 'SECRET=abc';
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    });
+
+    const { readEnvVars } = await import('./deploy.js');
+
+    await expect(readEnvVars('/project', { envFile: 'config/prod.env' })).resolves.toEqual({
+      SECRET: 'abc',
+    });
+    expect(prompts.select).not.toHaveBeenCalled();
+    expect(prompts.log.step).toHaveBeenCalledWith('Using env file: config/prod.env');
+  });
+
+  it('fails when the requested env file does not exist on disk', async () => {
+    const { access } = await import('node:fs/promises');
+    vi.mocked(access).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
 
     const { readEnvVars } = await import('./deploy.js');
 
     await expect(readEnvVars('/project', { envFile: '.env.staging' })).rejects.toThrow(
-      'Env file not found for deploy: .env.staging. Available files: .env, .env.production',
+      'Env file not found: .env.staging',
     );
   });
 

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -111,40 +111,48 @@ export async function readEnvVars(
   projectDir: string,
   options: { autoAccept?: boolean; envFile?: string } = {},
 ): Promise<Record<string, string>> {
+  // When an explicit env file is provided, trust the user — read it directly.
+  if (options.envFile) {
+    const filePath = join(projectDir, options.envFile);
+    try {
+      await access(filePath);
+    } catch {
+      throw new Error(`Env file not found: ${options.envFile}`);
+    }
+    p.log.step(`Using env file: ${options.envFile}`);
+    return parseEnvFile(await readFile(filePath, 'utf-8'));
+  }
+
   const availableDeployEnvFiles = await getDeployEnvFiles(projectDir);
 
   if (availableDeployEnvFiles.length === 0) {
     throw new Error('No env file found for deploy. Add a .env or .env.* file before deploying.');
   }
 
-  let selectedEnvFile = options.envFile;
+  let selectedEnvFile: string;
 
-  if (selectedEnvFile) {
-    if (!availableDeployEnvFiles.includes(selectedEnvFile)) {
-      throw new Error(
-        `Env file not found for deploy: ${selectedEnvFile}. Available files: ${availableDeployEnvFiles.join(', ')}`,
-      );
-    }
+  if (availableDeployEnvFiles.length === 1) {
+    selectedEnvFile = availableDeployEnvFiles[0]!;
+  } else if (options.autoAccept) {
+    throw new Error(
+      `Multiple env files found: ${availableDeployEnvFiles.join(', ')}. Use --env-file to specify which one to deploy.`,
+    );
   } else {
-    selectedEnvFile =
+    const defaultFile =
       availableDeployEnvFiles.find(envFile => envFile === '.env.production') ?? availableDeployEnvFiles[0]!;
 
-    if (availableDeployEnvFiles.length > 1) {
-      if (!options.autoAccept) {
-        const selected = await p.select({
-          message: 'Choose env file to deploy',
-          options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
-          initialValue: selectedEnvFile,
-        });
+    const selected = await p.select({
+      message: 'Choose env file to deploy',
+      options: availableDeployEnvFiles.map(envFile => ({ value: envFile, label: envFile })),
+      initialValue: defaultFile,
+    });
 
-        if (p.isCancel(selected)) {
-          p.cancel('Deploy cancelled.');
-          process.exit(0);
-        }
-
-        selectedEnvFile = selected as string;
-      }
+    if (p.isCancel(selected)) {
+      p.cancel('Deploy cancelled.');
+      process.exit(0);
     }
+
+    selectedEnvFile = selected as string;
   }
 
   p.log.step(`Using env file: ${selectedEnvFile}`);


### PR DESCRIPTION
## What

Two behavior changes to deploy env file handling in both server and studio deploy commands.

### 1. Throw on ambiguous env file in non-interactive mode

When `autoAccept` is true (via `--yes` or `MASTRA_API_TOKEN`) and multiple `.env*` files are discovered without `--env-file` specified, `readEnvVars` now throws an error instead of silently picking one:

```
Multiple env files found: .env, .env.production, .env.staging. Use --env-file to specify which one to deploy.
```

If only one env file exists, it is auto-selected without error.

### 2. Trust the user when `--env-file` is explicit

When `--env-file` is provided, skip the `.env*` discovery list entirely and just validate the file exists on disk. This means any filename or path works (e.g. `--env-file config/prod.env`), not just files matching the `.env*` naming convention.

## Test plan

- All 39 existing tests pass (`vitest run src/commands/server/deploy.test.ts src/commands/studio/deploy.test.ts`)
- New test cases added for both fixes in both server and studio deploy
- TypeScript compiles cleanly (`tsc --noEmit`)