### PR TITLE
feat(editor): apply builder default memory config on agent creation

### DIFF
--- a/packages/core/src/agent-builder/ee/types.ts
+++ b/packages/core/src/agent-builder/ee/types.ts
@@ -1,3 +1,14 @@
+import type { SerializedMemoryConfig } from '../../memory/types';
+
+/**
+ * Default values for agents created via the builder.
+ * Used as fallbacks when the user doesn't specify a value.
+ */
+export interface BuilderAgentDefaults extends Record<string, unknown> {
+  /** Default memory configuration for new agents */
+  memory?: SerializedMemoryConfig;
+}
+
 /**
  * Feature toggles for the agent editor surface.
  * Each key controls visibility of that section in the builder UI.
@@ -46,11 +57,10 @@ export interface AgentBuilderOptions {
    * Admin-pinned values applied to every artifact the builder produces.
    * Not overridable by end-users.
    *
-   * Shape is intentionally loose (Record<string, unknown>) while we finalize
-   * the exact configuration options.
+   * Known fields are typed explicitly; additional fields allowed for extensibility.
    */
   configuration?: {
-    agent?: Record<string, unknown>;
+    agent?: BuilderAgentDefaults;
   };
 }
 

--- a/packages/editor/src/editor.test.ts
+++ b/packages/editor/src/editor.test.ts
@@ -1446,3 +1446,118 @@ describe('MastraEditor.resolveBuilder', () => {
     expect(result?.getConfiguration()).toBe(configuration);
   });
 });
