### PR TITLE
fix(core): match provider-executed tool results by toolName when toolCallId mismatches

### DIFF
--- a/.changeset/fix-file-search-tool-result-match.md
+++ b/.changeset/fix-file-search-tool-result-match.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': patch
+---
+
+fix(core): match provider-executed tool results by toolName when toolCallId mismatches
+
+When server-side tools like Google's `file_search` are combined with function-calling tools,
+the Google AI SDK may assign different `toolCallId` values to the tool-call and tool-result
+chunks. This caused `updateToolInvocation` to drop the result, leaving the stored message
+with an incomplete tool call (state stuck at 'call'). On the next turn, replaying this
+incomplete message to Gemini produces a "Corrupted tool call context" error.
+
+Added a fallback in `updateToolInvocation`: when no exact `toolCallId` match is found, search
+for a provider-executed (`providerExecuted: true`) tool-invocation part with the same
+`toolName` that is still in `state: 'call'`. This safely handles ID mismatches for server-side
+tools without affecting client-executed tools which always have stable IDs.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -763,6 +763,57 @@ export class MessageList {
         }
       }
     }
+    // Fallback: match by toolName for provider-executed tools whose toolCallId may differ
+    // between call and result chunks (e.g. Google AI SDK server tools like file_search).
+    const inputToolName = inputPart.toolInvocation.toolName;
+    if (inputToolName) {
+      for (let m = this.messages.length - 1; m >= 0; m--) {
+        const msg = this.messages[m]!;
+        if (msg.role !== 'assistant' || !msg.content?.parts) continue;
+
+        for (let i = 0; i < msg.content.parts.length; i++) {
+          const part = msg.content.parts[i];
+          if (part?.type !== 'tool-invocation') continue;
+          const partWithMeta = part as typeof part & { providerExecuted?: boolean };
+          if (
+            partWithMeta.providerExecuted === true &&
+            part.toolInvocation?.toolName === inputToolName &&
+            part.toolInvocation?.state === 'call'
+          ) {
+            const originalPart = part as typeof part & { providerExecuted?: boolean; providerMetadata?: unknown };
+            const inputPartWithMeta = inputPart as typeof inputPart & {
+              providerExecuted?: boolean;
+              providerMetadata?: unknown;
+            };
+
+            msg.content.parts[i] = {
+              ...inputPart,
+              toolInvocation: {
+                ...inputPart.toolInvocation,
+                args: part.toolInvocation.args,
+              },
+              ...(originalPart.providerExecuted !== undefined && inputPartWithMeta.providerExecuted === undefined
+                ? { providerExecuted: originalPart.providerExecuted }
+                : {}),
+              ...(originalPart.providerMetadata !== undefined && inputPartWithMeta.providerMetadata === undefined
+                ? { providerMetadata: originalPart.providerMetadata }
+                : {}),
+            };
+
+            if (!this.stateManager.isResponseMessage(msg)) {
+              this.stateManager.removeMessage(msg);
+              this.stateManager.addToSource(msg, 'response');
+            }
+
+            this.logger?.debug?.(
+              `updateToolInvocation: matched provider-executed tool by toolName="${inputToolName}" (toolCallId mismatch: expected="${part.toolInvocation.toolCallId}", got="${toolCallId}")`,
+            );
+            return true;
+          }
+        }
+      }
+    }
+
     this.logger?.warn(`updateToolInvocation: no matching tool call found for toolCallId=${toolCallId}`);
     return false;
   }

--- a/packages/core/src/agent/message-list/tests/update-tool-invocation.test.ts
+++ b/packages/core/src/agent/message-list/tests/update-tool-invocation.test.ts
@@ -542,6 +542,125 @@ describe('MessageList.updateToolInvocation', () => {
     expect(part.providerExecuted).toBe(false);
   });
 
