### PR TITLE
feat(clickhouse): add opt-in replicated table engine support

### DIFF
--- a/.changeset/some-cloths-beg.md
+++ b/.changeset/some-cloths-beg.md
@@ -13,7 +13,7 @@ const storage = new ClickhouseStore({
   engine: {
     type: 'replicated',
     cluster: 'production_cluster',
-    zooPath: '/clickhouse/tables/{shard}/{table}',
+    zooPath: '/clickhouse/tables/{shard}/{database}/{table}',
     replica: '{replica}',
   },
 });

--- a/.changeset/some-cloths-beg.md
+++ b/.changeset/some-cloths-beg.md
@@ -1,0 +1,20 @@
+---
+'@mastra/clickhouse': minor
+---
+
+Added an opt-in replicated table engine mode for ClickHouse stores. Configure replicated engines to create `ReplicatedMergeTree` and `ReplicatedReplacingMergeTree` tables, with optional `ON CLUSTER` DDL for replicated ClickHouse clusters.
+
+```ts
+const storage = new ClickhouseStore({
+  id: 'clickhouse',
+  url: process.env.CLICKHOUSE_URL!,
+  username: process.env.CLICKHOUSE_USERNAME!,
+  password: process.env.CLICKHOUSE_PASSWORD!,
+  engine: {
+    type: 'replicated',
+    cluster: 'production_cluster',
+    zooPath: '/clickhouse/tables/{shard}/{table}',
+    replica: '{replica}',
+  },
+});
+```

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -298,7 +298,7 @@ const storage = new MastraCompositeStore({
       engine: {
         type: 'replicated',
         cluster: 'production_cluster',
-        zooPath: '/clickhouse/tables/{shard}/{table}',
+        zooPath: '/clickhouse/tables/{shard}/{database}/{table}',
         replica: '{replica}',
       },
     }),

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -277,3 +277,31 @@ const storage = new MastraCompositeStore({
 This approach is also required when using storage providers that don't support observability (like Convex, DynamoDB, or Cloudflare). See the [DefaultExporter documentation](/docs/observability/tracing/exporters/default#storage-provider-support) for the full list of supported providers.
 
 :::
+
+For multi-replica ClickHouse clusters behind a load balancer, configure replicated table engines when Mastra initializes the ClickHouse tables. Without replicated engines, ClickHouse stores each table locally on the replica that receives the write, so Studio can show different observability data depending on which replica serves a read.
+
+```typescript
+import { MastraCompositeStore } from '@mastra/core/storage'
+import { MemoryPG, WorkflowsPG, ScoresPG } from '@mastra/pg'
+import { ObservabilityStorageClickhouse } from '@mastra/clickhouse'
+
+const storage = new MastraCompositeStore({
+  id: 'composite',
+  domains: {
+    memory: new MemoryPG({ connectionString: process.env.DATABASE_URL }),
+    workflows: new WorkflowsPG({ connectionString: process.env.DATABASE_URL }),
+    scores: new ScoresPG({ connectionString: process.env.DATABASE_URL }),
+    observability: new ObservabilityStorageClickhouse({
+      url: process.env.CLICKHOUSE_URL,
+      username: process.env.CLICKHOUSE_USERNAME,
+      password: process.env.CLICKHOUSE_PASSWORD,
+      engine: {
+        type: 'replicated',
+        cluster: 'production_cluster',
+        zooPath: '/clickhouse/tables/{shard}/{table}',
+        replica: '{replica}',
+      },
+    }),
+  },
+})
+```

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -278,7 +278,7 @@ This approach is also required when using storage providers that don't support o
 
 :::
 
-For multi-replica ClickHouse clusters behind a load balancer, configure replicated table engines when Mastra initializes the ClickHouse tables. Without replicated engines, ClickHouse stores each table locally on the replica that receives the write, so Studio can show different observability data depending on which replica serves a read.
+For multi-replica ClickHouse clusters behind a load balancer, configure replicated table engines when Mastra initializes the ClickHouse tables. Without replicated engines, ClickHouse stores each table locally on the replica that receives the write, so Studio can show different observability data depending on which replica serves a read. For self-managed clusters, set `cluster` so DDL includes `ON CLUSTER` and creates the tables on every replica.
 
 ```typescript
 import { MastraCompositeStore } from '@mastra/core/storage'

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -298,8 +298,6 @@ const storage = new MastraCompositeStore({
       engine: {
         type: 'replicated',
         cluster: 'production_cluster',
-        zooPath: '/clickhouse/tables/{shard}/{database}/{table}',
-        replica: '{replica}',
       },
     }),
   },

--- a/stores/clickhouse/README.md
+++ b/stores/clickhouse/README.md
@@ -66,6 +66,15 @@ type ClickhouseConfig = {
   url: string; // Clickhouse HTTP interface URL
   username: string; // Database username
   password: string; // Database password
+  engine?:
+    | 'default'
+    | 'replicated'
+    | {
+        type: 'replicated';
+        cluster?: string;
+        zooPath?: string; // Supports {table}; defaults to /clickhouse/tables/{shard}/{table}
+        replica?: string; // Defaults to {replica}
+      };
 };
 ```
 
@@ -87,6 +96,8 @@ The store uses different table engines for different types of data:
 
 - `MergeTree()`: Used for messages, traces, and evals
 - `ReplacingMergeTree()`: Used for threads and workflow snapshots
+
+For replicated ClickHouse clusters, configure `engine: 'replicated'` or pass a replicated engine object. Mastra will create `ReplicatedMergeTree` and `ReplicatedReplacingMergeTree` tables instead of local `MergeTree` variants. Use `cluster` when DDL should include `ON CLUSTER`.
 
 ## Storage Methods
 

--- a/stores/clickhouse/README.md
+++ b/stores/clickhouse/README.md
@@ -72,7 +72,7 @@ type ClickhouseConfig = {
     | {
         type: 'replicated';
         cluster?: string;
-        zooPath?: string; // Supports {table}; defaults to /clickhouse/tables/{shard}/{table}
+        zooPath?: string; // Supports {table}; defaults to /clickhouse/tables/{shard}/{database}/{table}
         replica?: string; // Defaults to {replica}
       };
 };

--- a/stores/clickhouse/README.md
+++ b/stores/clickhouse/README.md
@@ -97,7 +97,7 @@ The store uses different table engines for different types of data:
 - `MergeTree()`: Used for messages, traces, and evals
 - `ReplacingMergeTree()`: Used for threads and workflow snapshots
 
-For replicated ClickHouse clusters, configure `engine: 'replicated'` or pass a replicated engine object. Mastra will create `ReplicatedMergeTree` and `ReplicatedReplacingMergeTree` tables instead of local `MergeTree` variants. Use `cluster` when DDL should include `ON CLUSTER`.
+For replicated ClickHouse clusters, configure `engine: 'replicated'` or pass a replicated engine object. Mastra will create `ReplicatedMergeTree` and `ReplicatedReplacingMergeTree` tables instead of local `MergeTree` variants. For self-managed multi-replica clusters behind a load balancer, set `cluster` so DDL includes `ON CLUSTER` and creates the tables on every replica.
 
 ## Storage Methods
 

--- a/stores/clickhouse/src/storage/db/engine.test.ts
+++ b/stores/clickhouse/src/storage/db/engine.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { applyClickhouseDDLConfig, buildClickhouseTableEngine } from './engine';
+
+describe('buildClickhouseTableEngine', () => {
+  it('keeps plain engines by default', () => {
+    expect(buildClickhouseTableEngine('MergeTree()', 'mastra_log_events')).toBe('MergeTree()');
+    expect(buildClickhouseTableEngine('ReplacingMergeTree(updatedAt)', 'mastra_spans')).toBe(
+      'ReplacingMergeTree(updatedAt)',
+    );
+  });
+
+  it('maps MergeTree engines to replicated variants', () => {
+    expect(buildClickhouseTableEngine('MergeTree', 'mastra_discovery_pairs', 'replicated')).toBe(
+      "ReplicatedMergeTree('/clickhouse/tables/{shard}/mastra_discovery_pairs', '{replica}')",
+    );
+    expect(buildClickhouseTableEngine('ReplacingMergeTree', 'mastra_log_events', 'replicated')).toBe(
+      "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/mastra_log_events', '{replica}')",
+    );
+    expect(buildClickhouseTableEngine('ReplacingMergeTree(updatedAt)', 'mastra_spans', 'replicated')).toBe(
+      "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/mastra_spans', '{replica}', updatedAt)",
+    );
+  });
+
+  it('honors custom replicated engine settings', () => {
+    expect(
+      buildClickhouseTableEngine('ReplacingMergeTree', 'mastra_span_events', {
+        type: 'replicated',
+        zooPath: '/clickhouse/custom/{table}',
+        replica: '{replica_name}',
+      }),
+    ).toBe("ReplicatedReplacingMergeTree('/clickhouse/custom/mastra_span_events', '{replica_name}')");
+  });
+});
+
+describe('applyClickhouseDDLConfig', () => {
+  it('updates table engines and ON CLUSTER clauses for replicated table DDL', () => {
+    const ddl = `
+CREATE TABLE IF NOT EXISTS mastra_discovery_pairs (
+  kind String
+)
+ENGINE = MergeTree
+ORDER BY kind
+`;
+
+    expect(
+      applyClickhouseDDLConfig(ddl, {
+        type: 'replicated',
+        cluster: 'prod_cluster',
+        zooPath: '/clickhouse/observability/{table}',
+      }),
+    ).toContain(
+      "CREATE TABLE IF NOT EXISTS mastra_discovery_pairs ON CLUSTER 'prod_cluster' (\n  kind String\n)\nENGINE = ReplicatedMergeTree('/clickhouse/observability/mastra_discovery_pairs', '{replica}')",
+    );
+  });
+
+  it('supports CREATE TABLE without IF NOT EXISTS', () => {
+    expect(
+      applyClickhouseDDLConfig(`CREATE TABLE mastra_spans (id String) ENGINE = ReplacingMergeTree(updatedAt)`, {
+        type: 'replicated',
+        cluster: 'prod_cluster',
+      }),
+    ).toBe(
+      `CREATE TABLE mastra_spans ON CLUSTER 'prod_cluster' (id String) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/mastra_spans', '{replica}', updatedAt)`,
+    );
+  });
+
+  it('adds ON CLUSTER to materialized views and ALTER statements', () => {
+    expect(
+      applyClickhouseDDLConfig(
+        `CREATE MATERIALIZED VIEW IF NOT EXISTS mastra_mv_trace_roots TO mastra_trace_roots AS SELECT * FROM mastra_span_events`,
+        { type: 'replicated', cluster: 'prod_cluster' },
+      ),
+    ).toContain("mastra_mv_trace_roots ON CLUSTER 'prod_cluster' TO");
+
+    expect(
+      applyClickhouseDDLConfig(`ALTER TABLE mastra_span_events ADD COLUMN IF NOT EXISTS resourceId Nullable(String)`, {
+        type: 'replicated',
+        cluster: 'prod_cluster',
+      }),
+    ).toBe(
+      `ALTER TABLE mastra_span_events ON CLUSTER 'prod_cluster' ADD COLUMN IF NOT EXISTS resourceId Nullable(String)`,
+    );
+  });
+});

--- a/stores/clickhouse/src/storage/db/engine.test.ts
+++ b/stores/clickhouse/src/storage/db/engine.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { applyClickhouseDDLConfig, buildClickhouseTableEngine } from './engine';
+import {
+  applyClickhouseDDLConfig,
+  buildClickhouseTableEngine,
+  isReplicatedEngineConfig,
+  isReplicatedTableEngineName,
+} from './engine';
 
 describe('buildClickhouseTableEngine', () => {
   it('keeps plain engines by default', () => {
@@ -29,6 +34,20 @@ describe('buildClickhouseTableEngine', () => {
         replica: '{replica_name}',
       }),
     ).toBe("ReplicatedReplacingMergeTree('/clickhouse/custom/mastra_span_events', '{replica_name}')");
+  });
+});
+
+describe('replicated engine detection', () => {
+  it('detects replicated config and table engine names', () => {
+    expect(isReplicatedEngineConfig('replicated')).toBe(true);
+    expect(isReplicatedEngineConfig({ type: 'replicated' })).toBe(true);
+    expect(isReplicatedEngineConfig('default')).toBe(false);
+
+    expect(isReplicatedTableEngineName('ReplicatedMergeTree')).toBe(true);
+    expect(isReplicatedTableEngineName('ReplicatedReplacingMergeTree')).toBe(true);
+    expect(isReplicatedTableEngineName('SharedReplacingMergeTree')).toBe(true);
+    expect(isReplicatedTableEngineName('ReplacingMergeTree')).toBe(false);
+    expect(isReplicatedTableEngineName('MergeTree')).toBe(false);
   });
 });
 

--- a/stores/clickhouse/src/storage/db/engine.test.ts
+++ b/stores/clickhouse/src/storage/db/engine.test.ts
@@ -16,13 +16,13 @@ describe('buildClickhouseTableEngine', () => {
 
   it('maps MergeTree engines to replicated variants', () => {
     expect(buildClickhouseTableEngine('MergeTree', 'mastra_discovery_pairs', 'replicated')).toBe(
-      "ReplicatedMergeTree('/clickhouse/tables/{shard}/mastra_discovery_pairs', '{replica}')",
+      "ReplicatedMergeTree('/clickhouse/tables/{shard}/{database}/mastra_discovery_pairs', '{replica}')",
     );
     expect(buildClickhouseTableEngine('ReplacingMergeTree', 'mastra_log_events', 'replicated')).toBe(
-      "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/mastra_log_events', '{replica}')",
+      "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/{database}/mastra_log_events', '{replica}')",
     );
     expect(buildClickhouseTableEngine('ReplacingMergeTree(updatedAt)', 'mastra_spans', 'replicated')).toBe(
-      "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/mastra_spans', '{replica}', updatedAt)",
+      "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/{database}/mastra_spans', '{replica}', updatedAt)",
     );
   });
 
@@ -79,7 +79,7 @@ ORDER BY kind
         cluster: 'prod_cluster',
       }),
     ).toBe(
-      `CREATE TABLE mastra_spans ON CLUSTER 'prod_cluster' (id String) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/mastra_spans', '{replica}', updatedAt)`,
+      `CREATE TABLE mastra_spans ON CLUSTER 'prod_cluster' (id String) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/{database}/mastra_spans', '{replica}', updatedAt)`,
     );
   });
 

