### PR TITLE
 fix(core): close dataset.startExperiment workflow gaps

### DIFF
--- a/.changeset/silent-lions-draw.md
+++ b/.changeset/silent-lions-draw.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `dataset.startExperiment` for workflow targets to match `runEvals`. Previously, scorers running inside a persisted experiment could not access per-step input or output, `requestContext` configured on the experiment was not forwarded into the workflow run, and direct agent calls inside workflow steps could start detached traces instead of nesting under the workflow step span. Step-level data is now exposed to scorers via `run.targetMetadata.stepResults` and `run.targetMetadata.stepExecutionPath`, the workflow's root span ID is available as `run.targetSpanId`, `requestContext` propagates into every step, and ambient workflow step tracing is used when creating nested spans. Fixes [#15613](https://github.com/mastra-ai/mastra/issues/15613).

--- a/packages/core/src/datasets/experiment/__tests__/executor.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/executor.test.ts
@@ -310,6 +310,69 @@ describe('executeTarget', () => {
       expect(result.output).toEqual({ processed: true });
       expect(result.error).toBeNull();
     });
+
+    it('surfaces stepResults, stepExecutionPath and spanId from a successful run', async () => {
+      const stepResults = {
+        chat: { status: 'success', payload: { prompt: 'hi' }, output: { text: 'hello' } },
+      };
+      const mockWorkflow = createMockWorkflow({
+        status: 'success',
+        result: { text: 'hello' },
+        steps: stepResults,
+        stepExecutionPath: ['chat'],
+        traceId: 'trace-1',
+        spanId: 'span-1',
+      });
+
+      const result = await executeTarget(mockWorkflow, 'workflow', {
+        id: 'item-7',
+        datasetId: 'ds-1',
+        input: { prompt: 'hi' },
+        groundTruth: null,
+        version: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      expect(result.output).toEqual({ text: 'hello' });
+      expect(result.stepResults).toEqual(stepResults);
+      expect(result.stepExecutionPath).toEqual(['chat']);
+      expect(result.traceId).toBe('trace-1');
+      expect(result.spanId).toBe('span-1');
+    });
+
+    it('forwards requestContext and observability context into run.start', async () => {
+      const startSpy = vi.fn().mockResolvedValue({ status: 'success', result: {}, steps: {} });
+      const mockWorkflow = {
+        id: 'test-workflow',
+        name: 'Test Workflow',
+        createRun: vi.fn().mockResolvedValue({ start: startSpy }),
+      } as unknown as Workflow;
+
+      await executeTarget(
+        mockWorkflow,
+        'workflow',
+        {
+          id: 'item-8',
+          datasetId: 'ds-1',
+          input: { prompt: 'hi' },
+          groundTruth: null,
+          version: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        { requestContext: { tenantId: 't-1' } },
+      );
+
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      const startArgs = startSpy.mock.calls[0][0];
+      expect(startArgs.inputData).toEqual({ prompt: 'hi' });
+      expect(startArgs.requestContext).toBeInstanceOf(RequestContext);
+      expect(startArgs.requestContext.all).toEqual({ tenantId: 't-1' });
+      // Observability context fields are spread in (no-op when item carries no tracing context)
+      expect(startArgs).toHaveProperty('tracing');
+      expect(startArgs).toHaveProperty('tracingContext');
+    });
   });
 
   describe('v1 limitations', () => {

--- a/packages/core/src/datasets/experiment/executor.ts
+++ b/packages/core/src/datasets/experiment/executor.ts
@@ -5,9 +5,10 @@ import type { MastraScorer } from '../../evals/base';
 import type { ScorerRunInputForAgent, ScorerRunOutputForAgent } from '../../evals/types';
 import type { ScoringData } from '../../llm/model/base.types';
 import type { VersionOverrides } from '../../mastra/types';
+import { resolveObservabilityContext } from '../../observability';
 import { RequestContext } from '../../request-context';
 import type { TargetType } from '../../storage/types';
-import type { Workflow } from '../../workflows';
+import type { StepResult, Workflow } from '../../workflows';
 
 /**
  * Common fields extracted from both FullOutput (v2/v3) and GenerateTextResult/GenerateObjectResult (v1).
@@ -43,10 +44,16 @@ export interface ExecutionResult {
   error: { message: string; stack?: string; code?: string } | null;
   /** Trace ID from agent/workflow execution (null for scorers or errors) */
   traceId: string | null;
+  /** Root span ID from agent/workflow execution (null when not traced) */
+  spanId?: string | null;
   /** Structured input for scorers (extracted from agent scoring data) */
   scorerInput?: ScorerRunInputForAgent;
   /** Structured output for scorers (extracted from agent scoring data) */
   scorerOutput?: ScorerRunOutputForAgent;
+  /** Per-step results from a workflow run, keyed by step ID */
+  stepResults?: Record<string, StepResult<any, any, any, any>>;
+  /** Order in which workflow steps actually executed */
+  stepExecutionPath?: string[];
 }
 
 /**
@@ -126,7 +133,7 @@ export async function executeTarget(
         );
         break;
       case 'workflow':
-        executionPromise = executeWorkflow(target as Workflow, item);
+        executionPromise = executeWorkflow(target as Workflow, item, options?.requestContext);
         break;
       case 'scorer':
         executionPromise = executeScorer(target as MastraScorer<any, any, any, any>, item);
@@ -258,21 +265,40 @@ async function executeAgent(
 /**
  * Execute a dataset item against a workflow.
  * Creates a run with scorers disabled to avoid double-scoring.
+ *
+ * Mirrors `executeWorkflow` in evals/run so dataset experiments and runEvals
+ * produce the same observability spans and scoring data for workflow targets.
  */
 async function executeWorkflow(
   workflow: Workflow,
   item: { input: unknown; groundTruth?: unknown },
+  requestContext?: Record<string, unknown>,
 ): Promise<ExecutionResult> {
+  const reqCtx: RequestContext | undefined = requestContext
+    ? new RequestContext(Object.entries(requestContext))
+    : undefined;
+  const observabilityContext = resolveObservabilityContext({});
+
   const run = await workflow.createRun({ disableScorers: true });
   const result = await run.start({
     inputData: item.input,
+    ...(reqCtx ? { requestContext: reqCtx } : {}),
+    ...observabilityContext,
   });
 
   // TracingProperties is intersected on every WorkflowResult variant
   const traceId = result.traceId ?? null;
+  const spanId = result.spanId ?? null;
 
   if (result.status === 'success') {
-    return { output: result.result, error: null, traceId };
+    return {
+      output: result.result,
+      error: null,
+      traceId,
+      spanId,
+      stepResults: result.steps as Record<string, StepResult<any, any, any, any>>,
+      stepExecutionPath: result.stepExecutionPath,
+    };
   }
 
   // Handle all non-success statuses (still include traceId for debugging)
@@ -281,6 +307,9 @@ async function executeWorkflow(
       output: null,
       error: { message: result.error?.message ?? 'Workflow failed', stack: result.error?.stack },
       traceId,
+      spanId,
+      stepResults: result.steps as Record<string, StepResult<any, any, any, any>>,
+      stepExecutionPath: result.stepExecutionPath,
     };
   }
 
@@ -289,6 +318,9 @@ async function executeWorkflow(
       output: null,
       error: { message: `Workflow tripwire: ${result.tripwire?.reason ?? 'Unknown reason'}` },
       traceId,
+      spanId,
+      stepResults: result.steps as Record<string, StepResult<any, any, any, any>>,
+      stepExecutionPath: result.stepExecutionPath,
     };
   }
 
@@ -297,11 +329,21 @@ async function executeWorkflow(
       output: null,
       error: { message: 'Workflow suspended - not yet supported in dataset experiments' },
       traceId,
+      spanId,
+      stepResults: result.steps as Record<string, StepResult<any, any, any, any>>,
+      stepExecutionPath: result.stepExecutionPath,
     };
   }
 
   if (result.status === 'paused') {
-    return { output: null, error: { message: 'Workflow paused - not yet supported in dataset experiments' }, traceId };
+    return {
+      output: null,
+      error: { message: 'Workflow paused - not yet supported in dataset experiments' },
+      traceId,
+      spanId,
+      stepResults: result.steps as Record<string, StepResult<any, any, any, any>>,
+      stepExecutionPath: result.stepExecutionPath,
+    };
   }
 
   // Exhaustive check - should never reach here
