### PR TITLE
New DatadogBridge that links spans to Datadog's live APM tracing

### DIFF
--- a/.changeset/slow-emus-relate.md
+++ b/.changeset/slow-emus-relate.md
@@ -1,0 +1,32 @@
+---
+'@mastra/datadog': minor
+'@mastra/observability': patch
+---
+
+Added a new `DatadogBridge` integration for Mastra tracing so Datadog can keep auto-instrumented HTTP, database, and framework spans nested under the agent, workflow, model, and tool spans that triggered them.
+
+```typescript
+import tracer from 'dd-trace';
+
+tracer.init({
+  service: process.env.DD_SERVICE || 'my-mastra-app',
+  env: process.env.DD_ENV || 'production',
+});
+
+import { Mastra } from '@mastra/core';
+import { Observability } from '@mastra/observability';
+import { DatadogBridge } from '@mastra/datadog';
+
+const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'my-mastra-app',
+        bridge: new DatadogBridge({
+          mlApp: process.env.DD_LLMOBS_ML_APP!,
+        }),
+      },
+    },
+  }),
+});
+```

--- a/.changeset/tidy-ligers-warn.md
+++ b/.changeset/tidy-ligers-warn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed trace parenting for long-lived MCP Stream connections.

--- a/docs/src/content/en/docs/observability/tracing/bridges/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/bridges/datadog.mdx
@@ -1,0 +1,217 @@
+---
+title: "Datadog bridge | Tracing | Observability"
+description: "Integrate Mastra tracing with Datadog APM and LLM Observability"
+packages:
+  - "@mastra/observability"
+  - "@mastra/datadog"
+---
+
+# Datadog bridge
+
+:::warning
+
+The Datadog Bridge is currently **experimental**. APIs and configuration options may change in future releases.
+
+:::
+
+The Datadog Bridge enables bidirectional integration between Mastra's tracing system and Datadog. Unlike exporters that send trace data after execution completes, the bridge creates native dd-trace spans in real time so that auto-instrumented APM operations (HTTP calls, database queries, etc.) inside your tools and processors are correctly nested under their parent Mastra spans.
+
+:::info Not using dd-trace APM?
+
+If you only need to send LLM Observability data and don't use `dd-trace` APM auto-instrumentation, the [Datadog Exporter](/docs/observability/tracing/exporters/datadog) is simpler — it supports agentless mode and sends spans directly to Datadog without a local agent.
+
+:::
+
+## When to use the bridge
+
+Use the DatadogBridge when you:
+
+- Use `dd-trace` auto-instrumentation in your application (HTTP servers, database clients, etc.)
+- Want APM service calls made by tools, MCP tools, or output processors to appear under their parent Mastra span instead of the request handler
+- Need both APM traces and LLM Observability data to share a consistent trace topology
+- Are building a distributed system where Datadog trace context must propagate across services
+
+## How it works
+
+The DatadogBridge participates in two parts of the dd-trace pipeline:
+
+**APM context propagation (real time):**
+
+- Creates a dd-trace APM span via `tracer.startSpan()` when each Mastra span is created
+- Activates the APM span in dd-trace's scope via `tracer.scope().activate()` during execution
+- Auto-instrumented operations inside the active scope are parented to the correct Mastra span
+- Inherits the active dd-trace context (e.g., an incoming request span) when no explicit Mastra parent exists
+
+**LLM Observability emission (on span end):**
+
+- Emits annotations (model info, token usage, input/output, errors) through `dd-trace`'s LLM Observability pipeline
+- Maintains parent-child relationships in Datadog LLM Observability using nested `llmobs.trace()` calls
+- Reuses the same data shape and span-kind mapping as the [Datadog Exporter](/docs/observability/tracing/exporters/datadog#span-type-mapping)
+
+## Why this matters
+
+Without the bridge, the Datadog Exporter only creates LLM Observability spans after a trace completes. During execution, no `dd-trace` span is active in scope, so any HTTP or database call made by a tool falls back to whatever `dd-trace` span is active at the time — typically the incoming request handler. The result is that service calls from MCP tools or output processors appear as children of the request span instead of the agent or processor span that actually made them.
+
+The bridge fixes this by creating real dd-trace spans up front, so the scope is correct when auto-instrumentation runs.
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/datadog dd-trace
+```
+
+The bridge requires `dd-trace` to be installed and a local Datadog Agent (or compatible OTLP receiver) to receive APM data. See the [APM prerequisites](/docs/observability/tracing/exporters/datadog#prerequisites) on the exporter page for agent setup details.
+
+## Configuration
+
+Using the DatadogBridge requires two steps:
+
+1. Initialize `dd-trace` so its auto-instrumentation patches HTTP, database, and framework libraries
+1. Add the DatadogBridge to your Mastra observability config
+
+### Step 1: Initialize dd-trace
+
+`dd-trace` must be initialized before any other imports so its auto-instrumentation can patch libraries at load time. The bridge will detect an already-initialized tracer and reuse it.
+
+```typescript title="src/mastra/index.ts"
+import tracer from 'dd-trace'
+
+tracer.init({
+  service: process.env.DD_SERVICE || 'my-mastra-app',
+  env: process.env.DD_ENV || 'production',
+  version: process.env.DD_VERSION,
+})
+
+import { Mastra } from '@mastra/core'
+import { Observability } from '@mastra/observability'
+import { DatadogBridge } from '@mastra/datadog'
+
+// ...
+```
+
+:::note
+Import and initialize `dd-trace` before all other modules. If you can't reorder imports, use the `--import` or `--require` Node flag to load a separate initialization file.
+:::
+
+### Step 2: Mastra Configuration
+
+Add the DatadogBridge to your Mastra observability config:
+
+```typescript title="src/mastra/index.ts"
+export const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'my-mastra-app',
+        bridge: new DatadogBridge({
+          mlApp: process.env.DD_LLMOBS_ML_APP!,
+        }),
+      },
+    },
+  }),
+  bundler: {
+    externals: [
+      'dd-trace',
+      '@datadog/native-metrics',
+      '@datadog/native-appsec',
+      '@datadog/native-iast-taint-tracking',
+      '@datadog/pprof',
+    ],
+  },
+})
+```
+
+```bash title=".env"
+DD_SERVICE=my-mastra-app
+DD_ENV=production
+DD_VERSION=1.0.0
+DD_LLMOBS_ML_APP=my-llm-app
+```
+
+When `dd-trace` is initialized, it routes APM data to your local Datadog Agent on `localhost:8126`. The bridge enables LLM Observability on top of the same tracer, so both sets of data appear under the same service in Datadog.
+
+No Mastra exporters are required when using the bridge — both APM and LLM Observability data flow through `dd-trace`. You can still add Mastra exporters if you want to send traces to additional destinations.
+
+## Agent vs. agentless mode
+
+The bridge defaults to **agent mode** (`agentless: false`). This assumes a local Datadog Agent is running on `localhost:8126` to receive both APM and LLM Observability data. This is the typical setup when using `dd-trace` auto-instrumentation, since APM data always routes through the agent.
+
+If you don't have a local Datadog Agent and only need LLM Observability data (no APM auto-instrumentation), you can enable agentless mode to send data directly to Datadog. In this case, you must provide an API key.
+
+```typescript
+new DatadogBridge({
+  mlApp: process.env.DD_LLMOBS_ML_APP!,
+  apiKey: process.env.DD_API_KEY!,
+  agentless: true,
+})
+```
+
+:::note
+For most bridge users, agent mode is the right choice. APM data cannot be sent in agentless mode, so enabling agentless splits LLM Observability traffic away from APM traffic. If you want LLM Observability only without an agent, use the [Datadog Exporter](/docs/observability/tracing/exporters/datadog) instead.
+:::
+
+## Trace hierarchy
+
+With the DatadogBridge, your traces maintain proper hierarchy across dd-trace and Mastra boundaries. Service calls made by tools and processors appear under the correct Mastra span:
+
+```
+HTTP POST /api/chat (from web framework instrumentation)
+└── agent.orchestrator (from Mastra via DatadogBridge)
+    ├── chat gpt-5.4 (LLM call)
+    ├── tool.execute search (tool execution)
+    │   └── HTTP GET api.example.com (auto-instrumented from inside the tool)
+    └── processor.guardrail (output processor)
+        └── HTTP POST guardrail-service/check (auto-instrumented from inside the processor)
+```
+
+In Datadog, the APM trace shows this full topology, and the LLM Observability product shows the agent and LLM-specific spans with their inputs, outputs, and token metrics.
+
+## Span type mapping
+
+The bridge uses the same span-kind mapping as the Datadog Exporter for LLM Observability. See [span type mapping](/docs/observability/tracing/exporters/datadog#span-type-mapping) on the exporter page.
+
+## Using tags
+
+Tags help you categorize and filter traces in Datadog. Add tags when executing agents or workflows:
+
+```typescript
+const result = await agent.generate('Hello', {
+  tracingOptions: {
+    tags: ['production', 'experiment-v2', 'user-request'],
+  },
+})
+```
+
+Tags formatted as `key:value` (e.g., `instance_name:career-scout-api`) are split into structured tag entries; tags without a colon are set with a `true` value.
+
+## Promoting context keys to flat tags
+
+Use `requestContextKeys` to promote specific keys from the request context or span attributes into flat, indexable LLM Observability tags. This makes them filterable in the Datadog UI:
+
+```typescript
+new DatadogBridge({
+  mlApp: process.env.DD_LLMOBS_ML_APP!,
+  requestContextKeys: ['tenantId', 'agentId'],
+})
+```
+
+Promoted keys are removed from `annotations.metadata` and added as flat tags on each LLM Observability span.
+
+## Troubleshooting
+
+If APM spans aren't connecting to Mastra spans as expected:
+
+- Verify `dd-trace` is initialized **before** any other imports (it patches libraries at load time)
+- Verify a local Datadog Agent is running and reachable at `localhost:8126`
+- Ensure the DatadogBridge is set as `bridge` (not as an entry in `exporters`) in your observability config
+- Confirm you haven't also added the `DatadogExporter` to `exporters` — using both will double-emit LLM Observability data
+
+For native-module compatibility issues with `dd-trace` and bundler externals, see the [Datadog exporter troubleshooting](/docs/observability/tracing/exporters/datadog#troubleshooting) section.
+
+## Related
+
+- [Tracing Overview](/docs/observability/tracing/overview)
+- [Datadog Exporter](/docs/observability/tracing/exporters/datadog) - LLM Observability only, no `dd-trace` APM
+- [DatadogBridge Reference](/reference/observability/tracing/bridges/datadog) - API documentation
+- [Datadog APM documentation](https://docs.datadoghq.com/tracing/)
+- [Datadog LLM Observability documentation](https://docs.datadoghq.com/llm_observability/)

--- a/docs/src/content/en/docs/observability/tracing/bridges/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/bridges/datadog.mdx
@@ -90,7 +90,7 @@ import { DatadogBridge } from '@mastra/datadog'
 ```
 
 :::note
