### PR TITLE
chore(playground-ui): upgrade Storybook to v10

### DIFF
--- a/packages/playground-ui/.storybook/main.ts
+++ b/packages/playground-ui/.storybook/main.ts
@@ -1,10 +1,12 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: ['@storybook/addon-docs'],
+  addons: [getAbsolutePath("@storybook/addon-docs")],
   framework: {
-    name: '@storybook/react-vite',
+    name: getAbsolutePath("@storybook/react-vite"),
     options: {},
   },
   // Ensure modules are properly resolved
@@ -23,3 +25,7 @@ const config: StorybookConfig = {
 };
 
 export default config;
+
+function getAbsolutePath(value: string): any {
+  return dirname(fileURLToPath(import.meta.resolve(`${value}/package.json`)));
+}

--- a/packages/playground-ui/.storybook/main.ts
+++ b/packages/playground-ui/.storybook/main.ts
@@ -4,9 +4,9 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: [getAbsolutePath("@storybook/addon-docs")],
+  addons: [getAbsolutePath('@storybook/addon-docs')],
   framework: {
-    name: getAbsolutePath("@storybook/react-vite"),
+    name: getAbsolutePath('@storybook/react-vite'),
     options: {},
   },
   // Ensure modules are properly resolved

--- a/packages/playground-ui/eslint.config.js
+++ b/packages/playground-ui/eslint.config.js
@@ -7,14 +7,25 @@ const reactHooks = (await import('eslint-plugin-react-hooks')).default;
 const config = await createConfig();
 
 /** @type {import("eslint").Linter.Config[]} */
