### PR TITLE
Revert "fix(express): align handlerParams tools with fastify adapter"

### DIFF
--- a/.changeset/fix-express-tools.md
+++ b/.changeset/fix-express-tools.md
@@ -1,5 +1,0 @@
----
-'@mastra/express': patch
----
-
-Fix inconsistency between Express and Fastify adapters by exposing `tools` in handler params while preserving `registeredTools`

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -499,7 +499,6 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
           ...(typeof params.body === 'object' ? params.body : {}),
           requestContext: res.locals.requestContext,
           mastra: this.mastra,
-          tools: res.locals.registeredTools,
           registeredTools: res.locals.registeredTools,
           taskStore: res.locals.taskStore,
           abortSignal: res.locals.abortSignal,


### PR DESCRIPTION
Reverts mastra-ai/mastra#15632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR undoes a recent change that tried to make Express and Fastify request handlers work the same way. It removes a `tools` field that was added to route handlers, leaving only the existing `registeredTools` field for accessing available tools.

## Changes Made

### Deleted Files
- `.changeset/fix-express-tools.md` - Removed the changeset entry documenting the alignment of Express/Fastify adapter behavior for a `@mastra/express` patch release

### Modified Files
**server-adapters/express/src/index.ts**
- Removed the `tools: res.locals.registeredTools` line from the `handlerParams` object constructed in the `registerRoute` method
- Route handlers now rely solely on the `registeredTools` field populated from `res.locals.registeredTools` for accessing available tools

## Context
This PR reverts the changes from PR #15632, which had added a `tools` property to the Express adapter to align it with the Fastify adapter. That change exposed the same tools data under a new property name while maintaining backward compatibility with the existing `registeredTools` property. This revert removes the newly-added `tools` field entirely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->