### PR TITLE
fix(core): remove saveStepMessages and disable savePerStep when observational memory is enabled

### DIFF
--- a/.changeset/puny-actors-vanish.md
+++ b/.changeset/puny-actors-vanish.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed interaction between savePerStep and observational memory that caused message duplication. The saveStepMessages method redundantly re-added response messages to the message list on every step, duplicating them. Additionally, savePerStep is now force-disabled when observational memory is enabled, since OM handles its own per-step persistence and the two features conflict.

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -766,7 +766,8 @@ const response = await agent.generate('Help me organize my day', {
             name: 'savePerStep',
             type: 'boolean',
             isOptional: true,
-            description: 'Save messages incrementally after each generation step completes (default: false).',
+            description:
+              'Save messages incrementally after each generation step completes (default: false). Disabled internally when observational memory is enabled.',
           },
           {
             name: 'providerOptions',

--- a/docs/src/content/en/reference/agents/generateLegacy.mdx
+++ b/docs/src/content/en/reference/agents/generateLegacy.mdx
@@ -336,7 +336,8 @@ await agent.generateLegacy('message for agent')
             name: 'savePerStep',
             type: 'boolean',
             isOptional: true,
-            description: 'Save messages incrementally after each stream step completes (default: false).',
+            description:
+              'Save messages incrementally after each generation step completes (default: false). Disabled internally when observational memory is enabled.',
           },
           {
             name: 'providerOptions',

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -165,8 +165,6 @@ export interface AgentLegacyCapabilities {
     instructions?: DynamicArgument<string>;
     minMessages?: number;
   };
-  /** Save step messages */
-  saveStepMessages(args: { result: any; messageList: MessageList; runId: string }): Promise<void>;
   /** Convert instructions to string */
   convertInstructionsToString(instructions: AgentInstructions): string;
   /** Options for tracing policy */
@@ -834,12 +832,6 @@ export class AgentLegacyHandler {
                 });
                 threadCreatedByStep = true;
               }
-
-              await this.capabilities.saveStepMessages({
-                result: props,
-                messageList,
-                runId,
-              });
             }
 
             return onStepFinish?.({ ...props, runId });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1412,7 +1412,6 @@ export class Agent<
         getMostRecentUserMessage: this.getMostRecentUserMessage.bind(this),
         genTitle: this.genTitle.bind(this),
         resolveTitleGenerationConfig: this.resolveTitleGenerationConfig.bind(this),
-        saveStepMessages: this.saveStepMessages.bind(this),
         convertInstructionsToString: this.#convertInstructionsToString.bind(this),
         tracingPolicy: this.#options?.tracingPolicy,
         resolvedVersionId: this.toRawConfig()?.resolvedVersionId as string | undefined,
@@ -4530,47 +4529,6 @@ export class Agent<
     return tools;
   }
 
-  /**
-   * Adds response messages from a step to the MessageList and schedules persistence.
-   * This is used for incremental saving: after each agent step, messages are added to a save queue
-   * and a debounced save operation is triggered to avoid redundant writes.
-   *
-   * @param result - The step result containing response messages.
-   * @param messageList - The MessageList instance for the current thread.
-   * @param threadId - The thread ID.
-   * @param memoryConfig - The memory configuration for saving.
-   * @param runId - (Optional) The run ID for logging.
-   * @internal
-   */
-  private async saveStepMessages({
-    result,
-    messageList,
-    runId,
-  }: {
-    result: any;
-    messageList: MessageList;
-    runId?: string;
-  }) {
-    try {
-      // Prefer dbMessages (MastraDBMessage[] with original IDs) over response.messages
-      // (ModelMessage[] without IDs) to avoid generating new IDs during format conversion
-      const stepResponseMessages = result.response.dbMessages?.length
-        ? result.response.dbMessages
-        : result.response.messages;
-      if (stepResponseMessages?.length) {
-        messageList.add(stepResponseMessages, 'response');
-      }
-      // Message saving is now handled by MessageHistory output processor
-    } catch (e) {
-      this.logger.error('Error adding messages on step finish', {
-        agent: this.name,
-        error: e,
-        runId,
-      });
-      throw e;
-    }
-  }
-
   async #runScorers({
     messageList,
     runId,
@@ -5013,7 +4971,6 @@ export class Agent<
         '_agentNetworkAppend' in this
           ? Boolean((this as unknown as { _agentNetworkAppend: unknown })._agentNetworkAppend)
           : undefined,
-      saveStepMessages: this.saveStepMessages.bind(this),
       convertTools: this.convertTools.bind(this),
       getMemoryMessages: this.getMemoryMessages.bind(this),
       runInputProcessors: this.__runInputProcessors.bind(this),

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -450,7 +450,7 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
   /** Unique identifier for this execution run */
   runId?: string;
 
