### PR TITLE
fix(cli): improve mastra migrate path resolution for monorepos

### DIFF
--- a/.changeset/fruity-otters-burn.md
+++ b/.changeset/fruity-otters-burn.md
@@ -1,0 +1,9 @@
+---
+'mastra': patch
+---
+
+Fixed `mastra migrate` guidance for monorepos and other custom layouts.
+
+- Relative `--dir` now resolves from `--root` (or cwd if `--root` is not provided).
+- When `src/mastra/index.ts` is missing, the CLI now prints actionable `--dir` and `--root` instructions instead of a raw file-missing error.
+- The error message now includes detected `src/mastra/index.ts|js` candidates under the selected root to help users choose the correct path quickly.

--- a/.changeset/fruity-otters-burn.md
+++ b/.changeset/fruity-otters-burn.md
@@ -5,5 +5,5 @@
 Fixed `mastra migrate` guidance for monorepos and other custom layouts.
 
 - Relative `--dir` now resolves from `--root` (or cwd if `--root` is not provided).
-- When `src/mastra/index.ts` is missing, the CLI now prints actionable `--dir` and `--root` instructions instead of a raw file-missing error.
-- The error message now includes detected `src/mastra/index.ts|js` candidates under the selected root to help users choose the correct path quickly.
+- When neither `src/mastra/index.ts` nor `src/mastra/index.js` is present, the CLI now prints actionable `--dir` and `--root` instructions instead of a raw file-missing error.
+- The error message also includes detected `src/mastra/index.ts|js` candidates under the selected root to help users choose the correct path quickly.

--- a/packages/cli/src/commands/migrate/migrate-paths.test.ts
+++ b/packages/cli/src/commands/migrate/migrate-paths.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  findMastraEntryCandidates,
+  resolveMigrateEntryFile,
+  resolveMigratePaths,
+  toDetectedProjectRoot,
+} from './migrate-paths';
+
+describe('migrate path resolution', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  it('resolves relative --dir against --root', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'mastra-migrate-paths-'));
+    tempDirs.push(tempDir);
+
+    const paths = resolveMigratePaths({
+      cwd: tempDir,
+      root: 'apps/project',
+      dir: 'src/mastra',
+    });
+
+    expect(paths.rootDir).toBe(join(tempDir, 'apps', 'project'));
+    expect(paths.mastraDir).toBe(join(tempDir, 'apps', 'project', 'src', 'mastra'));
+  });
+
+  it('finds entry file from mastra directory', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'mastra-migrate-test-'));
+    tempDirs.push(tempDir);
+
+    const mastraDir = join(tempDir, 'src', 'mastra');
+    mkdirSync(mastraDir, { recursive: true });
+    writeFileSync(join(mastraDir, 'index.ts'), 'export const mastra = {};', 'utf8');
+
+    const resolution = resolveMigrateEntryFile(mastraDir);
+    expect(resolution.entryFile).toBe(join(mastraDir, 'index.ts'));
+    expect(resolution.checkedPaths).toEqual([join(mastraDir, 'index.ts'), join(mastraDir, 'index.js')]);
+  });
+
+  it('detects entrypoint candidates and ignores node_modules', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'mastra-migrate-candidates-'));
+    tempDirs.push(tempDir);
+
+    const appMastraDir = join(tempDir, 'apps', 'app-one', 'src', 'mastra');
+    mkdirSync(appMastraDir, { recursive: true });
+    writeFileSync(join(appMastraDir, 'index.ts'), 'export const mastra = {};', 'utf8');
+
+    const ignoredMastraDir = join(tempDir, 'node_modules', 'pkg', 'src', 'mastra');
+    mkdirSync(ignoredMastraDir, { recursive: true });
+    writeFileSync(join(ignoredMastraDir, 'index.ts'), 'export const ignored = true;', 'utf8');
+
+    const candidates = findMastraEntryCandidates(tempDir);
+    expect(candidates).toEqual([join(appMastraDir, 'index.ts')]);
+  });
+
+  it('derives project root from entry file path', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'mastra-migrate-root-'));
+    tempDirs.push(tempDir);
+
+    const entryFile = join(tempDir, 'apps', 'my-app', 'src', 'mastra', 'index.ts');
+    expect(toDetectedProjectRoot(entryFile)).toBe(join(tempDir, 'apps', 'my-app'));
+  });
+});

