### PR TITLE
core: block phantom nested-subpath imports with explicit null exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,23 @@
         "default": "./dist/*/index.cjs"
       }
     },
+    "./auth/defaults": null,
+    "./auth/interfaces": null,
+    "./auth/ee/defaults": null,
+    "./auth/ee/interfaces": null,
+    "./agent/message-list/adapters": null,
+    "./agent/message-list/cache": null,
+    "./evals/run": null,
+    "./llm/model": null,
+    "./llm/model/gateways": null,
+    "./processors/memory": null,
+    "./processors/processors": null,
+    "./stream/aisdk/v5/compat": null,
+    "./storage/domains": null,
+    "./workspace/filesystem": null,
+    "./workspace/sandbox": null,
+    "./workspace/skills": null,
+    "./workspace/tools": null,
     "./auth/ee": {
       "import": {
         "types": "./dist/auth/ee/index.d.ts",


### PR DESCRIPTION
The wildcard `./*` export in `@mastra/core` matches multi-segment paths (per Node.js spec, `*` captures `/`), so nested type-only files emitted by tsc resolve to importable subpaths whose `.js` bundle never exists in `dist`. TypeScript compiles them; the program crashes at runtime with `MODULE_NOT_FOUND`.

Add `null` entries for the subpaths called out in the issue as breaking customers (`@mastra/core/auth/ee/defaults` and friends), so resolution fails at import time with `ERR_PACKAGE_PATH_NOT_EXPORTED` / `TS2307` instead of silently mapping a phantom `.d.ts`. Build-time auto-generation of all phantom entries (Option 2 in the issue) can land in a follow-up.

Fixes #15758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR prevents broken imports from appearing to work in TypeScript. The @mastra/core package had some "phantom" subpaths where TypeScript definition files existed but the actual JavaScript code didn't, causing code to compile successfully but crash when run. The fix adds explicit "this path is blocked" entries in package.json for these phantom paths so TypeScript and Node.js both reject them at import time instead of failing silently at runtime.

## Changes

**packages/core/package.json**

Adds 16 explicit null export entries to the `exports` map for phantom subpaths that have TypeScript definitions but no corresponding runtime JavaScript bundles:

- `./auth/defaults`
- `./auth/interfaces`
- `./auth/ee/defaults`
- `./auth/ee/interfaces`
- `./agent/message-list/adapters`
- `./agent/message-list/cache`
- `./evals/run`
- `./llm/model`
- `./llm/model/gateways`
- `./processors/memory`
- `./processors/processors`
- `./stream/aisdk/v5/compat`
- `./storage/domains`
- `./workspace/filesystem`
- `./workspace/sandbox`
- `./workspace/skills`
- `./workspace/tools`

This targeted fix ensures these known phantom subpaths are explicitly marked as unexported in the package, causing Node.js to raise `ERR_PACKAGE_PATH_NOT_EXPORTED` errors and TypeScript to report `TS2307` compile errors when these paths are imported, rather than allowing them to resolve through the wildcard export and fail mysteriously at runtime.

## Impact

Prevents module resolution failures at deployment time by making import errors visible at compile time. This is a targeted mitigation for the 61 phantom subpaths identified across @mastra/core; build-time auto-generation of null entries for all such paths is deferred to a follow-up effort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->