-  /** Save messages incrementally after each stream step completes (default: false). */
+  /** Save messages incrementally after each stream step completes (default: false). Is disabled internally when observational memory is enabled, as OM handles its own message saving */
   savePerStep?: boolean;
 
   /** Request Context containing dynamic configuration and state */

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -76,7 +76,9 @@ export function createMapResultsStep<OUTPUT = undefined>({
       requestContext,
       messageList: memoryData.messageList,
       onStepFinish: async (props: any) => {
-        if (options.savePerStep && !memoryConfig?.readOnly) {
+        // When OM is enabled saving per step corrupts things because OM handles its own saving
+        const shouldSavePerStep = options.savePerStep && !memoryConfig?.observationalMemory;
+        if (shouldSavePerStep && !memoryConfig?.readOnly) {
           if (!memoryData.threadExists && !threadCreatedByStep && memory && memoryData.thread) {
             await memory.createThread({
               threadId: memoryData.thread?.id,
@@ -88,12 +90,6 @@ export function createMapResultsStep<OUTPUT = undefined>({
 
             threadCreatedByStep = true;
           }
-
-          await capabilities.saveStepMessages({
-            result: props,
-            messageList: memoryData.messageList!,
-            runId,
-          });
 
           if (saveQueueManager && memoryData.thread?.id) {
             await saveQueueManager.flushMessages(memoryData.messageList!, memoryData.thread.id, memoryConfig);

--- a/packages/core/src/agent/workflows/prepare-stream/schema.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/schema.ts
@@ -22,7 +22,6 @@ export type AgentCapabilities = {
   generateMessageId: Mastra['generateId'];
   mastra?: Mastra;
   _agentNetworkAppend?: boolean;
-  saveStepMessages: Agent['saveStepMessages'];
   convertTools: Agent['convertTools'];
   runInputProcessors: Agent['__runInputProcessors'];
   executeOnFinish: (args: AgentExecuteOnFinishOptions) => Promise<void>;

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1328,6 +1328,7 @@ export class Harness<TState = {}> {
         maxSteps: 1000,
         // Harness supports suspending + resuming streams (tool approvals, tool suspensions, workflows).
         // Persisting per-step snapshots ensures `resumeStream()` can load state reliably (especially in CI).
+        // Doesn't do anything when OM is enabled though, OM does its own saving per step
         savePerStep: true,
         requireToolApproval: !isYolo,
         modelSettings: { temperature: 1 },


### PR DESCRIPTION
fix(core): remove saveStepMessages and disable savePerStep when observational memory is enabled

The `saveStepMessages` method was redundantly re-adding response messages to the messageList on every step, causing pure duplication since the LLM execution step already adds messages.

Before (in `map-results-step.ts`):
```ts
await capabilities.saveStepMessages({
  result: props,
  messageList: memoryData.messageList!,
  runId,
});

if (saveQueueManager && memoryData.thread?.id) {
  await saveQueueManager.flushMessages(memoryData.messageList!, memoryData.thread.id, memoryConfig);
}
```

After:
```ts
if (saveQueueManager && memoryData.thread?.id) {
  await saveQueueManager.flushMessages(messageData.messageList!, memoryData.thread.id, memoryConfig);
}
```

Additionally, `savePerStep` now checks `!memoryConfig?.observationalMemory` before flushing. Observational memory handles its own per-step persistence, so `savePerStep` conflicts with it and is force-disabled when OM is on.

The `saveStepMessages` method has been completely removed from `Agent` and `AgentLegacyHandler` since it served no purpose beyond duplication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The code was accidentally saving messages to memory twice on each step - once automatically and once manually - causing duplication. This fix removes the duplicate manual save method and tells the automatic save feature to skip saving when observational memory (a smarter way to track messages) is already handling it.

## Overview

This PR eliminates redundant message-saving logic in the agent execution pipeline by removing the `saveStepMessages` capability entirely and adding a conditional check to prevent `savePerStep` from running when observational memory is enabled.

## Changes

### Core Functionality Changes
- **Removed `saveStepMessages` capability**: Deleted the entire `saveStepMessages` method from `Agent` and its interface in `AgentLegacyCapabilities`, eliminating the redundant per-step message re-adding that was conflicting with the automatic message addition during LLM execution
- **Conditional `savePerStep` flushing**: Modified `map-results-step.ts` to only flush queued messages when `savePerStep` is enabled AND observational memory is not configured, preventing conflicts with observational memory's own persistence mechanism

### Documentation Updates
- Updated JSDoc for `AgentExecutionOptionsBase.savePerStep` to document that it is internally disabled when observational memory is enabled
- Updated `docs/src/content/en/reference/agents/generate.mdx` and `generateLegacy.mdx` to clarify that `savePerStep` is disabled when observational memory is active
- Added clarifying comment in `harness.ts` regarding `savePerStep` behavior with observational memory

### Type/Interface Changes
- Removed `saveStepMessages` property from `AgentCapabilities` type definition in `schema.ts`
- Removed `saveStepMessages` method declaration from `AgentLegacyCapabilities` interface

### Supporting Changes
- Added changeset documentation for the `@mastra/core` patch release

## Impact

This change simplifies the message persistence architecture by eliminating redundancy and preventing conflicting persistence logic when observational memory is in use. Applications using observational memory will benefit from cleaner per-step persistence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->