### PR TITLE
fix(cli): correct success message when API key not provided during init

### DIFF
--- a/.changeset/fix-cli-env-success-message.md
+++ b/.changeset/fix-cli-env-success-message.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Correct success message to match actual file created when no API key is provided during init

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -185,8 +185,8 @@ export const init = async ({
       p.note(`
       ${color.green('Mastra initialized successfully!')}
 
-      Add your ${color.cyan(key)} as an environment variable
-      in your ${color.cyan('.env')} file
+      Rename ${color.cyan('.env.example')} to ${color.cyan('.env')}
+      and add your ${color.cyan(key)}
       `);
     } else {
       p.note(`


### PR DESCRIPTION
## Summary

When running `create mastra` or `mastra init` without providing an `--llm-api-key`, the CLI intentionally writes `.env.example` instead of `.env` (with a placeholder value). This is correct behaviour — it avoids creating an invalid `.env` that would break a first run.

However, the success message still told users:

> Add your `OPENAI_API_KEY` as an environment variable in your `.env` file

No `.env` file exists at that point, only `.env.example`. A new user following those instructions will look for a file that isn't there.

This PR updates the message to match reality:

> Rename `.env.example` to `.env` and add your `OPENAI_API_KEY`

The `else` branch (API key was provided, `.env` was written) is unchanged.

Open to alternative approaches here (e.g., always creating `.env` and leaving the key blank) — happy to adjust based on your preference.

## How to reproduce

```bash
npx create-mastra@latest my-project --llm openai
# do NOT enter an API key when prompted
# observe the success message references .env
ls my-project   # only .env.example exists
```

## Test plan

- Run `create mastra` without providing an API key — confirm the success message now says to rename `.env.example`
- Run `create mastra --llm-api-key sk-...` with a real key — confirm the success message is unchanged (shows only "Mastra initialized successfully!")
- Confirm `.env.example` is still created (not `.env`) when no key is given

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you create a new Mastra project without providing an API key, the CLI was telling you to add your API key to a `.env` file that doesn't exist yet. This PR fixes that by updating the message to tell you the correct steps: rename the `.env.example` file (which does get created) to `.env`, then add your API key to it.

## Summary

This PR fixes an inconsistency in the CLI's success message shown during initialization when users run `create mastra` or `mastra init` without providing an `--llm-api-key` parameter.

**The Problem:** When no API key is provided, the CLI intentionally creates a `.env.example` file with a placeholder value instead of a `.env` file. However, the success message was incorrectly instructing users to add their API key to `.env`, which doesn't exist in this scenario, creating confusion.

**The Solution:** The success message for the no-key initialization path has been updated to provide accurate instructions: rename `.env.example` to `.env`, then add the `OPENAI_API_KEY` (the CLI displays the provider key name dynamically). The success message for the path where an API key is provided (when `.env` is directly created) remains unchanged.

**Changes Made:**
- Modified packages/cli/src/commands/init/init.ts to show a different p.note() message when `llmApiKey` is not provided:
  - New message instructs users to rename `.env.example` to `.env` and add the displayed API key name.
  - When `llmApiKey` is provided, the original success message is preserved.
- Added .changeset/fix-cli-env-success-message.md to include a changeset (patch) for this fix.

**Verification:** Run `create mastra` (or `mastra init`) without `--llm-api-key` and confirm:
- The CLI prints the updated guidance telling you to rename `.env.example` to `.env` and add the API key.
- A `.env.example` file exists.
Run with `--llm-api-key` to confirm the original behavior and message are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->