### PR TITLE
fix(core): detect SKILL.md file changes for hot reload

### DIFF
--- a/.changeset/skill-mtime-detection.md
+++ b/.changeset/skill-mtime-detection.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': patch
+---
+
+Add opt-in `checkSkillFileMtime` option to detect in-place SKILL.md edits during hot reload.
+
+Previously, only directory mtime was checked for skill staleness, so editing a skill's name (to fix a validation error) or updating its description wouldn't trigger re-discovery until server restart.
+
+The option is off by default since it doubles `stat()` calls per skill during staleness checks. Recommended for local development only, not for cloud storage backends where `stat()` has higher latency.
+
+```ts
+const myAgent = new Agent({
+  workspace: {
+    filesystem: new LocalFilesystem({ basePath: process.cwd() }),
+    skills: ['./**/skills'],
+    checkSkillFileMtime: true, // Enable for local dev
+  },
+});
+```

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -1098,6 +1098,274 @@ Instructions for the new skill.`;
     });
   });
 
+  describe('maybeRefresh SKILL.md file mtime detection', () => {
+    it('should detect SKILL.md content changes even when directory mtime unchanged', async () => {
+      vi.useFakeTimers();
+      try {
+        // Separate mtimes for directories vs files
+        const dirMtime = new Date(Date.now() - 10000); // Old, never changes
+        let fileMtime = new Date(Date.now() - 10000); // Starts old, will be updated
+
+        const filesMap: Record<string, string> = {
+          'skills/test-skill/SKILL.md': `---
+name: bad-name
+description: A test skill with invalid name
+---
+# Test Skill
+Instructions here.`,
+        };
+
+        const filesystem = createMockFilesystem(filesMap);
+
+        // Mock stat to return different mtimes for directories vs files
+        (filesystem.stat as ReturnType<typeof vi.fn>).mockImplementation(
+          async (path: string): Promise<SkillSourceStat> => {
+            const isFile = path.endsWith('.md');
+            return {
+              name: path.split('/').pop() || path,
+              type: isFile ? ('file' as const) : ('directory' as const),
+              size: 0,
+              createdAt: isFile ? fileMtime : dirMtime,
+              modifiedAt: isFile ? fileMtime : dirMtime,
+            };
+          },
+        );
+
+        const skills = new WorkspaceSkillsImpl({
+          source: filesystem,
+          skills: ['skills'],
+          validateOnLoad: true,
+          checkSkillFileMtime: true, // Enable opt-in file mtime detection
+        });
+
+        // Initial discovery - skill has invalid name, should not be loaded
+        const initialList = await skills.list();
+        expect(initialList).toHaveLength(0);
+
+        // Advance past the staleness check cooldown
+        vi.advanceTimersByTime(WorkspaceSkillsImpl.STALENESS_CHECK_COOLDOWN + 100);
+
+        // Fix the SKILL.md content (only file mtime changes, not directory)
+        const fixedSkillMd = `---
+name: test-skill
+description: A test skill with valid name
+---
+# Test Skill
+Instructions here.`;
+        filesMap['skills/test-skill/SKILL.md'] = fixedSkillMd;
+        await filesystem.writeFile('skills/test-skill/SKILL.md', fixedSkillMd);
+
+        // Update only the file mtime, directory stays old
+        fileMtime = new Date(Date.now() + 1000);
+
+        // maybeRefresh should detect the file change and reload
+        await skills.maybeRefresh();
+        const afterRefresh = await skills.list();
+
+        // This test documents the expected behavior after the fix
+        // Currently fails because staleness only checks directory mtime
+        expect(afterRefresh).toHaveLength(1);
+        expect(afterRefresh[0]!.name).toBe('test-skill');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should detect SKILL.md content updates for existing valid skills', async () => {
+      vi.useFakeTimers();
+      try {
+        const dirMtime = new Date(Date.now() - 10000);
+        let fileMtime = new Date(Date.now() - 10000);
+
+        const filesMap: Record<string, string> = {
+          'skills/test-skill/SKILL.md': VALID_SKILL_MD,
+        };
+
+        const filesystem = createMockFilesystem(filesMap);
+
+        (filesystem.stat as ReturnType<typeof vi.fn>).mockImplementation(
+          async (path: string): Promise<SkillSourceStat> => {
+            const isFile = path.endsWith('.md');
+            return {
+              name: path.split('/').pop() || path,
+              type: isFile ? ('file' as const) : ('directory' as const),
+              size: 0,
+              createdAt: isFile ? fileMtime : dirMtime,
+              modifiedAt: isFile ? fileMtime : dirMtime,
+            };
+          },
+        );
+
+        const skills = new WorkspaceSkillsImpl({
+          source: filesystem,
+          skills: ['skills'],
+          checkSkillFileMtime: true, // Enable opt-in file mtime detection
+        });
+
+        // Initial discovery
+        const initialList = await skills.list();
+        expect(initialList).toHaveLength(1);
+        expect(initialList[0]!.description).toBe('A test skill for unit testing');
+
+        const initialReadFileCalls = (filesystem.readFile as ReturnType<typeof vi.fn>).mock.calls.length;
+
+        // Advance past cooldown
+        vi.advanceTimersByTime(WorkspaceSkillsImpl.STALENESS_CHECK_COOLDOWN + 100);
+
+        // Update SKILL.md content (description change)
+        const updatedSkillMd = `---
+name: test-skill
+description: Updated description for the skill
+---
+# Test Skill
+Updated instructions.`;
+        filesMap['skills/test-skill/SKILL.md'] = updatedSkillMd;
+        await filesystem.writeFile('skills/test-skill/SKILL.md', updatedSkillMd);
+
+        // Only file mtime changes
+        fileMtime = new Date(Date.now() + 1000);
+
+        await skills.maybeRefresh();
+        const afterRefreshCalls = (filesystem.readFile as ReturnType<typeof vi.fn>).mock.calls.length;
+
+        // Should have re-read the file
+        expect(afterRefreshCalls).toBeGreaterThan(initialReadFileCalls);
+
+        const afterRefresh = await skills.list();
+        expect(afterRefresh).toHaveLength(1);
+        expect(afterRefresh[0]!.description).toBe('Updated description for the skill');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should detect new agent-created skills via filesystem write', async () => {
+      vi.useFakeTimers();
+      try {
+        let dirMtime = new Date(Date.now() - 10000);
+        let fileMtime = new Date(Date.now() - 10000);
+
+        const filesMap: Record<string, string> = {
+          'skills/test-skill/SKILL.md': VALID_SKILL_MD, // name: test-skill matches directory
+        };
+
+        const filesystem = createMockFilesystem(filesMap);
+
+        (filesystem.stat as ReturnType<typeof vi.fn>).mockImplementation(
+          async (path: string): Promise<SkillSourceStat> => {
+            const isFile = path.endsWith('.md');
+            return {
+              name: path.split('/').pop() || path,
+              type: isFile ? ('file' as const) : ('directory' as const),
+              size: 0,
+              createdAt: isFile ? fileMtime : dirMtime,
+              modifiedAt: isFile ? fileMtime : dirMtime,
+            };
+          },
+        );
+
+        const skills = new WorkspaceSkillsImpl({
+          source: filesystem,
+          skills: ['skills'],
+        });
+
+        // Initial discovery
+        const initialList = await skills.list();
+        expect(initialList).toHaveLength(1);
+
+        // Advance past cooldown
+        vi.advanceTimersByTime(WorkspaceSkillsImpl.STALENESS_CHECK_COOLDOWN + 100);
+
+        // Agent creates a new skill by writing files directly
+        const newSkillMd = `---
+name: agent-created-skill
+description: A skill created by the agent
+---
+# Agent Created Skill
+This skill was created programmatically.`;
+        filesMap['skills/agent-created-skill/SKILL.md'] = newSkillMd;
+        await filesystem.writeFile('skills/agent-created-skill/SKILL.md', newSkillMd);
+
+        // Creating new directory updates parent directory mtime
+        dirMtime = new Date(Date.now() + 1000);
+        fileMtime = new Date(Date.now() + 1000);
+
+        await skills.maybeRefresh();
+        const afterRefresh = await skills.list();
+
+        expect(afterRefresh).toHaveLength(2);
+        expect(afterRefresh.map(s => s.name).sort()).toEqual(['agent-created-skill', 'test-skill']);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should NOT detect SKILL.md file changes by default (checkSkillFileMtime: false)', async () => {
+      vi.useFakeTimers();
+      try {
+        const dirMtime = new Date(Date.now() - 10000);
+        let fileMtime = new Date(Date.now() - 10000);
+
+        const filesMap: Record<string, string> = {
+          'skills/test-skill/SKILL.md': `---
+name: bad-name
+description: A test skill with invalid name
+---
+# Test Skill
+Instructions here.`,
+        };
+
+        const filesystem = createMockFilesystem(filesMap);
+
+        (filesystem.stat as ReturnType<typeof vi.fn>).mockImplementation(
+          async (path: string): Promise<SkillSourceStat> => {
+            const isFile = path.endsWith('.md');
+            return {
+              name: path.split('/').pop() || path,
+              type: isFile ? ('file' as const) : ('directory' as const),
+              size: 0,
+              createdAt: isFile ? fileMtime : dirMtime,
+              modifiedAt: isFile ? fileMtime : dirMtime,
+            };
+          },
+        );
+
+        // Default: checkSkillFileMtime is false
+        const skills = new WorkspaceSkillsImpl({
+          source: filesystem,
+          skills: ['skills'],
+          validateOnLoad: true,
+        });
+
+        // Initial discovery - skill has invalid name
+        const initialList = await skills.list();
+        expect(initialList).toHaveLength(0);
+
+        vi.advanceTimersByTime(WorkspaceSkillsImpl.STALENESS_CHECK_COOLDOWN + 100);
+
+        // Fix the SKILL.md content (only file mtime changes)
+        const fixedSkillMd = `---
+name: test-skill
+description: A test skill with valid name
+---
+# Test Skill
+Instructions here.`;
+        filesMap['skills/test-skill/SKILL.md'] = fixedSkillMd;
+        await filesystem.writeFile('skills/test-skill/SKILL.md', fixedSkillMd);
+        fileMtime = new Date(Date.now() + 1000);
+
+        // Without checkSkillFileMtime, this should NOT detect the change
+        await skills.maybeRefresh();
+        const afterRefresh = await skills.list();
+
+        // Still 0 because file mtime change was not detected
+        expect(afterRefresh).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('read-only mode (SkillSource)', () => {
     // Create a mock read-only source (no write methods)
     function createMockReadOnlySource(files: Record<string, string | Buffer> = {}) {

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -1099,6 +1099,31 @@ Instructions for the new skill.`;
   });
 
   describe('maybeRefresh SKILL.md file mtime detection', () => {
+    /**
+     * Helper to mock stat with separate mtimes for directories vs files.
+     * This simulates the real filesystem behavior where editing a file's content
+     * updates the file's mtime but not its parent directory's mtime.
+     */
+    function mockSplitMtimeStat(filesystem: MockSkillSource, getDirMtime: () => Date, getFileMtime: () => Date) {
+      (filesystem.stat as ReturnType<typeof vi.fn>).mockImplementation(
+        async (path: string): Promise<SkillSourceStat> => {
+          const exists = await filesystem.exists(path);
+          if (!exists) {
+            throw new Error(`ENOENT: no such file or directory, stat '${path}'`);
+          }
+          const isFile = path.endsWith('.md');
+          const mtime = isFile ? getFileMtime() : getDirMtime();
+          return {
+            name: path.split('/').pop() || path,
+            type: isFile ? ('file' as const) : ('directory' as const),
+            size: 0,
+            createdAt: mtime,
+            modifiedAt: mtime,
+          };
+        },
+      );
+    }
+
     it('should detect SKILL.md content changes even when directory mtime unchanged', async () => {
       vi.useFakeTimers();
       try {
@@ -1116,19 +1141,10 @@ Instructions here.`,
         };
 
         const filesystem = createMockFilesystem(filesMap);
-
-        // Mock stat to return different mtimes for directories vs files
-        (filesystem.stat as ReturnType<typeof vi.fn>).mockImplementation(
-          async (path: string): Promise<SkillSourceStat> => {
-            const isFile = path.endsWith('.md');
-            return {
-              name: path.split('/').pop() || path,
-              type: isFile ? ('file' as const) : ('directory' as const),
-              size: 0,
-              createdAt: isFile ? fileMtime : dirMtime,
-              modifiedAt: isFile ? fileMtime : dirMtime,
-            };
-          },
+        mockSplitMtimeStat(
+          filesystem,
+          () => dirMtime,
+          () => fileMtime,
         );
 
         const skills = new WorkspaceSkillsImpl({
@@ -1152,7 +1168,6 @@ description: A test skill with valid name
 ---
 # Test Skill
 Instructions here.`;
-        filesMap['skills/test-skill/SKILL.md'] = fixedSkillMd;
         await filesystem.writeFile('skills/test-skill/SKILL.md', fixedSkillMd);
 
         // Update only the file mtime, directory stays old
@@ -1162,8 +1177,7 @@ Instructions here.`;
         await skills.maybeRefresh();
         const afterRefresh = await skills.list();
 
-        // This test documents the expected behavior after the fix
-        // Currently fails because staleness only checks directory mtime
+        // With checkSkillFileMtime: true, SKILL.md file changes are detected
         expect(afterRefresh).toHaveLength(1);
         expect(afterRefresh[0]!.name).toBe('test-skill');
       } finally {
@@ -1182,18 +1196,10 @@ Instructions here.`;
         };
 
         const filesystem = createMockFilesystem(filesMap);
-
-        (filesystem.stat as ReturnType<typeof vi.fn>).mockImplementation(
-          async (path: string): Promise<SkillSourceStat> => {
-            const isFile = path.endsWith('.md');
-            return {
-              name: path.split('/').pop() || path,
-              type: isFile ? ('file' as const) : ('directory' as const),
-              size: 0,
-              createdAt: isFile ? fileMtime : dirMtime,
-              modifiedAt: isFile ? fileMtime : dirMtime,
-            };
-          },
+        mockSplitMtimeStat(
+          filesystem,
+          () => dirMtime,
+          () => fileMtime,
         );
 
         const skills = new WorkspaceSkillsImpl({
@@ -1219,7 +1225,6 @@ description: Updated description for the skill
 ---
 # Test Skill
 Updated instructions.`;
-        filesMap['skills/test-skill/SKILL.md'] = updatedSkillMd;
         await filesystem.writeFile('skills/test-skill/SKILL.md', updatedSkillMd);
 
         // Only file mtime changes
@@ -1239,7 +1244,7 @@ Updated instructions.`;
       }
     });
 
-    it('should detect new agent-created skills via filesystem write', async () => {
+    it('should detect new agent-created skills via directory mtime change (checkSkillFileMtime not required)', async () => {
       vi.useFakeTimers();
       try {
         let dirMtime = new Date(Date.now() - 10000);
@@ -1250,20 +1255,13 @@ Updated instructions.`;
         };
 
         const filesystem = createMockFilesystem(filesMap);
-
-        (filesystem.stat as ReturnType<typeof vi.fn>).mockImplementation(
-          async (path: string): Promise<SkillSourceStat> => {
-            const isFile = path.endsWith('.md');
-            return {
-              name: path.split('/').pop() || path,
-              type: isFile ? ('file' as const) : ('directory' as const),
-              size: 0,
-              createdAt: isFile ? fileMtime : dirMtime,
-              modifiedAt: isFile ? fileMtime : dirMtime,
-            };
-          },
+        mockSplitMtimeStat(
+          filesystem,
+          () => dirMtime,
+          () => fileMtime,
         );
 
+        // Note: checkSkillFileMtime is NOT enabled - directory mtime detection should still work
         const skills = new WorkspaceSkillsImpl({
           source: filesystem,
           skills: ['skills'],
@@ -1283,10 +1281,9 @@ description: A skill created by the agent
 ---
 # Agent Created Skill
 This skill was created programmatically.`;
-        filesMap['skills/agent-created-skill/SKILL.md'] = newSkillMd;
         await filesystem.writeFile('skills/agent-created-skill/SKILL.md', newSkillMd);
 
-        // Creating new directory updates parent directory mtime
+        // Creating new directory updates parent directory mtime - this triggers refresh
         dirMtime = new Date(Date.now() + 1000);
         fileMtime = new Date(Date.now() + 1000);
 
@@ -1316,18 +1313,10 @@ Instructions here.`,
         };
 
         const filesystem = createMockFilesystem(filesMap);
-
-        (filesystem.stat as ReturnType<typeof vi.fn>).mockImplementation(
-          async (path: string): Promise<SkillSourceStat> => {
-            const isFile = path.endsWith('.md');
-            return {
-              name: path.split('/').pop() || path,
-              type: isFile ? ('file' as const) : ('directory' as const),
-              size: 0,
-              createdAt: isFile ? fileMtime : dirMtime,
-              modifiedAt: isFile ? fileMtime : dirMtime,
-            };
-          },
+        mockSplitMtimeStat(
+          filesystem,
+          () => dirMtime,
+          () => fileMtime,
         );
 
         // Default: checkSkillFileMtime is false
@@ -1350,7 +1339,6 @@ description: A test skill with valid name
 ---
 # Test Skill
 Instructions here.`;
-        filesMap['skills/test-skill/SKILL.md'] = fixedSkillMd;
         await filesystem.writeFile('skills/test-skill/SKILL.md', fixedSkillMd);
         fileMtime = new Date(Date.now() + 1000);
 
@@ -1360,6 +1348,58 @@ Instructions here.`;
 
         // Still 0 because file mtime change was not detected
         expect(afterRefresh).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should detect SKILL.md changes for direct skill paths (e.g., **/SKILL.md glob)', async () => {
+      vi.useFakeTimers();
+      try {
+        // Separate mtimes for directories vs files
+        const dirMtime = new Date(Date.now() - 10000); // Old, never changes
+        let fileMtime = new Date(Date.now() - 10000); // Starts old, will be updated
+
+        const filesMap: Record<string, string> = {
+          'skills/my-skill/SKILL.md': VALID_SKILL_MD,
+        };
+
+        const filesystem = createMockFilesystem(filesMap);
+        mockSplitMtimeStat(
+          filesystem,
+          () => dirMtime,
+          () => fileMtime,
+        );
+
+        // Direct skill path (simulates glob that resolved directly to a skill directory)
+        const skills = new WorkspaceSkillsImpl({
+          source: filesystem,
+          skills: ['skills/my-skill'], // Direct skill path
+          validateOnLoad: false,
+          checkSkillFileMtime: true,
+        });
+
+        // Initial discovery
+        const initialList = await skills.list();
+        expect(initialList).toHaveLength(1);
+        expect(initialList[0]!.description).toBe('A test skill for unit testing');
+
+        // Advance past the staleness check cooldown
+        vi.advanceTimersByTime(WorkspaceSkillsImpl.STALENESS_CHECK_COOLDOWN + 100);
+
+        // Update the skill content (only file mtime changes, not directory)
+        const updatedSkillMd = VALID_SKILL_MD.replace('A test skill for unit testing', 'An updated skill description');
+        await filesystem.writeFile('skills/my-skill/SKILL.md', updatedSkillMd);
+
+        // Update only the file mtime, directory stays old
+        fileMtime = new Date(Date.now() + 1000);
+
+        // maybeRefresh should detect the SKILL.md mtime change via direct skill path check
+        await skills.maybeRefresh();
+        const afterRefresh = await skills.list();
+
+        expect(afterRefresh).toHaveLength(1);
+        expect(afterRefresh[0]!.description).toBe('An updated skill description');
       } finally {
         vi.useRealTimers();
       }

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -855,6 +855,23 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
             continue;
           }
 
+          // If this directory is itself a skill root, check its SKILL.md mtime.
+          // This covers direct skill paths and file-level glob expansions (e.g., **/SKILL.md).
+          if (this.#checkSkillFileMtime) {
+            const directSkillFilePath = this.#joinPath(pathToCheck, 'SKILL.md');
+            try {
+              const directSkillFileStat = await this.#source.stat(directSkillFilePath);
+              if (
+                directSkillFileStat.type === 'file' &&
+                directSkillFileStat.modifiedAt.getTime() > this.#lastDiscoveryTime
+              ) {
+                return true;
+              }
+            } catch {
+              // Not a direct skill dir (or SKILL.md unavailable), continue to subdirectory scan.
+            }
+          }
+
           // Also check subdirectories (skill directories) for changes
           const entries = await this.#source.readdir(pathToCheck);
           for (const entry of entries) {
@@ -873,7 +890,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
                 const skillFilePath = this.#joinPath(entryPath, 'SKILL.md');
                 try {
                   const skillFileStat = await this.#source.stat(skillFilePath);
-                  if (skillFileStat.modifiedAt.getTime() > this.#lastDiscoveryTime) {
+                  if (skillFileStat.type === 'file' && skillFileStat.modifiedAt.getTime() > this.#lastDiscoveryTime) {
                     return true;
                   }
                 } catch {

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -67,6 +67,13 @@ export interface WorkspaceSkillsImplConfig {
   searchEngine?: SkillSearchEngine;
   /** Validate skills on load (default: true) */
   validateOnLoad?: boolean;
+  /**
+   * Check SKILL.md file mtime in addition to directory mtime for staleness detection.
+   * Enables detection of in-place file edits (e.g., fixing validation errors).
+   * Increases stat calls - recommended for local development only.
+   * Default: false
+   */
+  checkSkillFileMtime?: boolean;
 }
 
 /**
@@ -77,6 +84,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
   readonly #skillsResolver: SkillsResolver;
   readonly #searchEngine?: SkillSearchEngine;
   readonly #validateOnLoad: boolean;
+  readonly #checkSkillFileMtime: boolean;
 
   /** Map of skill name -> array of candidates (supports same-named skills from different sources) */
   #skills: Map<string, InternalSkill[]> = new Map();
@@ -104,6 +112,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
     this.#skillsResolver = config.skills;
     this.#searchEngine = config.searchEngine;
     this.#validateOnLoad = config.validateOnLoad ?? true;
+    this.#checkSkillFileMtime = config.checkSkillFileMtime ?? false;
   }
 
   // ===========================================================================
@@ -856,6 +865,20 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
               const entryStat = await this.#source.stat(entryPath);
               if (entryStat.modifiedAt.getTime() > this.#lastDiscoveryTime) {
                 return true;
+              }
+
+              // Optionally check SKILL.md file mtime - editing file content may not update directory mtime.
+              // This doubles stat calls per skill, so it's opt-in for local development scenarios.
+              if (this.#checkSkillFileMtime) {
+                const skillFilePath = this.#joinPath(entryPath, 'SKILL.md');
+                try {
+                  const skillFileStat = await this.#source.stat(skillFilePath);
+                  if (skillFileStat.modifiedAt.getTime() > this.#lastDiscoveryTime) {
+                    return true;
+                  }
+                } catch {
+                  // SKILL.md doesn't exist or can't be stat'd, skip
+                }
               }
             } catch {
               // Couldn't stat entry, skip it

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -278,6 +278,20 @@ export interface WorkspaceConfig<
    */
   skillSource?: SkillSource;
 
+  /**
+   * Check SKILL.md file mtime in addition to directory mtime for staleness detection.
+   *
+   * When enabled, allows hot-reload detection of in-place SKILL.md edits
+   * (e.g., fixing a validation error or updating a skill description).
+   *
+   * Trade-off: This doubles the stat() calls per skill during staleness checks.
+   * Recommended for local development only. Not recommended for cloud storage
+   * backends (S3, etc.) where stat() calls have higher latency.
+   *
+   * @default false
+   */
+  checkSkillFileMtime?: boolean;
+
   // ---------------------------------------------------------------------------
   // LSP Configuration
   // ---------------------------------------------------------------------------
@@ -689,6 +703,7 @@ export class Workspace<
         skills: this._config.skills!,
         searchEngine: this._searchEngine,
         validateOnLoad: true,
+        checkSkillFileMtime: this._config.checkSkillFileMtime,
       });
     }
 


### PR DESCRIPTION
## Description

Add opt-in `checkSkillFileMtime` option to detect in-place SKILL.md edits during hot reload.

Previously, only directory mtime was checked for skill staleness, so editing a skill's name (to fix a validation error) or updating its description wouldn't trigger re-discovery until server restart.

The option is off by default since it doubles `stat()` calls per skill during staleness checks. Recommended for local development only, not for cloud storage backends where `stat()` has higher latency.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds an optional switch so the dev server can notice edits made inside a skill's SKILL.md (like name or description fixes) and reload that skill without restarting. It's off by default because enabling it doubles filesystem stat() calls and can be slow on remote/cloud backends.

---

## Summary

Adds an opt-in Workspace configuration flag, checkSkillFileMtime, which makes skill hot-reload staleness detection check SKILL.md file mtimes in addition to directory mtimes. When enabled, any SKILL.md modified after the last discovery time triggers re-discovery; missing/unreadable SKILL.md files are ignored so existing directory-based behavior remains the fallback.

### Changes

- Configuration & interface
  - Added optional checkSkillFileMtime?: boolean to WorkspaceConfig.
  - Added optional checkSkillFileMtime?: boolean to WorkspaceSkillsImplConfig.
  - Workspace now forwards the flag into WorkspaceSkillsImpl.

- Implementation
  - WorkspaceSkillsImpl stores #checkSkillFileMtime (default false).
  - isSkillsPathStale() now, when the flag is true, performs additional stat() calls on SKILL.md at inspected roots and on each scanned subdirectory; if any SKILL.md mtime > lastDiscoveryTime, staleness is reported.
  - File stat errors for SKILL.md are swallowed so directory-mtime logic still governs discovery when files are absent/unreadable.

- Tests
  - Added tests in workspace-skills.test.ts covering:
    - SKILL.md mtime change triggers refresh when checkSkillFileMtime is enabled (including invalid→valid transitions).
    - Cached skill descriptions are re-read when SKILL.md changes for existing skills.
    - Default behavior (flag off) does not refresh on SKILL.md-only changes; directory mtime still drives discovery for new skill dirs.
    - Direct skill-path lookups honor SKILL.md mtime detection when enabled.

- Documentation
  - Added a changeset documenting the new opt-in option, rationale, performance tradeoff, and example usage enabling it for local development.

### Notes / Design

- Default: checkSkillFileMtime = false to avoid doubling stat() calls per skill during staleness checks.
- Recommended for local development; not recommended for cloud storage backends with higher stat() latency.
- Change type: Bug fix (non-breaking, opt-in).
- Tests and a documentation changeset are included; addressing any outstanding reviewer comments remains to be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->