### PR TITLE
feat(playground): agent builder routes, access gating, and config-driven form [DONT MERGE]

### DIFF
--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -133,6 +133,23 @@ export const mastra = new Mastra({
     toolProviders: {
       composio: new ComposioToolProvider({ apiKey: '' }),
     },
+    builder: {
+      enabled: true,
+      features: {
+        agent: {
+          tools: true,
+        }
+      },
+      configuration: {
+        agent: {
+          memory: {
+            options: {
+              lastMessages: 10, 
+            }
+          }
+        },
+      },
+    },
   }),
   observability: new Observability({
     configs: {

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -85,6 +85,8 @@ import Workflows from './pages/workflows';
 import { Workflow } from './pages/workflows/workflow';
 import Workspace from './pages/workspace';
 import WorkspaceSkillDetailPage from './pages/workspace/skills/[skillName]';
+import AgentBuilderIndex from './pages/agent-builder';
+import AgentBuilderCreatePage from './pages/agent-builder/agents/create';
 import { Layout } from '@/components/layout';
 import { MinimalLayout } from '@/components/minimal-layout';
 import { AgentLayout } from '@/domains/agents/agent-layout';
@@ -119,6 +121,7 @@ const paths: LinkComponentProviderProps['paths'] = {
   cmsScorerEditLink: (scorerId: string) => `/cms/scorers/${scorerId}/edit`,
   cmsAgentCreateLink: () => '/cms/agents/create',
   cmsAgentEditLink: (agentId: string) => `/cms/agents/${agentId}/edit`,
+  agentBuilderCreateLink: () => '/agent-builder/agents/create',
   promptBlockLink: (promptBlockId: string) => `/prompts/${promptBlockId}`,
   promptBlocksLink: () => '/prompts',
   cmsPromptBlockCreateLink: () => '/cms/prompts/create',
@@ -234,6 +237,10 @@ const routes = [
       },
       { path: '/cms/scorers/create', element: <CmsScorersCreatePage /> },
       { path: '/cms/scorers/:scorerId/edit', element: <CmsScorersEditPage /> },
+
+      // Agent Builder routes
+      { path: '/agent-builder', element: <AgentBuilderIndex /> },
+      { path: '/agent-builder/agents/create', element: <AgentBuilderCreatePage /> },
       { path: '/prompts', element: <PromptBlocks /> },
       { path: '/cms/prompts/create', element: <CmsPromptBlocksCreatePage /> },
       { path: '/cms/prompts/:promptBlockId/edit', element: <CmsPromptBlocksEditPage /> },

--- a/packages/playground/src/domains/agents/hooks/use-can-create-agent.ts
+++ b/packages/playground/src/domains/agents/hooks/use-can-create-agent.ts
@@ -1,16 +1,30 @@
-import { usePermissions } from '@/domains/auth/hooks/use-permissions';
-import { useIsBuilderEnabled } from '@/domains/builder/hooks/use-builder-settings';
+import { useBuilderAgentAccess } from '@/domains/builder/hooks/use-builder-agent-access';
 
-export const useCanCreateAgent = () => {
-  const { hasPermission, rbacEnabled } = usePermissions();
-  const { isEnabled: isBuilderEnabled } = useIsBuilderEnabled();
+// CMS route used for legacy env-var mode
+const CMS_AGENT_CREATE_ROUTE = '/cms/agents/create';
+// Builder route for agent creation (Phase 2 adds this route)
+const BUILDER_AGENT_CREATE_ROUTE = '/agent-builder/agents/create';
+
+export interface UseCanCreateAgentResult {
+  /** Whether user can create agents (via env flag or builder access) */
+  canCreateAgent: boolean;
+  /** Route to navigate to for agent creation */
+  createRoute: string;
+  /** Loading state */
+  isLoading: boolean;
+}
+
+export const useCanCreateAgent = (): UseCanCreateAgentResult => {
+  const { canAccessAgentBuilder, isLoading } = useBuilderAgentAccess();
 
   // Legacy: env var check (for users without EE license)
   const hasEnvFlag =
     typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).MASTRA_EXPERIMENTAL_UI === 'true';
 
-  // New: builder enabled (EE) + RBAC permission
-  const hasBuilderAccess = isBuilderEnabled && (!rbacEnabled || hasPermission('stored-agents:write'));
+  const canCreateAgent = hasEnvFlag || canAccessAgentBuilder;
 
-  return { canCreateAgent: hasEnvFlag || hasBuilderAccess };
+  // Route to builder if has builder access, else CMS for legacy env mode
+  const createRoute = canAccessAgentBuilder ? BUILDER_AGENT_CREATE_ROUTE : CMS_AGENT_CREATE_ROUTE;
+
+  return { canCreateAgent, createRoute, isLoading };
 };

--- a/packages/playground/src/domains/agents/hooks/use-can-create-agent.ts
+++ b/packages/playground/src/domains/agents/hooks/use-can-create-agent.ts
@@ -1,6 +1,16 @@
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+import { useIsBuilderEnabled } from '@/domains/builder/hooks/use-builder-settings';
+
 export const useCanCreateAgent = () => {
-  const canCreateAgent =
+  const { hasPermission, rbacEnabled } = usePermissions();
+  const { isEnabled: isBuilderEnabled } = useIsBuilderEnabled();
+
+  // Legacy: env var check (for users without EE license)
+  const hasEnvFlag =
     typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).MASTRA_EXPERIMENTAL_UI === 'true';
 
-  return { canCreateAgent };
+  // New: builder enabled (EE) + RBAC permission
+  const hasBuilderAccess = isBuilderEnabled && (!rbacEnabled || hasPermission('stored-agents:write'));
+
+  return { canCreateAgent: hasEnvFlag || hasBuilderAccess };
 };

--- a/packages/playground/src/domains/builder/components/agent-builder-form.tsx
+++ b/packages/playground/src/domains/builder/components/agent-builder-form.tsx
@@ -1,0 +1,178 @@
+import {
+  AgentIcon,
+  Button,
+  Header,
+  HeaderAction,
+  HeaderTitle,
+  Icon,
+  Input,
+  Label,
+  MainContentLayout,
+  Spinner,
+  Textarea,
+} from '@mastra/playground-ui';
+import { Check } from 'lucide-react';
+import { Controller, useWatch } from 'react-hook-form';
+
+import type { VisibleSections } from '../hooks/use-agent-builder-form';
+import { useAgentBuilderForm } from '../hooks/use-agent-builder-form';
+import { LLMModels, LLMProviders } from '@/domains/llm';
+
+interface AgentBuilderFormProps {
+  visibleSections: VisibleSections;
+}
+
+export function AgentBuilderForm({ visibleSections }: AgentBuilderFormProps) {
+  const { form, onSubmit, isSubmitting } = useAgentBuilderForm(visibleSections);
+  const { control, formState } = form;
+  const { errors } = formState;
+
+  const modelProvider = useWatch({ control, name: 'model.provider' });
+
+  return (
+    <MainContentLayout>
+      <Header className="bg-surface1">
+        <HeaderTitle>
+          <Icon>
+            <AgentIcon />
+          </Icon>
+          Create an agent
+        </HeaderTitle>
+
+        <HeaderAction>
+          <Button variant="primary" onClick={onSubmit} disabled={isSubmitting} className="w-full">
+            {isSubmitting ? (
+              <>
+                <Spinner className="h-4 w-4" />
+                Creating...
+              </>
+            ) : (
+              <>
+                <Icon>
+                  <Check />
+                </Icon>
+                Create agent
+              </>
+            )}
+          </Button>
+        </HeaderAction>
+      </Header>
+
+      <div className="flex-1 overflow-auto p-6">
+        <form onSubmit={onSubmit} className="max-w-2xl space-y-6">
+          {/* Base Fields - Always visible */}
+          <section className="space-y-4">
+            <h2 className="text-lg font-medium text-text1">Identity</h2>
+
+            <div className="space-y-2">
+              <Label htmlFor="name">Name *</Label>
+              <Controller
+                name="name"
+                control={control}
+                render={({ field }) => (
+                  <Input id="name" placeholder="My Agent" {...field} className={errors.name ? 'border-red-500' : ''} />
+                )}
+              />
+              {errors.name && <p className="text-sm text-red-500">{errors.name.message}</p>}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Controller
+                name="description"
+                control={control}
+                render={({ field }) => <Input id="description" placeholder="A helpful agent..." {...field} />}
+              />
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-lg font-medium text-text1">Instructions</h2>
+
+            <div className="space-y-2">
+              <Label htmlFor="instructions">Instructions *</Label>
+              <Controller
+                name="instructions"
+                control={control}
+                render={({ field }) => (
+                  <Textarea
+                    id="instructions"
+                    placeholder="You are a helpful assistant..."
+                    rows={6}
+                    {...field}
+                    className={errors.instructions ? 'border-red-500' : ''}
+                  />
+                )}
+              />
+              {errors.instructions && <p className="text-sm text-red-500">{errors.instructions.message}</p>}
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h2 className="text-lg font-medium text-text1">Model</h2>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Provider *</Label>
+                <Controller
+                  name="model.provider"
+                  control={control}
+                  render={({ field }) => <LLMProviders value={field.value} onValueChange={field.onChange} />}
+                />
+                {errors.model?.provider && <p className="text-sm text-red-500">{errors.model.provider.message}</p>}
+              </div>
+
+              <div className="space-y-2">
+                <Label>Model *</Label>
+                <Controller
+                  name="model.name"
+                  control={control}
+                  render={({ field }) => (
+                    <LLMModels value={field.value} onValueChange={field.onChange} llmId={modelProvider} />
+                  )}
+                />
+                {errors.model?.name && <p className="text-sm text-red-500">{errors.model.name.message}</p>}
+              </div>
+            </div>
+          </section>
+
+          {/* Capability Sections - Conditionally visible based on features */}
+          {visibleSections.tools && (
+            <section className="space-y-4">
+              <h2 className="text-lg font-medium text-text1">Tools</h2>
+              <p className="text-sm text-text2">Tool selection coming soon...</p>
+            </section>
+          )}
+
+          {visibleSections.memory && (
+            <section className="space-y-4">
+              <h2 className="text-lg font-medium text-text1">Memory</h2>
+              <p className="text-sm text-text2">Memory configuration coming soon...</p>
+            </section>
+          )}
+
+          {visibleSections.skills && (
+            <section className="space-y-4">
+              <h2 className="text-lg font-medium text-text1">Skills</h2>
+              <p className="text-sm text-text2">Skills selection coming soon...</p>
+            </section>
+          )}
+
+          {visibleSections.workflows && (
+            <section className="space-y-4">
+              <h2 className="text-lg font-medium text-text1">Workflows</h2>
+              <p className="text-sm text-text2">Workflow selection coming soon...</p>
+            </section>
+          )}
+
+          {visibleSections.agents && (
+            <section className="space-y-4">
+              <h2 className="text-lg font-medium text-text1">Sub-Agents</h2>
+              <p className="text-sm text-text2">Agent selection coming soon...</p>
+            </section>
+          )}
+        </form>
+      </div>
+    </MainContentLayout>
+  );
+}

--- a/packages/playground/src/domains/builder/hooks/__tests__/use-builder-agent-access.test.ts
+++ b/packages/playground/src/domains/builder/hooks/__tests__/use-builder-agent-access.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+
+// Mock the dependencies before importing the hook
+vi.mock('@/domains/auth/hooks/use-permissions', () => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock('../use-builder-settings', () => ({
+  useBuilderSettings: vi.fn(),
+}));
+
+import { useBuilderAgentAccess } from '../use-builder-agent-access';
+import { useBuilderSettings } from '../use-builder-settings';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+
+describe('useBuilderAgentAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('permission checks', () => {
+    it('returns permission-denied when missing agents:read', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: true,
+        hasAllPermissions: (perms: string[]) => {
+          // Has stored-agents:write but not agents:read
+          if (perms.includes('agents:read')) return false;
+          return true;
+        },
+      });
+
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: { enabled: true, features: { agent: { tools: true } } },
+        isLoading: false,
+        error: null,
+      });
+
+      const result = useBuilderAgentAccess();
+
+      expect(result.denialReason).toBe('permission-denied');
+      expect(result.canAccessAgentBuilder).toBe(false);
+      expect(result.hasRequiredPermissions).toBe(false);
+    });
+
+    it('returns permission-denied when missing stored-agents:write', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: true,
+        hasAllPermissions: (perms: string[]) => {
+          // Has agents:read but not stored-agents:write
+          if (perms.includes('stored-agents:write')) return false;
+          return true;
+        },
+      });
+
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: { enabled: true, features: { agent: { tools: true } } },
+        isLoading: false,
+        error: null,
+      });
+
+      const result = useBuilderAgentAccess();
+
+      expect(result.denialReason).toBe('permission-denied');
+      expect(result.canAccessAgentBuilder).toBe(false);
+      expect(result.hasRequiredPermissions).toBe(false);
+    });
+
+    it('skips settings fetch when missing agents:read permission', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: true,
+        hasAllPermissions: (perms: string[]) => {
+          if (perms.includes('agents:read')) return false;
+          return true;
+        },
+      });
+
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+      });
+
+      useBuilderAgentAccess();
+
+      // Check that useBuilderSettings was called with enabled: false
+      expect(useBuilderSettings).toHaveBeenCalledWith({ enabled: false });
+    });
+
+    it('bypasses permission checks when RBAC is disabled', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: false,
+        hasAllPermissions: () => true, // Always returns true when RBAC disabled
+      });
+
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: { enabled: true, features: { agent: { tools: true } } },
+        isLoading: false,
+        error: null,
+      });
+
+      const result = useBuilderAgentAccess();
+
+      expect(result.hasRequiredPermissions).toBe(true);
+      expect(result.canAccessAgentBuilder).toBe(true);
+      expect(result.denialReason).toBeNull();
+    });
+  });
+
+  describe('builder state checks', () => {
+    it('returns not-configured when builder.enabled is false', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: false,
+        hasAllPermissions: () => true,
+      });
+
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: { enabled: false, features: { agent: { tools: true } } },
+        isLoading: false,
+        error: null,
+      });
+
+      const result = useBuilderAgentAccess();
+
+      expect(result.denialReason).toBe('not-configured');
+      expect(result.isBuilderEnabled).toBe(false);
+      expect(result.canAccessAgentBuilder).toBe(false);
+    });
+
+    it('returns not-configured when features.agent is undefined', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: false,
+        hasAllPermissions: () => true,
+      });
+
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: { enabled: true, features: {} },
+        isLoading: false,
+        error: null,
+      });
+
+      const result = useBuilderAgentAccess();
+
+      expect(result.denialReason).toBe('not-configured');
+      expect(result.hasAgentFeature).toBe(false);
+      expect(result.canAccessAgentBuilder).toBe(false);
+    });
+
+    it('returns error denial reason on settings fetch error', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: false,
+        hasAllPermissions: () => true,
+      });
+
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: new Error('Failed to fetch'),
+      });
+
+      const result = useBuilderAgentAccess();
+
+      expect(result.denialReason).toBe('error');
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.canAccessAgentBuilder).toBe(false);
+    });
+  });
+
+  describe('success cases', () => {
+    it('returns canAccessAgentBuilder: true when all checks pass', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: true,
+        hasAllPermissions: () => true,
+      });
+
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: {
+          enabled: true,
+          features: { agent: { tools: true, memory: true } },
+        },
+        isLoading: false,
+        error: null,
+      });
+
+      const result = useBuilderAgentAccess();
+
+      expect(result.canAccessAgentBuilder).toBe(true);
+      expect(result.denialReason).toBeNull();
+      expect(result.isBuilderEnabled).toBe(true);
+      expect(result.hasAgentFeature).toBe(true);
+      expect(result.hasRequiredPermissions).toBe(true);
+      expect(result.agentFeatures).toEqual({ tools: true, memory: true });
+    });
+
+    it('returns agentFeatures from builder config', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: false,
+        hasAllPermissions: () => true,
+      });
+
+      const features = { tools: true, memory: false, instructions: true };
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: { enabled: true, features: { agent: features } },
+        isLoading: false,
+        error: null,
+      });
+
+      const result = useBuilderAgentAccess();
+
+      expect(result.agentFeatures).toEqual(features);
+    });
+  });
+
+  describe('loading state', () => {
+    it('returns isLoading: true when settings are loading', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: false,
+        hasAllPermissions: () => true,
+      });
+
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: null,
+        isLoading: true,
+        error: null,
+      });
+
+      const result = useBuilderAgentAccess();
+
+      expect(result.isLoading).toBe(true);
+    });
+
+    it('returns isLoading: false when fetch is skipped due to permissions', () => {
+      (usePermissions as Mock).mockReturnValue({
+        rbacEnabled: true,
+        hasAllPermissions: (perms: string[]) => {
+          if (perms.includes('agents:read')) return false;
+          return true;
+        },
+      });
+
+      (useBuilderSettings as Mock).mockReturnValue({
+        data: null,
+        isLoading: true, // Would be loading if enabled
+        error: null,
+      });
+
+      const result = useBuilderAgentAccess();
+
+      // Should not be loading because we skipped the fetch
+      expect(result.isLoading).toBe(false);
+    });
+  });
+});

