### PR TITLE
chore(create-mastra): Smaller deps

### DIFF
--- a/.changeset/young-cows-ring.md
+++ b/.changeset/young-cows-ring.md
@@ -1,0 +1,8 @@
+---
+'create-mastra': patch
+---
+
+Improve bundle size.
+
+- Remove `fs-extra` dependency to use native Node.js APIs instead
+- Replace `execa` with `tinyexec` for executing shell commands

--- a/.changeset/young-cows-ring.md
+++ b/.changeset/young-cows-ring.md
@@ -2,7 +2,5 @@
 'create-mastra': patch
 ---
 
-Improve bundle size.
-
-- Remove `fs-extra` dependency to use native Node.js APIs instead
-- Replace `execa` with `tinyexec` for executing shell commands
+Improved `create-mastra` package size by reducing runtime dependency overhead.
+This decreases install surface while preserving existing CLI behavior.

--- a/packages/_config/package.json
+++ b/packages/_config/package.json
@@ -15,6 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@vitest/eslint-plugin": "^1.6.16",
+    "eslint-plugin-depend": "^1.5.0",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.0",

--- a/packages/_config/src/eslint.js
+++ b/packages/_config/src/eslint.js
@@ -71,15 +71,17 @@ export const createConfig = async ({ e18e = false }) =>
 
     // Suggest replacing dependencies for native or smaller ones
     // https://e18e.dev/docs/replacements/
