### PR TITLE
fix(agent-browser): return expression results from browser_evaluate

### DIFF
--- a/.changeset/sour-parks-refuse.md
+++ b/.changeset/sour-parks-refuse.md
@@ -2,4 +2,4 @@
 '@mastra/agent-browser': patch
 ---
 
-Fixed browser_evaluate tool to correctly return values from expression-style scripts. Previously, bare expressions like `document.querySelectorAll('a').length` were wrapped in an IIFE without a `return` statement, causing the result to always be `undefined`. The tool now detects whether the script contains an explicit `return` and automatically adds one for expression-style scripts.
+Fixed `browser_evaluate` so expression scripts now return their computed value instead of `undefined` (for example, `document.querySelectorAll('a').length`).

--- a/.changeset/sour-parks-refuse.md
+++ b/.changeset/sour-parks-refuse.md
@@ -1,0 +1,5 @@
+---
+'@mastra/agent-browser': patch
+---
+
+Fixed browser_evaluate tool to correctly return values from expression-style scripts. Previously, bare expressions like `document.querySelectorAll('a').length` were wrapped in an IIFE without a `return` statement, causing the result to always be `undefined`. The tool now detects whether the script contains an explicit `return` and automatically adds one for expression-style scripts.

--- a/browser/agent-browser/src/__tests__/evaluate.test.ts
+++ b/browser/agent-browser/src/__tests__/evaluate.test.ts
@@ -44,7 +44,7 @@ describe('browser_evaluate', () => {
   });
 
   it('evaluates script and returns number result', async () => {
-    mockPage.evaluate.mockResolvedValueOnce(42);
+    mockPage.evaluate.mockResolvedValue(42);
 
     const result = await browser.evaluate({ script: 'return 1 + 41' });
 
@@ -53,7 +53,7 @@ describe('browser_evaluate', () => {
   });
 
   it('evaluates script and returns string result', async () => {
-    mockPage.evaluate.mockResolvedValueOnce('Hello World');
+    mockPage.evaluate.mockResolvedValue('Hello World');
 
     const result = await browser.evaluate({ script: 'return "Hello World"' });
 
@@ -63,7 +63,7 @@ describe('browser_evaluate', () => {
 
   it('evaluates script and returns object result', async () => {
     const obj = { name: 'John', age: 30 };
-    mockPage.evaluate.mockResolvedValueOnce(obj);
+    mockPage.evaluate.mockResolvedValue(obj);
 
     const result = await browser.evaluate({ script: 'return { name: "John", age: 30 }' });
 
@@ -72,7 +72,7 @@ describe('browser_evaluate', () => {
   });
 
   it('evaluates script and returns array result', async () => {
-    mockPage.evaluate.mockResolvedValueOnce([1, 2, 3]);
+    mockPage.evaluate.mockResolvedValue([1, 2, 3]);
 
     const result = await browser.evaluate({ script: 'return [1, 2, 3]' });
 
@@ -81,7 +81,7 @@ describe('browser_evaluate', () => {
   });
 
   it('evaluates script and returns null', async () => {
-    mockPage.evaluate.mockResolvedValueOnce(null);
+    mockPage.evaluate.mockResolvedValue(null);
 
     const result = await browser.evaluate({ script: 'return null' });
 
@@ -90,7 +90,7 @@ describe('browser_evaluate', () => {
   });
 
   it('evaluates script and returns undefined', async () => {
-    mockPage.evaluate.mockResolvedValueOnce(undefined);
+    mockPage.evaluate.mockResolvedValue(undefined);
 
     const result = await browser.evaluate({ script: 'console.log("hi")' });
 
@@ -99,7 +99,7 @@ describe('browser_evaluate', () => {
   });
 
   it('returns error for syntax errors', async () => {
-    mockPage.evaluate.mockRejectedValueOnce(new Error('SyntaxError'));
+    mockPage.evaluate.mockRejectedValue(new Error('SyntaxError'));
 
     const result = await browser.evaluate({ script: 'return {' });
 
@@ -107,7 +107,7 @@ describe('browser_evaluate', () => {
   });
 
   it('returns error for runtime errors', async () => {
-    mockPage.evaluate.mockRejectedValueOnce(new Error('ReferenceError: x is not defined'));
+    mockPage.evaluate.mockRejectedValue(new Error('ReferenceError: x is not defined'));
 
     const result = await browser.evaluate({ script: 'return x' });
 
@@ -115,7 +115,7 @@ describe('browser_evaluate', () => {
   });
 
   it('returns error for thrown exceptions', async () => {
-    mockPage.evaluate.mockRejectedValueOnce(new Error('Custom error'));
+    mockPage.evaluate.mockRejectedValue(new Error('Custom error'));
 
     const result = await browser.evaluate({ script: 'throw new Error("Custom error")' });
 
@@ -123,7 +123,7 @@ describe('browser_evaluate', () => {
   });
 
   it('handles async scripts', async () => {
-    mockPage.evaluate.mockResolvedValueOnce('resolved');
+    mockPage.evaluate.mockResolvedValue('resolved');
 
     const result = await browser.evaluate({ script: 'return await Promise.resolve("resolved")' });
 
@@ -132,7 +132,7 @@ describe('browser_evaluate', () => {
   });
 
   it('returns hint about taking snapshot', async () => {
-    mockPage.evaluate.mockResolvedValueOnce(true);
+    mockPage.evaluate.mockResolvedValue(true);
 
     const result = await browser.evaluate({ script: 'return true' });
 
@@ -141,10 +141,100 @@ describe('browser_evaluate', () => {
   });
 
   it('handles empty script', async () => {
-    mockPage.evaluate.mockResolvedValueOnce(undefined);
+    mockPage.evaluate.mockResolvedValue(undefined);
 
     const result = await browser.evaluate({ script: '' });
 
     expect(result.success).toBe(true);
+  });
+
+  describe('script wrapping', () => {
+    // These tests use a realistic mock that actually evaluates the wrapped
+    // script string, so they verify the wrapping logic produces correct JS.
+    function useRealisticEvaluate() {
+      mockPage.evaluate.mockImplementation((script: string) => {
+        const fn = new Function(`return ${script}`) as () => Promise<unknown>;
+        return fn();
+      });
+    }
+
+    it('returns result from bare expression scripts', async () => {
+      // Models commonly send bare expressions like document.body.innerText
+      // These must produce a return value, not undefined.
+      // We use JSON.stringify here to simulate an expression with method calls,
+      // since document.body isn't available in the Node test environment.
+      useRealisticEvaluate();
+
+      const result = await browser.evaluate({ script: 'JSON.stringify({ a: 1 })' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toBe('{"a":1}');
+      }
+    });
+
+    it('returns result from expression with property access', async () => {
+      useRealisticEvaluate();
+
+      const result = await browser.evaluate({ script: '1 + 41' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toBe(42);
+      }
+    });
+
+    it('returns result from scripts with explicit return', async () => {
+      useRealisticEvaluate();
+
+      const result = await browser.evaluate({ script: 'return 42' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toBe(42);
+      }
+    });
+
+    it('handles multi-statement scripts with explicit return', async () => {
+      useRealisticEvaluate();
+
+      const result = await browser.evaluate({ script: 'const x = 1; const y = 2; return x + y' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toBe(3);
+      }
+    });
+
+    it('handles async expression scripts', async () => {
+      useRealisticEvaluate();
+
+      const result = await browser.evaluate({ script: 'await Promise.resolve("hello")' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toBe('hello');
+      }
+    });
+
+    it('handles scripts that are just a string literal', async () => {
+      useRealisticEvaluate();
+
+      const result = await browser.evaluate({ script: '"hello world"' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toBe('hello world');
+      }
+    });
+
+    it('handles void/side-effect scripts without return', async () => {
+      useRealisticEvaluate();
+
+      const result = await browser.evaluate({ script: 'console.log("hi")' });
+
+      expect(result.success).toBe(true);
+      // Side-effect-only scripts returning undefined is acceptable
+    });
   });
 });

--- a/browser/agent-browser/src/__tests__/evaluate.test.ts
+++ b/browser/agent-browser/src/__tests__/evaluate.test.ts
@@ -43,53 +43,61 @@ describe('browser_evaluate', () => {
     await browser.close();
   });
 
-  it('evaluates script and returns number result', async () => {
+  it('passes script directly to page.evaluate', async () => {
     mockPage.evaluate.mockResolvedValue(42);
 
-    const result = await browser.evaluate({ script: 'return 1 + 41' });
+    await browser.evaluate({ script: '1 + 41' });
+
+    expect(mockPage.evaluate).toHaveBeenCalledWith('1 + 41');
+  });
+
+  it('returns number result', async () => {
+    mockPage.evaluate.mockResolvedValue(42);
+
+    const result = await browser.evaluate({ script: '1 + 41' });
 
     expect(result.success).toBe(true);
     if (result.success) expect(result.result).toBe(42);
   });
 
-  it('evaluates script and returns string result', async () => {
+  it('returns string result', async () => {
     mockPage.evaluate.mockResolvedValue('Hello World');
 
-    const result = await browser.evaluate({ script: 'return "Hello World"' });
+    const result = await browser.evaluate({ script: '"Hello World"' });
 
     expect(result.success).toBe(true);
     if (result.success) expect(result.result).toBe('Hello World');
   });
 
-  it('evaluates script and returns object result', async () => {
+  it('returns object result', async () => {
     const obj = { name: 'John', age: 30 };
     mockPage.evaluate.mockResolvedValue(obj);
 
-    const result = await browser.evaluate({ script: 'return { name: "John", age: 30 }' });
+    const result = await browser.evaluate({ script: '({ name: "John", age: 30 })' });
 
     expect(result.success).toBe(true);
     if (result.success) expect(result.result).toEqual(obj);
   });
 
-  it('evaluates script and returns array result', async () => {
+  it('returns array result', async () => {
     mockPage.evaluate.mockResolvedValue([1, 2, 3]);
 
-    const result = await browser.evaluate({ script: 'return [1, 2, 3]' });
+    const result = await browser.evaluate({ script: '[1, 2, 3]' });
 
     expect(result.success).toBe(true);
     if (result.success) expect(result.result).toEqual([1, 2, 3]);
   });
 
-  it('evaluates script and returns null', async () => {
+  it('returns null', async () => {
     mockPage.evaluate.mockResolvedValue(null);
 
-    const result = await browser.evaluate({ script: 'return null' });
+    const result = await browser.evaluate({ script: 'null' });
 
     expect(result.success).toBe(true);
     if (result.success) expect(result.result).toBeNull();
   });
 
-  it('evaluates script and returns undefined', async () => {
+  it('returns undefined for side-effect scripts', async () => {
     mockPage.evaluate.mockResolvedValue(undefined);
 
     const result = await browser.evaluate({ script: 'console.log("hi")' });
@@ -101,7 +109,7 @@ describe('browser_evaluate', () => {
   it('returns error for syntax errors', async () => {
     mockPage.evaluate.mockRejectedValue(new Error('SyntaxError'));
 
-    const result = await browser.evaluate({ script: 'return {' });
+    const result = await browser.evaluate({ script: '{invalid' });
 
     expect(result.success).toBe(false);
   });
@@ -109,7 +117,7 @@ describe('browser_evaluate', () => {
   it('returns error for runtime errors', async () => {
     mockPage.evaluate.mockRejectedValue(new Error('ReferenceError: x is not defined'));
 
-    const result = await browser.evaluate({ script: 'return x' });
+    const result = await browser.evaluate({ script: 'x' });
 
     expect(result.success).toBe(false);
   });
@@ -122,19 +130,10 @@ describe('browser_evaluate', () => {
     expect(result.success).toBe(false);
   });
 
-  it('handles async scripts', async () => {
-    mockPage.evaluate.mockResolvedValue('resolved');
-
-    const result = await browser.evaluate({ script: 'return await Promise.resolve("resolved")' });
-
-    expect(result.success).toBe(true);
-    if (result.success) expect(result.result).toBe('resolved');
-  });
-
   it('returns hint about taking snapshot', async () => {
     mockPage.evaluate.mockResolvedValue(true);
 
-    const result = await browser.evaluate({ script: 'return true' });
+    const result = await browser.evaluate({ script: 'true' });
 
     expect(result.success).toBe(true);
     if (result.success) expect(result.hint).toContain('snapshot');
@@ -146,95 +145,5 @@ describe('browser_evaluate', () => {
     const result = await browser.evaluate({ script: '' });
 
     expect(result.success).toBe(true);
-  });
-
-  describe('script wrapping', () => {
-    // These tests use a realistic mock that actually evaluates the wrapped
-    // script string, so they verify the wrapping logic produces correct JS.
-    function useRealisticEvaluate() {
-      mockPage.evaluate.mockImplementation((script: string) => {
-        const fn = new Function(`return ${script}`) as () => Promise<unknown>;
-        return fn();
-      });
-    }
-
-    it('returns result from bare expression scripts', async () => {
-      // Models commonly send bare expressions like document.body.innerText
-      // These must produce a return value, not undefined.
-      // We use JSON.stringify here to simulate an expression with method calls,
-      // since document.body isn't available in the Node test environment.
-      useRealisticEvaluate();
-
-      const result = await browser.evaluate({ script: 'JSON.stringify({ a: 1 })' });
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.result).toBe('{"a":1}');
-      }
-    });
-
-    it('returns result from expression with property access', async () => {
-      useRealisticEvaluate();
-
-      const result = await browser.evaluate({ script: '1 + 41' });
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.result).toBe(42);
-      }
-    });
-
-    it('returns result from scripts with explicit return', async () => {
-      useRealisticEvaluate();
-
-      const result = await browser.evaluate({ script: 'return 42' });
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.result).toBe(42);
-      }
-    });
-
-    it('handles multi-statement scripts with explicit return', async () => {
-      useRealisticEvaluate();
-
-      const result = await browser.evaluate({ script: 'const x = 1; const y = 2; return x + y' });
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.result).toBe(3);
-      }
-    });
-
-    it('handles async expression scripts', async () => {
-      useRealisticEvaluate();
-
-      const result = await browser.evaluate({ script: 'await Promise.resolve("hello")' });
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.result).toBe('hello');
-      }
-    });
-
-    it('handles scripts that are just a string literal', async () => {
-      useRealisticEvaluate();
-
-      const result = await browser.evaluate({ script: '"hello world"' });
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.result).toBe('hello world');
-      }
-    });
-
-    it('handles void/side-effect scripts without return', async () => {
-      useRealisticEvaluate();
-
-      const result = await browser.evaluate({ script: 'console.log("hi")' });
-
-      expect(result.success).toBe(true);
-      // Side-effect-only scripts returning undefined is acceptable
-    });
   });
 });

--- a/browser/agent-browser/src/agent-browser.ts
+++ b/browser/agent-browser/src/agent-browser.ts
@@ -1298,8 +1298,13 @@ export class AgentBrowser extends MastraBrowser {
   ): Promise<{ success: true; result: unknown; hint: string } | BrowserToolError> {
     try {
       const page = await this.getPage(threadId);
-      // Wrap script in an async function to allow return statements
-      const wrappedScript = `(async () => { ${input.script} })()`;
+      // If the script already has a return statement, treat it as a function
+      // body. Otherwise treat it as an expression and add an implicit return
+      // so that bare expressions like `document.body.innerText` produce a value.
+      const hasReturn = /\breturn\b/.test(input.script);
+      const wrappedScript = hasReturn
+        ? `(async () => { ${input.script} })()`
+        : `(async () => { return (${input.script}); })()`;
       const result = await page.evaluate(wrappedScript);
 
       return {

--- a/browser/agent-browser/src/agent-browser.ts
+++ b/browser/agent-browser/src/agent-browser.ts
@@ -1298,14 +1298,7 @@ export class AgentBrowser extends MastraBrowser {
   ): Promise<{ success: true; result: unknown; hint: string } | BrowserToolError> {
     try {
       const page = await this.getPage(threadId);
-      // If the script already has a return statement, treat it as a function
-      // body. Otherwise treat it as an expression and add an implicit return
-      // so that bare expressions like `document.body.innerText` produce a value.
-      const hasReturn = /\breturn\b/.test(input.script);
-      const wrappedScript = hasReturn
-        ? `(async () => { ${input.script} })()`
-        : `(async () => { return (${input.script}); })()`;
-      const result = await page.evaluate(wrappedScript);
+      const result = await page.evaluate(input.script);
 
       return {
         success: true,

--- a/browser/agent-browser/src/schemas.ts
+++ b/browser/agent-browser/src/schemas.ts
@@ -208,7 +208,11 @@ export type DragInput = z.output<typeof dragInputSchema>;
  * browser_evaluate - Execute JavaScript in the browser
  */
 export const evaluateInputSchema = z.object({
-  script: z.string().describe('JavaScript code to execute'),
+  script: z
+    .string()
+    .describe(
+      'JavaScript expression to evaluate in the browser and return the result. Do not use `return` — write a bare expression like `document.title` or `1 + 1`. For async code, wrap in an async IIFE: `(async () => { ... })()`.',
+    ),
   arg: z.unknown().optional().describe('Argument to pass to the script (JSON-serializable)'),
 });
 export type EvaluateInput = z.output<typeof evaluateInputSchema>;

--- a/docs/src/content/en/docs/browser/browser-viewer.mdx
+++ b/docs/src/content/en/docs/browser/browser-viewer.mdx
@@ -125,7 +125,7 @@ const viewer = new BrowserViewer({
 | Option | Type | Default | Description |
 | - | - | - | - |
 | `cli` | `'agent-browser' \| 'browser-use' \| 'browse-cli'` | Required | Which CLI the agent uses |
-| `headless` | `boolean` | `true` | Run browser in headless mode |
+| `headless` | `boolean` | `false` | Run browser in headless mode |
 | `cdpUrl` | `string` | — | Connect to an existing browser instead of launching one |
 | `cdpPort` | `number` | `0` (auto) | Port for Chrome remote debugging |
 | `viewport` | `{ width, height }` | `1280×720` | Browser viewport size |

--- a/docs/src/content/en/docs/browser/browser-viewer.mdx
+++ b/docs/src/content/en/docs/browser/browser-viewer.mdx
@@ -125,7 +125,7 @@ const viewer = new BrowserViewer({
 | Option | Type | Default | Description |
 | - | - | - | - |
 | `cli` | `'agent-browser' \| 'browser-use' \| 'browse-cli'` | Required | Which CLI the agent uses |
-| `headless` | `boolean` | `false` | Run browser in headless mode |
+| `headless` | `boolean` | `true` | Run browser in headless mode |
 | `cdpUrl` | `string` | — | Connect to an existing browser instead of launching one |
 | `cdpPort` | `number` | `0` (auto) | Port for Chrome remote debugging |
 | `viewport` | `{ width, height }` | `1280×720` | Browser viewport size |

--- a/docs/src/content/en/reference/browser/browser-viewer.mdx
+++ b/docs/src/content/en/reference/browser/browser-viewer.mdx
@@ -304,7 +304,7 @@ pip install browser-use
 npx skills add browser-use/browser-use --skill browser-use
 ```
 
-### [browse](https://www.npmjs.com/package/@browserbasehq/browse-cli)
+### [browse-cli](https://www.npmjs.com/package/@browserbasehq/browse-cli) (command: `browse`)
 
 Config value: `'browse-cli'` · CDP flag: `--ws`
 

--- a/docs/src/content/en/reference/browser/browser-viewer.mdx
+++ b/docs/src/content/en/reference/browser/browser-viewer.mdx
@@ -61,7 +61,7 @@ When `cdpUrl` is provided, `BrowserViewer` connects to the existing browser inst
     type: 'boolean',
     description: 'Whether to run Chrome in headless mode.',
     isOptional: true,
-    defaultValue: 'true',
+    defaultValue: 'false',
   },
   {
     name: 'cdpUrl',


### PR DESCRIPTION
## Description

**Fix `browser_evaluate` tool returning `undefined` for expression scripts**

The `browser_evaluate` tool wrapped all scripts in an async IIFE without a `return` statement. This meant expression scripts like `document.querySelectorAll("a").length` always resolved to `undefined`, and the `result` field was missing from the tool response. The agent would then hallucinate answers from snapshots instead.

**Fix:** Removed the IIFE wrapping entirely and pass the script directly to Playwright's `page.evaluate()`. Expressions evaluate and return naturally, and there's no wrapping logic to misclassify scripts.

**Improved `browser_evaluate` tool description**

Updated the `script` field description to guide the agent to:
- Send bare expressions (not `return` statements)
- Wrap async code in an async IIFE: `(async () => { ... })()`

Before the description update, the agent took 3 attempts to evaluate `await` expressions (bare `return`, bare `await`, then IIFE). After the update, the agent wraps `await` in an async IIFE on the first try — zero wasted tool calls.

**Docs: fix BrowserViewer `headless` default**

Both the guide and reference docs for BrowserViewer now correctly document `headless` as defaulting to `false`. The core `BrowserConfigBase` defaults to `true`, but `BrowserViewerThreadManager` overrides to `false` since the whole point of BrowserViewer is watching the browser.

**Docs: clarify `browse-cli` naming**

Renamed the `browse` heading in the reference docs to `browse-cli` to match the actual config value.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR