### PR TITLE
feat(agent-builder): add workspace and browser builder defaults

### DIFF
--- a/packages/core/src/agent-builder/ee/types.ts
+++ b/packages/core/src/agent-builder/ee/types.ts
@@ -1,4 +1,5 @@
 import type { SerializedMemoryConfig } from '../../memory/types';
+import type { StorageBrowserRef, StorageWorkspaceRef } from '../../storage/types';
 
 /**
  * Default values for agents created via the builder.
@@ -7,6 +8,10 @@ import type { SerializedMemoryConfig } from '../../memory/types';
 export interface BuilderAgentDefaults extends Record<string, unknown> {
   /** Default memory configuration for new agents */
   memory?: SerializedMemoryConfig;
+  /** Default workspace reference for new agents */
+  workspace?: StorageWorkspaceRef;
+  /** Default browser configuration for new agents */
+  browser?: StorageBrowserRef;
 }
 
 /**

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -165,6 +165,7 @@ export const AGENT_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
   workspace: { type: 'jsonb', nullable: true },
   skills: { type: 'jsonb', nullable: true },
   skillsFormat: { type: 'text', nullable: true },
+  browser: { type: 'jsonb', nullable: true },
   // Version metadata
   changedFields: { type: 'jsonb', nullable: true }, // Array of field names
   changeMessage: { type: 'text', nullable: true },

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -425,6 +425,8 @@ export interface StorageAgentSnapshotType {
   mcpClients?: StorageConditionalField<Record<string, StorageMCPClientToolsConfig>>;
   /** Workspace reference — ID of a stored workspace or inline config — static or conditional on request context */
   workspace?: StorageConditionalField<StorageWorkspaceRef>;
+  /** Browser configuration — provider and config for browser automation — static or conditional on request context */
+  browser?: StorageConditionalField<StorageBrowserRef>;
   /** Skill entity IDs with optional per-skill overrides — static or conditional on request context */
   skills?: StorageConditionalField<Record<string, StorageSkillConfig>>;
   /** Skill format for system message injection (default: 'xml') */
