### PR TITLE
fix(playground): restore dark variant for class-based theme switching

### DIFF
--- a/.changeset/fix-studio-provider-icons-dark-mode.md
+++ b/.changeset/fix-studio-provider-icons-dark-mode.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed provider picker icons appearing black instead of white in Studio dark mode. Restored the Tailwind v4 class-based dark variant in the playground CSS so `dark:` utilities fire when users toggle Studio's theme to dark, regardless of the OS color scheme preference.

--- a/packages/playground/src/index.css
+++ b/packages/playground/src/index.css
@@ -3,6 +3,8 @@
 /* Scan playground-ui package for Tailwind classes */
 @source '../../node_modules/@mastra/playground-ui';
 
+@custom-variant dark (&:is(.dark *));
+
 @font-face {
   font-family: 'TasaExplorer';
   src:

--- a/packages/playground/src/index.css
+++ b/packages/playground/src/index.css
@@ -2,7 +2,6 @@
 
 /* Scan playground-ui package for Tailwind classes */
 @source '../../node_modules/@mastra/playground-ui';
-
 @custom-variant dark (&:is(.dark *));
 
 @font-face {


### PR DESCRIPTION
## Summary

- Provider picker icons (and every other `dark:*` utility in `packages/playground/src`) stopped flipping colour with the Studio theme toggle after the Tailwind v4 migration + the `playground-ui → playground` split.
- `packages/playground-ui/src/index.css` declares `@custom-variant dark (&:is(.dark *));` but `packages/playground/src/index.css` never did. Without it, Tailwind v4 defaults `dark:` to `@media (prefers-color-scheme: dark)` — so when the OS is in light mode but the user toggles Studio to dark, `dark:brightness-0 dark:invert` on the provider logos (and similar elsewhere) never triggers, and icons stay black.
- Adds the same `@custom-variant dark (&:is(.dark *));` to the playground's own CSS entry so the `.dark` class that `theme-provider.tsx` sets on `<html>` drives the variant across both packages.

### Before / after
- **Before:** Dark mode + light OS → provider picker icons rendered black on dark surface.
- **After:** Provider picker icons render white in dark mode regardless of OS preference; unchanged in light mode.

## Test plan

- [x] `pnpm build:cli` — 31/31 tasks pass
- [x] `pnpm mastra:dev` in `examples/agent-v6`, open Studio at `http://localhost:4112`, toggle theme → dark, open provider picker → icons render white
- [x] Toggle back to light → icons render black
- [x] Grep confirms the fix covers the other offenders in playground (`agent-memory-config`, `template-failure`, `observation-marker`, etc.) that were silently regressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The in-app dark mode button stopped changing some icons to white because the playground CSS wasn't listening for the app's `.dark` class. This PR adds one CSS rule so the app's dark toggle works again and icons become white in dark Studio regardless of the OS theme.

## Changes

### packages/playground/src/index.css
- Adds Tailwind v4 custom variant declaration:
  @custom-variant dark (&:is(.dark *));
  This restores class-based `dark:` behavior so `dark:*` utilities respond to the `.dark` ancestor applied by the theme provider.

### .changeset/fix-studio-provider-icons-dark-mode.md
- Adds a patch changeset describing the fix for provider picker icons rendering correctly in Studio dark mode.

## Technical Details

- Cause: After migrating to Tailwind v4 and splitting playground-ui → playground, packages/playground/src/index.css lacked the class-based dark variant declaration. Tailwind defaulted `dark:` to `@media (prefers-color-scheme: dark)`, so toggling Studio's `.dark` class had no effect when the OS theme remained light.
- Fix: Declare @custom-variant dark (&:is(.dark *)); in packages/playground/src/index.css to match playground-ui and ensure `dark:` utilities trigger from a `.dark` ancestor.
- Result: Provider picker icons and other affected components now render white in Studio dark mode regardless of OS preference; light-mode behavior unchanged.

## Test plan / Verification

- pnpm build:cli — 31/31 tasks pass
- pnpm mastra:dev in examples/agent-v6 — toggling Studio theme verifies icons flip to white in dark and back to black in light
- Grep confirmed other affected playground components are covered by the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->