--- a/packages/playground/src/domains/builder/hooks/use-agent-builder-form.ts
+++ b/packages/playground/src/domains/builder/hooks/use-agent-builder-form.ts
@@ -1,0 +1,140 @@
+import type { CreateStoredAgentParams } from '@mastra/client-js';
+import { toast } from '@mastra/playground-ui';
+import type { Resolver } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+
+import { useStoredAgentMutations } from '@/domains/agents/hooks/use-stored-agents';
+import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
+import { useLinkComponent } from '@/lib/framework';
+
+export interface AgentBuilderFormValues {
+  name: string;
+  description?: string;
+  instructions: string;
+  model: {
+    provider: string;
+    name: string;
+  };
+  // Capability sections (optional, only included if section is visible)
+  tools?: Record<string, { description?: string }>;
+  memory?: {
+    enabled: boolean;
+    lastMessages?: number;
+    semanticRecall?: boolean;
+  };
+  skills?: Record<string, { description?: string }>;
+  workflows?: Record<string, { description?: string }>;
+  agents?: Record<string, { description?: string }>;
+}
+
+export interface VisibleSections {
+  tools: boolean;
+  memory: boolean;
+  skills: boolean;
+  workflows: boolean;
+  agents: boolean;
+}
+
+// Simple validation resolver
+function createAgentBuilderResolver(): Resolver<AgentBuilderFormValues> {
+  return async values => {
+    const errors: Record<string, { type: string; message: string }> = {};
+
+    if (!values.name || values.name.trim() === '') {
+      errors.name = { type: 'required', message: 'Name is required' };
+    } else if (values.name.length > 100) {
+      errors.name = { type: 'maxLength', message: 'Name must be 100 characters or less' };
+    }
+
+    if (!values.instructions || values.instructions.trim() === '') {
+      errors.instructions = { type: 'required', message: 'Instructions are required' };
+    }
+
+    if (!values.model?.provider || values.model.provider.trim() === '') {
+      errors['model.provider'] = { type: 'required', message: 'Provider is required' };
+    }
+
+    if (!values.model?.name || values.model.name.trim() === '') {
+      errors['model.name'] = { type: 'required', message: 'Model is required' };
+    }
+
+    return {
+      values: Object.keys(errors).length === 0 ? values : {},
+      errors: Object.keys(errors).length > 0 ? errors : {},
+    };
+  };
+}
+
+export function useAgentBuilderForm(visibleSections: VisibleSections) {
+  const navigate = useNavigate();
+  const { paths } = useLinkComponent();
+  const { data: user } = useCurrentUser();
+  const { createStoredAgent } = useStoredAgentMutations();
+
+  const form = useForm<AgentBuilderFormValues>({
+    resolver: createAgentBuilderResolver(),
+    defaultValues: {
+      name: '',
+      description: '',
+      instructions: '',
+      model: { provider: '', name: '' },
+      tools: {},
+      memory: { enabled: false, lastMessages: 40, semanticRecall: false },
+      skills: {},
+      workflows: {},
+      agents: {},
+    },
+  });
+
+  const onSubmit = async (values: AgentBuilderFormValues) => {
+    // Build payload with only visible sections
+    const payload: CreateStoredAgentParams = {
+      name: values.name,
+      description: values.description || undefined,
+      instructions: values.instructions,
+      model: values.model,
+      authorId: user?.id,
+    };
+
+    // Include visible sections if they have values
+    if (visibleSections.tools && values.tools && Object.keys(values.tools).length > 0) {
+      payload.tools = values.tools;
+    }
+    if (visibleSections.memory && values.memory?.enabled) {
+      payload.memory = {
+        options: {
+          lastMessages: values.memory.lastMessages,
+          semanticRecall: values.memory.semanticRecall,
+        },
+      };
+    }
+    if (visibleSections.skills && values.skills && Object.keys(values.skills).length > 0) {
+      payload.skills = values.skills;
+    }
+    if (visibleSections.workflows && values.workflows && Object.keys(values.workflows).length > 0) {
+      payload.workflows = values.workflows;
+    }
+    if (visibleSections.agents && values.agents && Object.keys(values.agents).length > 0) {
+      payload.agents = values.agents;
+    }
+
+    // Hidden sections with admin defaults handled server-side (memory only for now)
+
+    try {
+      const result = await createStoredAgent.mutateAsync(payload);
+      toast.success('Agent created successfully');
+      void navigate(paths.agentLink(result.id));
+    } catch (error) {
+      toast.error('Failed to create agent');
+      throw error;
+    }
+  };
+
+  return {
+    form,
+    onSubmit: form.handleSubmit(onSubmit),
+    isSubmitting: createStoredAgent.isPending,
+    error: createStoredAgent.error,
+  };
+}

