### PR TITLE
docs: document observability exporter event callbacks

### DIFF
--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -178,6 +178,13 @@ interface ObservabilityExporter {
 }
 ```
 
+Event callback payloads use observability event bus envelopes:
+`TracingEvent` carries span lifecycle events with `exportedSpan`, `LogEvent`
+wraps `ExportedLog` in `log`, `MetricEvent` wraps `ExportedMetric` in
+`metric`, `ScoreEvent` wraps `ExportedScore` in `score`, and `FeedbackEvent`
+wraps `ExportedFeedback` in `feedback`. For Cloud exporter behavior for these
+callbacks, see [CloudExporter](/reference/observability/tracing/exporters/cloud-exporter).
+
 ### `SpanOutputProcessor`
 
 Interface for span output processors.

--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -135,6 +135,21 @@ interface ObservabilityExporter {
   /** Initialize exporter with tracing configuration and/or access to Mastra */
   init?(options: InitExporterOptions): void
 
+  /** Handle tracing events */
+  onTracingEvent?(event: TracingEvent): void | Promise<void>
+
+  /** Handle log events */
+  onLogEvent?(event: LogEvent): void | Promise<void>
+
+  /** Handle metric events */
+  onMetricEvent?(event: MetricEvent): void | Promise<void>
+
+  /** Handle score events */
+  onScoreEvent?(event: ScoreEvent): void | Promise<void>
+
+  /** Handle feedback events */
+  onFeedbackEvent?(event: FeedbackEvent): void | Promise<void>
+
   /** Export tracing events */
   exportTracingEvent(event: TracingEvent): Promise<void>
 


### PR DESCRIPTION
## What changed

Updates the `ObservabilityExporter` interface reference to include the event callback methods exposed by the current TypeScript interface: `onTracingEvent`, `onLogEvent`, `onMetricEvent`, `onScoreEvent`, and `onFeedbackEvent`.

## Why

The reference page already shows `addScoreToTrace`, and the Cloud exporter page documents `onScoreEvent`, but the main exporter interface reference did not surface the shared event callbacks. Including them makes the custom exporter surface easier to discover from the interface docs.

## Validation

Ran locally:

```bash
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 - Simple Explanation

This PR updates the docs so it's easy for developers to find and use the event callback hooks exporters can implement to observe traces, logs, metrics, scores, and feedback.

## Changes

- Documentation for the ObservabilityExporter interface now documents five optional event callback hooks (async-capable):
  - onTracingEvent?(event: TracingEvent): void | Promise<void>
  - onLogEvent?(event: LogEvent): void | Promise<void>
  - onMetricEvent?(event: MetricEvent): void | Promise<void>
  - onScoreEvent?(event: ScoreEvent): void | Promise<void>
  - onFeedbackEvent?(event: FeedbackEvent): void | Promise<void>
- Clarifies the payload/envelope shapes for each callback:
  - TracingEvent carries span lifecycle events (exportedSpan).
  - LogEvent/MetricEvent/ScoreEvent/FeedbackEvent wrap their exported objects under log/metric/score/feedback respectively.
- Notes that these callbacks complement existing methods like exportTracingEvent, addScoreToTrace, flush(), and shutdown(), and points readers to the Cloud exporter docs for concrete behavior.

## Files Modified

- docs/src/content/en/reference/observability/tracing/interfaces.mdx (+22/-0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->