### PR TITLE
fix(redis): include built files in package releases

### DIFF
--- a/.changeset/odd-wolves-fly.md
+++ b/.changeset/odd-wolves-fly.md
@@ -1,0 +1,5 @@
+---
+'@mastra/redis': patch
+---
+
+Fixed Redis package releases to include built files.

--- a/stores/redis/package.json
+++ b/stores/redis/package.json
@@ -25,7 +25,7 @@
     "posttest": "docker compose down",
     "lint": "eslint .",
     "build:lib": "tsup --silent --config tsup.config.ts",
-    "build:docs": "pnpx tsx ../../scripts/generate-package-docs.ts stores/redis",
+    "prepack": "pnpx tsx ../../scripts/generate-package-docs.ts",
     "build:watch": "tsup --watch --silent --config tsup.config.ts"
   },
   "license": "Apache-2.0",

--- a/stores/redis/turbo.json
+++ b/stores/redis/turbo.json
@@ -2,8 +2,23 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**", "!dist/docs/**"]
+    },
     "build": {
-      "outputs": ["dist/**"]
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes the `@mastra/redis` package release process so published artifacts include the built `dist/` files. The previous `build:docs` script was renamed to `prepack` so docs generation runs automatically before publish, and Turbo task wiring was restructured to ensure `build:lib` runs as part of `build`.

- Renamed `build:docs` script to `prepack` in `stores/redis/package.json` and dropped the explicit `stores/redis` path argument so it works from the package directory at pack time
- Added a dedicated `build:lib` task in `stores/redis/turbo.json` with proper `inputs` (src, configs) and `outputs` (`dist/**`, excluding `dist/docs/**`)
- Updated the `build` task to depend on `build:lib` so the library is built before packing
- Added changeset `.changeset/odd-wolves-fly.md` (patch bump for `@mastra/redis`)

## Related Issue(s)

Fixes #15762

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The @mastra/redis package published on npm was broken because it didn't include any of the actual code files—only the documentation and metadata. This fix changes the build process so that when the package is packed for release, it automatically includes all the compiled code files, making the package actually usable.

## Changes Overview

The PR fixes the package release process for @mastra/redis by restructuring the build pipeline to ensure compiled files (the `dist/` directory) are included in the npm package.

### File Changes

**`.changeset/odd-wolves-fly.md`**
- Added a changeset file documenting a patch version bump for @mastra/redis
- Notes that Redis package releases now include built files

**`stores/redis/package.json`**
- Replaced the `build:docs` npm script with a `prepack` script
- The `prepack` script runs automatically during the npm packaging lifecycle and invokes the same docs-generation command
- This ensures documentation is built as part of the packing process

**`stores/redis/turbo.json`**
- Introduced a new `build:lib` task that explicitly defines:
  - **Inputs**: `src` and config files (dependencies for the build)
  - **Outputs**: `dist/**` (excluding `dist/docs/**`)
  - **Dependencies**: Runs after upstream `^build` tasks complete
- Updated the existing `build` task to depend on `build:lib`, ensuring the library is built before packing
- Refined the `build` task's change detection to focus on `package.json` changes

## Why This Matters

The root cause of issue #15762 was that the npm release process wasn't properly capturing the compiled output files. By introducing the `prepack` lifecycle script and the dedicated `build:lib` task in Turbo, the package now automatically includes all built artifacts when published, making it installable and importable for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->