-Import and initialize `dd-trace` before all other modules. If you can't reorder imports, use the `--import` or `--require` Node flag to load a separate initialization file.
+Import and initialize `dd-trace` at the very top of your application's entry file, before any other imports.
 :::
 
 ### Step 2: Mastra Configuration

--- a/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/datadog.mdx
@@ -9,6 +9,12 @@ packages:
 
 [Datadog](https://datadoghq.com/) is a comprehensive monitoring platform with dedicated LLM Observability features. The Datadog exporter sends your traces to Datadog's LLM Observability product, providing insights into model performance, token usage, and conversation flows.
 
+:::info Also using `dd-trace` APM?
+
+If you also use `dd-trace` APM auto-instrumentation, consider the [Datadog Bridge](/docs/observability/tracing/bridges/datadog) instead. The bridge creates `dd-trace` spans in real time so HTTP and database calls inside tools and processors are correctly nested under their parent Mastra span. The exporter on its own sends LLM Observability data after execution completes, which means auto-instrumented APM spans fall back to the request handler.
+
+:::
+
 ## Installation
 
 ```bash npm2yarn
@@ -117,7 +123,7 @@ Note: When using agent mode, the API key is read from the local agent's configur
 
 ## Span type mapping
 
-Mastra span types are automatically mapped to Datadog LLMObs span kinds:
+Mastra span types are automatically mapped to Datadog LLM Observability span kinds:
 
 | Mastra SpanType | Datadog Kind |
 | - | - |

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -550,6 +550,11 @@ const sidebars = {
               items: [
                 {
                   type: 'doc',
+                  id: 'observability/tracing/bridges/datadog',
+                  label: 'Datadog',
+                },
+                {
+                  type: 'doc',
                   id: 'observability/tracing/bridges/otel',
                   label: 'OpenTelemetry',
                 },

--- a/docs/src/content/en/reference/observability/tracing/bridges/datadog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/bridges/datadog.mdx
@@ -1,0 +1,319 @@
+---
+title: "Reference: DatadogBridge | Observability"
+description: Datadog bridge for Tracing
+packages:
+  - "@mastra/core"
+  - "@mastra/observability"
+  - "@mastra/datadog"
+---
+
+import PropertiesTable from "@site/src/components/PropertiesTable";
+
+# DatadogBridge
+
+:::warning
+
+The Datadog Bridge is currently **experimental**. APIs and configuration options may change in future releases.
+
+:::
+
+Enables bidirectional integration between Mastra tracing and Datadog. Creates native `dd-trace` APM spans in real time so that auto-instrumented operations inside tools and processors are correctly nested under their parent Mastra span. Emits LLM Observability data through `dd-trace`'s pipeline when spans end.
+
+## Constructor
+
+```typescript prettier:false
+new DatadogBridge(config?: DatadogBridgeConfig)
+```
+
+## `DatadogBridgeConfig`
+
+```typescript
+interface DatadogBridgeConfig extends BaseExporterConfig {
+  apiKey?: string
+  mlApp?: string
+  site?: string
+  service?: string
+  env?: string
+  agentless?: boolean
+  integrationsEnabled?: boolean
+  requestContextKeys?: string[]
+}
+```
+
+Extends `BaseExporterConfig`, which includes:
+
+- `logger?: IMastraLogger` - Logger instance
+- `logLevel?: LogLevel | 'debug' | 'info' | 'warn' | 'error'` - Log level (default: INFO)
+
+<PropertiesTable
+  props={[
+  {
+    name: 'mlApp',
+    type: 'string',
+    description:
+      'ML application name for grouping LLM Observability traces. Required. Falls back to DD_LLMOBS_ML_APP env var.',
+    required: false,
+  },
+  {
+    name: 'apiKey',
+    type: 'string',
+    description: 'Datadog API key. Required only when agentless mode is enabled. Falls back to DD_API_KEY env var.',
+    required: false,
+  },
+  {
+    name: 'site',
+    type: 'string',
+    description:
+      "Datadog site (e.g., 'datadoghq.com', 'datadoghq.eu', 'us3.datadoghq.com'). Falls back to DD_SITE env var. Default: 'datadoghq.com'.",
+    required: false,
+  },
+  {
+    name: 'service',
+    type: 'string',
+    description: 'Service name for the application. Defaults to mlApp value.',
+    required: false,
+  },
+  {
+    name: 'env',
+    type: 'string',
+    description: "Environment name (e.g., 'production', 'staging'). Falls back to DD_ENV env var.",
+    required: false,
+  },
+  {
+    name: 'agentless',
+    type: 'boolean',
+    description:
+      'Use direct HTTPS intake (true) or local Datadog Agent (false). Default: false. Most bridge users should leave this as false because dd-trace APM data always routes through the agent.',
+    required: false,
+  },
+  {
+    name: 'integrationsEnabled',
+    type: 'boolean',
+    description:
+      'Enable dd-trace automatic integrations (HTTP, database, etc.). Default: true. The bridge enables this by default because APM context propagation depends on auto-instrumentation.',
+    required: false,
+  },
+  {
+    name: 'requestContextKeys',
+    type: 'string[]',
+    description:
+      'Keys from request context or span attributes to promote into flat, searchable LLM Observability tags (e.g., tenantId, agentId). Promoted keys are removed from annotations.metadata.',
+    required: false,
+  },
+]}
+/>
+
+## Methods
+
+### `createSpan`
+
+```typescript prettier:false
+createSpan(options: CreateSpanOptions<SpanType>): SpanIds | undefined
+```
+
+Called by the Mastra observability instance during span construction. Creates a dd-trace APM span eagerly via `tracer.startSpan()` and returns Mastra-compatible identifiers. The returned IDs are used by Mastra throughout the span's lifetime; the dd-trace span object is stored internally and used for scope activation.
+
+**Returns:** `SpanIds | undefined` - `{ spanId, traceId, parentSpanId }`, or `undefined` if the bridge is disabled.
+
+### `executeInContext`
+
+```typescript prettier:false
+executeInContext<T>(spanId: string, fn: () => Promise<T>): Promise<T>
+```
+
+Executes an async function within the dd-trace context of a Mastra span. dd-trace auto-instrumented operations running inside the function (HTTP, database, etc.) will be parented to this span.
+
+<PropertiesTable
+  props={[
+  {
+    name: 'spanId',
+    type: 'string',
+    description: 'The ID of the Mastra span to use as context',
+    required: true,
+  },
+  {
+    name: 'fn',
+    type: '() => Promise<T>',
+    description: 'The async function to execute within the span context',
+    required: true,
+  },
+]}
+/>
+
+**Returns:** `Promise<T>` - The result of the function execution.
+
+### `executeInContextSync`
+
+```typescript prettier:false
+executeInContextSync<T>(spanId: string, fn: () => T): T
+```
+
+Executes a synchronous function within the dd-trace context of a Mastra span.
+
+<PropertiesTable
+  props={[
+  {
+    name: 'spanId',
+    type: 'string',
+    description: 'The ID of the Mastra span to use as context',
+    required: true,
+  },
+  {
+    name: 'fn',
+    type: '() => T',
+    description: 'The synchronous function to execute within the span context',
+    required: true,
+  },
+]}
+/>
+
+**Returns:** `T` - The result of the function execution.
+
+### `flush`
+
+```typescript prettier:false
+async flush(): Promise<void>
+```
+
+Force-flushes any buffered LLM Observability data to Datadog without shutting down the bridge. Useful in serverless environments where you need to ensure data is exported before the runtime terminates.
+
+### `shutdown`
+
+```typescript prettier:false
+async shutdown(): Promise<void>
+```
+
+Force-finishes any APM spans that weren't properly closed, flushes pending LLM Observability data, disables the LLM Observability integration, and clears all internal state.
+
+## Usage examples
+
+### Basic Usage
+
+```typescript
+import tracer from 'dd-trace'
+
+tracer.init({
+  service: process.env.DD_SERVICE || 'my-mastra-app',
+  env: process.env.DD_ENV || 'production',
+})
+
+import { Mastra } from '@mastra/core'
+import { Observability } from '@mastra/observability'
+import { DatadogBridge } from '@mastra/datadog'
+
+const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'my-mastra-app',
+        bridge: new DatadogBridge({
+          mlApp: process.env.DD_LLMOBS_ML_APP!,
+        }),
+      },
+    },
+  }),
+  agents: { myAgent },
+})
+```
+
+### Agentless Mode (LLM Observability only, no local agent)
+
+If you don't have a local Datadog Agent and only want LLM Observability data, enable agentless mode:
+
+```typescript
+new DatadogBridge({
+  mlApp: process.env.DD_LLMOBS_ML_APP!,
+  apiKey: process.env.DD_API_KEY!,
+  agentless: true,
+})
+```
+
+Note: APM data cannot be sent in agentless mode. If you only need LLM Observability data without `dd-trace` APM, the [Datadog Exporter](/reference/observability/tracing/exporters/datadog) is a simpler choice.
+
+### With Additional Exporters
+
+The bridge can be combined with non-Datadog exporters to send traces to additional destinations:
+
+```typescript
+import { Observability, DefaultExporter } from '@mastra/observability'
+import { DatadogBridge } from '@mastra/datadog'
+
+const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'my-mastra-app',
+        bridge: new DatadogBridge({
+          mlApp: process.env.DD_LLMOBS_ML_APP!,
+        }),
+        exporters: [
+          new DefaultExporter(), // Studio access
+        ],
+      },
+    },
+  }),
+})
+```
+
+:::note
+Don't combine `DatadogBridge` with `DatadogExporter` in the same configuration — both emit to LLM Observability and would double-write the same data.
+:::
+
+## Setup requirements
+
+The DatadogBridge requires `dd-trace` to be initialized before any other imports so its auto-instrumentation can patch HTTP, database, and framework libraries at load time.
+
+See the [DatadogBridge Guide](/docs/observability/tracing/bridges/datadog#configuration) for complete setup instructions, including dd-trace initialization, bundler externals, and agent configuration.
+
+## Span mapping
+
+Mastra span types are mapped to Datadog LLM Observability span kinds:
+
+| Mastra SpanType | Datadog Kind |
+| - | - |
+| `AGENT_RUN` | `agent` |
+| `MODEL_GENERATION` | `workflow` |
+| `MODEL_STEP` | `llm` |
+| `TOOL_CALL` | `tool` |
+| `MCP_TOOL_CALL` | `tool` |
+| `WORKFLOW_RUN` | `workflow` |
+| All other types | `task` |
+
+## Tags support
+
+Tags supplied via `tracingOptions.tags` are converted into structured LLM Observability annotation tags. Tags formatted as `key:value` are split into separate entries; tags without a colon are set with a `true` value.
+
+```typescript
+const result = await agent.generate('Hello', {
+  tracingOptions: {
+    tags: ['production', 'instance_name:career-scout-api'],
+  },
+})
+```
+
+This produces:
+
+```json
+{
+  "production": true,
+  "instance_name": "career-scout-api"
+}
+```
+
+## Environment variables
+
+The bridge reads configuration from these environment variables:
+
+| Variable | Description |
+| - | - |
+| `DD_API_KEY` | Datadog API key (only required for agentless mode) |
+| `DD_LLMOBS_ML_APP` | ML application name |
+| `DD_SITE` | Datadog site |
+| `DD_ENV` | Environment name |
+| `DD_LLMOBS_AGENTLESS_ENABLED` | Set to `'true'` or `'1'` to enable agentless mode |
+
+## Related
+
+- [DatadogBridge Guide](/docs/observability/tracing/bridges/datadog) - Setup guide with examples
+- [Tracing Overview](/docs/observability/tracing/overview) - General tracing concepts
+- [DatadogExporter Reference](/reference/observability/tracing/exporters/datadog) - LLM Observability only, no `dd-trace` APM

--- a/docs/src/content/en/reference/observability/tracing/bridges/datadog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/bridges/datadog.mdx
@@ -51,7 +51,7 @@ Extends `BaseExporterConfig`, which includes:
     name: 'mlApp',
     type: 'string',
     description:
-      'ML application name for grouping LLM Observability traces. Required. Falls back to DD_LLMOBS_ML_APP env var.',
+      'ML application name for grouping LLM Observability traces. Required if DD_LLMOBS_ML_APP is not set; otherwise falls back to the env var.',
     required: false,
   },
   {
@@ -235,6 +235,7 @@ Note: APM data cannot be sent in agentless mode. If you only need LLM Observabil
 The bridge can be combined with non-Datadog exporters to send traces to additional destinations:
 
 ```typescript