--- a/stores/clickhouse/src/storage/db/engine.ts
+++ b/stores/clickhouse/src/storage/db/engine.ts
@@ -13,7 +13,7 @@ export type ClickhouseTableEngineConfig =
       /**
        * Keeper path for replicated tables. Supports a {table} placeholder.
        *
-       * Defaults to /clickhouse/tables/{shard}/{table}.
+       * Defaults to /clickhouse/tables/{shard}/{database}/{table}.
        */
       zooPath?: string;
       /**
@@ -58,7 +58,7 @@ export function buildClickhouseTableEngine(
 
   const [, engineName, engineArgs] = match;
   const replicatedConfig = getReplicatedEngineConfig(config);
-  const zooPathTemplate = replicatedConfig.zooPath ?? '/clickhouse/tables/{shard}/{table}';
+  const zooPathTemplate = replicatedConfig.zooPath ?? '/clickhouse/tables/{shard}/{database}/{table}';
   const zooPath = zooPathTemplate.includes('{table}')
     ? zooPathTemplate.replaceAll('{table}', tableName)
     : `${zooPathTemplate}/${tableName}`;

--- a/stores/clickhouse/src/storage/db/engine.ts
+++ b/stores/clickhouse/src/storage/db/engine.ts
@@ -1,0 +1,108 @@
+export type ClickhouseTableEngineConfig =
+  | 'default'
+  | 'replicated'
+  | {
+      type: 'default';
+    }
+  | {
+      type: 'replicated';
+      /**
+       * Optional ClickHouse cluster name for ON CLUSTER DDL.
+       */
+      cluster?: string;
+      /**
+       * Keeper path for replicated tables. Supports a {table} placeholder.
+       *
+       * Defaults to /clickhouse/tables/{shard}/{table}.
+       */
+      zooPath?: string;
+      /**
+       * Replica macro/name passed to Replicated*MergeTree.
+       *
+       * Defaults to {replica}.
+       */
+      replica?: string;
+    };
+
+function isReplicatedEngineConfig(config?: ClickhouseTableEngineConfig): boolean {
+  return config === 'replicated' || (typeof config === 'object' && config.type === 'replicated');
+}
+
+function getReplicatedEngineConfig(
+  config?: ClickhouseTableEngineConfig,
+): Extract<ClickhouseTableEngineConfig, { type: 'replicated' }> {
+  return typeof config === 'object' && config.type === 'replicated' ? config : { type: 'replicated' };
+}
+
+function quoteClickhouseString(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+export function buildClickhouseTableEngine(
+  baseEngine: string,
+  tableName: string,
+  config?: ClickhouseTableEngineConfig,
+): string {
+  if (!isReplicatedEngineConfig(config)) {
+    return baseEngine;
+  }
+
+  const match = baseEngine.trim().match(/^(ReplacingMergeTree|MergeTree)(?:\((.*)\))?$/);
+  if (!match) {
+    return baseEngine;
+  }
+
+  const [, engineName, engineArgs] = match;
+  const replicatedConfig = getReplicatedEngineConfig(config);
+  const zooPathTemplate = replicatedConfig.zooPath ?? '/clickhouse/tables/{shard}/{table}';
+  const zooPath = zooPathTemplate.includes('{table}')
+    ? zooPathTemplate.replaceAll('{table}', tableName)
+    : `${zooPathTemplate}/${tableName}`;
+  const replica = replicatedConfig.replica ?? '{replica}';
+  const replicatedEngineName =
+    engineName === 'ReplacingMergeTree' ? 'ReplicatedReplacingMergeTree' : 'ReplicatedMergeTree';
+  const args = [quoteClickhouseString(zooPath), quoteClickhouseString(replica)];
+
+  if (engineArgs?.trim()) {
+    args.push(engineArgs.trim());
+  }
+
+  return `${replicatedEngineName}(${args.join(', ')})`;
+}
+
+function getClickhouseCluster(config?: ClickhouseTableEngineConfig): string | undefined {
+  if (!isReplicatedEngineConfig(config)) {
+    return undefined;
+  }
+  return getReplicatedEngineConfig(config).cluster;
+}
+
+function addOnCluster(ddl: string, config?: ClickhouseTableEngineConfig): string {
+  const cluster = getClickhouseCluster(config);
+  if (!cluster) {
+    return ddl;
+  }
+
+  const quotedCluster = quoteClickhouseString(cluster);
+  return ddl
+    .replace(/(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?\S+)(\s*\()/i, `$1 ON CLUSTER ${quotedCluster}$2`)
+    .replace(
+      /(CREATE\s+MATERIALIZED\s+VIEW\s+IF\s+NOT\s+EXISTS\s+\S+)(\s+(?:REFRESH|TO|AS)\b)/i,
+      `$1 ON CLUSTER ${quotedCluster}$2`,
+    )
+    .replace(/(ALTER\s+TABLE\s+\S+)(\s+)/i, `$1 ON CLUSTER ${quotedCluster}$2`);
+}
+
+export function applyClickhouseDDLConfig(ddl: string, config?: ClickhouseTableEngineConfig): string {
+  const tableMatch =
+    ddl.match(/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)/i) ?? ddl.match(/ALTER\s+TABLE\s+(\S+)/i);
+  const tableName = tableMatch?.[1];
+  const configuredDDL = tableName
+    ? ddl.replace(/ENGINE\s*=\s*(ReplacingMergeTree|MergeTree)(?:\(([^)]*)\))?/g, match => {
+        const baseEngine = match.replace(/ENGINE\s*=\s*/i, '');
+        return `ENGINE = ${buildClickhouseTableEngine(baseEngine, tableName, config)}`;
+      })
+    : ddl;
+
+  return addOnCluster(configuredDDL, config);
+}

