### PR TITLE
fix(cli): remove Prettier from generated project setup

### DIFF
--- a/.changeset/cold-colts-write.md
+++ b/.changeset/cold-colts-write.md
@@ -1,0 +1,8 @@
+---
+'create-mastra': patch
+'mastra': patch
+---
+
+Improved create-mastra dependency installation by installing Mastra runtime packages together, reducing setup time and avoiding stalls between package installs.
+
+Removed Prettier from the CLI install path so generated project setup no longer pulls in the prettier dependency.

--- a/.changeset/cold-colts-write.md
+++ b/.changeset/cold-colts-write.md
@@ -3,6 +3,4 @@
 'mastra': patch
 ---
 
-Improved create-mastra dependency installation by installing Mastra runtime packages together, reducing setup time and avoiding stalls between package installs.
-
 Removed Prettier from the CLI install path so generated project setup no longer pulls in the prettier dependency.

--- a/e2e-tests/create-mastra/create-mastra.test.ts
+++ b/e2e-tests/create-mastra/create-mastra.test.ts
@@ -130,20 +130,18 @@ describe('create mastra', () => {
               "hasDraft": false,
               "id": "weather-agent",
               "inputProcessors": [],
-              "instructions": "
-                You are a helpful weather assistant that provides accurate weather information and can help planning activities based on the weather.
+              "instructions": "You are a helpful weather assistant that provides accurate weather information and can help planning activities based on the weather.
 
-                Your primary function is to help users get weather details for specific locations. When responding:
-                - Always ask for a location if none is provided
-                - If the location name isn't in English, please translate it
-                - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
-                - Include relevant details like humidity, wind conditions, and precipitation
-                - Keep responses concise but informative
-                - If the user asks for activities and provides the weather forecast, suggest activities based on the weather forecast.
-                - If the user asks for activities, respond in the format they request.
+          Your primary function is to help users get weather details for specific locations. When responding:
+          - Always ask for a location if none is provided
+          - If the location name isn't in English, please translate it
+          - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
+          - Include relevant details like humidity, wind conditions, and precipitation
+          - Keep responses concise but informative
+          - If the user asks for activities and provides the weather forecast, suggest activities based on the weather forecast.
+          - If the user asks for activities, respond in the format they request.
 
-                Use the weatherTool to fetch current weather data.
-          ",
+          Use the weatherTool to fetch current weather data.",
               "modelId": "gpt-5-mini",
               "modelVersion": "v2",
               "name": "Weather Agent",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,6 @@
     "openapi-fetch": "^0.17.0",
     "picocolors": "^1.1.1",
     "posthog-node": "5.17.2",
-    "prettier": "^3.8.3",
     "semver": "^7.7.4",
     "serve": "^14.2.6",
     "serve-handler": "^6.1.7",

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -5,7 +5,6 @@ import path from 'node:path';
 import util from 'node:util';
 import * as p from '@clack/prompts';
 import color from 'picocolors';
-import prettier from 'prettier';
 
 import { DepsService } from '../../services/service.deps.js';
 import { getPackageManagerAddCommand } from '../../utils/package-manager.js';
@@ -113,12 +112,7 @@ The [Mastra platform](https://projects.mastra.ai) provides two products for depl
 
 Learn more in the [Mastra platform documentation](https://mastra.ai/docs/mastra-platform/overview).`;
 
-  const formattedContent = await prettier.format(content, {
-    parser: 'markdown',
-    singleQuote: true,
-  });
-
-  await fs.writeFile(readmePath, formattedContent);
+  await fs.writeFile(readmePath, content);
 };
 
 async function installMastraDependency(

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -115,9 +115,9 @@ Learn more in the [Mastra platform documentation](https://mastra.ai/docs/mastra-
   await fs.writeFile(readmePath, content);
 };
 
-async function installMastraDependency(
+async function installMastraDependencies(
   pm: PackageManager,
-  dependency: string,
+  dependencies: string[],
   versionTag: string,
   isDev: boolean,
   timeout?: number,
@@ -132,19 +132,23 @@ async function installMastraDependency(
     installCommand = `${installCommand} -D`;
   }
 
+  const dependenciesWithVersion = dependencies.map(dependency => `${dependency}${versionTag}`).join(' ');
+
   try {
-    await execWithTimeout(`${pm} ${installCommand} ${dependency}${versionTag}`, timeout);
+    await execWithTimeout(`${pm} ${installCommand} ${dependenciesWithVersion}`, timeout);
   } catch (err) {
     if (versionTag === '@latest') {
       throw new Error(
-        `Failed to install ${dependency}@latest: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        `Failed to install ${dependenciesWithVersion}: ${err instanceof Error ? err.message : 'Unknown error'}`,
       );
     }
+
+    const latestDependencies = dependencies.map(dependency => `${dependency}@latest`).join(' ');
     try {
-      await execWithTimeout(`${pm} ${installCommand} ${dependency}@latest`, timeout);
+      await execWithTimeout(`${pm} ${installCommand} ${latestDependencies}`, timeout);
     } catch (fallbackErr) {
       throw new Error(
-        `Failed to install ${dependency} (tried ${versionTag} and @latest): ${fallbackErr instanceof Error ? fallbackErr.message : 'Unknown error'}`,
+        `Failed to install ${dependencies.join(', ')} (tried ${versionTag} and @latest): ${fallbackErr instanceof Error ? fallbackErr.message : 'Unknown error'}`,
       );
     }
   }
@@ -279,7 +283,7 @@ export const createMastraProject = async ({
     const versionTag = createVersionTag ? `@${createVersionTag}` : '@latest';
 
     try {
-      await installMastraDependency(pm, 'mastra', versionTag, true, timeout);
+      await installMastraDependencies(pm, ['mastra'], versionTag, true, timeout);
     } catch (error) {
       throw new Error(`Failed to install Mastra CLI: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
@@ -287,9 +291,13 @@ export const createMastraProject = async ({
 
     s.start('Installing Mastra dependencies');
     try {
-      await installMastraDependency(pm, '@mastra/core', versionTag, false, timeout);
-      await installMastraDependency(pm, '@mastra/libsql', versionTag, false, timeout);
-      await installMastraDependency(pm, '@mastra/memory', versionTag, false, timeout);
+      await installMastraDependencies(
+        pm,
+        ['@mastra/core', '@mastra/libsql', '@mastra/memory'],
+        versionTag,
+        false,
+        timeout,
+      );
     } catch (error) {
       throw new Error(
         `Failed to install Mastra dependencies: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -6,7 +6,6 @@ import * as p from '@clack/prompts';
 import type { ModelRouterModelId } from '@mastra/core/llm/model';
 import fsExtra from 'fs-extra/esm';
 import color from 'picocolors';
-import prettier from 'prettier';
 import shellQuote from 'shell-quote';
 import yoctoSpinner from 'yocto-spinner';
 
@@ -67,35 +66,27 @@ export async function writeAgentSample(
 ) {
   const modelString = getModelIdentifier(llmProvider);
 
-  const instructions = `
-      You are a helpful weather assistant that provides accurate weather information and can help planning activities based on the weather.
+  const instructions = `You are a helpful weather assistant that provides accurate weather information and can help planning activities based on the weather.
 
-      Your primary function is to help users get weather details for specific locations. When responding:
-      - Always ask for a location if none is provided
-      - If the location name isn't in English, please translate it
-      - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
-      - Include relevant details like humidity, wind conditions, and precipitation
-      - Keep responses concise but informative
-      - If the user asks for activities and provides the weather forecast, suggest activities based on the weather forecast.
-      - If the user asks for activities, respond in the format they request.
-
-      ${addExampleTool ? 'Use the weatherTool to fetch current weather data.' : ''}
-`;
-  const content = `
-import { Agent } from '@mastra/core/agent';
-import { Memory } from '@mastra/memory';
-${addExampleTool ? `import { weatherTool } from '../tools/weather-tool';` : ''}
-${addScorers ? `import { scorers } from '../scorers/weather-scorer';` : ''}
-
-export const weatherAgent = new Agent({
-  id: 'weather-agent',
-  name: 'Weather Agent',
-  instructions: \`${instructions}\`,
-  model: '${modelString}',
-  ${addExampleTool ? 'tools: { weatherTool },' : ''}
-  ${
-    addScorers
-      ? `scorers: {
+Your primary function is to help users get weather details for specific locations. When responding:
+- Always ask for a location if none is provided
+- If the location name isn't in English, please translate it
+- If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
+- Include relevant details like humidity, wind conditions, and precipitation
+- Keep responses concise but informative
+- If the user asks for activities and provides the weather forecast, suggest activities based on the weather forecast.
+- If the user asks for activities, respond in the format they request.${addExampleTool ? '\n\nUse the weatherTool to fetch current weather data.' : ''}`;
+  const imports = [
+    `import { Agent } from '@mastra/core/agent';`,
+    `import { Memory } from '@mastra/memory';`,
+    addExampleTool ? `import { weatherTool } from '../tools/weather-tool';` : undefined,
+    addScorers ? `import { scorers } from '../scorers/weather-scorer';` : undefined,
+  ]
+    .filter(Boolean)
+    .join('\n');
+  const toolsConfig = addExampleTool ? `  tools: { weatherTool },\n` : '';
+  const scorersConfig = addScorers
+    ? `  scorers: {
     toolCallAppropriateness: {
       scorer: scorers.toolCallAppropriatenessScorer,
       sampling: {
@@ -117,19 +108,21 @@ export const weatherAgent = new Agent({
         rate: 1,
       },
     },
-  },`
-      : ''
-  }
-  memory: new Memory()
-});
-    `;
-  const formattedContent = await prettier.format(content, {
-    parser: 'typescript',
-    singleQuote: true,
-  });
+  },
+`
+    : '';
+  const content = `${imports}
 
-  await fs.writeFile(destPath, '');
-  await fs.writeFile(destPath, formattedContent);
+export const weatherAgent = new Agent({
+  id: 'weather-agent',
+  name: 'Weather Agent',
+  instructions: \`${instructions}\`,
+  model: '${modelString}',
+${toolsConfig}${scorersConfig}  memory: new Memory(),
+});
+`;
+
+  await fs.writeFile(destPath, content);
 }
 
 export async function writeWorkflowSample(destPath: string) {
@@ -319,13 +312,7 @@ weatherWorkflow.commit();
 
 export { weatherWorkflow };`;
 
-  const formattedContent = await prettier.format(content, {
-    parser: 'typescript',
-    semi: true,
-    singleQuote: true,
-  });
-
-  await fs.writeFile(destPath, formattedContent);
+  await fs.writeFile(destPath, content);
 }
 
 export async function writeToolSample(destPath: string) {
@@ -416,12 +403,7 @@ export const scorers = {
   translationScorer,
 };`;
 
-  const formattedContent = await prettier.format(content, {
-    parser: 'typescript',
-    singleQuote: true,
-  });
-
-  await fs.writeFile(destPath, formattedContent);
+  await fs.writeFile(destPath, content);
 }
 
 export async function writeCodeSampleForComponents(
@@ -1065,12 +1047,8 @@ Learn more in the [MCP Documentation](https://mastra.ai/docs/mcp/overview).
  */
 export async function writeAgentsMarkdown(options: { skills?: string[]; mcpServer?: Editor }): Promise<void> {
   const content = generateAgentsMarkdown(options);
-  const formattedContent = await prettier.format(content, {
-    parser: 'markdown',
-    singleQuote: true,
-  });
   const filePath = path.join(process.cwd(), 'AGENTS.md');
-  await fs.writeFile(filePath, formattedContent);
+  await fs.writeFile(filePath, content);
 }
 
 /**

--- a/packages/create-mastra/package.json
+++ b/packages/create-mastra/package.json
@@ -40,8 +40,7 @@
     "fs-extra": "^11.3.4",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
-    "posthog-node": "^5.28.2",
-    "prettier": "^3.8.3"
+    "posthog-node": "^5.28.2"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/packages/create-mastra/rollup.config.js
+++ b/packages/create-mastra/rollup.config.js
@@ -9,7 +9,7 @@ import esbuild from 'rollup-plugin-esbuild';
 import nodeExternals from 'rollup-plugin-node-externals';
 import pkgJson from './package.json' with { type: 'json' };
 
-const external = ['commander', 'fs-extra', 'execa', 'prettier', 'posthog-node', 'pino', 'pino-pretty'];
+const external = ['commander', 'fs-extra', 'execa', 'posthog-node', 'pino', 'pino-pretty'];
 external.forEach(pkg => {
   if (!pkgJson.dependencies[pkg]) {
     throw new Error(`${pkg} is not in the dependencies of create-mastra`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2904,9 +2904,6 @@ importers:
       posthog-node:
         specifier: 5.17.2
         version: 5.17.2
-      prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
       semver:
         specifier: ^7.7.4
         version: 7.7.4
@@ -3312,9 +3309,6 @@ importers:
       posthog-node:
         specifier: ^5.28.2
         version: 5.28.3(rxjs@7.8.1)
-      prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
     devDependencies:
       '@internal/lint':
         specifier: workspace:*


### PR DESCRIPTION
This removes Prettier from the CLI path used by create/init generated projects and writes the templates directly instead.

Before, the CLI formatted generated files with Prettier during setup, which pulled Prettier into the CLI dependency path.

After, the generated templates are already formatted and written directly. The create flow also installs the Mastra runtime packages together instead of one at a time, which should make setup less likely to stall between installs.

Prettier is 8MB! https://pkg-size.dev/create-mastra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 - Explain Like I'm 5
When you make a new project, the CLI used to run a tool (Prettier) to tidy files which forced Prettier into the CLI. This PR stops running Prettier during project setup by writing already-formatted templates and installs runtime packages in a single batch so creation is smaller, faster, and less likely to stall.

## Changes Overview
Removes Prettier from the CLI/create-mastra runtime path and simplifies project initialization by:
- Removing Prettier from CLI and create-mastra package manifests and build externals.
- Writing pre-formatted template files directly to disk instead of formatting them at runtime.
- Installing Mastra runtime packages in a single batched command (with a retry strategy) rather than one-by-one.
- Updating an e2e snapshot to reflect the new template formatting.
- Adding a Changesets release note explaining the user-facing change.

## Detailed Changes

### Dependency & Build Manifest
- packages/cli/package.json: removed Prettier from runtime dependencies.
- packages/create-mastra/package.json: removed Prettier from runtime dependencies.
- packages/create-mastra/rollup.config.js: removed Prettier from Rollup externals.

### CLI create/init flow
- packages/cli/src/commands/create/utils.ts:
  - Replaced single-package installer with a batched installer that accepts an array of dependencies, attempts install with the chosen version tag, and retries the whole batch with @latest on failure.
  - Updated create flow to use the batched installer for Mastra runtime packages and for the CLI package installation (as arrays).

- packages/cli/src/commands/init/utils.ts:
  - Removed runtime Prettier formatting from template generation paths (README, agent/workflow/scorers samples, agents markdown).
  - Templates are now assembled as strings and written directly to disk (no prettier.format).

### Tests & Release Notes
- e2e-tests/create-mastra/create-mastra.test.ts: updated inline snapshot(s) to match the new pre-formatted templates.
- .changeset/cold-colts-write.md: adds a release note describing that create-mastra/CLI no longer pull Prettier and that Mastra runtime packages are installed in batch.

## Impact
- Smaller CLI install footprint (Prettier removed from published CLI runtime).
- More robust and faster project initialization (no runtime formatting; batched installs with retry reduce chance of stalls).
- Minor test snapshot update to reflect formatting change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->