### PR TITLE
fix(core): forward thread context from network validation to routing agent

### DIFF
--- a/.changeset/pretty-rats-bow.md
+++ b/.changeset/pretty-rats-bow.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a crash in agent networks when observational memory is configured with `scope: 'thread'`. The network's completion and final-result steps now forward the thread context to the routing agent, so observational memory no longer throws `ObservationalMemory (scope: 'thread') requires a threadId` at the end of a successful network run.
+
+Fixes #15736 and #13651.

--- a/packages/core/src/loop/network/validation.test.ts
+++ b/packages/core/src/loop/network/validation.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod/v4';
 
+import type { Agent } from '../../agent';
 import type { CompletionContext, CompletionRunResult, StreamCompletionContext } from './validation';
 import {
   runCompletionScorers,
   formatCompletionFeedback,
   runStreamCompletionScorers,
   formatStreamCompletionFeedback,
+  runDefaultCompletionCheck,
+  generateFinalResult,
+  generateStructuredFinalResult,
 } from './validation';
 
 // Helper to create a mock scorer
@@ -776,5 +781,127 @@ describe('formatStreamCompletionFeedback', () => {
 
     expect(feedback).toContain('Score: 1 ✅');
     expect(feedback).not.toContain('Reason:');
+  });
+});
+
+// ============================================================================
+// Memory forwarding to agent.stream() (regression for observational memory)
+// ============================================================================
+//
+// When ObservationalMemory is configured with scope: 'thread', the OM input
+// processor throws if a threadId is missing from RequestContext/MessageList.
+// The network validation/final-result agent.stream() calls must forward the
+// memory { thread, resource } so the routing agent's input processors (which
+// include memory-derived processors like OM) can resolve the threadId.
+// See https://github.com/mastra-ai/mastra/issues/13651 and #15736.
+
+function createFakeStreamAgent() {
+  const stream = vi.fn(async () => ({
+    objectStream: (async function* () {
+      yield { isComplete: true, finalResult: 'ok', completionReason: 'done' };
+    })(),
+    getFullOutput: async () => ({
+      object: { isComplete: true, finalResult: 'ok', completionReason: 'done' },
+    }),
+  }));
+  return { stream } as unknown as Agent & { stream: ReturnType<typeof vi.fn> };
+}
+
+function createContextWithMemory(): CompletionContext {
+  return {
+    iteration: 1,
+    maxIterations: 10,
+    messages: [],
+    originalTask: 'Test task',
+    selectedPrimitive: { id: 'sub-agent', type: 'agent' },
+    primitivePrompt: 'Do something',
+    primitiveResult: 'Done',
+    networkName: 'test-network',
+    runId: 'run-123',
+    threadId: 'thread-abc',
+    resourceId: 'resource-xyz',
+  };
+}
+
+describe('network validation forwards memory options to agent.stream()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runDefaultCompletionCheck forwards thread/resource to agent.stream()', async () => {
+    const agent = createFakeStreamAgent();
+    const context = createContextWithMemory();
+
+    await runDefaultCompletionCheck(agent as unknown as Agent, context);
+
+    expect(agent.stream).toHaveBeenCalledTimes(1);
+    const [, options] = agent.stream.mock.calls[0];
+    expect(options?.memory).toEqual({
+      thread: context.threadId,
+      resource: context.resourceId,
+      options: {
+        readOnly: true,
+        workingMemory: { enabled: false },
+      },
+    });
+  });
+
+  it('generateFinalResult forwards thread/resource to agent.stream()', async () => {
+    const agent = createFakeStreamAgent();
+    const context = createContextWithMemory();
+
+    await generateFinalResult(agent as unknown as Agent, context);
+
+    expect(agent.stream).toHaveBeenCalledTimes(1);
+    const [, options] = agent.stream.mock.calls[0];
+    expect(options?.memory).toEqual({
+      thread: context.threadId,
+      resource: context.resourceId,
+      options: {
+        readOnly: true,
+        workingMemory: { enabled: false },
+      },
+    });
+  });
+
+  it('generateStructuredFinalResult forwards thread/resource to agent.stream()', async () => {
+    const agent = createFakeStreamAgent();
+    const context = createContextWithMemory();
+
+    await generateStructuredFinalResult(agent as unknown as Agent, context, {
+      schema: z.object({ answer: z.string() }),
+    });
+
+    expect(agent.stream).toHaveBeenCalledTimes(1);
+    const [, options] = agent.stream.mock.calls[0];
+    expect(options?.memory).toEqual({
+      thread: context.threadId,
+      resource: context.resourceId,
+      options: {
+        readOnly: true,
+        workingMemory: { enabled: false },
+      },
+    });
+  });
+
+  it('runDefaultCompletionCheck falls back to runId/networkName when thread/resource absent', async () => {
+    const agent = createFakeStreamAgent();
+    const context: CompletionContext = {
+      ...createContextWithMemory(),
+      threadId: undefined,
+      resourceId: undefined,
+    };
+
+    await runDefaultCompletionCheck(agent as unknown as Agent, context);
+
+    const [, options] = agent.stream.mock.calls[0];
+    expect(options?.memory).toEqual({
+      thread: context.runId,
+      resource: context.networkName,
+      options: {
+        readOnly: true,
+        workingMemory: { enabled: false },
+      },
+    });
   });
 });

