### PR TITLE
fix(server): handle callable Standard Schema types in resolveLazySchema

### DIFF
--- a/.changeset/fast-lands-smoke.md
+++ b/.changeset/fast-lands-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed non-Zod Standard Schema types (e.g. ArkType) being incorrectly called as lazy getters in resolveLazySchema, which caused Studio UI tool forms to receive validation errors instead of the actual JSON Schema

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -162,7 +162,7 @@ interface SerializedToolInput {
 }
 
 function resolveLazySchema(schema: unknown): unknown {
-  if (typeof schema === 'function') {
+  if (typeof schema === 'function' && !('~standard' in schema)) {
     return resolveLazySchema(schema());
   }
   return schema;

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -22,9 +22,11 @@ import { validateBody } from './utils';
 /**
  * Resolves a schema that may be a lazy function (e.g. AI SDK provider tools).
  * Recursively resolves until a non-function value is returned.
+ * Skips functions that are themselves valid schemas (e.g. ArkType types are
+ * callable but also implement StandardSchema via ~standard).
  */
 function resolveLazySchema(schema: unknown): unknown {
-  if (typeof schema === 'function') {
+  if (typeof schema === 'function' && !('~standard' in schema)) {
     return resolveLazySchema(schema());
   }
   return schema;


### PR DESCRIPTION
ArkType (and other callable Standard Schema implementations) were being incorrectly invoked as lazy getter functions in `resolveLazySchema`. This caused the schema to run validation with no arguments instead of returning itself, so the Studio UI received validation errors instead of the actual JSON Schema.

The fix checks for the `~standard` property before calling the function — if it's already a valid Standard Schema, we return it as-is.

Before: ArkType schemas like `type({ location: 'string' })` would be called as `schema()`, producing an `ArkErrors` object instead of the schema.

After: The same schema is recognized as a Standard Schema via `'~standard' in schema` and returned directly, allowing proper JSON Schema serialization for the Studio UI tool forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you have a toolbox that can contain either instructions for how to make something (lazy), or the actual finished tool itself. The bug was that the system was always trying to read the instructions, even when you already had the finished tool in your hand. This PR fixes it so the system checks if it's a finished tool first—and if it is, it just uses it directly instead of trying to read non-existent instructions.

## Overview

This PR fixes a bug in the `resolveLazySchema` function where callable Standard Schema implementations (such as ArkType) were being incorrectly invoked as lazy getter functions. This caused validation to run with no arguments, producing validation errors instead of proper schemas, which prevented the Studio UI from correctly rendering tool forms with the right JSON Schema.

## Changes

The fix adds a check for the `~standard` property before invoking functions in `resolveLazySchema`. If the property is present, indicating the value is already a valid Standard Schema, the function returns the schema as-is instead of calling it. This preserves callable Standard Schema instances and ensures correct JSON Schema serialization.

### Files Modified

- **packages/server/src/server/handlers/agents.ts** — Updated `resolveLazySchema` to check for `~standard` property before calling functions (1 line changed)
- **packages/server/src/server/handlers/tools.ts** — Updated `resolveLazySchema` to distinguish between lazy schema providers and standard schema functions (3 lines changed)
- **.changeset/fast-lands-smoke.md** — Added changeset documentation for the `@mastra/server` package fix (5 lines added)

## Impact

This change ensures that non-Zod Standard Schema types like ArkType are no longer incorrectly treated as lazy getter functions, allowing the Studio UI to receive correct JSON Schemas instead of validation errors for tool forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->