-export default [{ ignores: ['**/*.stories.tsx'] }, ...config, {
-  plugins: {
-    'react-hooks': reactHooks,
-    'react-refresh': reactRefresh,
+export default [
+  ...config,
+  {
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
   },
-  rules: {
-    'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warn',
-    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+  ...storybook.configs['flat/recommended'],
+  {
+    files: ['**/*.stories.tsx'],
+    rules: {
+      'no-console': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+    },
   },
-}, ...storybook.configs["flat/recommended"]];
+];

--- a/packages/playground-ui/eslint.config.js
+++ b/packages/playground-ui/eslint.config.js
@@ -1,23 +1,20 @@
 import { createConfig } from '@internal/lint/eslint';
 import reactRefresh from 'eslint-plugin-react-refresh';
+import storybook from 'eslint-plugin-storybook';
 
 const reactHooks = (await import('eslint-plugin-react-hooks')).default;
 
 const config = await createConfig();
 
 /** @type {import("eslint").Linter.Config[]} */
-export default [
-  { ignores: ['**/*.stories.tsx'] },
-  ...config,
-  {
-    plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
-    },
-    rules: {
-      'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'warn',
-      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
-    },
+export default [{ ignores: ['**/*.stories.tsx'] }, ...config, {
+  plugins: {
+    'react-hooks': reactHooks,
+    'react-refresh': reactRefresh,
   },
-];
+  rules: {
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+  },
+}, ...storybook.configs["flat/recommended"]];

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -116,8 +116,8 @@
     "@mastra/client-js": "workspace:^",
     "@mastra/core": "workspace:*",
     "@mastra/react": "workspace:*",
-    "@storybook/addon-docs": "^9.1.20",
-    "@storybook/react-vite": "^9.1.20",
+    "@storybook/addon-docs": "^10.3.5",
+    "@storybook/react-vite": "^10.3.5",
     "@tanstack/react-query": "^5.90.21",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/typography": "^0.5.19",
@@ -135,7 +135,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "jsdom": "^26.1.0",
     "rollup-plugin-node-externals": "^8.1.2",
-    "storybook": "^9.1.20",
+    "storybook": "^10.3.5",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "4.2.2",
     "tw-animate-css": "^1.4.0",
@@ -143,7 +143,8 @@
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-lib-inject-css": "^2.2.2",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "eslint-plugin-storybook": "^10.3.5"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { AlertDialog } from './alert-dialog';
 import { Button } from '../Button';
+import { AlertDialog } from './alert-dialog';
 
 const meta: Meta<typeof AlertDialog> = {
   title: 'Feedback/AlertDialog',

--- a/packages/playground-ui/src/ds/components/Badge/badge.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/badge.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Badge } from './Badge';
 import { Check, AlertCircle, Info as InfoIcon } from 'lucide-react';
+import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {
   title: 'Elements/Badge',

--- a/packages/playground-ui/src/ds/components/Breadcrumb/breadcrumb.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/breadcrumb.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Breadcrumb, Crumb } from './Breadcrumb';
 import { ChevronDown } from 'lucide-react';
+import { Breadcrumb, Crumb } from './Breadcrumb';
 
 const meta: Meta<typeof Breadcrumb> = {
   title: 'Navigation/Breadcrumb',

--- a/packages/playground-ui/src/ds/components/Button/button.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Button/button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Button } from './Button';
 import { Plus, Settings, Trash } from 'lucide-react';
+import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   title: 'Elements/Button',

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ButtonsGroup } from './buttons-group';
-import { Button } from '../Button';
 import { ChevronDown, ChevronDownIcon } from 'lucide-react';
+import { Button } from '../Button';
+import { ButtonsGroup } from './buttons-group';
 
 const meta: Meta<typeof ButtonsGroup> = {
   title: 'Composite/ButtonsGroup',

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Checkbox } from './checkbox';
 import { Label } from '../Label';
+import { Checkbox } from './checkbox';
 
 const meta: Meta<typeof Checkbox> = {
   title: 'Elements/Checkbox',

--- a/packages/playground-ui/src/ds/components/Chip/chip.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Chip/chip.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Chip } from './chip';
 import { StarIcon, ZapIcon, FlameIcon } from 'lucide-react';
+import { Chip } from './chip';
 
 const meta: Meta<typeof Chip> = {
   title: 'Elements/Chip',

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { JsonSchema } from '@/lib/json-schema';
-import { CodeEditor } from './code-editor';
 import { TooltipProvider } from '../Tooltip';
+import { CodeEditor } from './code-editor';
+import type { JsonSchema } from '@/lib/json-schema';
 
 const meta: Meta<typeof CodeEditor> = {
   title: 'Composite/CodeEditor',

--- a/packages/playground-ui/src/ds/components/Collapsible/collapsible.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Collapsible/collapsible.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './collapsible';
-import { Button } from '../Button';
 import { ChevronDown } from 'lucide-react';
 import { useState } from 'react';
+import { Button } from '../Button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './collapsible';
 
 const meta: Meta<typeof Collapsible> = {
   title: 'Layout/Collapsible',

--- a/packages/playground-ui/src/ds/components/CombinedButtons/combined-buttons.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CombinedButtons/combined-buttons.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { CombinedButtons } from './combined-buttons';
-import { Button } from '../Button';
 import { ChevronDown, Plus, Settings, Trash } from 'lucide-react';
+import { Button } from '../Button';
+import { CombinedButtons } from './combined-buttons';
 
 const meta: Meta<typeof CombinedButtons> = {
   title: 'Composite/CombinedButtons',

--- a/packages/playground-ui/src/ds/components/Command/command.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Calculator, Calendar, CreditCard, Settings, Smile, User } from 'lucide-react';
 import * as React from 'react';
 
+import { Button } from '../Button';
 import {
   Command,
   CommandDialog,
@@ -13,7 +14,6 @@ import {
   CommandSeparator,
   CommandShortcut,
 } from './command';
-import { Button } from '../Button';
 
 const meta: Meta<typeof Command> = {
   title: 'Composite/Command',

--- a/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { ContentBlocks } from './content-blocks';
-import { ContentBlock } from './content-block';
 import { useState } from 'react';
+import { ContentBlock } from './content-block';
+import { ContentBlocks } from './content-blocks';
 
 let nextId = 0;
 

--- a/packages/playground-ui/src/ds/components/CopyButton/copy-button.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CopyButton/copy-button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { CopyButton } from './copy-button';
 import { TooltipProvider } from '../Tooltip';
+import { CopyButton } from './copy-button';
 
 const meta: Meta<typeof CopyButton> = {
   title: 'Composite/CopyButton',

--- a/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CodeIcon } from 'lucide-react';
-import { DataCodeSection } from './data-code-section';
 import { TooltipProvider } from '../Tooltip';
+import { DataCodeSection } from './data-code-section';
 
 const meta: Meta<typeof DataCodeSection> = {
   title: 'Composite/DataCodeSection',

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { forwardRef } from 'react';
 import { DataKeysAndValues } from './data-keys-and-values';
 import type { DataKeysAndValuesProps } from './data-keys-and-values-root';
-import { forwardRef } from 'react';
 import { TooltipProvider } from '@/ds/components/Tooltip';
 import type { LinkComponentProps } from '@/ds/types/link-component';
 

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { DataPanel } from './data-panel';
 import { TooltipProvider } from '../Tooltip';
+import { DataPanel } from './data-panel';
 import type { DataPanelProps } from './data-panel-root';
 
 const meta: Meta<typeof DataPanel> = {

--- a/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { DateTimePicker } from './date-time-picker';
 import { useState } from 'react';
+import { DateTimePicker } from './date-time-picker';
 
 const meta: Meta<typeof DateTimePicker> = {
   title: 'Composite/DateTimePicker',

--- a/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
+import { TooltipProvider } from '../Tooltip';
 import { DateTimeRangePicker } from './date-time-range-picker';
 import type { DateRangePreset, DateTimeRangePickerProps } from './date-time-range-picker';
-import { TooltipProvider } from '../Tooltip';
 
 const meta: Meta<typeof DateTimeRangePicker> = {
   title: 'Composite/DateTimeRangePicker',

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
@@ -1,4 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../Button';
+import { Input } from '../Input';
+import { Label } from '../Label';
 import {
   Dialog,
   DialogBody,
@@ -9,9 +12,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from './dialog';
-import { Button } from '../Button';
-import { Input } from '../Input';
-import { Label } from '../Label';
 
 const meta: Meta<typeof Dialog> = {
   title: 'Feedback/Dialog',

--- a/packages/playground-ui/src/ds/components/EmptyState/empty-state.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EmptyState/empty-state.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { EmptyState } from './EmptyState';
-import { Button } from '../Button';
 import { FileX, Inbox, Search, Users } from 'lucide-react';
+import { Button } from '../Button';
+import { EmptyState } from './EmptyState';
 
 const meta: Meta<typeof EmptyState> = {
   title: 'Feedback/EmptyState',

--- a/packages/playground-ui/src/ds/components/Entity/entity.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Entity/entity.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Entity, EntityIcon, EntityName, EntityDescription, EntityContent } from './Entity';
 import { Bot, Workflow, Database, Settings } from 'lucide-react';
+import { Entity, EntityIcon, EntityName, EntityDescription, EntityContent } from './Entity';
 
 const meta: Meta<typeof Entity> = {
   title: 'Composite/Entity',

--- a/packages/playground-ui/src/ds/components/EntityHeader/entity-header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EntityHeader/entity-header.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { EntityHeader } from './entity-header';
 import { Bot, Workflow, Database, Settings } from 'lucide-react';
 import { Badge } from '../Badge';
+import { EntityHeader } from './entity-header';
 
 const meta: Meta<typeof EntityHeader> = {
   title: 'Composite/EntityHeader',

--- a/packages/playground-ui/src/ds/components/Entry/entry.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Entry/entry.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Entry } from './entry';
-import { Txt } from '../Txt';
 import { Badge } from '../Badge';
+import { Txt } from '../Txt';
+import { Entry } from './entry';
 
 const meta: Meta<typeof Entry> = {
   title: 'DataDisplay/Entry',

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.stories.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { SearchFieldBlock, type SearchFieldBlockProps } from './search-field-block';
 import { TooltipProvider } from '../../Tooltip';
+import { SearchFieldBlock } from './search-field-block';
+import type { SearchFieldBlockProps } from './search-field-block';
 
 function SearchFieldBlockControlled(props: SearchFieldBlockProps) {
   const [value, setValue] = useState(props.value ?? '');

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/layout/field-blocks-layout.stories.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/layout/field-blocks-layout.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { FieldBlocksLayout } from './field-blocks-layout';
-import { TextFieldBlock } from '../fields/text-field-block';
-import { SelectFieldBlock } from '../fields/select-field-block';
 import { SearchFieldBlock } from '../fields/search-field-block';
+import { SelectFieldBlock } from '../fields/select-field-block';
+import { TextFieldBlock } from '../fields/text-field-block';
+import { FieldBlocksLayout } from './field-blocks-layout';
 
 const roleOptions = [
   { value: 'admin', label: 'Admin' },

--- a/packages/playground-ui/src/ds/components/Header/header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Header/header.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Header, HeaderTitle, HeaderAction, HeaderGroup } from './Header';
-import { Button } from '../Button';
 import { Settings, Bell, Plus, Search } from 'lucide-react';
+import { Button } from '../Button';
+import { Header, HeaderTitle, HeaderAction, HeaderGroup } from './Header';
 
 const meta: Meta<typeof Header> = {
   title: 'Layout/Header',

--- a/packages/playground-ui/src/ds/components/IconButton/icon-button.stories.tsx
+++ b/packages/playground-ui/src/ds/components/IconButton/icon-button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { IconButton } from './IconButton';
-import { TooltipProvider } from '../Tooltip';
 import { Settings, Plus, Trash } from 'lucide-react';
+import { TooltipProvider } from '../Tooltip';
+import { IconButton } from './IconButton';
 
 const meta: Meta<typeof IconButton> = {
   title: 'Elements/IconButton',

--- a/packages/playground-ui/src/ds/components/JSONSchemaForm/json-schema-form.stories.tsx
+++ b/packages/playground-ui/src/ds/components/JSONSchemaForm/json-schema-form.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
 import { PlusIcon } from 'lucide-react';
-import type { JsonSchema } from '@/lib/json-schema';
+import { useState } from 'react';
 import { TooltipProvider } from '../Tooltip';
-import { JSONSchemaForm } from './index';
 import type { SchemaField } from './types';
 import { createField } from './types';
+import { JSONSchemaForm } from './index';
+import type { JsonSchema } from '@/lib/json-schema';
 
 const meta: Meta<typeof JSONSchemaForm.Root> = {
   title: 'Forms/JSONSchemaForm',

--- a/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { KeyValueList } from './key-value-list';
 import { BrainIcon, WorkflowIcon, UserIcon, TagIcon } from 'lucide-react';
+import { KeyValueList } from './key-value-list';
 
 const meta: Meta<typeof KeyValueList> = {
   title: 'Elements/KeyValueList',

--- a/packages/playground-ui/src/ds/components/Label/label.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Label/label.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Label } from './label';
 import { Input } from '../Input';
+import { Label } from './label';
 
 const meta: Meta<typeof Label> = {
   title: 'Elements/Label',

--- a/packages/playground-ui/src/ds/components/MainContent/main-content.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainContent/main-content.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MainContentLayout, MainContentContent } from './main-content';
 import { PageHeader } from '../PageHeader';
+import { MainContentLayout, MainContentContent } from './main-content';
 
 const meta: Meta<typeof MainContentLayout> = {
   title: 'Layout/MainContent',

--- a/packages/playground-ui/src/ds/components/MainHeader/main-header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainHeader/main-header.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MainHeader } from './main-header';
 import { BotIcon, Edit2Icon } from 'lucide-react';
 import { Button } from '../Button';
-import { TextAndIcon } from '../Text';
 import { CopyButton } from '../CopyButton';
+import { TextAndIcon } from '../Text';
 import { TooltipProvider } from '../Tooltip';
+import { MainHeader } from './main-header';
 
 const meta: Meta<typeof MainHeader> = {
   title: 'Layout/MainHeader',

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MainSidebar, MainSidebarProvider } from './main-sidebar';
-import { TooltipProvider } from '../Tooltip';
 import { Home, Bot, Workflow, Settings, Database, FileText, Users, Bell } from 'lucide-react';
 import { forwardRef } from 'react';
+import { TooltipProvider } from '../Tooltip';
+import { MainSidebar, MainSidebarProvider } from './main-sidebar';
 import type { LinkComponentProps } from '@/ds/types/link-component';
 
 const StoryLink = forwardRef<HTMLAnchorElement, LinkComponentProps>(({ href, children, ...props }, ref) => (

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MarkdownRenderer } from './markdown-renderer';
 import { TooltipProvider } from '../Tooltip';
+import { MarkdownRenderer } from './markdown-renderer';
 
 const meta: Meta<typeof MarkdownRenderer> = {
   title: 'Composite/MarkdownRenderer',

--- a/packages/playground-ui/src/ds/components/MetricsFlexGrid/metrics-flex-grid.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsFlexGrid/metrics-flex-grid.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MetricsFlexGrid } from './metrics-flex-grid';
 import { DashboardCard } from '../DashboardCard';
+import { MetricsFlexGrid } from './metrics-flex-grid';
 
 const meta: Meta<typeof MetricsFlexGrid> = {
   title: 'Metrics/MetricsFlexGrid',

--- a/packages/playground-ui/src/ds/components/Notification/notification.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Notification/notification.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Notification } from './notification';
 import { Info, AlertCircle, Check } from 'lucide-react';
+import { Notification } from './notification';
 
 const meta: Meta<typeof Notification> = {
   title: 'Feedback/Notification',

--- a/packages/playground-ui/src/ds/components/Popover/popover.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Popover, PopoverContent, PopoverTrigger } from './popover';
+import { Settings } from 'lucide-react';
 import { Button } from '../Button';
 import { Input } from '../Input';
 import { Label } from '../Label';
-import { Settings } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
 
 const meta: Meta<typeof Popover> = {
   title: 'Feedback/Popover',

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { RadioGroup, RadioGroupItem } from './radio-group';
 import { Label } from '../Label';
+import { RadioGroup, RadioGroupItem } from './radio-group';
 
 const meta: Meta<typeof RadioGroup> = {
   title: 'Elements/RadioGroup',

--- a/packages/playground-ui/src/ds/components/Searchbar/searchbar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Searchbar/searchbar.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Searchbar, SearchbarWrapper } from './searchbar';
 import { useState } from 'react';
+import { Searchbar, SearchbarWrapper } from './searchbar';
 
 const meta: Meta<typeof Searchbar> = {
   title: 'Composite/Searchbar',

--- a/packages/playground-ui/src/ds/components/Section/section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Section } from './section';
-import { Button } from '../Button';
 import { Plus } from 'lucide-react';
+import { Button } from '../Button';
+import { Section } from './section';
 
 const meta: Meta<typeof Section> = {
   title: 'Layout/Section',

--- a/packages/playground-ui/src/ds/components/Sections/sections.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Sections/sections.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Sections } from './sections';
-import { Section } from '../Section';
 import { Button } from '../Button';
+import { Section } from '../Section';
+import { Sections } from './sections';
 
 const meta: Meta<typeof Sections> = {
   title: 'Layout/Sections',

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { SideDialog } from './side-dialog';
-import { Button } from '../Button';
 import { useState } from 'react';
+import { Button } from '../Button';
+import { SideDialog } from './side-dialog';
 
 const meta: Meta<typeof SideDialog> = {
   title: 'Layout/SideDialog',

--- a/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Switch } from './switch';
 import { Label } from '../Label';
+import { Switch } from './switch';
 
 const meta: Meta<typeof Switch> = {
   title: 'Elements/Switch',

--- a/packages/playground-ui/src/ds/components/Table/table.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Table/table.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Table, Thead, Th, Tbody, Row } from './Table';
-import { Cell, TxtCell, DateTimeCell, EntryCell } from './Cells';
-import { Badge } from '../Badge';
 import { Bot, Workflow } from 'lucide-react';
+import { Badge } from '../Badge';
+import { Cell, TxtCell, DateTimeCell, EntryCell } from './Cells';
+import { Table, Thead, Th, Tbody, Row } from './Table';
 
 const meta: Meta<typeof Table> = {
   title: 'DataDisplay/Table',

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Tabs } from './tabs-root';
-import { TabList } from './tabs-list';
-import { Tab } from './tabs-tab';
 import { TabContent } from './tabs-content';
+import { TabList } from './tabs-list';
+import { Tabs } from './tabs-root';
+import { Tab } from './tabs-tab';
 
 const meta: Meta<typeof Tabs> = {
   title: 'Navigation/Tabs',

--- a/packages/playground-ui/src/ds/components/Text/text.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Text/text.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { TextAndIcon } from './text-and-icon';
 import { Clock, User, MapPin, Mail, Phone, Calendar } from 'lucide-react';
+import { TextAndIcon } from './text-and-icon';
 
 const meta: Meta<typeof TextAndIcon> = {
   title: 'DataDisplay/TextAndIcon',

--- a/packages/playground-ui/src/ds/components/Tooltip/tooltip.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tooltip/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
-import { Button } from '../Button';
 import { Info } from 'lucide-react';
+import { Button } from '../Button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
 
 const meta: Meta<typeof Tooltip> = {
   title: 'Elements/Tooltip',

--- a/packages/playground-ui/src/ds/components/Tree/tree.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState, useCallback } from 'react';
 import { File, FileCode, FileJson, FileText, Folder, FolderGit2, FolderPlus, Plus, Trash2 } from 'lucide-react';
-import { Tree } from './tree';
+import { useState, useCallback } from 'react';
 import { IconButton } from '../IconButton';
 import { TooltipProvider } from '../Tooltip';
+import { Tree } from './tree';
 
 const meta: Meta<typeof Tree> = {
   title: 'DataDisplay/Tree',

--- a/packages/playground-ui/src/ds/components/Truncate/truncate.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Truncate/truncate.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Truncate } from './truncate';
 import { TooltipProvider } from '../Tooltip';
+import { Truncate } from './truncate';
 
 const meta: Meta<typeof Truncate> = {
   title: 'Elements/Truncate',

--- a/packages/playground-ui/src/ds/tokens/tokens.stories.tsx
+++ b/packages/playground-ui/src/ds/tokens/tokens.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Txt } from '../components/Txt/Txt';
-import { FontSizes, LineHeights } from './fonts';
-import { Colors, BorderColors } from './colors';
-import { Spacings } from './spacings';
-import { BorderRadius } from './borders';
-import { Shadows, Glows } from './shadows';
 import { Animations } from './animations';
+import { BorderRadius } from './borders';
+import { Colors, BorderColors } from './colors';
+import { FontSizes, LineHeights } from './fonts';
+import { Shadows, Glows } from './shadows';
+import { Spacings } from './spacings';
 
 const meta: Meta = {
   title: 'Foundations/Tokens',

--- a/packages/playground-ui/src/lib/rule-engine/components/rule-builder.stories.tsx
+++ b/packages/playground-ui/src/lib/rule-engine/components/rule-builder.stories.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 
 import type { RuleGroup } from '../types';
 
+import { complexSchema } from './fixtures';
 import { RuleBuilder } from './rule-builder';
 import type { JsonSchema } from './types';
-import { complexSchema } from './fixtures';
 import { TooltipProvider } from '@/ds/components/Tooltip';
 
 const meta: Meta<typeof RuleBuilder> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4351,11 +4351,11 @@ importers:
         specifier: workspace:*
         version: link:../../client-sdks/react
       '@storybook/addon-docs':
-        specifier: ^9.1.20
-        version: 9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))
+        specifier: ^10.3.5
+        version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.27.7))
       '@storybook/react-vite':
-        specifier: ^9.1.20
-        version: 9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^10.3.5
+        version: 10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.27.7))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4401,6 +4401,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
         version: 0.5.2(eslint@10.2.1(jiti@2.6.1))
+      eslint-plugin-storybook:
+        specifier: 10.3.5
+        version: 10.3.5(eslint@10.2.1(jiti@2.6.1))(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0(bufferutil@4.1.0)
@@ -4408,8 +4411,8 @@ importers:
         specifier: ^8.1.2
         version: 8.1.2(rollup@4.60.2)
       storybook:
-        specifier: ^9.1.20
-        version: 9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^10.3.5
+        version: 10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -11150,6 +11153,15 @@ packages:
       typescript:
         optional: true
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
+    resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
+    peerDependencies:
+      typescript: ^5.9.3
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@jpwilliams/waitgroup@2.1.1':
     resolution: {integrity: sha512-0CxRhNfkvFCTLZBKGvKxY2FYtYW1yWhO2McLqBL0X5UWvYjIf9suH8anKW/DNutl369A75Ewyoh2iJMwBZ2tRg==}
 
@@ -14808,16 +14820,40 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  '@storybook/addon-docs@9.1.20':
-    resolution: {integrity: sha512-eUIOd4u/p9994Nkv8Avn6r/xmS7D+RNmhmu6KGROefN3myLe3JfhSdimal2wDFe/h/OUNZ/LVVKMZrya9oEfKQ==}
+  '@storybook/addon-docs@10.3.5':
+    resolution: {integrity: sha512-WuHbxia/o5TX4Rg/IFD0641K5qId/Nk0dxhmAUNoFs5L0+yfZUwh65XOBbzXqrkYmYmcVID4v7cgDRmzstQNkA==}
     peerDependencies:
-      storybook: ^9.1.20
+      storybook: ^10.3.5
+
+  '@storybook/builder-vite@10.3.5':
+    resolution: {integrity: sha512-i4KwCOKbhtlbQIbhm53+Kk7bMnxa0cwTn1pxmtA/x5wm1Qu7FrrBQV0V0DNjkUqzcSKo1CjspASJV/HlY0zYlw==}
+    peerDependencies:
+      storybook: ^10.3.5
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@storybook/builder-vite@9.1.20':
     resolution: {integrity: sha512-cdU3Q2/wEaT8h+mApFToRiF/0hYKH1eAkD0scQn67aODgp7xnkr0YHcdA+8w0Uxd2V7U8crV/cmT/HD0ELVOGw==}
     peerDependencies:
       storybook: ^9.1.20
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@storybook/csf-plugin@10.3.5':
+    resolution: {integrity: sha512-qlEzNKxOjq86pvrbuMwiGD/bylnsXk1dg7ve0j77YFjEEchqtl7qTlrXvFdNaLA89GhW6D/EV6eOCu/eobPDgw==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.3.5
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   '@storybook/csf-plugin@9.1.20':
     resolution: {integrity: sha512-HHgk50YQhML7mT01Mzf9N7lNMFHWN4HwwRP90kPT9Ct+Jhx7h3LBDbdmWjI96HwujcpY7eoYdTfpB1Sw8Z7nBQ==}
@@ -14827,12 +14863,18 @@ packages:
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
-  '@storybook/icons@1.6.0':
-    resolution: {integrity: sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw==}
-    engines: {node: '>=14.0.0'}
+  '@storybook/icons@2.0.1':
+    resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/react-dom-shim@10.3.5':
+    resolution: {integrity: sha512-Gw8R7XZm0zSUH0XAuxlQJhmizsLzyD6x00KOlP6l7oW9eQHXGfxg3seNDG3WrSAcW07iP1/P422kuiriQlOv7g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.5
 
   '@storybook/react-dom-shim@9.1.20':
     resolution: {integrity: sha512-UYdZavfPwHEqCKMqPssUOlyFVZiJExLxnSHwkICSZBmw3gxXJcp1aXWs7PvoZdWz2K4ztl3IcKErXXHeiY6w+A==}
@@ -14840,6 +14882,14 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^9.1.20
+
+  '@storybook/react-vite@10.3.5':
+    resolution: {integrity: sha512-UB5sJHeh26bfd8sNMx2YPGYRYmErIdTRaLOT28m4bykQIa1l9IgVktsYg/geW7KsJU0lXd3oTbnUjLD+enpi3w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.5
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@storybook/react-vite@9.1.20':
     resolution: {integrity: sha512-buXeNvEJ9kp4FKbGYV7zW4sh/KS01EAjeq8Z6AVxaXOh4W2CIRTKM9maWGz+Rr+YyqQIq/Gl+RqNwxctpxeuHA==}
@@ -14849,6 +14899,17 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^9.1.20
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@storybook/react@10.3.5':
+    resolution: {integrity: sha512-tpLTLaVGoA6fLK3ReyGzZUricq7lyPaV2hLPpj5wqdXLV/LpRtAHClUpNoPDYSBjlnSjL81hMZijbkGC3mA+gw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.5
+      typescript: ^5.9.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@storybook/react@9.1.20':
     resolution: {integrity: sha512-TJhqzggs7HCvLhTXKfx8HodnVq9YizsB2J31s9v6olU0UCxbCY+FYaCF+XdE8qUCyefGRZgHKzGBIczJ/q9e2g==}
@@ -16415,6 +16476,9 @@ packages:
 
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
   '@wong2/mcp-cli@1.13.0':
     resolution: {integrity: sha512-yNgGKwW4Kz9vyvb/hTYvROehWj4LgAeEokxJgtOZWQSPGhhXtNHOrq/8VfT+dYtus4mChLtnMcB8lafX3RsATA==}
@@ -19380,9 +19444,9 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@13.0.0:
-    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
-    engines: {node: 20 || >=22}
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -21456,8 +21520,8 @@ packages:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@2.1.2:
@@ -22228,9 +22292,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.1:
-    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
-    engines: {node: 20 || >=22}
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
@@ -24282,6 +24346,15 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  storybook@10.3.5:
+    resolution: {integrity: sha512-uBSZu/GZa9aEIW3QMGvdQPMZWhGxSe4dyRWU8B3/Vd47Gy/XLC7tsBxRr13txmmPOEDHZR94uLuq0H50fvuqBw==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
   storybook@9.1.20:
     resolution: {integrity: sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==}
     hasBin: true
@@ -25156,6 +25229,10 @@ packages:
   unplugin@1.16.1:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
     engines: {node: '>=14.0.0'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -30938,7 +31015,7 @@ snapshots:
       content-disposition: 1.0.1
       fastify-plugin: 5.1.0
       fastq: 1.20.1
-      glob: 13.0.0
+      glob: 13.0.6
 
   '@fastify/swagger-ui@5.2.5':
     dependencies:
@@ -31531,7 +31608,7 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@isaacs/ttlcache@2.1.4': {}
 
@@ -31552,6 +31629,14 @@ snapshots:
     dependencies:
       glob: 10.5.0
       magic-string: 0.30.21
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      vite: 7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       vite: 7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
@@ -36146,18 +36231,33 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-docs@9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.27.7))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))
-      '@storybook/icons': 1.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.27.7))
+      '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
+  '@storybook/builder-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.27.7))':
+    dependencies:
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.27.7))
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      ts-dedent: 2.2.0
+      vite: 7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
 
   '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -36166,6 +36266,16 @@ snapshots:
       ts-dedent: 2.2.0
       vite: 7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.27.7))':
+    dependencies:
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.7
+      rollup: 4.60.2
+      vite: 7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      webpack: 5.104.1(esbuild@0.27.7)
+
   '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       storybook: 9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -36173,16 +36283,44 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@1.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@storybook/icons@2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  '@storybook/react-dom-shim@10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   '@storybook/react-dom-shim@9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       storybook: 9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  '@storybook/react-vite@10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.27.7))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      '@storybook/builder-vite': 10.3.5(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.27.7))
+      '@storybook/react': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+      empathic: 2.0.0
+      magic-string: 0.30.21
+      react: 19.2.5
+      react-docgen: 8.0.2
+      react-dom: 19.2.5(react@19.2.5)
+      resolve: 1.22.11
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tsconfig-paths: 4.2.0
+      vite: 7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - supports-color
+      - typescript
+      - webpack
 
   '@storybook/react-vite@9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -36203,6 +36341,20 @@ snapshots:
       - rollup
       - supports-color
       - typescript
+
+  '@storybook/react@10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      react: 19.2.5
+      react-docgen: 8.0.2
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@storybook/react@9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))(typescript@5.9.3)':
     dependencies:
@@ -37982,6 +38134,8 @@ snapshots:
     dependencies:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
+
+  '@webcontainer/env@1.1.1': {}
 
   '@wong2/mcp-cli@1.13.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
@@ -40630,6 +40784,15 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
+  eslint-plugin-storybook@10.3.5(eslint@10.2.1(jiti@2.6.1))(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.58.2(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 10.2.1(jiti@2.6.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   eslint-plugin-storybook@10.3.5(eslint@10.2.1(jiti@2.6.1))(storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.58.2(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)
@@ -41528,7 +41691,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.9
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -41537,15 +41700,15 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 4.2.1
       minimatch: 10.2.4
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
-      path-scurry: 2.0.1
+      path-scurry: 2.0.2
 
-  glob@13.0.0:
+  glob@13.0.6:
     dependencies:
       minimatch: 10.2.4
-      minipass: 7.1.2
-      path-scurry: 2.0.1
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   global-agent@3.0.0:
     dependencies:
@@ -44327,7 +44490,7 @@ snapshots:
 
   minipass@5.0.0: {}
 
-  minipass@7.1.2: {}
+  minipass@7.1.3: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -44336,7 +44499,7 @@ snapshots:
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   mitt@3.0.1: {}
 
@@ -45188,12 +45351,12 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
-  path-scurry@2.0.1:
+  path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.7
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
 
@@ -47938,6 +48101,30 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.27.7
+      open: 10.2.0
+      recast: 0.23.11
+      semver: 7.7.4
+      use-sync-external-store: 1.6.0(react@19.2.5)
+      ws: 8.20.0(bufferutil@4.1.0)
+    optionalDependencies:
+      prettier: 3.8.3
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - react-dom
+      - utf-8-validate
+
   storybook@9.1.20(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(prettier@3.8.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@storybook/global': 5.0.0
@@ -48316,7 +48503,7 @@ snapshots:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
 
@@ -48392,6 +48579,18 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.7(@swc/helpers@0.5.17))
     optionalDependencies:
       '@swc/core': 1.15.7(@swc/helpers@0.5.17)
+
+  terser-webpack-plugin@5.3.16(esbuild@0.27.7)(webpack@5.104.1(esbuild@0.27.7)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 7.0.5
+      terser: 5.44.1
+      webpack: 5.104.1(esbuild@0.27.7)
+    optionalDependencies:
+      esbuild: 0.27.7
+    optional: true
 
   terser@5.44.1:
     dependencies:
@@ -48944,6 +49143,13 @@ snapshots:
   unplugin@1.16.1:
     dependencies:
       acorn: 8.16.0
+      webpack-virtual-modules: 0.6.2
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   unrs-resolver@1.11.1:
@@ -49673,6 +49879,39 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  webpack@5.104.1(esbuild@0.27.7):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(esbuild@0.27.7)(webpack@5.104.1(esbuild@0.27.7))
+      watchpack: 2.5.1
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
 
   webpackbar@6.0.1(webpack@5.104.1(@swc/core@1.15.7(@swc/helpers@0.5.17))):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4402,7 +4402,7 @@ importers:
         specifier: ^0.5.2
         version: 0.5.2(eslint@10.2.1(jiti@2.6.1))
       eslint-plugin-storybook:
-        specifier: 10.3.5
+        specifier: ^10.3.5
         version: 10.3.5(eslint@10.2.1(jiti@2.6.1))(storybook@10.3.5(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       jsdom:
         specifier: ^26.1.0


### PR DESCRIPTION
## Summary
- Upgrade `storybook`, `@storybook/react-vite`, `@storybook/addon-docs` from `^9.1.20` → `^10.3.5`
- Add `eslint-plugin-storybook@^10.3.5` (applied by `storybook upgrade` automigration)
- `.storybook/main.ts`: wrap `addons` + `framework.name` with `getAbsolutePath` helper (required by Storybook 10 ESM-only config loader)
- `eslint.config.js`: enable `eslint-plugin-storybook` flat recommended preset

No runtime changes — dev-only dependency bump. Storybook 10 migration guide: https://storybook.js.org/docs/releases/migration-guide

## Test plan
- [x] `pnpm build-storybook` — builds successfully
- [x] `pnpm build` (tsc + vite) — passes
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 50/50 tests pass
- [ ] `pnpm storybook` dev server loads and stories render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR upgrades Storybook (a tool for building and testing UI components) from version 9 to version 10. To make this work, the configuration files had to be updated to use a new helper function and add an ESLint plugin, plus all the story files had their imports reordered for consistency.

## Overview

Upgrades Storybook and related packages in `packages/playground-ui` from v9.1.20 to v10.3.5, with corresponding configuration updates required by Storybook 10's new ESM-only config loader.

## Changes

**Package Dependencies**
- Upgraded `storybook`, `@storybook/react-vite`, and `@storybook/addon-docs` from `^9.1.20` to `^10.3.5`
- Added `eslint-plugin-storybook@^10.3.5` as a new dev dependency

**Configuration Updates**
- `.storybook/main.ts`: Introduced `getAbsolutePath` helper function that resolves package paths using `import.meta.resolve` and `fileURLToPath`. Updated both `addons` and `framework.name` entries to use this helper instead of plain package specifier strings.
- `eslint.config.js`: Added Storybook ESLint plugin by importing `eslint-plugin-storybook` and integrating its `flat/recommended` ruleset. Removed the blanket ignore for `**/*.stories.tsx` files and added story-specific rule overrides to disable `no-console` and `@typescript-eslint/no-unused-vars` for story files.

**Story Files**
- All 51 story files in `src/ds/components/`, `src/ds/tokens/`, and `src/lib/rule-engine/` underwent import statement reordering for consistency. No functional changes to story logic, component usage, or exports.

## Testing

All automated checks pass:
- `pnpm build-storybook` ✓
- `pnpm build` (tsc + vite) ✓
- `pnpm lint` ✓
- `pnpm test` (50/50 tests) ✓

Manual Storybook dev server testing remains pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->