### PR TITLE
fix(memory): temporal gap markers corrupted message list history

### DIFF
--- a/.changeset/curly-hairs-reply.md
+++ b/.changeset/curly-hairs-reply.md
@@ -1,5 +1,0 @@
----
-'@mastra/memory': patch
----
-
-Fixed a bug where temporal gap markers caused message duplication and history corruption. When observational memory temporal markers were enabled, inserting a gap marker destructively cleared and rebuilt the entire in-memory message list. This broke internal deduplication and sealed-message boundaries, causing identical messages to appear twice in the thread history. The marker is now added directly without rebuilding the list.

--- a/.changeset/curly-hairs-reply.md
+++ b/.changeset/curly-hairs-reply.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed a bug where temporal gap markers caused message duplication and history corruption. When observational memory temporal markers were enabled, inserting a gap marker destructively cleared and rebuilt the entire in-memory message list. This broke internal deduplication and sealed-message boundaries, causing identical messages to appear twice in the thread history. The marker is now added directly without rebuilding the list.

--- a/packages/memory/src/processors/observational-memory/temporal-markers.ts
+++ b/packages/memory/src/processors/observational-memory/temporal-markers.ts
@@ -91,7 +91,6 @@ export async function insertTemporalGapMarkers({
     return;
   }
 
-  const check = messageList.makeMessageSourceChecker();
   const allMessages = messageList.get.all.db().filter((message): message is MastraDBMessage => Boolean(message));
   const latestInputIndex = allMessages.findIndex(message => message.id === latestInputMessage.id);
 
@@ -136,11 +135,5 @@ export async function insertTemporalGapMarkers({
   });
 
   const marker = createTemporalGapMarker(latestInputMessage, gapText, gapMs, timestamp);
-  const rebuiltMessages = [...allMessages];
-  rebuiltMessages.splice(latestInputIndex, 0, marker);
-
-  messageList.clear.all.db();
-  for (const message of rebuiltMessages) {
-    messageList.add(message, message === marker ? 'input' : (check.getSource(message) ?? 'memory'));
-  }
+  messageList.add(marker, 'input');
 }


### PR DESCRIPTION
fix(memory): temporal gap markers corrupted message list history

The original implementation in #15605 inserted temporal gap markers by calling `messageList.clear.all.db()` and rebuilding the entire message list from scratch. This broke internal deduplication and sealed-message boundary tracking, causing duplicate messages in thread history.

Before:
```ts
const rebuiltMessages = [...allMessages];
rebuiltMessages.splice(latestInputIndex, 0, marker);

messageList.clear.all.db();
for (const message of rebuiltMessages) {
  messageList.add(message, message === marker ? 'input' : (check.getSource(message) ?? 'memory'));
}
```

After:
```ts
const marker = createTemporalGapMarker(latestInputMessage, gapText, gapMs, timestamp);
messageList.add(marker, 'input');
```

The fix simply adds the marker without touching any existing messages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Imagine you have a list of messages in a conversation. Previously, when adding a "time gap" marker (showing a break in conversation), the code would erase the entire list and rebuild it from scratch. This caused messages to appear twice. The fix is simple: just insert the marker directly without erasing everything, which prevents the duplicates.

## Problem
The previous implementation (PR #15605) for inserting temporal gap markers reconstructed the entire message list by:
1. Computing the source for each prior message using `makeMessageSourceChecker()`
2. Clearing all messages with `messageList.clear.all.db()`
3. Re-adding every message and the marker

This destructive approach broke internal deduplication and sealed-message boundary tracking, resulting in duplicate messages appearing in thread history.

## Solution
The fix removes the message list reconstruction logic. Instead of clearing and rebuilding, the temporal gap marker is now created and added directly to the list using `messageList.add(marker, 'input')` without any clearing or rebuilding of existing messages. This preserves deduplication integrity and sealed-message boundaries.

## Changes
- **`.changeset/curly-hairs-reply.md`**: Release note documenting the fix as a patch for `@mastra/memory`
- **`packages/memory/src/processors/observational-memory/temporal-markers.ts`**: Removed the destructive message list reconstruction logic; marker is now appended directly

## Testing
Temporal markers tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->