### PR TITLE
fix(mastracode): clear task list on new/switched thread

### DIFF
--- a/.changeset/clear-thread-task-list.md
+++ b/.changeset/clear-thread-task-list.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fix(mastracode): clear task list, active plan, and sandbox allowed paths when starting, switching, or cloning a thread so ephemeral per-thread harness state from a previous conversation no longer leaks across threads.

--- a/mastracode/src/schema.ts
+++ b/mastracode/src/schema.ts
@@ -32,7 +32,11 @@ export const stateSchema = z.object({
   smartEditing: z.boolean().default(true),
   // Notification mode — alert when TUI needs user attention
   notifications: z.enum(['bell', 'system', 'both', 'off']).default('off'),
-  // Task list (persisted per-thread)
+  // Task list — ephemeral and scoped to the active thread.
+  // NOTE: this lives on the harness's single global state (one per process)
+  // and is NOT persisted with the thread; callers (see mastracode TUI
+  // thread_changed / thread_created / /new handlers) must clear it when
+  // switching threads so tasks do not leak across conversations.
   tasks: z
     .array(
       z.object({

--- a/mastracode/src/tui/__tests__/event-dispatch-thread-clear.test.ts
+++ b/mastracode/src/tui/__tests__/event-dispatch-thread-clear.test.ts
@@ -9,11 +9,17 @@ vi.mock('../../utils/project.js', () => ({
 }));
 
 function createHarness() {
-  const state: { tasks: unknown[]; activePlan: unknown | null; escapeAsCancel?: boolean } = {
+  const state: {
+    tasks: unknown[];
+    activePlan: unknown | null;
+    sandboxAllowedPaths: string[];
+    escapeAsCancel?: boolean;
+  } = {
     tasks: [
       { content: 'leftover task', status: 'pending', activeForm: 'leftover task' },
     ],
     activePlan: { title: 'stale plan', plan: 'stale', approvedAt: new Date().toISOString() },
+    sandboxAllowedPaths: ['/tmp/leftover-allowed-path'],
   };
 
   return {
@@ -64,7 +70,7 @@ describe('event-dispatch thread state clearing', () => {
     state = createState(harness);
   });
 
-  it('clears tasks and activePlan on thread_changed', async () => {
+  it('clears tasks, activePlan, and sandboxAllowedPaths on thread_changed', async () => {
     const event: HarnessEvent = {
       type: 'thread_changed',
       threadId: 'thread-1',
@@ -73,14 +79,19 @@ describe('event-dispatch thread state clearing', () => {
 
     await dispatchEvent(event, createEctx(), state);
 
-    expect(harness.setState).toHaveBeenCalledWith({ tasks: [], activePlan: null });
+    expect(harness.setState).toHaveBeenCalledWith({
+      tasks: [],
+      activePlan: null,
+      sandboxAllowedPaths: [],
+    });
     expect(harness.state.tasks).toEqual([]);
     expect(harness.state.activePlan).toBeNull();
+    expect(harness.state.sandboxAllowedPaths).toEqual([]);
     expect((state.taskProgress!.updateTasks as any)).toHaveBeenCalledWith([]);
     expect(state.taskWriteInsertIndex).toBe(-1);
   });
 
-  it('clears tasks and activePlan on thread_created', async () => {
+  it('clears tasks, activePlan, and sandboxAllowedPaths on thread_created', async () => {
     const event: HarnessEvent = {
       type: 'thread_created',
       thread: {
@@ -95,9 +106,14 @@ describe('event-dispatch thread state clearing', () => {
 
     await dispatchEvent(event, createEctx(), state);
 
-    expect(harness.setState).toHaveBeenCalledWith({ tasks: [], activePlan: null });
+    expect(harness.setState).toHaveBeenCalledWith({
+      tasks: [],
+      activePlan: null,
+      sandboxAllowedPaths: [],
+    });
     expect(harness.state.tasks).toEqual([]);
     expect(harness.state.activePlan).toBeNull();
+    expect(harness.state.sandboxAllowedPaths).toEqual([]);
     expect((state.taskProgress!.updateTasks as any)).toHaveBeenCalledWith([]);
     expect(state.taskWriteInsertIndex).toBe(-1);
     expect(state.currentThreadTitle).toBe('Thread 2');

--- a/mastracode/src/tui/__tests__/event-dispatch-thread-clear.test.ts
+++ b/mastracode/src/tui/__tests__/event-dispatch-thread-clear.test.ts
@@ -1,0 +1,105 @@
+import type { HarnessEvent, HarnessThread } from '@mastra/core/harness';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dispatchEvent } from '../event-dispatch.js';
+import type { TUIState } from '../state.js';
+
+vi.mock('../../utils/project.js', () => ({
+  getCurrentGitBranch: vi.fn(() => null),
+}));
+
+function createHarness() {
+  const state: { tasks: unknown[]; activePlan: unknown | null; escapeAsCancel?: boolean } = {
+    tasks: [
+      { content: 'leftover task', status: 'pending', activeForm: 'leftover task' },
+    ],
+    activePlan: { title: 'stale plan', plan: 'stale', approvedAt: new Date().toISOString() },
+  };
+
+  return {
+    state,
+    getState: vi.fn(() => state),
+    setState: vi.fn(async (updates: Record<string, unknown>) => {
+      Object.assign(state, updates);
+    }),
+    loadOMProgress: vi.fn(async () => {}),
+    listThreads: vi.fn(async (): Promise<HarnessThread[]> => [
+      {
+        id: 'thread-1',
+        resourceId: 'resource-1',
+        title: 'Thread 1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        metadata: {},
+      } as HarnessThread,
+    ]),
+  };
+}
+
+function createState(harness: ReturnType<typeof createHarness>): TUIState {
+  return {
+    harness: harness as any,
+    editor: { escapeEnabled: true },
+    projectInfo: { rootPath: '/tmp' },
+    taskProgress: { updateTasks: vi.fn() },
+    ui: { requestRender: vi.fn() },
+    taskWriteInsertIndex: 0,
+    currentThreadTitle: undefined,
+  } as unknown as TUIState;
+}
+
+function createEctx() {
+  return {
+    showInfo: vi.fn(),
+    renderExistingMessages: vi.fn(async () => {}),
+  } as any;
+}
+
+describe('event-dispatch thread state clearing', () => {
+  let harness: ReturnType<typeof createHarness>;
+  let state: TUIState;
+
+  beforeEach(() => {
+    harness = createHarness();
+    state = createState(harness);
+  });
+
+  it('clears tasks and activePlan on thread_changed', async () => {
+    const event: HarnessEvent = {
+      type: 'thread_changed',
+      threadId: 'thread-1',
+      previousThreadId: 'thread-0',
+    } as HarnessEvent;
+
+    await dispatchEvent(event, createEctx(), state);
+
+    expect(harness.setState).toHaveBeenCalledWith({ tasks: [], activePlan: null });
+    expect(harness.state.tasks).toEqual([]);
+    expect(harness.state.activePlan).toBeNull();
+    expect((state.taskProgress!.updateTasks as any)).toHaveBeenCalledWith([]);
+    expect(state.taskWriteInsertIndex).toBe(-1);
+  });
+
+  it('clears tasks and activePlan on thread_created', async () => {
+    const event: HarnessEvent = {
+      type: 'thread_created',
+      thread: {
+        id: 'thread-2',
+        resourceId: 'resource-1',
+        title: 'Thread 2',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        metadata: {},
+      },
+    } as HarnessEvent;
+
+    await dispatchEvent(event, createEctx(), state);
+
+    expect(harness.setState).toHaveBeenCalledWith({ tasks: [], activePlan: null });
+    expect(harness.state.tasks).toEqual([]);
+    expect(harness.state.activePlan).toBeNull();
+    expect((state.taskProgress!.updateTasks as any)).toHaveBeenCalledWith([]);
+    expect(state.taskWriteInsertIndex).toBe(-1);
+    expect(state.currentThreadTitle).toBe('Thread 2');
+  });
+});

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -73,7 +73,7 @@ export async function dispatchSlashCommand(
 
   switch (command) {
     case 'new':
-      handleNewCommand(buildCtx());
+      await handleNewCommand(buildCtx());
       return true;
     case 'clone':
       await handleCloneCommand(buildCtx());

--- a/mastracode/src/tui/commands/__tests__/new.test.ts
+++ b/mastracode/src/tui/commands/__tests__/new.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleNewCommand } from '../new.js';
+import type { SlashCommandContext } from '../types.js';
+
+function createContext() {
+  const harnessState: { tasks: unknown[]; activePlan: unknown | null } = {
+    tasks: [{ content: 'leftover', status: 'pending', activeForm: 'leftover' }],
+    activePlan: { title: 'stale', plan: 'stale', approvedAt: '2026-01-01T00:00:00.000Z' },
+  };
+  const setState = vi.fn(async (updates: Record<string, unknown>) => {
+    Object.assign(harnessState, updates);
+  });
+  const modifiedFiles = new Map<string, unknown>([['/tmp/a.ts', {}]]);
+
+  const ctx = {
+    state: {
+      pendingNewThread: false,
+      chatContainer: { clear: vi.fn() },
+      pendingTools: { clear: vi.fn() },
+      allToolComponents: [{}],
+      allSlashCommandComponents: [{}],
+      allSystemReminderComponents: [{}],
+      messageComponentsById: { clear: vi.fn() },
+      allShellComponents: [{}],
+      harness: {
+        getDisplayState: vi.fn(() => ({ modifiedFiles })),
+        setState,
+        getState: vi.fn(() => harnessState),
+      },
+      taskProgress: { updateTasks: vi.fn() },
+      taskWriteInsertIndex: 3,
+      ui: { requestRender: vi.fn() },
+    },
+    updateStatusLine: vi.fn(),
+    showInfo: vi.fn(),
+  } as unknown as SlashCommandContext;
+
+  return { ctx, harnessState, setState };
+}
+
+describe('handleNewCommand', () => {
+  it('clears ephemeral per-thread harness state (tasks, activePlan)', async () => {
+    const { ctx, harnessState, setState } = createContext();
+
+    await handleNewCommand(ctx);
+
+    expect(setState).toHaveBeenCalledWith({ tasks: [], activePlan: null });
+    expect(harnessState.tasks).toEqual([]);
+    expect(harnessState.activePlan).toBeNull();
+    expect(ctx.state.pendingNewThread).toBe(true);
+    expect(ctx.state.taskWriteInsertIndex).toBe(-1);
+  });
+});

--- a/mastracode/src/tui/commands/__tests__/new.test.ts
+++ b/mastracode/src/tui/commands/__tests__/new.test.ts
@@ -4,9 +4,14 @@ import { handleNewCommand } from '../new.js';
 import type { SlashCommandContext } from '../types.js';
 
 function createContext() {
-  const harnessState: { tasks: unknown[]; activePlan: unknown | null } = {
+  const harnessState: {
+    tasks: unknown[];
+    activePlan: unknown | null;
+    sandboxAllowedPaths: string[];
+  } = {
     tasks: [{ content: 'leftover', status: 'pending', activeForm: 'leftover' }],
     activePlan: { title: 'stale', plan: 'stale', approvedAt: '2026-01-01T00:00:00.000Z' },
+    sandboxAllowedPaths: ['/tmp/leftover-allowed-path'],
   };
   const setState = vi.fn(async (updates: Record<string, unknown>) => {
     Object.assign(harnessState, updates);
@@ -40,14 +45,19 @@ function createContext() {
 }
 
 describe('handleNewCommand', () => {
-  it('clears ephemeral per-thread harness state (tasks, activePlan)', async () => {
+  it('clears ephemeral per-thread harness state (tasks, activePlan, sandboxAllowedPaths)', async () => {
     const { ctx, harnessState, setState } = createContext();
 
     await handleNewCommand(ctx);
 
-    expect(setState).toHaveBeenCalledWith({ tasks: [], activePlan: null });
+    expect(setState).toHaveBeenCalledWith({
+      tasks: [],
+      activePlan: null,
+      sandboxAllowedPaths: [],
+    });
     expect(harnessState.tasks).toEqual([]);
     expect(harnessState.activePlan).toBeNull();
+    expect(harnessState.sandboxAllowedPaths).toEqual([]);
     expect(ctx.state.pendingNewThread).toBe(true);
     expect(ctx.state.taskWriteInsertIndex).toBe(-1);
   });

--- a/mastracode/src/tui/commands/clone.ts
+++ b/mastracode/src/tui/commands/clone.ts
@@ -83,6 +83,14 @@ export function askCloneName(state: TUIState): Promise<string | null> {
  * Shared post-clone UI reset: clears chat, tools, tasks, re-renders messages,
  * and shows an info banner. Every clone path should call this after
  * `harness.cloneThread()` succeeds.
+ *
+ * NOTE: Ephemeral per-thread harness state (tasks, activePlan,
+ * sandboxAllowedPaths) is cleared by the `thread_created` event handler in
+ * `event-dispatch.ts`, which `harness.cloneThread()` emits before this
+ * function runs (see packages/core/src/harness/harness.ts cloneThread).
+ * If clone ever stops emitting `thread_created`/`thread_changed`, this
+ * function must call `harness.setState({ tasks: [], activePlan: null,
+ * sandboxAllowedPaths: [] })` directly.
  */
 export async function resetUIAfterClone(ctx: CloneResetContext, clonedTitle: string): Promise<void> {
   const { state } = ctx;

--- a/mastracode/src/tui/commands/new.ts
+++ b/mastracode/src/tui/commands/new.ts
@@ -14,9 +14,10 @@ export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> 
   // Clear file tracking in display state (thread_created will also reset this)
   state.harness.getDisplayState().modifiedFiles.clear();
   // Clear ephemeral per-thread harness state so the next system prompt
-  // (built before `thread_created` fires) does not re-inject stale tasks
-  // or a stale active plan from the previous thread.
-  await state.harness.setState({ tasks: [], activePlan: null });
+  // (built before `thread_created` fires) does not re-inject stale tasks,
+  // a stale active plan, or stale sandbox allowed paths from the previous
+  // thread.
+  await state.harness.setState({ tasks: [], activePlan: null, sandboxAllowedPaths: [] });
   if (state.taskProgress) {
     state.taskProgress.updateTasks([]);
   }

--- a/mastracode/src/tui/commands/new.ts
+++ b/mastracode/src/tui/commands/new.ts
@@ -1,6 +1,6 @@
 import type { SlashCommandContext } from './types.js';
 
-export function handleNewCommand(ctx: SlashCommandContext): void {
+export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> {
   const { state } = ctx;
 
   state.pendingNewThread = true;
@@ -13,6 +13,10 @@ export function handleNewCommand(ctx: SlashCommandContext): void {
   state.allShellComponents = [];
   // Clear file tracking in display state (thread_created will also reset this)
   state.harness.getDisplayState().modifiedFiles.clear();
+  // Clear ephemeral per-thread harness state so the next system prompt
+  // (built before `thread_created` fires) does not re-inject stale tasks
+  // or a stale active plan from the previous thread.
+  await state.harness.setState({ tasks: [], activePlan: null });
   if (state.taskProgress) {
     state.taskProgress.updateTasks([]);
   }

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -122,6 +122,10 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
 
     case 'thread_changed': {
       ectx.showInfo(`Switched to thread: ${event.threadId}`);
+      // Clear ephemeral per-thread harness state so it does not leak
+      // from the previous thread (Harness.state is a single global snapshot
+      // and is not reset by switchThread itself).
+      await state.harness.setState({ tasks: [], activePlan: null });
       await ectx.renderExistingMessages();
       await state.harness.loadOMProgress();
       // Refresh git branch so TUI status line reflects the current branch
@@ -135,8 +139,7 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       if (currentThread) {
         state.currentThreadTitle = currentThread.title;
       }
-      // Clear tasks — they are ephemeral per-thread and should not leak
-      // from the previous thread's global harness state.
+      // Clear task UI component to reflect the freshly cleared state
       if (state.taskProgress) {
         state.taskProgress.updateTasks([]);
         state.ui.requestRender();
@@ -149,12 +152,15 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       ectx.showInfo(`Created thread: ${event.thread.id}`);
       // Update current thread title for status line display
       state.currentThreadTitle = event.thread.title;
+      // Clear ephemeral per-thread harness state (tasks, activePlan) so the
+      // new thread does not inherit stale values from the previous thread.
+      await state.harness.setState({ tasks: [], activePlan: null });
       // Sync inherited resource-level settings
       const tState = state.harness.getState() as any;
       if (typeof tState?.escapeAsCancel === 'boolean') {
         state.editor.escapeEnabled = tState.escapeAsCancel;
       }
-      // Clear stale tasks from the previous thread
+      // Clear task UI component to reflect the freshly cleared state
       if (state.taskProgress) {
         state.taskProgress.updateTasks([]);
       }

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -125,7 +125,7 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       // Clear ephemeral per-thread harness state so it does not leak
       // from the previous thread (Harness.state is a single global snapshot
       // and is not reset by switchThread itself).
-      await state.harness.setState({ tasks: [], activePlan: null });
+      await state.harness.setState({ tasks: [], activePlan: null, sandboxAllowedPaths: [] });
       await ectx.renderExistingMessages();
       await state.harness.loadOMProgress();
       // Refresh git branch so TUI status line reflects the current branch
@@ -152,9 +152,10 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       ectx.showInfo(`Created thread: ${event.thread.id}`);
       // Update current thread title for status line display
       state.currentThreadTitle = event.thread.title;
-      // Clear ephemeral per-thread harness state (tasks, activePlan) so the
-      // new thread does not inherit stale values from the previous thread.
-      await state.harness.setState({ tasks: [], activePlan: null });
+      // Clear ephemeral per-thread harness state (tasks, activePlan,
+      // sandboxAllowedPaths) so the new thread does not inherit stale
+      // values from the previous thread.
+      await state.harness.setState({ tasks: [], activePlan: null, sandboxAllowedPaths: [] });
       // Sync inherited resource-level settings
       const tState = state.harness.getState() as any;
       if (typeof tState?.escapeAsCancel === 'boolean') {

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -497,8 +497,9 @@ export async function promptForThreadSelection(state: TUIState): Promise<void> {
 
 export async function renderExistingTasks(state: TUIState): Promise<void> {
   try {
-    const harnessState = state.harness.getState() as { tasks?: TaskItem[] };
-    const tasks = harnessState.tasks || [];
+    // Read from display state which is already scoped per-thread, rather
+    // than from the global harness state which can leak tasks across threads.
+    const tasks: TaskItem[] = state.harness.getDisplayState().tasks ?? [];
 
     if (tasks.length > 0 && state.taskProgress) {
       state.taskProgress.updateTasks(tasks);


### PR DESCRIPTION
## Bug

The task list state lives on `Harness.state.tasks` (and `Harness.state.activePlan`), which is a single global object held by the harness process — it is **not** persisted per-thread. `resetThreadDisplayState()` in the core harness correctly clears the per-thread *display* state on thread switch/create, but the schema-level harness state is never reset.

As a result, when you switch threads (or create a new one), the previous conversation's tasks and active plan remain on `harness.getState()` and get re-injected into the next thread's system prompt, causing stale tasks/plans to "leak" across threads.

## Fix

Clear the ephemeral per-thread fields on the mastracode side (keeping the fix out of the core harness public API):

- `mastracode/src/tui/event-dispatch.ts` — call `state.harness.setState({ tasks: [], activePlan: null })` inside both the `thread_changed` and `thread_created` handlers.
- `mastracode/src/tui/commands/new.ts` — do the same inside `/new`, so the next system prompt (which is built before the subsequent `thread_created` event fires) does not carry over stale tasks/plan. The command is now `async` and awaited in `command-dispatch.ts`.
- `mastracode/src/tui/setup.ts` — `renderExistingTasks` now reads from `harness.getDisplayState().tasks` (already per-thread) instead of `getState().tasks`, so the UI matches the cleared harness state.
- `mastracode/src/schema.ts` — the `tasks` comment claimed "persisted per-thread", which was misleading. Updated to accurately describe that it is ephemeral, lives on the single global state object, and must be cleared by callers on thread transitions.

`omProgress` / `om status` were already handled via the display state reset and are not touched.

## Tests

- `mastracode/src/tui/__tests__/event-dispatch-thread-clear.test.ts` — dispatches `thread_changed` and `thread_created` events directly and asserts `harness.setState` is called with `{ tasks: [], activePlan: null }` and that the underlying state is cleared.
- `mastracode/src/tui/commands/__tests__/new.test.ts` — calls `handleNewCommand` and verifies tasks/activePlan are cleared plus the other `/new` side effects.

Both new test files pass locally:

```
✓ src/tui/__tests__/event-dispatch-thread-clear.test.ts (2 tests)
✓ src/tui/commands/__tests__/new.test.ts (1 test)
✓ src/tui/__tests__/command-dispatch.test.ts (7 tests)
✓ src/tui/commands/__tests__/thread.test.ts (4 tests)
✓ src/tui/commands/__tests__/threads.test.ts (3 tests)
```

`pnpm --filter mastracode lint` is clean. `pnpm --filter mastracode check` shows only pre-existing type errors unrelated to this change (they reproduce on `main`). The rest of the `mastracode` test suite has environmental flakiness tied to `process.stdout.columns` / `isolate: false` that is also present on `main`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mastra-ai/mastra/pull/15748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Switching or creating a new conversation thread sometimes showed leftover tasks and plans from a previous thread. This PR makes sure those task lists and the active plan are cleared whenever a thread is created or changed so every thread starts fresh.

## Overview

Fixes a bug where transient task list and activePlan state leaked across threads in the mastracode TUI because those fields lived on the single global harness state rather than being scoped/cleared per-thread. The PR ensures harness-level ephemeral fields are explicitly reset on thread creation/switch and during the `/new` command so stale tasks/activePlan are not injected into subsequent threads' system prompts.

## Changes Made

- mastracode/src/tui/event-dispatch.ts
  - In both `thread_changed` and `thread_created` handlers call `state.harness.setState({ tasks: [], activePlan: null, sandboxAllowedPaths: [] })` to clear harness-level ephemeral state.
  - Retain and align UI refresh logic (taskProgress update, render requests) with the cleared state.

- mastracode/src/tui/commands/new.ts
  - Convert `handleNewCommand` to async and await the harness state reset, explicitly clearing `tasks`, `activePlan`, and `sandboxAllowedPaths` during new-thread initialization so the next system prompt cannot include stale data.

- mastracode/src/tui/command-dispatch.ts
  - Await `handleNewCommand(...)` in the `/new` slash-command path to ensure async clearing completes before returning.

- mastracode/src/tui/setup.ts
  - `renderExistingTasks` now reads tasks from the harness display state (per-thread) via `harness.getDisplayState().tasks` instead of global `getState().tasks` to keep UI consistent with cleared per-thread state.

- mastracode/src/schema.ts
  - Updated comment clarifying that `tasks` are ephemeral and stored on the global harness state and must be cleared on thread transitions.

- mastracode/src/tui/commands/clone.ts
  - Clarifying comment about when ephemeral per-thread harness state must be cleared in clone flows.

- .changeset/clear-thread-task-list.md
  - Adds a changeset note describing the clearing behavior on thread start/switch/clone.

## Tests Added

- mastracode/src/tui/__tests__/event-dispatch-thread-clear.test.ts
  - Asserts `harness.setState` is called to clear `{ tasks: [], activePlan: null, sandboxAllowedPaths: [] }` on `thread_changed` and `thread_created`, verifies in-memory state and UI/task-progress side effects, and checks created-thread title handling.

- mastracode/src/tui/commands/__tests__/new.test.ts
  - Verifies `/new` clears `tasks`/`activePlan`/`sandboxAllowedPaths`, and checks related command-side state updates (pending new thread flag, taskWriteInsertIndex reset).

## Impact

- Prevents task list and active plan from leaking between threads; each thread starts with a clean ephemeral state.
- Keeps existing per-thread display-state reset mechanisms intact while ensuring the underlying harness-level ephemeral fields are also reset.
- No exported/public APIs changed except `handleNewCommand` now returns a Promise (signature changed from `void` → `Promise<void>`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->