### PR TITLE
fix(core): keep deferred provider calls only on the last surviving assistant turn

### DIFF
--- a/.changeset/puny-rats-talk.md
+++ b/.changeset/puny-rats-talk.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a bug where orphaned provider-executed tool calls (e.g. Anthropic `web_search`, Gemini `code_execution`) could brick a thread. When a provider dropped the tool-result chunk ([#15668](https://github.com/mastra-ai/mastra/issues/15668)) or a run aborted mid-stream ([#14148](https://github.com/mastra-ai/mastra/issues/14148)), the unresolved call was replayed on every subsequent request — causing Gemini to return empty text and Anthropic to reject the tool-call/tool-result invariant.
+
+`sanitizeV5UIMessages` now only keeps an `input-available` provider-executed tool part on the most recent assistant message, and only when no user turn has followed it. Orphans on earlier assistant turns are dropped so the outgoing history always satisfies the tool-call/tool-result pairing required by provider APIs.

--- a/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AIV5Type } from '../types';
-import { addStartStepPartsForAIV5, sanitizeV5UIMessages } from './output-converter';
+import { addStartStepPartsForAIV5, aiV5UIMessagesToAIV5ModelMessages, sanitizeV5UIMessages } from './output-converter';
 
 /**
  * Tests for provider-executed tool handling in sanitizeV5UIMessages.
@@ -206,6 +206,202 @@ describe('sanitizeV5UIMessages — provider-executed tool handling', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]!.parts).toHaveLength(2);
+  });
+});
+
+/**
+ * Regression tests for https://github.com/mastra-ai/mastra/issues/15668
+ *
+ * Gemini `code_execution` (and `google_search`) on Vertex AI non-deterministically
+ * omits the paired `codeExecutionResult` after emitting `executableCode`. The AI SDK
+ * surfaces this as a `tool-call { providerExecuted: true }` chunk with no paired
+ * `tool-result`. Mastra currently persists that as
+ * `tool-invocation { state: 'call', providerExecuted: true }` with no result part.
+ *
+ * When the thread is replayed on the next turn, `sanitizeV5UIMessages` keeps the
+ * orphaned provider-executed call (line ~150 of output-converter.ts). The Google
+ * provider then serializes it as a bare `functionCall` in the `contents` array —
+ * with no paired `functionResponse`. Gemini returns `text: ""` for this turn and
+ * every subsequent turn on the thread (verified by the reporter: 5/5 empty STOP).
+ *
+ * The bricking is deterministic once the orphan lands. The contract that must
+ * hold is: after UI→Model conversion, there must NEVER be a `tool-call` content
+ * part without a corresponding `tool-result` somewhere in the outgoing messages.
+ * Whether the fix synthesizes a placeholder result or strips the call is an
+ * implementation detail — but one of the two must happen.
+ */
+describe('sanitizeV5UIMessages — orphaned provider-executed tool calls (issue #15668)', () => {
+  const makeToolPart = (
+    overrides: Partial<AIV5Type.ToolUIPart> & { type: string; toolCallId: string },
+  ): AIV5Type.ToolUIPart =>
+    ({
+      state: 'input-available' as const,
+      input: {},
+      ...overrides,
+    }) as AIV5Type.ToolUIPart;
+
+  it('drops or resolves an orphaned Gemini code_execution call so the next request is not an unpaired functionCall', () => {
+    // This is the exact shape Mastra persists after Vertex drops codeExecutionResult.
+    // It is NOT a legitimate deferred provider tool — Gemini code_execution does not
+    // defer across turns (unlike Anthropic web_search). Replaying this to the model
+    // deterministically produces empty text on every subsequent turn.
+    const user: AIV5Type.UIMessage = {
+      id: 'u1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Parse the attached spreadsheet and tell me the column names.' }],
+    };
+
+    const assistantWithOrphan: AIV5Type.UIMessage = {
+      id: 'a1',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: "I'll parse it with pandas via code_execution." },
+        makeToolPart({
+          type: 'tool-code_execution',
+          toolCallId: 'gem_tool_1',
+          state: 'input-available',
+          input: { code: "import pandas as pd; print(pd.read_excel('/tmp/x.xlsx').columns.tolist())" },
+          providerExecuted: true,
+        }),
+      ],
+    };
+
+    const followUp: AIV5Type.UIMessage = {
+      id: 'u2',
+      role: 'user',
+      parts: [{ type: 'text', text: 'what were the columns?' }],
+    };
+
+    const modelMessages = aiV5UIMessagesToAIV5ModelMessages(
+      [user, assistantWithOrphan, followUp],
+      [],
+      /* filterIncompleteToolCalls */ true,
+    );
+
+    // Walk all assistant content parts and collect tool-call / tool-result IDs.
+    const orphanCallIds: string[] = [];
+    const resultIds = new Set<string>();
+    for (const m of modelMessages) {
+      if (typeof m.content === 'string') continue;
+      for (const part of m.content) {
+        if (part.type === 'tool-call') {
+          orphanCallIds.push((part as any).toolCallId);
+        }
+        if (part.type === 'tool-result') {
+          resultIds.add((part as any).toolCallId);
+        }
+      }
+    }
+
+    // The invariant: every tool-call sent to the provider must have a matching
+    // tool-result. An orphaned `gem_tool_1` call without a result is exactly
+    // what bricks the thread.
+    const unpaired = orphanCallIds.filter(id => !resultIds.has(id));
+    expect(unpaired).toEqual([]);
+  });
+
+  it('drops or resolves an orphaned Anthropic web_search call stuck in state:"call" (same defect class)', () => {
+    // Same underlying issue as #14148 — once a provider-executed tool is persisted
+    // as state:"call" with no paired result, every subsequent turn replays it.
+    // The safeguard must be provider-agnostic.
+    const user: AIV5Type.UIMessage = {
+      id: 'u1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'find me recent news on X' }],
+    };
+
+    const assistantWithOrphan: AIV5Type.UIMessage = {
+      id: 'a1',
+      role: 'assistant',
+      parts: [
+        makeToolPart({
+          type: 'tool-web_search_20250305',
+          toolCallId: 'srvtoolu_orphan1',
+          state: 'input-available',
+          input: { query: 'X' },
+          providerExecuted: true,
+        }),
+      ],
+    };
+
+    const followUp: AIV5Type.UIMessage = {
+      id: 'u2',
+      role: 'user',
+      parts: [{ type: 'text', text: 'you good?' }],
+    };
+
+    const modelMessages = aiV5UIMessagesToAIV5ModelMessages(
+      [user, assistantWithOrphan, followUp],
+      [],
+      /* filterIncompleteToolCalls */ true,
+    );
+
+    const orphanCallIds: string[] = [];
+    const resultIds = new Set<string>();
+    for (const m of modelMessages) {
+      if (typeof m.content === 'string') continue;
+      for (const part of m.content) {
+        if (part.type === 'tool-call') orphanCallIds.push((part as any).toolCallId);
+        if (part.type === 'tool-result') resultIds.add((part as any).toolCallId);
+      }
+    }
+
+    const unpaired = orphanCallIds.filter(id => !resultIds.has(id));
+    expect(unpaired).toEqual([]);
+  });
+
+  it('drops a stale deferred provider call on an EARLIER assistant message when a later assistant message exists', () => {
+    // Multi-assistant history shape — this guards against the class of bug #14192:
+    // a provider-executed tool left in `input-available` on an earlier assistant
+    // turn must not be replayed to the provider just because the final turn is
+    // also an assistant. Only the most recent assistant message may legitimately
+    // carry a deferred provider tool.
+    const user: AIV5Type.UIMessage = {
+      id: 'u1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'search for recent news about X' }],
+    };
+
+    const earlierAssistantWithStaleProviderCall: AIV5Type.UIMessage = {
+      id: 'a1',
+      role: 'assistant',
+      parts: [
+        makeToolPart({
+          type: 'tool-web_search_20250305',
+          toolCallId: 'srvtoolu_stale',
+          state: 'input-available',
+          input: { query: 'X' },
+          providerExecuted: true,
+        }),
+      ],
+    };
+
+    const laterAssistant: AIV5Type.UIMessage = {
+      id: 'a2',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Here is a summary based on what I found earlier.' }],
+    };
+
+    const modelMessages = aiV5UIMessagesToAIV5ModelMessages(
+      [user, earlierAssistantWithStaleProviderCall, laterAssistant],
+      [],
+      /* filterIncompleteToolCalls */ true,
+    );
+
+    const orphanCallIds: string[] = [];
+    const resultIds = new Set<string>();
+    for (const m of modelMessages) {
+      if (typeof m.content === 'string') continue;
+      for (const part of m.content) {
+        if (part.type === 'tool-call') orphanCallIds.push((part as any).toolCallId);
+        if (part.type === 'tool-result') resultIds.add((part as any).toolCallId);
+      }
+    }
+
+    const unpaired = orphanCallIds.filter(id => !resultIds.has(id));
+    expect(unpaired).toEqual([]);
+    // Belt-and-suspenders: the stale id must not have leaked through at all.
+    expect(orphanCallIds).not.toContain('srvtoolu_stale');
   });
 });
 

