### PR TITLE
fix(mastracode): keep custom slash commands in the active thread

### DIFF
--- a/.changeset/puny-dingos-knock.md
+++ b/.changeset/puny-dingos-knock.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed custom slash commands to create the pending thread before sending the first prompt so the initial exchange stays in the same conversation.

--- a/mastracode/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/src/tui/__tests__/command-dispatch.test.ts
@@ -93,10 +93,14 @@ describe('dispatchSlashCommand models routing', () => {
     const state = {
       customSlashCommands: [{ name: 'deploy', description: 'Deploy to prod', template: 'deploy now', sourcePath: '' }],
       getCurrentThreadId: vi.fn(() => 'thread-1'),
+      pendingNewThread: false,
       allSlashCommandComponents: [],
       chatContainer: { addChild: vi.fn() },
       ui: { requestRender: vi.fn() },
-      harness: { sendMessage: vi.fn().mockResolvedValue(undefined) },
+      harness: {
+        createThread: vi.fn().mockResolvedValue(undefined),
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+      },
     } as any;
 
     const handled = await dispatchSlashCommand('//deploy', state, () => ({}) as any);
@@ -104,7 +108,32 @@ describe('dispatchSlashCommand models routing', () => {
     expect(handled).toBe(true);
     expect(mocks.processSlashCommand).toHaveBeenCalledTimes(1);
     expect(mocks.processSlashCommand).toHaveBeenCalledWith(state.customSlashCommands[0], [], process.cwd());
+    expect(state.harness.createThread).not.toHaveBeenCalled();
     expect(mocks.showError).not.toHaveBeenCalled();
+  });
+
+  it('creates the pending new thread before sending a custom slash command', async () => {
+    const state = {
+      customSlashCommands: [{ name: 'deploy', description: 'Deploy to prod', template: 'deploy now', sourcePath: '' }],
+      pendingNewThread: true,
+      allSlashCommandComponents: [],
+      chatContainer: { addChild: vi.fn() },
+      ui: { requestRender: vi.fn() },
+      harness: {
+        createThread: vi.fn().mockResolvedValue(undefined),
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+      },
+    } as any;
+
+    const handled = await dispatchSlashCommand('//deploy', state, () => ({}) as any);
+
+    expect(handled).toBe(true);
+    expect(state.harness.createThread).toHaveBeenCalledTimes(1);
+    expect(state.harness.sendMessage).toHaveBeenCalledTimes(1);
+    expect(state.harness.createThread.mock.invocationCallOrder[0]).toBeLessThan(
+      state.harness.sendMessage.mock.invocationCallOrder[0],
+    );
+    expect(state.pendingNewThread).toBe(false);
   });
 
   it('keeps /new routed to the built-in command when a custom command has the same name', async () => {

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -205,6 +205,11 @@ async function handleCustomSlashCommand(
       state.chatContainer.addChild(slashComp);
       state.ui.requestRender();
 
+      if (state.pendingNewThread) {
+        await state.harness.createThread();
+        state.pendingNewThread = false;
+      }
+
       // Wrap in <slash-command> tags so the assistant sees the full
       // content but addUserMessage won't double-render it.
       const wrapped = `<slash-command name="${command.name}">\n${processedContent.trim()}\n</slash-command>`;


### PR DESCRIPTION
This keeps the first `//...` command in the same thread when `/new` is still pending, so the next user message does not create a second thread and lose the earlier context.

Before:
```text
/new
//make-move ...
hello again
```
The custom command reply could land before the thread was created, and `hello again` could start a new thread.

After:
```text
/new
//make-move ...
hello again
```
The pending thread is created before the custom slash command is sent, so the whole exchange stays together.

Tested with `pnpm exec vitest run src/tui/__tests__/command-dispatch.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're having a conversation and you say "Start something new" followed by a special command. The bug was that the special command could arrive so fast that it doesn't know which conversation to attach to, creating a new conversation instead. This PR fixes it by making sure the new conversation is created first, so the special command attaches to the right place.

## Overview

This PR fixes a race condition in the mastracode TUI where custom slash commands (prefixed with `//`) could execute and deliver their response before a pending thread (from a `/new` command) was created, causing the subsequent exchange to be split across multiple conversation threads.

## Changes

**Implementation** (`mastracode/src/tui/command-dispatch.ts`)
- Modified the custom slash command handler to conditionally create a pending thread before sending the command message to the harness
- The thread is created after rendering the slash command UI but before sending the wrapped `<slash-command>` message
- Resets `state.pendingNewThread` to `false` after thread creation to prevent duplicate creation

**Tests** (`mastracode/src/tui/__tests__/command-dispatch.test.ts`)
- Updated existing `//deploy` routing test to set `pendingNewThread: false` and assert that `createThread` is not called
- Added new test case that verifies: when `pendingNewThread` is `true`, `harness.createThread` is called before `harness.sendMessage`, and the flag is properly reset to `false`

**Changelog** (`.changeset/puny-dingos-knock.md`)
- Added changeset entry documenting the patch fix for mastracode

## Impact

This ensures that the initial exchange of a conversation (e.g., `/new` → `//make-move ...` → user follow-up) remains attached to the same thread, preserving conversation continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->