-    e18e ? {
-      files: ['**/*.ts?(x)', '**/*.js?(x)'],
-      plugins: {
-        depend: (await import('eslint-plugin-depend')).default,
-      },
-      rules: {
-        'depend/ban-dependencies': ERROR,
-      }
-    } : null,
+    e18e
+      ? {
+          files: ['**/*.ts?(x)', '**/*.js?(x)'],
+          plugins: {
+            depend: (await import('eslint-plugin-depend')).default,
+          },
+          rules: {
+            'depend/ban-dependencies': ERROR,
+          },
+        }
+      : null,
 
     // non-test files only - console and debugger rules
     {

--- a/packages/_config/src/eslint.js
+++ b/packages/_config/src/eslint.js
@@ -26,7 +26,7 @@ const playwrightFiles = ['**/e2e/**'];
  * @param {boolean} options.e18e Whether to include rules for https://e18e.dev/ or not
  * @returns {Promise<import("eslint").Linter.Config[]>}
  */
-export const createConfig = async ({ e18e = false }) =>
+export const createConfig = async ({ e18e = false } = {}) =>
   [
     {
       ignores: [

--- a/packages/_config/src/eslint.js
+++ b/packages/_config/src/eslint.js
@@ -21,7 +21,12 @@ const vitestFiles = ['**/__tests__/**/*', '**/*.test.*', '**/*.spec.*'];
 const testFiles = ['**/tests/**', '**/#tests/**', ...vitestFiles];
 const playwrightFiles = ['**/e2e/**'];
 
-export const createConfig = async () =>
+/**
+ * @param {Object} options
+ * @param {boolean} options.e18e Whether to include rules for https://e18e.dev/ or not
+ * @returns {Promise<import("eslint").Linter.Config[]>}
+ */
+export const createConfig = async ({ e18e = false }) =>
   [
     {
       ignores: [
@@ -63,6 +68,18 @@ export const createConfig = async () =>
         ],
       },
     },
+
+    // Suggest replacing dependencies for native or smaller ones
+    // https://e18e.dev/docs/replacements/
+    e18e ? {
+      files: ['**/*.ts?(x)', '**/*.js?(x)'],
+      plugins: {
+        depend: (await import('eslint-plugin-depend')).default,
+      },
+      rules: {
+        'depend/ban-dependencies': ERROR,
+      }
+    } : null,
 
     // non-test files only - console and debugger rules
     {

--- a/packages/create-mastra/eslint.config.js
+++ b/packages/create-mastra/eslint.config.js
@@ -1,6 +1,6 @@
 import { createConfig } from '@internal/lint/eslint';
 
-const config = await createConfig();
+const config = await createConfig({ e18e: true });
 
 /** @type {import("eslint").Linter.Config[]} */
 export default [...config.map(conf => ({ ...conf, ignores: [...(conf.ignores || []), '**/starter-files/**'] }))];

--- a/packages/create-mastra/package.json
+++ b/packages/create-mastra/package.json
@@ -36,10 +36,10 @@
   ],
   "dependencies": {
     "commander": "^14.0.3",
-    "execa": "^9.6.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
-    "posthog-node": "^5.28.2"
+    "posthog-node": "^5.28.2",
+    "tinyexec": "^1.1.1"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/packages/create-mastra/package.json
+++ b/packages/create-mastra/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "commander": "^14.0.3",
     "execa": "^9.6.1",
-    "fs-extra": "^11.3.4",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "posthog-node": "^5.28.2"
@@ -47,7 +46,6 @@
     "@rollup/plugin-commonjs": "29.0.2",
     "@rollup/plugin-json": "6.1.0",
     "@rollup/plugin-node-resolve": "16.0.3",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "22.19.15",
     "esbuild": "^0.27.4",
     "eslint": "^10.2.1",

--- a/packages/create-mastra/rollup.config.js
+++ b/packages/create-mastra/rollup.config.js
@@ -1,15 +1,15 @@
+import * as fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
-import fsExtra from 'fs-extra/esm';
 import { defineConfig } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
 import nodeExternals from 'rollup-plugin-node-externals';
 import pkgJson from './package.json' with { type: 'json' };
 
-const external = ['commander', 'fs-extra', 'execa', 'posthog-node', 'pino', 'pino-pretty'];
+const external = ['commander', 'execa', 'posthog-node', 'pino', 'pino-pretty'];
 external.forEach(pkg => {
   if (!pkgJson.dependencies[pkg]) {
     throw new Error(`${pkg} is not in the dependencies of create-mastra`);
@@ -31,7 +31,7 @@ export default defineConfig({
       exportConditions: ['node'],
     }),
     esbuild({
-      target: 'node20',
+      target: 'node22',
       sourceMap: true,
     }),
     nodeExternals(),
@@ -42,8 +42,10 @@ export default defineConfig({
         const mastraPath = path.dirname(fileURLToPath(import.meta.resolve('mastra/package.json')));
 
         // Copy to dist directory instead of root
-        await fsExtra.copy(path.join(mastraPath, 'dist', 'starter-files'), './dist/starter-files');
-        await fsExtra.copy(path.join(mastraPath, 'dist', 'templates'), './dist/templates');
+        await fsPromises.cp(path.join(mastraPath, 'dist', 'starter-files'), './dist/starter-files', {
+          recursive: true,
+        });
+        await fsPromises.cp(path.join(mastraPath, 'dist', 'templates'), './dist/templates', { recursive: true });
       },
     },
   ],

--- a/packages/create-mastra/rollup.config.js
+++ b/packages/create-mastra/rollup.config.js
@@ -9,7 +9,7 @@ import esbuild from 'rollup-plugin-esbuild';
 import nodeExternals from 'rollup-plugin-node-externals';
 import pkgJson from './package.json' with { type: 'json' };
 
-const external = ['commander', 'execa', 'posthog-node', 'pino', 'pino-pretty'];
+const external = ['commander', 'tinyexec', 'posthog-node', 'pino', 'pino-pretty'];
 external.forEach(pkg => {
   if (!pkgJson.dependencies[pkg]) {
     throw new Error(`${pkg} is not in the dependencies of create-mastra`);

--- a/packages/create-mastra/src/utils.ts
+++ b/packages/create-mastra/src/utils.ts
@@ -1,7 +1,7 @@
 import * as fsPromises from 'node:fs/promises';
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execa } from 'execa';
+import { x } from 'tinyexec';
 
 export async function getPackageVersion() {
   const __filename = fileURLToPath(import.meta.url);
@@ -17,7 +17,7 @@ export async function getCreateVersionTag(): Promise<string | undefined> {
     const pkgPath = fileURLToPath(import.meta.resolve('create-mastra/package.json'));
     const json = await fsPromises.readFile(pkgPath, 'utf8').then(JSON.parse);
 
-    const { stdout } = await execa('npm', ['dist-tag', 'create-mastra']);
+    const { stdout } = await x('npm', ['dist-tag', 'create-mastra'], { throwOnError: true });
     const tagLine = stdout.split('\n').find(distLine => distLine.endsWith(`: ${json.version}`));
     const tag = tagLine ? tagLine.split(':')[0].trim() : 'latest';
 

--- a/packages/create-mastra/src/utils.ts
+++ b/packages/create-mastra/src/utils.ts
@@ -1,21 +1,21 @@
+import * as fsPromises from 'node:fs/promises';
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execa } from 'execa';
-import fsExtra from 'fs-extra';
 
 export async function getPackageVersion() {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = dirname(__filename);
   const pkgJsonPath = path.join(__dirname, '..', 'package.json');
 
-  const content = await fsExtra.readJSON(pkgJsonPath);
+  const content = await fsPromises.readFile(pkgJsonPath, 'utf8').then(JSON.parse);
   return content.version;
 }
 
 export async function getCreateVersionTag(): Promise<string | undefined> {
   try {
     const pkgPath = fileURLToPath(import.meta.resolve('create-mastra/package.json'));
-    const json = await fsExtra.readJSON(pkgPath);
+    const json = await fsPromises.readFile(pkgPath, 'utf8').then(JSON.parse);
 
     const { stdout } = await execa('npm', ['dist-tag', 'create-mastra']);
     const tagLine = stdout.split('\n').find(distLine => distLine.endsWith(`: ${json.version}`));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2347,6 +2347,9 @@ importers:
       '@vitest/eslint-plugin':
         specifier: ^1.6.16
         version: 1.6.16(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.5)
+      eslint-plugin-depend:
+        specifier: ^1.5.0
+        version: 1.5.0(eslint@10.2.1(jiti@2.6.1))
       eslint-plugin-import-x:
         specifier: ^4.16.2
         version: 4.16.2(@typescript-eslint/utils@8.58.2(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))
@@ -18673,6 +18676,11 @@ packages:
       unrs-resolver:
         optional: true
 
+  eslint-plugin-depend@1.5.0:
+    resolution: {integrity: sha512-i3UeLYmclf1Icp35+6W7CR4Bp2PIpDgBuf/mpmXK5UeLkZlvYJ21VuQKKHHAIBKRTPivPGX/gZl5JGno1o9Y0A==}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
   eslint-plugin-import-x@4.16.2:
     resolution: {integrity: sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -21486,6 +21494,9 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  module-replacements@2.11.0:
+    resolution: {integrity: sha512-j5sNQm3VCpQQ7nTqGeOZtoJtV3uKERgCBm9QRhmGRiXiqkf7iRFOkfxdJRZWLkqYY8PNf4cDQF/WfXUYLENrRA==}
 
   mongodb-connection-string-url@7.0.0:
     resolution: {integrity: sha512-irhhjRVLE20hbkRl4zpAYLnDMM+zIZnp0IDB9akAFFUZp/3XdOfwwddc7y6cNvF2WCEtfTYRwYbIfYa2kVY0og==}
@@ -40557,6 +40568,13 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.11.1
 
+  eslint-plugin-depend@1.5.0(eslint@10.2.1(jiti@2.6.1)):
+    dependencies:
+      empathic: 2.0.0
+      eslint: 10.2.1(jiti@2.6.1)
+      module-replacements: 2.11.0
+      semver: 7.7.4
+
   eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.2(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1)):
     dependencies:
       '@package-json/types': 0.0.12
@@ -44349,6 +44367,8 @@ snapshots:
   modern-tar@0.7.6: {}
 
   module-details-from-path@1.0.4: {}
+
+  module-replacements@2.11.0: {}
 
   mongodb-connection-string-url@7.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3294,9 +3294,6 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
-      execa:
-        specifier: ^9.6.1
-        version: 9.6.1
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -3306,6 +3303,9 @@ importers:
       posthog-node:
         specifier: ^5.28.2
         version: 5.28.3(rxjs@7.8.1)
+      tinyexec:
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
       '@internal/lint':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3297,9 +3297,6 @@ importers:
       execa:
         specifier: ^9.6.1
         version: 9.6.1
-      fs-extra:
-        specifier: ^11.3.4
-        version: 11.3.4
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -3322,9 +3319,6 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: 16.0.3
         version: 16.0.3(rollup@4.60.2)
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15


### PR DESCRIPTION
## Description

Improve bundle size of create-mastra

- Remove `fs-extra` dependency to use native Node.js APIs instead
- Replace `execa` with `tinyexec` for executing shell commands

Also add https://github.com/es-tooling/eslint-plugin-depend/tree/main to optionally have an ESLint rule for that

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

This PR makes the create-mastra CLI smaller and simpler by removing two heavier libraries and using Node’s built-in file tools plus a tiny command-runner, and it adds an optional ESLint rule to help avoid future dependency bloat.

## Overview

Reduce bundle/runtime dependency surface for create-mastra by replacing fs-extra and execa with native Node APIs and tinyexec, respectively, and add optional dependency-usage linting via eslint-plugin-depend.

## Changes

- Dependency updates
  - Removed: fs-extra, execa, @types/fs-extra
  - Added: tinyexec
  - Added dev/runtime dependency in packages/_config: eslint-plugin-depend (^1.5.0)
  - Rollup build target bumped from node20 → node22

- Code changes
  - Replaced fs-extra JSON helpers with fs/promises + JSON.parse for reading package.json.
  - Replaced fs-extra copy usage with fs/promises.cp(...) for recursive copying in rollup config.
  - Replaced execa usage with tinyexec for running npm commands (npm dist-tag), configured to throw on errors.
  - Utility and build code preserved existing behavior and error handling; no exported/public API changes.

- ESLint config
  - packages/_config/src/eslint.js: createConfig signature changed to async ({ e18e = false } = {}) and conditionally loads eslint-plugin-depend to enable depend/ban-dependencies when e18e is true.
  - packages/create-mastra/eslint.config.js: invokes createConfig({ e18e: true }) to enable the rule for the create-mastra package.

- Release metadata
  - Added a changeset documenting the patch release and reduced runtime dependency overhead.

## Impact / Notes

- Change type: refactor (bundle size / dependency surface reduction).
- No public API or exported entity signature changes.
- Estimated review effort: Low–Medium (mostly dependency and build/tooling updates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->