+import { Mastra } from '@mastra/core'
 import { Observability, DefaultExporter } from '@mastra/observability'
 import { DatadogBridge } from '@mastra/datadog'
 
@@ -281,7 +282,7 @@ Mastra span types are mapped to Datadog LLM Observability span kinds:
 
 ## Tags support
 
-Tags supplied via `tracingOptions.tags` are converted into structured LLM Observability annotation tags. Tags formatted as `key:value` are split into separate entries; tags without a colon are set with a `true` value.
+`tracingOptions.tags` values become structured LLM Observability annotation tags: `key:value` entries are split into key/value pairs, and tags without a colon are set to `true`.
 
 ```typescript
 const result = await agent.generate('Hello', {

--- a/docs/src/content/en/reference/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/datadog.mdx
@@ -12,6 +12,10 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 Sends Tracing data to Datadog's LLM Observability product for monitoring and analytics.
 
+:::info
+If you also use `dd-trace` APM auto-instrumentation and need it correctly parented under Mastra spans, use the [DatadogBridge](/reference/observability/tracing/bridges/datadog) instead. The exporter sends LLM Observability data after execution completes, so it doesn't participate in `dd-trace`'s live scope.
+:::
+
 ## Constructor
 
 ```typescript prettier:false
@@ -147,7 +151,7 @@ const exporter = new DatadogExporter({
 
 ## Span mapping
 
-Mastra span types are mapped to Datadog LLMObs span kinds:
+Mastra span types are mapped to Datadog LLM Observability span kinds:
 
 | Mastra SpanType | Datadog Kind |
 | - | - |

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -310,7 +310,10 @@ const sidebars = {
             {
               type: 'category',
               label: 'Bridges',
-              items: [{ type: 'doc', id: 'observability/tracing/bridges/otel', label: 'OtelBridge' }],
+              items: [
+                { type: 'doc', id: 'observability/tracing/bridges/datadog', label: 'DatadogBridge' },
+                { type: 'doc', id: 'observability/tracing/bridges/otel', label: 'OtelBridge' },
+              ],
             },
             {
               type: 'category',

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -1,0 +1,599 @@
+/**
+ * Tests for Datadog Bridge
+ *
+ * Uses mock dd-trace to verify that the bridge keeps a single eager dd span
+ * per Mastra span lifecycle and does not create a second synthetic span tree
+ * via llmobs.trace().
+ */
+
+/// <reference types="node" />
+
+import type {
+  TracingEvent,
+  AnyExportedSpan,
+  CreateSpanOptions,
+  SpanType as SpanTypeGeneric,
+} from '@mastra/core/observability';
+import { SpanType, TracingEventType } from '@mastra/core/observability';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  capturedApmSpans,
+  llmobsRegistrations,
+  mockAnnotate,
+  mockDisable,
+  mockEnable,
+  mockExporterFlush,
+  mockFlush,
+  mockInit,
+  mockLlmobsActivate,
+  mockScopeActivate,
+  mockScopeActive,
+  mockStartSpan,
+  mockTrace,
+} = vi.hoisted(() => {
+  let currentScopeSpan: any = undefined;
+  let apmSpanCounter = 0;
+  let rootTraceCounter = 0;
+
+  const apmSpans: any[] = [];
+  const registrations: Array<{ span: any; options: any }> = [];
+
+  const activate = vi.fn((span: any, fn: () => any) => {
+    const previous = currentScopeSpan;
+    currentScopeSpan = span;
+    try {
+      return fn();
+    } finally {
+      currentScopeSpan = previous;
+    }
+  });
+
+  const active = vi.fn(() => currentScopeSpan);
+
+  const llmobsActivate = vi.fn((span: any, _options: any, fn: () => any) => fn());
+
+  const startSpan = vi.fn((name: string, options?: any) => {
+    apmSpanCounter++;
+
+    const parent = options?.childOf;
+    const spanHex = apmSpanCounter.toString(16).padStart(16, '0');
+    const traceHex = parent?.context?.()?.toTraceId?.(true) ?? (++rootTraceCounter).toString(16).padStart(32, '0');
+
+    const span = {
+      _name: name,
+      _options: options,
+      finish: vi.fn(),
+      setTag: vi.fn(),
+      context: vi.fn(() => ({
+        toSpanId: (_hex?: boolean) => spanHex,
+        toTraceId: (_hex?: boolean) => traceHex,
+      })),
+    };
+
+    apmSpans.push(span);
+    return span;
+  });
+
+  return {
+    capturedApmSpans: apmSpans,
+    llmobsRegistrations: registrations,
+    mockAnnotate: vi.fn(),
+    mockDisable: vi.fn(),
+    mockEnable: vi.fn(),
+    mockExporterFlush: vi.fn((done?: (error?: unknown) => void) => done?.()),
+    mockFlush: vi.fn().mockResolvedValue(undefined),
+    mockInit: vi.fn(),
+    mockLlmobsActivate: llmobsActivate,
+    mockScopeActivate: activate,
+    mockScopeActive: active,
+    mockStartSpan: startSpan,
+    mockTrace: vi.fn(),
+  };
+});
+
+vi.mock('dd-trace', () => {
+  const mockTagger = {
+    registerLLMObsSpan: vi.fn((span: any, options: any) => {
+      llmobsRegistrations.push({ span, options });
+    }),
+  };
+
+  return {
+    default: {
+      init: mockInit,
+      startSpan: mockStartSpan,
+      llmobs: {
+        _tagger: mockTagger,
+        _activate: mockLlmobsActivate,
+        enable: mockEnable,
+        disable: mockDisable,
+        annotate: mockAnnotate,
+        flush: mockFlush,
+        trace: mockTrace,
+      },
+      _tracer: {
+        started: false,
+        _exporter: {
+          flush: mockExporterFlush,
+        },
+      },
+      scope: () => ({
+        activate: mockScopeActivate,
+        active: mockScopeActive,
+      }),
+    },
+  };
+});
+
+import { DatadogBridge } from './bridge';
+
+function createMockSpan(overrides: Partial<AnyExportedSpan> = {}): AnyExportedSpan {
+  return {
+    id: '0000000000000001',
+    traceId: '00000000000000000000000000000001',
+    name: 'test-span',
+    type: SpanType.GENERIC,
+    startTime: new Date('2024-01-01T00:00:00Z'),
+    endTime: new Date('2024-01-01T00:00:01Z'),
+    isEvent: false,
+    isRootSpan: true,
+    ...overrides,
+  } as AnyExportedSpan;
+}
+
+function createTracingEvent(type: TracingEventType, span: AnyExportedSpan): TracingEvent {
+  return { type, exportedSpan: span } as TracingEvent;
+}
+
+function createMockSpanOptions(
+  overrides: Partial<CreateSpanOptions<SpanTypeGeneric>> = {},
+): CreateSpanOptions<SpanTypeGeneric> {
+  return {
+    name: 'test-span',
+    type: SpanType.GENERIC as SpanTypeGeneric,
+    ...overrides,
+  } as CreateSpanOptions<SpanTypeGeneric>;
+}
+
+describe('DatadogBridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedApmSpans.length = 0;
+    llmobsRegistrations.length = 0;
+    mockExporterFlush.mockImplementation((done?: (error?: unknown) => void) => done?.());
+    delete process.env.DD_API_KEY;
+    delete process.env.DD_LLMOBS_ML_APP;
+    delete process.env.DD_SITE;
+    delete process.env.DD_LLMOBS_AGENTLESS_ENABLED;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('configuration', () => {
+    it('initializes with valid config', () => {
+      const bridge = new DatadogBridge({
+        mlApp: 'test-app',
+        apiKey: 'test-key',
+        agentless: true,
+      });
+
+      expect(mockEnable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mlApp: 'test-app',
+          agentlessEnabled: true,
+        }),
+      );
+      expect(bridge.name).toBe('datadog-bridge');
+    });
+
+    it('disables bridge when mlApp is missing', () => {
+      const bridge = new DatadogBridge({});
+      expect(mockEnable).not.toHaveBeenCalled();
+      expect(bridge['isDisabled']).toBe(true);
+    });
+
+    it('disables bridge when agentless mode lacks apiKey', () => {
+      const bridge = new DatadogBridge({
+        mlApp: 'test-app',
+        agentless: true,
+      });
+      expect(mockEnable).not.toHaveBeenCalled();
+      expect(bridge['isDisabled']).toBe(true);
+    });
+  });
+
+  describe('createSpan', () => {
+    it('creates a single eager APM span and returns dd-trace ids', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const result = bridge.createSpan(createMockSpanOptions({ name: 'my-agent' }));
+
+      expect(mockStartSpan).toHaveBeenCalledWith('my-agent', expect.any(Object));
+      expect(result).toEqual({
+        spanId: '0000000000000001',
+        traceId: '00000000000000000000000000000001',
+        parentSpanId: undefined,
+      });
+    });
+
+    it('registers the eager span with the LLMObs tagger', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      bridge.createSpan(createMockSpanOptions({ name: 'my-agent', type: SpanType.AGENT_RUN as SpanTypeGeneric }));
+
+      expect(llmobsRegistrations).toHaveLength(1);
+      expect(llmobsRegistrations[0]?.options).toMatchObject({
+        kind: 'agent',
+        name: 'my-agent',
+      });
+      expect(mockTrace).not.toHaveBeenCalled();
+    });
+
+    it('propagates trace-level user and session context from the root span to descendants', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const rootResult = bridge.createSpan(
+        createMockSpanOptions({
+          name: 'root',
+          metadata: {
+            userId: 'user-123',
+            sessionId: 'session-456',
+          },
+        }),
+      )!;
+
+      bridge.createSpan(
+        createMockSpanOptions({
+          name: 'child',
+          parent: {
+            id: rootResult.spanId,
+            traceId: rootResult.traceId,
+            isInternal: false,
+            metadata: {},
+            getParentSpanId: () => undefined,
+          } as any,
+        }),
+      );
+
+      expect(llmobsRegistrations[1]?.options).toMatchObject({
+        userId: 'user-123',
+        sessionId: 'session-456',
+      });
+    });
+
+    it('uses the parent dd span when creating a child span', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const parentResult = bridge.createSpan(createMockSpanOptions({ name: 'parent' }))!;
+      const parentApmSpan = capturedApmSpans[0];
+      const mockParent = {
+        id: parentResult.spanId,
+        traceId: parentResult.traceId,
+        isInternal: false,
+        metadata: {},
+        getParentSpanId: () => undefined,
+      };
+
+      const childResult = bridge.createSpan(
+        createMockSpanOptions({
+          name: 'child',
+          parent: mockParent as any,
+        }),
+      )!;
+
+      expect(childResult.parentSpanId).toBe(parentResult.spanId);
+      expect(childResult.traceId).toBe(parentResult.traceId);
+      expect(capturedApmSpans[1]._options).toEqual({ childOf: parentApmSpan });
+      expect(llmobsRegistrations[1]?.options.parent).toBe(parentApmSpan);
+    });
+
+    it('falls back to the active dd-trace scope when no explicit parent exists', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const requestSpan = {
+        context: () => ({
+          toSpanId: () => 'aaaaaaaaaaaaaaaa',
+          toTraceId: () => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        }),
+      };
+      mockScopeActive.mockReturnValueOnce(requestSpan);
+
+      const result = bridge.createSpan(createMockSpanOptions())!;
+
+      expect(mockStartSpan).toHaveBeenCalledWith('test-span', { childOf: requestSpan });
+      expect(result.parentSpanId).toBe('aaaaaaaaaaaaaaaa');
+      expect(result.traceId).toBe('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+      expect(llmobsRegistrations[0]?.options.parent).toBeUndefined();
+    });
+
+    it('falls back to the active distributed dd-trace scope when an explicit external parent is missing from the bridge map', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const requestSpan = {
+        context: () => ({
+          toSpanId: () => 'aaaaaaaaaaaaaaaa',
+          toTraceId: () => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        }),
+      };
+      mockScopeActive.mockReturnValueOnce(requestSpan);
+
+      const result = bridge.createSpan(
+        createMockSpanOptions({
+          parent: {
+            id: 'missing-parent-id',
+            traceId: 'cccccccccccccccccccccccccccccccc',
+            isInternal: false,
+            metadata: {},
+            getParentSpanId: () => undefined,
+          } as any,
+        }),
+      )!;
+
+      expect(mockStartSpan).toHaveBeenCalledWith('test-span', { childOf: requestSpan });
+      expect(result.parentSpanId).toBe('aaaaaaaaaaaaaaaa');
+      expect(result.traceId).toBe('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+      expect(llmobsRegistrations[0]?.options.parent).toBe(requestSpan);
+    });
+
+    it('uses the distributed APM parent for LLMObs when an external parent exists but is not in the local bridge map', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const distributedParent = {
+        context: () => ({
+          toSpanId: () => 'aaaaaaaaaaaaaaaa',
+          toTraceId: () => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        }),
+      };
+      mockScopeActive.mockReturnValueOnce(distributedParent);
+
+      bridge.createSpan(
+        createMockSpanOptions({
+          parent: {
+            id: 'missing-parent-id',
+            traceId: 'cccccccccccccccccccccccccccccccc',
+            isInternal: false,
+            metadata: {},
+            getParentSpanId: () => undefined,
+          } as any,
+        }),
+      )!;
+
+      expect(llmobsRegistrations[0]?.options.parent).toBe(distributedParent);
+    });
+
+    it('inherits model info for MODEL_STEP spans from a MODEL_GENERATION parent when needed', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      bridge.createSpan(
+        createMockSpanOptions({
+          name: 'step',
+          type: SpanType.MODEL_STEP as SpanTypeGeneric,
+          parent: {
+            id: 'gen-id',
+            traceId: 'gen-trace',
+            type: SpanType.MODEL_GENERATION,
+            isInternal: false,
+            metadata: {},
+            attributes: { model: 'gpt-5.4', provider: 'openai' },
+            getParentSpanId: () => undefined,
+          } as any,
+        }),
+      );
+
+      expect(llmobsRegistrations[0]?.options).toMatchObject({
+        kind: 'llm',
+        modelName: 'gpt-5.4',
+        modelProvider: 'openai',
+      });
+    });
+  });
+
+  describe('executeInContext', () => {
+    it('activates the eager dd span in scope for async functions', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      await bridge.executeInContext(spanResult.spanId, async () => {});
+
+      expect(mockScopeActivate).toHaveBeenCalledWith(apmSpan, expect.any(Function));
+      expect(mockLlmobsActivate).toHaveBeenCalledWith(apmSpan, undefined, expect.any(Function));
+    });
+
+    it('falls back to direct execution when the span is not in the map', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const result = await bridge.executeInContext('nonexistent-span', async () => 42);
+
+      expect(result).toBe(42);
+      expect(mockScopeActivate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('span lifecycle', () => {
+    it('annotates and finishes the eager dd span on span_ended', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      const span = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+        input: 'hello',
+        output: 'world',
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        apmSpan,
+        expect.objectContaining({
+          inputData: 'hello',
+          outputData: 'world',
+        }),
+      );
+      expect(apmSpan.finish).toHaveBeenCalledWith(span.endTime!.getTime());
+      expect(mockTrace).not.toHaveBeenCalled();
+    });
+
+    it('annotates and finishes event spans on span_started', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      const startTime = new Date('2024-01-01T00:00:00Z');
+      const eventSpan = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+        isEvent: true,
+        startTime,
+        endTime: undefined,
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_STARTED, eventSpan));
+
+      expect(apmSpan.finish).toHaveBeenCalledWith(startTime.getTime());
+      expect(mockTrace).not.toHaveBeenCalled();
+    });
+
+    it('annotates and finishes event spans on span_ended', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      const endTime = new Date('2024-01-01T00:00:05Z');
+      const eventSpan = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+        isEvent: true,
+        output: 'tool-result',
+        endTime,
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, eventSpan));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        apmSpan,
+        expect.objectContaining({
+          outputData: 'tool-result',
+        }),
+      );
+      expect(apmSpan.finish).toHaveBeenCalledWith(endTime.getTime());
+      expect(mockTrace).not.toHaveBeenCalled();
+    });
+
+    it('sets native Datadog error tags before finishing', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      const span = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+        errorInfo: {
+          message: 'Something went wrong',
+          name: 'ValidationError',
+          stack: 'ValidationError: Something went wrong',
+        },
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(apmSpan.setTag).toHaveBeenCalledWith('error', true);
+      expect(apmSpan.setTag).toHaveBeenCalledWith('error.message', 'Something went wrong');
+      expect(apmSpan.setTag).toHaveBeenCalledWith('error.type', 'ValidationError');
+    });
+
+    it('still finishes the eager dd span when LLMObs annotation throws', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      mockAnnotate.mockImplementationOnce(() => {
+        throw new Error('annotation failed');
+      });
+
+      const span = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+        input: { prompt: 'hello' },
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockAnnotate).toHaveBeenCalled();
+      expect(apmSpan.finish).toHaveBeenCalledWith(span.endTime!.getTime());
+    });
+
+    it('promotes requestContextKeys to flat LLMObs tags during annotation', async () => {
+      const bridge = new DatadogBridge({
+        mlApp: 'test',
+        agentless: false,
+        requestContextKeys: ['tenantId'],
+      });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+
+      const span = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+        metadata: { tenantId: 'tenant-123', other: 'value' },
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          metadata: { other: 'value' },
+          tags: { tenantId: 'tenant-123' },
+        }),
+      );
+    });
+
+    it('releases stored trace context after the last span in a trace finishes', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const rootResult = bridge.createSpan(
+        createMockSpanOptions({
+          name: 'root',
+          metadata: {
+            userId: 'user-123',
+            sessionId: 'session-456',
+          },
+        }),
+      )!;
+
+      await bridge.exportTracingEvent(
+        createTracingEvent(
+          TracingEventType.SPAN_ENDED,
+          createMockSpan({
+            id: rootResult.spanId,
+            traceId: rootResult.traceId,
+          }),
+        ),
+      );
+
+      expect(bridge['traceContext'].size).toBe(0);
+      expect(bridge['openSpanCounts'].size).toBe(0);
+    });
+  });
+
+  describe('shutdown', () => {
+    it('force-finishes remaining spans on shutdown', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      bridge.createSpan(createMockSpanOptions({ name: 'orphan-1' }));
+      bridge.createSpan(createMockSpanOptions({ name: 'orphan-2' }));
+
+      await bridge.shutdown();
+
+      expect(capturedApmSpans[0].finish).toHaveBeenCalled();
+      expect(capturedApmSpans[1].finish).toHaveBeenCalled();
+      expect(mockExporterFlush).toHaveBeenCalled();
+      expect(mockDisable).toHaveBeenCalled();
+    });
+  });
+});

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -403,10 +403,30 @@ describe('DatadogBridge', () => {
       expect(mockLlmobsActivate).toHaveBeenCalledWith(apmSpan, undefined, expect.any(Function));
     });
 