--- a/packages/playground/src/domains/builder/hooks/use-builder-agent-access.ts
+++ b/packages/playground/src/domains/builder/hooks/use-builder-agent-access.ts
@@ -1,0 +1,79 @@
+import { useBuilderSettings } from './use-builder-settings';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+
+export type DenialReason = 'permission-denied' | 'not-configured' | 'error' | null;
+
+export interface UseBuilderAgentAccessResult {
+  /** Loading state (false if skipped due to missing permissions) */
+  isLoading: boolean;
+  /** Error from settings fetch (null if skipped) */
+  error: Error | null;
+  /** Reason access is denied, null if allowed */
+  denialReason: DenialReason;
+  /** Whether builder.enabled is true */
+  isBuilderEnabled: boolean;
+  /** Whether features.agent is defined */
+  hasAgentFeature: boolean;
+  /** Whether user has both agents:read and stored-agents:write */
+  hasRequiredPermissions: boolean;
+  /** Final access decision: all checks pass */
+  canAccessAgentBuilder: boolean;
+  /** Agent feature flags from builder config */
+  agentFeatures: Record<string, unknown> | undefined;
+}
+
+/**
+ * Unified access check for Agent Builder.
+ *
+ * Checks:
+ * 1. Permissions (agents:read + stored-agents:write) — checked first to avoid 403 on settings fetch
+ * 2. Builder enabled (builder.enabled === true)
+ * 3. Agent feature defined (features.agent exists)
+ *
+ * Returns `canAccessAgentBuilder: true` only when all checks pass.
+ */
+export function useBuilderAgentAccess(): UseBuilderAgentAccessResult {
+  const { hasAllPermissions, rbacEnabled } = usePermissions();
+
+  // Check permissions FIRST — before fetching settings
+  const hasRequiredPermissions = !rbacEnabled || hasAllPermissions(['agents:read', 'stored-agents:write']);
+
+  // Only fetch settings if user has agents:read permission
+  const canFetchSettings = !rbacEnabled || hasAllPermissions(['agents:read']);
+  const {
+    data: builderSettings,
+    isLoading,
+    error,
+  } = useBuilderSettings({
+    enabled: canFetchSettings,
+  });
+
+  // Check builder state
+  const isBuilderEnabled = builderSettings?.enabled === true;
+  const hasAgentFeature = builderSettings?.features?.agent !== undefined;
+
+  // Combined access decision
+  const canAccessAgentBuilder = hasRequiredPermissions && isBuilderEnabled && hasAgentFeature;
+
+  // Determine denial reason (priority order)
+  const denialReason: DenialReason = !hasRequiredPermissions
+    ? 'permission-denied'
+    : error
+      ? 'error'
+      : !isBuilderEnabled
+        ? 'not-configured'
+        : !hasAgentFeature
+          ? 'not-configured'
+          : null;
+
+  return {
+    isLoading: canFetchSettings && isLoading,
+    error: canFetchSettings ? (error as Error | null) : null,
+    denialReason,
+    isBuilderEnabled,
+    hasAgentFeature,
+    hasRequiredPermissions,
+    canAccessAgentBuilder,
+    agentFeatures: builderSettings?.features?.agent as Record<string, unknown> | undefined,
+  };
+}

