### PR TITLE
fix(core): preserve requireApproval on ToolSearchProcessor tools

### DIFF
--- a/.changeset/sunny-rats-cheat.md
+++ b/.changeset/sunny-rats-cheat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `requireApproval` being silently ignored for tools loaded dynamically via `ToolSearchProcessor`. The approval gate now fires a `tool-call-approval` event and pauses execution before running, matching the behaviour of tools registered directly on the agent.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -569,6 +569,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                         requestContext: requestContext || new RequestContext(),
                         outputWriter,
                         workspace: currentStep.workspace,
+                        requireApproval: (tool as any).requireApproval,
+                        backgroundConfig: (tool as any).background,
                       },
                       undefined,
                       autoResumeSuspendedTools,

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -330,6 +330,25 @@ describe('makeCoreTool', () => {
     expect(() => schema['~standard'].validate({})).not.toThrow();
     expect(() => schema['~standard'].validate({ extra: 'field' })).not.toThrow();
   });
+
+  it('should propagate requireApproval from options to the built CoreTool', () => {
+    const tool = createTool({
+      id: 'dangerous-tool',
+      description: 'Deletes something important',
+      inputSchema: z.object({ target: z.string() }),
+      requireApproval: true,
+      execute: async ({ target }) => ({ deleted: target }),
+    });
+
+    const coreToolWithFlag = makeCoreTool(tool, {
+      ...mockOptions,
+      requireApproval: (tool as any).requireApproval,
+    });
+    expect((coreToolWithFlag as any).requireApproval).toBe(true);
+
+    const coreToolWithoutFlag = makeCoreTool(tool, mockOptions);
+    expect((coreToolWithoutFlag as any).requireApproval).toBe(false);
+  });
 });
 
 it('should log correctly for Vercel tool execution', async () => {


### PR DESCRIPTION
## Description

Fixes a silent security-flag drop where tools marked `requireApproval: true` and exposed via `ToolSearchProcessor` (or any input processor that injects raw `Tool` objects through `processInputStep`) executed without firing the `tool-call-approval` gate. The conversion to `CoreTool` inside the agentic LLM execution step omitted `requireApproval` from its options object, so `CoreToolBuilder` defaulted the flag to `false`.

- Forward `requireApproval` and `background` from the original tool into the options passed to `makeCoreTool` in `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`, matching the canonical pattern used at every other call site in `agent.ts` (lines 2368–2369, 2980, etc.).
- Add a regression test in `packages/core/src/utils.test.ts` asserting `makeCoreTool` propagates `requireApproval` from options to the built `CoreTool`, and that omitting it (the bug condition) drops the flag to `false`.
- Add a patch changeset for `@mastra/core` describing the user-visible fix.

## Related Issue(s)

Fixes #15776

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you have a special tool that needs your approval before it can run. If you tell the tool "please ask for approval first," but then someone uses a special tool-searching method to get that tool, the approval requirement got accidentally thrown away. This PR makes sure that when tools are found through the search method, their approval requirement is remembered, just like it would be for tools defined normally.

## Summary

This PR fixes a bug where tools injected via `ToolSearchProcessor` that were marked with `requireApproval: true` had their approval requirement silently dropped during conversion to `CoreTool`, causing the `tool-call-approval` gate to be skipped.

### Root Cause

The tool conversion in `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts` was not forwarding the `requireApproval` and `background` configuration flags when calling `makeCoreTool`, allowing these properties to default to `false`.

### Changes

**llm-execution-step.ts**: Updated the tool conversion logic to forward `requireApproval` and `background` from the original tool object into the options passed to `makeCoreTool`, aligning with other call sites in the codebase.

**utils.test.ts**: Added a regression test that verifies `makeCoreTool` correctly propagates the `requireApproval` flag from options into the resulting `CoreTool` instance, and that the flag defaults to `false` when not explicitly provided.

**Changeset**: Added a patch version bump entry for `@mastra/core` documenting that `requireApproval` is no longer silently ignored for tools loaded dynamically through `ToolSearchProcessor`, ensuring the approval gate respects these tools just as it does for directly registered tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->