### PR TITLE
fix: True vercel ai sdk-like approval system in mastra

### DIFF
--- a/client-sdks/ai-sdk/src/convert-streams.ts
+++ b/client-sdks/ai-sdk/src/convert-streams.ts
@@ -241,8 +241,8 @@ export function toAISdkStream(
     return agentReadable.pipeThrough(
       AgentStreamToAISDKV6Transformer<any>({
         lastMessageId: options.lastMessageId,
-        sendStart: options.sendStart,
-        sendFinish: options.sendFinish,
+        sendStart: options.sendStart ?? true,
+        sendFinish: options.sendFinish ?? true,
         sendReasoning: options.sendReasoning,
         sendSources: options.sendSources,
         messageMetadata: options.messageMetadata,
@@ -280,8 +280,8 @@ export function toAISdkStream(
   return agentReadable.pipeThrough(
     AgentStreamToAISDKTransformer<any>({
       lastMessageId: options.lastMessageId,
-      sendStart: options.sendStart,
-      sendFinish: options.sendFinish,
+      sendStart: options.sendStart ?? true,
+      sendFinish: options.sendFinish ?? true,
       sendReasoning: options.sendReasoning,
       sendSources: options.sendSources,
       messageMetadata: options.messageMetadata,


### PR DESCRIPTION
## Problem
The `toAISdkStream` function's default options for `sendStart` and `sendFinish` are only applied when the `options` argument is entirely omitted, leading to `undefined` values being passed to stream transformers when partial options are provided, which may cause unexpected behavior or demo failures.

## Changes Made
- client-sdks/ai-sdk/src/convert-streams.ts: applied fix for described issue.

## How to Test
1. Run the `assistant-ui` Mastra demo mentioned in the issue. Verify that it now functions correctly and does not fail when `sendStart` or `sendFinish` are not explicitly set in the `toAISdkStream` call.
2. Create a test case that calls `toAISdkStream` with `from: 'agent'`, `version: 'v6'`, and no explicit `sendStart` or `sendFinish` options. Observe the resulting stream (e.g., via a debugger or by logging chunks) to confirm that 'start' and 'finish' messages are emitted by the stream.
3. Create test cases that explicitly set `sendStart: false` and `sendFinish: false` (or `true`) to ensure that these explicit overrides are respected and the respective messages are (or are not) emitted.

## Related Issue
Closes #15735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

When you use Mastra's `toAISdkStream` function without explicitly saying whether to send start/finish messages, it should default to sending them. However, if you passed some options (like the version), the function was forgetting those defaults and sending nothing instead. This PR fixes that so the defaults always apply when you don't explicitly set them.

## Summary

This PR fixes a bug in `toAISdkStream` where default values for `sendStart` and `sendFinish` were not being applied correctly when partial options were provided.

**Problem**: The function signature had default values for `sendStart: true` and `sendFinish: true`, but these only applied when the entire `options` argument was omitted. When users passed partial options (e.g., `{ from: 'agent', version: 'v6' }`), these fields would be `undefined`, causing the stream transformers to not emit start and finish messages as expected.

**Solution**: Updated both the v5 and v6 agent stream conversion paths in `client-sdks/ai-sdk/src/convert-streams.ts` to use the nullish coalescing operator (`??`) when passing `sendStart` and `sendFinish` to the transformers. This ensures that `undefined` values are replaced with `true`, making the defaults reliable regardless of whether the entire options object or just partial options are provided.

**Impact**: Stream transformers now consistently receive `true` as the default for start/finish emission unless explicitly overridden by the caller, fixing the assistant-ui Mastra demo failure and enabling proper native approval/transport flow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->