--- a/packages/playground/src/domains/builder/hooks/use-builder-agent-access.ts
+++ b/packages/playground/src/domains/builder/hooks/use-builder-agent-access.ts
@@ -3,6 +3,16 @@ import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 
 export type DenialReason = 'permission-denied' | 'not-configured' | 'error' | null;
 
+export interface AgentFeatureFlags {
+  tools?: boolean;
+  agents?: boolean;
+  workflows?: boolean;
+  scorers?: boolean;
+  skills?: boolean;
+  memory?: boolean;
+  variables?: boolean;
+}
+
 export interface UseBuilderAgentAccessResult {
   /** Loading state (false if skipped due to missing permissions) */
   isLoading: boolean;
@@ -19,7 +29,7 @@ export interface UseBuilderAgentAccessResult {
   /** Final access decision: all checks pass */
   canAccessAgentBuilder: boolean;
   /** Agent feature flags from builder config */
-  agentFeatures: Record<string, unknown> | undefined;
+  agentFeatures: AgentFeatureFlags | undefined;
 }
 
 /**
@@ -74,6 +84,6 @@ export function useBuilderAgentAccess(): UseBuilderAgentAccessResult {
     hasAgentFeature,
     hasRequiredPermissions,
     canAccessAgentBuilder,
-    agentFeatures: builderSettings?.features?.agent as Record<string, unknown> | undefined,
+    agentFeatures: builderSettings?.features?.agent as AgentFeatureFlags | undefined,
   };
 }

--- a/packages/playground/src/domains/builder/hooks/use-builder-settings.ts
+++ b/packages/playground/src/domains/builder/hooks/use-builder-settings.ts
@@ -33,3 +33,21 @@ export const useIsBuilderEnabled = () => {
     error,
   };
 };
+
+/**
+ * Returns feature flags for agent builder sections.
+ * Supports tools, memory, skills, workflows, agents.
+ * Scorers and variables deferred (always false).
+ */
+export const useBuilderAgentFeatures = () => {
+  const { data } = useBuilderSettings();
+  const features = data?.features?.agent;
+
+  return {
+    tools: features?.tools === true,
+    memory: features?.memory === true,
+    skills: features?.skills === true,
+    workflows: features?.workflows === true,
+    agents: features?.agents === true,
+  };
+};

--- a/packages/playground/src/domains/builder/hooks/use-builder-settings.ts
+++ b/packages/playground/src/domains/builder/hooks/use-builder-settings.ts
@@ -1,16 +1,22 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
+interface UseBuilderSettingsOptions {
+  /** Skip fetch when false (default: true) */
+  enabled?: boolean;
+}
+
 /**
  * Fetches agent builder settings from the server.
  * Returns feature flags and configuration set by admin.
  */
-export const useBuilderSettings = () => {
+export const useBuilderSettings = (options?: UseBuilderSettingsOptions) => {
   const client = useMastraClient();
 
   return useQuery({
     queryKey: ['builder-settings'],
     queryFn: () => client.getBuilderSettings(),
+    enabled: options?.enabled ?? true,
   });
 };
 

--- a/packages/playground/src/domains/builder/index.ts
+++ b/packages/playground/src/domains/builder/index.ts
@@ -1,1 +1,6 @@
-export { useBuilderSettings, useIsBuilderEnabled } from './hooks/use-builder-settings';
+export { useBuilderSettings, useIsBuilderEnabled, useBuilderAgentFeatures } from './hooks/use-builder-settings';
+export { useBuilderAgentAccess } from './hooks/use-builder-agent-access';
+export type { AgentFeatureFlags, DenialReason, UseBuilderAgentAccessResult } from './hooks/use-builder-agent-access';
+export { useAgentBuilderForm } from './hooks/use-agent-builder-form';
+export type { AgentBuilderFormValues, VisibleSections } from './hooks/use-agent-builder-form';
+export { AgentBuilderForm } from './components/agent-builder-form';

--- a/packages/playground/src/lib/framework.tsx
+++ b/packages/playground/src/lib/framework.tsx
@@ -29,6 +29,8 @@ type LinkComponentPaths = {
   cmsAgentCreateLink: () => string;
   cmsAgentEditLink: (agentId: string) => string;
 
+  agentBuilderCreateLink: () => string;
+
   promptBlockLink: (promptBlockId: string) => string;
   promptBlocksLink: () => string;
   cmsPromptBlockCreateLink: () => string;
@@ -76,6 +78,7 @@ const LinkComponentContext = createContext<{
     cmsScorerEditLink: () => '',
     cmsAgentCreateLink: () => '',
     cmsAgentEditLink: () => '',
+    agentBuilderCreateLink: () => '',
     promptBlockLink: () => '',
     promptBlocksLink: () => '',
     cmsPromptBlockCreateLink: () => '',

--- a/packages/playground/src/pages/agent-builder/agents/create.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/create.tsx
@@ -1,0 +1,61 @@
+import { EmptyState } from '@mastra/playground-ui';
+import { AlertTriangle, LockIcon, Settings } from 'lucide-react';
+
+import { useBuilderAgentAccess } from '@/domains/builder/hooks/use-builder-agent-access';
+
+/**
+ * Agent Builder create page shell.
+ * Phase 3 will add the actual form implementation.
+ */
+export default function AgentBuilderCreatePage() {
+  const { isLoading, denialReason, agentFeatures } = useBuilderAgentAccess();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (denialReason === 'permission-denied') {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<LockIcon />}
+          titleSlot="Access Denied"
+          descriptionSlot="You don't have permission to create agents."
+        />
+      </div>
+    );
+  }
+
+  if (denialReason === 'error') {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<AlertTriangle />}
+          titleSlot="Error"
+          descriptionSlot="Failed to load Agent Builder configuration."
+        />
+      </div>
+    );
+  }
+
+  if (denialReason) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<Settings />}
+          titleSlot="Agent Builder Not Configured"
+          descriptionSlot="Agent creation is not enabled. Contact your administrator to enable this feature."
+        />
+      </div>
+    );
+  }
+
+  // Phase 3 will replace this with actual form
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Create Agent</h1>
+      <p className="text-muted-foreground mb-4">Agent Builder form will be implemented in Phase 3.</p>
+      <pre className="bg-muted p-4 rounded text-sm">{JSON.stringify({ agentFeatures }, null, 2)}</pre>
+    </div>
+  );
+}

