### PR TITLE
Fix public origin resolution for AWS ALB deployments

### DIFF
--- a/.changeset/warm-bottles-wish.md
+++ b/.changeset/warm-bottles-wish.md
@@ -1,0 +1,13 @@
+---
+'@mastra/server': patch
+---
+
+Fix: Public origin resolution for AWS ALB deployments
+
+Implement cascading header resolution in getPublicOrigin() to properly handle:
+
+- X-Forwarded-Host (traditional reverse proxies) → always HTTPS
+- Host header (AWS ALB with Preserve Host Header) → respect X-Forwarded-Proto or default HTTPS
+- request.url (local development) → fallback
+
+Fixes OAuth callback URLs being resolved to http:// instead of https:// when deployed behind AWS ALB with Preserve Host Header enabled.

--- a/packages/server/src/server/handlers/auth.ts
+++ b/packages/server/src/server/handlers/auth.ts
@@ -65,17 +65,21 @@ function getAuthProvider(mastra: any): MastraAuthProvider | null {
 
 /**
  * Get the public-facing origin from a request, respecting reverse proxy headers.
- * Behind a proxy (e.g. edge router), request.url contains the internal hostname.
- * X-Forwarded-Host tells us the real public hostname.
- * Always uses https when behind a proxy — Knative's queue-proxy overwrites
- * X-Forwarded-Proto based on the internal HTTP connection, so it's unreliable.
+ * Behind a proxy (e.g. edge router), request.url contains the internal hostname,
+ * so we rely on forwarded headers to reconstruct the real public origin.
+ *
+ * Assumes the server is behind a trusted proxy (or running locally). When
+ * exposed directly to untrusted clients, the Host header is attacker-controlled
+ * and must be validated upstream.
  *
  * Priority:
- * 1. X-Forwarded-Host (traditional reverse proxy) → always HTTPS
- * 2. Host header with X-Forwarded-Proto (AWS ALB, some proxies) → respect proto
- * 3. Host header alone → ambiguous; could be direct HTTP or proxy without proto header
- *    Fallback to request.url to preserve the actual scheme
- * 4. No headers → fallback to request.url
+ * 1. X-Forwarded-Host (traditional reverse proxy) → always HTTPS. Knative's
+ *    queue-proxy overwrites X-Forwarded-Proto based on the internal HTTP
+ *    connection, so X-Forwarded-Proto is ignored here.
+ * 2. Host header with X-Forwarded-Proto (AWS ALB, some proxies) → respect proto.
+ * 3. Host header alone → use the scheme from request.url (covers both direct
+ *    HTTP access and proxies that preserve Host but don't set a proto header).
+ * 4. No Host header → fall back to request.url.origin (local dev / direct access).
  */
 export function getPublicOrigin(request: Request): string {
   const forwardedHost = request.headers.get('x-forwarded-host')?.split(',')[0]?.trim();

--- a/packages/server/src/server/handlers/auth.ts
+++ b/packages/server/src/server/handlers/auth.ts
@@ -75,6 +75,13 @@ export function getPublicOrigin(request: Request): string {
   if (forwardedHost) {
     return `https://${forwardedHost}`;
   }
+
+  const host = request.headers.get('host');
+  if (host) {
+    const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+    return `${proto}://${host}`;
+  }
+
   return new URL(request.url).origin;
 }
 

--- a/packages/server/src/server/handlers/auth.ts
+++ b/packages/server/src/server/handlers/auth.ts
@@ -69,6 +69,13 @@ function getAuthProvider(mastra: any): MastraAuthProvider | null {
  * X-Forwarded-Host tells us the real public hostname.
  * Always uses https when behind a proxy — Knative's queue-proxy overwrites
  * X-Forwarded-Proto based on the internal HTTP connection, so it's unreliable.
+ *
+ * Priority:
+ * 1. X-Forwarded-Host (traditional reverse proxy) → always HTTPS
+ * 2. Host header with X-Forwarded-Proto (AWS ALB, some proxies) → respect proto
+ * 3. Host header alone → ambiguous; could be direct HTTP or proxy without proto header
+ *    Fallback to request.url to preserve the actual scheme
+ * 4. No headers → fallback to request.url
  */
 export function getPublicOrigin(request: Request): string {
   const forwardedHost = request.headers.get('x-forwarded-host')?.split(',')[0]?.trim();
@@ -78,7 +85,8 @@ export function getPublicOrigin(request: Request): string {
 
   const host = request.headers.get('host');
   if (host) {
-    const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+    const forwardedProto = request.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();
+    const proto = forwardedProto || new URL(request.url).protocol.replace(':', '');
     return `${proto}://${host}`;
   }
 

--- a/packages/server/src/server/handlers/get-public-origin.test.ts
+++ b/packages/server/src/server/handlers/get-public-origin.test.ts
@@ -43,13 +43,13 @@ describe('getPublicOrigin — reverse proxy header resolution', () => {
     expect(getPublicOrigin(request)).toBe('http://example.com');
   });
 
-  it('should fall back to request.url when Host is present but X-Forwarded-Proto is absent', () => {
+  it('should use request.url scheme with Host header when X-Forwarded-Proto is absent (http)', () => {
     const headers = new Headers({
       host: 'example.com',
     });
     const request = new Request('http://example.com/some-path', { headers });
 
-    // Host without X-Forwarded-Proto: fallback to request.url scheme
+    // Host without X-Forwarded-Proto: scheme comes from request.url, host from header
     expect(getPublicOrigin(request)).toBe('http://example.com');
   });
 

--- a/packages/server/src/server/handlers/get-public-origin.test.ts
+++ b/packages/server/src/server/handlers/get-public-origin.test.ts
@@ -26,6 +26,7 @@ describe('getPublicOrigin — reverse proxy header resolution', () => {
   it('should use Host header when X-Forwarded-Host absent (AWS ALB)', () => {
     const headers = new Headers({
       host: 'example.com',
+      'x-forwarded-proto': 'https',
     });
     const request = new Request('http://example.com/some-path', { headers });
 
@@ -37,16 +38,19 @@ describe('getPublicOrigin — reverse proxy header resolution', () => {
       host: 'example.com',
       'x-forwarded-proto': 'http',
     });
-    const request = new Request('http://example.com/some-path', { headers });
+    const request = new Request('https://example.com/some-path', { headers });
 
     expect(getPublicOrigin(request)).toBe('http://example.com');
   });
 
-  it('should fall back to request.url when no headers present', () => {
-    const headers = new Headers();
-    const request = new Request('http://localhost:3000/some-path', { headers });
+  it('should fall back to request.url when Host is present but X-Forwarded-Proto is absent', () => {
+    const headers = new Headers({
+      host: 'example.com',
+    });
+    const request = new Request('http://example.com/some-path', { headers });
 
-    expect(getPublicOrigin(request)).toBe('http://localhost:3000');
+    // Host without X-Forwarded-Proto: fallback to request.url scheme
+    expect(getPublicOrigin(request)).toBe('http://example.com');
   });
 
   it('should preserve port in X-Forwarded-Host', () => {
@@ -84,7 +88,21 @@ describe('getPublicOrigin — reverse proxy header resolution', () => {
     });
     const request = new Request('http://example.com:8443/api/auth/sso/callback', { headers });
 
-    expect(getPublicOrigin(request)).toBe('https://example.com:8443');
+    // Host without X-Forwarded-Proto is ambiguous (could be direct HTTP or proxy without proto header)
+    // Fall back to request.url scheme
+    expect(getPublicOrigin(request)).toBe('http://example.com:8443');
+  });
+
+  it('should fall back to request.url when Host is present but X-Forwarded-Proto is absent', () => {
+    // AWS ALB with Preserve Host Header ON but no X-Forwarded-Proto header
+    // Proto comes from request.url, host from the header
+    const headers = new Headers({
+      host: 'example.com',
+    });
+    const request = new Request('https://internal-host/api/auth/sso/callback', { headers });
+
+    // Host without X-Forwarded-Proto: use proto from request.url + host header
+    expect(getPublicOrigin(request)).toBe('https://example.com');
   });
 
   it('should trim whitespace in comma-separated X-Forwarded-Host', () => {

--- a/packages/server/src/server/handlers/get-public-origin.test.ts
+++ b/packages/server/src/server/handlers/get-public-origin.test.ts
@@ -82,18 +82,17 @@ describe('getPublicOrigin — reverse proxy header resolution', () => {
     expect(getPublicOrigin(request)).toBe('https://api.example.com');
   });
 
-  it('should default to HTTPS when Host present but X-Forwarded-Proto absent', () => {
+  it('should use request.url protocol when Host header lacks X-Forwarded-Proto', () => {
     const headers = new Headers({
       host: 'example.com:8443',
     });
     const request = new Request('http://example.com:8443/api/auth/sso/callback', { headers });
 
-    // Host without X-Forwarded-Proto is ambiguous (could be direct HTTP or proxy without proto header)
-    // Fall back to request.url scheme
+    // Host without X-Forwarded-Proto: proto comes from request.url, host from header
     expect(getPublicOrigin(request)).toBe('http://example.com:8443');
   });
 
-  it('should fall back to request.url when Host is present but X-Forwarded-Proto is absent', () => {
+  it('should merge request.url protocol with Host header when X-Forwarded-Proto absent', () => {
     // AWS ALB with Preserve Host Header ON but no X-Forwarded-Proto header
     // Proto comes from request.url, host from the header
     const headers = new Headers({
@@ -101,7 +100,7 @@ describe('getPublicOrigin — reverse proxy header resolution', () => {
     });
     const request = new Request('https://internal-host/api/auth/sso/callback', { headers });
 
-    // Host without X-Forwarded-Proto: use proto from request.url + host header
+    // Host without X-Forwarded-Proto: proto from request.url (https) + host header (example.com)
     expect(getPublicOrigin(request)).toBe('https://example.com');
   });
 
@@ -112,5 +111,22 @@ describe('getPublicOrigin — reverse proxy header resolution', () => {
     const request = new Request('http://internal:3000/some-path', { headers });
 
     expect(getPublicOrigin(request)).toBe('https://api.example.com');
+  });
+
+  it('should fall back to request.url.origin when no proxy headers present', () => {
+    // Local development or direct access: no proxy headers at all
+    const headers = new Headers();
+    const request = new Request('http://localhost:3000/api/auth/sso/callback', { headers });
+
+    // No headers: preserve full request.url origin
+    expect(getPublicOrigin(request)).toBe('http://localhost:3000');
+  });
+
+  it('should preserve HTTPS in request.url fallback', () => {
+    // Local HTTPS server without proxy headers
+    const headers = new Headers();
+    const request = new Request('https://localhost:8443/api/auth/sso/login', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://localhost:8443');
   });
 });

--- a/packages/server/src/server/handlers/get-public-origin.test.ts
+++ b/packages/server/src/server/handlers/get-public-origin.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for getPublicOrigin helper function.
+ *
+ * Covers reverse proxy header resolution for:
+ * - X-Forwarded-Host (traditional reverse proxies)
+ * - Host header (AWS ALB with Preserve Host Header)
+ * - X-Forwarded-Proto (protocol detection)
+ * - Fallback to request.url (local development)
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { getPublicOrigin } from './auth';
+
+describe('getPublicOrigin — reverse proxy header resolution', () => {
+  it('should use X-Forwarded-Host when present (reverse proxy)', () => {
+    const headers = new Headers({
+      'x-forwarded-host': 'api.example.com',
+      host: 'internal-hostname',
+    });
+    const request = new Request('http://internal-hostname:3000/some-path', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://api.example.com');
+  });
+
+  it('should use Host header when X-Forwarded-Host absent (AWS ALB)', () => {
+    const headers = new Headers({
+      host: 'example.com',
+    });
+    const request = new Request('http://example.com/some-path', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://example.com');
+  });
+
+  it('should respect X-Forwarded-Proto when using Host header', () => {
+    const headers = new Headers({
+      host: 'example.com',
+      'x-forwarded-proto': 'http',
+    });
+    const request = new Request('http://example.com/some-path', { headers });
+
+    expect(getPublicOrigin(request)).toBe('http://example.com');
+  });
+
+  it('should fall back to request.url when no headers present', () => {
+    const headers = new Headers();
+    const request = new Request('http://localhost:3000/some-path', { headers });
+
+    expect(getPublicOrigin(request)).toBe('http://localhost:3000');
+  });
+
+  it('should preserve port in X-Forwarded-Host', () => {
+    const headers = new Headers({
+      'x-forwarded-host': 'api.example.com:8080',
+    });
+    const request = new Request('http://internal:3000/some-path', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://api.example.com:8080');
+  });
+
+  it('should handle comma-separated X-Forwarded-Host by using first value', () => {
+    const headers = new Headers({
+      'x-forwarded-host': 'api.example.com, other.example.com',
+    });
+    const request = new Request('http://internal:3000/some-path', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://api.example.com');
+  });
+
+  it('should always use HTTPS with X-Forwarded-Host (ignore X-Forwarded-Proto)', () => {
+    const headers = new Headers({
+      'x-forwarded-host': 'api.example.com',
+      'x-forwarded-proto': 'http',
+    });
+    const request = new Request('http://internal:3000/some-path', { headers });
+
+    // Always HTTPS with X-Forwarded-Host due to Knative queue-proxy unreliability
+    expect(getPublicOrigin(request)).toBe('https://api.example.com');
+  });
+
+  it('should default to HTTPS when Host present but X-Forwarded-Proto absent', () => {
+    const headers = new Headers({
+      host: 'example.com:8443',
+    });
+    const request = new Request('http://example.com:8443/api/auth/sso/callback', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://example.com:8443');
+  });
+
+  it('should trim whitespace in comma-separated X-Forwarded-Host', () => {
+    const headers = new Headers({
+      'x-forwarded-host': '  api.example.com  , other.example.com',
+    });
+    const request = new Request('http://internal:3000/some-path', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://api.example.com');
+  });
+});


### PR DESCRIPTION
fixes https://github.com/mastra-ai/mastra/issues/14886

This PR improves the logic used to reconstruct the public origin in server-side
handlers by extending `getPublicOrigin()` to correctly handle environments where
`X-Forwarded-Host` is not injected by the proxy/load balancer.

Some infrastructures (e.g. AWS Application Load Balancer with “Preserve Host
Header” enabled) forward the original `Host` header but do not add
`X-Forwarded-Host`. In these cases, the current implementation falls back to
`new URL(request.url).origin`, which results in internal container URLs such as
`http://10.x.x.x:3000` and breaks redirect flows (OAuth, SSO, callback URLs,
etc.).

### What this PR changes
- Uses `X-Forwarded-Host` when present (unchanged behavior)
- Falls back to `Host` + `X-Forwarded-Proto` when `X-Forwarded-Host` is missing
- Falls back to `request.url` only when no headers are available (dev mode)

### Why this is safe
- No API changes
- No breaking behavior
- Existing deployments that rely on `X-Forwarded-Host` continue to work
- Improves compatibility with ALB, Cloudflare, Nginx, and other proxies that
  preserve the `Host` header

This is a patch-level fix that corrects origin reconstruction in real-world
deployments without introducing breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The server sometimes used its internal address (like http://10.x.x.x:3000) for redirects when behind certain load balancers. This PR makes the server detect the real public address from proxy headers so redirects (OAuth/SSO) use the correct public origin.

---

## Changes Made

### Core Implementation: Public Origin Resolution Logic
- Enhanced getPublicOrigin(request) to build the public origin with a cascading strategy:
  1. Use X-Forwarded-Host (when present) and always treat it as HTTPS (preserves existing behavior and avoids relying on X-Forwarded-Proto).
  2. If X-Forwarded-Host is missing, use the Host header combined with X-Forwarded-Proto (first comma-separated value) when available.
  3. If X-Forwarded-Proto is absent but Host exists, derive the scheme from request.url and combine it with Host.
  4. If no Host header is present, fall back to new URL(request.url).origin (development/direct access fallback).
- Adds JSDoc and comments documenting the trusted-proxy assumption and the resolution priority.

### Tests
- Added get-public-origin.test.ts (Vitest) covering:
  - X-Forwarded-Host parsing (ports preserved, comma-separated lists use first value, whitespace trimmed).
  - X-Forwarded-Host takes precedence and forces HTTPS (ignores X-Forwarded-Proto).
  - Host + X-Forwarded-Proto handling and behavior when X-Forwarded-Proto is absent (scheme comes from request.url).
  - Fallback to request.url.origin when no proxy headers exist.

### Documentation / Changeset
- Added a Changeset (.changeset/warm-bottles-wish.md) describing the patch fix for @mastra/server and the header/url fallback behavior.

---

## Impact & Compatibility
- No API or exported signature changes.
- Non-breaking; existing deployments using X-Forwarded-Host continue to work.
- Fixes incorrect internal-container origins (e.g., http://10.x.x.x:3000) observed with AWS ALB Preserve Host Header and similar proxies, improving OAuth/SSO redirect correctness for ALB, Cloudflare, Nginx, and other proxy setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->