--- a/packages/cli/src/commands/migrate/migrate-paths.ts
+++ b/packages/cli/src/commands/migrate/migrate-paths.ts
@@ -1,0 +1,92 @@
+import { existsSync, readdirSync } from 'node:fs';
+import type { Dirent } from 'node:fs';
+import { dirname, isAbsolute, join, sep } from 'node:path';
+
+const IGNORED_DIRECTORIES = new Set([
+  'node_modules',
+  '.git',
+  '.mastra',
+  '.turbo',
+  '.next',
+  'dist',
+  'build',
+  'coverage',
+]);
+
+export interface MigratePathResolution {
+  rootDir: string;
+  mastraDir: string;
+}
+
+export interface MigrateEntryResolution {
+  checkedPaths: string[];
+  entryFile?: string;
+}
+
+export function resolveMigratePaths(args: { cwd: string; root?: string; dir?: string }): MigratePathResolution {
+  const rootDir = args.root ? (isAbsolute(args.root) ? args.root : join(args.cwd, args.root)) : args.cwd;
+  const mastraDir = args.dir
+    ? isAbsolute(args.dir)
+      ? args.dir
+      : join(rootDir, args.dir)
+    : join(rootDir, 'src', 'mastra');
+
+  return { rootDir, mastraDir };
+}
+
+export function resolveMigrateEntryFile(mastraDir: string): MigrateEntryResolution {
+  const checkedPaths = [join(mastraDir, 'index.ts'), join(mastraDir, 'index.js')];
+  const entryFile = checkedPaths.find(path => existsSync(path));
+  return { checkedPaths, entryFile };
+}
+
+function isMastraSourceDirectory(path: string): boolean {
+  const parts = path.split(sep);
+  return parts.length >= 2 && parts[parts.length - 1] === 'mastra' && parts[parts.length - 2] === 'src';
+}
+
+export function findMastraEntryCandidates(rootDir: string, maxCandidates = 5): string[] {
+  const candidates: string[] = [];
+  const queue: string[] = [rootDir];
+
+  while (queue.length > 0 && candidates.length < maxCandidates) {
+    const currentDir = queue.pop()!;
+
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(currentDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryName = entry.name;
+      const fullPath = join(currentDir, entryName);
+
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRECTORIES.has(entryName)) {
+          continue;
+        }
+        queue.push(fullPath);
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      if ((entryName === 'index.ts' || entryName === 'index.js') && isMastraSourceDirectory(currentDir)) {
+        candidates.push(fullPath);
+        if (candidates.length >= maxCandidates) {
+          break;
+        }
+      }
+    }
+  }
+
+  return candidates.sort();
+}
+
+export function toDetectedProjectRoot(entryFile: string): string {
+  return dirname(dirname(dirname(entryFile)));
+}