--- a/stores/clickhouse/src/storage/db/engine.ts
+++ b/stores/clickhouse/src/storage/db/engine.ts
@@ -24,8 +24,12 @@ export type ClickhouseTableEngineConfig =
       replica?: string;
     };
 
-function isReplicatedEngineConfig(config?: ClickhouseTableEngineConfig): boolean {
+export function isReplicatedEngineConfig(config?: ClickhouseTableEngineConfig): boolean {
   return config === 'replicated' || (typeof config === 'object' && config.type === 'replicated');
+}
+
+export function isReplicatedTableEngineName(engine: string): boolean {
+  return engine.startsWith('Replicated') || engine.startsWith('Shared');
 }
 
 function getReplicatedEngineConfig(

--- a/stores/clickhouse/src/storage/db/index.ts
+++ b/stores/clickhouse/src/storage/db/index.ts
@@ -12,7 +12,12 @@ import {
 } from '@mastra/core/storage';
 import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
 import type { ClickhouseTableEngineConfig } from './engine';
-import { applyClickhouseDDLConfig, buildClickhouseTableEngine } from './engine';
+import {
+  applyClickhouseDDLConfig,
+  buildClickhouseTableEngine,
+  isReplicatedEngineConfig,
+  isReplicatedTableEngineName,
+} from './engine';
 import type { ClickhouseConfig } from './utils';
 import { TABLE_ENGINES, transformRow } from './utils';
 
@@ -202,6 +207,20 @@ export class ClickhouseDB extends MastraBase {
     }
   }
 
+  async getTableEngineName(tableName: string): Promise<string | null> {
+    try {
+      const result = await this.client.query({
+        query: `SELECT engine FROM system.tables WHERE database = currentDatabase() AND name = {tableName:String}`,
+        query_params: { tableName },
+        format: 'JSONEachRow',
+      });
+      const rows = (await result.json()) as Array<{ engine: string }>;
+      return rows[0]?.engine ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   /**
    * Checks if migration is needed for the spans table.
    * Returns information about the current state.
@@ -320,6 +339,19 @@ export class ClickhouseDB extends MastraBase {
 
     const backupTableName = `${tableName}_backup_${Date.now()}`;
     const rowTtl = this.ttl?.[tableName]?.row;
+    const currentEngine = await this.getTableEngineName(tableName);
+
+    if (isReplicatedEngineConfig(this.engine) || (currentEngine && isReplicatedTableEngineName(currentEngine))) {
+      throw new MastraError({
+        id: createStorageErrorId('CLICKHOUSE', 'MIGRATE_SPANS_SORTING_KEY', 'REPLICATED_ENGINE_UNSUPPORTED'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text:
+          `ClickHouse spans sorting-key migration cannot run automatically with replicated table engines. ` +
+          `Run the migration before enabling replicated engines, or recreate the replicated table manually with the updated schema.`,
+        details: { tableName, currentEngine: currentEngine ?? 'unknown' },
+      });
+    }
 
     try {
       // Step 1: Rename old table to backup
@@ -363,7 +395,7 @@ export class ClickhouseDB extends MastraBase {
       `;
 
       await this.client.command({
-        query: this.applyDDLConfig(createSql),
+        query: createSql,
       });
 
       // Step 3: Copy data from backup to new table, deduplicating by (traceId, spanId)

--- a/stores/clickhouse/src/storage/db/index.ts
+++ b/stores/clickhouse/src/storage/db/index.ts
@@ -11,6 +11,8 @@ import {
   getDefaultValue,
 } from '@mastra/core/storage';
 import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
+import type { ClickhouseTableEngineConfig } from './engine';
+import { applyClickhouseDDLConfig, buildClickhouseTableEngine } from './engine';
 import type { ClickhouseConfig } from './utils';
 import { TABLE_ENGINES, transformRow } from './utils';
 
@@ -28,6 +30,7 @@ export type ClickhouseDomainConfig = ClickhouseDomainClientConfig | ClickhouseDo
 export interface ClickhouseDomainClientConfig {
   client: ClickHouseClient;
   ttl?: ClickhouseConfig['ttl'];
+  engine?: ClickhouseTableEngineConfig;
 }
 
 /**
@@ -38,6 +41,7 @@ export interface ClickhouseDomainRestConfig {
   username: string;
   password: string;
   ttl?: ClickhouseConfig['ttl'];
+  engine?: ClickhouseTableEngineConfig;
 }
 
 /**
@@ -47,10 +51,11 @@ export interface ClickhouseDomainRestConfig {
 export function resolveClickhouseConfig(config: ClickhouseDomainConfig): {
   client: ClickHouseClient;
   ttl?: ClickhouseConfig['ttl'];
+  engine?: ClickhouseTableEngineConfig;
 } {
   // Existing client
   if ('client' in config) {
-    return { client: config.client, ttl: config.ttl };
+    return { client: config.client, ttl: config.ttl, engine: config.engine };
   }
 
   // Config to create new client
@@ -66,22 +71,40 @@ export function resolveClickhouseConfig(config: ClickhouseDomainConfig): {
     },
   });
 
-  return { client, ttl: config.ttl };
+  return { client, ttl: config.ttl, engine: config.engine };
 }
 
 export class ClickhouseDB extends MastraBase {
   protected ttl: ClickhouseConfig['ttl'];
   protected client: ClickHouseClient;
+  protected engine?: ClickhouseTableEngineConfig;
 
   /** Cache of actual table columns: tableName -> Promise<Set<columnName>> (stores in-flight promise to coalesce concurrent calls) */
   private tableColumnsCache = new Map<string, Promise<Set<string>>>();
 
-  constructor({ client, ttl }: { client: ClickHouseClient; ttl: ClickhouseConfig['ttl'] }) {
+  constructor({
+    client,
+    ttl,
+    engine,
+  }: {
+    client: ClickHouseClient;
+    ttl: ClickhouseConfig['ttl'];
+    engine?: ClickhouseTableEngineConfig;
+  }) {
     super({
       name: 'CLICKHOUSE_DB',
     });
     this.ttl = ttl;
     this.client = client;
+    this.engine = engine;
+  }
+
+  private getTableEngine(tableName: string): string {
+    return buildClickhouseTableEngine(TABLE_ENGINES[tableName as TABLE_NAMES] ?? 'MergeTree()', tableName, this.engine);
+  }
+
+  private applyDDLConfig(sql: string): string {
+    return applyClickhouseDDLConfig(sql, this.engine);
   }
 
   /**
@@ -332,7 +355,7 @@ export class ClickhouseDB extends MastraBase {
         CREATE TABLE ${tableName} (
           ${columns}
         )
-        ENGINE = ${TABLE_ENGINES[tableName] ?? 'MergeTree()'}
+        ENGINE = ${this.getTableEngine(tableName)}
         PRIMARY KEY (traceId, spanId)
         ORDER BY (traceId, spanId)
         ${rowTtl ? `TTL toDateTime(${rowTtl.ttlKey ?? 'createdAt'}) + INTERVAL ${rowTtl.interval} ${rowTtl.unit}` : ''}
@@ -340,7 +363,7 @@ export class ClickhouseDB extends MastraBase {
       `;
 
       await this.client.command({
-        query: createSql,
+        query: this.applyDDLConfig(createSql),
       });
 
       // Step 3: Copy data from backup to new table, deduplicating by (traceId, spanId)
@@ -487,7 +510,7 @@ export class ClickhouseDB extends MastraBase {
             CREATE TABLE IF NOT EXISTS ${tableName} (
               ${['id String'].concat(columns)}
             )
-            ENGINE = ${TABLE_ENGINES[tableName] ?? 'MergeTree()'}
+            ENGINE = ${this.getTableEngine(tableName)}
             PRIMARY KEY (createdAt, run_id, workflow_name)
             ORDER BY (createdAt, run_id, workflow_name)
             ${rowTtl ? `TTL toDateTime(${rowTtl.ttlKey ?? 'createdAt'}) + INTERVAL ${rowTtl.interval} ${rowTtl.unit}` : ''}
@@ -502,7 +525,7 @@ export class ClickhouseDB extends MastraBase {
             CREATE TABLE IF NOT EXISTS ${tableName} (
               ${columns}
             )
-            ENGINE = ${TABLE_ENGINES[tableName] ?? 'MergeTree()'}
+            ENGINE = ${this.getTableEngine(tableName)}
             PRIMARY KEY (traceId, spanId)
             ORDER BY (traceId, spanId)
             ${rowTtl ? `TTL toDateTime(${rowTtl.ttlKey ?? 'createdAt'}) + INTERVAL ${rowTtl.interval} ${rowTtl.unit}` : ''}
@@ -513,7 +536,7 @@ export class ClickhouseDB extends MastraBase {
             CREATE TABLE IF NOT EXISTS ${tableName} (
               ${columns}
             )
-            ENGINE = ${TABLE_ENGINES[tableName] ?? 'MergeTree()'}
+            ENGINE = ${this.getTableEngine(tableName)}
             PRIMARY KEY (createdAt, ${'id'})
             ORDER BY (createdAt, ${'id'})
             ${this.ttl?.[tableName]?.row ? `TTL toDateTime(createdAt) + INTERVAL ${this.ttl[tableName].row.interval} ${this.ttl[tableName].row.unit}` : ''}
@@ -522,7 +545,7 @@ export class ClickhouseDB extends MastraBase {
       }
 
       await this.client.query({
-        query: sql,
+        query: this.applyDDLConfig(sql),
         clickhouse_settings: {
           // Allows to insert serialized JS Dates (such as '2023-12-06T10:54:48.000Z')
           date_time_input_format: 'best_effort',
@@ -578,7 +601,7 @@ export class ClickhouseDB extends MastraBase {
             `ALTER TABLE ${tableName} ADD COLUMN IF NOT EXISTS "${columnName}" ${sqlType} ${defaultValue}`.trim();
 
           await this.client.query({
-            query: alterSql,
+            query: this.applyDDLConfig(alterSql),
           });
           this.logger?.debug?.(`Added column ${columnName} to table ${tableName}`);
         }

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -28,6 +28,7 @@ import {
   TABLE_SKILL_VERSIONS,
   TABLE_SKILL_BLOBS,
 } from '@mastra/core/storage';
+import type { ClickhouseTableEngineConfig } from './engine';
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   [TABLE_MESSAGES]: `MergeTree()`,
@@ -91,6 +92,7 @@ export type ClickhouseConfig = {
   url: string;
   username: string;
   password: string;
+  engine?: ClickhouseTableEngineConfig;
   ttl?: {
     [TableKey in TABLE_NAMES]?: {
       row?: { interval: number; unit: IntervalUnit; ttlKey?: string };

--- a/stores/clickhouse/src/storage/domains/background-tasks/index.ts
+++ b/stores/clickhouse/src/storage/domains/background-tasks/index.ts
@@ -54,9 +54,9 @@ export class BackgroundTasksStorageClickhouse extends BackgroundTasksStorage {
 
   constructor(config: ClickhouseDomainConfig) {
     super();
-    const { client, ttl } = resolveClickhouseConfig(config);
+    const { client, ttl, engine } = resolveClickhouseConfig(config);
     this.client = client;
-    this.#db = new ClickhouseDB({ client, ttl });
+    this.#db = new ClickhouseDB({ client, ttl, engine });
   }
 
   async init(): Promise<void> {

--- a/stores/clickhouse/src/storage/domains/memory/index.ts
+++ b/stores/clickhouse/src/storage/domains/memory/index.ts
@@ -59,9 +59,9 @@ export class MemoryStorageClickhouse extends MemoryStorage {
   #db: ClickhouseDB;
   constructor(config: ClickhouseDomainConfig) {
     super();
-    const { client, ttl } = resolveClickhouseConfig(config);
+    const { client, ttl, engine } = resolveClickhouseConfig(config);
     this.client = client;
-    this.#db = new ClickhouseDB({ client, ttl });
+    this.#db = new ClickhouseDB({ client, ttl, engine });
   }
 
   async init(): Promise<void> {

--- a/stores/clickhouse/src/storage/domains/observability/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/index.ts
@@ -37,9 +37,9 @@ export class ObservabilityStorageClickhouse extends ObservabilityStorage {
 
   constructor(config: ClickhouseDomainConfig) {
     super();
-    const { client, ttl } = resolveClickhouseConfig(config);
+    const { client, ttl, engine } = resolveClickhouseConfig(config);
     this.client = client;
-    this.#db = new ClickhouseDB({ client, ttl });
+    this.#db = new ClickhouseDB({ client, ttl, engine });
   }
 
   async init(): Promise<void> {

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
@@ -82,6 +82,8 @@ import type {
 
 import { resolveClickhouseConfig } from '../../../db';
 import type { ClickhouseDomainConfig } from '../../../db';
+import type { ClickhouseTableEngineConfig } from '../../../db/engine';
+import { applyClickhouseDDLConfig } from '../../../db/engine';
 
 import {
   ALL_TABLE_DDL,
@@ -99,6 +101,7 @@ export type { RetentionConfig } from './ddl';
 /** Extended config for v-next observability, adding per-signal retention. */
 export type VNextObservabilityConfig = ClickhouseDomainConfig & {
   retention?: RetentionConfig;
+  engine?: ClickhouseTableEngineConfig;
 };
 import * as discoveryOps from './discovery';
 import * as feedbackOps from './feedback';
@@ -144,12 +147,14 @@ function buildSignalMigrationRequiredMessage(args: {
 export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
   readonly #client: ClickHouseClient;
   readonly #retention?: RetentionConfig;
+  readonly #engine?: ClickhouseTableEngineConfig;
 
   constructor(config: VNextObservabilityConfig) {
     super();
-    const { client } = resolveClickhouseConfig(config);
+    const { client, engine } = resolveClickhouseConfig(config);
     this.#client = client;
     this.#retention = config.retention;
+    this.#engine = engine;
   }
 
   // -------------------------------------------------------------------------
@@ -173,12 +178,12 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
     try {
       // Core tables + incremental MVs (must succeed)
       for (const ddl of [...ALL_TABLE_DDL, ...ALL_MV_DDL]) {
-        await this.#client.command({ query: ddl });
+        await this.#client.command({ query: applyClickhouseDDLConfig(ddl, this.#engine) });
       }
 
       // Additive migrations for existing databases (add new columns)
       for (const migration of ALL_MIGRATIONS) {
-        await this.#client.command({ query: migration });
+        await this.#client.command({ query: applyClickhouseDDLConfig(migration, this.#engine) });
       }
 
       // Apply retention TTL if configured (per design doc: per-signal, day increments).
@@ -186,7 +191,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
       if (this.#retention) {
         const ttlStatements = buildRetentionDDL(this.#retention);
         for (const stmt of ttlStatements) {
-          await this.#client.command({ query: stmt });
+          await this.#client.command({ query: applyClickhouseDDLConfig(stmt, this.#engine) });
         }
       }
     } catch (error) {
@@ -210,7 +215,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
     // discovery methods should continue returning empty results until a later refresh succeeds."
     try {
       for (const ddl of DISCOVERY_MV_DDL) {
-        await this.#client.command({ query: ddl });
+        await this.#client.command({ query: applyClickhouseDDLConfig(ddl, this.#engine) });
       }
       // Trigger an immediate refresh so discovery data is available right away
       // instead of waiting for the first scheduled refresh cycle.
@@ -248,7 +253,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
       };
     }
 
-    await migrateSignalTables(this.#client, this.logger);
+    await migrateSignalTables(this.#client, this.logger, this.#engine);
 
     return {
       success: true,

--- a/stores/clickhouse/src/storage/domains/observability/v-next/migration.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/migration.ts
@@ -3,7 +3,7 @@ import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { IMastraLogger } from '@mastra/core/logger';
 import { createStorageErrorId } from '@mastra/core/storage';
 import type { ClickhouseTableEngineConfig } from '../../../db/engine';
-import { applyClickhouseDDLConfig } from '../../../db/engine';
+import { isReplicatedEngineConfig, isReplicatedTableEngineName } from '../../../db/engine';
 
 import {
   TABLE_METRIC_EVENTS,
@@ -118,12 +118,24 @@ export async function migrateSignalTables(
     const currentEngine = await getTableEngine(client, table);
     if (!currentEngine || isReplacingMergeTreeEngine(currentEngine)) continue;
 
+    if (isReplicatedEngineConfig(engine) || isReplicatedTableEngineName(currentEngine)) {
+      throw new MastraError({
+        id: createStorageErrorId('CLICKHOUSE', 'MIGRATE_SIGNAL_TABLES', 'REPLICATED_ENGINE_UNSUPPORTED'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text:
+          `ClickHouse signal-ID migration cannot run automatically with replicated table engines. ` +
+          `Run the migration before enabling replicated engines, or recreate the replicated table manually with the signal-ID schema.`,
+        details: { table, currentEngine, idColumn },
+      });
+    }
+
     logger?.info?.(`Migrating ${table} from ${currentEngine} to ReplacingMergeTree with ${idColumn} column`);
 
     const temp = `${table}_migrating_${Date.now()}`;
 
     try {
-      await client.command({ query: applyClickhouseDDLConfig(buildTemporaryTableDDL(createDDL, table, temp), engine) });
+      await client.command({ query: buildTemporaryTableDDL(createDDL, table, temp) });
 
       const newColumns = await getTableColumns(client, temp);
       const currentColumns = new Set(await getTableColumns(client, table));

--- a/stores/clickhouse/src/storage/domains/observability/v-next/migration.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/migration.ts
@@ -2,6 +2,8 @@ import type { ClickHouseClient } from '@clickhouse/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { IMastraLogger } from '@mastra/core/logger';
 import { createStorageErrorId } from '@mastra/core/storage';
+import type { ClickhouseTableEngineConfig } from '../../../db/engine';
+import { applyClickhouseDDLConfig } from '../../../db/engine';
 
 import {
   TABLE_METRIC_EVENTS,
@@ -107,17 +109,21 @@ export async function checkSignalTablesMigrationStatus(client: ClickHouseClient)
  * → drop old data. EXCHANGE swaps the two table names atomically, so concurrent
  * writers never observe a missing table.
  */
-export async function migrateSignalTables(client: ClickHouseClient, logger?: IMastraLogger): Promise<void> {
+export async function migrateSignalTables(
+  client: ClickHouseClient,
+  logger?: IMastraLogger,
+  engine?: ClickhouseTableEngineConfig,
+): Promise<void> {
   for (const { table, createDDL, idColumn } of SIGNAL_MIGRATIONS) {
-    const engine = await getTableEngine(client, table);
-    if (!engine || isReplacingMergeTreeEngine(engine)) continue;
+    const currentEngine = await getTableEngine(client, table);
+    if (!currentEngine || isReplacingMergeTreeEngine(currentEngine)) continue;
 
-    logger?.info?.(`Migrating ${table} from ${engine} to ReplacingMergeTree with ${idColumn} column`);
+    logger?.info?.(`Migrating ${table} from ${currentEngine} to ReplacingMergeTree with ${idColumn} column`);
 
     const temp = `${table}_migrating_${Date.now()}`;
 
     try {
-      await client.command({ query: buildTemporaryTableDDL(createDDL, table, temp) });
+      await client.command({ query: applyClickhouseDDLConfig(buildTemporaryTableDDL(createDDL, table, temp), engine) });
 
       const newColumns = await getTableColumns(client, temp);
       const currentColumns = new Set(await getTableColumns(client, table));

--- a/stores/clickhouse/src/storage/domains/scores/index.ts
+++ b/stores/clickhouse/src/storage/domains/scores/index.ts
@@ -21,9 +21,9 @@ export class ScoresStorageClickhouse extends ScoresStorage {
   #db: ClickhouseDB;
   constructor(config: ClickhouseDomainConfig) {
     super();
-    const { client, ttl } = resolveClickhouseConfig(config);
+    const { client, ttl, engine } = resolveClickhouseConfig(config);
     this.client = client;
-    this.#db = new ClickhouseDB({ client, ttl });
+    this.#db = new ClickhouseDB({ client, ttl, engine });
   }
 
   async init(): Promise<void> {

--- a/stores/clickhouse/src/storage/domains/workflows/index.ts
+++ b/stores/clickhouse/src/storage/domains/workflows/index.ts
@@ -23,9 +23,9 @@ export class WorkflowsStorageClickhouse extends WorkflowsStorage {
   #db: ClickhouseDB;
   constructor(config: ClickhouseDomainConfig) {
     super();
-    const { client, ttl } = resolveClickhouseConfig(config);
+    const { client, ttl, engine } = resolveClickhouseConfig(config);
     this.client = client;
-    this.#db = new ClickhouseDB({ client, ttl });
+    this.#db = new ClickhouseDB({ client, ttl, engine });
   }
 
   supportsConcurrentUpdates(): boolean {

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -3,6 +3,7 @@ import { createClient } from '@clickhouse/client';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
 import type { TABLE_NAMES, StorageDomains, TABLE_SCHEMAS } from '@mastra/core/storage';
+import type { ClickhouseTableEngineConfig } from './db/engine';
 import { BackgroundTasksStorageClickhouse } from './domains/background-tasks';
 import { MemoryStorageClickhouse } from './domains/memory';
 import { ObservabilityStorageClickhouse } from './domains/observability';
@@ -21,6 +22,7 @@ export {
   WorkflowsStorageClickhouse,
 };
 export type { ClickhouseDomainConfig } from './db';
+export type { ClickhouseTableEngineConfig } from './db/engine';
 
 type IntervalUnit =
   | 'NANOSECOND'
@@ -116,6 +118,13 @@ export type ClickhouseConfig = {
    * // No auto-init, tables must already exist
    */
   disableInit?: boolean;
+  /**
+   * Optional table engine configuration for ClickHouse-managed tables.
+   *
+   * Use `replicated` or `{ type: 'replicated', ... }` when the store initializes
+   * tables on a replicated ClickHouse cluster.
+   */
+  engine?: ClickhouseTableEngineConfig;
 } & (
   | {
       /**
@@ -199,7 +208,7 @@ export class ClickhouseStore extends MastraCompositeStore {
       }
 
       // Extract Mastra-specific config, pass rest to ClickHouse client
-      const { id, ttl, disableInit, clickhouse_settings, ...clientOptions } = config;
+      const { id, ttl, disableInit, engine, clickhouse_settings, ...clientOptions } = config;
 
       // Create client with all provided options
       this.db = createClient({
@@ -216,7 +225,7 @@ export class ClickhouseStore extends MastraCompositeStore {
 
     this.ttl = config.ttl;
 
-    const domainConfig = { client: this.db, ttl: this.ttl };
+    const domainConfig = { client: this.db, ttl: this.ttl, engine: config.engine };
     const workflows = new WorkflowsStorageClickhouse(domainConfig);
     const scores = new ScoresStorageClickhouse(domainConfig);
     const memory = new MemoryStorageClickhouse(domainConfig);


### PR DESCRIPTION
## Description

Adds an opt-in replicated table engine mode to `@mastra/clickhouse` so stores can initialize tables on replicated ClickHouse clusters. When configured, DDL emits `ReplicatedMergeTree` / `ReplicatedReplacingMergeTree` engines and can optionally apply `ON CLUSTER` to `CREATE TABLE`, `CREATE MATERIALIZED VIEW`, and `ALTER TABLE`
statements.

## Related Issue(s)

Fixes #15618

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds an opt-in setting so Mastra's ClickHouse integration can create replicated tables (copies coordinated across multiple ClickHouse servers) and optionally add ON CLUSTER to DDL — making multi-replica deployments safe from split‑brain.

## Overview

Adds opt-in replicated table engine support to @mastra/clickhouse so stores can emit ReplicatedMergeTree / ReplicatedReplacingMergeTree engines (and optional ON CLUSTER clauses) instead of plain MergeTree variants. Implemented via a single engine/DDL helper threaded through all ClickHouse-managed DDL paths; includes tests and docs.

## Key Changes

- New engine/DDL module: stores/clickhouse/src/storage/db/engine.ts
  - Exported type ClickhouseTableEngineConfig (shorthand 'replicated' and object form with optional cluster, zooPath, replica).
  - buildClickhouseTableEngine(baseEngine, tableName, config): converts MergeTree / ReplacingMergeTree → ReplicatedMergeTree / ReplicatedReplacingMergeTree, preserves engine args, supports {table} templating and replica defaults.
  - applyClickhouseDDLConfig(ddl, config): rewrites CREATE TABLE, CREATE MATERIALIZED VIEW, and ALTER TABLE (ADD COLUMN) to replace engine clauses and inject ON CLUSTER when configured.
  - Helpers: isReplicatedEngineConfig, isReplicatedTableEngineName.

- Config & propagation
  - Adds ClickhouseConfig.engine?: ClickhouseTableEngineConfig and re-exports the type.
  - resolveClickhouseConfig returns engine and ClickhouseDB stores it; domain constructors (background-tasks, memory, observability, v-next observability, scores, workflows) forward engine into ClickhouseDB so all DDL goes through applyClickhouseDDLConfig/getTableEngine.
  - TABLE_ENGINES usage replaced by getTableEngine that respects configured engine.

- Migration safety
  - migrateSignalTables and spans sorting-key migration paths observe engine config and abort with a MastraError (CLICKHOUSE/MIGRATE_SIGNAL_TABLES/REPLICATED_ENGINE_UNSUPPORTED) if a replicated engine is configured or detected to avoid unsafe automatic destructive changes.
  - Spans sorting-key migration is blocked when replicated engines are configured or detected, requiring operator review.

- DDL execution changes
  - CREATE TABLE and ALTER TABLE ... ADD COLUMN execution paths apply applyClickhouseDDLConfig so created/altered tables reflect configured replicated engines and include ON CLUSTER when provided.

- Tests & docs
  - Tests: stores/clickhouse/src/storage/db/engine.test.ts covers engine detection, conversion, zooPath/replica templating, and DDL rewriting (CREATE TABLE, MATERIALIZED VIEW, ALTER TABLE).
  - Documentation/changeset: updates in stores/clickhouse/README.md, docs composite example, and a changeset describing the feature and usage (examples show engine: 'replicated' or object with cluster/zooPath/replica).

## Notable behavioral details

- Opt-in and backwards compatible: default behavior unchanged; operators must enable replicated engines.
- zooPath supports {table} substitution and defaults to /clickhouse/tables/{shard}/{database}/{table}; replica defaults to '{replica}'.
- When cluster is provided, ON CLUSTER '<cluster>' is injected into CREATE TABLE, CREATE MATERIALIZED VIEW IF NOT EXISTS, and ALTER TABLE statements.
- Original MergeTree/ReplacingMergeTree engine arguments (e.g., ReplacingMergeTree(updatedAt)) are preserved inside the replicated wrapper.
- DDL rewriting is conservative: only affects recognized MergeTree / ReplacingMergeTree engine patterns; other engines/DDL are left unchanged.

## Types / API additions

- New exported type: ClickhouseTableEngineConfig
- New exported functions: isReplicatedEngineConfig, isReplicatedTableEngineName, buildClickhouseTableEngine, applyClickhouseDDLConfig
- ClickhouseConfig.engine?: ClickhouseTableEngineConfig (new optional property)

## Tests & Checklist

- Tests added for engine logic and DDL rewriting; docs and a changeset included.
- PR metadata notes Coderabbit comments are not fully addressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->