+
+// ============================================================================
+// agent.create with builder defaults
+// ============================================================================
+
+describe('agent.create with builder defaults', () => {
+  it('applies default memory config when input has none', async () => {
+    const storage = new InMemoryStore();
+    const builderMemory = { vector: 'default-vector', options: { lastMessages: 10 } };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: { agent: { memory: builderMemory } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-no-memory',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.memory).toEqual(builderMemory);
+  });
+
+  it('preserves input memory config when provided', async () => {
+    const storage = new InMemoryStore();
+    const builderMemory = { vector: 'default-vector', options: { lastMessages: 10 } };
+    const inputMemory = { vector: 'custom-vector', options: { lastMessages: 5 } };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: { agent: { memory: builderMemory } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-with-memory',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+      memory: inputMemory,
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.memory).toEqual(inputMemory);
+  });
+
+  it('does not override null memory (explicit disable)', async () => {
+    const storage = new InMemoryStore();
+    const builderMemory = { vector: 'default-vector', options: { lastMessages: 10 } };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: { agent: { memory: builderMemory } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-null-memory',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+      memory: null,
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.memory).toBeNull();
+  });
+
+  it('does nothing when builder has no configuration', async () => {
+    const storage = new InMemoryStore();
+    const editor = new MastraEditor({
+      builder: { enabled: true },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-no-config',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.memory).toBeUndefined();
+  });
+
+  it('does nothing when builder is disabled', async () => {
+    const storage = new InMemoryStore();
+    const builderMemory = { vector: 'default-vector', options: { lastMessages: 10 } };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: false,
+        configuration: { agent: { memory: builderMemory } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-disabled-builder',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.memory).toBeUndefined();
+  });
+});

--- a/packages/editor/src/editor.test.ts
+++ b/packages/editor/src/editor.test.ts
@@ -1560,4 +1560,36 @@ describe('agent.create with builder defaults', () => {
     const rawConfig = agent.toRawConfig?.();
     expect(rawConfig?.memory).toBeUndefined();
   });
+
+  it('clone() does not apply builder default memory', async () => {
+    const storage = new InMemoryStore();
+    const builderMemory = { vector: 'default-vector', options: { lastMessages: 50 } };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: { agent: { memory: builderMemory } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    // Create an agent via storage directly (bypassing builder defaults) with no memory
+    const agentsStore = await storage.getStore('agents');
+    await agentsStore.create({
+      agent: {
+        id: 'no-memory-agent',
+        name: 'No Memory Agent',
+        instructions: 'No memory',
+        model: { provider: 'openai', name: 'gpt-4' },
+        // memory is undefined - no memory config
+      },
+    });
+
+    const noMemoryAgent = await editor.agent.getById('no-memory-agent');
+    expect(noMemoryAgent).not.toBeNull();
+
+    // Clone this agent - should NOT pick up builder defaults
+    // clone() copies source agent config exactly, bypassing EditorAgentNamespace.create()
+    const clonedNoMemory = await editor.agent.clone(noMemoryAgent!, { newId: 'cloned-no-memory' });
+    expect(clonedNoMemory.memory).toBeUndefined();
+  });
 });

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -44,6 +44,38 @@ import { CrudEditorNamespace } from './base';
 import type { StorageAdapter } from './base';
 import { EditorMCPNamespace } from './mcp';
 
+// ============================================================================
+// Builder Defaults
+// ============================================================================
+
+/** Fields from builder.configuration.agent that can be applied as creation defaults */
+const BUILDER_DEFAULT_FIELDS = ['memory'] as const;
+
+/**
+ * Apply builder defaults to agent creation input.
+ * Only applies for fields where input is `undefined` (not `null` — null is explicit disable).
+ */
+function applyBuilderDefaults(
+  input: StorageCreateAgentInput,
+  builderAgentConfig: Record<string, unknown> | undefined,
+): StorageCreateAgentInput {
+  if (!builderAgentConfig) return input;
+
+  const defaults: Partial<StorageCreateAgentInput> = {};
+
+  for (const field of BUILDER_DEFAULT_FIELDS) {
+    if (input[field] === undefined && builderAgentConfig[field] !== undefined) {
+      (defaults as Record<string, unknown>)[field] = builderAgentConfig[field];
+    }
+  }
+
+  return Object.keys(defaults).length > 0 ? { ...input, ...defaults } : input;
+}
+
+// ============================================================================
+// EditorAgentNamespace
+// ============================================================================
+
 export class EditorAgentNamespace extends CrudEditorNamespace<
   StorageCreateAgentInput,
   StorageUpdateAgentInput,
@@ -111,6 +143,21 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
    */
   protected async hydrate(storedAgent: StorageResolvedAgentType): Promise<Agent> {
     return this.createAgentFromStoredConfig(storedAgent);
+  }
+
+  /**
+   * Create a new agent, applying builder defaults for fields not specified in input.
+   */
+  async create(input: StorageCreateAgentInput): Promise<Agent> {
+    let finalInput = input;
+
+    if (this.editor.hasEnabledBuilderConfig()) {
+      const builder = await this.editor.resolveBuilder();
+      const agentConfig = builder?.getConfiguration()?.agent;
+      finalInput = applyBuilderDefaults(input, agentConfig);
+    }
+
+    return super.create(finalInput);
   }
 
   protected override onCacheEvict(id: string): void {

--- a/packages/server/src/server/handlers/stored-agents.test.ts
+++ b/packages/server/src/server/handlers/stored-agents.test.ts
@@ -213,16 +213,24 @@ function createMockStorage(agentsStore?: MockAgentsStore): MockStorage {
 interface MockEditor {
   agent: {
     clearCache: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
   };
   prompt: {
     preview: ReturnType<typeof vi.fn>;
   };
 }
 
-function createMockEditor(): MockEditor {
+function createMockEditor(agentsStore?: MockAgentsStore): MockEditor {
   return {
     agent: {
       clearCache: vi.fn(),
+      // Delegate to storage so existing assertions work
+      create: vi.fn().mockImplementation(async (input: unknown) => {
+        if (agentsStore) {
+          await agentsStore.create({ agent: input });
+        }
+        return {} as unknown;
+      }),
     },
     prompt: {
       preview: vi.fn().mockResolvedValue('resolved instructions'),
@@ -266,7 +274,7 @@ describe('Stored Agents Handlers', () => {
     mockAgentsData = new Map();
     mockAgentsStore = createMockAgentsStore(mockAgentsData);
     mockStorage = createMockStorage(mockAgentsStore);
-    mockEditor = createMockEditor();
+    mockEditor = createMockEditor(mockAgentsStore);
     mockMastra = createMockMastra({ storage: mockStorage, editor: mockEditor });
   });
 

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -201,32 +201,37 @@ export const CREATE_STORED_AGENT_ROUTE: ServerRoute<
         throw new HTTPException(409, { message: `Agent with id ${id} already exists` });
       }
 
-      // Create agent with flat StorageCreateAgentInput
-      // Cast needed because Zod's passthrough() output types don't exactly match the handwritten TS interfaces
-      await agentsStore.create({
-        agent: {
-          id,
-          authorId,
-          metadata,
-          name,
-          description,
-          instructions,
-          model,
-          tools,
-          defaultOptions,
-          workflows,
-          agents,
-          integrationTools,
-          mcpClients,
-          inputProcessors,
-          outputProcessors,
-          memory,
-          scorers,
-          skills,
-          workspace,
-          requestContextSchema,
-        } as StorageCreateAgentInput,
-      });
+      const input = {
+        id,
+        authorId,
+        metadata,
+        name,
+        description,
+        instructions,
+        model,
+        tools,
+        defaultOptions,
+        workflows,
+        agents,
+        integrationTools,
+        mcpClients,
+        inputProcessors,
+        outputProcessors,
+        memory,
+        scorers,
+        skills,
+        workspace,
+        requestContextSchema,
+      } as StorageCreateAgentInput;
+
+      // Use editor.agent.create() when available to apply builder defaults
+      const editor = mastra.getEditor?.();
+      if (editor) {
+        await editor.agent.create(input);
+      } else {
+        // Fallback to direct storage create
+        await agentsStore.create({ agent: input });
+      }
 
       // Return the resolved agent (thin record + version config)
       // Use draft status since newly created entities start as drafts


### PR DESCRIPTION
## Summary

When an admin configures a default memory config in the builder settings (`builder.configuration.agent.memory`), newly created agents inherit that config as a fallback.

## Changes

- Add `BUILDER_DEFAULT_FIELDS` allowlist for safe, extensible field merging
- Add `applyBuilderDefaults()` utility for merging builder defaults into create input
- Override `create()` in `EditorAgentNamespace` to apply defaults when input lacks them
- Add 5 tests covering:
  - Fallback when no memory provided
  - Preservation when memory already specified
  - Explicit `null` not overridden (user disabled memory)
  - No builder config scenario
  - Builder disabled scenario

## Design Decisions

- **Allowlist approach**: Only `memory` field currently, but extensible for future fields
- **`undefined` vs `null`**: Only `undefined` triggers fallback; `null` means user explicitly disabled
- **`clone()` bypass**: Intentional — cloning copies source agent config, not builder defaults

## Test Plan

```bash
pnpm --filter @mastra/editor test -- src/editor.test.ts --run
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When admins configure a default memory setting for agents in the builder, new agents automatically inherit that setting unless the creator specifically says otherwise. This is like having a default setting that all new agents follow, unless you explicitly change it for a particular agent.

## Changes Overview

This PR enables agents created through the editor to automatically inherit default memory configuration from builder settings, with a fallback mechanism that respects explicit user choices.

### Key Changes

**Type Definitions & Configuration**
- Added `BuilderAgentDefaults` interface in `packages/core/src/agent-builder/ee/types.ts` to properly type agent-level builder defaults
- Updated `AgentBuilderOptions.configuration.agent` to use the new typed interface instead of generic `Record<string, unknown>`, explicitly supporting `memory?: SerializedMemoryConfig` as a known field

**Agent Creation Override**
- `EditorAgentNamespace.create()` now applies builder defaults when creating agents
- When builder config is enabled and contains agent defaults, the method merges whitelisted fields (currently `memory`) into the creation input only if those fields are `undefined`
- Explicitly set `null` values are preserved (user-disabled settings are not overridden)
- Delegates to parent `CrudEditorNamespace` after applying defaults
- Cloning agents intentionally bypasses builder defaults

**Server-side Agent Creation**
- Updated `packages/server/src/server/handlers/stored-agents.ts` to use `editor.agent.create()` when the editor is available, enabling builder defaults to be applied on the server
- Falls back to direct `agentsStore.create()` when no editor is present

**Test Coverage**
- Added comprehensive test suite in `packages/editor/src/editor.test.ts` validating:
  - Default memory is applied when creating agents without explicit memory config
  - Explicitly provided memory values override builder defaults
  - Explicit `null` values are preserved (not overridden by defaults)
  - No defaulting occurs when builder config lacks agent configuration
  - No defaulting occurs when builder is disabled
  - Cloning agents does not inject builder defaults retroactively

**Test Infrastructure**
- Updated `packages/server/src/server/handlers/stored-agents.test.ts` to support the new editor mock with `agent.create` capability, wiring it to the underlying agent store

### Implementation Details

A `BUILDER_DEFAULT_FIELDS` allowlist controls which builder configuration fields can be safely merged as defaults, enabling safe extensibility. The fallback treats `undefined` as the trigger for applying defaults while preserving explicit `null` to respect user-disabled settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->