### PR TITLE
fix(core): drop undefined chunks from processOutputStream

### DIFF
--- a/.changeset/cozy-roses-report.md
+++ b/.changeset/cozy-roses-report.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': patch
+---
+
+Fixed output processors returning `undefined` from `processOutputStream` causing an `undefined` chunk to be enqueued into the consumer stream. A processor that forgets to `return part` (or explicitly returns `undefined`) now drops that chunk, matching existing `null` behavior, instead of emitting a bogus value to downstream readers.
+
+```ts
+// Before: returning undefined emitted { value: undefined, done: false } to consumers
+// After:  returning undefined drops the chunk, same as returning null
+const processor = {
+  id: 'my-processor',
+  processOutputStream: async ({ part }) => {
+    if (shouldDrop(part)) return; // implicit undefined — now safely dropped
+    return part;
+  },
+};
+```

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -1081,6 +1081,58 @@ describe('ProcessorRunner', () => {
       expect(chunks[1]).toEqual({ type: 'tool-call', toolCallId: '123' });
       expect(chunks[2]).toEqual({ type: 'finish' });
     });
+
+    it('should not enqueue undefined into the stream when a processor returns undefined', async () => {
+      const outputProcessors: Processor[] = [
+        {
+          id: 'returnUndefined',
+          name: 'Return Undefined',
+          processOutputStream: async ({ part }) => {
+            if (part.type === 'text-delta' && part.payload.text === 'bad') {
+              // Simulate a processor that forgets to `return part`
+              return undefined as unknown as ChunkType;
+            }
+            return part;
+          },
+        },
+      ];
+
+      runner = new ProcessorRunner({
+        inputProcessors: [],
+        outputProcessors,
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const mockStream = {
+        fullStream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'text-delta', payload: { text: 'hello' } });
+            controller.enqueue({ type: 'text-delta', payload: { text: 'bad' } });
+            controller.enqueue({ type: 'text-delta', payload: { text: 'world' } });
+            controller.enqueue({ type: 'finish' });
+            controller.close();
+          },
+        }),
+      };
+
+      const processedStream = await runner.runOutputProcessorsForStream(mockStream as any);
+      const reader = processedStream.getReader();
+      const chunks: Array<ChunkType | undefined> = [];
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      // Consumer should never see an `undefined` chunk.
+      expect(chunks.some(c => c === undefined)).toBe(false);
+      expect(chunks).toHaveLength(3);
+      expect(chunks[0]).toEqual({ type: 'text-delta', payload: { text: 'hello' } });
+      expect(chunks[1]).toEqual({ type: 'text-delta', payload: { text: 'world' } });
+      expect(chunks[2]).toEqual({ type: 'finish' });
+    });
   });
 
   /**

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -760,11 +760,11 @@ export class ProcessorRunner {
               });
               controller.close();
               break;
-            } else if (processedPart !== null) {
-              // Send processed part only if it's not null (which indicates don't emit)
+            } else if (processedPart != null) {
+              // Send processed part only if it's not null/undefined (which indicates don't emit)
               controller.enqueue(processedPart);
             }
-            // If processedPart is null, don't emit anything for this part
+            // If processedPart is null/undefined, don't emit anything for this part
           }
         } catch (error) {
           controller.error(error);


### PR DESCRIPTION
Fixes #15658.

The [`processOutputStream` reference](https://mastra.ai/reference/processors/processor-interface#processoutputstream) documents the return value as:

> - Return the `ChunkType` to emit it (possibly modified)
> - Return `null` or `undefined` to skip emitting the chunk

…but in practice, returning `undefined` (e.g. forgetting to `return part`) enqueued `undefined` into the consumer's `ReadableStream`, so readers saw `{ value: undefined, done: false }` instead of the chunk being skipped. Only `null` was actually dropped.

This PR makes `undefined` behave like `null` — the chunk is skipped and the stream continues — matching the documented contract.

```ts
const processor = {
  id: 'my-processor',
  processOutputStream: async ({ part }) => {
    if (shouldDrop(part)) return; // implicit undefined — now correctly skipped
    return part;
  },
};
```

Chain-gating behavior in `processPart` (returning `null`/`undefined` still halts subsequent processors for that part) is unchanged. Added a regression test in `runner.test.ts`.