### PR TITLE
docs(processors): clarify processor interface and message access

### DIFF
--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -102,8 +102,11 @@ const agent = new Agent({
   name: 'support-agent',
   model: 'openai/gpt-5',
   instructions: '...',
-  inputProcessors: [new ModerationProcessor({ model: 'openai/gpt-4.1-nano' })],
-  outputProcessors: [new TokenLimiter(4000)],
+  inputProcessors: [
+    new TokenLimiter(4000),
+    new ModerationProcessor({ model: 'openai/gpt-4.1-nano' }),
+  ],
+  outputProcessors: [new ModerationProcessor({ model: 'openai/gpt-4.1-nano' })],
   errorProcessors: [new PrefillErrorHandler()],
 })
 ```
@@ -117,7 +120,7 @@ Each array also accepts a function that returns an array, so processors can be b
 ```typescript
 new Agent({
   // ...
-  outputProcessors: ({ requestContext }) => {
+  inputProcessors: ({ requestContext }) => {
     const limit = requestContext.get('tokenLimit') ?? 4000
     return [new TokenLimiter(limit)]
   },
@@ -130,7 +133,7 @@ new Agent({
 
 ```typescript
 await agent.stream('Summarize this', {
-  outputProcessors: [new TokenLimiter(2000)],
+  inputProcessors: [new TokenLimiter(2000)],
   maxProcessorRetries: 5,
 })
 ```

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -90,9 +90,61 @@ Your processors run first, then memory persists messages.
 
 This ordering ensures that if your output guardrail calls `abort()`, memory processors are skipped and no messages are saved. See [Memory Processors](/docs/memory/memory-processors#processor-execution-order) for details.
 
+## Attach processors to an agent
+
+Processors are configured on the agent through three arrays:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { PrefillErrorHandler, TokenLimiter, ModerationProcessor } from '@mastra/core/processors'
+
+const agent = new Agent({
+  name: 'support-agent',
+  model: 'openai/gpt-5',
+  instructions: '...',
+  inputProcessors: [new ModerationProcessor({ model: 'openai/gpt-4.1-nano' })],
+  outputProcessors: [new TokenLimiter(4000)],
+  errorProcessors: [new PrefillErrorHandler()],
+})
+```
+
+- `inputProcessors` run before the LLM.
+- `outputProcessors` run during and after the LLM response.
+- `errorProcessors` run when the LLM API call throws, so they can recover from provider errors.
+
+Each array also accepts a function that returns an array, so processors can be built per-request from `RequestContext`:
+
+```typescript
+new Agent({
+  // ...
+  outputProcessors: ({ requestContext }) => {
+    const limit = requestContext.get('tokenLimit') ?? 4000
+    return [new TokenLimiter(limit)]
+  },
+})
+```
+
+### Override processors per call
+
+`agent.generate()` and `agent.stream()` accept the same three arrays. When you pass one, it **replaces** the matching array on the agent for that call only. Memory, workspace, and other framework-managed processors still run around your array.
+
+```typescript
+await agent.stream('Summarize this', {
+  outputProcessors: [new TokenLimiter(2000)],
+  maxProcessorRetries: 5,
+})
+```
+
 ## Create custom processors
 
-Custom processors implement the `Processor` interface:
+Custom processors implement the `Processor` interface.
+
+Processor methods receive two arguments for accessing the conversation:
+
+- `messages`: A snapshot array of `MastraDBMessage` objects for the current stage.
+- `messageList`: The live `MessageList` instance. Use it to read other stages, or to add, remove, or replace messages in place.
+
+Text lives in `message.content.parts`, not on `message.content` itself. Iterate `parts` and filter by `part.type === 'text'` to read user or assistant text. A flattened `message.content.content` string exists for legacy compatibility and can be used as a fallback. See [Message arguments](/reference/processors/processor-interface#message-arguments) in the `Processor` reference for full details.
 
 ### Transform input messages
 
@@ -104,12 +156,15 @@ export class CustomInputProcessor implements Processor {
   id = 'custom-input'
 
   async processInput({ messages }: ProcessInputArgs): Promise<MastraDBMessage[]> {
-    // Transform messages before they reach the LLM
+    // Transform messages before they reach the LLM.
+    // Text lives in content.parts — iterate parts and rewrite text parts only.
     return messages.map(msg => ({
       ...msg,
       content: {
         ...msg.content,
-        content: msg.content.content.toLowerCase(),
+        parts: msg.content.parts?.map(part =>
+          part.type === 'text' ? { ...part, text: part.text.toLowerCase() } : part,
+        ),
       },
     }))
   }
@@ -221,11 +276,22 @@ export class StreamFilter implements Processor {
   id = 'stream-filter'
 
   async processOutputStream({ part }): Promise<ChunkType | null> {
-    // Transform or filter streaming chunks
+    // Drop text-delta chunks that contain the word "secret"
+    if (part.type === 'text-delta' && part.payload.text.includes('secret')) {
+      return null
+    }
+
+    // Return the (possibly modified) chunk to emit it
     return part
   }
 }
 ```
+
+Return values:
+
+- A `ChunkType` emits that chunk. Return the original `part` to pass it through unchanged.
+- `null` or `undefined` drops the chunk. Both behave the same way, so a method that falls through without returning also drops the chunk.
+- Dropping only affects one chunk. To stop the stream entirely, call `abort()`.
 
 To also receive custom `data-*` chunks emitted by tools via `writer.custom()`, set `processDataParts = true` on your processor. This lets you inspect, modify, or block tool-emitted data chunks before they reach the client.
 
@@ -252,6 +318,31 @@ export class ResponseValidator implements Processor {
 ```
 
 For more on retry behavior, see [Retry mechanism](#retry-mechanism) in Advanced patterns.
+
+### Persist data across chunks and steps
+
+Output methods receive a `state` object that persists for the lifetime of one request. State is keyed by the processor's `id`, so each processor sees only its own data, and it is shared between `processOutputStream`, `processOutputStep`, and `processOutputResult`. A new state object is created for every new `agent.generate()` or `agent.stream()` call.
+
+```typescript title="src/mastra/processors/word-counter.ts"
+import type { Processor } from '@mastra/core/processors'
+
+export class WordCounter implements Processor {
+  id = 'word-counter'
+
+  async processOutputStream({ part, state }) {
+    state.wordCount ??= 0
+    if (part.type === 'text-delta') {
+      state.wordCount += part.payload.text.split(/\s+/).filter(Boolean).length
+    }
+    return part
+  }
+
+  async processOutputResult({ messages, state }) {
+    console.log(`Total words: ${state.wordCount}`)
+    return messages
+  }
+}
+```
 
 ## Built-in utility processors
 
@@ -400,6 +491,23 @@ for await (const chunk of stream.fullStream) {
 
 Custom chunk types must use the `data-` prefix (e.g., `data-moderation-update`, `data-status`).
 
+By default, `processOutputStream()` skips `data-*` chunks so it does not accidentally operate on tool telemetry or other processors' output. To inspect, modify, or block these chunks in a processor, set `processDataParts = true` on that processor:
+
+```typescript
+class ModerationCollector implements Processor {
+  id = 'moderation-collector'
+  processDataParts = true
+
+  async processOutputStream({ part, state }) {
+    if (part.type === 'data-moderation-update') {
+      state.warnings ??= []
+      state.warnings.push(part.data)
+    }
+    return part
+  }
+}
+```
+
 ### Add metadata to messages
 
 You can add custom metadata to messages in `processOutputResult`. This metadata is accessible via the response object:
@@ -535,7 +643,7 @@ const agent = new Agent({
   name: 'Quality Agent',
   model: 'openai/gpt-5.4',
   outputProcessors: [new QualityChecker()],
-  maxProcessorRetries: 3, // Maximum retry attempts (default: 3)
+  maxProcessorRetries: 3, // Maximum retry attempts. If unset, retries are disabled (unless errorProcessors are configured, in which case it defaults to 10).
 })
 ```
 
@@ -545,6 +653,26 @@ The retry mechanism:
 - Replays the step with the abort reason added as context for the LLM
 - Tracks retry count via the `retryCount` parameter
 - Respects `maxProcessorRetries` limit on the agent
+
+### Abort and tripwire chunks
+
+Calling `abort(reason, options)` throws a `TripWire` error that ends processing. On streams, Mastra emits a `tripwire` chunk clients can detect:
+
+```typescript
+for await (const chunk of stream.fullStream) {
+  if (chunk.type === 'tripwire') {
+    console.log('Blocked by', chunk.payload.processorId, '-', chunk.payload.reason)
+    break
+  }
+}
+```
+
+For `agent.generate()`, the result exposes the same information as `result.tripwire` with `result.finishReason === 'other'`.
+
+`abort` accepts a second options argument:
+
+- `retry: true` asks the agent to retry instead of ending. Retries require `maxProcessorRetries` to be set on the agent or call.
+- `metadata` attaches structured data to the `tripwire` chunk so downstream consumers can branch on categories like `pii`, `quality`, or `moderation`.
 
 ## API error handling
 

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -306,7 +306,15 @@ The method can return one of three types:
 Processes input messages at each step of the agentic loop, before they're sent to the LLM. Unlike `processInput` which runs once at the start, this runs at every step including tool call continuations.
 
 ```typescript prettier:false
-processInputStep?(args: ProcessInputStepArgs): ProcessorMessageResult;
+processInputStep?(
+  args: ProcessInputStepArgs,
+):
+  | Promise<ProcessInputStepResult | MessageList | MastraDBMessage[] | void | undefined>
+  | ProcessInputStepResult
+  | MessageList
+  | MastraDBMessage[]
+  | void
+  | undefined;
 ```
 
 #### Execution order in the agentic loop
@@ -1165,7 +1173,7 @@ await writer.custom({
   type: 'data-moderation',
   runId,
   from: 'AGENT',
-  payload: { level: 'warn', reason: 'Possibly unsafe' },
+  data: { level: 'warn', reason: 'Possibly unsafe' },
 })
 ```
 
@@ -1179,7 +1187,7 @@ class ModerationCollector implements Processor {
   async processOutputStream({ part, state }) {
     if (part.type === 'data-moderation') {
       state.warnings ??= []
-      state.warnings.push(part.payload)
+      state.warnings.push(part.data)
     }
     return part
   }

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -171,6 +171,15 @@ Use `messages` when you only need to read or map over the current stage's messag
 
 `messages` is always derived from `messageList`, so mutating `messageList` is the canonical way to change the conversation. If you return a new array from `messages`, Mastra replaces the corresponding stage in `messageList` for you.
 
+### Persistence
+
+When memory is enabled, only what ends up in `messageList` after all processors finish is persisted to storage. The two return styles are equivalent for persistence:
+
+- Mutating `messageList` directly (or returning the same `MessageList` instance) — recorded mutations are applied in place, so the saved conversation reflects your changes.
+- Returning a `MastraDBMessage[]` or `{ messages, systemMessages }` — Mastra reconciles the returned array against `messageList` for the current stage, removing missing messages and replacing system messages.
+
+Returning a different `MessageList` instance is an error; always mutate the one passed to your processor.
+
 ### Reading text from a message
 
 `MastraDBMessage.content` is a structured object, not a string. The canonical way to read user or assistant text is `content.parts`:

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -160,16 +160,16 @@ Most processor methods receive both `messages` and `messageList`. They point to 
 
 ### `messages` vs `messageList`
 
-- `messages`: A plain array of `MastraDBMessage` objects, scoped to the current stage. For `processInput` and `processInputStep` this excludes system messages. For `processOutputResult` and `processOutputStep` this includes the latest LLM response. Treat this array as a read-only snapshot.
+- `messages`: A plain array of `MastraDBMessage` objects, scoped to the current stage. For `processInput` and `processInputStep` this excludes system messages. For `processOutputResult` and `processOutputStep` this includes the latest LLM response. The array is backed by `messageList`, so editing a message's `content.parts` in place is visible to downstream processors and to persistence.
 - `messageList`: The live `MessageList` instance backing the run. It exposes filtered views (input, response, remembered, all), multiple output formats (db, ui, core), and methods for mutating the conversation.
 
-Use `messages` when you only need to read or map over the current stage's messages. Use `messageList` when you need to:
+Use `messages` when you only need to read, map over, or lightly edit fields on the current stage's messages. Use `messageList` when you need to:
 
 - Read messages from another stage, for example input messages while processing output.
-- Add, remove, or replace messages in place.
+- Add, remove, or replace whole messages.
 - Convert to another format such as UI or core messages for a third-party API.
 
-`messages` is always derived from `messageList`, so mutating `messageList` is the canonical way to change the conversation. If you return a new array from `messages`, Mastra replaces the corresponding stage in `messageList` for you.
+`messages` is always derived from `messageList`, so mutating `messageList` is the canonical way to add, remove, or reorder messages. For in-place edits to a message's content (for example, rewriting `content.parts`), mutating `messages` directly is equivalent. If you return a new array from `messages`, Mastra reconciles it against `messageList` for the current stage.
 
 ### Persistence
 

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -1159,11 +1159,11 @@ export class WordCounter implements Processor {
 
 ## State lifecycle
 
-Every processor receives a `state` object in `processOutputStream`, `processOutputStep`, and `processOutputResult`. State has three important properties:
+Every processor receives a `state` object in `processOutputStream`, `processOutputStep`, `processOutputResult`, and `processAPIError`. State has three important properties:
 
 - **Per-processor**: Each processor gets its own `state` object, keyed by the processor's `id`. Two processors with different ids cannot read or overwrite each other's state.
 - **Per-request**: A fresh state object is created at the start of every `agent.generate()` or `agent.stream()` call. State does not leak between requests or between users.
-- **Shared across methods**: Within one request, the same `state` object is passed to `processOutputStream` (for every chunk), `processOutputStep` (after every LLM step), and `processOutputResult` (once at the end). Accumulate data in `processOutputStream` and read it in `processOutputResult`.
+- **Shared across methods**: Within one request, the same `state` object is passed to `processOutputStream` (for every chunk), `processOutputStep` (after every LLM step), `processOutputResult` (once at the end), and `processAPIError` (when an LLM call fails). Accumulate data in `processOutputStream` and read it in `processOutputResult` or `processAPIError`.
 
 Initialize fields defensively on first access, because `state` starts as an empty object:
 

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -306,8 +306,8 @@ The method can return one of three types:
 Processes input messages at each step of the agentic loop, before they're sent to the LLM. Unlike `processInput` which runs once at the start, this runs at every step including tool call continuations.
 
 ```typescript prettier:false
-processInputStep?(
-  args: ProcessInputStepArgs,
+processInputStep?<TTripwireMetadata = unknown>(
+  args: ProcessInputStepArgs<TTripwireMetadata>,
 ):
   | Promise<ProcessInputStepResult | MessageList | MastraDBMessage[] | void | undefined>
   | ProcessInputStepResult

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -78,18 +78,40 @@ The six processor methods run at different points in the agent execution lifecyc
 ## Interface definition
 
 ```typescript
-interface Processor<TId extends string = string> {
+interface Processor<TId extends string = string, TTripwireMetadata = unknown> {
   readonly id: TId
   readonly name?: string
+  readonly description?: string
+  /** Index of this processor in the workflow (set at runtime when combining processors). */
+  processorIndex?: number
+  /** When true, processOutputStream also receives `data-*` chunks. Default: false. */
+  processDataParts?: boolean
 
-  processInput?(args: ProcessInputArgs): Promise<ProcessInputResult> | ProcessInputResult
-  processInputStep?(args: ProcessInputStepArgs): ProcessorMessageResult
+  processInput?(
+    args: ProcessInputArgs<TTripwireMetadata>,
+  ): Promise<ProcessInputResult> | ProcessInputResult
+
+  processInputStep?(
+    args: ProcessInputStepArgs<TTripwireMetadata>,
+  ):
+    | Promise<ProcessInputStepResult | MessageList | MastraDBMessage[] | undefined | void>
+    | ProcessInputStepResult
+    | MessageList
+    | MastraDBMessage[]
+    | void
+    | undefined
+
   processAPIError?(
-    args: ProcessAPIErrorArgs,
+    args: ProcessAPIErrorArgs<TTripwireMetadata>,
   ): Promise<ProcessAPIErrorResult | void> | ProcessAPIErrorResult | void
-  processOutputStream?(args: ProcessOutputStreamArgs): Promise<ChunkType | null | undefined>
-  processOutputStep?(args: ProcessOutputStepArgs): ProcessorMessageResult
-  processOutputResult?(args: ProcessOutputResultArgs): ProcessorMessageResult
+
+  processOutputStream?(
+    args: ProcessOutputStreamArgs<TTripwireMetadata>,
+  ): Promise<ChunkType | null | undefined>
+
+  processOutputStep?(args: ProcessOutputStepArgs<TTripwireMetadata>): ProcessorMessageResult
+
+  processOutputResult?(args: ProcessOutputResultArgs<TTripwireMetadata>): ProcessorMessageResult
 }
 ```
 
@@ -110,6 +132,19 @@ interface Processor<TId extends string = string> {
     isOptional: true,
   },
   {
+    name: 'description',
+    type: 'string',
+    description: 'Optional human-readable description shown in tracing and Studio.',
+    isOptional: true,
+  },
+  {
+    name: 'processorIndex',
+    type: 'number',
+    description:
+      'Position of the processor in the combined processor list. Set at runtime by Mastra when processors are merged with memory, workspace, and per-call overrides. You do not set this yourself.',
+    isOptional: true,
+  },
+  {
     name: 'processDataParts',
     type: 'boolean',
     description:
@@ -118,6 +153,56 @@ interface Processor<TId extends string = string> {
   },
 ]}
 />
+
+## Message arguments
+
+Most processor methods receive both `messages` and `messageList`. They point to the same underlying conversation but expose it differently.
+
+### `messages` vs `messageList`
+
+- `messages`: A plain array of `MastraDBMessage` objects, scoped to the current stage. For `processInput` and `processInputStep` this excludes system messages. For `processOutputResult` and `processOutputStep` this includes the latest LLM response. Treat this array as a read-only snapshot.
+- `messageList`: The live `MessageList` instance backing the run. It exposes filtered views (input, response, remembered, all), multiple output formats (db, ui, core), and methods for mutating the conversation.
+
+Use `messages` when you only need to read or map over the current stage's messages. Use `messageList` when you need to:
+
+- Read messages from another stage, for example input messages while processing output.
+- Add, remove, or replace messages in place.
+- Convert to another format such as UI or core messages for a third-party API.
+
+`messages` is always derived from `messageList`, so mutating `messageList` is the canonical way to change the conversation. If you return a new array from `messages`, Mastra replaces the corresponding stage in `messageList` for you.
+
+### Reading text from a message
+
+`MastraDBMessage.content` is a structured object, not a string. The canonical way to read user or assistant text is `content.parts`:
+
+```typescript
+import type { MastraDBMessage } from '@mastra/core/memory'
+
+function getText(message: MastraDBMessage): string {
+  let text = ''
+
+  if (message.content.parts) {
+    for (const part of message.content.parts) {
+      if (part.type === 'text' && typeof part.text === 'string') {
+        text += part.text
+      }
+    }
+  }
+
+  // Fallback for legacy messages that only have the flattened `content` string
+  if (!text && typeof message.content.content === 'string') {
+    text = message.content.content
+  }
+
+  return text
+}
+```
+
+Key points:
+
+- `message.content.parts` is the primary source. A single message can contain multiple parts, including non-text parts such as tool calls, tool results, and file parts. Filter by `part.type === 'text'` before reading `part.text`.
+- `message.content.content` is a flattened string kept for backward compatibility. Use it only as a fallback when `parts` is empty or missing.
+- `message.content` itself is never a plain string on `MastraDBMessage`. Legacy `CoreMessage` shapes may be strings, but processors always receive `MastraDBMessage`.
 
 ## Methods
 
@@ -163,8 +248,8 @@ processInput?(args: ProcessInputArgs): Promise<ProcessInputResult> | ProcessInpu
     name: 'retryCount',
     type: 'number',
     description:
-      'Number of times processors have triggered retry for this generation. Use this to limit retry attempts.',
-    isOptional: true,
+      'Number of times processors have triggered retry for this generation. Use this to limit retry attempts. Always passed by Mastra; starts at 0.',
+    isOptional: false,
   },
   {
     name: 'tracingContext',
@@ -581,13 +666,15 @@ processOutputStream?(args: ProcessOutputStreamArgs): Promise<ChunkType | null | 
   {
     name: 'state',
     type: 'Record<string, unknown>',
-    description: 'Mutable state object that persists across chunks within a single stream.',
+    description:
+      'Mutable per-processor state that persists across every chunk and every method call within a single request. A fresh state object is created for each new generate or stream call.',
     isOptional: false,
   },
   {
     name: 'abort',
-    type: '(reason?: string) => never',
-    description: 'Function to abort the stream.',
+    type: '(reason?: string, options?: { retry?: boolean; metadata?: unknown }) => never',
+    description:
+      'Function to abort the stream. Throws a TripWire error that ends the stream and emits a `tripwire` chunk. Pass `retry: true` to request another LLM attempt instead of ending.',
     isOptional: false,
   },
   {
@@ -620,8 +707,13 @@ processOutputStream?(args: ProcessOutputStreamArgs): Promise<ChunkType | null | 
 
 #### Return value
 
-- Return the `ChunkType` to emit it (possibly modified)
-- Return `null` or `undefined` to skip emitting the chunk
+`processOutputStream` returns `Promise<ChunkType | null | undefined>`.
+
+- Return the `ChunkType` to emit the chunk. Return the original `part` to emit it unchanged, or a new `ChunkType` to emit a modified chunk.
+- Return `null` to drop the chunk. Nothing is sent to the next processor or the client.
+- Return `undefined` (including implicit `undefined` from a `return;` statement or a method that falls off the end) to drop the chunk. `null` and `undefined` behave the same way.
+
+Dropping a chunk only affects that single chunk. The stream continues and the next chunk is still processed. To stop the stream entirely, call `abort()`.
 
 ---
 
@@ -756,8 +848,9 @@ processOutputStep?(args: ProcessOutputStepArgs): ProcessorMessageResult;
   {
     name: 'retryCount',
     type: 'number',
-    description: 'Number of times processors have triggered retry. Use this to limit retry attempts.',
-    isOptional: true,
+    description:
+      'Number of times processors have triggered retry. Use this to limit retry attempts. Always passed by Mastra; starts at 0.',
+    isOptional: false,
   },
   {
     name: 'tracingContext',
@@ -784,7 +877,7 @@ processOutputStep?(args: ProcessOutputStepArgs): ProcessorMessageResult;
 #### Example: Quality guardrail with retry
 
 ```typescript title="src/mastra/processors/quality-guardrail.ts"
-import type { Processor } from '@mastra/core'
+import type { Processor } from '@mastra/core/processors'
 
 export class QualityGuardrail implements Processor {
   id = 'quality-guardrail'
@@ -844,7 +937,8 @@ const agent = new Agent({
 ### Basic input processor
 
 ```typescript title="src/mastra/processors/lowercase.ts"
-import type { Processor, MastraDBMessage } from '@mastra/core'
+import type { Processor } from '@mastra/core/processors'
+import type { MastraDBMessage } from '@mastra/core/memory'
 
 export class LowercaseProcessor implements Processor {
   id = 'lowercase'
@@ -866,7 +960,11 @@ export class LowercaseProcessor implements Processor {
 ### Per-step processor with `processInputStep`
 
 ```typescript title="src/mastra/processors/dynamic-model.ts"
-import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from '@mastra/core'
+import type {
+  Processor,
+  ProcessInputStepArgs,
+  ProcessInputStepResult,
+} from '@mastra/core/processors'
 
 export class DynamicModelProcessor implements Processor {
   id = 'dynamic-model'
@@ -899,7 +997,8 @@ export class DynamicModelProcessor implements Processor {
 ### Message transformer with `processInputStep`
 
 ```typescript title="src/mastra/processors/reasoning-transformer.ts"
-import type { Processor, MastraDBMessage } from '@mastra/core'
+import type { Processor } from '@mastra/core/processors'
+import type { MastraDBMessage } from '@mastra/core/memory'
 
 export class ReasoningTransformer implements Processor {
   id = 'reasoning-transformer'
@@ -924,7 +1023,9 @@ export class ReasoningTransformer implements Processor {
 ### Hybrid processor (input and output)
 
 ```typescript title="src/mastra/processors/content-filter.ts"
-import type { Processor, MastraDBMessage, ChunkType } from '@mastra/core'
+import type { Processor } from '@mastra/core/processors'
+import type { MastraDBMessage } from '@mastra/core/memory'
+import type { ChunkType } from '@mastra/core/stream'
 
 export class ContentFilter implements Processor {
   id = 'content-filter'
@@ -950,7 +1051,7 @@ export class ContentFilter implements Processor {
 
   async processOutputStream({ part, abort }): Promise<ChunkType | null> {
     if (part.type === 'text-delta') {
-      if (this.blockedWords.some(word => part.textDelta.includes(word))) {
+      if (this.blockedWords.some(word => part.payload.text.includes(word))) {
         abort('Blocked content detected in output')
       }
     }
@@ -962,7 +1063,8 @@ export class ContentFilter implements Processor {
 ### Stream accumulator with state
 
 ```typescript title="src/mastra/processors/word-counter.ts"
-import type { Processor, ChunkType } from '@mastra/core'
+import type { Processor } from '@mastra/core/processors'
+import type { ChunkType } from '@mastra/core/stream'
 
 export class WordCounter implements Processor {
   id = 'word-counter'
@@ -975,7 +1077,7 @@ export class WordCounter implements Processor {
 
     // Count words in text chunks
     if (part.type === 'text-delta') {
-      const words = part.textDelta.split(/\s+/).filter(Boolean)
+      const words = part.payload.text.split(/\s+/).filter(Boolean)
       state.wordCount += words.length
     }
 
@@ -988,6 +1090,142 @@ export class WordCounter implements Processor {
   }
 }
 ```
+
+## State lifecycle
+
+Every processor receives a `state` object in `processOutputStream`, `processOutputStep`, and `processOutputResult`. State has three important properties:
+
+- **Per-processor**: Each processor gets its own `state` object, keyed by the processor's `id`. Two processors with different ids cannot read or overwrite each other's state.
+- **Per-request**: A fresh state object is created at the start of every `agent.generate()` or `agent.stream()` call. State does not leak between requests or between users.
+- **Shared across methods**: Within one request, the same `state` object is passed to `processOutputStream` (for every chunk), `processOutputStep` (after every LLM step), and `processOutputResult` (once at the end). Accumulate data in `processOutputStream` and read it in `processOutputResult`.
+
+Initialize fields defensively on first access, because `state` starts as an empty object:
+
+```typescript
+import type { Processor } from '@mastra/core/processors'
+
+export class WordCounter implements Processor {
+  id = 'word-counter'
+
+  async processOutputStream({ part, state }) {
+    state.wordCount ??= 0
+    if (part.type === 'text-delta') {
+      state.wordCount += part.payload.text.split(/\s+/).filter(Boolean).length
+    }
+    return part
+  }
+}
+```
+
+## Aborting and tripwire chunks
+
+The `abort` function on each method throws a `TripWire` error that stops processing and emits a `tripwire` chunk on the output stream. Clients can detect the chunk to distinguish a blocked response from a normal finish.
+
+```typescript
+abort('Blocked content detected', { retry: false, metadata: { category: 'pii' } })
+```
+
+- `reason`: A human-readable explanation. Appears as `tripwire.payload.reason`.
+- `retry`: When `true`, the agent retries the same step with `reason` fed back as feedback. Retries only run when `maxProcessorRetries` is set on the agent or call; otherwise the request aborts. When `errorProcessors` are configured, `maxProcessorRetries` defaults to `10` for that call.
+- `metadata`: Optional structured data attached to the `tripwire` chunk for downstream consumers.
+
+The emitted `tripwire` chunk has the shape:
+
+```typescript
+type TripwireChunk = {
+  type: 'tripwire'
+  runId: string
+  from: 'AGENT'
+  payload: {
+    reason: string
+    retry?: boolean
+    metadata?: unknown
+    processorId: string
+  }
+}
+```
+
+In non-streaming calls (`agent.generate()`), the result exposes the same information as `result.tripwire` and `result.finishReason === 'other'`.
+
+## Emitting custom data chunks
+
+Processors with access to `writer` can stream custom `data-*` chunks to the client by calling `writer.custom(chunk)`. Tools can do the same through their own writer. This is the only way for a processor to emit content outside of normal text and tool chunks.
+
+```typescript
+await writer.custom({
+  type: 'data-moderation',
+  runId,
+  from: 'AGENT',
+  payload: { level: 'warn', reason: 'Possibly unsafe' },
+})
+```
+
+By default, processors do **not** see `data-*` chunks in `processOutputStream` so they don't accidentally process tool telemetry or their own output. Opt in by setting `processDataParts: true` on the processor:
+
+```typescript
+class ModerationCollector implements Processor {
+  id = 'moderation-collector'
+  processDataParts = true
+
+  async processOutputStream({ part, state }) {
+    if (part.type === 'data-moderation') {
+      state.warnings ??= []
+      state.warnings.push(part.payload)
+    }
+    return part
+  }
+}
+```
+
+The chunk `type` must start with `data-` to be treated as a custom data chunk. Returning `null` or `undefined` from `processOutputStream` still drops the chunk, so a processor can inspect, modify, or filter custom data the same way it filters text chunks.
+
+## Configuring processors on an agent
+
+Processors are attached to an agent through three arrays:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { PrefillErrorHandler } from '@mastra/core/processors'
+
+const agent = new Agent({
+  name: 'support-agent',
+  model: 'openai/gpt-5',
+  instructions: '...',
+  inputProcessors: [new ContentFilter(['secret'])],
+  outputProcessors: [new WordCounter()],
+  errorProcessors: [new PrefillErrorHandler()],
+  maxProcessorRetries: 3,
+})
+```
+
+- `inputProcessors`: Run before the LLM. Receives input messages.
+- `outputProcessors`: Run during or after the LLM response. Receives output chunks or messages.
+- `errorProcessors`: Run when the LLM API call throws. Receives the raw error.
+
+Each array also accepts a function so processors can be built per-request from `RequestContext`:
+
+```typescript
+new Agent({
+  // ...
+  inputProcessors: ({ requestContext }) => {
+    const blockedWords = requestContext.get('blockedWords') ?? []
+    return [new ContentFilter(blockedWords)]
+  },
+})
+```
+
+### Per-call overrides
+
+`agent.generate()` and `agent.stream()` accept `inputProcessors`, `outputProcessors`, `errorProcessors`, and `maxProcessorRetries`. When any processor array is set on the call, it **replaces** the matching array configured on the agent for that request. Memory, workspace, skill, channel, and browser processors that Mastra adds automatically are always preserved and run around your array.
+
+```typescript
+await agent.stream('Summarize this', {
+  outputProcessors: [new StreamFilter()],
+  maxProcessorRetries: 5,
+})
+```
+
+`maxProcessorRetries` passed on the call overrides the agent default. If neither is set, processor-requested retries are treated as aborts.
 
 ## Related
 

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -404,8 +404,9 @@ processInputStep?(
   },
   {
     name: 'abort',
-    type: '(reason?: string) => never',
-    description: 'Function to abort processing.',
+    type: '(reason?: string, options?: { retry?: boolean; metadata?: unknown }) => never',
+    description:
+      'Function to abort processing. Throws a TripWire error that stops execution. Pass `retry: true` to request the LLM retry the step with feedback.',
     isOptional: false,
   },
   {
@@ -425,7 +426,14 @@ processInputStep?(
 
 #### `ProcessInputStepResult`
 
-The method can return any combination of these properties:
+`processInputStep` can return several shapes:
+
+- **`ProcessInputStepResult` object** — override any combination of the properties below for this step (described next).
+- **`MessageList`** — return the same `messageList` instance to signal you mutated messages in place.
+- **`MastraDBMessage[]`** — return a transformed messages array; replaces the step's messages.
+- **`void` or `undefined`** — return nothing to leave the step unchanged.
+
+The object form can return any combination of these properties:
 
 <PropertiesTable
   content={[
@@ -774,8 +782,9 @@ processOutputResult?(args: ProcessOutputResultArgs): ProcessorMessageResult;
   },
   {
     name: 'abort',
-    type: '(reason?: string) => never',
-    description: 'Function to abort processing.',
+    type: '(reason?: string, options?: { retry?: boolean; metadata?: unknown }) => never',
+    description:
+      'Function to abort processing. Throws a TripWire error that stops execution and emits a `tripwire` chunk.',
     isOptional: false,
   },
   {
@@ -851,10 +860,29 @@ processOutputStep?(args: ProcessOutputStepArgs): ProcessorMessageResult;
     isOptional: true,
   },
   {
+    name: 'usage',
+    type: 'LanguageModelUsage',
+    description: 'Token usage for the current step (`inputTokens`, `outputTokens`, `totalTokens`).',
+    isOptional: false,
+  },
+  {
     name: 'systemMessages',
     type: 'CoreMessage[]',
     description: 'All system messages for read/modify access.',
-    isOptional: true,
+    isOptional: false,
+  },
+  {
+    name: 'steps',
+    type: 'StepResult[]',
+    description: 'All completed steps so far, including the current step.',
+    isOptional: false,
+  },
+  {
+    name: 'state',
+    type: 'Record<string, unknown>',
+    description:
+      'Per-processor state that persists across all method calls within this request. Shared with processOutputStream and processOutputResult.',
+    isOptional: false,
   },
   {
     name: 'abort',

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -410,6 +410,13 @@ processInputStep?(
     isOptional: false,
   },
   {
+    name: 'retryCount',
+    type: 'number',
+    description:
+      'Current retry attempt count from `ProcessorContext`. Starts at `0`; use to cap processor-triggered retries.',
+    isOptional: false,
+  },
+  {
     name: 'tracingContext',
     type: 'TracingContext',
     description: 'Tracing context for observability.',
@@ -703,6 +710,13 @@ processOutputStream?(args: ProcessOutputStreamArgs): Promise<ChunkType | null | 
     isOptional: false,
   },
   {
+    name: 'retryCount',
+    type: 'number',
+    description:
+      'Current retry attempt count from `ProcessorContext`. Starts at `0`; use to cap processor-triggered retries.',
+    isOptional: false,
+  },
+  {
     name: 'messageList',
     type: 'MessageList',
     description: 'MessageList instance for accessing conversation history.',
@@ -785,6 +799,13 @@ processOutputResult?(args: ProcessOutputResultArgs): ProcessorMessageResult;
     type: '(reason?: string, options?: { retry?: boolean; metadata?: unknown }) => never',
     description:
       'Function to abort processing. Throws a TripWire error that stops execution and emits a `tripwire` chunk.',
+    isOptional: false,
+  },
+  {
+    name: 'retryCount',
+    type: 'number',
+    description:
+      'Current retry attempt count from `ProcessorContext`. Starts at `0`; use to cap processor-triggered retries.',
     isOptional: false,
   },
   {


### PR DESCRIPTION
Fills in the processor docs gaps called out in #15658.

Covers `MessageList` vs `messages`, the canonical way to read text from a `MastraDBMessage` (`content.parts`), and the return semantics for `processOutputStream` (now `ChunkType | null | undefined`, with `undefined` dropping the chunk). Also adds sections on state lifecycle, tripwire chunks, custom data chunks via `writer.custom` + `processDataParts`, per-call processor overrides, and `maxProcessorRetries`.

Fixes broken import paths in the reference snippets to use the real subpath exports:

```ts
// before
import type { Processor, MastraDBMessage, ChunkType } from '@mastra/core'

// after
import type { Processor } from '@mastra/core/processors'
import type { MastraDBMessage } from '@mastra/core/memory'
import type { ChunkType } from '@mastra/core/stream'
```

Refs #15658.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Summary

This PR updates the processors documentation to clearly show how processors read/edit messages, handle streamed chunks (emit/drop/abort/retry), persist per-request state, opt into custom data chunks, and configure per-call overrides — with corrected import paths and concrete examples.

---

## Overview

Documentation-only PR addressing gaps from #15658. Clarifies processor APIs, message access/persistence, streaming chunk behavior, processor configuration/overrides, retry semantics, tripwire/data-chunk handling, and example imports so processor authors can implement correct, safe behavior.

## Key Changes

- Message access and persistence
  - Canonical text access: message.content.parts (filter parts where part.type === 'text'); legacy flattened message.content.content retained only as a compatibility fallback.
  - Distinguishes MessageList (live, mutable list — mutate to change staged convo state) vs MastraDBMessage[] (snapshot replacement). Only final MessageList contents persist when memory is enabled.
  - processInputStep return union documented: MessageList | MastraDBMessage[] | void | undefined | ProcessInputStepResult.

- Streaming and chunk semantics
  - processOutputStream return semantics clarified to ChunkType | null | undefined: returning a ChunkType emits/transforms it; null or undefined drops that single chunk and the stream continues. abort() throws a TripWire to terminate the stream and emits a tripwire chunk.
  - abort(reason, options?: { retry?: boolean; metadata?: unknown }) documented: tripwire chunk shape, retry signaling, and metadata threading to downstream handlers.
  - processDataParts opt-in: data-* chunks (writer.custom) are skipped by default; set processDataParts = true to receive/inspect/modify/block them.
  - Examples updated to show concrete filtering (e.g., drop text-delta chunks containing "secret") and to use part.payload.text / content.parts access patterns.

- Processor interface and properties
  - Added TTripwireMetadata generic threaded through processor method argument types to propagate tripwire metadata.
  - New optional Processor properties documented: description?: string, processorIndex?: number, processDataParts?: boolean.
  - processInputStep broadened to allow returning either ProcessInputStepResult or direct MessageList / MastraDBMessage[] / void; retryCount is non-optional and documented as starting at 0 for input/output-step calls.
  - ProcessOutputStepArgs expanded with usage, steps, and shared per-request state; systemMessages made non-optional.
  - Documented that ProcessAPIErrorArgs receives the per-request, per-processor state object so error handlers can access streaming state.

- State lifecycle
  - Documents per-request, per-processor state object shared across output processing methods with example (WordCounter) and guidance on lifecycle and persistence across retries/streams.

- Configuration, overrides, and retries
  - Documents agent-level processor arrays: inputProcessors, outputProcessors, and auto-injected errorProcessors.
  - Per-call overrides: agent.generate()/agent.stream() accept processor arrays that replace the agent’s configured arrays for that call while framework-managed processors still wrap around them.
  - Clarified maxProcessorRetries: disabled when unset unless errorProcessors are present (where a conditional default may apply); retry-related abort/metadata options documented and examples updated.
  - Moved TokenLimiter to inputProcessors in examples per review feedback; documented abort retry/metadata options for processInputStep and processOutputResult.

- Tripwire, custom data chunks, and examples
  - Documents TripWire usage (abort/retry/metadata) and tripwire chunk emission to streams; TTripwireMetadata is propagated through relevant types.
  - Documents emitting custom data-* chunks with writer.custom + processDataParts opt-in and corrected examples to use the data field for custom chunks.
  - Examples and prose updated to reflect correct mutation semantics (in-place edits to message.content.parts) and the canonical APIs.

- Imports and small fixes
  - Fixed reference snippets to use subpath exports:
    - import type { Processor } from '@mastra/core/processors'
    - import type { MastraDBMessage } from '@mastra/core/memory'
    - import type { ChunkType } from '@mastra/core/stream'
  - Adjusted examples and docs to match revised argument/return contracts and chunk payload access.

## Files Changed (high-level)

- docs/src/content/en/docs/agents/processors.mdx (+136/-5): expanded how-to, examples, processDataParts, TripWire, state lifecycle, per-call overrides, and streaming semantics.
- docs/src/content/en/reference/processors/processor-interface.mdx (+~314/-31): updated Processor interface docs (generic tripwire metadata), new properties, method signatures/return types, argument docs, lifecycle details, and examples.

## API Surface Impact

Documentation-only; no code exports or runtime public API signatures changed. Implementers should follow the updated documented contracts (new return semantics, abort options, processDataParts opt-in, tripwire metadata, and message access rules) when writing processors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->