### PR TITLE
fix(docs): use relative paths for skill configuration examples

### DIFF
--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -45,7 +45,7 @@ const workspace = new Workspace({
   sandbox: new LocalSandbox({
     workingDirectory: './workspace',
   }),
-  skills: ['/skills'],
+  skills: ['skills'],
 })
 ```
 

--- a/docs/src/content/en/docs/workspace/search.mdx
+++ b/docs/src/content/en/docs/workspace/search.mdx
@@ -152,7 +152,7 @@ Configure `autoIndexPaths` to automatically index files when the workspace initi
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
   bm25: true,
-  autoIndexPaths: ['/docs', '/support/faq'],
+  autoIndexPaths: ['docs', 'support/faq'],
 })
 
 await workspace.init()
@@ -167,7 +167,7 @@ const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
   bm25: true,
   // highlight-next-line
-  autoIndexPaths: ['/docs/**/*.md', '/support/**/*.txt'],
+  autoIndexPaths: ['docs/**/*.md', 'support/**/*.txt'],
 })
 ```
 

--- a/docs/src/content/en/docs/workspace/skills.mdx
+++ b/docs/src/content/en/docs/workspace/skills.mdx
@@ -19,13 +19,13 @@ A skill is a folder containing:
 - `assets/`: Images and other files (optional)
 
 ```plaintext title="Folder structure"
-/skills
-  /code-review
+skills/
+  code-review/
     SKILL.md
-    /references
+    references/
       style-guide.md
       pr-checklist.md
-    /scripts
+    scripts/
       lint.ts
 ```
 
@@ -71,18 +71,18 @@ import { Workspace, LocalFilesystem } from '@mastra/core/workspace'
 
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
-  skills: ['/skills'],
+  skills: ['skills'],
 })
 ```
 
-The `skills` directory is relative to your `basePath`. You can specify multiple skill directories or use glob patterns for discovery:
+You can specify multiple skill directories:
 
 ```typescript title="src/mastra/workspaces.ts"
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
   skills: [
-    '/skills', // Project skills
-    '/team-skills', // Shared team skills
+    'skills', // Project skills
+    'team-skills', // Shared team skills
   ],
 })
 ```
@@ -92,7 +92,7 @@ You can also pass a direct path to a skill directory or `SKILL.md` file:
 ```typescript
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
-  skills: ['/path/to/my-skill'],
+  skills: ['path/to/my-skill'],
 })
 ```
 
@@ -112,10 +112,10 @@ For dynamic skill paths based on context, pass a function:
 ```typescript
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
-  skills: context => {
-    const paths = ['/skills']
-    if (context.user?.role === 'developer') {
-      paths.push('/dev-skills')
+  skills: ctx => {
+    const paths = ['skills']
+    if (ctx.requestContext?.get('userRole') === 'developer') {
+      paths.push('dev-skills')
     }
     return paths
   },
@@ -149,7 +149,7 @@ const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
   skills: [
     'node_modules/@myorg/skills', // external: provides "brand-guidelines"
-    '/skills', // local: also provides "brand-guidelines"
+    'skills', // local: also provides "brand-guidelines"
   ],
 })
 
@@ -164,7 +164,7 @@ If BM25 or vector search is enabled on the workspace, skills are automatically i
 ```typescript
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
-  skills: ['/skills'],
+  skills: ['skills'],
   // highlight-next-line
   bm25: true,
 })
@@ -183,7 +183,7 @@ import { VersionedSkillSource } from '@mastra/core/workspace'
 
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
-  skills: ['/skills'],
+  skills: ['skills'],
   // highlight-next-line
   skillSource: new VersionedSkillSource(versionTree, blobStore, versionCreatedAt),
 })

--- a/docs/src/content/en/guides/guide/code-review-bot.mdx
+++ b/docs/src/content/en/guides/guide/code-review-bot.mdx
@@ -32,7 +32,7 @@ const workspace = new Workspace({
   filesystem: new LocalFilesystem({
     basePath: resolve(import.meta.dirname, '../../workspace'),
   }),
-  skills: ['/skills'],
+  skills: ['skills'],
 })
 // highlight-end
 
@@ -152,7 +152,7 @@ const workspace = new Workspace({
   filesystem: new LocalFilesystem({
     basePath: resolve(import.meta.dirname, '../../workspace'),
   }),
-  skills: ['/skills'],
+  skills: ['skills'],
 })
 
 export const mastra = new Mastra({

--- a/docs/src/content/en/guides/guide/dev-assistant.mdx
+++ b/docs/src/content/en/guides/guide/dev-assistant.mdx
@@ -45,9 +45,9 @@ import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: resolve(import.meta.dirname, '../../workspace') }),
   sandbox: new LocalSandbox({ workingDirectory: resolve(import.meta.dirname, '../../workspace') }),
-  skills: ['/skills'],
+  skills: ['skills'],
   bm25: true,
-  autoIndexPaths: ['/docs', '/src'],
+  autoIndexPaths: ['docs', 'src'],
 })
 // highlight-end
 
@@ -201,9 +201,9 @@ import { devAssistant } from './agents/dev-assistant'
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: resolve(import.meta.dirname, '../../workspace') }),
   sandbox: new LocalSandbox({ workingDirectory: resolve(import.meta.dirname, '../../workspace') }),
-  skills: ['/skills'],
+  skills: ['skills'],
   bm25: true,
-  autoIndexPaths: ['/docs', '/src'],
+  autoIndexPaths: ['docs', 'src'],
 })
 
 export const mastra = new Mastra({

--- a/docs/src/content/en/reference/processors/skill-search-processor.mdx
+++ b/docs/src/content/en/reference/processors/skill-search-processor.mdx
@@ -112,7 +112,7 @@ import { Workspace, LocalFilesystem } from '@mastra/core/workspace'
 
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './project' }),
-  skills: ['/skills'],
+  skills: ['skills'],
   bm25: true,
 })
 

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -26,7 +26,7 @@ const workspace = new Workspace({
     workingDirectory: './workspace',
   }),
   bm25: true,
-  autoIndexPaths: ['/docs'],
+  autoIndexPaths: ['docs'],
 })
 ```
 

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -10,7 +10,7 @@
  * const agent = new Agent({
  *   workspace: new Workspace({
  *     filesystem: new LocalFilesystem({ basePath: './data' }),
- *     skills: ['/skills'],
+ *     skills: ['skills'],
  *   }),
  * });
  *

