### PR TITLE
docs: add BrowserViewer documentation

### DIFF
--- a/docs/src/content/en/docs/browser/browser-viewer.mdx
+++ b/docs/src/content/en/docs/browser/browser-viewer.mdx
@@ -84,11 +84,32 @@ When the agent runs a CLI command like `browser-use open https://example.com`, M
 
 BrowserViewer supports three CLI providers. Each CLI must be installed separately in your workspace environment. Each CLI also publishes a [skill](/docs/workspace/skills) that teaches the agent its commands and workflows.
 
-| CLI | Install CLI | Install skill | CDP flag |
-| - | - | - | - |
-| `agent-browser` | `npm install -g agent-browser` | `npx skills add vercel-labs/agent-browser` | `--cdp` |
-| `browser-use` | `pip install browser-use` | `npx skills add browser-use/browser-use --skill browser-use` | `--cdp-url` |
-| `browse-cli` | `npm install -g @browserbasehq/browse-cli` | `npx skills add browserbase/skills` | `--ws` |
+### agent-browser
+
+```bash
+npm install -g agent-browser
+npx skills add vercel-labs/agent-browser
+```
+
+CDP flag: `--cdp`
+
+### browser-use
+
+```bash
+pip install browser-use
+npx skills add browser-use/browser-use --skill browser-use
+```
+
+CDP flag: `--cdp-url`
+
+### browse-cli
+
+```bash
+npm install -g @browserbasehq/browse-cli
+npx skills add browserbase/skills
+```
+
+CDP flag: `--ws`
 
 Set the `cli` option to match the CLI your agent uses:
 

--- a/docs/src/content/en/docs/browser/browser-viewer.mdx
+++ b/docs/src/content/en/docs/browser/browser-viewer.mdx
@@ -7,7 +7,7 @@ packages:
 
 # BrowserViewer
 