--- a/packages/playground/src/pages/agent-builder/agents/create.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/create.tsx
@@ -1,11 +1,12 @@
 import { EmptyState } from '@mastra/playground-ui';
 import { AlertTriangle, LockIcon, Settings } from 'lucide-react';
 
+import { AgentBuilderForm } from '@/domains/builder/components/agent-builder-form';
 import { useBuilderAgentAccess } from '@/domains/builder/hooks/use-builder-agent-access';
 
 /**
- * Agent Builder create page shell.
- * Phase 3 will add the actual form implementation.
+ * Agent Builder create page.
+ * Shows config-driven form for creating agents.
  */
 export default function AgentBuilderCreatePage() {
   const { isLoading, denialReason, agentFeatures } = useBuilderAgentAccess();
@@ -50,12 +51,14 @@ export default function AgentBuilderCreatePage() {
     );
   }
 
-  // Phase 3 will replace this with actual form
-  return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold mb-4">Create Agent</h1>
-      <p className="text-muted-foreground mb-4">Agent Builder form will be implemented in Phase 3.</p>
-      <pre className="bg-muted p-4 rounded text-sm">{JSON.stringify({ agentFeatures }, null, 2)}</pre>
-    </div>
-  );
+  // Build visible sections from agent features
+  const visibleSections = {
+    tools: agentFeatures?.tools ?? false,
+    memory: agentFeatures?.memory ?? false,
+    skills: agentFeatures?.skills ?? false,
+    workflows: agentFeatures?.workflows ?? false,
+    agents: agentFeatures?.agents ?? false,
+  };
+
+  return <AgentBuilderForm visibleSections={visibleSections} />;
 }

