### PR TITLE
fix: integrate workflow processing in ProcessorRunner and update tests

### DIFF
--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -717,6 +717,52 @@ describe('ProcessorRunner', () => {
       expect(result.part?.type === 'text-delta' ? result.part?.payload.text : '').toBe('original text');
       expect(result.blocked).toBe(false);
     });
+
+    it('should track input before workflow transformation and output after', async () => {
+      const mockWorkflow = {
+        id: 'test-workflow',
+        createRun: async () => ({
+          start: async ({ inputData }: any) => {
+            return {
+              status: 'success',
+              result: {
+                phase: 'outputStream',
+                part: {
+                  type: 'text-delta',
+                  payload: { text: inputData.part.payload.text.toUpperCase() },
+                },
+              },
+            };
+          },
+        }),
+      };
+
+      const runner = new ProcessorRunner({
+        inputProcessors: [],
+        outputProcessors: [mockWorkflow as any],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const processorStates = new Map();
+
+      const inputPart = {
+        type: 'text-delta',
+        payload: { text: 'hello', id: 'text-1' },
+        runId: '1',
+        from: ChunkFrom.AGENT,
+      } as ChunkType;
+
+      const result = await runner.processPart(inputPart, processorStates);
+
+      expect(result.part?.type === 'text-delta' ? result.part.payload.text : '').toBe('HELLO');
+
+      const state = processorStates.get('test-workflow');
+
+      expect(state?.streamParts[0].payload.text).toBe('hello');
+
+      expect(state?.getFinalOutput().accumulatedText).toBe('HELLO');
+    });
   });
 
   describe('Stateful Stream Processing', () => {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -571,8 +571,11 @@ export class ProcessorRunner {
             processorStates.set(workflowId, state);
           }
 
-          // Track input chunk (before processor transformation)
-          state.addInputPart(processedPart);
+          // Track input BEFORE workflow transformation to preserve original stream history.
+          // This ensures streamParts reflects raw input, while output tracking reflects transformed chunks.
+          if (processedPart != null) {
+            state.addInputPart(processedPart);
+          }
 
           try {
             const result = await this.executeWorkflowAsProcessor(


### PR DESCRIPTION
## Description
Integrated workflow processing into `ProcessorRunner` and updated tests accordingly.

## Related Issue(s)
<!-- If this is tied to a GitHub issue, add: Fixes #<issue-number> -->
N/A

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Notes
- Added/updated test: "should track input before workflow transformation and output after"
- Currently 1 failing test related to workflow transformation: Expected "HELLO" but received "hello"
- This suggests the workflow transformation is not being applied correctly in `processPart`

## Questions
Looking for guidance on the correct integration point for workflow transformation inside `ProcessorRunner`.

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR tries to fix how the ProcessorRunner handles data transformations through workflows. Imagine you're playing a game where you write something down, a machine transforms it (like making it uppercase), and then you want to check both what you wrote originally AND what the machine created. The PR makes sure both versions are properly recorded, but there's still a bug where the transformation isn't happening correctly.

---

## Changes Overview

### Test Addition: `packages/core/src/processors/runner.test.ts`
- **New test case**: "should track input before workflow transformation and output after"
- **Purpose**: Validates that `ProcessorRunner.processPart` correctly records:
  - The original input chunk into the workflow processor state (before transformation)
  - The transformed content in the workflow state's final accumulated output
- **Test assertions**: 
  - Verifies the returned transformed chunk matches expected output
  - Checks that `streamParts[0].payload.text` preserves the original input
  - Verifies `getFinalOutput().accumulatedText` reflects the transformed content

### Code Modification: `packages/core/src/processors/runner.ts`
- **Change**: Conditional recording of input stream parts
- **Details**: Modified the workflow stream processing path to add `processedPart` to `state.streamParts` only when it is not null/undefined
- **Benefit**: Prevents invalid or empty chunks from being recorded in the preserved "raw input" history while maintaining subsequent output transformation tracking logic

---

## Known Issues

- **Failing test**: The workflow transformation is not being applied correctly in `processPart`. Expected output is "HELLO" (uppercase) but the actual output is "hello" (unchanged), indicating the transformation logic is not executing properly.
- **Outstanding question**: Author seeks guidance on the correct integration point for workflow transformation inside `ProcessorRunner`.

---

## Review Notes

- Tests have been added to demonstrate behavior
- Coderabbit comments not fully addressed
- Documentation updates have not been made
- Estimated review effort: Medium

<!-- end of auto-generated comment: release notes by coderabbit.ai -->