### PR TITLE
chore(docs): Document Standard JSON Schema

### DIFF
--- a/docs/src/content/en/docs/agents/structured-output.mdx
+++ b/docs/src/content/en/docs/agents/structured-output.mdx
@@ -18,7 +18,7 @@ Use structured output when you need an agent to return a data object rather than
 
 ## Define schemas
 
-Agents can return structured data by defining the expected output with either [Zod](https://zod.dev/) or [JSON Schema](https://json-schema.org/). Zod is recommended because it provides TypeScript type inference and runtime validation, while JSON Schema is useful when you need a language agnostic format.
+Agents can return structured data by defining the expected output with either [Standard JSON Schema](https://standardschema.dev/json-schema) ([Zod](https://zod.dev/), [Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), etc.) or [JSON Schema](https://json-schema.org/). Libraries like Zod are recommended because they provide TypeScript type inference and runtime validation, while JSON Schema is useful when you need a language agnostic format.
 
 <Tabs>
   <TabItem value="zod" label="Zod">
@@ -35,6 +35,49 @@ Agents can return structured data by defining the expected output with either [Z
             activities: z.array(z.string()),
           }),
         ),
+      },
+    })
+
+    console.log(response.object)
+    ```
+  </TabItem>
+
+  <TabItem value="valibot" label="Valibot">
+    Define the `output` shape using [Valibot](https://valibot.dev/):
+
+    ```typescript
+    import * as v from 'valibot'
+    import { toStandardJsonSchema } from '@valibot/to-json-schema'
+
+    const response = await testAgent.generate('Help me plan my day.', {
+      structuredOutput: {
+        schema: toStandardJsonSchema(
+          v.array(
+            v.object({
+              name: v.string(),
+              activities: v.array(v.string()),
+            }),
+          ),
+        ),
+      },
+    })
+
+    console.log(response.object)
+    ```
+  </TabItem>
+
+  <TabItem value="arktype" label="ArkType">
+    Define the `output` shape using [ArkType](https://arktype.io/):
+
+    ```typescript
+    import { type } from 'arktype'
+
+    const response = await testAgent.generate('Help me plan my day.', {
+      structuredOutput: {
+        schema: type({
+          name: 'string',
+          activities: 'string[]',
+        }).array(),
       },
     })
 

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -5,6 +5,9 @@ packages:
   - "@mastra/core"
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 # Tools
 
 Agents use tools to call APIs, query databases, or run custom functions from your codebase. Tools give agents capabilities beyond language generation by providing structured access to data and performing clearly defined operations. You can also load tools from remote [MCP servers](/docs/mcp/overview) to expand an agent's capabilities.