@@ -2005,6 +2007,85 @@ export interface StorageBlobEntry {
 export type StorageWorkspaceRef =
   | { type: 'id'; workspaceId: string }
   | { type: 'inline'; config: StorageWorkspaceSnapshotType };
+
+/**
+ * Serializable browser configuration for storage.
+ * Mirrors BrowserConfigBase but excludes non-serializable fields (functions).
+ *
+ * Runtime-only options (onLaunch, onClose, cdpUrl as function) are not stored;
+ * they're added when instantiating the browser at runtime.
+ */
+export interface StorageBrowserConfig {
+  /** Provider type identifier (e.g., 'stagehand', 'playwright', 'browserbase') — resolved by the editor's browser registry */
+  provider: string;
+
+  /**
+   * Whether to run the browser in headless mode (no visible UI).
+   * @default true
+   */
+  headless?: boolean;
+
+  /**
+   * Browser viewport dimensions.
+   * Controls the size of the browser window and how websites render.
+   */
+  viewport?: {
+    width: number;
+    height: number;
+  };
+
+  /**
+   * Default timeout in milliseconds for browser operations.
+   * @default 10000 (10 seconds)
+   */
+  timeout?: number;
+
+  /**
+   * CDP WebSocket URL for connecting to an existing browser.
+   * Only string URLs are storable; function providers must be set at runtime.
+   */
+  cdpUrl?: string;
+
+  /**
+   * Browser instance scope across threads.
+   * - `'thread'`: Each thread gets its own isolated browser instance.
+   * - `'shared'`: All threads share a single browser instance.
+   * @default 'thread'
+   */
+  scope?: 'shared' | 'thread';
+
+  /**
+   * Screencast options for streaming browser frames.
+   */
+  screencast?: {
+    /** Image format (default: 'jpeg') */
+    format?: 'jpeg' | 'png';
+    /** JPEG quality 0-100 (default: 80) */
+    quality?: number;
+    /** Max width in pixels (default: 1280) */
+    maxWidth?: number;
+    /** Max height in pixels (default: 720) */
+    maxHeight?: number;
+    /** Capture every Nth frame (default: 1) */
+    everyNthFrame?: number;
+  };
+
+  /**
+   * Path to a Chrome/Chromium user data directory (profile).
+   */
+  profile?: string;
+
+  /**
+   * Path to the browser executable to use.
+   */
+  executablePath?: string;
+}
+
+/**
+ * Browser reference configuration stored in agent snapshots.
+ * Provides inline browser config that the editor resolves at hydration time.
+ */
+export type StorageBrowserRef = { type: 'inline'; config: StorageBrowserConfig };
 
 // ============================================
 // Workflow Storage Types

--- a/packages/editor/src/editor.test.ts
+++ b/packages/editor/src/editor.test.ts
@@ -1592,4 +1592,154 @@ describe('agent.create with builder defaults', () => {
     const clonedNoMemory = await editor.agent.clone(noMemoryAgent!, { newId: 'cloned-no-memory' });
     expect(clonedNoMemory.memory).toBeUndefined();
   });
+
+  it('applies default workspace config when input has none', async () => {
+    const storage = new InMemoryStore();
+    const builderWorkspace = { type: 'id' as const, workspaceId: 'default-workspace-id' };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: { agent: { workspace: builderWorkspace } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-no-workspace',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.workspace).toEqual(builderWorkspace);
+  });
+
+  it('preserves input workspace config when provided', async () => {
+    const storage = new InMemoryStore();
+    const builderWorkspace = { type: 'id' as const, workspaceId: 'default-workspace-id' };
+    const inputWorkspace = { type: 'id' as const, workspaceId: 'custom-workspace-id' };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: { agent: { workspace: builderWorkspace } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-with-workspace',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+      workspace: inputWorkspace,
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.workspace).toEqual(inputWorkspace);
+  });
+
+  it('does not override null workspace (explicit disable)', async () => {
+    const storage = new InMemoryStore();
+    const builderWorkspace = { type: 'id' as const, workspaceId: 'default-workspace-id' };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: { agent: { workspace: builderWorkspace } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-null-workspace',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+      workspace: null,
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.workspace).toBeNull();
+  });
+
+  it('applies default browser config when input has none', async () => {
+    const storage = new InMemoryStore();
+    const builderBrowser = {
+      type: 'inline' as const,
+      config: { provider: 'stagehand', config: { headless: true } },
+    };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: { agent: { browser: builderBrowser } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-no-browser',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.browser).toEqual(builderBrowser);
+  });
+
+  it('preserves input browser config when provided', async () => {
+    const storage = new InMemoryStore();
+    const builderBrowser = {
+      type: 'inline' as const,
+      config: { provider: 'stagehand', config: { headless: true } },
+    };
+    const inputBrowser = {
+      type: 'inline' as const,
+      config: { provider: 'browserbase', config: { headless: false } },
+    };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: { agent: { browser: builderBrowser } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-with-browser',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+      browser: inputBrowser,
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.browser).toEqual(inputBrowser);
+  });
+
+  it('does not override null browser (explicit disable)', async () => {
+    const storage = new InMemoryStore();
+    const builderBrowser = {
+      type: 'inline' as const,
+      config: { provider: 'stagehand', config: { headless: true } },
+    };
+    const editor = new MastraEditor({
+      builder: {
+        enabled: true,
+        configuration: { agent: { browser: builderBrowser } },
+      },
+    });
+    new Mastra({ storage, editor });
+
+    const agent = await editor.agent.create({
+      id: 'test-agent-null-browser',
+      name: 'Test Agent',
+      instructions: 'Test',
+      model: { provider: 'openai', name: 'gpt-4' },
+      browser: null,
+    });
+
+    const rawConfig = agent.toRawConfig?.();
+    expect(rawConfig?.browser).toBeNull();
+  });
 });

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -49,7 +49,7 @@ import { EditorMCPNamespace } from './mcp';
 // ============================================================================
 
 /** Fields from builder.configuration.agent that can be applied as creation defaults */
-const BUILDER_DEFAULT_FIELDS = ['memory'] as const;
+const BUILDER_DEFAULT_FIELDS = ['memory', 'workspace', 'browser'] as const;
 
 /**
  * Apply builder defaults to agent creation input.

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -42,6 +42,7 @@ const AGENT_SNAPSHOT_CONFIG_FIELDS = [
   'mcpClients',
   'skills',
   'workspace',
+  'browser',
 ] as const;
 
 // ============================================================================
@@ -172,6 +173,7 @@ export const CREATE_STORED_AGENT_ROUTE: ServerRoute<
     scorers,
     skills,
     workspace,
+    browser,
     requestContextSchema,
   }) => {
     try {
@@ -221,6 +223,7 @@ export const CREATE_STORED_AGENT_ROUTE: ServerRoute<
         scorers,
         skills,
         workspace,
+        browser,
         requestContextSchema,
       } as StorageCreateAgentInput;
 
@@ -296,6 +299,7 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
     scorers,
     skills,
     workspace,
+    browser,
     requestContextSchema,
     // Version metadata
     changeMessage,
@@ -341,6 +345,7 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
         scorers,
         skills,
         workspace,
+        browser,
         requestContextSchema,
       } as StorageUpdateAgentInput);
 
@@ -362,6 +367,7 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
         scorers,
         skills,
         workspace,
+        browser,
         requestContextSchema,
       };
 

--- a/packages/server/src/server/schemas/stored-agents.ts
+++ b/packages/server/src/server/schemas/stored-agents.ts
@@ -126,6 +126,40 @@ const workspaceRefSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('inline'), config: workspaceSnapshotConfigSchema }),
 ]);
 
+/** Screencast options for streaming browser frames */
+const screencastOptionsSchema = z.object({
+  format: z.enum(['jpeg', 'png']).optional().describe('Image format (default: jpeg)'),
+  quality: z.number().min(0).max(100).optional().describe('JPEG quality 0-100 (default: 80)'),
+  maxWidth: z.number().optional().describe('Max width in pixels (default: 1280)'),
+  maxHeight: z.number().optional().describe('Max height in pixels (default: 720)'),
+  everyNthFrame: z.number().optional().describe('Capture every Nth frame (default: 1)'),
+});
+
+/** Browser config: serializable browser configuration matching BrowserConfigBase */
+const browserConfigSchema = z.object({
+  provider: z.string().describe('Browser provider type (e.g., stagehand, playwright, browserbase)'),
+  headless: z.boolean().optional().describe('Run browser in headless mode (default: true)'),
+  viewport: z
+    .object({
+      width: z.number().describe('Viewport width in pixels'),
+      height: z.number().describe('Viewport height in pixels'),
+    })
+    .optional()
+    .describe('Browser viewport dimensions'),
+  timeout: z.number().optional().describe('Default timeout in milliseconds (default: 10000)'),
+  cdpUrl: z.string().optional().describe('CDP WebSocket URL for connecting to existing browser'),
+  scope: z.enum(['shared', 'thread']).optional().describe('Browser instance scope (default: thread)'),
+  screencast: screencastOptionsSchema.optional().describe('Screencast options for streaming browser frames'),
+  profile: z.string().optional().describe('Path to Chrome/Chromium user data directory'),
+  executablePath: z.string().optional().describe('Path to browser executable'),
+});
+
+/** Browser reference: inline browser configuration */
+const browserRefSchema = z.object({
+  type: z.literal('inline'),
+  config: browserConfigSchema,
+});
+
 /**
  * Processor phase enum matching ProcessorPhase type
  */
@@ -247,6 +281,9 @@ const snapshotConfigSchema = z.object({
   workspace: conditionalFieldSchema(workspaceRefSchema)
     .optional()
     .describe('Workspace reference (stored ID or inline config) — static or conditional'),
+  browser: conditionalFieldSchema(browserRefSchema)
+    .optional()
+    .describe('Browser configuration — static or conditional'),
   requestContextSchema: z
     .record(z.string(), z.unknown())
     .optional()
@@ -360,6 +397,9 @@ export const storedAgentSchema = z.object({
   workspace: conditionalFieldSchema(workspaceRefSchema)
     .optional()
     .describe('Workspace reference (stored ID or inline config) — static or conditional'),
+  browser: conditionalFieldSchema(browserRefSchema)
+    .optional()
+    .describe('Browser configuration — static or conditional'),
   requestContextSchema: z
     .record(z.string(), z.unknown())
     .optional()

--- a/stores/libsql/src/storage/domains/agents/index.ts
+++ b/stores/libsql/src/storage/domains/agents/index.ts
@@ -53,7 +53,7 @@ export class AgentsLibSQL extends AgentsStorage {
     await this.#db.alterTable({
       tableName: TABLE_AGENT_VERSIONS,
       schema: AGENT_VERSIONS_SCHEMA,
-      ifNotExists: ['mcpClients', 'requestContextSchema', 'workspace', 'skills', 'skillsFormat'],
+      ifNotExists: ['mcpClients', 'requestContextSchema', 'workspace', 'skills', 'skillsFormat', 'browser'],
     });
 
     // Migrate tools field from string[] to JSONB format
@@ -606,6 +606,7 @@ export class AgentsLibSQL extends AgentsStorage {
           workspace: input.workspace ?? null,
           skills: input.skills ?? null,
           skillsFormat: input.skillsFormat ?? null,
+          browser: input.browser ?? null,
           changedFields: input.changedFields ?? null,
           changeMessage: input.changeMessage ?? null,
           createdAt: now,
@@ -911,6 +912,7 @@ export class AgentsLibSQL extends AgentsStorage {
       workspace: this.parseJson(row.workspace, 'workspace'),
       skills: this.parseJson(row.skills, 'skills'),
       skillsFormat: row.skillsFormat as 'xml' | 'json' | 'markdown' | undefined,
+      browser: this.parseJson(row.browser, 'browser'),
       changedFields: this.parseJson(row.changedFields, 'changedFields'),
       changeMessage: row.changeMessage as string | undefined,
       createdAt: new Date(row.createdAt as string),

--- a/stores/mongodb/src/storage/domains/agents/index.ts
+++ b/stores/mongodb/src/storage/domains/agents/index.ts
@@ -49,6 +49,7 @@ const SNAPSHOT_FIELDS = [
   'workspace',
   'skills',
   'skillsFormat',
+  'browser',
 ] as const;
 
 export class MongoDBAgentsStorage extends AgentsStorage {

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -103,7 +103,7 @@ export class AgentsPG extends AgentsStorage {
     await this.#db.alterTable({
       tableName: TABLE_AGENT_VERSIONS,
       schema: TABLE_SCHEMAS[TABLE_AGENT_VERSIONS],
-      ifNotExists: ['mcpClients', 'requestContextSchema', 'workspace', 'skills', 'skillsFormat'],
+      ifNotExists: ['mcpClients', 'requestContextSchema', 'workspace', 'skills', 'skillsFormat', 'browser'],
     });
 
     // Migrate tools field from string[] to JSONB format
@@ -680,9 +680,10 @@ export class AgentsPG extends AgentsStorage {
           "defaultOptions", workflows, agents, "integrationTools",
           "inputProcessors", "outputProcessors", memory, scorers,
           "mcpClients", "requestContextSchema", workspace, skills, "skillsFormat",
+          browser,
           "changedFields", "changeMessage",
           "createdAt", "createdAtZ"
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)`,
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)`,
         [
           input.id,
           input.agentId,
@@ -705,6 +706,7 @@ export class AgentsPG extends AgentsStorage {
           input.workspace ? JSON.stringify(input.workspace) : null,
           input.skills ? JSON.stringify(input.skills) : null,
           input.skillsFormat ?? null,
+          input.browser ? JSON.stringify(input.browser) : null,
           input.changedFields ? JSON.stringify(input.changedFields) : null,
           input.changeMessage ?? null,
           nowIso,
@@ -976,6 +978,7 @@ export class AgentsPG extends AgentsStorage {
       workspace: this.parseJson(row.workspace, 'workspace'),
       skills: this.parseJson(row.skills, 'skills'),
       skillsFormat: row.skillsFormat as 'xml' | 'json' | 'markdown' | undefined,
+      browser: this.parseJson(row.browser, 'browser'),
       changedFields: this.parseJson(row.changedFields, 'changedFields'),
       changeMessage: row.changeMessage as string | undefined,
       createdAt: row.createdAtZ || row.createdAt,


### PR DESCRIPTION
## Summary

Add workspace and browser configuration options to Agent Builder defaults, allowing stored agents to inherit these settings from the builder config when created via the Editor API.

This builds on #15607 and implements:
- **COR-818**: Add an option to the Editor for Browser configuration
- **COR-819**: Add an option to the Editor for Workspace configuration

## Changes

### Core Types
- Add `StorageBrowserConfig` and `StorageBrowserRef` types to storage types
- Add `browser` field to `StorageAgentSnapshotType`
- Add `workspace` and `browser` to `BuilderAgentDefaults` interface

### Editor
- Add `workspace` and `browser` to `BUILDER_DEFAULT_FIELDS` allowlist
- `editor.agent.create()` now applies workspace and browser defaults

### Storage Backends
- Add `browser` field to LibSQL agents storage (schema, createVersion, parseVersionRow)
- Add `browser` field to MongoDB agents storage (SNAPSHOT_FIELDS)
- Add `browser` field to PostgreSQL agents storage (schema, createVersion, parseVersionRow)

### Server
- Add `browserConfigSchema` and `browserRefSchema` to stored-agents schemas
- Add `browser` to stored-agent request body and response schemas
- Add `browser` to create/update agent handlers

### Tests
- Add 6 unit tests for workspace and browser builder defaults

## Test Plan
1. Configure `MastraEditor` with builder defaults for memory, workspace, and browser
2. Create a new stored agent via `POST /api/stored/agents`
3. Verify the response includes all three builder defaults applied

Tested locally - all three defaults (memory, workspace, browser) are correctly applied to new agents.