### PR TITLE
fix(core): stop agent loop when finishReason is 'length' with pending tool calls

### DIFF
--- a/.changeset/stop-loop-on-length-truncation.md
+++ b/.changeset/stop-loop-on-length-truncation.md
@@ -1,0 +1,10 @@
+---
+'@mastra/core': patch
+---
+
+fix(core): stop agent loop when finishReason is 'length' with pending tool calls
+
+When `max_tokens` truncates a response mid-tool-call, the agent loop now terminates
+instead of retrying indefinitely. Previously, `hasPendingToolCalls` overrode the
+`finishReason === 'length'` check, causing the same truncation on every iteration
+until `maxSteps` was exhausted.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -1083,3 +1083,151 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     expect(assistantMessage?.content.metadata?.provider).toBe('openai');
   });
 });
+
+describe('finishReason length with pending tool calls', () => {
+  let controller: ReadableStreamDefaultController;
+  let messageList: MessageList;
+  let bail: Mock;
+
+  const createIterationInput = (): IterationData => ({
+    messageId: 'msg-0',
+    messages: {
+      all: messageList.get.all.aiV5.model(),
+      user: messageList.get.input.aiV5.model(),
+      nonUser: messageList.get.response.aiV5.model(),
+    },
+    output: {
+      usage: testUsage,
+      steps: [],
+    },
+    metadata: {},
+    stepResult: {
+      reason: 'stop',
+      warnings: [],
+      isContinued: true,
+    },
+  });
+
+  const createExecuteParams = (
+    inputData: IterationData,
+  ): ExecuteFunctionParams<{}, IterationData, any, any, any, any> => ({
+    runId: 'test-run',
+    workflowId: 'test-workflow',
+    mastra: {} as any,
+    requestContext: new RequestContext(),
+    state: {},
+    setState: vi.fn(),
+    retryCount: 1,
+    tracingContext: {} as any,
+    getInitData: vi.fn(),
+    getStepResult: vi.fn(),
+    suspend: vi.fn(),
+    bail,
+    abort: vi.fn(),
+    engine: 'default' as any,
+    abortSignal: new AbortController().signal,
+    writer: new ToolStream({
+      emit: vi.fn(),
+    }).getWriter(controller),
+    inputData,
+    validateSchemas: false,
+    [PUBSUB_SYMBOL]: {} as any,
+    [STREAM_FORMAT_SYMBOL]: undefined,
+  });
+
+  beforeEach(() => {
+    controller = {
+      enqueue: vi.fn(),
+      desiredSize: 1,
+      close: vi.fn(),
+      error: vi.fn(),
+    } as unknown as ReadableStreamDefaultController;
+
+    messageList = new MessageList();
+    messageList.add({ role: 'user', content: 'Generate a large structured output' }, 'input');
+
+    bail = vi.fn(data => data);
+  });
+
+  it('should stop the loop when finishReason is length even with pending tool calls (#15717)', async () => {
+    const tools = {
+      generateReport: {
+        description: 'Generate a report',
+        parameters: { type: 'object' as const, properties: { query: { type: 'string' as const } } },
+        execute: vi.fn(),
+      },
+    };
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream: vi.fn(async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'resp-1',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'generateReport',
+                  input: '{"query":"truncated...',
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'length',
+                  usage: testUsage,
+                },
+              ]),
+              request: {},
+              response: {
+                headers: undefined,
+              },
+              warnings: [],
+            })),
+          } as any,
+        },
+      ],
+      tools,
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<typeof tools>);
+
+    const input = createIterationInput();
+    const result = await llmExecutionStep.execute(createExecuteParams(input));
+
+    // When finishReason is 'length', the loop should stop even if there are
+    // pending tool calls, because those tool calls were truncated by max_tokens
+    // and retrying with the same parameters would produce the same truncation.
+    expect(result.stepResult.isContinued).toBe(false);
+    expect(result.stepResult.reason).toBe('length');
+  });
+});

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -1127,8 +1127,11 @@ describe('finishReason length with pending tool calls', () => {
     engine: 'default' as any,
     abortSignal: new AbortController().signal,
     writer: new ToolStream({
-      emit: vi.fn(),
-    }).getWriter(controller),
+      prefix: 'tool',
+      callId: 'call-1',
+      name: 'generateReport',
+      runId: 'test-run',
+    }),
     inputData,
     validateSchemas: false,
     [PUBSUB_SYMBOL]: {} as any,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1355,13 +1355,17 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       // isContinued should be true if:
       // - shouldRetry is true (processor requested retry)
       // - OR there are non-provider-executed tool calls to process (some LLMs return finishReason 'stop' even with tool calls)