--- a/packages/core/src/workspace/skills/types.ts
+++ b/packages/core/src/workspace/skills/types.ts
@@ -116,7 +116,7 @@ export interface SkillsContext {
  * @example Static paths
  * ```typescript
  * const workspace = new Workspace({
- *   skills: ['/skills', '/node_modules/@myorg/skills'],
+ *   skills: ['skills', '../node_modules/@myorg/skills'],
  * });
  * ```
  *
@@ -126,9 +126,9 @@ export interface SkillsContext {
  *   skills: (ctx) => {
  *     const tier = ctx.requestContext?.get('userTier');
  *     if (tier === 'premium') {
- *       return ['/skills/basic', '/skills/premium'];
+ *       return ['skills/basic', 'skills/premium'];
  *     }
- *     return ['/skills/basic'];
+ *     return ['skills/basic'];
  *   },
  * });
  * ```
@@ -211,7 +211,7 @@ export interface SkillSearchOptions extends BaseSearchOptions {
  * ```typescript
  * const workspace = new Workspace({
  *   filesystem: new LocalFilesystem({ basePath: './data' }),
- *   skills: ['/skills'],
+ *   skills: ['skills'],
  * });
  *
  * // List all skills


### PR DESCRIPTION
## Summary

Fixes documentation examples that incorrectly showed absolute paths (e.g., `'/skills'`) for skill configuration with `LocalFilesystem`. Paths starting with `/` resolve from the host filesystem root, not from `basePath`.

## Changes

Updated all skill path examples to use relative paths:
- `skills: ['/skills']` → `skills: ['skills']`
- `autoIndexPaths: ['/docs', '/src']` → `autoIndexPaths: ['docs', 'src']`

**Docs updated:**
- `docs/workspace/skills.mdx`
- `docs/workspace/overview.mdx`
- `guides/dev-assistant.mdx`
- `guides/code-review-bot.mdx`
- `reference/processors/skill-search-processor.mdx`

**JSDoc updated:**
- `packages/core/src/workspace/skills/types.ts`
- `packages/core/src/processors/processors/skills.ts`

## Test Plan

- [x] Docs build passes
- [x] Core package type-checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The docs showed paths like "/skills" which point at the computer's root instead of your project. This PR changes those examples to use "skills" (no leading slash) so they correctly refer to folders inside the workspace.

## Changes Summary

This PR updates documentation and JSDoc examples to use basePath-relative directory strings (no leading slash) for LocalFilesystem skill configuration across 7 files:

Documentation Files Updated
- docs/workspace/overview.mdx: `'/skills'` → `'skills'`
- docs/workspace/skills.mdx: removed leading slashes in all LocalFilesystem examples (e.g., `'/skills'` → `'skills'`) and adjusted related examples and explanatory snippets
- guides/dev-assistant.mdx: `skills: ['/skills']` → `skills: ['skills']`; `autoIndexPaths: ['/docs', '/src']` → `['docs', 'src']`
- guides/code-review-bot.mdx: `'/skills'` → `'skills'` in both snippets
- reference/processors/skill-search-processor.mdx: `['/skills']` → `['skills']`
- docs/workspace/search.mdx: autoIndexPaths examples changed from `'/docs/...', '/support/...'` → `'docs/...', 'support/...'`
- docs/reference/workspace/workspace-class.mdx: `autoIndexPaths: ['/docs']` → `['docs']`

Source/JSDoc Updates
- packages/core/src/processors/processors/skills.ts: inline JSDoc example `['/skills']` → `['skills']`
- packages/core/src/workspace/skills/types.ts: JSDoc examples (static and dynamic path examples) changed from leading-slash strings to relative ones (e.g., `'/skills'` → `'skills'`, `'/skills/...'` → `'skills/...'`, node_modules example adjusted to `'../node_modules/@myorg/skills'`)

Impact
- Examples now correctly resolve from Workspace LocalFilesystem basePath.
- Explanatory text and example folder listings updated where relevant.
- No runtime logic, types, exported APIs, or behavior were changed.
- Test plan: docs build passes and core package type-checks.

Note: The repository still contains other code/tests and templates that use leading-slash paths (e.g., tests and some workspace examples) which were not modified by this PR; this change is documentation/JSDoc-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->