+  it('should match provider-executed tool result by toolName when toolCallId mismatches', () => {
+    const messageList = new MessageList();
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-call-id',
+          toolName: 'file_search',
+          args: { query: 'test' },
+        },
+        providerExecuted: true,
+      } as any,
+    ]);
+    messageList.add(msg, 'response');
+
+    const updated = messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'result',
+        toolCallId: 'tc-different-id',
+        toolName: 'file_search',
+        args: {},
+        result: { content: [{ type: 'text', text: 'found it' }] },
+      },
+    });
+
+    expect(updated).toBe(true);
+
+    const part = msg.content.parts[0] as any;
+    expect(part.toolInvocation.state).toBe('result');
+    expect(part.toolInvocation.result).toEqual({ content: [{ type: 'text', text: 'found it' }] });
+    expect(part.toolInvocation.args).toEqual({ query: 'test' });
+  });
+
+  it('should not use toolName fallback for client-executed tools', () => {
+    const warnFn = vi.fn();
+    const messageList = new MessageList({ logger: { warn: warnFn } as any });
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-call-id',
+          toolName: 'my_tool',
+          args: { x: 1 },
+        },
+        // no providerExecuted or providerExecuted: false
+      } as any,
+    ]);
+    messageList.add(msg, 'response');
+
+    const updated = messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'result',
+        toolCallId: 'tc-different-id',
+        toolName: 'my_tool',
+        args: {},
+        result: 'done',
+      },
+    });
+
+    expect(updated).toBe(false);
+    expect(warnFn).toHaveBeenCalled();
+  });
+
+  it('should match correct tool when multiple pending provider-executed calls exist', () => {
+    const messageList = new MessageList();
+
+    const msg = makeAssistantMessage([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-a',
+          toolName: 'file_search',
+          args: { query: 'first' },
+        },
+        providerExecuted: true,
+      } as any,
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'call',
+          toolCallId: 'tc-b',
+          toolName: 'google_search',
+          args: { query: 'second' },
+        },
+        providerExecuted: true,
+      } as any,
+    ]);
+    messageList.add(msg, 'response');
+
+    const updated = messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'result',
+        toolCallId: 'tc-mismatched',
+        toolName: 'google_search',
+        args: {},
+        result: { data: 'search results' },
+      },
+    });
+
+    expect(updated).toBe(true);
+
+    const parts = msg.content.parts;
+    // file_search should still be pending
+    expect((parts[0] as any).toolInvocation.state).toBe('call');
+    expect((parts[0] as any).toolInvocation.toolName).toBe('file_search');
+    // google_search should be resolved
+    expect((parts[1] as any).toolInvocation.state).toBe('result');
+    expect((parts[1] as any).toolInvocation.toolName).toBe('google_search');
+    expect((parts[1] as any).toolInvocation.result).toEqual({ data: 'search results' });
+  });
+
   it('should allow result to override providerMetadata from original call', () => {
     const messageList = new MessageList();
 


### PR DESCRIPTION
## Fix

Closes #15706

### Problem

When Google's `file_search` (a server-side/provider-executed tool) is combined with any other function-calling tool, `updateToolInvocation` drops the `file_search` results because the `toolCallId` on the result chunk doesn't match the stored call's `toolCallId`. This leaves the assistant message with an incomplete tool call (`state: 'call'`). On the next turn, replaying this to Gemini produces:

```
AI_APICallError: contents[N].parts[0]: Corrupted tool call context.
status: 400 INVALID_ARGUMENT
```

### Root Cause

The Google AI SDK (`@ai-sdk/google`) uses `lastServerToolCallId` to correlate server tool calls with their results. When the API response format changes due to function declarations coexisting with server tools, the `toolCallId` values between `tool-call` and `tool-result` chunks may diverge.

### Solution

Added a fallback in `MessageList.updateToolInvocation()`: when no exact `toolCallId` match is found, search for a provider-executed (`providerExecuted: true`) tool-invocation part with:
1. The same `toolName` as the incoming result
2. Still in `state: 'call'` (hasn't received a result yet)

This safely handles ID mismatches for server-side tools without affecting client-executed tools (which always have stable IDs from the AI SDK).

### Tests

Added 3 new test cases to `update-tool-invocation.test.ts`:
- ✅ Provider-executed tool result matches by `toolName` when `toolCallId` mismatches
- ✅ Fallback does NOT trigger for client-executed tools (preserves existing behavior)
- ✅ Correct tool matched when multiple pending provider-executed calls exist

All 17 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an AI service (like Google) runs a tool internally and sends back the result, it sometimes gives that result a different ID number than expected. This PR fixes that by looking for the tool by its name instead, so the result doesn't get lost. Without this fix, later conversations with the AI would break because the result was never recorded.

## Overview

This PR fixes a bug where tool results from provider-executed tools (such as Google's `file_search`) were being dropped and lost during processing. When the incoming result's `toolCallId` didn't match the stored call's ID—a common occurrence with Google's AI SDK when server-side tools coexist with function-declaration tools—the system logged a warning and discarded the result entirely. This left assistant messages with tool-calls stuck in the `'call'` state, causing subsequent turns to fail with "Corrupted tool call context" errors.

## Changes Made

**Core fix in `message-list.ts`:**
Added a fallback matching mechanism to `updateToolInvocation`. When an exact `toolCallId` match is not found, the method now searches for a provider-executed (`providerExecuted: true`) tool-invocation part that:
- Has the same `toolName` as the incoming result
- Remains in `state: 'call'`

When a match is found, the stored part is updated with the incoming result while preserving any `providerExecuted` flag and `providerMetadata` from the original call if omitted from the incoming chunk. Client-executed tools with stable IDs are not affected by this fallback.

**Test coverage:**
Three new test cases validate the fix:
1. Provider-executed pending tools can be matched and updated by `toolName` even when `toolCallId` mismatches
2. Client-executed pending tools remain unmatched by the fallback, preserving the warning behavior
3. Multiple pending provider-executed calls are correctly disambiguated by `toolName`, with only the matching invocation updated

**Changesets entry:**
Includes a `@mastra/core` patch documenting the fix.

## Result

All 17 tests pass. Tool results from provider-executed services are no longer dropped, allowing subsequent conversation turns to complete successfully without "Corrupted tool call context" errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->