--- a/packages/cli/src/commands/migrate/migrate.ts
+++ b/packages/cli/src/commands/migrate/migrate.ts
@@ -59,8 +59,9 @@ export async function migrate({
       logger.info('');
       logger.info('Detected candidate entrypoints under the selected root:');
       for (const candidate of candidates) {
-        const suggestedDir = relative(process.cwd(), candidate).replace(/[\\/]index\.(ts|js)$/u, '');
-        const suggestedRoot = relative(process.cwd(), toDetectedProjectRoot(candidate)) || '.';
+        const rootBase = toDetectedProjectRoot(candidate);
+        const suggestedDir = relative(rootBase, candidate).replace(/[\\/]index\.(ts|js)$/u, '');
+        const suggestedRoot = relative(process.cwd(), rootBase) || '.';
         logger.info(`  - ${candidate}`);
         logger.info(pc.dim(`    Example: npx mastra migrate --dir ${suggestedDir} --root ${suggestedRoot}`));
       }

--- a/packages/cli/src/commands/migrate/migrate.ts
+++ b/packages/cli/src/commands/migrate/migrate.ts
@@ -1,12 +1,17 @@
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import process from 'node:process';
 import * as p from '@clack/prompts';
-import { FileService } from '@mastra/deployer';
 import { execa } from 'execa';
 import pc from 'picocolors';
 
 import { createLogger } from '../../utils/logger.js';
 
+import {
+  findMastraEntryCandidates,
+  resolveMigrateEntryFile,
+  resolveMigratePaths,
+  toDetectedProjectRoot,
+} from './migrate-paths';
 import { MigrateBundler } from './MigrateBundler';
 
 interface MigrationResult {
@@ -30,9 +35,39 @@ export async function migrate({
   yes: boolean;
 }) {
   const logger = createLogger(debug);
-  const rootDir = root || process.cwd();
-  const mastraDir = dir ? (dir.startsWith('/') ? dir : join(process.cwd(), dir)) : join(process.cwd(), 'src', 'mastra');
+  const { rootDir, mastraDir } = resolveMigratePaths({
+    cwd: process.cwd(),
+    root,
+    dir,
+  });
+  const { checkedPaths, entryFile } = resolveMigrateEntryFile(mastraDir);
   const dotMastraPath = join(rootDir, '.mastra');
+
+  if (!entryFile) {
+    logger.error(pc.red('Error: Could not find Mastra entry file.'));
+    logger.info('');
+    logger.info('Expected one of the following files:');
+    checkedPaths.forEach(path => logger.info(`  - ${path}`));
+    logger.info('');
+    logger.info('This command requires a Mastra entrypoint (src/mastra/index.ts or index.js).');
+    logger.info('If your project is in a custom location (for example in a monorepo), run:');
+    logger.info(pc.cyan('  npx mastra migrate --dir <path/to/src/mastra> --root <path/to/project-root>'));
+    logger.info(pc.cyan('  pnpm exec mastra migrate --dir <path/to/src/mastra> --root <path/to/project-root>'));
+
+    const candidates = findMastraEntryCandidates(rootDir, 5);
+    if (candidates.length > 0) {
+      logger.info('');
+      logger.info('Detected candidate entrypoints under the selected root:');
+      for (const candidate of candidates) {
+        const suggestedDir = relative(process.cwd(), candidate).replace(/[\\/]index\.(ts|js)$/u, '');
+        const suggestedRoot = relative(process.cwd(), toDetectedProjectRoot(candidate)) || '.';
+        logger.info(`  - ${candidate}`);
+        logger.info(pc.dim(`    Example: npx mastra migrate --dir ${suggestedDir} --root ${suggestedRoot}`));
+      }
+    }
+
+    process.exit(1);
+  }
 
   p.intro(pc.cyan('Mastra Storage Migration'));
 
@@ -56,9 +91,6 @@ export async function migrate({
   }
 
   try {
-    const fileService = new FileService();
-    const entryFile = fileService.getFirstExistingFile([join(mastraDir, 'index.ts'), join(mastraDir, 'index.js')]);
-
     const bundler = new MigrateBundler(env);
     bundler.__setLogger(logger);
 
@@ -158,11 +190,11 @@ export async function migrate({
     if (error.code === 'ERR_MODULE_NOT_FOUND' || error.message?.includes('Cannot find module')) {
       logger.error(pc.red('Error: Could not find Mastra entry file.'));
       logger.info('');
-      logger.info('Make sure you have a mastra directory with an index.ts or index.js file.');
+      logger.info('Make sure your Mastra directory has an index.ts or index.js file.');
       logger.info('Expected location', { path: mastraDir });
       logger.info('');
       logger.info('You can specify a custom directory:');
-      logger.info(pc.cyan('  npx mastra migrate --dir path/to/mastra'));
+      logger.info(pc.cyan('  npx mastra migrate --dir <path/to/src/mastra> --root <path/to/project-root>'));
     } else {
       logger.error(pc.red(`Error: ${error.message}`));
       if (debug) {

--- a/packages/cli/src/commands/migrate/migrate.ts
+++ b/packages/cli/src/commands/migrate/migrate.ts
@@ -21,6 +21,10 @@ interface MigrationResult {
   message: string;
 }
 
+function quoteShellArg(value: string): string {
+  return `"${value.replace(/(["\\$`])/gu, '\\$1')}"`;
+}
+
 export async function migrate({
   dir,
   root,
@@ -63,7 +67,11 @@ export async function migrate({
         const suggestedDir = relative(rootBase, candidate).replace(/[\\/]index\.(ts|js)$/u, '');
         const suggestedRoot = relative(process.cwd(), rootBase) || '.';
         logger.info(`  - ${candidate}`);
-        logger.info(pc.dim(`    Example: npx mastra migrate --dir ${suggestedDir} --root ${suggestedRoot}`));
+        logger.info(
+          pc.dim(
+            `    Example: npx mastra migrate --dir ${quoteShellArg(suggestedDir)} --root ${quoteShellArg(suggestedRoot)}`,
+          ),
+        );
       }
     }
 


### PR DESCRIPTION
## Description

Fixes `mastra migrate` guidance for monorepos and other custom project layouts. Relative `--dir` paths are now resolved against `--root` (instead of `process.cwd()`), and when no Mastra entrypoint is found the CLI prints actionable instructions plus detected candidate entrypoints instead of a raw module-not-found error.

## Related Issue(s)

Fixes : N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes mastra migrate better at finding your project's Mastra code in monorepos or custom layouts and gives clear, copy/pasteable instructions (with quoted paths) and candidate locations when it can't find the entry file.

## Overview

Fixes path resolution and error guidance for the CLI's migrate command: relative --dir is resolved against --root (falling back to cwd), mastraDir defaults to <root>/src/mastra, the command prefers src/mastra/index.ts then index.js, and when no entrypoint is found it prints the exact paths checked, actionable --dir/--root examples (shell-quoted), and detected candidate entrypoints under the chosen root. The CLI exits with code 1 on missing entrypoint and improves ERR_MODULE_NOT_FOUND messaging to reference the expected mastraDir.

## Changes Made

- packages/cli/src/commands/migrate/migrate-paths.ts
  - New helpers and exports:
    - Interfaces: MigratePathResolution, MigrateEntryResolution
    - resolveMigratePaths({ cwd, root?, dir? }) — computes rootDir (root resolved against cwd) and mastraDir (dir resolved against rootDir or defaults to rootDir/src/mastra)
    - resolveMigrateEntryFile(mastraDir) — checks [mastraDir/index.ts, mastraDir/index.js] and returns checkedPaths + optional entryFile
    - findMastraEntryCandidates(rootDir, maxCandidates=5) — breadth-first search for src/mastra/index.ts|index.js, skipping ignored dirs (node_modules, .git, .mastra, .turbo, .next, dist, build, coverage), returns sorted candidates
    - toDetectedProjectRoot(entryFile) — derives project root by walking up three directories
- packages/cli/src/commands/migrate/migrate.ts
  - Uses the new helpers to compute rootDir/mastraDir and resolve the entryFile.
  - If no entryFile is found:
    - Logs an error header and the exact checked paths.
    - Prints monorepo guidance with example commands including --dir and --root (examples shell-quoted for safe copy/paste).
    - Lists detected candidate entrypoints under the selected root and prints example npx/pnpm commands with suggested --dir and --root.
    - Exits with process.exit(1).
  - Improved ERR_MODULE_NOT_FOUND handling to explicitly mention the expected mastraDir path and suggest --dir/--root.
- packages/cli/src/commands/migrate/migrate-paths.test.ts
  - New tests verifying:
    - --dir is resolved relative to --root
    - entry file selection (index.ts preferred; checkedPaths reported)
    - candidate detection excludes node_modules and returns correct candidates
    - project root derivation from an entry file path
  - Tests use isolated temp directories and cleanup.
- .changeset/fruity-otters-burn.md
  - Patch changeset documenting the behavior and guidance improvements.

## Key Improvements

- Correct resolution of relative --dir against provided --root (avoids incorrect path joining in monorepos).
- Clear, actionable CLI guidance when the Mastra entrypoint is missing, including shell-quoted example commands to copy/paste safely even with spaces.
- Candidate discovery to help users locate src/mastra/index.ts|index.js in large repositories.
- New tests covering path resolution, entry-file detection, candidate discovery, and project-root derivation.
- Non-breaking bug fix with low-to-medium review effort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->