### PR TITLE
docs: add script to generate single-file PDF of docs

### DIFF
--- a/docs/scripts/generate-pdf/.gitignore
+++ b/docs/scripts/generate-pdf/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+mastra-docs.pdf
+mastra-docs.html
+debug.html
+*.log

--- a/docs/scripts/generate-pdf/.gitignore
+++ b/docs/scripts/generate-pdf/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 mastra-docs.pdf
 mastra-docs.html
 debug.html
+chapters/
 *.log

--- a/docs/scripts/generate-pdf/chapter-style.css
+++ b/docs/scripts/generate-pdf/chapter-style.css
@@ -1,0 +1,259 @@
+/*
+ * Minimal stylesheet for per-chapter PDFs intended as RAG source documents.
+ * Optimized for clean text extraction rather than visual polish:
+ *   - single-column, linear reading order
+ *   - no cover, TOC, page counters, or decorative chrome
+ *   - no background colors that could confuse OCR fallbacks
+ *   - code blocks stay monospace with visible fences; no syntax coloring
+ *   - admonitions collapse to a bold label + plain body
+ */
+
+@page {
+  size: A4;
+  margin: 18mm 20mm 18mm 20mm;
+}
+
+html,
+body {
+  background: #ffffff;
+  color: #000000;
+  font-family: 'Times New Roman', 'Liberation Serif', Georgia, serif;
+  font-size: 11pt;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* ---------- Chapter header ---------- */
+
+.chapter-title {
+  font-family: 'Helvetica', 'Arial', sans-serif;
+  font-size: 22pt;
+  font-weight: 700;
+  margin: 0 0 1.5mm 0;
+  line-height: 1.15;
+}
+
+.chapter-kicker {
+  font-family: 'Helvetica', 'Arial', sans-serif;
+  font-size: 9pt;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #555555;
+  margin: 0 0 8mm 0;
+}
+
+/* A thin rule under the header + between major sections keeps the
+   reading rhythm without colored ornament. */
+.chapter-divider {
+  border: none;
+  border-top: 0.5pt solid #bbbbbb;
+  margin: 6mm 0;
+}
+
+/* Per-doc boundary inside a chapter. */
+.doc-header {
+  margin: 8mm 0 2mm 0;
+}
+
+.doc-header h2 {
+  font-family: 'Helvetica', 'Arial', sans-serif;
+  font-size: 15pt;
+  font-weight: 700;
+  margin: 0;
+  line-height: 1.2;
+  page-break-after: avoid;
+}
+
+.doc-header .doc-description {
+  font-size: 10.5pt;
+  font-style: italic;
+  color: #444444;
+  margin-top: 1mm;
+}
+
+/* ---------- Body ---------- */
+
+article {
+  margin: 0 0 4mm 0;
+}
+
+article h1 {
+  font-family: 'Helvetica', 'Arial', sans-serif;
+  font-size: 13pt;
+  font-weight: 700;
+  margin: 6mm 0 2mm 0;
+  page-break-after: avoid;
+}
+
+article h2 {
+  font-family: 'Helvetica', 'Arial', sans-serif;
+  font-size: 12pt;
+  font-weight: 700;
+  margin: 5mm 0 1.5mm 0;
+  page-break-after: avoid;
+}
+
+article h3,
+article h4,
+article h5,
+article h6 {
+  font-family: 'Helvetica', 'Arial', sans-serif;
+  font-size: 11pt;
+  font-weight: 700;
+  margin: 4mm 0 1.2mm 0;
+  page-break-after: avoid;
+}
+
+article p {
+  margin: 0 0 2.5mm 0;
+  orphans: 2;
+  widows: 2;
+}
+
+article ul,
+article ol {
+  margin: 0 0 3mm 0;
+  padding-left: 6mm;
+}
+
+article li {
+  margin: 0.4mm 0;
+}
+
+article a {
+  color: #000000;
+  text-decoration: underline;
+}
+
+article hr {
+  border: none;
+  border-top: 0.5pt solid #bbbbbb;
+  margin: 5mm 0;
+}
+
+article blockquote {
+  border-left: 2pt solid #999999;
+  margin: 3mm 0;
+  padding: 0 0 0 3mm;
+  color: #333333;
+  font-style: italic;
+}
+
+/* ---------- Code ---------- */
+
+article code {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 9.8pt;
+  background: #f2f2f2;
+  padding: 0 2pt;
+}
+
+article pre {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 9.2pt;
+  line-height: 1.4;
+  background: #f5f5f5;
+  border: 0.5pt solid #cccccc;
+  padding: 2mm 3mm;
+  margin: 2.5mm 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  page-break-inside: avoid;
+}
+
+article pre code {
+  background: transparent;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* Keep the filename chip simple and monochrome. */
+.code-block {
+  margin: 2.5mm 0;
+  page-break-inside: avoid;
+}
+
+.code-block-title {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 8.5pt;
+  color: #555555;
+  padding: 0 0 0.5mm 1mm;
+}
+
+/* Drop every highlight.js color so code extracts as plain text. */
+.hljs,
+.hljs * {
+  color: inherit !important;
+  font-style: normal !important;
+  font-weight: inherit !important;
+  background: transparent !important;
+}
+
+/* ---------- Tables ---------- */
+
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2.5mm 0;
+  font-size: 10pt;
+  page-break-inside: avoid;
+}
+
+article th,
+article td {
+  border: 0.5pt solid #888888;
+  padding: 1.3mm 2mm;
+  vertical-align: top;
+  text-align: left;
+}
+
+article th {
+  background: #eeeeee;
+  font-weight: 700;
+}
+
+/* ---------- Admonitions ---------- */
+
+.admonition {
+  border-left: 2pt solid #888888;
+  padding: 0.5mm 3mm;
+  margin: 3mm 0;
+  page-break-inside: avoid;
+}
+
+.admonition p {
+  margin: 0 0 2mm 0;
+}
+
+.admonition p:last-child {
+  margin-bottom: 0;
+}
+
+.admonition strong {
+  font-family: 'Helvetica', 'Arial', sans-serif;
+  font-size: 9pt;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+}
+
+/* ---------- Steps ---------- */
+
+.step-label {
+  font-family: 'Helvetica', 'Arial', sans-serif;
+  font-size: 10pt;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #333333;
+  margin: 5mm 0 1.5mm 0;
+  padding-top: 2mm;
+  border-top: 0.5pt solid #cccccc;
+  page-break-after: avoid;
+}
+
+.step-label:first-of-type {
+  padding-top: 0;
+  border-top: none;
+  margin-top: 2mm;
+}

--- a/docs/scripts/generate-pdf/index.mjs
+++ b/docs/scripts/generate-pdf/index.mjs
@@ -186,15 +186,11 @@ async function resolvePartTree(part) {
 
 async function renderNode(node, ctx) {
   if (node.type === 'category') {
-    const slug = slugify(node.label, ctx.usedSlugs)
-    const categoryToc = { id: slug, title: node.label, depth: node.depth, children: [] }
+    // Categories only appear in the TOC as a labelled group header; we no
+    // longer emit a per-category body page since it would render as a nearly
+    // blank sheet between the previous chapter and the category's first doc.
+    const categoryToc = { title: node.label, depth: node.depth, children: [] }
     ctx.tocChildren.push(categoryToc)
-    ctx.rendered.push(
-      `<section class="chapter-header" id="${slug}">` +
-        `<div class="chapter-eyebrow">Category</div>` +
-        `<h2>${escapeHtml(node.label)}</h2>` +
-        `</section>`,
-    )
     for (const child of node.children) {
       await renderNode(child, { ...ctx, tocChildren: categoryToc.children })
     }
@@ -241,19 +237,10 @@ function buildHtml({ sections, toc, style }) {
   })
 
   const tocHtml = renderToc(toc)
-  const body = sections
-    .map(
-      (s) =>
-        `<section class="part-header" id="${s.tocId}">` +
-        `<div class="part-eyebrow">Part</div>` +
-        `<h1>${escapeHtml(s.part.title)}</h1>` +
-        (s.part.description
-          ? `<p class="part-description">${escapeHtml(s.part.description)}</p>`
-          : '') +
-        `</section>\n` +
-        s.body,
-    )
-    .join('\n')
+  // Part headers used to be full-page title sheets (mostly blank). They added
+  // little beyond what the TOC already conveys and disrupted the reading flow,
+  // so body rendering now goes straight into the first chapter of each part.
+  const body = sections.map((s) => s.body).join('\n')
 
   return `<!doctype html>
 <html lang="en">
@@ -285,9 +272,8 @@ function buildHtml({ sections, toc, style }) {
 function renderToc(entries) {
   const lines = ['<ol>']
   for (const part of entries) {
-    lines.push(
-      `<li class="toc-part"><a href="#${part.id}">${escapeHtml(part.title)}</a></li>`,
-    )
+    // Parts no longer have a body anchor, so render the label as plain text.
+    lines.push(`<li class="toc-part">${escapeHtml(part.title)}</li>`)
     lines.push(...renderTocChildren(part.children, 'toc-chapter'))
   }
   lines.push('</ol>')
@@ -298,9 +284,12 @@ function renderTocChildren(children, cls) {
   const out = []
   for (const child of children || []) {
     const childCls = cls === 'toc-chapter' && child.children ? 'toc-chapter' : cls
-    out.push(
-      `<li class="${child.children ? 'toc-chapter' : childCls}"><a href="#${child.id}">${escapeHtml(child.title)}</a></li>`,
-    )
+    const itemCls = child.children ? 'toc-chapter' : childCls
+    const label = escapeHtml(child.title)
+    // Categories have no id (they're just visual grouping), so render the
+    // label as plain text instead of a broken anchor.
+    const inner = child.id ? `<a href="#${child.id}">${label}</a>` : label
+    out.push(`<li class="${itemCls}">${inner}</li>`)
     if (child.children && child.children.length) {
       out.push(...renderTocChildren(child.children, 'toc-section'))
     }

--- a/docs/scripts/generate-pdf/index.mjs
+++ b/docs/scripts/generate-pdf/index.mjs
@@ -26,6 +26,8 @@ const CONTENT_ROOT = path.join(REPO_DOCS_ROOT, 'src/content/en')
 const STYLE_FILE = path.join(__dirname, 'style.css')
 
 const DEFAULT_OUTPUT = path.join(__dirname, 'mastra-docs.pdf')
+const DEFAULT_CHAPTER_DIR = path.join(__dirname, 'chapters')
+const CHAPTER_STYLE_FILE = path.join(__dirname, 'chapter-style.css')
 
 // Ordered list of top-level "parts". Each part corresponds to a sidebar
 // config in a docs subdirectory. The order below is the order they appear
@@ -75,15 +77,25 @@ const PARTS = [
 ]
 
 function parseArgs(argv) {
-  const args = { out: DEFAULT_OUTPUT, htmlOnly: false, only: null }
+  const args = {
+    out: DEFAULT_OUTPUT,
+    htmlOnly: false,
+    only: null,
+    chapters: false,
+    outDir: DEFAULT_CHAPTER_DIR,
+  }
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--out' || a === '-o') args.out = path.resolve(argv[++i])
+    else if (a === '--out-dir') args.outDir = path.resolve(argv[++i])
     else if (a === '--html-only') args.htmlOnly = true
+    else if (a === '--chapters') args.chapters = true
     else if (a === '--only') args.only = new Set(argv[++i].split(',').map((s) => s.trim()))
     else if (a === '--help' || a === '-h') {
       console.log(
-        'Usage: node index.mjs [--out path.pdf] [--html-only] [--only docs,reference]',
+        'Usage:\n' +
+          '  node index.mjs [--out path.pdf] [--html-only] [--only docs,reference]\n' +
+          '  node index.mjs --chapters [--out-dir ./chapters] [--only docs,reference]',
       )
       process.exit(0)
     }
@@ -95,6 +107,11 @@ async function main() {
   const args = parseArgs(process.argv.slice(2))
   console.log('Mastra Docs PDF generator')
   console.log('─'.repeat(40))
+
+  if (args.chapters) {
+    await buildChapters(args)
+    return
+  }
 
   const md = buildMarkdownIt()
   const usedSlugs = new Set()
@@ -165,6 +182,200 @@ async function main() {
 
   const stat = await fs.stat(args.out)
   console.log(`\nDone. Wrote ${formatBytes(stat.size)} → ${args.out}`)
+}
+
+// ---------- Chapter mode ----------
+//
+// Produces one PDF per TOC category (e.g. "Memory", "Workflows", "Agents").
+// The output is intended as a corpus for RAG — plain styling, no cover, no
+// TOC, no page chrome, no syntax-highlight colors, one coherent topic per
+// file. Filenames are numeric-prefixed for stable ordering:
+//   chapters/02-docs-memory.pdf
+//   chapters/05-reference-agents.pdf
+
+async function buildChapters(args) {
+  const outDir = args.outDir
+  await fs.mkdir(outDir, { recursive: true })
+
+  const md = buildMarkdownIt()
+  const style = await fs.readFile(CHAPTER_STYLE_FILE, 'utf8')
+
+  const chapters = []
+  for (let pi = 0; pi < PARTS.length; pi++) {
+    const part = PARTS[pi]
+    if (args.only && !args.only.has(part.id)) continue
+    const tree = await resolvePartTree(part)
+    for (const ch of enumerateChapters(tree, part)) {
+      chapters.push({ ...ch, partIndex: pi + 1 })
+    }
+  }
+
+  if (chapters.length === 0) {
+    console.log('No chapters to render.')
+    return
+  }
+
+  console.log(`\nRendering ${chapters.length} chapters → ${outDir}`)
+  const { default: puppeteer } = await import('puppeteer')
+  const browser = await puppeteer.launch({ headless: 'new' })
+  try {
+    const page = await browser.newPage()
+    let totalBytes = 0
+    for (const chapter of chapters) {
+      const html = await buildChapterHtml(chapter, md, style)
+      const slug = `${String(chapter.partIndex).padStart(2, '0')}-${chapter.part.id}-${chapter.slug}.pdf`
+      const outPath = path.join(outDir, slug)
+      await page.setContent(html, { waitUntil: 'networkidle0' })
+      await page.emulateMediaType('print')
+      await page.pdf({
+        path: outPath,
+        format: 'A4',
+        printBackground: false,
+        preferCSSPageSize: true,
+        margin: { top: '18mm', bottom: '18mm', left: '20mm', right: '20mm' },
+      })
+      const stat = await fs.stat(outPath)
+      totalBytes += stat.size
+      console.log(`  ✓ ${slug}  (${formatBytes(stat.size)}, ${chapter.docCount} docs)`)
+    }
+    console.log(
+      `\nDone. ${chapters.length} chapters, ${formatBytes(totalBytes)} total in ${outDir}`,
+    )
+  } finally {
+    await browser.close()
+  }
+}
+
+// Split a part's tree into "chapters". Loose docs that sit directly under a
+// part (no enclosing category) roll up into a single part-level chapter;
+// each category becomes its own chapter with all its nested descendants
+// included.
+function enumerateChapters(tree, part) {
+  const out = []
+  const looseDocs = tree.filter((n) => n.type === 'doc' && !(part.skipIds && part.skipIds.has(n.id)))
+  const categories = tree.filter((n) => n.type === 'category')
+
+  if (looseDocs.length) {
+    out.push({
+      part,
+      slug: 'overview',
+      title: part.title,
+      nodes: looseDocs,
+      docCount: looseDocs.length,
+    })
+  }
+  for (const cat of categories) {
+    const nodes = collectChapterNodes(cat, 2)
+    const docCount = nodes.filter((n) => n.type === 'doc').length
+    if (docCount === 0) continue
+    out.push({
+      part,
+      slug: simpleSlug(cat.label),
+      title: cat.label,
+      nodes,
+      docCount,
+    })
+  }
+  return out
+}
+
+// Flatten a category subtree into a linear list. Sub-category boundaries
+// become "subheading" nodes so the chapter still reads with structure, but
+// there is only ever one chapter file per top-level category.
+function collectChapterNodes(node, headingLevel) {
+  const out = []
+  if (node.type === 'doc') {
+    out.push({ type: 'doc', ...node })
+    return out
+  }
+  for (const child of node.children) {
+    if (child.type === 'doc') {
+      out.push({ type: 'doc', ...child })
+    } else if (child.type === 'category') {
+      out.push({ type: 'subheading', label: child.label, level: Math.min(headingLevel, 4) })
+      for (const n of collectChapterNodes(child, headingLevel + 1)) out.push(n)
+    }
+  }
+  return out
+}
+
+async function buildChapterHtml(chapter, md, style) {
+  const parts = []
+  parts.push(
+    `<header>` +
+      `<div class="chapter-kicker">${escapeHtml(chapter.part.title)}</div>` +
+      `<h1 class="chapter-title">${escapeHtml(chapter.title)}</h1>` +
+      `<hr class="chapter-divider"/>` +
+      `</header>`,
+  )
+
+  // For a single-doc chapter, the chapter H1 already names the topic, so
+  // skip the per-doc header to avoid three redundant "Memory" / "Get
+  // Started" style headings stacked on top of each other.
+  const suppressDocHeader = chapter.docCount === 1 && chapter.nodes.filter((n) => n.type === 'doc').length === 1
+
+  for (const node of chapter.nodes) {
+    if (node.type === 'subheading') {
+      const tag = `h${node.level}`
+      parts.push(`<${tag}>${escapeHtml(node.label)}</${tag}>`)
+      continue
+    }
+    // doc
+    let raw
+    try {
+      raw = await fs.readFile(node.file, 'utf8')
+    } catch {
+      continue
+    }
+    const { data, content } = preprocessMdx(raw)
+    const title = node.label || data.title || node.id
+    const clean = stripTitleDecoration(title)
+    const dropAgainst = suppressDocHeader ? chapter.title : clean
+    const contentNoLeadingH1 = dropLeadingH1IfMatchesTitle(content, dropAgainst)
+
+    if (suppressDocHeader) {
+      if (data.description) {
+        parts.push(`<div class="doc-description">${escapeHtml(data.description)}</div>`)
+      }
+      parts.push(`<article>${md.render(contentNoLeadingH1)}</article>`)
+    } else {
+      parts.push(
+        `<section class="doc">` +
+          `<div class="doc-header">` +
+          `<h2>${escapeHtml(clean)}</h2>` +
+          (data.description ? `<div class="doc-description">${escapeHtml(data.description)}</div>` : '') +
+          `</div>` +
+          `<article>${md.render(contentNoLeadingH1)}</article>` +
+          `</section>`,
+      )
+    }
+  }
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(chapter.title)} — Mastra Documentation</title>
+<style>${style}</style>
+</head>
+<body>
+${parts.join('\n')}
+</body>
+</html>`
+}
+
+// If the preprocessed markdown begins with the same H1 we already emit in
+// the doc header, drop it to avoid a duplicate heading. Matching is lenient
+// on whitespace and trailing punctuation.
+function dropLeadingH1IfMatchesTitle(content, title) {
+  const match = /^\s*#\s+(.+)\n/.exec(content)
+  if (!match) return content
+  const heading = match[1].trim().replace(/\s+/g, ' ').toLowerCase()
+  const wanted = title.trim().replace(/\s+/g, ' ').toLowerCase()
+  if (heading === wanted || heading.startsWith(wanted) || wanted.startsWith(heading)) {
+    return content.slice(match[0].length)
+  }
+  return content
 }
 
 // ---------- Tree resolution ----------
@@ -269,32 +480,70 @@ function buildHtml({ sections, toc, style }) {
 </html>`
 }
 
+// Compact TOC: each part becomes a labelled section containing a two-column
+// flow of category cards. Inside each card, doc links render as
+// horizontally-flowing pills so the full table of contents fits in 2-3 pages
+// rather than 12.
 function renderToc(entries) {
-  const lines = ['<ol>']
+  const out = ['<div class="toc-parts">']
   for (const part of entries) {
-    // Parts no longer have a body anchor, so render the label as plain text.
-    lines.push(`<li class="toc-part">${escapeHtml(part.title)}</li>`)
-    lines.push(...renderTocChildren(part.children, 'toc-chapter'))
+    out.push('<div class="toc-part-group">')
+    out.push(`<div class="toc-part-label">${escapeHtml(part.title)}</div>`)
+
+    const { looseDocs, categories } = partitionTocChildren(part.children)
+    out.push('<div class="toc-cards">')
+    if (looseDocs.length) {
+      out.push(`<div class="toc-card toc-card-loose">${renderPills(looseDocs)}</div>`)
+    }
+    for (const cat of categories) {
+      out.push(...renderCategoryCards(cat))
+    }
+    out.push('</div>')
+    out.push('</div>')
   }
-  lines.push('</ol>')
-  return lines.join('\n')
+  out.push('</div>')
+  return out.join('\n')
 }
 
-function renderTocChildren(children, cls) {
-  const out = []
-  for (const child of children || []) {
-    const childCls = cls === 'toc-chapter' && child.children ? 'toc-chapter' : cls
-    const itemCls = child.children ? 'toc-chapter' : childCls
-    const label = escapeHtml(child.title)
-    // Categories have no id (they're just visual grouping), so render the
-    // label as plain text instead of a broken anchor.
-    const inner = child.id ? `<a href="#${child.id}">${label}</a>` : label
-    out.push(`<li class="${itemCls}">${inner}</li>`)
-    if (child.children && child.children.length) {
-      out.push(...renderTocChildren(child.children, 'toc-section'))
-    }
+// A category renders as a titled card of pills. Nested sub-categories are
+// flattened to sibling cards with breadcrumb-style titles (e.g. "Workflows ›
+// Run Methods") so the layout stays two-level and readable.
+function renderCategoryCards(cat, prefix = '') {
+  const fullTitle = prefix ? `${prefix} › ${cat.title}` : cat.title
+  const { looseDocs, categories: subCats } = partitionTocChildren(cat.children)
+  const cards = []
+  if (looseDocs.length) {
+    cards.push(
+      `<div class="toc-card">` +
+        `<div class="toc-card-title">${escapeHtml(fullTitle)}</div>` +
+        renderPills(looseDocs) +
+        `</div>`,
+    )
   }
-  return out
+  for (const sub of subCats) {
+    cards.push(...renderCategoryCards(sub, fullTitle))
+  }
+  return cards
+}
+
+function renderPills(docs) {
+  const pills = docs
+    .map(
+      (d) =>
+        `<a class="toc-pill" href="#${d.id}">${escapeHtml(d.title)}</a>`,
+    )
+    .join('')
+  return `<div class="toc-pills">${pills}</div>`
+}
+
+function partitionTocChildren(children) {
+  const looseDocs = []
+  const categories = []
+  for (const c of children || []) {
+    if (c.children && c.children.length) categories.push(c)
+    else if (c.id) looseDocs.push(c)
+  }
+  return { looseDocs, categories }
 }
 
 // ---------- Markdown rendering ----------

--- a/docs/scripts/generate-pdf/index.mjs
+++ b/docs/scripts/generate-pdf/index.mjs
@@ -1,0 +1,442 @@
+#!/usr/bin/env node
+// Generates a single, printable PDF from the Mastra documentation.
+//
+// Usage:
+//   node index.mjs                     # writes mastra-docs.pdf next to this script
+//   node index.mjs --out path.pdf      # custom output path
+//   node index.mjs --html-only         # emit only the intermediate HTML (for debugging)
+//   node index.mjs --only docs,reference  # restrict the parts included
+//
+// Run `npm install` in this directory first to fetch puppeteer + markdown-it.
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import MarkdownIt from 'markdown-it'
+import anchor from 'markdown-it-anchor'
+import hljs from 'highlight.js'
+
+import { preprocessMdx } from './mdx.mjs'
+import { loadSidebar, flattenSidebar } from './sidebar.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_DOCS_ROOT = path.resolve(__dirname, '../..')
+const CONTENT_ROOT = path.join(REPO_DOCS_ROOT, 'src/content/en')
+const STYLE_FILE = path.join(__dirname, 'style.css')
+
+const DEFAULT_OUTPUT = path.join(__dirname, 'mastra-docs.pdf')
+
+// Ordered list of top-level "parts". Each part corresponds to a sidebar
+// config in a docs subdirectory. The order below is the order they appear
+// in the final PDF.
+const PARTS = [
+  {
+    id: 'get-started',
+    title: 'Get Started',
+    description: 'A warm welcome and a quick overview of Mastra.',
+    contentDir: path.join(CONTENT_ROOT, 'docs'),
+    docs: [{ id: 'index', label: 'Get Started' }],
+  },
+  {
+    id: 'docs',
+    title: 'Core Documentation',
+    description: 'Concepts and how-to guides for building with Mastra.',
+    sidebarFile: path.join(CONTENT_ROOT, 'docs', 'sidebars.js'),
+    sidebarKey: 'docsSidebar',
+    contentDir: path.join(CONTENT_ROOT, 'docs'),
+    // Skip the root index, since it is already in "Get Started".
+    skipIds: new Set(['index']),
+  },
+  {
+    id: 'guides',
+    title: 'Guides',
+    description: 'End-to-end walkthroughs, integrations, and deployment recipes.',
+    sidebarFile: path.join(CONTENT_ROOT, 'guides', 'sidebars.js'),
+    sidebarKey: 'guidesSidebar',
+    contentDir: path.join(CONTENT_ROOT, 'guides'),
+  },
+  {
+    id: 'models',
+    title: 'Model Providers & Gateways',
+    description: 'Model routing, embeddings, and supported gateways.',
+    sidebarFile: path.join(CONTENT_ROOT, 'models', 'sidebars.js'),
+    sidebarKey: 'modelsSidebar',
+    contentDir: path.join(CONTENT_ROOT, 'models'),
+  },
+  {
+    id: 'reference',
+    title: 'API Reference',
+    description: 'Complete API documentation for every Mastra package.',
+    sidebarFile: path.join(CONTENT_ROOT, 'reference', 'sidebars.js'),
+    sidebarKey: 'referenceSidebar',
+    contentDir: path.join(CONTENT_ROOT, 'reference'),
+  },
+]
+
+function parseArgs(argv) {
+  const args = { out: DEFAULT_OUTPUT, htmlOnly: false, only: null }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--out' || a === '-o') args.out = path.resolve(argv[++i])
+    else if (a === '--html-only') args.htmlOnly = true
+    else if (a === '--only') args.only = new Set(argv[++i].split(',').map((s) => s.trim()))
+    else if (a === '--help' || a === '-h') {
+      console.log(
+        'Usage: node index.mjs [--out path.pdf] [--html-only] [--only docs,reference]',
+      )
+      process.exit(0)
+    }
+  }
+  return args
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  console.log('Mastra Docs PDF generator')
+  console.log('─'.repeat(40))
+
+  const md = buildMarkdownIt()
+  const usedSlugs = new Set()
+  const toc = []
+  const sections = []
+
+  for (const part of PARTS) {
+    if (args.only && !args.only.has(part.id)) continue
+
+    console.log(`\n▸ Part: ${part.title}`)
+    const tree = await resolvePartTree(part)
+    const rendered = []
+    const tocPart = { id: slugify(part.title, usedSlugs), title: part.title, children: [] }
+    toc.push(tocPart)
+
+    for (const node of tree) {
+      await renderNode(node, {
+        md,
+        rendered,
+        tocChildren: tocPart.children,
+        usedSlugs,
+        skipIds: part.skipIds,
+      })
+    }
+
+    if (rendered.length === 0) {
+      console.log('  (no docs found)')
+      continue
+    }
+
+    sections.push({
+      part,
+      tocId: tocPart.id,
+      body: rendered.join('\n'),
+    })
+    console.log(`  rendered ${rendered.length} sections`)
+  }
+
+  const html = buildHtml({ sections, toc, style: await fs.readFile(STYLE_FILE, 'utf8') })
+
+  if (args.htmlOnly) {
+    const outHtml = args.out.endsWith('.pdf') ? args.out.replace(/\.pdf$/, '.html') : args.out
+    await fs.writeFile(outHtml, html, 'utf8')
+    console.log(`\nWrote HTML → ${outHtml}`)
+    return
+  }
+
+  console.log('\nStarting Puppeteer…')
+  const { default: puppeteer } = await import('puppeteer')
+  const browser = await puppeteer.launch({ headless: 'new' })
+  try {
+    const page = await browser.newPage()
+    await page.setContent(html, { waitUntil: 'networkidle0' })
+    await page.emulateMediaType('print')
+    await page.pdf({
+      path: args.out,
+      format: 'A4',
+      printBackground: true,
+      preferCSSPageSize: true,
+      displayHeaderFooter: true,
+      headerTemplate: '<div></div>',
+      footerTemplate: footerTemplate(),
+      margin: { top: '22mm', bottom: '22mm', left: '18mm', right: '18mm' },
+    })
+  } finally {
+    await browser.close()
+  }
+
+  const stat = await fs.stat(args.out)
+  console.log(`\nDone. Wrote ${formatBytes(stat.size)} → ${args.out}`)
+}
+
+// ---------- Tree resolution ----------
+
+async function resolvePartTree(part) {
+  if (part.docs) {
+    // Explicit list (used for the single-file "Get Started" part).
+    return part.docs.map((d) => ({
+      type: 'doc',
+      id: d.id,
+      label: d.label,
+      file: path.join(part.contentDir, `${d.id}.mdx`),
+      depth: 1,
+    }))
+  }
+  const items = await loadSidebar(part.sidebarFile, part.sidebarKey)
+  return flattenSidebar(items, { contentDir: part.contentDir })
+}
+
+async function renderNode(node, ctx) {
+  if (node.type === 'category') {
+    const slug = slugify(node.label, ctx.usedSlugs)
+    const categoryToc = { id: slug, title: node.label, depth: node.depth, children: [] }
+    ctx.tocChildren.push(categoryToc)
+    ctx.rendered.push(
+      `<section class="chapter-header" id="${slug}">` +
+        `<div class="chapter-eyebrow">Category</div>` +
+        `<h2>${escapeHtml(node.label)}</h2>` +
+        `</section>`,
+    )
+    for (const child of node.children) {
+      await renderNode(child, { ...ctx, tocChildren: categoryToc.children })
+    }
+    return
+  }
+  if (node.type === 'doc') {
+    if (ctx.skipIds && ctx.skipIds.has(node.id)) return
+    await renderDoc(node, ctx)
+  }
+}
+
+async function renderDoc(doc, ctx) {
+  let raw
+  try {
+    raw = await fs.readFile(doc.file, 'utf8')
+  } catch (err) {
+    console.warn(`  ! missing: ${doc.file}`)
+    return
+  }
+  const { data, content } = preprocessMdx(raw)
+  const title = doc.label || data.title || doc.id
+  const slug = slugify(`${doc.id}-${title}`, ctx.usedSlugs)
+
+  ctx.tocChildren.push({ id: slug, title: stripTitleDecoration(title), depth: doc.depth })
+
+  const header =
+    `<section class="chapter-header" id="${slug}">` +
+    `<div class="chapter-eyebrow">${escapeHtml(doc.id.split('/')[0] || 'Doc')}</div>` +
+    `<h2>${escapeHtml(stripTitleDecoration(title))}</h2>` +
+    (data.description ? `<div class="chapter-description">${escapeHtml(data.description)}</div>` : '') +
+    `</section>`
+
+  const body = ctx.md.render(content)
+  ctx.rendered.push(`${header}\n<article>${body}</article>`)
+}
+
+// ---------- HTML assembly ----------
+
+function buildHtml({ sections, toc, style }) {
+  const today = new Date().toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+
+  const tocHtml = renderToc(toc)
+  const body = sections
+    .map(
+      (s) =>
+        `<section class="part-header" id="${s.tocId}">` +
+        `<div class="part-eyebrow">Part</div>` +
+        `<h1>${escapeHtml(s.part.title)}</h1>` +
+        (s.part.description
+          ? `<p class="part-description">${escapeHtml(s.part.description)}</p>`
+          : '') +
+        `</section>\n` +
+        s.body,
+    )
+    .join('\n')
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Mastra Documentation</title>
+<style>${style}</style>
+</head>
+<body>
+  <section class="cover">
+    <div>
+      <div class="cover-eyebrow">The Mastra Framework</div>
+      <div class="cover-title">Mastra<br/>Documentation</div>
+      <div class="cover-subtitle">The complete printable reference — core framework, guides, API reference, model gateways, and more.</div>
+    </div>
+    <div class="cover-meta">
+      <strong>Generated</strong> ${today} · <strong>Source</strong> mastra-ai/mastra · <strong>Format</strong> one-file print
+    </div>
+  </section>
+  <section class="toc" id="table-of-contents">
+    <h1>Contents</h1>
+    ${tocHtml}
+  </section>
+  ${body}
+</body>
+</html>`
+}
+
+function renderToc(entries) {
+  const lines = ['<ol>']
+  for (const part of entries) {
+    lines.push(
+      `<li class="toc-part"><a href="#${part.id}">${escapeHtml(part.title)}</a></li>`,
+    )
+    lines.push(...renderTocChildren(part.children, 'toc-chapter'))
+  }
+  lines.push('</ol>')
+  return lines.join('\n')
+}
+
+function renderTocChildren(children, cls) {
+  const out = []
+  for (const child of children || []) {
+    const childCls = cls === 'toc-chapter' && child.children ? 'toc-chapter' : cls
+    out.push(
+      `<li class="${child.children ? 'toc-chapter' : childCls}"><a href="#${child.id}">${escapeHtml(child.title)}</a></li>`,
+    )
+    if (child.children && child.children.length) {
+      out.push(...renderTocChildren(child.children, 'toc-section'))
+    }
+  }
+  return out
+}
+
+// ---------- Markdown rendering ----------
+
+function buildMarkdownIt() {
+  const md = new MarkdownIt({
+    html: true,
+    linkify: true,
+    breaks: false,
+    typographer: true,
+    highlight(str, lang) {
+      if (lang && hljs.getLanguage(lang)) {
+        try {
+          return hljs.highlight(str, { language: lang, ignoreIllegals: true }).value
+        } catch {
+          /* fall through */
+        }
+      }
+      return escapeHtml(str)
+    },
+  })
+
+  md.use(anchor, {
+    permalink: false,
+    slugify: (s) => simpleSlug(s),
+  })
+
+  // Custom fence rendering so we can honour Docusaurus fence metadata such as
+  // `title="src/foo.ts"` and `{1,3-5}` highlight ranges.
+  const defaultFence = md.renderer.rules.fence
+  md.renderer.rules.fence = (tokens, idx, opts, env, self) => {
+    const token = tokens[idx]
+    const info = (token.info || '').trim()
+    const { lang, title } = parseFenceInfo(info)
+    token.info = lang // reset so the base renderer picks up only the language.
+
+    const base = defaultFence
+      ? defaultFence(tokens, idx, opts, env, self)
+      : `<pre><code>${escapeHtml(token.content)}</code></pre>`
+
+    if (!title) return `<div class="code-block">${base}</div>`
+    return `<div class="code-block has-title"><div class="code-block-title">${escapeHtml(title)}</div>${base}</div>`
+  }
+
+  return md
+}
+
+function parseFenceInfo(info) {
+  // Examples:
+  //   typescript title="src/mastra/index.ts"
+  //   typescript {2,5-7}
+  //   bash npm2yarn
+  //   typescript title="x.ts" {2}
+  const parts = info.split(/\s+/).filter(Boolean)
+  const lang = parts.shift() || ''
+  let title = ''
+  const titleRe = /^title=(["'])(.*)\1$/
+  for (const p of parts) {
+    const m = titleRe.exec(p)
+    if (m) title = m[2]
+  }
+  // Grab bare title="..." that had a space inside quotes (rare but possible).
+  const bareTitle = /title=(["'])([^"']+)\1/.exec(info)
+  if (!title && bareTitle) title = bareTitle[2]
+  return { lang, title }
+}
+
+// ---------- Utilities ----------
+
+function slugify(str, usedSlugs) {
+  let slug = simpleSlug(str)
+  if (!usedSlugs) return slug
+  let candidate = slug
+  let n = 2
+  while (usedSlugs.has(candidate)) {
+    candidate = `${slug}-${n++}`
+  }
+  usedSlugs.add(candidate)
+  return candidate
+}
+
+function simpleSlug(s) {
+  return String(s)
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+}
+
+function stripTitleDecoration(title) {
+  // Drop the trailing " | Category" Docusaurus convention so headings read cleanly.
+  return String(title).replace(/\s*\|\s*[^|]+$/, '').replace(/^Reference:\s*/i, '')
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function footerTemplate() {
+  return `
+  <style>
+    .pdf-footer {
+      width: 100%;
+      font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      font-size: 8pt;
+      color: #8a8f98;
+      padding: 0 18mm;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+  </style>
+  <div class="pdf-footer">
+    <span>Mastra Documentation</span>
+    <span><span class="pageNumber"></span> / <span class="totalPages"></span></span>
+  </div>`
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/docs/scripts/generate-pdf/mdx.mjs
+++ b/docs/scripts/generate-pdf/mdx.mjs
@@ -1,0 +1,260 @@
+// MDX → plain-markdown preprocessor for the PDF generator.
+// Strips imports, unwraps JSX components we care about (Tabs, Steps, CardGrid,
+// admonitions, etc.), and leaves behind markdown that markdown-it can render.
+
+import matter from 'gray-matter'
+
+const JSX_COMPONENTS_TO_UNWRAP = new Set([
+  'Tabs',
+  'TabItem',
+  'Steps',
+  'StepItem',
+  'CardGrid',
+  'CardGridItem',
+  'Step',
+  'Callout',
+  'FileTree',
+])
+
+const JSX_COMPONENTS_TO_STRIP = new Set([
+  'YouTube',
+  'PropertiesTable',
+  'QuickstartPrompt',
+  'StartCards',
+  'Chat',
+])
+
+/**
+ * Preprocess a raw .mdx file into markdown suitable for markdown-it.
+ */
+export function preprocessMdx(raw) {
+  const parsed = matter(raw)
+  let body = parsed.content
+
+  body = stripImportsAndExports(body)
+  // Steps / Tabs / CardGrid must run BEFORE admonitions, because the inner
+  // content of those JSX blocks may itself contain admonitions, and inserting
+  // an `<div>` at column 0 inside an indented Step would break the dedent
+  // heuristic used to normalize fenced code blocks.
+  body = convertSteps(body)
+  body = convertTabs(body)
+  body = convertCardGrids(body)
+  body = convertAdmonitions(body)
+  body = convertYouTube(body)
+  body = convertPropertiesTables(body)
+  body = stripRemainingJsxComponents(body)
+  body = collapseBlankLines(body)
+
+  return {
+    data: parsed.data,
+    content: body.trim(),
+  }
+}
+
+function stripImportsAndExports(src) {
+  return src
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trimStart()
+      if (trimmed.startsWith('import ')) return false
+      if (trimmed.startsWith('export default') || trimmed.startsWith('export const')) return false
+      return true
+    })
+    .join('\n')
+}
+
+// :::note / :::tip / :::warning / :::info / :::danger  →  styled blockquote.
+function convertAdmonitions(src) {
+  const types = ['note', 'tip', 'warning', 'info', 'danger', 'caution']
+  const labels = {
+    note: 'Note',
+    tip: 'Tip',
+    warning: 'Warning',
+    info: 'Info',
+    danger: 'Danger',
+    caution: 'Caution',
+  }
+
+  for (const type of types) {
+    const re = new RegExp(`:::${type}(?:\\[([^\\]]+)\\])?\\s*\\n([\\s\\S]*?)\\n?:::`, 'g')
+    src = src.replace(re, (_m, customTitle, inner) => {
+      const title = customTitle || labels[type]
+      return `\n<div class="admonition admonition-${type}">\n\n**${title}**\n\n${inner.trim()}\n\n</div>\n`
+    })
+  }
+  return src
+}
+
+// <CardGrid>…<CardGridItem title="X" href="/y" .../>…</CardGrid>  →  bullet list.
+function convertCardGrids(src) {
+  const cardItemRe = /<CardGridItem\b([^>]*?)(?:\/>|>([\s\S]*?)<\/CardGridItem>)/g
+  const cardGridRe = /<CardGrid\b[^>]*>([\s\S]*?)<\/CardGrid>/g
+
+  return src.replace(cardGridRe, (_m, inner) => {
+    const items = []
+    let match
+    cardItemRe.lastIndex = 0
+    while ((match = cardItemRe.exec(inner))) {
+      const attrs = match[1]
+      const title = extractAttr(attrs, 'title') || 'Link'
+      const href = extractAttr(attrs, 'href') || ''
+      items.push(href ? `- [${title}](${href})` : `- ${title}`)
+    }
+    return items.length ? `\n${items.join('\n')}\n` : ''
+  })
+}
+
+// <Tabs>…<TabItem value="x" label="Y">inner</TabItem>…</Tabs>
+// Render each tab as a small heading followed by its contents.
+function convertTabs(src) {
+  const tabsRe = /<Tabs\b[^>]*>([\s\S]*?)<\/Tabs>/g
+  const tabItemRe = /<TabItem\b([^>]*)>([\s\S]*?)<\/TabItem>/g
+
+  return src.replace(tabsRe, (_m, inner) => {
+    let out = ''
+    let match
+    tabItemRe.lastIndex = 0
+    while ((match = tabItemRe.exec(inner))) {
+      const attrs = match[1]
+      const content = dedent(match[2])
+      const label = extractAttr(attrs, 'label') || extractAttr(attrs, 'value') || 'Option'
+      out += `\n\n**${label}**\n\n${content}\n`
+    }
+    return out
+  })
+}
+
+// <Steps>…<StepItem>inner</StepItem>…</Steps>  →  "Step N" headings followed
+// by the verbatim content. Using numbered-list markdown would re-indent the
+// body, which breaks fenced code blocks inside steps.
+function convertSteps(src) {
+  const stepsRe = /<Steps\b[^>]*>([\s\S]*?)<\/Steps>/g
+  const stepItemRe = /<StepItem\b[^>]*>([\s\S]*?)<\/StepItem>/g
+
+  return src.replace(stepsRe, (_m, inner) => {
+    let n = 1
+    let out = ''
+    let match
+    stepItemRe.lastIndex = 0
+    while ((match = stepItemRe.exec(inner))) {
+      const body = dedent(match[1])
+      out += `\n\n<p class="step-label">Step ${n}</p>\n\n${body}\n\n`
+      n++
+    }
+    return out
+  })
+}
+
+// <YouTube id="abc"/>  →  markdown link.
+function convertYouTube(src) {
+  return src.replace(/<YouTube\b([^>]*?)\/>/g, (_m, attrs) => {
+    const id = extractAttr(attrs, 'id')
+    if (!id) return ''
+    return `\n[Watch on YouTube → youtu.be/${id}](https://youtu.be/${id})\n`
+  })
+}
+
+// <PropertiesTable content={[{...}]} />  →  best-effort markdown table.
+// When the embedded array is complex JSX/JS, fall back to a short placeholder.
+function convertPropertiesTables(src) {
+  const re = /<PropertiesTable\b[\s\S]*?\/>/g
+  return src.replace(re, (match) => {
+    const rows = tryParsePropertyRows(match)
+    if (!rows || rows.length === 0) {
+      return '\n_(Property table omitted — see online reference.)_\n'
+    }
+    const header = '| Name | Type | Description |\n|------|------|-------------|'
+    const body = rows
+      .map(({ name, type, description, isOptional, defaultValue }) => {
+        const opt = isOptional ? ' _(optional)_' : ''
+        const def = defaultValue != null && defaultValue !== '' ? ` _Default: \`${defaultValue}\`_` : ''
+        const desc = `${(description || '').replace(/\|/g, '\\|').replace(/\n+/g, ' ')}${opt}${def}`.trim()
+        const escName = `\`${(name || '').replace(/\|/g, '\\|')}\``
+        const escType = `\`${(type || '').replace(/\|/g, '\\|')}\``
+        return `| ${escName} | ${escType} | ${desc} |`
+      })
+      .join('\n')
+    return `\n${header}\n${body}\n`
+  })
+}
+
+// Very loose extraction for the common PropertiesTable pattern.
+// Looks for `{ name: '...', type: '...', description: '...', isOptional: true, defaultValue: '...' }`.
+function tryParsePropertyRows(src) {
+  const objectRe = /\{\s*([\s\S]*?)\}/g
+  const rows = []
+  let match
+  while ((match = objectRe.exec(src))) {
+    const chunk = match[1]
+    if (!/\bname\s*:/.test(chunk)) continue
+    const row = {
+      name: matchField(chunk, 'name'),
+      type: matchField(chunk, 'type'),
+      description: matchField(chunk, 'description'),
+      isOptional: /isOptional\s*:\s*true/.test(chunk),
+      defaultValue: matchField(chunk, 'defaultValue'),
+    }
+    if (row.name) rows.push(row)
+  }
+  return rows
+}
+
+function matchField(src, field) {
+  const re = new RegExp(`${field}\\s*:\\s*(["'\`])((?:\\\\.|(?!\\1).)*?)\\1`, 's')
+  const m = re.exec(src)
+  return m ? m[2].replace(/\\n/g, ' ').replace(/\\'/g, "'").replace(/\\"/g, '"') : ''
+}
+
+// Unwrap components inside JSX_COMPONENTS_TO_UNWRAP, strip components in
+// JSX_COMPONENTS_TO_STRIP, and remove any leftover JSX tags whose name starts
+// with an uppercase letter.
+function stripRemainingJsxComponents(src) {
+  // Drop self-closing tags for components we want to remove.
+  src = src.replace(/<([A-Z][A-Za-z0-9]*)\b[^>]*\/>/g, (match, name) => {
+    if (JSX_COMPONENTS_TO_STRIP.has(name)) return ''
+    return ''
+  })
+
+  // Drop opening/closing tags for known wrapper components (keep inner text).
+  src = src.replace(/<\/?([A-Z][A-Za-z0-9]*)\b[^>]*>/g, (match, name) => {
+    if (JSX_COMPONENTS_TO_UNWRAP.has(name)) return ''
+    if (JSX_COMPONENTS_TO_STRIP.has(name)) return ''
+    // Unknown component — unwrap conservatively.
+    return ''
+  })
+
+  // Drop leftover JSX expression braces that wrap pure strings, e.g. {' '}.
+  src = src.replace(/\{\s*["'`][^"'`]*["'`]\s*\}/g, '')
+
+  return src
+}
+
+function extractAttr(attrs, name) {
+  const re = new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|\\{([^}]*)\\})`)
+  const m = re.exec(attrs)
+  if (!m) return ''
+  const raw = m[1] ?? m[2] ?? m[3] ?? ''
+  // Strip surrounding quotes if we grabbed a {"..."} expression.
+  return raw.replace(/^['"`]|['"`]$/g, '').trim()
+}
+
+function collapseBlankLines(src) {
+  return src.replace(/\n{3,}/g, '\n\n')
+}
+
+// Strip the common leading whitespace from every non-empty line. Used when
+// extracting content from JSX children in the source MDX, where inner lines
+// are often indented by 2 or 4 spaces; those indents would otherwise make
+// markdown treat fenced code blocks as indented literal blocks.
+function dedent(src) {
+  const lines = src.replace(/^\n+/, '').replace(/\s+$/, '').split('\n')
+  let min = Infinity
+  for (const line of lines) {
+    if (!line.trim()) continue
+    const m = /^[ \t]*/.exec(line)
+    const n = m ? m[0].length : 0
+    if (n < min) min = n
+  }
+  if (!Number.isFinite(min) || min === 0) return lines.join('\n')
+  return lines.map((l) => (l.length >= min ? l.slice(min) : l)).join('\n')
+}

--- a/docs/scripts/generate-pdf/package-lock.json
+++ b/docs/scripts/generate-pdf/package-lock.json
@@ -1,0 +1,1422 @@
+{
+  "name": "mastra-docs-pdf",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mastra-docs-pdf",
+      "version": "0.1.0",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "highlight.js": "^11.10.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^9.2.0",
+        "puppeteer": "^23.11.1"
+      },
+      "bin": {
+        "mastra-docs-pdf": "index.mjs"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.1.tgz",
+      "integrity": "sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
+      "integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.2.0.tgz",
+      "integrity": "sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==",
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "23.11.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.11.1.tgz",
+      "integrity": "sha512-53uIX3KR5en8l7Vd8n5DUv90Ae9QDQsyIthaUFVzwV6yU750RjqRznEtNMBT20VthqAdemnJN+hxVdmMHKt7Zw==",
+      "deprecated": "< 24.15.0 is no longer supported",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.11.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1367902",
+        "puppeteer-core": "23.11.1",
+        "typed-query-selector": "^2.12.0"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "23.11.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
+      "integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.11.0",
+        "debug": "^4.4.0",
+        "devtools-protocol": "0.0.1367902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "license": "MIT"
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/docs/scripts/generate-pdf/package.json
+++ b/docs/scripts/generate-pdf/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mastra-docs-pdf",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Renders the Mastra documentation into a single printable PDF.",
+  "bin": {
+    "mastra-docs-pdf": "./index.mjs"
+  },
+  "scripts": {
+    "build": "node index.mjs"
+  },
+  "dependencies": {
+    "gray-matter": "^4.0.3",
+    "highlight.js": "^11.10.0",
+    "markdown-it": "^14.1.0",
+    "markdown-it-anchor": "^9.2.0",
+    "puppeteer": "^23.11.1"
+  }
+}

--- a/docs/scripts/generate-pdf/sidebar.mjs
+++ b/docs/scripts/generate-pdf/sidebar.mjs
@@ -1,0 +1,88 @@
+// Flatten Docusaurus sidebar configs into an ordered list of doc IDs.
+// Sidebar entries may be:
+//   - a string, shorthand for { type: 'doc', id: <string> }
+//   - { type: 'doc', id, label? }
+//   - { type: 'category', label, items: [...] }
+//   - { type: 'html' | 'link' | 'ref' } — skipped
+//
+// The flattener returns a tree of sections, so the PDF can render chapter /
+// category headings in the same order as the live docs.
+
+import { pathToFileURL } from 'node:url'
+import path from 'node:path'
+import fs from 'node:fs'
+
+export async function loadSidebar(sidebarFile, sidebarKey) {
+  const url = pathToFileURL(sidebarFile).href
+  const mod = await import(url)
+  const sidebars = mod.default || mod
+  const key = sidebarKey || Object.keys(sidebars)[0]
+  const items = sidebars[key]
+  if (!Array.isArray(items)) {
+    throw new Error(`Sidebar key "${key}" not found in ${sidebarFile}`)
+  }
+  return items
+}
+
+/**
+ * Walk a sidebar's items array and resolve each doc entry to its MDX path.
+ * Returns nested sections that mirror the sidebar structure, for rendering
+ * chapter and sub-chapter headings in the PDF.
+ */
+export function flattenSidebar(items, options) {
+  const { contentDir, depth = 1 } = options
+  const out = []
+
+  for (const raw of items) {
+    const item = typeof raw === 'string' ? { type: 'doc', id: raw } : raw
+    if (!item || typeof item !== 'object') continue
+
+    if (item.type === 'doc' || (item.type === undefined && item.id)) {
+      const mdxPath = resolveDocFile(contentDir, item.id)
+      if (mdxPath) {
+        out.push({
+          type: 'doc',
+          id: item.id,
+          label: item.label,
+          file: mdxPath,
+          depth,
+        })
+      }
+      continue
+    }
+
+    if (item.type === 'category') {
+      out.push({
+        type: 'category',
+        label: item.label,
+        depth,
+        children: flattenSidebar(item.items || [], {
+          contentDir,
+          depth: depth + 1,
+        }),
+      })
+      continue
+    }
+
+    // html, link, ref, etc. — skip.
+  }
+
+  return out
+}
+
+function resolveDocFile(contentDir, id) {
+  const candidates = [
+    path.join(contentDir, `${id}.mdx`),
+    path.join(contentDir, `${id}.md`),
+    path.join(contentDir, id, 'index.mdx'),
+    path.join(contentDir, id, 'index.md'),
+  ]
+  for (const p of candidates) {
+    try {
+      if (fs.statSync(p).isFile()) return p
+    } catch {
+      // try next
+    }
+  }
+  return null
+}

--- a/docs/scripts/generate-pdf/style.css
+++ b/docs/scripts/generate-pdf/style.css
@@ -1,0 +1,516 @@
+/*
+ * Print stylesheet for the Mastra documentation PDF.
+ * Optimized for readability and a calm, book-like feel.
+ */
+
+:root {
+  --text: #1b1d21;
+  --muted: #5c6270;
+  --border: #e4e6ea;
+  --rule: #d0d4da;
+  --accent: #2d6cdf;
+  --accent-soft: #eef3fb;
+  --code-bg: #f6f7f9;
+  --code-text: #1b1d21;
+  --admon-note-bar: #2d6cdf;
+  --admon-tip-bar: #2e9f6a;
+  --admon-warn-bar: #c47f11;
+  --admon-danger-bar: #c0392b;
+  --admon-info-bar: #5a6270;
+}
+
+@page {
+  size: A4;
+  margin: 22mm 18mm 22mm 18mm;
+}
+
+html,
+body {
+  background: #ffffff;
+  color: var(--text);
+  font-family: 'Charter', 'Iowan Old Style', 'Palatino Linotype', 'Georgia', serif;
+  font-size: 10.5pt;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  margin: 0;
+}
+
+/* ---------- Cover page ---------- */
+
+.cover {
+  /* A4 printable area is roughly 210mm × 297mm, minus ~22/18mm margins.
+     Using a fixed frame slightly smaller keeps everything on one page. */
+  height: 240mm;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 20mm 16mm;
+  box-sizing: border-box;
+  background: #0b0d10;
+  color: #f5f6f8;
+  page-break-after: always;
+  border-radius: 4mm;
+}
+
+.cover-eyebrow {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 10pt;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: #a7adb7;
+}
+
+.cover-title {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-weight: 700;
+  font-size: 44pt;
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  margin: 12mm 0 6mm 0;
+  color: #ffffff;
+}
+
+.cover-subtitle {
+  font-family: 'Charter', Georgia, serif;
+  font-style: italic;
+  font-size: 14pt;
+  max-width: 120mm;
+  color: #d6dae1;
+  line-height: 1.4;
+}
+
+.cover-meta {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 9.5pt;
+  color: #a7adb7;
+  border-top: 1px solid #333740;
+  padding-top: 6mm;
+}
+
+.cover-meta strong {
+  color: #f5f6f8;
+  font-weight: 600;
+}
+
+/* ---------- Table of contents ---------- */
+
+.toc {
+  page-break-after: always;
+}
+
+.toc h1 {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 22pt;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 6mm;
+  margin: 0 0 8mm 0;
+}
+
+.toc ol {
+  list-style: none;
+  counter-reset: toc-counter;
+  padding: 0;
+  margin: 0;
+}
+
+.toc li.toc-part {
+  counter-increment: toc-counter;
+  margin: 6mm 0 3mm 0;
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 13pt;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.toc li.toc-part::before {
+  content: counter(toc-counter, upper-roman) '. ';
+  color: var(--muted);
+  margin-right: 6pt;
+}
+
+.toc li.toc-chapter {
+  margin: 1.2mm 0;
+  padding-left: 6mm;
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 10.5pt;
+  color: var(--text);
+}
+
+.toc li.toc-section {
+  padding-left: 12mm;
+  margin: 0.6mm 0;
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 9.5pt;
+  color: var(--muted);
+}
+
+.toc a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* ---------- Chapter / section headings ---------- */
+
+.part-header {
+  page-break-before: always;
+  padding-top: 30mm;
+  margin-bottom: 10mm;
+}
+
+.part-header .part-eyebrow {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 10pt;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 4mm;
+}
+
+.part-header h1 {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 36pt;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.05;
+  margin: 0;
+  border: none;
+}
+
+.part-header p.part-description {
+  font-family: 'Charter', Georgia, serif;
+  font-style: italic;
+  font-size: 13pt;
+  color: var(--muted);
+  margin-top: 4mm;
+  max-width: 130mm;
+}
+
+.chapter-header {
+  page-break-before: always;
+  margin: 0 0 6mm 0;
+  padding-bottom: 4mm;
+  border-bottom: 1px solid var(--rule);
+}
+
+.chapter-eyebrow {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 9pt;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 2mm;
+}
+
+.chapter-header h2 {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 24pt;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+  margin: 0;
+  border: none;
+}
+
+.chapter-description {
+  font-family: 'Charter', Georgia, serif;
+  font-style: italic;
+  font-size: 11pt;
+  color: var(--muted);
+  margin-top: 3mm;
+}
+
+/* ---------- Body typography ---------- */
+
+article {
+  margin: 0 0 8mm 0;
+}
+
+article h1 {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-weight: 700;
+  font-size: 18pt;
+  letter-spacing: -0.005em;
+  line-height: 1.2;
+  margin: 10mm 0 4mm 0;
+  page-break-after: avoid;
+}
+
+article h2 {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-weight: 700;
+  font-size: 14pt;
+  letter-spacing: -0.003em;
+  line-height: 1.25;
+  margin: 8mm 0 3mm 0;
+  page-break-after: avoid;
+}
+
+article h3 {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-weight: 600;
+  font-size: 12pt;
+  line-height: 1.3;
+  margin: 6mm 0 2mm 0;
+  page-break-after: avoid;
+}
+
+article h4,
+article h5,
+article h6 {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-weight: 600;
+  font-size: 11pt;
+  margin: 5mm 0 2mm 0;
+  page-break-after: avoid;
+}
+
+article p {
+  margin: 0 0 3mm 0;
+  orphans: 3;
+  widows: 3;
+}
+
+article ul,
+article ol {
+  margin: 0 0 3mm 0;
+  padding-left: 6mm;
+}
+
+article li {
+  margin: 0.6mm 0;
+}
+
+article a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 0.3pt solid rgba(45, 108, 223, 0.35);
+}
+
+article hr {
+  border: none;
+  border-top: 1px solid var(--rule);
+  margin: 6mm 0;
+}
+
+article blockquote {
+  border-left: 2px solid var(--rule);
+  margin: 3mm 0;
+  padding: 0 0 0 4mm;
+  color: var(--muted);
+  font-style: italic;
+}
+
+/* ---------- Inline code ---------- */
+
+article code {
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9.3pt;
+  background: var(--code-bg);
+  padding: 0.5pt 3pt;
+  border-radius: 3pt;
+  border: 0.5pt solid var(--border);
+  color: var(--code-text);
+}
+
+article a code {
+  color: var(--accent);
+  border-color: rgba(45, 108, 223, 0.25);
+}
+
+/* ---------- Code blocks ---------- */
+
+article pre {
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 8.8pt;
+  line-height: 1.5;
+  background: var(--code-bg);
+  border: 0.5pt solid var(--border);
+  border-radius: 4pt;
+  padding: 3mm 4mm;
+  margin: 3mm 0;
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+  page-break-inside: avoid;
+}
+
+article pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+  white-space: pre-wrap;
+}
+
+.code-block {
+  margin: 3mm 0;
+  page-break-inside: avoid;
+}
+
+.code-block-title {
+  display: inline-block;
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 8pt;
+  font-weight: 600;
+  color: var(--muted);
+  padding: 1.2mm 3mm;
+  background: #eef1f4;
+  border: 0.5pt solid var(--border);
+  border-bottom: none;
+  border-top-left-radius: 4pt;
+  border-top-right-radius: 4pt;
+}
+
+.code-block.has-title pre {
+  margin-top: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+/* ---------- Tables ---------- */
+
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 9.5pt;
+  margin: 3mm 0;
+  page-break-inside: avoid;
+}
+
+article th,
+article td {
+  border: 0.5pt solid var(--border);
+  padding: 1.8mm 2.4mm;
+  vertical-align: top;
+  text-align: left;
+}
+
+article th {
+  background: var(--code-bg);
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-weight: 600;
+}
+
+/* ---------- Admonitions ---------- */
+
+.admonition {
+  border-left: 3px solid var(--admon-note-bar);
+  background: var(--accent-soft);
+  padding: 3mm 4mm;
+  margin: 3mm 0;
+  border-radius: 0 3pt 3pt 0;
+  page-break-inside: avoid;
+}
+
+.admonition p {
+  margin: 0 0 2mm 0;
+}
+
+.admonition p:last-child {
+  margin-bottom: 0;
+}
+
+.admonition-tip {
+  border-left-color: var(--admon-tip-bar);
+  background: #ecf7f1;
+}
+
+.admonition-warning,
+.admonition-caution {
+  border-left-color: var(--admon-warn-bar);
+  background: #fbf3e7;
+}
+
+.admonition-danger {
+  border-left-color: var(--admon-danger-bar);
+  background: #fbeceb;
+}
+
+.admonition-info {
+  border-left-color: var(--admon-info-bar);
+  background: #f1f2f4;
+}
+
+.admonition strong {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 9.8pt;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+/* ---------- Steps ---------- */
+
+.step-label {
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 10.5pt;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 6mm 0 2mm 0;
+  padding-top: 3mm;
+  border-top: 0.5pt solid var(--rule);
+  page-break-after: avoid;
+}
+
+.step-label:first-of-type {
+  padding-top: 0;
+  border-top: none;
+  margin-top: 3mm;
+}
+
+/* ---------- Highlight.js "github" look, but toned down ---------- */
+
+.hljs {
+  color: #24292e;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a737d;
+  font-style: italic;
+}
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal,
+.hljs-type {
+  color: #d73a49;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-symbol {
+  color: #032f62;
+}
+.hljs-number,
+.hljs-built_in,
+.hljs-meta {
+  color: #005cc5;
+}
+.hljs-title,
+.hljs-name,
+.hljs-attr,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #6f42c1;
+}
+.hljs-variable,
+.hljs-template-variable {
+  color: #e36209;
+}
+.hljs-tag {
+  color: #22863a;
+}
+.hljs-attribute {
+  color: #005cc5;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: 700;
+}

--- a/docs/scripts/generate-pdf/style.css
+++ b/docs/scripts/generate-pdf/style.css
@@ -107,51 +107,92 @@ body {
   font-weight: 700;
   letter-spacing: -0.01em;
   border-bottom: 1px solid var(--rule);
-  padding-bottom: 6mm;
-  margin: 0 0 8mm 0;
+  padding-bottom: 5mm;
+  margin: 0 0 6mm 0;
 }
 
-.toc ol {
-  list-style: none;
-  counter-reset: toc-counter;
-  padding: 0;
-  margin: 0;
+.toc-parts {
+  counter-reset: toc-part;
 }
 
-.toc li.toc-part {
-  counter-increment: toc-counter;
-  margin: 6mm 0 3mm 0;
+.toc-part-group {
+  margin-bottom: 6mm;
+}
+
+.toc-part-label {
+  counter-increment: toc-part;
   font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 13pt;
+  font-size: 11pt;
   font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
   color: var(--text);
+  border-bottom: 0.5pt solid var(--rule);
+  padding: 2.5mm 0 1.4mm 0;
+  margin-bottom: 2.8mm;
+  break-after: avoid;
 }
 
-.toc li.toc-part::before {
-  content: counter(toc-counter, upper-roman) '. ';
+.toc-part-label::before {
+  content: counter(toc-part, upper-roman) ' · ';
   color: var(--muted);
-  margin-right: 6pt;
+  margin-right: 2pt;
+  font-weight: 500;
 }
 
-.toc li.toc-chapter {
-  margin: 1.2mm 0;
-  padding-left: 6mm;
+/* Two-column flow for category cards. break-inside on cards keeps each
+   card intact whenever it fits in a column; large cards are allowed to
+   break rather than pushing to the next page and leaving whitespace. */
+.toc-cards {
+  column-count: 2;
+  column-gap: 3.5mm;
+}
+
+.toc-card {
+  border: 0.5pt solid var(--border);
+  border-radius: 2.5pt;
+  padding: 2mm 2.4mm 2.2mm 2.4mm;
+  margin: 0 0 2.2mm 0;
+  background: #ffffff;
+  break-inside: avoid;
+}
+
+.toc-card-loose {
+  border-color: transparent;
+  padding-left: 0;
+  padding-right: 0;
+  background: transparent;
+}
+
+.toc-card-title {
   font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 10.5pt;
+  font-size: 9pt;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 1.6mm;
+}
+
+.toc-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.4mm 1.6mm;
+}
+
+.toc-pill {
+  display: inline-block;
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 8.5pt;
+  font-weight: 500;
+  line-height: 1.3;
+  padding: 0.9mm 2.4mm;
+  background: var(--code-bg);
+  border: 0.4pt solid var(--border);
+  border-radius: 40pt;
   color: var(--text);
-}
-
-.toc li.toc-section {
-  padding-left: 12mm;
-  margin: 0.6mm 0;
-  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 9.5pt;
-  color: var(--muted);
-}
-
-.toc a {
-  color: inherit;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 /* ---------- Chapter / section headings ---------- */


### PR DESCRIPTION
Adds a standalone script under `docs/scripts/generate-pdf/` that renders the full Mastra documentation into a single printable PDF using puppeteer and markdown-it. Useful for offline reading and feeding the docs into tools that prefer one long document.

Run from the script directory:

```bash
npm install
node index.mjs
```

Outputs `mastra-docs.pdf` next to the script. Flags: `--out <path>`, `--html-only`, `--only docs,reference` to scope parts.

No published packages are touched, so no changeset.