### PR TITLE
 fix(core): type requireApproval to accept a function on tools

### DIFF
--- a/.changeset/tool-require-approval-function-type.md
+++ b/.changeset/tool-require-approval-function-type.md
@@ -1,0 +1,34 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the TypeScript type for `requireApproval` on tools so it accepts a function. The runtime already supported function values for conditional approval (added in #15346), but the type still required `boolean` and rejected functions, forcing an `as any` cast.
+
+**Before**
+
+```typescript
+createTool({
+  id: 'delete-file',
+  inputSchema: z.object({ isDryRun: z.boolean() }),
+  // Type error: function not assignable to boolean
+  requireApproval: async ({ isDryRun }) => !isDryRun,
+  execute: async (input) => {
+    /* ... */
+  },
+});
+```
+
+**After**
+
+```typescript
+createTool({
+  id: 'delete-file',
+  inputSchema: z.object({ isDryRun: z.boolean() }),
+  requireApproval: async ({ isDryRun }) => !isDryRun,
+  execute: async (input) => {
+    /* ... */
+  },
+});
+```
+
+The function receives the validated tool input and an optional second context argument with `requestContext` and `workspace`, matching the existing workspace tool config pattern.

--- a/.changeset/tool-require-approval-function-type.md
+++ b/.changeset/tool-require-approval-function-type.md
@@ -2,33 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed the TypeScript type for `requireApproval` on tools so it accepts a function. The runtime already supported function values for conditional approval (added in #15346), but the type still required `boolean` and rejected functions, forcing an `as any` cast.
-
-**Before**
-
-```typescript
-createTool({
-  id: 'delete-file',
-  inputSchema: z.object({ isDryRun: z.boolean() }),
-  // Type error: function not assignable to boolean
-  requireApproval: async ({ isDryRun }) => !isDryRun,
-  execute: async (input) => {
-    /* ... */
-  },
-});
-```
-
-**After**
-
-```typescript
-createTool({
-  id: 'delete-file',
-  inputSchema: z.object({ isDryRun: z.boolean() }),
-  requireApproval: async ({ isDryRun }) => !isDryRun,
-  execute: async (input) => {
-    /* ... */
-  },
-});
-```
-
-The function receives the validated tool input and an optional second context argument with `requestContext` and `workspace`, matching the existing workspace tool config pattern.
+Fixed the TypeScript type for `requireApproval` on tools so it accepts a function in addition to a boolean. The runtime already supported per-call approval functions (added in #15346), but the type still required `boolean`, forcing an `as any` cast. You can now pass a sync or async predicate without a cast — the predicate receives the validated tool input and an optional `{ requestContext, workspace }` second argument. Fixes #15647.

--- a/packages/core/src/tools/createtool-types.test.ts
+++ b/packages/core/src/tools/createtool-types.test.ts
@@ -174,6 +174,27 @@ describe('createTool type improvements', () => {
     expect(output.result).toBe(8);
     expect(output.operation).toBe('add');
   });
+
+  it('should accept a function for requireApproval and type the predicate input', () => {
+    const tool = createTool({
+      id: 'conditional-approval',
+      description: 'Tool with conditional approval',
+      inputSchema: z.object({
+        isDryRun: z.boolean(),
+        target: z.string(),
+      }),
+      requireApproval: async ({ isDryRun, target }) => {
+        // TypeScript should infer these from inputSchema
+        expectTypeOf(isDryRun).toEqualTypeOf<boolean>();
+        expectTypeOf(target).toEqualTypeOf<string>();
+        return !isDryRun;
+      },
+      execute: async () => ({ ok: true }),
+    });
+
+    expect(tool.requireApproval).toBeDefined();
+    expect(typeof tool.requireApproval).toBe('function');
+  });
 });
 
 /**

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -226,7 +226,7 @@ describe('MCP Tool Tracing', () => {
         originalTool: testTool as any,
         options: {
           name: 'test-tool',
-          requireApproval: needsApprovalFn as any,
+          requireApproval: needsApprovalFn,
         },
       });
 

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -115,14 +115,27 @@ export class Tool<
   mastra?: Mastra;
 
   /**
-   * Whether the tool requires explicit user approval before execution
+   * Whether the tool requires explicit user approval before execution.
+   * Accepts a boolean for static behavior, or a function evaluated per-call
+   * for conditional approval.
    * @example
    * ```typescript
-   * // For destructive operations
+   * // Static
    * requireApproval: true
+   *
+   * // Conditional — only require approval for non-dry-run calls
+   * requireApproval: async ({ isDryRun }) => !isDryRun
    * ```
    */
-  requireApproval?: boolean;
+  requireApproval?: ToolAction<
+    TSchemaIn,
+    TSchemaOut,
+    TSuspendSchema,
+    TResumeSchema,
+    TContext,
+    TId,
+    TRequestContext
+  >['requireApproval'];
 
   /**
    * Enables strict tool input generation for providers that support it.

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -393,7 +393,18 @@ export interface ToolAction<
   // Note: { error?: never } enables inline type narrowing with 'error' in result checks
   execute?: (inputData: TSchemaIn, context: TContext) => Promise<TSchemaOut | ValidationError>;
   mastra?: Mastra;
-  requireApproval?: boolean;
+  /**
+   * Whether the tool requires explicit user approval before execution.
+   * Pass `true` to always require approval, or a function evaluated per-call
+   * with the tool input (and optional request context/workspace) to require
+   * approval conditionally.
+   */
+  requireApproval?:
+    | boolean
+    | ((
+        input: TSchemaIn,
+        ctx?: { requestContext?: Record<string, unknown>; workspace?: Workspace },
+      ) => boolean | Promise<boolean>);
   /**
    * Enables strict tool input generation for providers that support it.
    * When enabled, supported providers will attempt to generate arguments

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -345,7 +345,12 @@ export interface ToolOptions extends Partial<ObservabilityContext> {
    * Optional async writer used to stream tool output chunks back to the caller. Tools should treat this as fire-and-forget I/O.
    */
   outputWriter?: OutputWriter;
-  requireApproval?: boolean;
+  requireApproval?:
+    | boolean
+    | ((
+        input: any,
+        ctx?: { requestContext?: Record<string, unknown>; workspace?: Workspace },
+      ) => boolean | Promise<boolean>);
   // Workflow-specific properties
   workflow?: any;
   workflowId?: string;


### PR DESCRIPTION
## Description

Aligns the TypeScript type for `requireApproval` on tools with the runtime that already supports function values. PR #15346 fixed `CoreToolBuilder` so a function passed to `requireApproval` is evaluated per-call (storing it as `needsApprovalFn`), but the type on `ToolAction`, the `Tool` class field, and `CreateToolBuilderOptions` still required `boolean` —  forcing users to cast with `as any`.

## Related Issue(s)

Fixes #15647

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Tools can now declare "require approval" as either a simple yes/no or a small function that decides, for each call, whether approval is needed — the TypeScript types now match the runtime behavior.

## Changes

**Type Definition Updates**
- Widened `requireApproval` to accept a boolean or a predicate (sync or async):
  (input: TSchemaIn, ctx?: { requestContext?: Record<string, unknown>; workspace?: Workspace }) => boolean | Promise<boolean>
  - Updated on `ToolAction` (`packages/core/src/tools/types.ts`)
  - `Tool.requireApproval` updated to use the `ToolAction`-derived type (`packages/core/src/tools/tool.ts`)
  - `ToolOptions.requireApproval` updated in `packages/core/src/utils.ts`

**Tests & Docs**
- Added a type-level test verifying `createTool` accepts an async predicate for `requireApproval` and correctly infers the predicate's input type (`packages/core/src/tools/createtool-types.test.ts`).
- Removed an `as any` cast in `packages/core/src/tools/tool-builder/builder.test.ts` by passing the predicate directly.
- Added a Changesets patch note documenting the fix (`.changeset/tool-require-approval-function-type.md`) and updated inline docs/examples in `tool.ts`.

## Rationale & Impact

Aligns TypeScript typings with runtime logic introduced in PR #15346 so callers can pass per-call approval functions without casts or type errors. Prevents regressions via tests and closes issue #15647.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->