### PR TITLE
fix(arize): emit llm.tools.* from mastra.model_step.input when native…

### DIFF
--- a/observability/arize/src/openInferenceOTLPExporter.ts
+++ b/observability/arize/src/openInferenceOTLPExporter.ts
@@ -234,6 +234,27 @@ export class OpenInferenceOTLPTraceExporter extends OTLPTraceExporter {
 
         mutableSpan.attributes = { ...processedAttributes, ...mastraOther };
 
+        // Emit tool definitions from mastra.model_step.input as OpenInference llm.tools.*
+        // Only runs when native llm.tools.* attributes are not already present.
+        if (!mutableSpan.attributes['llm.tools.0.tool.json_schema']) {
+          const modelStepRaw = mastraOther[MASTRA_MODEL_STEP_INPUT];
+          if (modelStepRaw) {
+            try {
+              const modelStep = typeof modelStepRaw === 'string' ? JSON.parse(modelStepRaw) : modelStepRaw;
+              if (Array.isArray(modelStep?.tools)) {
+                (modelStep.tools as Record<string, unknown>[]).forEach((tool, i) => {
+                  const { name, description, parameters } = tool;
+                  mutableSpan.attributes[`llm.tools.${i}.tool.json_schema`] = JSON.stringify({
+                    name,
+                    description,
+                    parameters,
+                  });
+                });
+              }
+            } catch {}
+          }
+        }
+
         // Set span kind based on mastra.span.type for proper trace categorization
         const spanType = mastraOther[MASTRA_SPAN_TYPE];
         if (typeof spanType === 'string') {

--- a/observability/arize/src/tracing.test.ts
+++ b/observability/arize/src/tracing.test.ts
@@ -868,6 +868,86 @@ describe('ArizeExporter', () => {
       expect(attrs[SemanticConventions.INPUT_MIME_TYPE]).toBe('application/json');
       expect(attrs[SemanticConventions.OUTPUT_MIME_TYPE]).toBe('application/json');
     });
+
+    it('emits llm.tools.* from mastra.model_step.input when native tool definitions are absent', async () => {
+      exporter = new ArizeExporter({
+        endpoint: 'http://localhost:4318/v1/traces',
+      });
+
+      const tools = [
+        {
+          type: 'function',
+          name: 'vectorSearchTool',
+          description: 'Search the knowledge base for relevant information.',
+          parameters: { query: 'string (required)' },
+        },
+      ];
+
+      const modelStepSpan: Mutable<AnyExportedSpan> = {
+        id: 'model-step-tools-span',
+        traceId: 'trace-model-step-tools',
+        parentSpanId: 'parent-span',
+        type: SpanType.MODEL_STEP,
+        name: 'model_step Research Agent',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: false,
+        input: { model: 'gpt-4o-mini', tools },
+        output: { text: 'result' },
+        attributes: {},
+      } as unknown as AnyExportedSpan;
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: modelStepSpan,
+      });
+
+      expect(exportedSpans.length).toBe(1);
+      const attrs = exportedSpans[0].attributes;
+
+      // Tool definitions should be emitted as OpenInference llm.tools.* attributes
+      const toolSchema = JSON.parse(attrs['llm.tools.0.tool.json_schema'] as string);
+      expect(toolSchema.name).toBe('vectorSearchTool');
+      expect(toolSchema.description).toBe('Search the knowledge base for relevant information.');
+      expect(toolSchema.parameters).toEqual({ query: 'string (required)' });
+      // The wrapper 'type' field should be stripped from the emitted schema
+      expect(toolSchema.type).toBeUndefined();
+    });
+
+    it('does not overwrite native llm.tools.* attributes with mastra.model_step.input tools', async () => {
+      exporter = new ArizeExporter({
+        endpoint: 'http://localhost:4318/v1/traces',
+      });
+
+      const nativeToolSchema = JSON.stringify({ name: 'nativeTool', description: 'native', parameters: {} });
+
+      const modelStepSpan: Mutable<AnyExportedSpan> = {
+        id: 'model-step-native-tools-span',
+        traceId: 'trace-model-step-native-tools',
+        parentSpanId: 'parent-span',
+        type: SpanType.MODEL_STEP,
+        name: 'model_step Research Agent',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: false,
+        input: { model: 'gpt-4o-mini', tools: [{ name: 'mastraTool' }] },
+        output: { text: 'result' },
+        attributes: {
+          'llm.tools.0.tool.json_schema': nativeToolSchema,
+        },
+      } as unknown as AnyExportedSpan;
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: modelStepSpan,
+      });
+
+      expect(exportedSpans.length).toBe(1);
+      const attrs = exportedSpans[0].attributes;
+
+      // Native llm.tools.* should be preserved unchanged
+      expect(attrs['llm.tools.0.tool.json_schema']).toBe(nativeToolSchema);
+    });
   });
 
   describe('Model Chunk Span Support', () => {


### PR DESCRIPTION
… tool definitions are absent

Mastra model_step spans carry tool definitions inside mastra.model_step.input as a tools[] array, but the OpenInferenceOTLPTraceExporter did not convert these to the OpenInference llm.tools.{i}.tool.json_schema format.

As a result, observability backends that read llm.tools.* (including Arize and Phoenix) showed no tool definitions for Mastra agents even when tools were configured and used.

This change adds a fallback: when llm.tools.0.tool.json_schema is not already present on the span, parse mastra.model_step.input and emit each tool's name, description, and parameters as llm.tools.{i}.tool.json_schema. The type field and other wrapper-specific keys are intentionally excluded to keep the output schema-agnostic.

The guard ensures native llm.tools.* attributes (from Vercel AI SDK or other OpenInference-native sources) are never overwritten.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation
When Mastra agents use tools, the information about those tools wasn't being properly sent to observability tools like Arize. This PR adds code that takes the tool information that Mastra has and converts it to the format that Arize and other tools expect, so you can actually see what tools your agent is using.

## Changes

**observability/arize/src/openInferenceOTLPExporter.ts**
- Added fallback logic to extract and emit tool definitions from `mastra.model_step.input` when native OpenInference `llm.tools.*.tool.json_schema` attributes are not already present on the span
- When tools array exists in the input, the exporter now iterates through each tool and sets `llm.tools.{index}.tool.json_schema` with a JSON string containing the tool's `name`, `description`, and `parameters`
- Intentionally omits the `type` field and wrapper-specific keys to keep the schema agnostic
- Includes a guard to prevent overwriting pre-existing native `llm.tools.*` attributes from other sources (e.g., Vercel AI SDK)
- All parsing/processing errors are silently ignored

**observability/arize/src/tracing.test.ts**
- Added test coverage for tool schema emission from `mastra.model_step.input.tools` when no native OpenInference `llm.tools.*` attributes exist, verifying correct `name`, `description`, and `parameters` in the emitted schema and that extraneous wrapper fields like `type` are omitted
- Added test coverage to ensure pre-existing native `llm.tools.*` attributes are preserved unchanged and not overwritten by the fallback logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->