@@ -67,6 +70,80 @@ export const weatherAgent = new Agent({
   tools: { weatherTool },
 })
 ```
+
+## Define schemas
+
+You can define the tool's `inputSchema` and `outputSchema` with any library that supports [Standard JSON Schema](https://standardschema.dev/json-schema). This includes libraries like [Zod](https://zod.dev/), [Valibot](https://valibot.dev/), and [ArkType](https://arktype.io/).
+
+<Tabs>
+  <TabItem value="zod" label="Zod">
+    ```typescript title="src/mastra/tools/weather-tool.ts"
+    import { createTool } from '@mastra/core/tools'
+    import { z } from 'zod'
+
+    export const weatherTool = createTool({
+      id: 'weather-tool',
+      description: 'Fetches weather for a location',
+      inputSchema: z.object({
+        location: z.string(),
+      }),
+      outputSchema: z.object({
+        weather: z.string(),
+      }),
+      execute: async inputData => {
+        // Fetch weather data
+      },
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="valibot" label="Valibot">
+    ```typescript title="src/mastra/tools/weather-tool.ts"
+    import { createTool } from '@mastra/core/tools'
+    import * as v from 'valibot'
+    import { toStandardJsonSchema } from '@valibot/to-json-schema'
+
+    export const weatherTool = createTool({
+      id: 'weather-tool',
+      description: 'Fetches weather for a location',
+      inputSchema: toStandardJsonSchema(
+        v.object({
+          location: v.string(),
+        }),
+      ),
+      outputSchema: toStandardJsonSchema(
+        v.object({
+          weather: v.string(),
+        }),
+      ),
+      execute: async inputData => {
+        // Fetch weather data
+      },
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="arktype" label="ArkType">
+    ```typescript title="src/mastra/tools/weather-tool.ts"
+    import { createTool } from '@mastra/core/tools'
+    import { type } from 'arktype'
+
+    export const weatherTool = createTool({
+      id: 'weather-tool',
+      description: 'Fetches weather for a location',
+      inputSchema: type({
+        location: 'string',
+      }),
+      outputSchema: type({
+        weather: 'string',
+      }),
+      execute: async inputData => {
+        // Fetch weather data
+      },
+    })
+    ```
+  </TabItem>
+</Tabs>
 
 ## Multiple tools
 

--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -412,7 +412,7 @@ Defines how the LLM should analyze the input and what structured output to retur
 The analysis step uses a prompt object to:
 
 - Provide a clear description of the analysis task
-- Define expected output structure with Zod schema (both boolean result and list of gluten sources)
+- Define expected output structure with a Standard JSON Schema (both boolean result and list of gluten sources)
 - Generate dynamic prompts based on the input content
 
 ### Score Generation

--- a/docs/src/content/en/docs/evals/datasets/overview.mdx
+++ b/docs/src/content/en/docs/evals/datasets/overview.mdx
@@ -82,7 +82,7 @@ console.log(dataset.id) // auto-generated UUID
 
 ### Defining schemas
 
-You can enforce the shape of `input` and `groundTruth` by passing Zod schemas. Mastra converts them to JSON Schema at creation time:
+You can enforce the shape of `input` and `groundTruth` by passing a [Standard JSON Schema](https://standardschema.dev/json-schema) ([Zod](https://zod.dev/), [Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), etc.) when creating the dataset:
 
 ```typescript title="src/mastra/datasets/create-with-schema.ts"
 import { z } from 'zod'

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -228,7 +228,7 @@ const paragraphMemory = new Memory({
 
 ## Structured working memory
 
-Working memory can also be defined using a structured schema instead of a Markdown template. This allows you to specify the exact fields and types that should be tracked, using a [Zod](https://zod.dev/) schema. When using a schema, the agent will see and update working memory as a JSON object matching your schema.
+Working memory can also be defined using a structured schema instead of a Markdown template. This allows you to specify the exact fields and types that should be tracked, using a [Standard JSON Schema](https://standardschema.dev/json-schema) ([Zod](https://zod.dev/), [Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), etc.). When using a schema, the agent will see and update working memory as a JSON object matching your schema.
 
 **Important:** You must specify either `template` or `schema`, but not both.
 

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -335,7 +335,7 @@ for (const [key, value] of ctx.entries()) {
 
 ## Schema validation
 
-Use `requestContextSchema` to define a Zod schema that validates request context values at runtime. This catches missing or invalid context values early, provides clear error messages, and gives you type inference within your component.
+Use `requestContextSchema` to define a [Standard JSON Schema](https://standardschema.dev/json-schema) ([Zod](https://zod.dev/), [Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), etc.) that validates request context values at runtime. This catches missing or invalid context values early, provides clear error messages, and gives you type inference within your component.
 
 ### Agent schema validation
 

--- a/docs/src/content/en/docs/workflows/agents-and-tools.mdx
+++ b/docs/src/content/en/docs/workflows/agents-and-tools.mdx
@@ -115,7 +115,7 @@ export const testWorkflow = createWorkflow({})
   .commit()
 ```
 
-The `structuredOutput.schema` option accepts any Zod schema. The agent will generate output conforming to this schema, and the step's `outputSchema` will be automatically set to match.
+The `structuredOutput.schema` option accepts any Standard JSON Schema. The agent will generate output conforming to this schema, and the step's `outputSchema` will be automatically set to match.
 
 :::info
 

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -28,8 +28,8 @@ Watch an introduction to workflows, and how they compare to agents on [YouTube (
 
 Mastra workflows operate using these principles:
 
-- Defining **steps** with `createStep`, specifying input/output schemas and business logic.
-- Composing **steps** with `createWorkflow` to define the execution flow.
+- Defining **steps** with [`createStep`](/reference/workflows/step), specifying input/output schemas and business logic.
+- Composing **steps** with [`createWorkflow`](/reference/workflows/workflow) to define the execution flow.
 - Running **workflows** to execute the entire sequence, with built-in support for suspension, resumption, and streaming results.
 
 ## Creating a workflow step
@@ -64,7 +64,7 @@ The `execute` function defines what the step does. Use it to call functions in y
   </TabItem>
 
   <TabItem value="valibot" label="Valibot">
-    ```typescript {8,11,17} title="src/mastra/workflows/test-workflow.ts"
+    ```typescript {9,14,21} title="src/mastra/workflows/test-workflow.ts"
     import { createStep } from '@mastra/core/workflows'
     import * as v from 'valibot'
     import { toStandardJsonSchema } from '@valibot/to-json-schema'
@@ -131,24 +131,71 @@ Workflow steps can also call registered agents or import and execute tools direc
 
 Create a workflow using `createWorkflow()` with `inputSchema` and `outputSchema` to define the data it accepts and returns. You can define both schemas using [Standard JSON Schema](https://standardschema.dev/json-schema) ([Zod](https://zod.dev/), [Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), etc.). Add steps using `.then()` and complete the workflow with `.commit()`.
 
-```typescript {9,12,15,16} title="src/mastra/workflows/test-workflow.ts" prettier:false
-import { createWorkflow, createStep } from "@mastra/core/workflows";
-import { z } from "zod";
+<Tabs>
+  <TabItem value="zod" label="Zod">
+    ```typescript {9,12,15,16} title="src/mastra/workflows/test-workflow.ts" prettier:false
+    import { createWorkflow, createStep } from "@mastra/core/workflows";
+    import { z } from "zod";
 
-const step1 = createStep({...});
+    const step1 = createStep({...});
 
-export const testWorkflow = createWorkflow({
-  id: "test-workflow",
-  inputSchema: z.object({
-    message: z.string()
-  }),
-  outputSchema: z.object({
-    output: z.string()
-  })
-})
-  .then(step1)
-  .commit();
-```
+    export const testWorkflow = createWorkflow({
+      id: "test-workflow",
+      inputSchema: z.object({
+        message: z.string()
+      }),
+      outputSchema: z.object({
+        output: z.string()
+      })
+    })
+      .then(step1)
+      .commit();
+    ```
+  </TabItem>
+
+  <TabItem value="valibot" label="Valibot">
+    ```typescript {10,13,16,17} title="src/mastra/workflows/test-workflow.ts" prettier:false
+    import { createWorkflow, createStep } from "@mastra/core/workflows";
+    import * as v from "valibot";
+    import { toStandardJsonSchema } from "@valibot/to-json-schema";
+
+    const step1 = createStep({...});
+
+    export const testWorkflow = createWorkflow({
+      id: "test-workflow",
+      inputSchema: toStandardJsonSchema(v.object({
+        message: v.string()
+      })),
+      outputSchema: toStandardJsonSchema(v.object({
+        output: v.string()
+      }))
+    })
+      .then(step1)
+      .commit();
+    ```
+  </TabItem>
+
+  <TabItem value="arktype" label="ArkType">
+    ```typescript {9,12,15,16} title="src/mastra/workflows/test-workflow.ts" prettier:false
+    import { createWorkflow, createStep } from "@mastra/core/workflows";
+    import { type } from "arktype";
+
+    const step1 = createStep({...});
+
+    export const testWorkflow = createWorkflow({
+      id: "test-workflow",
+      inputSchema: type({
+        message: "string"
+      }),
+      outputSchema: type({
+        output: "string"
+      })
+    })
+      .then(step1)
+      .commit();
+    ```
+  </TabItem>
+</Tabs>
 
 :::info
 

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -34,30 +34,88 @@ Mastra workflows operate using these principles:
 
 ## Creating a workflow step
 
-Steps are the building blocks of workflows. Create a step using `createStep()` with `inputSchema` and `outputSchema` to define the data it accepts and returns.
+Steps are the building blocks of workflows. Create a step using `createStep()` with `inputSchema` and `outputSchema` to define the data it accepts and returns. You can define both schemas using [Standard JSON Schema](https://standardschema.dev/json-schema) ([Zod](https://zod.dev/), [Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), etc.).
 
 The `execute` function defines what the step does. Use it to call functions in your codebase, external APIs, agents, or tools.
 
-```typescript {6,9,15} title="src/mastra/workflows/test-workflow.ts"
-import { createStep } from '@mastra/core/workflows'
+<Tabs>
+  <TabItem value="zod" label="Zod">
+    ```typescript {7,10,16} title="src/mastra/workflows/test-workflow.ts"
+    import { createStep } from '@mastra/core/workflows'
+    import { z } from 'zod'
 
-const step1 = createStep({
-  id: 'step-1',
-  inputSchema: z.object({
-    message: z.string(),
-  }),
-  outputSchema: z.object({
-    formatted: z.string(),
-  }),
-  execute: async ({ inputData }) => {
-    const { message } = inputData
+    const step1 = createStep({
+      id: 'step-1',
+      inputSchema: z.object({
+        message: z.string(),
+      }),
+      outputSchema: z.object({
+        formatted: z.string(),
+      }),
+      execute: async ({ inputData }) => {
+        const { message } = inputData
 
-    return {
-      formatted: message.toUpperCase(),
-    }
-  },
-})
-```
+        return {
+          formatted: message.toUpperCase(),
+        }
+      },
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="valibot" label="Valibot">
+    ```typescript {8,11,17} title="src/mastra/workflows/test-workflow.ts"
+    import { createStep } from '@mastra/core/workflows'
+    import * as v from 'valibot'
+    import { toStandardJsonSchema } from '@valibot/to-json-schema'
+
+    const step1 = createStep({
+      id: 'step-1',
+      inputSchema: toStandardJsonSchema(
+        v.object({
+          message: v.string(),
+        }),
+      ),
+      outputSchema: toStandardJsonSchema(
+        v.object({
+          formatted: v.string(),
+        }),
+      ),
+      execute: async ({ inputData }) => {
+        const { message } = inputData
+
+        return {
+          formatted: message.toUpperCase(),
+        }
+      },
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="arktype" label="ArkType">
+    ```typescript {7,10,16} title="src/mastra/workflows/test-workflow.ts"
+    import { createStep } from '@mastra/core/workflows'
+    import { type } from 'arktype'
+
+    const step1 = createStep({
+      id: 'step-1',
+      inputSchema: type({
+        message: 'string',
+      }),
+      outputSchema: type({
+        formatted: 'string',
+      }),
+      execute: async ({ inputData }) => {
+        const { message } = inputData
+
+        return {
+          formatted: message.toUpperCase(),
+        }
+      },
+    })
+    ```
+  </TabItem>
+</Tabs>
 
 :::info
 
@@ -71,7 +129,7 @@ Workflow steps can also call registered agents or import and execute tools direc
 
 ## Creating a workflow
 
-Create a workflow using `createWorkflow()` with `inputSchema` and `outputSchema` to define the data it accepts and returns. Add steps using `.then()` and complete the workflow with `.commit()`.
+Create a workflow using `createWorkflow()` with `inputSchema` and `outputSchema` to define the data it accepts and returns. You can define both schemas using [Standard JSON Schema](https://standardschema.dev/json-schema) ([Zod](https://zod.dev/), [Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), etc.). Add steps using `.then()` and complete the workflow with `.commit()`.
 
 ```typescript {9,12,15,16} title="src/mastra/workflows/test-workflow.ts" prettier:false
 import { createWorkflow, createStep } from "@mastra/core/workflows";

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -226,10 +226,10 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
   },
   {
     name: 'requestContextSchema',
-    type: 'z.ZodType<any>',
+    type: 'StandardJSONSchemaV1',
     isOptional: true,
     description:
-      'Zod schema for validating request context values. When provided, the context is validated at the start of generate() or stream(), throwing a MastraError if validation fails.',
+      'Standard JSON Schema for validating request context values. When provided, the context is validated at the start of generate() or stream(), throwing a MastraError if validation fails.',
   },
 ]}
 />

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -476,9 +476,9 @@ const response = await agent.generate('Help me organize my day', {
                 parameters: [
                   {
                     name: 'schema',
-                    type: 'z.ZodSchema<S>',
+                    type: 'StandardJSONSchemaV1',
                     isOptional: false,
-                    description: 'Zod schema defining the expected output structure.',
+                    description: 'Standard JSON Schema defining the expected output structure.',
                   },
                 ],
               },

--- a/docs/src/content/en/reference/datasets/create.mdx
+++ b/docs/src/content/en/reference/datasets/create.mdx
@@ -9,7 +9,7 @@ packages:
 
 **Added in:** `@mastra/core@1.4.0`
 
-Creates a new dataset. Zod schemas passed as `inputSchema` or `groundTruthSchema` are automatically converted to JSON Schema.
+Creates a new dataset. Use Standard JSON Schema (Zod, Valibot, ArkType, etc.) for defining schemas.
 
 ## Usage example
 
@@ -28,7 +28,7 @@ const dataset = await mastra.datasets.create({
   metadata: { team: 'ml' },
 })
 
-// Create with Zod schemas
+// Create with Zod schema (library that supports Standard JSON Schema)
 const typedDataset = await mastra.datasets.create({
   name: 'Typed QA set',
   inputSchema: z.object({
@@ -58,15 +58,15 @@ const typedDataset = await mastra.datasets.create({
   },
   {
     name: 'inputSchema',
-    type: 'unknown',
+    type: 'StandardJSONSchemaV1',
     isOptional: true,
-    description: 'JSON Schema or Zod schema for item inputs. Zod schemas are auto-converted.',
+    description: 'Standard JSON Schema for item inputs.',
   },
   {
     name: 'groundTruthSchema',
-    type: 'unknown',
+    type: 'StandardJSONSchemaV1',
     isOptional: true,
-    description: 'JSON Schema or Zod schema for item ground truths. Zod schemas are auto-converted.',
+    description: 'Standard JSON Schema for item ground truths.',
   },
   {
     name: 'metadata',

--- a/docs/src/content/en/reference/datasets/update.mdx
+++ b/docs/src/content/en/reference/datasets/update.mdx
@@ -9,7 +9,7 @@ packages:
 
 **Added in:** `@mastra/core@1.4.0`
 
-Updates dataset metadata, name, description, and/or schemas. Zod schemas are automatically converted to JSON Schema.
+Updates dataset metadata, name, description, and/or schemas. Use Standard JSON Schema (Zod, Valibot, ArkType, etc.) for defining schemas.
 
 ## Usage example
 
@@ -29,7 +29,7 @@ const updated = await dataset.update({
   description: 'Revised evaluation set',
 })
 
-// Update with Zod schema (auto-converted to JSON Schema)
+// Update with Zod schema (library that supports Standard JSON Schema)
 const updated2 = await dataset.update({
   inputSchema: z.object({
     question: z.string(),
@@ -62,15 +62,15 @@ const updated2 = await dataset.update({
   },
   {
     name: 'inputSchema',
-    type: 'unknown',
+    type: 'StandardJSONSchemaV1',
     isOptional: true,
-    description: 'JSON Schema or Zod schema for item inputs.',
+    description: 'Standard JSON Schema for item inputs.',
   },
   {
     name: 'groundTruthSchema',
-    type: 'unknown',
+    type: 'StandardJSONSchemaV1',
     isOptional: true,
-    description: 'JSON Schema or Zod schema for item ground truths.',
+    description: 'Standard JSON Schema for item ground truths.',
   },
 ]}
 />

--- a/docs/src/content/en/reference/evals/create-scorer.mdx
+++ b/docs/src/content/en/reference/evals/create-scorer.mdx
@@ -248,9 +248,9 @@ The method can return any value. The returned value will be available to subsequ
   },
   {
     name: 'outputSchema',
-    type: 'ZodSchema',
+    type: 'StandardJSONSchemaV1',
     isOptional: false,
-    description: 'Zod schema for the expected output of the preprocess step.',
+    description: 'Standard JSON Schema for the expected output of the preprocess step.',
   },
   {
     name: 'createPrompt',
@@ -326,9 +326,9 @@ The method can return any value. The returned value will be available to subsequ
   },
   {
     name: 'outputSchema',
-    type: 'ZodSchema',
+    type: 'StandardJSONSchemaV1',
     isOptional: false,
-    description: 'Zod schema for the expected output of the analyze step.',
+    description: 'Standard JSON Schema for the expected output of the analyze step.',
   },
   {
     name: 'createPrompt',
@@ -410,9 +410,9 @@ The method must return a numerical score.
   },
   {
     name: 'outputSchema',
-    type: 'ZodSchema',
+    type: 'StandardJSONSchemaV1',
     isOptional: false,
-    description: 'Zod schema for the expected output of the generateScore step.',
+    description: 'Standard JSON Schema for the expected output of the generateScore step.',
   },
   {
     name: 'createPrompt',

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -71,8 +71,9 @@ await harness.sendMessage({ content: 'Hello!' })
   },
   {
     name: 'stateSchema',
-    type: 'z.ZodObject',
-    description: 'Zod schema defining the shape of harness state. Used for validation and extracting defaults.',
+    type: 'StandardJSONSchemaV1',
+    description:
+      'Standard JSON Schema defining the shape of harness state. Used for validation and extracting defaults.',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -362,9 +362,9 @@ const stream = await agent.stream('message for agent')
                 parameters: [
                   {
                     name: 'schema',
-                    type: 'z.ZodSchema<S>',
+                    type: 'StandardJSONSchemaV1',
                     isOptional: false,
-                    description: 'Zod schema defining the expected output structure.',
+                    description: 'Standard JSON Schema defining the expected output structure.',
                   },
                 ],
               },

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -163,14 +163,14 @@ export const weatherTool = createTool({
   },
   {
     name: 'inputSchema',
-    type: 'Zod schema',
-    description: "A Zod schema defining the expected input parameters for the tool's `execute` function.",
+    type: 'StandardJSONSchemaV1',
+    description: "A Standard JSON Schema defining the expected input parameters for the tool's `execute` function.",
     isOptional: true,
   },
   {
     name: 'outputSchema',
-    type: 'Zod schema',
-    description: "A Zod schema defining the expected output structure of the tool's `execute` function.",
+    type: 'StandardJSONSchemaV1',
+    description: "A Standard JSON Schema defining the expected output structure of the tool's `execute` function.",
     isOptional: true,
   },
   {
@@ -189,16 +189,16 @@ export const weatherTool = createTool({
   },
   {
     name: 'suspendSchema',
-    type: 'Zod schema',
+    type: 'StandardJSONSchemaV1',
     description:
-      'A Zod schema defining the structure of the payload passed to `suspend()`. This payload is returned to the client when the tool suspends execution.',
+      'A Standard JSON Schema defining the structure of the payload passed to `suspend()`. This payload is returned to the client when the tool suspends execution.',
     isOptional: true,
   },
   {
     name: 'resumeSchema',
-    type: 'Zod schema',
+    type: 'StandardJSONSchemaV1',
     description:
-      'A Zod schema defining the expected structure of `resumeData` when the tool is resumed. Used by the agent to extract data from user messages when `autoResumeSuspendedTools` is enabled.',
+      'A Standard JSON Schema defining the expected structure of `resumeData` when the tool is resumed. Used by the agent to extract data from user messages when `autoResumeSuspendedTools` is enabled.',
     isOptional: true,
   },
   {
@@ -217,9 +217,9 @@ export const weatherTool = createTool({
   },
   {
     name: 'requestContextSchema',
-    type: 'Zod schema',
+    type: 'StandardJSONSchemaV1',
     description:
-      'A Zod schema for validating request context values. When provided, the context is validated before execute() runs, returning an error object if validation fails.',
+      'A Standard JSON Schema for validating request context values. When provided, the context is validated before execute() runs, returning an error object if validation fails.',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -34,6 +34,80 @@ export const tool = createTool({
 })
 ```
 
+## Define schemas
+
+You can define the tool's `inputSchema` and `outputSchema` with any library that supports [Standard JSON Schema](https://standardschema.dev/json-schema). This includes libraries like [Zod](https://zod.dev/), [Valibot](https://valibot.dev/), and [ArkType](https://arktype.io/).
+
+<Tabs>
+  <TabItem value="zod" label="Zod">
+    ```typescript title="src/mastra/tools/weather-tool.ts"
+    import { createTool } from '@mastra/core/tools'
+    import { z } from 'zod'
+
+    export const weatherTool = createTool({
+      id: 'weather-tool',
+      description: 'Fetches weather for a location',
+      inputSchema: z.object({
+        location: z.string(),
+      }),
+      outputSchema: z.object({
+        weather: z.string(),
+      }),
+      execute: async inputData => {
+        // Fetch weather data
+      },
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="valibot" label="Valibot">
+    ```typescript title="src/mastra/tools/weather-tool.ts"
+    import { createTool } from '@mastra/core/tools'
+    import * as v from 'valibot'
+    import { toStandardJsonSchema } from '@valibot/to-json-schema'
+
+    export const weatherTool = createTool({
+      id: 'weather-tool',
+      description: 'Fetches weather for a location',
+      inputSchema: toStandardJsonSchema(
+        v.object({
+          location: v.string(),
+        }),
+      ),
+      outputSchema: toStandardJsonSchema(
+        v.object({
+          weather: v.string(),
+        }),
+      ),
+      execute: async inputData => {
+        // Fetch weather data
+      },
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="arktype" label="ArkType">
+    ```typescript title="src/mastra/tools/weather-tool.ts"
+    import { createTool } from '@mastra/core/tools'
+    import { type } from 'arktype'
+
+    export const weatherTool = createTool({
+      id: 'weather-tool',
+      description: 'Fetches weather for a location',
+      inputSchema: type({
+        location: 'string',
+      }),
+      outputSchema: type({
+        weather: 'string',
+      }),
+      execute: async inputData => {
+        // Fetch weather data
+      },
+    })
+    ```
+  </TabItem>
+</Tabs>
+
 ## Example with strict tool inputs
 
 Set `strict: true` when you want Mastra to ask supported model providers to generate tool arguments that exactly match the tool schema.

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -5,6 +5,9 @@ packages:
   - "@mastra/core"
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 # createTool()
 
 The `createTool()` function is used to define custom tools that your Mastra agents can execute. Tools extend an agent's capabilities by allowing it to interact with external systems, perform calculations, or access specific data.

--- a/docs/src/content/en/reference/workflows/step.mdx
+++ b/docs/src/content/en/reference/workflows/step.mdx
@@ -72,7 +72,7 @@ const agentStep = createStep(testAgent, {
   content={[
   {
     name: 'structuredOutput',
-    type: '{ schema: z.ZodType<any> }',
+    type: '{ schema: StandardJSONSchemaV1 }',
     description:
       "When provided, the agent returns structured data matching this schema instead of plain text. The step's outputSchema is set to the provided schema.",
     required: false,
@@ -104,40 +104,40 @@ const agentStep = createStep(testAgent, {
   },
   {
     name: 'inputSchema',
-    type: 'z.ZodType<any>',
-    description: 'Zod schema defining the input structure',
+    type: 'StandardJSONSchemaV1>',
+    description: 'Standard JSON Schema defining the input structure',
     required: true,
   },
   {
     name: 'outputSchema',
-    type: 'z.ZodType<any>',
-    description: 'Zod schema defining the output structure',
+    type: 'StandardJSONSchemaV1>',
+    description: 'Standard JSON Schema defining the output structure',
     required: true,
   },
   {
     name: 'resumeSchema',
-    type: 'z.ZodType<any>',
-    description: 'Optional Zod schema for resuming the step',
+    type: 'StandardJSONSchemaV1>',
+    description: 'Optional Standard JSON Schema for resuming the step',
     required: false,
   },
   {
     name: 'suspendSchema',
-    type: 'z.ZodType<any>',
-    description: 'Optional Zod schema for suspending the step',
+    type: 'StandardJSONSchemaV1>',
+    description: 'Optional Standard JSON Schema for suspending the step',
     required: false,
   },
   {
     name: 'stateSchema',
-    type: 'z.ZodObject<any>',
+    type: 'StandardJSONSchemaV1>',
     description:
-      "Optional Zod schema for the step state. Automatically injected when using Mastra's state system. The stateSchema must be a subset of the workflow's stateSchema. If not specified, type is 'any'.",
+      "Optional Standard JSON Schema for the step state. Automatically injected when using Mastra's state system. The stateSchema must be a subset of the workflow's stateSchema. If not specified, type is 'any'.",
     required: false,
   },
   {
     name: 'requestContextSchema',
-    type: 'z.ZodType<any>',
+    type: 'StandardJSONSchemaV1>',
     description:
-      "Zod schema for validating request context values. When provided, the context is validated before the step's execute() runs, failing the step if validation fails.",
+      "Standard JSON Schema for validating request context values. When provided, the context is validated before the step's execute() runs, failing the step if validation fails.",
     required: false,
   },
   {

--- a/docs/src/content/en/reference/workflows/step.mdx
+++ b/docs/src/content/en/reference/workflows/step.mdx
@@ -5,6 +5,9 @@ packages:
   - "@mastra/core"
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 # Step class
 
 The Step class defines individual units of work within a workflow, encapsulating execution logic, data validation, and input/output handling.
@@ -33,6 +36,89 @@ const step1 = createStep({
   },
 })
 ```
+
+## Define schemas
+
+You can define the step's `inputSchema` and `outputSchema` with any library that supports [Standard JSON Schema](https://standardschema.dev/json-schema). This includes libraries like [Zod](https://zod.dev/), [Valibot](https://valibot.dev/), and [ArkType](https://arktype.io/).
+
+<Tabs>
+  <TabItem value="zod" label="Zod">
+    ```typescript {7,10,16} title="src/mastra/workflows/test-workflow.ts"
+    import { createStep } from '@mastra/core/workflows'
+    import { z } from 'zod'
+
+    const step1 = createStep({
+      id: 'step-1',
+      inputSchema: z.object({
+        message: z.string(),
+      }),
+      outputSchema: z.object({
+        formatted: z.string(),
+      }),
+      execute: async ({ inputData }) => {
+        const { message } = inputData
+
+        return {
+          formatted: message.toUpperCase(),
+        }
+      },
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="valibot" label="Valibot">
+    ```typescript {9,14,21} title="src/mastra/workflows/test-workflow.ts"
+    import { createStep } from '@mastra/core/workflows'
+    import * as v from 'valibot'
+    import { toStandardJsonSchema } from '@valibot/to-json-schema'
+
+    const step1 = createStep({
+      id: 'step-1',
+      inputSchema: toStandardJsonSchema(
+        v.object({
+          message: v.string(),
+        }),
+      ),
+      outputSchema: toStandardJsonSchema(
+        v.object({
+          formatted: v.string(),
+        }),
+      ),
+      execute: async ({ inputData }) => {
+        const { message } = inputData
+
+        return {
+          formatted: message.toUpperCase(),
+        }
+      },
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="arktype" label="ArkType">
+    ```typescript {7,10,16} title="src/mastra/workflows/test-workflow.ts"
+    import { createStep } from '@mastra/core/workflows'
+    import { type } from 'arktype'
+
+    const step1 = createStep({
+      id: 'step-1',
+      inputSchema: type({
+        message: 'string',
+      }),
+      outputSchema: type({
+        formatted: 'string',
+      }),
+      execute: async ({ inputData }) => {
+        const { message } = inputData
+
+        return {
+          formatted: message.toUpperCase(),
+        }
+      },
+    })
+    ```
+  </TabItem>
+</Tabs>
 
 ## Creating steps from agents
 

--- a/docs/src/content/en/reference/workflows/step.mdx
+++ b/docs/src/content/en/reference/workflows/step.mdx
@@ -190,38 +190,38 @@ const agentStep = createStep(testAgent, {
   },
   {
     name: 'inputSchema',
-    type: 'StandardJSONSchemaV1>',
+    type: 'StandardJSONSchemaV1',
     description: 'Standard JSON Schema defining the input structure',
     required: true,
   },
   {
     name: 'outputSchema',
-    type: 'StandardJSONSchemaV1>',
+    type: 'StandardJSONSchemaV1',
     description: 'Standard JSON Schema defining the output structure',
     required: true,
   },
   {
     name: 'resumeSchema',
-    type: 'StandardJSONSchemaV1>',
+    type: 'StandardJSONSchemaV1',
     description: 'Optional Standard JSON Schema for resuming the step',
     required: false,
   },
   {
     name: 'suspendSchema',
-    type: 'StandardJSONSchemaV1>',
+    type: 'StandardJSONSchemaV1',
     description: 'Optional Standard JSON Schema for suspending the step',
     required: false,
   },
   {
     name: 'stateSchema',
-    type: 'StandardJSONSchemaV1>',
+    type: 'StandardJSONSchemaV1',
     description:
       "Optional Standard JSON Schema for the step state. Automatically injected when using Mastra's state system. The stateSchema must be a subset of the workflow's stateSchema. If not specified, type is 'any'.",
     required: false,
   },
   {
     name: 'requestContextSchema',
-    type: 'StandardJSONSchemaV1>',
+    type: 'StandardJSONSchemaV1',
     description:
       "Standard JSON Schema for validating request context values. When provided, the context is validated before the step's execute() runs, failing the step if validation fails.",
     required: false,

--- a/docs/src/content/en/reference/workflows/workflow.mdx
+++ b/docs/src/content/en/reference/workflows/workflow.mdx
@@ -37,26 +37,26 @@ export const workflow = createWorkflow({
   },
   {
     name: 'inputSchema',
-    type: 'z.ZodType<any>',
-    description: 'Zod schema defining the input structure for the workflow',
+    type: 'StandardJSONSchemaV1',
+    description: 'Standard JSON Schema defining the input structure for the workflow',
   },
   {
     name: 'outputSchema',
-    type: 'z.ZodType<any>',
-    description: 'Zod schema defining the output structure for the workflow',
+    type: 'StandardJSONSchemaV1',
+    description: 'Standard JSON Schema defining the output structure for the workflow',
   },
   {
     name: 'stateSchema',
-    type: 'z.ZodObject<any>',
+    type: 'StandardJSONSchemaV1',
     description:
-      "Optional Zod schema for the workflow state. Automatically injected when using Mastra's state system. If not specified, type is 'any'.",
+      "Optional Standard JSON Schema for the workflow state. Automatically injected when using Mastra's state system. If not specified, type is 'any'.",
     isOptional: true,
   },
   {
     name: 'requestContextSchema',
-    type: 'z.ZodType<any>',
+    type: 'StandardJSONSchemaV1',
     description:
-      'Zod schema for validating request context values. When provided, the context is validated at the start of run.start(), throwing an error if validation fails.',
+      'Standard JSON Schema for validating request context values. When provided, the context is validated at the start of run.start(), throwing an error if validation fails.',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/workflows/workflow.mdx
+++ b/docs/src/content/en/reference/workflows/workflow.mdx
@@ -5,6 +5,9 @@ packages:
   - "@mastra/core"
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 # Workflow class
 
 The `Workflow` class enables you to create state machines for complex sequences of operations with conditional branching and data validation.
@@ -25,6 +28,76 @@ export const workflow = createWorkflow({
   }),
 })
 ```
+
+## Define schemas
+
+You can define the workflow's `inputSchema` and `outputSchema` with any library that supports [Standard JSON Schema](https://standardschema.dev/json-schema). This includes libraries like [Zod](https://zod.dev/), [Valibot](https://valibot.dev/), and [ArkType](https://arktype.io/).
+
+<Tabs>
+  <TabItem value="zod" label="Zod">
+    ```typescript {9,12,15,16} title="src/mastra/workflows/test-workflow.ts" prettier:false
+    import { createWorkflow, createStep } from "@mastra/core/workflows";
+    import { z } from "zod";
+
+    const step1 = createStep({...});
+
+    export const testWorkflow = createWorkflow({
+      id: "test-workflow",
+      inputSchema: z.object({
+        message: z.string()
+      }),
+      outputSchema: z.object({
+        output: z.string()
+      })
+    })
+      .then(step1)
+      .commit();
+    ```
+  </TabItem>
+
+  <TabItem value="valibot" label="Valibot">
+    ```typescript {10,13,16,17} title="src/mastra/workflows/test-workflow.ts" prettier:false
+    import { createWorkflow, createStep } from "@mastra/core/workflows";
+    import * as v from "valibot";
+    import { toStandardJsonSchema } from "@valibot/to-json-schema";
+
+    const step1 = createStep({...});
+
+    export const testWorkflow = createWorkflow({
+      id: "test-workflow",
+      inputSchema: toStandardJsonSchema(v.object({
+        message: v.string()
+      })),
+      outputSchema: toStandardJsonSchema(v.object({
+        output: v.string()
+      }))
+    })
+      .then(step1)
+      .commit();
+    ```
+  </TabItem>
+
+  <TabItem value="arktype" label="ArkType">
+    ```typescript {9,12,15,16} title="src/mastra/workflows/test-workflow.ts" prettier:false
+    import { createWorkflow, createStep } from "@mastra/core/workflows";
+    import { type } from "arktype";
+
+    const step1 = createStep({...});
+
+    export const testWorkflow = createWorkflow({
+      id: "test-workflow",
+      inputSchema: type({
+        message: "string"
+      }),
+      outputSchema: type({
+        output: "string"
+      })
+    })
+      .then(step1)
+      .commit();
+    ```
+  </TabItem>
+</Tabs>
 
 ## Constructor parameters
 


### PR DESCRIPTION
## Description

Document that you can use any Standard JSON Schema compatible library with Mastra's schemas.

## Related Issue(s)

Fixes DEVED-199

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR updates Mastra's documentation to clarify that you can use any schema library that follows the Standard JSON Schema format (like Zod, Valibot, or ArkType), not just Zod. It adds examples showing how to use these different libraries throughout the documentation.

## Overview
Updates documentation across the Mastra project to establish Standard JSON Schema as the primary interface for schema definition, replacing Zod-specific references with broader language that acknowledges support for multiple schema libraries implementing the Standard JSON Schema specification.

## Changes by Category

### Core Documentation Files Updated
- **Agents**: Updated `structured-output.mdx` with tabbed examples for Valibot and ArkType alongside Zod; updated `using-tools.mdx` with a new "Define schemas" section showing schema definition patterns for multiple libraries
- **Workflows**: Expanded `overview.mdx` and reference docs to include tabbed examples for Zod, Valibot, and ArkType; updated `agents-and-tools.mdx` and `step.mdx` reference pages
- **Evals**: Updated `custom-scorers.mdx` and `create-scorer.mdx` reference documentation to describe output schemas as Standard JSON Schema
- **Datasets**: Updated `overview.mdx` and `create.mdx`/`update.mdx` reference pages to shift from Zod-only to Standard JSON Schema framing
- **Other Features**: Updated documentation for working memory (`working-memory.mdx`), request context (`request-context.mdx`), harness (`harness-class.mdx`), and tools (`create-tool.mdx`)

### Reference Documentation Updates
- Changed type annotations in API reference docs from `z.ZodType<any>`, `z.ZodObject<any>`, and `z.ZodSchema` to `StandardJSONSchemaV1`
- Updated `Agent` reference pages (`agent.mdx`, `generate.mdx`, `stream.mdx`) to reflect Standard JSON Schema types
- Updated `Tool` reference (`create-tool.mdx`) with schema definition examples and type changes
- Updated `Workflow` and `Step` reference pages with comprehensive examples and type updates

### Documentation Enhancements
- Added tabbed code examples in multiple reference docs showing equivalent schema definitions using Zod, Valibot (with `toStandardJsonSchema` conversion), and ArkType
- Added new "Define schemas" instructional sections in key reference documents

## Scope
- **Files changed**: ~18 documentation files
- **Total lines changed**: ~500 additions, ~100 deletions
- **Type**: Documentation-only (no code changes)
- **Related issue**: DEVED-199

## Assessment
Low-to-medium review effort overall, with most changes being straightforward documentation updates and example additions. Changes are consistent across files and primarily involve:
- Search-and-replace style updates (Zod → Standard JSON Schema)
- Addition of new tabbed example sections
- Type annotation updates in documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->