--- a/packages/playground/src/pages/agent-builder/index.tsx
+++ b/packages/playground/src/pages/agent-builder/index.tsx
@@ -1,0 +1,70 @@
+import { Navigate } from 'react-router';
+
+import { EmptyState } from '@mastra/playground-ui';
+import { AlertTriangle, LockIcon, Settings } from 'lucide-react';
+
+import { useBuilderAgentAccess } from '@/domains/builder/hooks/use-builder-agent-access';
+
+/**
+ * Agent Builder index page - redirects to first available feature.
+ * Currently only supports agent creation; future features (library, etc.) will be added.
+ */
+export default function AgentBuilderIndex() {
+  const { isLoading, denialReason, hasAgentFeature } = useBuilderAgentAccess();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (denialReason === 'permission-denied') {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<LockIcon />}
+          titleSlot="Access Denied"
+          descriptionSlot="You don't have permission to access the Agent Builder."
+        />
+      </div>
+    );
+  }
+
+  if (denialReason === 'error') {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<AlertTriangle />}
+          titleSlot="Error"
+          descriptionSlot="Failed to load Agent Builder configuration."
+        />
+      </div>
+    );
+  }
+
+  if (denialReason === 'not-configured') {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          iconSlot={<Settings />}
+          titleSlot="Agent Builder Not Configured"
+          descriptionSlot="Agent Builder is not enabled. Contact your administrator to enable this feature."
+        />
+      </div>
+    );
+  }
+
+  // Redirect to first available feature
+  if (hasAgentFeature) {
+    return <Navigate to="/agent-builder/agents/create" replace />;
+  }
+
+  // No features available (shouldn't reach here if denialReason logic is correct)
+  return (
+    <div className="flex h-full items-center justify-center">
+      <EmptyState
+        iconSlot={<Settings />}
+        titleSlot="No Features Enabled"
+        descriptionSlot="No Agent Builder features are configured."
+      />
+    </div>
+  );
+}

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -22,10 +22,9 @@ import { useLinkComponent } from '@/lib/framework';
 function Agents() {
   const { data: agents = {}, isLoading, error } = useAgents();
   const [search, setSearch] = useState('');
-  const { canCreateAgent } = useCanCreateAgent();
-  const { Link: FrameworkLink, paths } = useLinkComponent();
-  const createAgentPath = paths.cmsAgentCreateLink();
-  const showCreateCta = canCreateAgent && Boolean(createAgentPath);
+  const { canCreateAgent, createRoute } = useCanCreateAgent();
+  const { Link: FrameworkLink } = useLinkComponent();
+  const showCreateCta = canCreateAgent && Boolean(createRoute);
 
   if (error && is401UnauthorizedError(error)) {
     return (
@@ -72,7 +71,7 @@ function Agents() {
           </PageLayout.Column>
           <PageLayout.Column className="flex justify-end gap-2">
             {showCreateCta && (
-              <ButtonWithTooltip as={FrameworkLink} to={createAgentPath} tooltipContent="Create an agent">
+              <ButtonWithTooltip as={FrameworkLink} to={createRoute} tooltipContent="Create an agent">
                 <Plus />
               </ButtonWithTooltip>
             )}


### PR DESCRIPTION
## Summary

Implements agent builder UI with config-driven sections and proper access gating. This PR enables the "Create Agent" flow through the new `/agent-builder` routes, gated by EE builder config and RBAC permissions.

## What This PR Does

### Phase 1: Access Hooks
- **`useBuilderAgentAccess`** - Unified hook for checking builder access
  - Checks `agents:read` + `stored-agents:write` permissions
  - Fetches builder settings only if permissions allow
  - Returns `denialReason` (`permission-denied`, `not-configured`, `error`)
  - Returns `agentFeatures` from `builder.features.agent`
  
- **`useCanCreateAgent`** (refactored) - Determines if user can create agents
  - Legacy: `MASTRA_EXPERIMENTAL_UI=true` env var (no EE required, routes to CMS)
  - New: `isBuilderEnabled` + permissions (routes to builder)

### Phase 2: Routes and Pages
- `/agent-builder` - Redirects to first available feature (currently only agents)
- `/agent-builder/agents/create` - Agent creation page with access states

### Phase 3: Config-Driven Form
- **Base fields** (always visible): Name, Description, Instructions, Model
- **Capability sections** (config-driven): Tools, Memory, Skills, Workflows, Agents
  - Visible when `builder.features.agent.<key> = true`
  - Currently placeholders ("coming soon") - real implementations can follow
- Submits to existing `POST /api/stored/agents` endpoint
- Redirects to agent detail page on success

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                     MastraEditor Config                      │
│  builder: {                                                  │
│    enabled: true,                                            │
│    features: { agent: { tools: true, memory: true, ... } }, │
│    configuration: { agent: { memory: { ... } } }            │
│  }                                                           │
└─────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────┐
│              GET /editor/builder/settings                    │
│              (requires agents:read)                          │
└─────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────┐
│                  useBuilderAgentAccess                       │
│  - Check agents:read + stored-agents:write                  │
│  - Fetch builder settings                                    │
│  - Return canAccessAgentBuilder, denialReason, agentFeatures│
└─────────────────────────────────────────────────────────────┘
                              │
           ┌──────────────────┴──────────────────┐
           ▼                                      ▼
┌─────────────────────┐              ┌─────────────────────────┐
│  useCanCreateAgent  │              │  AgentBuilderCreatePage │
│  - canCreateAgent   │              │  - Shows denial states  │
│  - createRoute      │              │  - Renders form         │
└─────────────────────┘              └─────────────────────────┘
           │                                      │
           ▼                                      ▼
┌─────────────────────┐              ┌─────────────────────────┐
│  Create Agent CTA   │              │   AgentBuilderForm      │
│  (visibility gated) │              │   - Base fields always  │
│  (routes correctly) │              │   - Sections from config│
└─────────────────────┘              └─────────────────────────┘
                                                  │
                                                  ▼
                                     ┌─────────────────────────┐
                                     │  POST /api/stored/agents│
                                     │  (server applies memory │
                                     │   defaults if not set)  │
                                     └─────────────────────────┘
```

## Access Control Matrix

| User Type | Env Var | Builder Enabled | RBAC | Can Create? | Route |
|-----------|---------|-----------------|------|-------------|-------|
| Legacy | `MASTRA_EXPERIMENTAL_UI=true` | ❌ | - | ✅ | `/cms/agents/create` |
| EE, no RBAC | - | ✅ | disabled | ✅ | `/agent-builder/agents/create` |
| EE, has permission | - | ✅ | `stored-agents:write` | ✅ | `/agent-builder/agents/create` |
| EE, no permission | - | ✅ | missing | ❌ | - |
| Nothing | ❌ | ❌ | - | ❌ | - |

## Key Files

### New Files
- `packages/playground/src/domains/builder/hooks/use-builder-agent-access.ts`
- `packages/playground/src/domains/builder/hooks/use-agent-builder-form.ts`
- `packages/playground/src/domains/builder/components/agent-builder-form.tsx`
- `packages/playground/src/pages/agent-builder/index.tsx`
- `packages/playground/src/pages/agent-builder/agents/create.tsx`

### Modified Files
- `packages/playground/src/domains/agents/hooks/use-can-create-agent.ts` - Refactored
- `packages/playground/src/domains/builder/hooks/use-builder-settings.ts` - Added `enabled` option
- `packages/playground/src/App.tsx` - Added routes
- `packages/playground/src/lib/framework.tsx` - Added path helper
- `packages/playground/src/pages/agents/index.tsx` - Updated CTA routing

## Example Config

```ts
const mastra = new Mastra({
  // ... other config
  editor: {
    builder: {
      enabled: true,
      features: {
        agent: {
          tools: true,      // Shows Tools section
          memory: false,    // Hides Memory section (server default applied)
          skills: true,     // Shows Skills section
          // workflows, agents, scorers, variables...
        },
      },
      configuration: {
        agent: {
          memory: {
            options: { lastMessages: 50 },
          },
        },
      },
    },
  },
});
```

## Extending This Work

### Adding Real Section Implementations
The capability sections are currently placeholders. To implement a real section:

1. Create section component in `domains/builder/components/sections/`
2. Import and use in `agent-builder-form.tsx`
3. Add form fields to `use-agent-builder-form.ts` schema and default values
4. Map form values to API payload in `onSubmit`

### Adding New Features (e.g., Library)
1. Add to `builder.features` type in `@mastra/core`
2. Update `AgentBuilderIndex` redirect logic
3. Create new route `/agent-builder/<feature>`

## Test Plan

1. **Access Gating**
   - Navigate to `/agent-builder` without permissions → shows "Access Denied"
   - Navigate with permissions but builder disabled → shows "Not Configured"
   - Navigate with full access → redirects to create page

2. **Form Behavior**
   - Only sections matching `features.agent.*` appear
   - Base fields (name, instructions, model) always visible
   - Validation prevents empty required fields

3. **Create Flow**
   - Fill form, click "Create agent"
   - Agent created with server-applied defaults
   - Redirects to agent detail page

## Notes

- **Memory defaults**: Server applies `configuration.agent.memory` when user doesn't provide memory config (PR #15648)
- **Edit flow**: Not included - still uses CMS route
- **scorers/variables**: UI deferred, flags ignored