--- a/packages/core/src/loop/network/validation.ts
+++ b/packages/core/src/loop/network/validation.ts
@@ -456,6 +456,14 @@ export async function runDefaultCompletionCheck(
       structuredOutput: {
         schema: defaultCompletionSchema,
       },
+      memory: {
+        thread: context.threadId || context.runId,
+        resource: context.resourceId || context.networkName,
+        options: {
+          readOnly: true,
+          workingMemory: { enabled: false },
+        },
+      },
       abortSignal,
       onAbort,
     });
@@ -573,6 +581,14 @@ export async function generateFinalResult(
   const stream = await agent.stream(prompt, {
     maxSteps: 1,
     structuredOutput: { schema: finalResultSchema },
+    memory: {
+      thread: context.threadId || context.runId,
+      resource: context.resourceId || context.networkName,
+      options: {
+        readOnly: true,
+        workingMemory: { enabled: false },
+      },
+    },
     abortSignal,
     onAbort,
   });
@@ -657,6 +673,14 @@ export async function generateStructuredFinalResult<OUTPUT extends {}>(
   const stream = await agent.stream<OUTPUT>(prompt, {
     maxSteps: 1,
     structuredOutput: structuredOutputOptions,
+    memory: {
+      thread: context.threadId || context.runId,
+      resource: context.resourceId || context.networkName,
+      options: {
+        readOnly: true,
+        workingMemory: { enabled: false },
+      },
+    },
     abortSignal,
     onAbort,
   });


### PR DESCRIPTION
Fixes #15736 and #13651.

When observational memory is configured with `scope: 'thread'`, the network's validation and final-result steps crash at the end of an otherwise successful run with:

```
ObservationalMemory (scope: 'thread') requires a threadId, but none was found in RequestContext or MessageList.
```

The routing step (`packages/core/src/loop/network/index.ts`) already forwards memory correctly, but `runDefaultCompletionCheck`, `generateFinalResult`, and `generateStructuredFinalResult` in `validation.ts` called `agent.stream()` without forwarding the memory options — so the routing agent's input processors couldn't resolve the threadId. The `CompletionContext` already carries `threadId`/`resourceId`; we just weren't passing them through.

Doesn't seem quite right though, to now always be passing in memory inside of `network/validation.ts`. Seems like a big expansion. Going to make a draft and ask rabbit to PR - @CalebBarnes this involves the loop, so tagging you here.

Before:

```ts
const stream = await agent.stream(prompt, {
  maxSteps: 1,
  structuredOutput: { schema: finalResultSchema },
  abortSignal,
  onAbort,
});
```

After:

```ts
const stream = await agent.stream(prompt, {
  maxSteps: 1,
  structuredOutput: { schema: finalResultSchema },
  memory: {
    thread: context.threadId || context.runId,
    resource: context.resourceId || context.networkName,
    options: {
      readOnly: true,
      workingMemory: { enabled: false },
    },
  },
  abortSignal,
  onAbort,
});
```

Added unit tests in `validation.test.ts` that assert the memory options are forwarded to `agent.stream()` for all three functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When using a certain memory feature with multi-step AI conversations, the system was crashing at the end with an error about a missing conversation ID. This PR fixes it by making sure the conversation ID information is passed along correctly when the system checks if the AI's response is good enough.

## Changes

### Core fix: Memory context forwarding in network validation

The PR addresses crashes in agent networks configured with observational memory using `scope: 'thread'`. The root cause was that three code paths in the validation module (`runDefaultCompletionCheck`, `generateFinalResult`, and `generateStructuredFinalResult`) were calling `agent.stream()` without forwarding the memory/threading context from the parent completion context.

**Solution:** Each of these three functions now passes a `memory` configuration block to `agent.stream()` that specifies:
- The thread context (using `context.threadId`, falling back to `context.runId`)
- The resource context (using `context.resourceId`, falling back to `context.networkName`)
- Read-only mode with working memory disabled to prevent unintended state mutations

This ensures the routing agent's input processors can properly resolve the thread ID and prevents the `"ObservationalMemory (scope: 'thread') requires a threadId"` error from being thrown.

### Test coverage

Added comprehensive regression tests in `validation.test.ts` that:
- Verify each of the three functions forwards the correct memory options to `agent.stream()`
- Confirm the expected structure: `{ thread, resource, options: { readOnly: true, workingMemory: { enabled: false } } }`
- Test fallback behavior when thread ID and resource ID are absent from the context

### Release notes

Updated changesets metadata to document the fix for issues #15736 and #13651 in the next `@mastra/core` patch release.

## Files Modified

- `.changeset/pretty-rats-bow.md` — Release notes (+7 lines)
- `packages/core/src/loop/network/validation.test.ts` — New regression tests (+127 lines)
- `packages/core/src/loop/network/validation.ts` — Memory context forwarding (+24 lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->