### PR TITLE
fix(core): prevent agent loop continuation when finishReason='length'…

### DIFF
--- a/.changeset/sharp-pianos-carry.md
+++ b/.changeset/sharp-pianos-carry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent loops so truncated model responses stop instead of retrying pending tool calls until max steps.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -2,9 +2,11 @@ import { APICallError } from '@internal/ai-sdk-v5';
 import { convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Mock } from 'vitest';
+import { z } from 'zod/v4';
 import { MessageList } from '../../../agent/message-list';
 import { RequestContext } from '../../../request-context';
 import { ToolStream } from '../../../tools/stream';
+import { createTool } from '../../../tools/tool';
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from '../../../workflows/constants';
 import type { ExecuteFunctionParams } from '../../../workflows/step';
 import { testUsage } from '../../test-utils/utils';
@@ -243,6 +245,87 @@ describe('createLLMExecutionStep gateway provider tools', () => {
 
     expect(toolResult).toEqual(toolCallById['call-1']);
     expect(toolResult.result).toBeUndefined();
+  });
+
+  it('does not continue when finishReason is length with pending tool calls', async () => {
+    const tools = {
+      echo: createTool({
+        id: 'echo',
+        description: 'Echo input text',
+        inputSchema: z.object({
+          text: z.string(),
+        }),
+        execute: vi.fn(async ({ text }) => ({ text })),
+      }),
+    };
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream: vi.fn(async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'echo',
+                  input: '{"text":"partial"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'length',
+                  usage: testUsage,
+                },
+              ]),
+              request: {},
+              response: {
+                headers: undefined,
+              },
+              warnings: [],
+            })),
+          } as any,
+        },
+      ],
+      tools,
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<typeof tools>);
+
+    const result = await llmExecutionStep.execute(createExecuteParams(createIterationInput()));
+
+    expect(result.output.toolCalls).toEqual([
+      expect.objectContaining({
+        toolCallId: 'call-1',
+        toolName: 'echo',
+      }),
+    ]);
+    expect(result.stepResult.reason).toBe('length');
+    expect(result.stepResult.isContinued).toBe(false);
   });
 
   it('merges model config headers with explicit modelSettings headers and lets modelSettings override duplicates', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1358,7 +1358,16 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       // - OR finishReason indicates more work (e.g., tool-use)
       // Provider-executed tools (e.g. web_search) are handled server-side — the response already
       // contains both the tool execution and the text output, so no additional loop iteration is needed.
-      const hasPendingToolCalls = toolCalls && toolCalls.some(tc => !tc.providerExecuted);
+      //
+      // NOTE: hasPendingToolCalls must NOT override finishReason='length'.
+      // When the provider hits max_tokens mid-generation, it returns finishReason='length' and
+      // may also emit a partial/truncated tool call. Retrying with the same parameters produces
+      // the same truncation → infinite loop until maxSteps. PR #13861 / issue #13012 explicitly
+      // excluded 'length' from shouldContinue; this guard prevents hasPendingToolCalls from
+      // inadvertently re-enabling it.
+      // See: https://github.com/mastra-ai/mastra/issues/15717
+      const hasPendingToolCalls =
+        toolCalls && toolCalls.some(tc => !tc.providerExecuted) && finishReason !== 'length';
       const shouldContinue =
         shouldRetry ||
         (!tripwireTriggered && (hasPendingToolCalls || !['stop', 'error', 'length'].includes(finishReason)));

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1366,8 +1366,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       // excluded 'length' from shouldContinue; this guard prevents hasPendingToolCalls from
       // inadvertently re-enabling it.
       // See: https://github.com/mastra-ai/mastra/issues/15717
-      const hasPendingToolCalls =
-        toolCalls && toolCalls.some(tc => !tc.providerExecuted) && finishReason !== 'length';
+      const hasPendingToolCalls = toolCalls && toolCalls.some(tc => !tc.providerExecuted) && finishReason !== 'length';
       const shouldContinue =
         shouldRetry ||
         (!tripwireTriggered && (hasPendingToolCalls || !['stop', 'error', 'length'].includes(finishReason)));


### PR DESCRIPTION
… with pending tool calls

Closes #15717

## Description

### Problem

The agentic execution loop in `llm-execution-step.ts` had a logic bug where `hasPendingToolCalls` was overriding the explicit `finishReason === 'length'` exclusion:

```ts
// Before (buggy)
const hasPendingToolCalls = toolCalls && toolCalls.some(tc => !tc.providerExecuted);
const shouldContinue =
  shouldRetry ||
  (!tripwireTriggered && (hasPendingToolCalls || !['stop', 'error', 'length'].includes(finishReason)));
```

When `max_tokens` is hit mid-generation:
1. Provider returns `finishReason: 'length'`
2. The truncated tool call is still emitted as a "pending" tool call with partial/invalid args
3. `hasPendingToolCalls === true` overrides the `'length'` exclusion
4. `shouldContinue === true` → loop retries with identical params → identical truncation
5. Repeat until `maxSteps` → **infinite loop burning tokens and rate-limit budget**

PR #13861 (fix for #13012) explicitly excluded `'length'` from `shouldContinue`; `hasPendingToolCalls` inadvertently re-enabled it for the truncation case.

### Fix

Add `&& finishReason !== 'length'` to the `hasPendingToolCalls` condition:

```ts
// After (fixed)
const hasPendingToolCalls =
  toolCalls && toolCalls.some(tc => !tc.providerExecuted) && finishReason !== 'length';
```

When truncation occurs, pending tool calls with partial args are treated as non-actionable. The loop terminates with `finishReason: 'length'`, which callers can handle (e.g. increase `maxOutputTokens`).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the model runs out of tokens and stops mid-answer, the agent now stops too instead of trying to act on the incomplete tool call and retrying the same truncated response.

## Summary

This PR fixes a logic bug in the agentic execution loop where pending tool calls could revive loop continuation even when the language model signaled truncation via finishReason === 'length'. A truncated tool call should be treated as non-actionable; previously hasPendingToolCalls could override finishReason and cause repeated identical retries that waste tokens and rate-limit budget.

### Changes

- packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
  - Update computation of hasPendingToolCalls to exclude cases where finishReason === 'length':
    const hasPendingToolCalls = toolCalls && toolCalls.some(tc => !tc.providerExecuted) && finishReason !== 'length';
  - Result: shouldContinue no longer becomes true solely because of truncated pending tool calls; finishReason: 'length' is honored as terminal.

- packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
  - Add unit test covering the streaming edge case where a tool-call is emitted and the stream finishes with finishReason: 'length'. Asserts that the tool call is recorded but the step result reason is 'length' and isContinued is false.

- .changeset/sharp-pianos-carry.md
  - Add changeset noting the patch: truncated model responses stop rather than retry pending tool calls until max steps.

### Impact

- Prevents wasteful loop retries and token/rate-limit consumption when models truncate output.
- Ensures finishReason === 'length' is treated as a terminal condition even if the stream included pending tool-call chunks.
- Minimal, localized behavioral change with no public API modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->