-The `@mastra/browser-viewer` package provides browser automation for CLI-based tools like [agent-browser](https://github.com/vercel-labs/agent-browser), [browser-use](https://github.com/browser-use/browser-use), and [browse](https://www.npmjs.com/package/@browserbasehq/browse-cli). BrowserViewer launches Chrome via Playwright, exposes a Chrome DevTools Protocol (CDP) URL, and automatically injects it into CLI commands run through [workspace tools](/docs/workspace/overview).
+The `@mastra/browser-viewer` package provides browser automation for CLI-based tools like [agent-browser](https://github.com/vercel-labs/agent-browser), [browser-use](https://github.com/browser-use/browser-use), and [browse](https://github.com/browserbase/stagehand/tree/main/packages/cli). BrowserViewer launches Chrome via Playwright, exposes a Chrome DevTools Protocol (CDP) URL, and automatically injects it into CLI commands run through [workspace tools](/docs/workspace/overview).
 
 ## When to use BrowserViewer
 

--- a/docs/src/content/en/docs/browser/browser-viewer.mdx
+++ b/docs/src/content/en/docs/browser/browser-viewer.mdx
@@ -1,0 +1,126 @@
+---
+title: "BrowserViewer | Browser"
+description: "Use BrowserViewer for CLI-based browser automation with automatic CDP injection and Studio screencast."
+packages:
+  - "@mastra/browser-viewer"
+---
+
+# BrowserViewer
+
+The `@mastra/browser-viewer` package provides browser automation for CLI-based tools like [agent-browser](https://github.com/AugmentCode/agent-browser), [browser-use](https://github.com/browser-use/browser-use), and [browse](https://github.com/AugmentCode/browse). BrowserViewer launches Chrome via Playwright, exposes a Chrome DevTools Protocol (CDP) URL, and automatically injects it into CLI commands run through [workspace tools](/docs/workspace/overview).
+
+## When to use BrowserViewer
+
+Use BrowserViewer when your agent drives a browser through a CLI tool rather than an SDK. BrowserViewer handles:
+
+- Launching and managing Chrome for CLI tools to connect to
+- Automatic CDP URL injection into `workspace_execute_command` calls
+- Live screencast streaming to Studio
+- Thread-scoped browser isolation
+
+For SDK-based browser automation, use [AgentBrowser](/docs/browser/agent-browser) or [Stagehand](/docs/browser/stagehand) instead.
+
+## Quickstart
+
+Install the package:
+
+```bash npm2yarn
+npm install @mastra/browser-viewer
+```
+
+Create a workspace with BrowserViewer and assign it to an agent:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+import { Agent } from '@mastra/core/agent'
+import { Workspace, LocalSandbox } from '@mastra/core/workspace'
+import { BrowserViewer } from '@mastra/browser-viewer'
+
+const workspace = new Workspace({
+  sandbox: new LocalSandbox({
+    workingDirectory: './workspace',
+  }),
+  browser: new BrowserViewer({
+    cli: 'agent-browser',
+    headless: false,
+  }),
+})
+
+const browserAgent = new Agent({
+  id: 'browser-agent',
+  model: 'openai/gpt-5.4',
+  workspace,
+  instructions: `You are a web automation assistant.
+Use agent-browser commands to navigate and interact with websites.`,
+})
+
+export const mastra = new Mastra({
+  agents: { browserAgent },
+})
+```
+
+When the agent runs a CLI command like `agent-browser open https://example.com`, Mastra automatically launches Chrome, injects the CDP connection, and starts streaming the screencast to Studio.
+
+## How it works
+
+1. The agent calls `workspace_execute_command` with a browser CLI command.
+1. Mastra detects the CLI command and launches Chrome via Playwright (if not already running).
+1. The CDP URL is injected into the command so the CLI connects to the managed browser.
+1. Screencast frames stream from page-level CDP sessions to Studio.
+
+## Supported CLIs
+
+BrowserViewer supports three CLI providers:
+
+| CLI | CDP flag | Description |
+| - | - | - |
+| `agent-browser` | `--cdp` | Accessibility-first browser automation CLI |
+| `browser-use` | `--cdp-url` | Python-based browser automation |
+| `browse-cli` | `--ws` | Browserbase's Stagehand CLI |
+
+Set the `cli` option to tell BrowserViewer which CLI the agent uses:
+
+```typescript
+const viewer = new BrowserViewer({
+  cli: 'browser-use',
+  headless: false,
+})
+```
+
+The CLI tool must be installed separately in the workspace environment.
+
+## Configuration
+
+| Option | Type | Default | Description |
+| - | - | - | - |
+| `cli` | `'agent-browser' \| 'browser-use' \| 'browse-cli'` | Required | Which CLI the agent uses |
+| `headless` | `boolean` | `false` | Run browser in headless mode |
+| `cdpUrl` | `string` | — | Connect to an existing browser instead of launching one |
+| `cdpPort` | `number` | `0` (auto) | Port for Chrome remote debugging |
+| `viewport` | `{ width, height }` | `1280×720` | Browser viewport size |
+| `userDataDir` | `string` | — | Chrome profile directory for persistent state |
+| `executablePath` | `string` | — | Path to a Chrome executable |
+
+## Connecting to an existing browser
+
+To connect to a browser that is already running, pass a `cdpUrl`:
+
+```typescript
+const viewer = new BrowserViewer({
+  cli: 'agent-browser',
+  cdpUrl: 'ws://127.0.0.1:9222/devtools/browser/abc123',
+})
+```
+
+BrowserViewer connects via the CDP endpoint and enables screencast without launching its own browser.
+
+## External CDP connections
+
+When the agent provides its own CDP URL in a command (for example, `browser-use --cdp-url wss://cloud.example.com/session`), BrowserViewer detects this and skips injection. It connects to the external browser for screencast only, without managing the browser lifecycle.
+
+## Related
+
+- [Browser overview](/docs/browser/overview)
+- [AgentBrowser](/docs/browser/agent-browser)
+- [Stagehand](/docs/browser/stagehand)
+- [Workspace overview](/docs/workspace/overview)

--- a/docs/src/content/en/docs/browser/browser-viewer.mdx
+++ b/docs/src/content/en/docs/browser/browser-viewer.mdx
@@ -7,7 +7,7 @@ packages:
 
 # BrowserViewer
 
-The `@mastra/browser-viewer` package provides browser automation for CLI-based tools like [agent-browser](https://github.com/AugmentCode/agent-browser), [browser-use](https://github.com/browser-use/browser-use), and [browse](https://github.com/AugmentCode/browse). BrowserViewer launches Chrome via Playwright, exposes a Chrome DevTools Protocol (CDP) URL, and automatically injects it into CLI commands run through [workspace tools](/docs/workspace/overview).
+The `@mastra/browser-viewer` package provides browser automation for CLI-based tools like [agent-browser](https://github.com/vercel-labs/agent-browser), [browser-use](https://github.com/browser-use/browser-use), and [browse](https://www.npmjs.com/package/@browserbasehq/browse-cli). BrowserViewer launches Chrome via Playwright, exposes a Chrome DevTools Protocol (CDP) URL, and automatically injects it into CLI commands run through [workspace tools](/docs/workspace/overview).
 
 ## When to use BrowserViewer
 

--- a/docs/src/content/en/docs/browser/browser-viewer.mdx
+++ b/docs/src/content/en/docs/browser/browser-viewer.mdx
@@ -7,7 +7,7 @@ packages:
 
 # BrowserViewer
 
-The `@mastra/browser-viewer` package provides browser automation for CLI-based tools like [agent-browser](https://github.com/vercel-labs/agent-browser), [browser-use](https://github.com/browser-use/browser-use), and [browse](https://github.com/browserbase/stagehand/tree/main/packages/cli). BrowserViewer launches Chrome via Playwright, exposes a Chrome DevTools Protocol (CDP) URL, and automatically injects it into CLI commands run through [workspace tools](/docs/workspace/overview).
+The `@mastra/browser-viewer` package provides browser automation for CLI-based tools like [agent-browser](https://www.npmjs.com/package/agent-browser), [browser-use](https://pypi.org/project/browser-use/), and [browse](https://www.npmjs.com/package/@browserbasehq/browse-cli). BrowserViewer launches Chrome via Playwright, exposes a Chrome DevTools Protocol (CDP) URL, and automatically injects it into CLI commands run through [workspace tools](/docs/workspace/overview).
 
 ## When to use BrowserViewer
 
@@ -22,10 +22,22 @@ For SDK-based browser automation, use [AgentBrowser](/docs/browser/agent-browser
 
 ## Quickstart
 
-Install the package:
+Install `@mastra/browser-viewer` and the CLI tool your agent will use. BrowserViewer manages Chrome, but the CLI tool itself must be installed separately.
 
 ```bash npm2yarn
 npm install @mastra/browser-viewer
+```
+
+Install the CLI tool in your workspace environment. This example uses `browser-use`:
+
+```bash
+pip install browser-use
+```
+
+Install the corresponding [skill](/docs/workspace/skills) so the agent knows how to use the CLI:
+
+```bash
+npx skills add browser-use/browser-use --skill browser-use
 ```
 
 Create a workspace with BrowserViewer and assign it to an agent:
@@ -41,7 +53,7 @@ const workspace = new Workspace({
     workingDirectory: './workspace',
   }),
   browser: new BrowserViewer({
-    cli: 'agent-browser',
+    cli: 'browser-use',
     headless: false,
   }),
 })
@@ -51,7 +63,7 @@ const browserAgent = new Agent({
   model: 'openai/gpt-5.4',
   workspace,
   instructions: `You are a web automation assistant.
-Use agent-browser commands to navigate and interact with websites.`,
+Use browser-use commands to navigate and interact with websites.`,
 })
 
 export const mastra = new Mastra({
@@ -59,7 +71,7 @@ export const mastra = new Mastra({
 })
 ```
 
-When the agent runs a CLI command like `agent-browser open https://example.com`, Mastra automatically launches Chrome, injects the CDP connection, and starts streaming the screencast to Studio.
+When the agent runs a CLI command like `browser-use open https://example.com`, Mastra automatically launches Chrome, injects the CDP connection, and starts streaming the screencast to Studio.
 
 ## How it works
 
@@ -70,15 +82,15 @@ When the agent runs a CLI command like `agent-browser open https://example.com`,
 
 ## Supported CLIs
 
-BrowserViewer supports three CLI providers:
+BrowserViewer supports three CLI providers. Each CLI must be installed separately in your workspace environment. Each CLI also publishes a [skill](/docs/workspace/skills) that teaches the agent its commands and workflows.
 
-| CLI | CDP flag | Description |
-| - | - | - |
-| `agent-browser` | `--cdp` | Accessibility-first browser automation CLI |
-| `browser-use` | `--cdp-url` | Python-based browser automation |
-| `browse-cli` | `--ws` | Browserbase's Stagehand CLI |
+| CLI | Install CLI | Install skill | CDP flag |
+| - | - | - | - |
+| `agent-browser` | `npm install -g agent-browser` | `npx skills add vercel-labs/agent-browser` | `--cdp` |
+| `browser-use` | `pip install browser-use` | `npx skills add browser-use/browser-use --skill browser-use` | `--cdp-url` |
+| `browse-cli` | `npm install -g @browserbasehq/browse-cli` | `npx skills add browserbase/skills` | `--ws` |
 
-Set the `cli` option to tell BrowserViewer which CLI the agent uses:
+Set the `cli` option to match the CLI your agent uses:
 
 ```typescript
 const viewer = new BrowserViewer({
@@ -86,8 +98,6 @@ const viewer = new BrowserViewer({
   headless: false,
 })
 ```
-
-The CLI tool must be installed separately in the workspace environment.
 
 ## Configuration
 
@@ -107,7 +117,7 @@ To connect to a browser that is already running, pass a `cdpUrl`:
 
 ```typescript
 const viewer = new BrowserViewer({
-  cli: 'agent-browser',
+  cli: 'browser-use',
   cdpUrl: 'ws://127.0.0.1:9222/devtools/browser/abc123',
 })
 ```
@@ -124,3 +134,4 @@ When the agent provides its own CDP URL in a command (for example, `browser-use 
 - [AgentBrowser](/docs/browser/agent-browser)
 - [Stagehand](/docs/browser/stagehand)
 - [Workspace overview](/docs/workspace/overview)
+- [Workspace skills](/docs/workspace/skills)

--- a/docs/src/content/en/docs/browser/overview.mdx
+++ b/docs/src/content/en/docs/browser/overview.mdx
@@ -1,20 +1,22 @@
 ---
 title: "Browser overview"
-description: "Give agents browser control through SDK providers like AgentBrowser and Stagehand."
+description: "Give agents browser control through SDK providers, CLI tools, or cloud browser services."
 packages:
   - "@mastra/core"
   - "@mastra/agent-browser"
   - "@mastra/stagehand"
+  - "@mastra/browser-viewer"
 ---
 
 # Browser overview
 
-Browser support enables agents to navigate websites, interact with page elements, fill forms, and extract data. Mastra provides browser capabilities through SDK providers that wrap popular browser automation libraries.
+Browser support enables agents to navigate websites, interact with page elements, fill forms, and extract data. Mastra provides browser capabilities through SDK providers that wrap browser automation libraries and a CLI provider for agents that drive browsers through command-line tools.
 
-Mastra supports two browser SDK providers:
+Mastra supports two SDK providers and one CLI provider:
 
 - [**AgentBrowser**](/docs/browser/agent-browser): A Playwright-based provider with accessibility-first element targeting. Best for general web automation and scraping.
 - [**Stagehand**](/docs/browser/stagehand): A Browserbase provider with AI-powered element detection. Best for complex interactions that benefit from natural language selectors.
+- [**BrowserViewer**](/docs/browser/browser-viewer): A CLI provider that launches Chrome and injects CDP URLs into CLI tools like agent-browser, browser-use, and browse. Best for workspace agents that drive browsers through shell commands.
 
 ## When to use browser
 
@@ -134,4 +136,5 @@ const browser = new AgentBrowser({
 
 - [AgentBrowser](/docs/browser/agent-browser)
 - [Stagehand](/docs/browser/stagehand)
+- [BrowserViewer](/docs/browser/browser-viewer)
 - [MastraBrowser reference](/reference/browser/mastra-browser)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -358,6 +358,11 @@ const sidebars = {
           id: 'browser/stagehand',
           label: 'Stagehand',
         },
+        {
+          type: 'doc',
+          id: 'browser/browser-viewer',
+          label: 'BrowserViewer',
+        },
       ],
     },
     {

--- a/docs/src/content/en/reference/browser/browser-viewer.mdx
+++ b/docs/src/content/en/reference/browser/browser-viewer.mdx
@@ -1,0 +1,310 @@
+---
+title: "Reference: BrowserViewer | Browser"
+description: "API reference for BrowserViewer, a CLI-based browser provider that launches Chrome via Playwright and exposes a CDP URL for CLI tools."
+packages:
+  - "@mastra/browser-viewer"
+---
+
+# BrowserViewer
+
+The `BrowserViewer` class provides browser automation for CLI-based tools. It launches Chrome via Playwright, exposes a Chrome DevTools Protocol (CDP) URL, and automatically injects it into CLI commands run through workspace tools.
+
+Use `BrowserViewer` when your agent drives a browser through a CLI tool like `browser-use`, `agent-browser`, or `browse`. For SDK-based browser automation, use [`AgentBrowser`](/reference/browser/agent-browser) or [`StagehandBrowser`](/reference/browser/stagehand-browser).
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { Workspace, LocalSandbox } from '@mastra/core/workspace'
+import { BrowserViewer } from '@mastra/browser-viewer'
+import { Agent } from '@mastra/core/agent'
+
+const workspace = new Workspace({
+  sandbox: new LocalSandbox({
+    workingDirectory: './workspace',
+  }),
+  browser: new BrowserViewer({
+    cli: 'browser-use',
+    headless: false,
+  }),
+})
+
+const browserAgent = new Agent({
+  id: 'browser-agent',
+  model: 'openai/gpt-5.4',
+  workspace,
+  instructions: 'You are a web automation assistant.',
+})
+```
+
+### Connecting to an existing browser
+
+```typescript
+const viewer = new BrowserViewer({
+  cli: 'browser-use',
+  cdpUrl: 'ws://127.0.0.1:9222/devtools/browser/abc123',
+})
+```
+
+When `cdpUrl` is provided, `BrowserViewer` connects to the existing browser instead of launching a new one. Scope defaults to `'shared'`.
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'cli',
+    type: "'agent-browser' | 'browser-use' | 'browse-cli'",
+    description: 'Which CLI the agent uses for browser automation. The CLI connects to Chrome via the CDP URL.',
+  },
+  {
+    name: 'headless',
+    type: 'boolean',
+    description: 'Whether to run Chrome in headless mode.',
+    isOptional: true,
+    defaultValue: 'true',
+  },
+  {
+    name: 'cdpUrl',
+    type: 'string | (() => string | Promise<string>)',
+    description: 'CDP WebSocket URL for connecting to an existing browser instead of launching one.',
+    isOptional: true,
+  },
+  {
+    name: 'cdpPort',
+    type: 'number',
+    description: 'Port for Chrome remote debugging. Only used when launching Chrome (not when connecting via cdpUrl).',
+    isOptional: true,
+    defaultValue: '0 (auto-assign)',
+  },
+  {
+    name: 'scope',
+    type: "'shared' | 'thread'",
+    description:
+      "Browser instance scope. 'thread' gives each thread its own browser. 'shared' shares one browser across all threads. Defaults to 'shared' when cdpUrl is provided.",
+    isOptional: true,
+    defaultValue: "'thread'",
+  },
+  {
+    name: 'viewport',
+    type: '{ width: number; height: number }',
+    description: 'Browser viewport dimensions.',
+    isOptional: true,
+    defaultValue: '{ width: 1280, height: 720 }',
+  },
+  {
+    name: 'userDataDir',
+    type: 'string',
+    description: 'Path to Chrome user data directory. Persists cookies, localStorage, and extensions across sessions.',
+    isOptional: true,
+  },
+  {
+    name: 'executablePath',
+    type: 'string',
+    description: "Path to a Chrome executable. Uses Playwright's bundled Chromium by default.",
+    isOptional: true,
+  },
+  {
+    name: 'timeout',
+    type: 'number',
+    description: 'Default timeout in milliseconds for browser operations.',
+    isOptional: true,
+    defaultValue: '10000',
+  },
+  {
+    name: 'onLaunch',
+    type: '(args: { browser: MastraBrowser }) => void | Promise<void>',
+    description: 'Callback invoked after the browser is ready.',
+    isOptional: true,
+  },
+  {
+    name: 'onClose',
+    type: '(args: { browser: MastraBrowser }) => void | Promise<void>',
+    description: 'Callback invoked before the browser closes.',
+    isOptional: true,
+  },
+  {
+    name: 'screencast',
+    type: 'ScreencastOptions',
+    description: 'Configuration for streaming browser frames to Studio.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: "Unique identifier for this browser instance. Generated as 'browser-viewer-{timestamp}'.",
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: "'BrowserViewer'",
+  },
+  {
+    name: 'provider',
+    type: 'string',
+    description: "'browser-viewer'",
+  },
+  {
+    name: 'providerType',
+    type: "'cli'",
+    description: "Always 'cli'. Distinguishes BrowserViewer from SDK-based providers like AgentBrowser.",
+  },
+  {
+    name: 'cli',
+    type: "'agent-browser' | 'browser-use' | 'browse-cli'",
+    description: 'The CLI provider this instance is configured for.',
+  },
+  {
+    name: 'status',
+    type: 'BrowserStatus',
+    description: "Current browser status: 'pending', 'launching', 'ready', 'error', 'closing', or 'closed'.",
+  },
+]}
+/>
+
+## Methods
+
+### Lifecycle
+
+#### `launch(threadId?)`
+
+Launches Chrome. For `'shared'` scope, launches a single shared browser. For `'thread'` scope, launches a browser for the specified thread.
+
+```typescript
+await viewer.launch()
+await viewer.launch('thread-123')
+```
+
+#### `ensureReady()`
+
+Ensures the browser is launched and ready. For `'thread'` scope, creates a new browser for the current thread if needed.
+
+```typescript
+await viewer.ensureReady()
+```
+
+#### `isBrowserRunning(threadId?)`
+
+Checks if a browser is running. For `'thread'` scope, checks the specified thread.
+
+```typescript
+const running = viewer.isBrowserRunning()
+const threadRunning = viewer.isBrowserRunning('thread-123')
+```
+
+Returns: `boolean`
+
+#### `close()`
+
+Closes all browser instances and cleans up resources.
+
+```typescript
+await viewer.close()
+```
+
+### CDP access
+
+#### `getCdpUrl(threadId?)`
+
+Returns the CDP WebSocket URL for the current or specified thread. CLI tools use this URL to connect to the managed browser.
+
+```typescript
+const cdpUrl = viewer.getCdpUrl()
+// => 'ws://127.0.0.1:52481/devtools/browser/abc...'
+```
+
+Returns: `string | null`
+
+#### `connectToExternalCdp(cdpUrl, threadId?)`
+
+Connects to an external browser via CDP URL for screencast. Use this when the agent provides its own browser endpoint (for example, a cloud browser service). BrowserViewer connects for screencast without managing the browser lifecycle.
+
+```typescript
+await viewer.connectToExternalCdp('wss://cloud.example.com/session', 'thread-123')
+```
+
+### Screencast
+
+#### `startScreencast(options?)`
+
+Starts streaming browser frames. Returns a `ScreencastStream` that emits frame events. Handles tab switching automatically by creating fresh CDP sessions when tabs change.
+
+```typescript
+const stream = await viewer.startScreencast({
+  format: 'jpeg',
+  quality: 80,
+})
+
+stream.on('frame', frame => {
+  console.log('Frame received:', frame.data.length, 'bytes')
+})
+
+stream.on('stop', reason => {
+  console.log('Screencast stopped:', reason)
+})
+```
+
+Returns: `Promise<ScreencastStream>`
+
+### Input injection
+
+#### `injectMouseEvent(params, threadId?)`
+
+Injects a mouse event into the browser via CDP. Used by Studio for live interaction.
+
+```typescript
+await viewer.injectMouseEvent({
+  type: 'mousePressed',
+  x: 100,
+  y: 200,
+  button: 'left',
+  clickCount: 1,
+})
+```
+
+#### `injectKeyboardEvent(params, threadId?)`
+
+Injects a keyboard event into the browser via CDP. Used by Studio for live interaction.
+
+```typescript
+await viewer.injectKeyboardEvent({
+  type: 'keyDown',
+  key: 'Enter',
+  code: 'Enter',
+})
+```
+
+### Tools
+
+#### `getTools()`
+
+Returns an empty tool set. Unlike SDK providers, `BrowserViewer` does not provide agent tools. The agent uses CLI commands through `workspace_execute_command` instead.
+
+```typescript
+const tools = viewer.getTools()
+// => {}
+```
+
+Returns: `Record<string, Tool>`
+
+## Supported CLIs
+
+| CLI | Config value | CDP flag | Install CLI | Install skill |
+| - | - | - | - | - |
+| [agent-browser](https://www.npmjs.com/package/agent-browser) | `'agent-browser'` | `--cdp` | `npm install -g agent-browser` | `npx skills add vercel-labs/agent-browser` |
+| [browser-use](https://pypi.org/project/browser-use/) | `'browser-use'` | `--cdp-url` | `pip install browser-use` | `npx skills add browser-use/browser-use --skill browser-use` |
+| [browse](https://www.npmjs.com/package/@browserbasehq/browse-cli) | `'browse-cli'` | `--ws` | `npm install -g @browserbasehq/browse-cli` | `npx skills add browserbase/skills` |
+
+Each CLI must be installed separately. Each also publishes a [skill](/docs/workspace/skills) that teaches the agent its commands and workflows. When a CLI command runs through `workspace_execute_command`, Mastra detects it and injects the CDP URL automatically using the correct flag.
+
+## Related
+
+- [BrowserViewer guide](/docs/browser/browser-viewer) — setup and usage walkthrough
+- [MastraBrowser](/reference/browser/mastra-browser) — base class API reference
+- [Workspace overview](/docs/workspace/overview) — workspace configuration

--- a/docs/src/content/en/reference/browser/browser-viewer.mdx
+++ b/docs/src/content/en/reference/browser/browser-viewer.mdx
@@ -280,28 +280,38 @@ await viewer.injectKeyboardEvent({
 })
 ```
 
-### Tools
-
-#### `getTools()`
-
-Returns an empty tool set. Unlike SDK providers, `BrowserViewer` does not provide agent tools. The agent uses CLI commands through `workspace_execute_command` instead.
-
-```typescript
-const tools = viewer.getTools()
-// => {}
-```
-
-Returns: `Record<string, Tool>`
-
 ## Supported CLIs
 
-| CLI | Config value | CDP flag | Install CLI | Install skill |
-| - | - | - | - | - |
-| [agent-browser](https://www.npmjs.com/package/agent-browser) | `'agent-browser'` | `--cdp` | `npm install -g agent-browser` | `npx skills add vercel-labs/agent-browser` |
-| [browser-use](https://pypi.org/project/browser-use/) | `'browser-use'` | `--cdp-url` | `pip install browser-use` | `npx skills add browser-use/browser-use --skill browser-use` |
-| [browse](https://www.npmjs.com/package/@browserbasehq/browse-cli) | `'browse-cli'` | `--ws` | `npm install -g @browserbasehq/browse-cli` | `npx skills add browserbase/skills` |
-
 Each CLI must be installed separately. Each also publishes a [skill](/docs/workspace/skills) that teaches the agent its commands and workflows. When a CLI command runs through `workspace_execute_command`, Mastra detects it and injects the CDP URL automatically using the correct flag.
+
+Unlike SDK providers, `BrowserViewer` does not provide agent tools. The agent uses CLI commands through `workspace_execute_command` instead.
+
+### [agent-browser](https://www.npmjs.com/package/agent-browser)
+
+Config value: `'agent-browser'` · CDP flag: `--cdp`
+
+```bash
+npm install -g agent-browser
+npx skills add vercel-labs/agent-browser
+```
+
+### [browser-use](https://pypi.org/project/browser-use/)
+
+Config value: `'browser-use'` · CDP flag: `--cdp-url`
+
+```bash
+pip install browser-use
+npx skills add browser-use/browser-use --skill browser-use
+```
+
+### [browse](https://www.npmjs.com/package/@browserbasehq/browse-cli)
+
+Config value: `'browse-cli'` · CDP flag: `--ws`
+
+```bash
+npm install -g @browserbasehq/browse-cli
+npx skills add browserbase/skills
+```
 
 ## Related
 

--- a/docs/src/content/en/reference/browser/mastra-browser.mdx
+++ b/docs/src/content/en/reference/browser/mastra-browser.mdx
@@ -13,6 +13,7 @@ You don't instantiate `MastraBrowser` directly. Instead, use a provider implemen
 
 - [`AgentBrowser`](/reference/browser/agent-browser): Deterministic browser automation using refs
 - [`StagehandBrowser`](/reference/browser/stagehand-browser): AI-powered browser automation using natural language
+- [`BrowserViewer`](/reference/browser/browser-viewer): CLI-based browser automation with CDP URL injection
 
 ## Usage example
 

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -86,6 +86,7 @@ const sidebars = {
       collapsed: true,
       items: [
         { type: 'doc', id: 'browser/agent-browser', label: 'AgentBrowser' },
+        { type: 'doc', id: 'browser/browser-viewer', label: 'BrowserViewer' },
         { type: 'doc', id: 'browser/mastra-browser', label: 'MastraBrowser Class' },
         { type: 'doc', id: 'browser/stagehand-browser', label: 'StagehandBrowser' },
       ],


### PR DESCRIPTION
## Description

Add documentation for the `@mastra/browser-viewer` package, which provides CLI-based browser automation with automatic CDP injection and Studio screencast support.

Changes:
- New `docs/browser/browser-viewer.mdx` page covering quickstart, how CDP injection works, supported CLIs, configuration options, and external CDP connections
- Updated browser overview to list BrowserViewer alongside AgentBrowser and Stagehand
- Added BrowserViewer to the docs sidebar

## Related Issue(s)

Related to #15415

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds complete documentation for a browser automation tool called BrowserViewer that helps developers control browsers through command-line tools. It explains how to use it, how it connects to browsers, and what commands it supports—making it easier for users to get started and understand all its features.

## Summary

This pull request introduces comprehensive documentation for the `@mastra/browser-viewer` package, a CLI-based browser automation provider that launches and manages Chrome instances via Playwright while exposing a CDP (Chrome DevTools Protocol) URL for automation.

### New Documentation Pages

**User Guide (`docs/browser/browser-viewer.mdx`)**:
Covers the quickstart workflow, explaining how BrowserViewer launches browsers via Playwright, injects CDP connection details into CLI command calls, and streams screencasts to Studio. Details the thread-scoped browser isolation model, lists three supported CLI providers (`agent-browser`, `browser-use`, `browse-cli`) with their installation and CDP flag requirements, and documents configuration options (`cli`, `headless`, `cdpUrl`, `cdpPort`, `viewport`, `userDataDir`, `executablePath`). Also covers connecting to an already-running browser via external CDP URLs.

**API Reference (`reference/browser/browser-viewer.mdx`)**:
Provides complete TypeScript usage examples and structured API documentation including constructor parameters, instance properties, and methods for lifecycle management (`launch`, `ensureReady`, `isBrowserRunning`, `close`), CDP access (`getCdpUrl`, `connectToExternalCdp`), screencast streaming (`startScreencast`), and event injection (`injectMouseEvent`, `injectKeyboardEvent`). Lists all supported CLIs with their installation and configuration steps.

### Updated Documentation

- **Browser Overview**: Expanded scope from SDK-only providers to include CLI tools and cloud services; added BrowserViewer entry with its CDP/CLI workflow description and linked to the new BrowserViewer documentation.
- **MastraBrowser Reference**: Added BrowserViewer to the enumerated list of MastraBrowser implementations.
- **Documentation & Reference Sidebars**: Added new `browser/browser-viewer` entries to both sidebar configurations for navigation.

All changes are documentation-only with no modifications to public API declarations or code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->