### PR TITLE
fix(scripts): use workflow.createRun() in gh-issue-triage

### DIFF
--- a/scripts/gh-issue-triage/index.ts
+++ b/scripts/gh-issue-triage/index.ts
@@ -76,7 +76,7 @@ async function main() {
 
   const workflow = await mastraClient.getWorkflow('triageWorkflow');
 
-  const run = await workflow.createRunAsync();
+  const run = await workflow.createRun();
 
   const result = await run.startAsync({
     inputData: {


### PR DESCRIPTION
## Description

`scripts/gh-issue-triage/index.ts` calls `workflow.createRunAsync()` on the client-js `Workflow` resource, but that method was renamed back to `createRun()` — `packages/codemod/src/codemods/v1/workflow-create-run-async.ts` is the codemod that applies the same rename to user code. The internal script was missed.

So every new GitHub issue currently fails the `GH_Issue_Triage` workflow with:

    TypeError: workflow.createRunAsync is not a function
      at main (scripts/gh-issue-triage/index.ts:79)

One-line rename.

## Related Issue(s)

Fixes #15700

Example failing run: https://github.com/mastra-ai/mastra/actions/runs/24867240199 (8 consecutive failures with the same TypeError on issues opened 2026-04-23 / 2026-04-24).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
