### PR TITLE
fix(playground): show browser tool calls in chat UI and document screencast deps

### DIFF
--- a/.changeset/bright-screens-glow.md
+++ b/.changeset/bright-screens-glow.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed browser tool calls not rendering in Studio chat UI. Browser tools (`browser_*` and `stagehand_*`) were filtered from the chat, making it look like the agent was looping or idle. They now render inline alongside other tool calls.

--- a/docs/src/content/en/docs/browser/overview.mdx
+++ b/docs/src/content/en/docs/browser/overview.mdx
@@ -104,6 +104,18 @@ This works with any [CDP-compatible](https://chromedevtools.github.io/devtools-p
 
 Browser providers stream a live video feed of the browser to the Mastra Studio UI. This lets you watch the agent interact with pages in real-time.
 
+Screencast requires WebSocket support. Install these packages in your project:
+
+```bash npm2yarn
+npm install ws @hono/node-ws
+```
+
+:::note
+
+These packages are not included by default because they are incompatible with serverless environments like Cloudflare Workers. If they are not installed, screencast is disabled but all other browser functionality works normally.
+
+:::
+
 Screencast is enabled by default and can be configured:
 
 ```typescript

--- a/packages/playground/src/lib/ai-ui/tools/tool-fallback.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/tool-fallback.tsx
@@ -69,11 +69,6 @@ const ToolFallbackInner = ({ toolName, result, args, metadata, toolCallId, ...pr
     return <ObservationMarkerBadge toolName={toolName} args={args} metadata={metadata} />;
   }
 
-  // Hide browser tools from chat when context is available
-  if (isBrowser && browserCtx) {
-    return null;
-  }
-
   // We need to handle the stream data even if the workflow is not resolved yet
   // The response from the fetch request resolving the workflow might theoretically
   // be resolved after we receive the first stream event


### PR DESCRIPTION
## Description

Browser tool calls (`browser_*` and `stagehand_*`) were filtered out of the Studio chat UI, making it appear as though the agent was looping or taking no action. This removes the filter so browser tool calls render inline alongside other tool calls.

Additionally, the browser screencast feature requires `ws` and `@hono/node-ws` packages but this was undocumented. Adds install instructions to the browser docs screencast section with an explanation of why they aren't bundled by default (serverless compatibility).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

The Studio chat was hiding messages showing what the browser tool was doing, so it looked like nothing was happening — this PR makes those browser actions visible in the chat again. It also updates the docs to tell developers to install two WebSocket packages if they want the screencast feature.

## Changes

### Bug Fix: Browser Tool Calls Now Display in Chat UI
- **File**: packages/playground/src/lib/ai-ui/tools/tool-fallback.tsx  
- Removed the logic that filtered out browser tool calls (identifiers like `browser_*` and `stagehand_*`), so those tool calls are no longer short-circuited to `null`.
- Browser tool calls now render inline with other tool calls using the existing badge selection logic (observation/memory, agent/workflow badges, file tree, sandbox execution, or generic `ToolBadge`).
- **Impact**: Studio users will see browser tool activity in the chat, preventing the UI from appearing to loop or be idle when browser tools are used.

### Documentation: WebSocket Dependencies for Screencast Feature
- **File**: docs/src/content/en/docs/browser/overview.mdx  
- Added a Screencast section instructing users to install `ws` and `@hono/node-ws` for WebSocket support:
  - npm install ws @hono/node-ws
- Clarified these packages are not bundled by default because they’re incompatible with serverless environments (e.g., Cloudflare Workers); without them, screencast is disabled but other browser features function normally.

### Changeset
- **File**: .changeset/bright-screens-glow.md  
- Bumped patch; documents that browser-related tool calls are no longer filtered from the Studio chat UI.

## Type of change
- Bug fix (non-breaking)
- Documentation update

## Checklist
- Documentation changes: yes
- Tests added: no
<!-- end of auto-generated comment: release notes by coderabbit.ai -->