+    it('activates the eager dd span in scope for sync functions', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(createMockSpanOptions())!;
+      const apmSpan = capturedApmSpans[0];
+
+      bridge.executeInContextSync(spanResult.spanId, () => {});
+
+      expect(mockScopeActivate).toHaveBeenCalledWith(apmSpan, expect.any(Function));
+      expect(mockLlmobsActivate).toHaveBeenCalledWith(apmSpan, undefined, expect.any(Function));
+    });
+
     it('falls back to direct execution when the span is not in the map', async () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
 
       const result = await bridge.executeInContext('nonexistent-span', async () => 42);
+
+      expect(result).toBe(42);
+      expect(mockScopeActivate).not.toHaveBeenCalled();
+    });
+
+    it('falls back to direct sync execution when the span is not in the map', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      const result = bridge.executeInContextSync('nonexistent-span', () => 42);
 
       expect(result).toBe(42);
       expect(mockScopeActivate).not.toHaveBeenCalled();

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -1,0 +1,669 @@
+/**
+ * Datadog Bridge for Mastra Observability
+ *
+ * This bridge enables bidirectional integration with dd-trace:
+ * 1. Creates real dd-trace APM spans eagerly when Mastra spans are created
+ * 2. Activates spans in dd-trace's scope so auto-instrumented operations
+ *    (HTTP requests, database queries, etc.) have correct parent spans
+ * 3. Registers those same spans with Datadog LLMObs and annotates them
+ *    before finish, avoiding a second synthetic APM span tree
+ *
+ * This fixes the core problem with the DatadogExporter: because the exporter
+ * creates LLMObs spans retroactively (after execution completes), there is no
+ * active dd-trace span in scope when tools and processors make outbound calls.
+ * dd-trace's auto-instrumentation can't find the correct parent, so APM spans
+ * fall back to the nearest active span (typically the request handler).
+ */
+
+import type {
+  TracingEvent,
+  AnyExportedSpan,
+  ModelGenerationAttributes,
+  ModelStepAttributes,
+  ObservabilityBridge,
+  CreateSpanOptions,
+  SpanType,
+  SpanIds,
+} from '@mastra/core/observability';
+import { SpanType as SpanTypeEnum } from '@mastra/core/observability';
+import { omitKeys } from '@mastra/core/utils';
+import { BaseExporter, getExternalParentId } from '@mastra/observability';
+import type { BaseExporterConfig } from '@mastra/observability';
+import tracer from 'dd-trace';
+import { formatUsageMetrics } from './metrics';
+import { ensureTracer, formatInput, formatOutput, kindFor, toDate } from './utils';
+import type { DatadogSpanKind } from './utils';
+
+type LLMObsTagger = {
+  registerLLMObsSpan: (
+    span: any,
+    options: {
+      parent?: any;
+      kind: DatadogSpanKind;
+      name: string;
+      userId?: string;
+      sessionId?: string;
+      modelName?: string;
+      modelProvider?: string;
+    },
+  ) => void;
+};
+
+type LLMObsInternalApi = {
+  _activate?: <T>(span: any, options: Record<string, never> | undefined, fn: () => T) => T;
+};
+
+interface TraceContext {
+  userId?: string;
+  sessionId?: string;
+}
+
+function flushApmExporter(): Promise<void> {
+  const exporterFlush = (tracer as any)?._tracer?._exporter?.flush;
+  if (typeof exporterFlush !== 'function') {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const done = (error?: unknown) => {
+      if (settled) return;
+      settled = true;
+
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    };
+
+    try {
+      exporterFlush.call((tracer as any)._tracer._exporter, done);
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+/**
+ * Configuration options for the Datadog Bridge.
+ */
+export interface DatadogBridgeConfig extends BaseExporterConfig {
+  /**
+   * Datadog API key. Required in agentless mode.
+   * Falls back to DD_API_KEY environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * ML application name for grouping traces.
+   * Required - falls back to DD_LLMOBS_ML_APP environment variable.
+   */
+  mlApp?: string;
+
+  /**
+   * Datadog site (e.g., 'datadoghq.com', 'datadoghq.eu').
+   * Falls back to DD_SITE environment variable, defaults to 'datadoghq.com'.
+   */
+  site?: string;
+
+  /**
+   * Service name for the application.
+   * Falls back to mlApp if not specified.
+   */
+  service?: string;
+
+  /**
+   * Environment name (e.g., 'production', 'staging').
+   * Falls back to DD_ENV environment variable.
+   */
+  env?: string;
+
+  /**
+   * Use agentless mode (direct HTTPS intake without a local Datadog Agent).
+   *
+   * Defaults to `false` for the bridge — most users running dd-trace
+   * auto-instrumentation already have a local Datadog Agent (required for
+   * APM data). Agentless mode only routes LLMObs data directly to Datadog
+   * intake, which would split your APM and LLMObs telemetry across two
+   * paths.
+   *
+   * Set to `true` if you only want LLMObs data (no APM auto-instrumentation)
+   * and don't have a local Datadog Agent. Falls back to the
+   * `DD_LLMOBS_AGENTLESS_ENABLED` environment variable.
+   */
+  agentless?: boolean;
+
+  /**
+   * Enable dd-trace automatic integrations (HTTP, database, etc.).
+   * Defaults to true since the bridge is designed for APM integration.
+   */
+  integrationsEnabled?: boolean;
+
+  /**
+   * Keys from the request context that should be promoted to flat Datadog
+   * LLM Observability tags instead of being nested in annotations.metadata.
+   */
+  requestContextKeys?: string[];
+}
+
+/**
+ * Datadog Bridge for Mastra Observability.
+ *
+ * Creates native dd-trace spans in real time during execution for proper APM
+ * context propagation, and uses the same live dd span for Datadog LLMObs
+ * tagging and annotations.
+ */
+export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
+  name = 'datadog-bridge';
+
+  private config: Required<Pick<DatadogBridgeConfig, 'mlApp' | 'site'>> & DatadogBridgeConfig;
+  private ddSpanMap = new Map<string, any>();
+  private traceContext = new Map<string, TraceContext>();
+  private openSpanCounts = new Map<string, number>();
+
+  constructor(config: DatadogBridgeConfig = {}) {
+    super(config);
+
+    const mlApp = config.mlApp ?? process.env.DD_LLMOBS_ML_APP;
+    const apiKey = config.apiKey ?? process.env.DD_API_KEY;
+    const site = config.site ?? process.env.DD_SITE ?? 'datadoghq.com';
+    const env = config.env ?? process.env.DD_ENV;
+
+    // Default to false for the bridge — assume a local Datadog Agent is
+    // present (required for the APM auto-instrumentation the bridge enables)
+    const envAgentless = process.env.DD_LLMOBS_AGENTLESS_ENABLED?.toLowerCase();
+    const agentless = config.agentless ?? (envAgentless === 'true' || envAgentless === '1' ? true : false);
+    if (!mlApp) {
+      this.setDisabled(`Missing required mlApp. Set DD_LLMOBS_ML_APP environment variable or pass mlApp in config.`);
+      this.config = config as any;
+      return;
+    }
+
+    if (agentless && !apiKey) {
+      this.setDisabled(
+        `Missing required apiKey for agentless mode. Set DD_API_KEY environment variable or pass apiKey in config.`,
+      );
+      this.config = config as any;
+      return;
+    }
+
+    this.config = { ...config, mlApp, site, apiKey, agentless, env };
+
+    ensureTracer({
+      mlApp,
+      site,
+      apiKey,
+      agentless,
+      service: config.service,
+      env,
+      integrationsEnabled: config.integrationsEnabled ?? true,
+    });
+
+    this.logger.info('Datadog bridge initialized', { mlApp, site, agentless });
+  }
+
+  /**
+   * Create a dd-trace span eagerly when a Mastra span is constructed.
+   */
+  createSpan(options: CreateSpanOptions<SpanType>): SpanIds | undefined {
+    if (this.isDisabled) return undefined;
+
+    try {
+      let apmParentDdSpan: any = undefined;
+      let llmobsParentDdSpan: any = undefined;
+      let parentSource: 'external-parent' | 'active-scope' | 'none' = 'none';
+
+      const externalParentId = getExternalParentId(options);
+      if (externalParentId) {
+        apmParentDdSpan = this.ddSpanMap.get(externalParentId);
+        llmobsParentDdSpan = apmParentDdSpan;
+        if (apmParentDdSpan) {
+          parentSource = 'external-parent';
+        }
+      }
+
+      if (!apmParentDdSpan && externalParentId) {
+        apmParentDdSpan = tracer.scope().active() ?? undefined;
+        if (apmParentDdSpan) {
+          parentSource = 'active-scope';
+        }
+      }
+
+      if (!apmParentDdSpan && !externalParentId) {
+        apmParentDdSpan = tracer.scope().active() ?? undefined;
+        if (apmParentDdSpan) {
+          parentSource = 'active-scope';
+        }
+      }
+
+      if (!llmobsParentDdSpan && externalParentId) {
+        llmobsParentDdSpan = apmParentDdSpan;
+      }
+
+      const ddSpan = tracer.startSpan(options.name, {
+        ...(apmParentDdSpan ? { childOf: apmParentDdSpan } : {}),
+        ...(options.startTime ? { startTime: toDate(options.startTime).getTime() } : {}),
+      });
+
+      const ddContext = ddSpan.context?.() as
+        | {
+            toSpanId?: (hex?: boolean) => string;
+            toTraceId?: (hex?: boolean) => string;
+          }
+        | undefined;
+      const spanId = ddContext?.toSpanId?.(true) ?? generateSpanId();
+      const traceId =
+        ddContext?.toTraceId?.(true) ??
+        (externalParentId ? (options.parent?.traceId ?? generateTraceId()) : generateTraceId());
+      const parentContext = apmParentDdSpan?.context?.() as { toSpanId?: (hex?: boolean) => string } | undefined;
+      const parentSpanId = parentContext?.toSpanId?.(true) ?? externalParentId;
+
+      this.captureTraceContext(traceId, options);
+      this.openSpanCounts.set(traceId, (this.openSpanCounts.get(traceId) ?? 0) + 1);
+      this.ddSpanMap.set(spanId, ddSpan);
+      this.registerLlmObsSpan(ddSpan, traceId, options, llmobsParentDdSpan);
+
+      this.logger.debug(
+        `[DatadogBridge.createSpan] Created APM span [spanId=${spanId}] [traceId=${traceId}] ` +
+          `[parentSpanId=${parentSpanId}] [type=${options.type}] [mapSize=${this.ddSpanMap.size}] ` +
+          `[parentSource=${parentSource}] [externalParentId=${externalParentId ?? 'none'}]`,
+      );
+
+      return { spanId, traceId, parentSpanId };
+    } catch (error) {
+      this.logger.error('[DatadogBridge] Failed to create span:', error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Execute an async function within the dd-trace context of a Mastra span.
+   */
+  executeInContext<T>(spanId: string, fn: () => Promise<T>): Promise<T> {
+    return this.executeWithSpanContext(spanId, fn);
+  }
+
+  /**
+   * Execute a synchronous function within the dd-trace context of a Mastra span.
+   */
+  executeInContextSync<T>(spanId: string, fn: () => T): T {
+    return this.executeWithSpanContext(spanId, fn);
+  }
+
+  private executeWithSpanContext<T>(spanId: string, fn: () => T): T {
+    const ddSpan = this.ddSpanMap.get(spanId);
+
+    if (ddSpan) {
+      return tracer.scope().activate(ddSpan, () => {
+        const llmobs = (tracer as any).llmobs as LLMObsInternalApi | undefined;
+        if (typeof llmobs?._activate === 'function') {
+          return llmobs._activate(ddSpan, undefined, fn);
+        }
+
+        return fn();
+      });
+    }
+
+    return fn();
+  }
+
+  /**
+   * Handle tracing events from the observability bus.
+   */
+  protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
+    if (this.isDisabled) return;
+
+    try {
+      const span = event.exportedSpan;
+
+      if (span.isEvent) {
+        if (event.type === 'span_started' || event.type === 'span_ended') {
+          this.annotateAndFinishSpan(span);
+        }
+        return;
+      }
+
+      switch (event.type) {
+        case 'span_started':
+        case 'span_updated':
+          return;
+        case 'span_ended':
+          this.annotateAndFinishSpan(span);
+          return;
+      }
+    } catch (error) {
+      this.logger.error('Datadog bridge error', {
+        error,
+        eventType: event.type,
+        spanId: event.exportedSpan?.id,
+        spanName: event.exportedSpan?.name,
+      });
+    }
+  }
+
+  private registerLlmObsSpan(
+    ddSpan: any,
+    traceId: string,
+    options: CreateSpanOptions<SpanType>,
+    parentDdSpan?: any,
+  ): void {
+    const tagger = this.getLlmObsTagger();
+    if (!tagger) return;
+
+    try {
+      const kind = kindFor(options.type);
+      const ownAttrs = options.attributes as ModelGenerationAttributes | undefined;
+      const inheritedModelAttrs =
+        options.parent?.type === SpanTypeEnum.MODEL_GENERATION
+          ? (options.parent.attributes as ModelGenerationAttributes | undefined)
+          : undefined;
+      const traceCtx = this.resolveTraceContext(traceId, options);
+
+      tagger.registerLLMObsSpan(ddSpan, {
+        parent: parentDdSpan,
+        kind,
+        name: options.name,
+        userId: traceCtx.userId,
+        sessionId: traceCtx.sessionId,
+        ...(kind === 'llm' && (ownAttrs?.model ?? inheritedModelAttrs?.model)
+          ? { modelName: ownAttrs?.model ?? inheritedModelAttrs?.model }
+          : {}),
+        ...(kind === 'llm' && (ownAttrs?.provider ?? inheritedModelAttrs?.provider)
+          ? { modelProvider: ownAttrs?.provider ?? inheritedModelAttrs?.provider }
+          : {}),
+      });
+    } catch (error) {
+      this.logger.warn('[DatadogBridge] Failed to register LLMObs span', {
+        error,
+        spanName: options.name,
+        spanType: options.type,
+      });
+    }
+  }
+
+  private getLlmObsTagger(): LLMObsTagger | undefined {
+    const tagger = (tracer as any).llmobs?._tagger;
+    if (tagger && typeof tagger.registerLLMObsSpan === 'function') {
+      return tagger as LLMObsTagger;
+    }
+    return undefined;
+  }
+
+  /**
+   * Annotate the eagerly-created dd span and finish it using the final Mastra
+   * span state.
+   */
+  private annotateAndFinishSpan(span: AnyExportedSpan): void {
+    const ddSpan = this.ddSpanMap.get(span.id);
+    if (!ddSpan) {
+      this.logger.warn('[DatadogBridge] No dd span found when finalizing Mastra span', {
+        spanId: span.id,
+        spanName: span.name,
+        spanType: span.type,
+        mapSize: this.ddSpanMap.size,
+      });
+      return;
+    }
+
+    const endTime = span.endTime ? toDate(span.endTime) : span.isEvent ? toDate(span.startTime) : new Date();
+
+    const annotations = this.buildAnnotations(span);
+
+    try {
+      if (Object.keys(annotations).length > 0 && tracer.llmobs?.annotate) {
+        tracer.llmobs.annotate(ddSpan, annotations);
+      }
+    } catch (error) {
+      this.logger.error('[DatadogBridge] Failed to annotate span before finish', {
+        error,
+        spanId: span.id,
+        spanName: span.name,
+      });
+    }
+
+    try {
+      if (span.errorInfo) {
+        this.setErrorTags(ddSpan, span.errorInfo);
+      }
+    } catch (error) {
+      this.logger.error('[DatadogBridge] Failed to set error tags on dd span', {
+        error,
+        spanId: span.id,
+        spanName: span.name,
+      });
+    }
+
+    try {
+      if (typeof ddSpan.finish === 'function') {
+        ddSpan.finish(endTime.getTime());
+      }
+    } catch (error) {
+      this.logger.error('[DatadogBridge] Failed to finish dd span', {
+        error,
+        spanId: span.id,
+        spanName: span.name,
+      });
+    } finally {
+      this.ddSpanMap.delete(span.id);
+      this.releaseTraceContext(span.traceId);
+    }
+  }
+
+  private captureTraceContext(traceId: string, options: CreateSpanOptions<SpanType>): void {
+    const existing = this.traceContext.get(traceId);
+    const next: TraceContext = {
+      userId: firstString(options.metadata?.userId, options.parent?.metadata?.userId, existing?.userId),
+      sessionId: firstString(options.metadata?.sessionId, options.parent?.metadata?.sessionId, existing?.sessionId),
+    };
+
+    if (next.userId || next.sessionId) {
+      this.traceContext.set(traceId, next);
+    }
+  }
+
+  private resolveTraceContext(traceId: string, options: CreateSpanOptions<SpanType>): TraceContext {
+    const stored = this.traceContext.get(traceId);
+    return {
+      userId: firstString(options.metadata?.userId, options.parent?.metadata?.userId, stored?.userId),
+      sessionId: firstString(options.metadata?.sessionId, options.parent?.metadata?.sessionId, stored?.sessionId),
+    };
+  }
+
+  private releaseTraceContext(traceId: string): void {
+    const nextCount = (this.openSpanCounts.get(traceId) ?? 1) - 1;
+    if (nextCount > 0) {
+      this.openSpanCounts.set(traceId, nextCount);
+      return;
+    }
+
+    this.openSpanCounts.delete(traceId);
+    this.traceContext.delete(traceId);
+  }
+
+  private buildAnnotations(span: AnyExportedSpan): Record<string, any> {
+    const annotations: Record<string, any> = {};
+
+    if (span.input !== undefined) {
+      annotations.inputData = formatInput(span.input, span.type);
+    }
+
+    if (span.output !== undefined) {
+      annotations.outputData = formatOutput(span.output, span.type);
+    }
+
+    if (span.type === SpanTypeEnum.MODEL_STEP) {
+      const usage = (span.attributes as ModelStepAttributes)?.usage;
+      const metrics = formatUsageMetrics(usage);
+      if (metrics) {
+        annotations.metrics = metrics;
+      }
+    }
+
+    const knownFields = ['usage', 'model', 'provider', 'parameters'];
+    const otherAttributes = omitKeys((span.attributes ?? {}) as Record<string, any>, knownFields);
+
+    const contextKeySet = new Set(this.config.requestContextKeys ?? []);
+    const flatContextTags: Record<string, any> = {};
+    const remainingMetadata: Record<string, any> = {};
+
+    for (const [key, value] of Object.entries(span.metadata ?? {})) {
+      if (contextKeySet.has(key)) {
+        flatContextTags[key] = value;
+      } else {
+        remainingMetadata[key] = value;
+      }
+    }
+
+    const remainingAttributes: Record<string, any> = {};
+    for (const [key, value] of Object.entries(otherAttributes)) {
+      if (contextKeySet.has(key)) {
+        if (!(key in flatContextTags)) {
+          flatContextTags[key] = value;
+        }
+      } else {
+        remainingAttributes[key] = value;
+      }
+    }
+
+    const combinedMetadata: Record<string, any> = {
+      ...remainingMetadata,
+      ...remainingAttributes,
+    };
+    if (span.errorInfo) {
+      combinedMetadata['error.message'] = span.errorInfo.message;
+    }
+    if (Object.keys(combinedMetadata).length > 0) {
+      annotations.metadata = combinedMetadata;
+    }
+
+    const tags: Record<string, any> = {
+      ...flatContextTags,
+    };
+
+    if (span.tags?.length) {
+      for (const tag of span.tags) {
+        const colonIndex = tag.indexOf(':');
+        if (colonIndex > 0) {
+          tags[tag.substring(0, colonIndex)] = tag.substring(colonIndex + 1);
+        } else {
+          tags[tag] = true;
+        }
+      }
+    }
+
+    if (span.errorInfo) {
+      tags.error = true;
+      if (span.errorInfo.id) {
+        tags['error.id'] = span.errorInfo.id;
+      }
+      if (span.errorInfo.domain) {
+        tags['error.domain'] = span.errorInfo.domain;
+      }
+      if (span.errorInfo.category) {
+        tags['error.category'] = span.errorInfo.category;
+      }
+    }
+
+    if (Object.keys(tags).length > 0) {
+      annotations.tags = tags;
+    }
+
+    return annotations;
+  }
+
+  private setErrorTags(ddSpan: any, errorInfo: NonNullable<AnyExportedSpan['errorInfo']>): void {
+    ddSpan.setTag('error', true);
+    ddSpan.setTag('error.message', errorInfo.message);
+    ddSpan.setTag('error.type', errorInfo.name ?? errorInfo.category ?? 'Error');
+    if (errorInfo.stack) {
+      ddSpan.setTag('error.stack', errorInfo.stack);
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.isDisabled) return;
+
+    if (tracer.llmobs?.flush) {
+      try {
+        await tracer.llmobs.flush();
+        this.logger.debug('Datadog llmobs flushed');
+      } catch (e) {
+        this.logger.error('Error flushing llmobs', { error: e });
+      }
+    }
+
+    try {
+      await flushApmExporter();
+      this.logger.debug('Datadog APM exporter flushed');
+    } catch (e) {
+      this.logger.error('Error flushing Datadog APM exporter', { error: e });
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    for (const [spanId, ddSpan] of this.ddSpanMap) {
+      this.logger.warn(`[DatadogBridge] Force-finishing APM span that was not properly closed [id=${spanId}]`);
+      try {
+        if (typeof ddSpan.finish === 'function') {
+          ddSpan.finish();
+        }
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+    this.ddSpanMap.clear();
+    this.openSpanCounts.clear();
+    this.traceContext.clear();
+
+    await this.flush();
+
+    if (tracer.llmobs?.disable) {
+      try {
+        tracer.llmobs.disable();
+      } catch (e) {
+        this.logger.error('Error disabling llmobs', { error: e });
+      }
+    }
+
+    await super.shutdown();
+  }
+}
+
+function firstString(...values: Array<unknown>): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function fillRandomBytes(bytes: Uint8Array): void {
+  try {
+    const webCrypto = globalThis.crypto;
+    if (webCrypto?.getRandomValues) {
+      webCrypto.getRandomValues.call(webCrypto, bytes);
+      return;
+    }
+  } catch {
+    // Fall through to fallback
+  }
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Math.floor(Math.random() * 256);
+  }
+}
+
+function generateSpanId(): string {
+  const bytes = new Uint8Array(8);
+  fillRandomBytes(bytes);
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function generateTraceId(): string {
+  const bytes = new Uint8Array(16);
+  fillRandomBytes(bytes);
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -34,6 +34,9 @@ import { formatUsageMetrics } from './metrics';
 import { ensureTracer, formatInput, formatOutput, kindFor, toDate } from './utils';
 import type { DatadogSpanKind } from './utils';
 
+// These types model dd-trace internals, not its public API surface.
+// The bridge uses them intentionally for experimental LLM Observability support
+// and they should be reviewed when upgrading dd-trace.
 type LLMObsTagger = {
   registerLLMObsSpan: (
     span: any,
@@ -225,14 +228,7 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
         }
       }
 
-      if (!apmParentDdSpan && externalParentId) {
-        apmParentDdSpan = tracer.scope().active() ?? undefined;
-        if (apmParentDdSpan) {
-          parentSource = 'active-scope';
-        }
-      }
-
-      if (!apmParentDdSpan && !externalParentId) {
+      if (!apmParentDdSpan) {
         apmParentDdSpan = tracer.scope().active() ?? undefined;
         if (apmParentDdSpan) {
           parentSource = 'active-scope';
@@ -299,6 +295,8 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
     if (ddSpan) {
       return tracer.scope().activate(ddSpan, () => {
         const llmobs = (tracer as any).llmobs as LLMObsInternalApi | undefined;
+        // `_activate` is an internal dd-trace hook. Keep this usage aligned
+        // with supported dd-trace versions when the dependency is upgraded.
         if (typeof llmobs?._activate === 'function') {
           return llmobs._activate(ddSpan, undefined, fn);
         }
@@ -362,6 +360,8 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
           : undefined;
       const traceCtx = this.resolveTraceContext(traceId, options);
 
+      // `registerLLMObsSpan` comes from dd-trace internals. Keep it under
+      // review because the bridge depends on experimental behavior here.
       tagger.registerLLMObsSpan(ddSpan, {
         parent: parentDdSpan,
         kind,
@@ -386,6 +386,7 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
 
   private getLlmObsTagger(): LLMObsTagger | undefined {
     const tagger = (tracer as any).llmobs?._tagger;
+    // `_tagger` is also internal dd-trace state and may change between releases.
     if (tagger && typeof tagger.registerLLMObsSpan === 'function') {
       return tagger as LLMObsTagger;
     }

--- a/observability/datadog/src/index.ts
+++ b/observability/datadog/src/index.ts
@@ -1,9 +1,20 @@
 /**
- * Datadog LLM Observability Exporter for Mastra
+ * Datadog integration for Mastra Observability
  *
- * Exports Mastra observability data to Datadog's LLM Observability product.
- * Uses a completion-only pattern where spans are emitted on span_ended events.
+ * Provides two integration modes:
+ *
+ * - DatadogBridge: Recommended for most users. Creates native dd-trace spans
+ *   in real-time for proper APM context propagation, and emits LLMObs data
+ *   through dd-trace's own pipeline. Use as an observability bridge.
+ *
+ * - DatadogExporter: Legacy exporter-only mode. Emits LLMObs spans
+ *   retroactively after execution completes. Does not participate in
+ *   dd-trace's live scope, so auto-instrumented APM spans (HTTP, DB)
+ *   will not be parented under Mastra spans.
  */
+
+export { DatadogBridge } from './bridge';
+export type { DatadogBridgeConfig } from './bridge';
 
 export { DatadogExporter } from './tracing';
 export type { DatadogExporterConfig } from './tracing';

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -423,13 +423,6 @@ export class DatadogExporter extends BaseExporter {
       } catch (e) {
         this.logger.error('Error flushing llmobs', { error: e });
       }
-    } else if ((tracer as any).flush) {
-      try {
-        await (tracer as any).flush();
-        this.logger.debug('Datadog tracer flushed');
-      } catch (e) {
-        this.logger.error('Error flushing tracer', { error: e });
-      }
     }
   }
 

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -414,7 +414,8 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     const bridge = this.observabilityInstance.getBridge();
 
     if (bridge?.executeInContext) {
-      return bridge.executeInContext(this.id, fn);
+      const bridgeContextSpan = this.isInternal ? this.getParentSpan(false) : this;
+      return bridge.executeInContext(bridgeContextSpan?.id ?? this.id, fn);
     }
 
     return fn();
@@ -428,7 +429,8 @@ export abstract class BaseSpan<TType extends SpanType = any> implements Span<TTy
     const bridge = this.observabilityInstance.getBridge();
 
     if (bridge?.executeInContextSync) {
-      return bridge.executeInContextSync(this.id, fn);
+      const bridgeContextSpan = this.isInternal ? this.getParentSpan(false) : this;
+      return bridge.executeInContextSync(bridgeContextSpan?.id ?? this.id, fn);
     }
 
     return fn();

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -1,6 +1,6 @@
 import { RequestContext } from '@mastra/core/di';
 import { MastraError } from '@mastra/core/error';
-import { SpanType, SamplingStrategyType, TracingEventType } from '@mastra/core/observability';
+import { InternalSpans, SpanType, SamplingStrategyType, TracingEventType } from '@mastra/core/observability';
 import type {
   TracingEvent,
   ObservabilityExporter,
@@ -9,6 +9,7 @@ import type {
   ExportedSpan,
   LogEvent,
   MetricEvent,
+  ObservabilityBridge,
 } from '@mastra/core/observability';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DefaultObservabilityInstance } from './instances';
@@ -108,6 +109,33 @@ class TestExporter implements ObservabilityExporter {
     this.logEvents = [];
     this.metricEvents = [];
   }
+}
+
+function createMockBridge(overrides: Partial<ObservabilityBridge> = {}): ObservabilityBridge {
+  return {
+    name: 'mock-bridge',
+    exportTracingEvent: vi.fn().mockResolvedValue(undefined),
+    createSpan: vi.fn().mockImplementation(({ parent }: any) => {
+      if (parent) {
+        return {
+          spanId: `bridge-${parent.id}-child`,
+          traceId: parent.traceId,
+          parentSpanId: parent.id,
+        };
+      }
+
+      return {
+        spanId: 'bridge-root-span',
+        traceId: 'bridge-root-trace',
+        parentSpanId: undefined,
+      };
+    }),
+    executeInContext: vi.fn().mockImplementation(async (_spanId: string, fn: () => Promise<any>) => fn()),
+    executeInContextSync: vi.fn().mockImplementation((_spanId: string, fn: () => any) => fn()),
+    flush: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
 }
 
 describe('Tracing', () => {
@@ -223,6 +251,33 @@ describe('Tracing', () => {
       // Grandchild should have correct parent and isRootSpan should be false
       expect(grandchildSpan.parent).toBe(childSpan);
       expect(grandchildSpan.isRootSpan).toBe(false);
+    });
+
+    it('should use the nearest external ancestor when executing an internal span in bridge context', async () => {
+      const bridge = createMockBridge();
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test-tracing',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [testExporter],
+        bridge,
+      });
+
+      const agentSpan = tracing.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'root-agent',
+        attributes: { agentId: 'agent-123' },
+      });
+
+      const internalStep = agentSpan.createChildSpan({
+        type: SpanType.MODEL_STEP,
+        name: 'internal-step',
+        tracingPolicy: { internal: InternalSpans.MODEL },
+      });
+
+      await internalStep.executeInContext(async () => 'ok');
+
+      expect(bridge.executeInContext).toHaveBeenCalledWith(agentSpan.id, expect.any(Function));
     });
 
     it('should maintain consistent traceId across span hierarchy', () => {

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -280,6 +280,33 @@ describe('Tracing', () => {
       expect(bridge.executeInContext).toHaveBeenCalledWith(agentSpan.id, expect.any(Function));
     });
 
+    it('should use the nearest external ancestor when executing an internal span in sync bridge context', () => {
+      const bridge = createMockBridge();
+      const tracing = new DefaultObservabilityInstance({
+        serviceName: 'test-tracing',
+        name: 'test-instance',
+        sampling: { type: SamplingStrategyType.ALWAYS },
+        exporters: [testExporter],
+        bridge,
+      });
+
+      const agentSpan = tracing.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'root-agent',
+        attributes: { agentId: 'agent-123' },
+      });
+
+      const internalStep = agentSpan.createChildSpan({
+        type: SpanType.MODEL_STEP,
+        name: 'internal-step',
+        tracingPolicy: { internal: InternalSpans.MODEL },
+      });
+
+      internalStep.executeInContextSync(() => 'ok');
+
+      expect(bridge.executeInContextSync).toHaveBeenCalledWith(agentSpan.id, expect.any(Function));
+    });
+
     it('should maintain consistent traceId across span hierarchy', () => {
       const tracing = new DefaultObservabilityInstance({
         serviceName: 'test-tracing',

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -2331,6 +2331,7 @@ describe('MastraMCPClient - mcpMetadata on tools', () => {
 });
 
 describe('MastraMCPClient fetch with requestContext', () => {
+  const datadogTracerTestSymbol = Symbol.for('mastra.mcp.dd-trace-test-tracer');
   let testServer: {
     httpServer: HttpServer;
     mcpServer: McpServer;
@@ -2344,6 +2345,7 @@ describe('MastraMCPClient fetch with requestContext', () => {
     await testServer?.mcpServer.close().catch(() => {});
     await testServer?.serverTransport?.close().catch(() => {});
     testServer?.httpServer.close();
+    delete (globalThis as Record<PropertyKey, unknown>)[datadogTracerTestSymbol];
   });
 
   it('should pass requestContext to the custom fetch function during tool execution', async () => {
@@ -2467,6 +2469,45 @@ describe('MastraMCPClient fetch with requestContext', () => {
     // The third argument should be defined (either null or an empty RequestContext)
     const lastToolCallFetch = callsDuringToolExec[callsDuringToolExec.length - 1];
     expect(lastToolCallFetch!.length).toBeGreaterThanOrEqual(3);
+  }, 15000);
+
+  it('should detach streamable transport GET requests from the active Datadog span', async () => {
+    testServer = await setupTestServer(true);
+    const fetchSpy = vi.fn((url: string | URL, init?: RequestInit, _requestContext?: RequestContext | null) => {
+      return fetch(url, init);
+    });
+    const activateSpy = vi.fn((_span: unknown, callback: () => unknown) => callback());
+
+    (globalThis as Record<PropertyKey, unknown>)[datadogTracerTestSymbol] = {
+      scope: () => ({
+        activate: activateSpy,
+      }),
+    };
+
+    client = new InternalMastraMCPClient({
+      name: 'fetch-datadog-stream-test',
+      server: {
+        url: testServer.baseUrl,
+        fetch: fetchSpy,
+      },
+    });
+
+    await client.connect();
+
+    const streamFetchCalls = fetchSpy.mock.calls.filter(([, init]) => (init?.method ?? 'GET').toUpperCase() === 'GET');
+
+    expect(streamFetchCalls.length).toBeGreaterThan(0);
+    expect(activateSpy).toHaveBeenCalledTimes(streamFetchCalls.length);
+    expect(activateSpy).toHaveBeenNthCalledWith(1, null, expect.any(Function));
+
+    activateSpy.mockClear();
+    fetchSpy.mockClear();
+
+    await client.tools();
+
+    const postFetchCalls = fetchSpy.mock.calls.filter(([, init]) => (init?.method ?? 'GET').toUpperCase() === 'POST');
+    expect(postFetchCalls.length).toBeGreaterThan(0);
+    expect(activateSpy).not.toHaveBeenCalled();
   }, 15000);
 });
 

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { createRequire } from 'node:module';
 import type { Stream } from 'node:stream';
 import { MastraBase } from '@mastra/core/base';
 import type { RequestContext } from '@mastra/core/di';
@@ -73,9 +74,85 @@ export type {
 } from './types';
 
 const DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC = 3000;
+const require = createRequire(import.meta.url);
 
 // Per MCP spec, only fallback to SSE for these status codes
 const SSE_FALLBACK_STATUS_CODES = [400, 404, 405];
+const DATADOG_TRACER_TEST_SYMBOL = Symbol.for('mastra.mcp.dd-trace-test-tracer');
+
+type DatadogScopeLike = {
+  activate<T>(span: unknown, callback: () => T): T;
+};
+
+type DatadogTracerLike = {
+  scope?: () => DatadogScopeLike;
+  default?: {
+    scope?: () => DatadogScopeLike;
+  };
+};
+
+function shouldDetachPersistentTransportRequest(init?: RequestInit): boolean {
+  return (init?.method ?? 'GET').toUpperCase() === 'GET';
+}
+
+function getDatadogScope(): DatadogScopeLike | null {
+  const testTracer = (globalThis as Record<PropertyKey, unknown>)[DATADOG_TRACER_TEST_SYMBOL] as
+    | DatadogTracerLike
+    | undefined;
+  const tracer = testTracer ?? loadDatadogTracer();
+
+  if (typeof tracer?.scope === 'function') {
+    return tracer.scope();
+  }
+
+  if (typeof tracer?.default?.scope === 'function') {
+    return tracer.default.scope();
+  }
+
+  return null;
+}
+
+function loadDatadogTracer(): DatadogTracerLike | null {
+  if (!isDatadogTracerLikelyLoaded()) {
+    return null;
+  }
+
+  try {
+    return require('dd-trace') as DatadogTracerLike;
+  } catch {
+    return null;
+  }
+}
+
+function isDatadogTracerLikelyLoaded(): boolean {
+  if ((globalThis as Record<PropertyKey, unknown>)[DATADOG_TRACER_TEST_SYMBOL]) {
+    return true;
+  }
+
+  if (process.execArgv.some(arg => arg.includes('dd-trace'))) {
+    return true;
+  }
+
+  if (process.env.NODE_OPTIONS?.includes('dd-trace')) {
+    return true;
+  }
+
+  try {
+    const resolvedPath = require.resolve('dd-trace');
+    return Boolean(require.cache[resolvedPath]);
+  } catch {
+    return false;
+  }
+}
+
+function runOutsideDatadogTraceScope<T>(callback: () => T): T {
+  const scope = getDatadogScope();
+  if (!scope) {
+    return callback();
+  }
+
+  return scope.activate(null, callback);
+}
 
 /**
  * Convert an MCP LoggingLevel to a logger method name that exists in our logger
@@ -311,12 +388,15 @@ export class InternalMastraMCPClient extends MastraBase {
   private async connectHttp(url: URL) {
     const { requestInit, eventSourceInit, authProvider, connectTimeout, fetch: userFetch } = this.serverConfig;
 
-    // Wrap the user's fetch function to inject requestContext as the third argument.
-    // The transport calls fetch with standard (url, init) signature, but we forward
-    // the current operation context so users can access request-scoped data (e.g., auth cookies).
-    const fetch: FetchLike | undefined = userFetch
-      ? (url: string | URL, init?: RequestInit) => userFetch(url, init, this.operationContextStore.getStore() ?? null)
-      : undefined;
+    // Wrap fetch so request-scoped metadata still flows through normal MCP POSTs, while
+    // the long-lived Streamable HTTP event stream does not inherit the active Datadog span.
+    const fetch: FetchLike = (requestUrl: string | URL, init?: RequestInit) => {
+      const requestContext = this.operationContextStore.getStore() ?? null;
+      const executeFetch = () =>
+        userFetch ? userFetch(requestUrl, init, requestContext) : globalThis.fetch(requestUrl, init);
+
+      return shouldDetachPersistentTransportRequest(init) ? runOutsideDatadogTraceScope(executeFetch) : executeFetch();
+    };
 
     this.log('debug', `Attempting to connect to URL: ${url}`);
 
@@ -357,7 +437,7 @@ export class InternalMastraMCPClient extends MastraBase {
         // Fallback to SSE transport
         // If fetch is provided, ensure it's also in eventSourceInit for the EventSource connection
         // The top-level fetch is used for POST requests, but eventSourceInit.fetch is needed for the SSE stream
-        const sseEventSourceInit = fetch ? { ...eventSourceInit, fetch } : eventSourceInit;
+        const sseEventSourceInit = { ...eventSourceInit, fetch };
 
         const sseTransport = new SSEClientTransport(url, {
           requestInit,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a DatadogBridge so Mastra can create live Datadog APM spans while it runs, ensuring auto-instrumented HTTP/DB/framework calls are nested under the correct Mastra spans and LLM Observability data is emitted in real time.

## Overview

Implements a DatadogBridge that eagerly creates and activates dd-trace spans during Mastra execution (so dd-trace auto-instrumentation attaches to the correct live scope) and emits LLM Observability annotations via dd-trace’s pipeline. This is complementary to the existing DatadogExporter (which emits LLM Observability only after execution completes). The PR also includes behavioral fixes, tests, docs, and packaging/changeset entries.

## Key Changes

- DatadogBridge implementation (observability/datadog/src/bridge.ts)
  - New exported DatadogBridge class and DatadogBridgeConfig.
  - createSpan() eagerly starts dd-trace spans, selecting parent from an external-parent map or active dd-trace scope.
  - executeInContext()/executeInContextSync() activate the corresponding dd span (and llmobs activation when available) so auto-instrumentation attaches to Mastra spans.
  - Registers spans with dd-trace LLM Observability tagger, annotates spans (input/output, model-step metrics, flattened request-context tags, error tags), finishes spans on events, and tracks/open-span counts per trace.
  - Provides flush() (llmobs flush) and shutdown() (finish leaked spans, flush, clear state).
- Public API
  - Re-exports DatadogBridge and DatadogBridgeConfig from observability/datadog/src/index.ts.
  - DatadogExporter remains available; do not configure DatadogBridge and DatadogExporter together.
- Behavioral fixes
  - executeInContext(...) now uses the nearest non-internal parent as bridge context for internal spans so the correct external ancestor is activated.
  - Preserves and iteratively emits late-arriving child spans; MODEL_STEP inherits model/provider from MODEL_GENERATION when needed.
  - Persistent streamable HTTP GET requests are executed outside active dd-trace scope to avoid unrelated span nesting.
  - Tracing flush simplified to call tracer.llmobs?.flush() only.
  - Ensures event spans finalize correctly and native error tags are applied from errorInfo.
- Tests
  - Comprehensive Vitest suite for DatadogBridge (observability/datadog/src/bridge.test.ts) covering enablement, ID propagation, parent-selection, LLMObs registration/annotation, activation behavior, lifecycle handling, error tagging, state cleanup, and shutdown.
  - Integration tests added: mcp client tests for detaching persistent GET requests and observability/tracing test verifying internal-span context selection.
- Documentation & Sidebars
  - New guides and reference pages for the Datadog bridge (installation, dd-trace init order, agent vs agentless modes, examples, config fields, span-kind mapping, troubleshooting).
  - Datadog exporter docs updated to recommend bridge for live dd-trace integration; new sidebar entries added.
- Packaging/Changesets
  - Changesets updated to bump @mastra/datadog and @mastra/observability, and note the DatadogBridge feature.

## Public API Changes

- Added: exported type DatadogBridgeConfig and exported class DatadogBridge (observability/datadog).
- No breaking changes to existing exported entities besides new exports; DatadogExporter remains unchanged.

## Config & Notes

- Env vars referenced: DD_API_KEY, DD_LLMOBS_ML_APP, DD_SITE, DD_ENV, DD_LLMOBS_AGENTLESS_ENABLED.
- Bridge is experimental; APIs/config may change. Agentless mode supported (requires API key); follow docs for dd-trace initialization order (dd-trace must be initialized before other imports).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->