+      //   BUT NOT when finishReason is 'length' — truncated tool calls have partial/invalid args
+      //   and retrying with the same max_tokens would produce the same truncation (see #15717)
       // - OR finishReason indicates more work (e.g., tool-use)
       // Provider-executed tools (e.g. web_search) are handled server-side — the response already
       // contains both the tool execution and the text output, so no additional loop iteration is needed.
       const hasPendingToolCalls = toolCalls && toolCalls.some(tc => !tc.providerExecuted);
       const shouldContinue =
         shouldRetry ||
-        (!tripwireTriggered && (hasPendingToolCalls || !['stop', 'error', 'length'].includes(finishReason)));
+        (!tripwireTriggered &&
+          ((hasPendingToolCalls && finishReason !== 'length') ||
+            !['stop', 'error', 'length'].includes(finishReason)));
 
       // Reset retry count after a successful non-retry step; only consecutive retries carry forward.
       const nextProcessorRetryCount = shouldRetry ? currentProcessorRetryCount + 1 : 0;


### PR DESCRIPTION
## Summary

Fixes #15717

When `max_tokens` truncates a response mid-tool-call, the agent loop now terminates instead of retrying indefinitely.

## Problem

In `llm-execution-step.ts`, the `shouldContinue` condition uses `hasPendingToolCalls || !['stop', 'error', 'length'].includes(finishReason)`. When `finishReason === 'length'` and a truncated tool call is present:

1. `hasPendingToolCalls` is `true` (the truncated tool call exists)
2. The `||` short-circuits — `shouldContinue` becomes `true`
3. The loop retries with the same `max_tokens` → same truncation → infinite loop until `maxSteps`

Each iteration burns tokens and rate-limit budget uselessly.

## Fix

Added a `finishReason !== 'length'` guard so that pending tool calls only continue the loop when the response was **not** truncated:

```typescript
const shouldContinue =
  shouldRetry ||
  (!tripwireTriggered &&
    ((hasPendingToolCalls && finishReason !== 'length') ||
      !['stop', 'error', 'length'].includes(finishReason)));
```

## Tests

Added a test that streams a tool-call with truncated JSON input followed by `finishReason: 'length'`, and verifies `isContinued` is `false`.

All 11 tests in `llm-execution-step.test.ts` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

Imagine a teacher asking a student to write a long answer, but limiting them to only write on a small piece of paper. If the student runs out of space mid-answer, they have an incomplete answer. This PR prevents the teacher from asking the student to try again with the same small paper (which will just get cut off again), and instead stops and tells the student they need a bigger paper first.

## Changes Summary

This PR fixes a bug in the agent execution loop where the loop would continue retrying even when the LLM's response was truncated due to hitting the `max_tokens` limit (`finishReason: 'length'`). If a tool call was emitted but truncated, the loop previously retried with the same parameters, causing repeated truncation and wasted tokens/rate limits until `maxSteps` was reached.

### Root Cause

The loop continuation condition allowed `hasPendingToolCalls` to override the `finishReason === 'length'` check, so pending tool calls could keep the agent loop running even when the output was known to be truncated and unsafe to execute.

### Fix Applied

Refined the `shouldContinue` condition in packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts so pending tool calls only keep the loop running when `finishReason !== 'length'`:

const shouldContinue =
  shouldRetry ||
  (!tripwireTriggered &&
    ((hasPendingToolCalls && finishReason !== 'length') ||
      !['stop', 'error', 'length'].includes(finishReason)));

This ensures the loop terminates on `'length'` regardless of pending tool calls, preventing repeated truncated retries.

### Test Coverage

Added a unit test that streams a truncated tool-call resulting in `finishReason: 'length'` and verifies `isContinued` is `false` and `reason` is `'length'`. All relevant tests (11 in llm-execution-step.test.ts) pass.

### Files Changed

- .changeset/stop-loop-on-length-truncation.md — release notes
- packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts — loop continuation guard
- packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts — new test validating the behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->