### PR TITLE
docs(ai-sdk-ui): use memory.thread/resource in useChat example

### DIFF
--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -265,8 +265,10 @@ const { messages, sendMessage } = useChat({
       return {
         body: {
           messages: [messages[messages.length - 1]],
-          threadId: 'user-thread-123',
-          resourceId: 'user-123',
+          memory: {
+            thread: 'user-thread-123',
+            resource: 'user-123',
+          },
         },
       }
     },
@@ -274,7 +276,7 @@ const { messages, sendMessage } = useChat({
 })
 ```
 
-Set `threadId` and `resourceId` from your app's own state, such as URL params, auth context, or your database.
+Set `memory.thread` and `memory.resource` from your app's own state, such as URL params, auth context, or your database.
 
 See [Message history](/docs/memory/message-history) for more on how Mastra memory loads and stores messages.
 

--- a/docs/src/content/en/reference/memory/clone-utilities.mdx
+++ b/docs/src/content/en/reference/memory/clone-utilities.mdx
@@ -205,8 +205,10 @@ async function manageClones() {
 
   // Have a conversation...
   await agent.generate("Hello! Let's discuss project options.", {
-    threadId: originalThread.id,
-    resourceId: 'user-123',
+    memory: {
+      thread: originalThread.id,
+      resource: 'user-123',
+    },
   })
 
   // Create multiple branches (clones) to explore different paths

--- a/docs/src/content/en/reference/memory/cloneThread.mdx
+++ b/docs/src/content/en/reference/memory/cloneThread.mdx
@@ -193,8 +193,10 @@ const { thread: dateFilteredClone } = await memory.cloneThread({
 
 // Continue conversation on the cloned thread
 const response = await agent.generate("Let's try a different approach", {
-  threadId: fullClone.id,
-  resourceId: fullClone.resourceId,
+  memory: {
+    thread: fullClone.id,
+    resource: fullClone.resourceId,
+  },
 })
 ```
 


### PR DESCRIPTION
## Description

Updates the AI SDK UI guide so the `useChat` example sends thread and resource IDs under the nested `memory`
object instead of the flat top-level `threadId`/`resourceId` fields. This matches the request shape Mastra currently accepts and prevents readers from copying an outdated snippet that silently fails to associate messages with a memory thread.

- Replace `threadId`/`resourceId` keys in the `prepareSendMessagesRequest` body with `memory: { thread, resource }`
- Update the surrounding prose to reference `memory.thread` and `memory.resource`

## Related Issue(s)

Fixes #15777

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes docs so examples send memory IDs inside a nested `memory` object (e.g., `memory.thread`, `memory.resource`) instead of as top-level `threadId`/`resourceId` fields, matching Mastra's current API so the examples actually associate messages with a memory thread.

---

## Changes

Updated documentation examples and surrounding guidance to use a nested `memory` shape for passing thread and resource identifiers:

- ai-sdk-ui guide: `prepareSendMessagesRequest` body now uses `memory: { thread, resource }` instead of top-level `threadId`/`resourceId`; prose updated to reference `memory.thread` and `memory.resource`. (docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx) (+5/-3)
- clone-utilities reference: example `agent.generate` call now passes memory context via `memory: { thread, resource }` instead of top-level `threadId`/`resourceId`. (docs/src/content/en/reference/memory/clone-utilities.mdx) (+4/-2)
- cloneThread reference: example showing continuing a conversation on a cloned thread updated to call `agent.generate` with `memory.thread` and `memory.resource` under a nested `memory` object. (docs/src/content/en/reference/memory/cloneThread.mdx) (+4/-2)

Type: Documentation-only change — no exported or public code entities modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->