### PR TITLE
fix(core): use configured modelId in message metadata to prevent false positive OM provider change

### DIFF
--- a/.changeset/pretty-streets-end.md
+++ b/.changeset/pretty-streets-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed false positive provider change detection in observational memory. Message metadata now uses the configured model ID instead of the API response model ID, ensuring consistency with step-start parts and preventing incorrect 'Model changed' activations when the provider returns versioned model names (e.g., gpt-5.4-2026-03-05 vs gpt-5.4).

--- a/packages/core/src/loop/test-utils/tools.ts
+++ b/packages/core/src/loop/test-utils/tools.ts
@@ -1049,7 +1049,7 @@ export function toolsTests({ loopFn, runId }: { loopFn: typeof loop; runId: stri
       );
       expect(assistantMsg).toBeDefined();
       expect(assistantMsg?.content.metadata).toEqual({
-        modelId: 'claude-code-model',
+        modelId: 'mock-model-id',
         provider: 'mock-provider',
       });
 

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -364,4 +364,21 @@ describe('buildMessagesFromChunks', () => {
     });
     expect(msgs[0]!.content.metadata).toEqual({ modelId: 'gpt-5' });
   });
+
+  it('should prefer configured modelId over API response modelId in metadata', () => {
+    // This test documents that responseModelMetadata should contain the configured
+    // model ID (e.g., 'gpt-5.4'), not the API response model ID (e.g., 'gpt-5.4-2026-03-05').
+    // The caller (buildResponseModelMetadata) is responsible for this preference.
+    const msgs = buildMessagesFromChunks({
+      chunks: [
+        { type: 'text-start', payload: { id: 't1' } },
+        { type: 'text-delta', payload: { id: 't1', text: 'response' } },
+        { type: 'text-end', payload: { id: 't1' } },
+      ],
+      messageId: 'msg-1',
+      responseModelMetadata: { metadata: { modelId: 'gpt-5.4', provider: 'openai.responses' } },
+    });
+    // Verify the configured modelId is preserved in the message metadata
+    expect(msgs[0]!.content.metadata).toEqual({ modelId: 'gpt-5.4', provider: 'openai.responses' });
+  });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -846,4 +846,94 @@ describe('createLLMExecutionStep gateway provider tools', () => {
       },
     });
   });
+
+  it('should use configured modelId in message metadata instead of API response modelId', async () => {
+    const configuredModelId = 'gpt-5.4';
+    const apiResponseModelId = 'gpt-5.4-2026-03-05'; // Versioned model ID returned by API
+
+    const doStream = vi.fn(async () => ({
+      stream: convertArrayToReadableStream([
+        {
+          type: 'response-metadata',
+          id: 'resp-1',
+          modelId: apiResponseModelId, // API returns versioned model ID
+          timestamp: new Date(0),
+        },
+        {
+          type: 'text-start',
+          id: 'text-1',
+        },
+        {
+          type: 'text-delta',
+          id: 'text-1',
+          delta: 'Hello!',
+        },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: testUsage,
+        },
+      ]),
+      request: {},
+      response: {
+        headers: undefined,
+      },
+      warnings: [],
+    }));
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'openai',
+            modelId: configuredModelId, // Configured model ID
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream,
+          } as any,
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+        threadId: 'thread-123',
+        resourceId: 'resource-456',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<{}>);
+
+    const input = createIterationInput();
+    input.stepResult.isContinued = false;
+
+    await llmExecutionStep.execute(createExecuteParams(input));
+
+    // Find the assistant message with metadata
+    const assistantMessage = messageList.get.all
+      .db()
+      .find(message => message.role === 'assistant' && message.content.metadata);
+
+    // The message metadata should use the configured modelId, not the API response modelId
+    expect(assistantMessage?.content.metadata?.modelId).toBe(configuredModelId);
+    expect(assistantMessage?.content.metadata?.modelId).not.toBe(apiResponseModelId);
+    expect(assistantMessage?.content.metadata?.provider).toBe('openai');
+  });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -65,10 +65,10 @@ type ProcessOutputStreamOptions<OUTPUT = undefined> = {
 
 function buildResponseModelMetadata(
   runState: AgenticRunState,
-  model?: { provider?: string },
+  model?: { provider?: string; modelId?: string },
 ): { metadata: Record<string, unknown> } | undefined {
   const metadata: Record<string, unknown> = {};
-  const modelId = runState.state.responseMetadata?.modelId;
+  const modelId = model?.modelId ?? runState.state.responseMetadata?.modelId;
 
   if (modelId) {
     metadata.modelId = modelId;


### PR DESCRIPTION
Fixes false positive "Model changed" activations in observational memory.

The issue was that `step-start.model` used the configured model ID while `message.content.metadata.modelId` used the API response model ID. When providers return versioned names (e.g., `gpt-5.4-2026-03-05` instead of `gpt-5.4`), this mismatch triggered incorrect provider change detection.

**Before:**
```typescript
const modelId = runState.state.responseMetadata?.modelId;
```

**After:**
```typescript
const modelId = model?.modelId ?? runState.state.responseMetadata?.modelId;
```

Now both sources consistently use the configured model ID.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The system was sometimes wrongly saying the AI model changed because two places used different model names: one used the simple configured name (like "gpt-5.4") and the other used the API's versioned name (like "gpt-5.4-2026-03-05"). This PR makes both places use the configured model name so the system stops raising false "Model changed" alerts.

---

## Changes Overview

This PR fixes false-positive "Model changed" activations in observational memory by ensuring message metadata prefers the configured model ID over any model ID reported by the API.

### Root Cause
- step-start used the configured model ID (e.g., `gpt-5.4`).
- message.content.metadata.modelId read `runState.state.responseMetadata?.modelId`, which could be provider-versioned (e.g., `gpt-5.4-2026-03-05`).
- The mismatch triggered incorrect provider/model-change detection.

### Solution
- Update `buildResponseModelMetadata` to derive `metadata.modelId` from `model?.modelId` when available, falling back to `runState.state.responseMetadata?.modelId`. This ensures consistency between step-start and message metadata.

### Files Changed
- packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
  - Prefer configured `model?.modelId` for response metadata (`model?.modelId ?? runState.state.responseMetadata?.modelId`).
- packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
  - New unit test verifying assistant message metadata uses the configured `modelId` (not the streamed API value) and that `provider` matches configuration.
- packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
  - Test added to assert built message content metadata equals configured metadata.
- packages/core/src/loop/test-utils/tools.ts
  - Test expectation updated to expect the configured `modelId` in persisted assistant message metadata.
- .changeset/pretty-streets-end.md
  - Changeset documenting the behavioral fix for `@mastra/core`.

### Tests
- Added/updated tests to assert metadata.modelId uses the configured model ID and that provider metadata matches configuration, preventing false "Model changed" detections.

### Review Notes
- Behavioral change limited to how metadata.modelId is selected; no public API changes.
- Estimated review effort: Low–Medium (mostly tests and a small helper update).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->