--- a/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
@@ -403,6 +403,56 @@ describe('sanitizeV5UIMessages — orphaned provider-executed tool calls (issue 
     // Belt-and-suspenders: the stale id must not have leaked through at all.
     expect(orphanCallIds).not.toContain('srvtoolu_stale');
   });
+
+  it('keeps a deferred provider call on the last surviving assistant when a trailing assistant sanitizes away', () => {
+    const user: AIV5Type.UIMessage = {
+      id: 'u1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'search for recent news about X' }],
+    };
+
+    const assistantWithDeferredProviderCall: AIV5Type.UIMessage = {
+      id: 'a1',
+      role: 'assistant',
+      parts: [
+        makeToolPart({
+          type: 'tool-web_search_20250305',
+          toolCallId: 'srvtoolu_deferred',
+          state: 'input-available',
+          input: { query: 'X' },
+          providerExecuted: true,
+        }),
+      ],
+    };
+
+    const trailingAssistantThatSanitizesAway: AIV5Type.UIMessage = {
+      id: 'a2',
+      role: 'assistant',
+      parts: [
+        makeToolPart({
+          type: 'tool-get_info',
+          toolCallId: 'client_streaming',
+          state: 'input-streaming',
+          input: { query: 'ignore me' },
+        }),
+      ],
+    };
+
+    const result = sanitizeV5UIMessages(
+      [user, assistantWithDeferredProviderCall, trailingAssistantThatSanitizesAway],
+      true,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[1]?.id).toBe('a1');
+    expect(result[1]?.parts).toEqual([
+      expect.objectContaining({
+        toolCallId: 'srvtoolu_deferred',
+        state: 'input-available',
+        providerExecuted: true,
+      }),
+    ]);
+  });
 });
 
 describe('addStartStepPartsForAIV5 — client/provider tool splitting', () => {

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -108,9 +108,31 @@ export function sanitizeV5UIMessages(
   messages: AIV5Type.UIMessage[],
   filterIncompleteToolCalls = false,
 ): AIV5Type.UIMessage[] {
+  // Precompute the index of the last user message AND the index of the last
+  // assistant message. A deferred provider-executed tool call (e.g. Anthropic
+  // non-deterministically defers web_search across steps N→N+1 within the same
+  // run) may legitimately carry `input-available` state ONLY on the most recent
+  // assistant message, AND only if no user turn has followed it. On any earlier
+  // assistant turn (or after a later user message) an unresolved provider-executed
+  // call is an orphan — provider dropped the result chunk (#15668), run aborted
+  // mid-stream (#14148), or a stale call from an earlier step (#14192) — and
+  // must be dropped to keep the tool-call/tool-result invariant.
+  let lastUserIdx = -1;
+  let lastAssistantIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const role = messages[i]!.role;
+    if (role === 'user' && lastUserIdx === -1) lastUserIdx = i;
+    if (role === 'assistant' && lastAssistantIdx === -1) lastAssistantIdx = i;
+    if (lastUserIdx !== -1 && lastAssistantIdx !== -1) break;
+  }
+
   const msgs = messages
-    .map(m => {
+    .map((m, idx) => {
       if (m.parts.length === 0) return false;
+
+      // Deferred-provider-tool behavior is ONLY valid on the most recent assistant
+      // message AND only when no user turn has followed it.
+      const assistantTurnStillOpen = m.role === 'assistant' && idx === lastAssistantIdx && idx > lastUserIdx;
 
       // Filter out streaming states and optionally input-available (which aren't supported by convertToModelMessages)
       const safeParts = m.parts.filter(p => {
@@ -146,8 +168,11 @@ export function sanitizeV5UIMessages(
           if (p.state === 'output-available' || p.state === 'output-error') return true;
           // Provider-executed tools may be deferred by the provider (e.g. Anthropic non-deterministically
           // defers web_search when mixed with client tool calls). Keep these so the provider API sees
-          // the server_tool_use block on the next request.
-          if (p.state === 'input-available' && p.providerExecuted) return true;
+          // the server_tool_use block on the next request — but ONLY on the most recent assistant
+          // message. On any earlier assistant turn an unresolved provider-executed call is an orphan
+          // (provider dropped the result chunk, or the run aborted mid-stream) and must be dropped
+          // to keep the tool-call/tool-result invariant required by provider APIs. See #15668, #14148.
+          if (p.state === 'input-available' && p.providerExecuted && assistantTurnStillOpen) return true;
           return false;
         }
 

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -108,78 +108,92 @@ export function sanitizeV5UIMessages(
   messages: AIV5Type.UIMessage[],
   filterIncompleteToolCalls = false,
 ): AIV5Type.UIMessage[] {
-  // Precompute the index of the last user message AND the index of the last
-  // assistant message. A deferred provider-executed tool call (e.g. Anthropic
-  // non-deterministically defers web_search across steps N→N+1 within the same
-  // run) may legitimately carry `input-available` state ONLY on the most recent
-  // assistant message, AND only if no user turn has followed it. On any earlier
-  // assistant turn (or after a later user message) an unresolved provider-executed
-  // call is an orphan — provider dropped the result chunk (#15668), run aborted
-  // mid-stream (#14148), or a stale call from an earlier step (#14192) — and
-  // must be dropped to keep the tool-call/tool-result invariant.
+  // Precompute the index of the last user message. A deferred provider-executed
+  // tool call (e.g. Anthropic non-deterministically defers web_search across
+  // steps N→N+1 within the same run) may legitimately carry `input-available`
+  // state ONLY on the most recent surviving assistant message, AND only if no
+  // user turn has followed it. On any earlier assistant turn (or after a later
+  // user message) an unresolved provider-executed call is an orphan — provider
+  // dropped the result chunk (#15668), run aborted mid-stream (#14148), or a
+  // stale call from an earlier step (#14192) — and must be dropped to keep the
+  // tool-call/tool-result invariant.
   let lastUserIdx = -1;
-  let lastAssistantIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
-    const role = messages[i]!.role;
-    if (role === 'user' && lastUserIdx === -1) lastUserIdx = i;
-    if (role === 'assistant' && lastAssistantIdx === -1) lastAssistantIdx = i;
-    if (lastUserIdx !== -1 && lastAssistantIdx !== -1) break;
+    if (messages[i]!.role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  const getSafeParts = (m: AIV5Type.UIMessage, assistantTurnStillOpen: boolean) =>
+    m.parts.filter(p => {
+      // Filter out data-* parts (custom streaming data from writer.custom())
+      // These are Mastra extensions not supported by LLM providers.
+      // If not filtered, convertToModelMessages produces empty content arrays
+      // which causes some models to fail with "must include at least one parts field"
+      if (typeof p.type === 'string' && p.type.startsWith('data-')) {
+        return false;
+      }
+
+      // Filter out empty text parts to handle legacy data from before this filtering was implemented.
+      // For assistant messages, preserve empty text parts if they are the only parts (placeholder messages).
+      // For user messages, always filter them out — Anthropic rejects empty user text content blocks.
+      if (p.type === 'text' && (!('text' in p) || p.text === '' || p.text?.trim() === '')) {
+        // Always filter empty text parts from user messages
+        if (m.role === 'user') return false;
+
+        // For non-user messages, only filter if there are other non-empty parts
+        const hasNonEmptyParts = m.parts.some(
+          part => !(part.type === 'text' && (!('text' in part) || part.text === '' || part.text?.trim() === '')),
+        );
+        if (hasNonEmptyParts) return false;
+      }
+
+      if (!AIV5.isToolUIPart(p)) return true;
+
+      // When sending messages TO the LLM: keep completed tool calls and provider-executed tools.
+      // Filter out incomplete client-side tool calls (input-available without providerExecuted)
+      // and input-streaming states.
+      if (filterIncompleteToolCalls) {
+        // Completed tools (client or provider) — keep them
+        if (p.state === 'output-available' || p.state === 'output-error') return true;
+        // Provider-executed tools may be deferred by the provider (e.g. Anthropic non-deterministically
+        // defers web_search when mixed with client tool calls). Keep these so the provider API sees
+        // the server_tool_use block on the next request — but ONLY on the most recent surviving
+        // assistant message. On any earlier assistant turn an unresolved provider-executed call is
+        // an orphan (provider dropped the result chunk, or the run aborted mid-stream) and must be
+        // dropped to keep the tool-call/tool-result invariant required by provider APIs. See #15668, #14148.
+        if (p.state === 'input-available' && p.providerExecuted && assistantTurnStillOpen) return true;
+        return false;
+      }
+
+      // When processing response messages FROM the LLM: keep input-available states
+      // (tool calls waiting for client-side execution) but filter out input-streaming
+      return p.state !== 'input-streaming';
+    });
+
+  let lastSurvivingAssistantIdx = -1;
+  if (lastUserIdx !== messages.length - 1) {
+    for (let i = messages.length - 1; i > lastUserIdx; i--) {
+      const message = messages[i]!;
+      if (message.role !== 'assistant' || message.parts.length === 0) continue;
+      if (getSafeParts(message, true).length > 0) {
+        lastSurvivingAssistantIdx = i;
+        break;
+      }
+    }
   }
 
   const msgs = messages
     .map((m, idx) => {
       if (m.parts.length === 0) return false;
 
-      // Deferred-provider-tool behavior is ONLY valid on the most recent assistant
-      // message AND only when no user turn has followed it.
-      const assistantTurnStillOpen = m.role === 'assistant' && idx === lastAssistantIdx && idx > lastUserIdx;
+      // Deferred-provider-tool behavior is ONLY valid on the most recent surviving
+      // assistant message AND only when no user turn has followed it.
+      const assistantTurnStillOpen = m.role === 'assistant' && idx === lastSurvivingAssistantIdx;
 
       // Filter out streaming states and optionally input-available (which aren't supported by convertToModelMessages)
-      const safeParts = m.parts.filter(p => {
-        // Filter out data-* parts (custom streaming data from writer.custom())
-        // These are Mastra extensions not supported by LLM providers.
-        // If not filtered, convertToModelMessages produces empty content arrays
-        // which causes some models to fail with "must include at least one parts field"
-        if (typeof p.type === 'string' && p.type.startsWith('data-')) {
-          return false;
-        }
-
-        // Filter out empty text parts to handle legacy data from before this filtering was implemented.
-        // For assistant messages, preserve empty text parts if they are the only parts (placeholder messages).
-        // For user messages, always filter them out — Anthropic rejects empty user text content blocks.
-        if (p.type === 'text' && (!('text' in p) || p.text === '' || p.text?.trim() === '')) {
-          // Always filter empty text parts from user messages
-          if (m.role === 'user') return false;
-
-          // For non-user messages, only filter if there are other non-empty parts
-          const hasNonEmptyParts = m.parts.some(
-            part => !(part.type === 'text' && (!('text' in part) || part.text === '' || part.text?.trim() === '')),
-          );
-          if (hasNonEmptyParts) return false;
-        }
-
-        if (!AIV5.isToolUIPart(p)) return true;
-
-        // When sending messages TO the LLM: keep completed tool calls and provider-executed tools.
-        // Filter out incomplete client-side tool calls (input-available without providerExecuted)
-        // and input-streaming states.
-        if (filterIncompleteToolCalls) {
-          // Completed tools (client or provider) — keep them
-          if (p.state === 'output-available' || p.state === 'output-error') return true;
-          // Provider-executed tools may be deferred by the provider (e.g. Anthropic non-deterministically
-          // defers web_search when mixed with client tool calls). Keep these so the provider API sees
-          // the server_tool_use block on the next request — but ONLY on the most recent assistant
-          // message. On any earlier assistant turn an unresolved provider-executed call is an orphan
-          // (provider dropped the result chunk, or the run aborted mid-stream) and must be dropped
-          // to keep the tool-call/tool-result invariant required by provider APIs. See #15668, #14148.
-          if (p.state === 'input-available' && p.providerExecuted && assistantTurnStillOpen) return true;
-          return false;
-        }
-
-        // When processing response messages FROM the LLM: keep input-available states
-        // (tool calls waiting for client-side execution) but filter out input-streaming
-        return p.state !== 'input-streaming';
-      });
+      const safeParts = getSafeParts(m, assistantTurnStillOpen);
 
       if (!safeParts.length) return false;
 


### PR DESCRIPTION
Fixes #15668 (similar class of bug to #14148).

When a provider drops a tool-result chunk (Vertex/Gemini `code_execution`) or a run aborts mid-stream after a `tool-call` (Anthropic `web_search`), the unresolved provider-executed call gets persisted in `input-available` state. `sanitizeV5UIMessages` was unconditionally keeping every `input-available + providerExecuted` part to protect Anthropic's legitimate N→N+1 deferral — which also meant orphans were replayed to the model forever, returning empty text on Gemini and violating the tool-call/tool-result invariant on Anthropic.

The fix tightens the keep-rule: `input-available` provider-executed parts are only preserved on the last surviving assistant message after sanitization, and only when no later user message has closed the turn. Anywhere else, they're treated as orphans and dropped.

Conceptually:
```ts
const lastSurvivingAssistantIdx = findLastAssistantAfterSanitization();
const assistantTurnStillOpen = idx === lastSurvivingAssistantIdx && idx > lastUserIdx;

if (p.state === 'input-available' && p.providerExecuted && assistantTurnStillOpen) {
  return true;
}
```

Regression tests cover the Gemini `code_execution` orphan (#15668), the Anthropic `web_search` orphan (#14148 class), a multi-assistant history where a stale provider call sits on an earlier assistant turn behind a later assistant message, and the case where a trailing assistant sanitizes away so the previous surviving assistant still keeps the legitimate deferred provider call. The existing deferred provider-executed coverage still passes unchanged.