@@ -310,5 +352,6 @@ async function executeWorkflow(
     output: null,
     error: { message: `Workflow ended with unexpected status: ${(_exhaustiveCheck as any).status}` },
     traceId,
+    spanId,
   };
 }

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -345,6 +345,15 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
         };
 
         // Run scorers (inline, after target completes)
+        const workflowData =
+          execResult.stepResults || execResult.stepExecutionPath
+            ? {
+                stepResults: execResult.stepResults,
+                stepExecutionPath: execResult.stepExecutionPath,
+                spanId: execResult.spanId,
+              }
+            : undefined;
+
         const itemScores = await runScorersForItem(
           scorers,
           item,
@@ -357,6 +366,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
           execResult.scorerInput,
           execResult.scorerOutput,
           execResult.traceId ?? undefined,
+          workflowData,
         );
 
         // Persist result with scores (if storage available)

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -6,6 +6,7 @@ import { EntityType } from '../../observability';
 import type { CorrelationContext } from '../../observability';
 import type { MastraCompositeStore } from '../../storage/base';
 import type { TargetType } from '../../storage/types';
+import type { StepResult } from '../../workflows';
 import type { ScorerResult } from './types';
 
 function toScorerTargetEntityType(targetType?: TargetType): EntityType | undefined {
@@ -47,6 +48,17 @@ export function resolveScorers(
 }
 
 /**
+ * Workflow-specific data forwarded to scorers so they can inspect step-level
+ * input/output and the executed step path. Surfaced via `targetMetadata` on
+ * the scorer run so existing scorer signatures stay unchanged.
+ */
+export interface WorkflowScorerData {
+  stepResults?: Record<string, StepResult<any, any, any, any>>;
+  stepExecutionPath?: string[];
+  spanId?: string | null;
+}
+
+/**
  * Run all scorers for a single item result.
  * Errors are isolated per scorer - one failing scorer doesn't affect others.
  */
@@ -62,6 +74,7 @@ export async function runScorersForItem(
   scorerInput?: ScorerRunInputForAgent,
   scorerOutput?: ScorerRunOutputForAgent,
   traceId?: string,
+  workflowData?: WorkflowScorerData,
 ): Promise<ScorerResult[]> {
   if (scorers.length === 0) return [];
 
@@ -85,6 +98,7 @@ export async function runScorersForItem(
         targetType,
         traceId,
         targetCorrelationContext,
+        workflowData,
       );
 
       // Persist score if storage available and score was computed
@@ -156,8 +170,19 @@ async function runScorerSafe(
   targetType?: TargetType,
   targetTraceId?: string,
   targetCorrelationContext?: CorrelationContext,
+  workflowData?: WorkflowScorerData,
 ): Promise<{ result: ScorerResult; promptMetadata: ScorerPromptMetadata }> {
   try {
+    // Surface step-level data via targetMetadata so workflow scorers can
+    // inspect per-step input/output without changing the scorer signature.
+    const targetMetadata: Record<string, unknown> | undefined =
+      workflowData && (workflowData.stepResults || workflowData.stepExecutionPath)
+        ? {
+            ...(workflowData.stepResults ? { stepResults: workflowData.stepResults } : {}),
+            ...(workflowData.stepExecutionPath ? { stepExecutionPath: workflowData.stepExecutionPath } : {}),
+          }
+        : undefined;
+
     const scoreResult: unknown = await scorer.run({
       input: scorerInput ?? item.input,
       output: scorerOutput ?? output,
@@ -166,7 +191,9 @@ async function runScorerSafe(
       targetScope: 'span',
       targetEntityType: toScorerTargetEntityType(targetType),
       targetTraceId,
+      ...(workflowData?.spanId ? { targetSpanId: workflowData.spanId } : {}),
       ...(targetCorrelationContext ? { targetCorrelationContext } : {}),
+      ...(targetMetadata ? { targetMetadata } : {}),
     });
 
     // Extract fields with typeof guards — scorer run result types use complex

--- a/packages/core/src/observability/context-storage.regression.test.ts
+++ b/packages/core/src/observability/context-storage.regression.test.ts
@@ -12,9 +12,10 @@
  * This test instantiates `Mastra` and verifies that the constructor-triggered
  * registration makes `resolveCurrentSpan()` work inside `executeWithContext`.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Mastra } from '../mastra';
-import { executeWithContext, resolveCurrentSpan } from './utils';
+import { EntityType, SpanType } from './types';
+import { executeWithContext, getOrCreateSpan, resolveCurrentSpan } from './utils';
 
 // Instantiate Mastra — this is the production path that triggers initContextStorage().
 new Mastra();
@@ -36,5 +37,75 @@ describe('context-storage resolver registration (regression for #15072)', () => 
 
   it('resolveCurrentSpan returns undefined outside any executeWithContext scope', () => {
     expect(resolveCurrentSpan()).toBeUndefined();
+  });
+
+  it('getOrCreateSpan creates a child of the ambient span inside executeWithContext', async () => {
+    const childSpan = { id: 'child-span', traceId: 'test-trace' };
+    const parentSpan = {
+      id: 'parent-span',
+      traceId: 'test-trace',
+      createChildSpan: vi.fn().mockReturnValue(childSpan),
+    } as any;
+
+    let resolved: unknown;
+    await executeWithContext({
+      span: parentSpan,
+      fn: async () => {
+        resolved = getOrCreateSpan({
+          type: SpanType.AGENT_RUN,
+          name: "agent run: 'test-agent'",
+          entityType: EntityType.AGENT,
+          entityId: 'test-agent',
+          mastra: {
+            observability: {
+              getSelectedInstance: vi.fn(),
+            },
+          } as any,
+        });
+      },
+    });
+
+    expect(resolved).toBe(childSpan);
+    expect(parentSpan.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: SpanType.AGENT_RUN,
+        name: "agent run: 'test-agent'",
+        entityType: EntityType.AGENT,
+        entityId: 'test-agent',
+      }),
+    );
+  });
+
+  it('getOrCreateSpan preserves explicit tracingOptions over the ambient span', async () => {
+    const parentSpan = {
+      id: 'parent-span',
+      traceId: 'ambient-trace',
+      createChildSpan: vi.fn(),
+    } as any;
+    const rootSpan = { id: 'root-span', traceId: 'explicit-trace' };
+    const startSpan = vi.fn().mockReturnValue(rootSpan);
+
+    let resolved: unknown;
+    await executeWithContext({
+      span: parentSpan,
+      fn: async () => {
+        resolved = getOrCreateSpan({
+          type: SpanType.AGENT_RUN,
+          name: "agent run: 'test-agent'",
+          entityType: EntityType.AGENT,
+          entityId: 'test-agent',
+          tracingOptions: { traceId: 'explicit-trace' },
+          mastra: {
+            observability: {
+              getSelectedInstance: vi.fn().mockReturnValue({ startSpan }),
+            },
+          } as any,
+        });
+      },
+    });
+
+    expect(resolved).toBe(rootSpan);
+    expect(parentSpan.createChildSpan).not.toHaveBeenCalled();
+    expect(startSpan).toHaveBeenCalledWith(expect.objectContaining({ traceId: 'explicit-trace' }));
   });
 });

--- a/packages/core/src/observability/utils.ts
+++ b/packages/core/src/observability/utils.ts
@@ -78,22 +78,26 @@ export function executeWithContextSync<T>(params: { span?: AnySpan; fn: () => T 
  * Creates or gets a child span from existing tracing context or starts a new trace.
  * This helper consolidates the common pattern of creating spans that can either be:
  * 1. Children of an existing span (when tracingContext.currentSpan exists)
- * 2. New root spans (when no current span exists)
+ * 2. Children of the ambient span installed by executeWithContext()
+ * 3. New root spans (when no current span exists)
  *
  * @param options - Configuration object for span creation
  * @returns The created Span or undefined if tracing is disabled
  */
 export function getOrCreateSpan<T extends SpanType>(options: GetOrCreateSpanOptions<T>): Span<T> | undefined {
   const { type, attributes, tracingContext, requestContext, tracingOptions, ...rest } = options;
+  const currentSpan =
+    tracingContext?.currentSpan ??
+    (tracingOptions?.traceId || tracingOptions?.parentSpanId ? undefined : resolveCurrentSpan());
 
   const metadata = {
     ...(rest.metadata ?? {}),
     ...(tracingOptions?.metadata ?? {}),
   };
 
-  // If we have a current span, create a child span
-  if (tracingContext?.currentSpan) {
-    return tracingContext.currentSpan.createChildSpan({
+  // If we have a current span, create a child span.
+  if (currentSpan) {
+    return currentSpan.createChildSpan({
       type,
       attributes,
       ...rest,


### PR DESCRIPTION
## Description

`dataset.startExperiment` for workflow targets had two gaps versus `runEvals`: scorers received only the workflow's final output (no per-step input/output), and the persisted observability trace contained only the outer `workflow_run` and `workflow_step` spans because direct agent calls inside steps started detached child traces. This PR surfaces step-level data to scorers and makes inner spans automatically nest under the workflow step.

## Before
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/f3af7f9f-667b-4e24-9dfd-2ad7c8565394" />

## After
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/769c5ee3-00ff-4851-9164-55d7a10da813" />

## Related Issue(s)

Fixes #15613

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR