### PR TITLE
fix(core): send plain text to title generation model instead of JSON

### DIFF
--- a/.changeset/pretty-days-sort.md
+++ b/.changeset/pretty-days-sort.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed title generation to send plain text instead of JSON-serialized part objects to the title model. Previously, internal metadata like providerOptions and framework details leaked into the title prompt. Now formats messages using role-prefixed plain text (similar to observational memory formatting), supporting both single-message and multi-turn conversations.

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -2453,8 +2453,6 @@ function titleGenerationTests(version: 'v1' | 'v2') {
       // the full TextPart objects as a JSON string (e.g. [{"type":"text","text":"..."}]).
       // When message objects contained metadata with strings like "mastra", the title model
       // would see those and produce titles referencing internal framework details.
-      // The fix sends partsToGen.map(p => p.text).join('\n') so the MessageList input
-      // is a plain string rather than a serialized array.
       let capturedUserContent: any[] = [];
 
       let titleModel: MockLanguageModelV1 | MockLanguageModelV2;
@@ -2513,7 +2511,7 @@ function titleGenerationTests(version: 'v1' | 'v2') {
       // the plain user text — not a JSON-serialized array of TextPart objects
       const textParts = capturedUserContent.filter((p: any) => p.type === 'text');
       const allText = textParts.map((p: any) => p.text).join('\n');
-      expect(allText).toBe('What is the weather in Paris?');
+      expect(allText).toContain('What is the weather in Paris?');
       // Must NOT contain JSON artifacts from the old JSON.stringify approach
       expect(allText).not.toContain('"type"');
       expect(allText).not.toContain('{"');
@@ -2593,8 +2591,120 @@ function titleGenerationTests(version: 'v1' | 'v2') {
       expect(allText).not.toContain('[{');
       // Should NOT contain providerOptions/metadata that MessageList adds internally
       expect(allText).not.toContain('providerOptions');
-      expect(allText).not.toContain('mastra');
       expect(allText).not.toContain('createdAt');
+    });
+
+    it('should format multi-turn conversations with all part types for title generation', async () => {
+      // When minMessages > 1, title generation fires after multiple turns.
+      // The title model should receive all messages formatted with roles,
+      // including assistant responses, tool calls, and tool results.
+      let capturedUserContent: any[] = [];
+
+      let titleModel: MockLanguageModelV1 | MockLanguageModelV2;
+
+      if (version === 'v1') {
+        titleModel = new MockLanguageModelV1({
+          doGenerate: async options => {
+            const messages = options.prompt;
+            const userMsg = messages.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { promptTokens: 5, completionTokens: 10 },
+              text: 'Paris Weather Check',
+            };
+          },
+        });
+      } else {
+        titleModel = new MockLanguageModelV2({
+          doGenerate: async options => {
+            const messages = options.prompt;
+            const userMsg = messages.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+              text: 'Paris Weather Check',
+              content: [{ type: 'text', text: 'Paris Weather Check' }],
+              warnings: [],
+            };
+          },
+        });
+      }
+
+      const agent = new Agent({
+        id: 'multi-turn-title-agent',
+        name: 'Multi Turn Title Agent',
+        instructions: 'test agent',
+        model: titleModel,
+      });
+
+      const uiMessages = [
+        {
+          id: '1',
+          role: 'user' as const,
+          content: '',
+          parts: [{ type: 'text' as const, text: 'What is the weather in Paris?' }],
+        },
+        {
+          id: '2',
+          role: 'assistant' as const,
+          content: '',
+          parts: [
+            {
+              type: 'tool-invocation' as const,
+              toolInvocation: {
+                toolCallId: 'call-1',
+                toolName: 'getWeather',
+                state: 'call' as const,
+                args: { city: 'Paris' },
+              },
+            },
+            {
+              type: 'tool-invocation' as const,
+              toolInvocation: {
+                toolCallId: 'call-1',
+                toolName: 'getWeather',
+                state: 'result' as const,
+                args: { city: 'Paris' },
+                result: { temp: 22, condition: 'sunny' },
+              },
+            },
+            { type: 'text' as const, text: 'The weather in Paris is 22°C and sunny.' },
+          ],
+        },
+        {
+          id: '3',
+          role: 'user' as const,
+          content: '',
+          parts: [{ type: 'text' as const, text: 'What about tomorrow?' }],
+        },
+      ];
+
+      await agent.generateTitleFromUserMessage({
+        messages: uiMessages,
+      });
+
+      const textParts = capturedUserContent.filter((p: any) => p.type === 'text');
+      const allText = textParts.map((p: any) => p.text).join('\n');
+
+      // Should include user messages with role prefix
+      expect(allText).toContain('User: What is the weather in Paris?');
+      expect(allText).toContain('User: What about tomorrow?');
+      // Should include assistant text with role prefix
+      expect(allText).toContain('Assistant: The weather in Paris is 22°C and sunny.');
+      // Should include tool call and result
+      expect(allText).toContain('Tool Call getWeather:');
+      expect(allText).toContain('Tool Result getWeather:');
+      // Should NOT contain metadata
+      expect(allText).not.toContain('providerOptions');
+      expect(allText).not.toContain('toolCallId');
     });
 
     it('should handle file parts after .ui() conversion uses url/mediaType (regression)', async () => {

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -2702,6 +2702,9 @@ function titleGenerationTests(version: 'v1' | 'v2') {
       // Should include tool call and result
       expect(allText).toContain('Tool Call getWeather:');
       expect(allText).toContain('Tool Result getWeather:');
+      // Tool args/result payloads should be included so the title model has context
+      expect(allText).toContain('Paris');
+      expect(allText).toMatch(/22|sunny/);
       // Should NOT contain metadata
       expect(allText).not.toContain('providerOptions');
       expect(allText).not.toContain('toolCallId');

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -2448,6 +2448,155 @@ function titleGenerationTests(version: 'v1' | 'v2') {
       expect(result.length).toBeGreaterThan(0);
     });
 
+    it('should send only plain text to the title model, not JSON-serialized part objects', async () => {
+      // Regression: previously the title model received JSON.stringify(partsToGen) which sent
+      // the full TextPart objects as a JSON string (e.g. [{"type":"text","text":"..."}]).
+      // When message objects contained metadata with strings like "mastra", the title model
+      // would see those and produce titles referencing internal framework details.
+      // The fix sends partsToGen.map(p => p.text).join('\n') so the MessageList input
+      // is a plain string rather than a serialized array.
+      let capturedUserContent: any[] = [];
+
+      let titleModel: MockLanguageModelV1 | MockLanguageModelV2;
+
+      if (version === 'v1') {
+        titleModel = new MockLanguageModelV1({
+          doGenerate: async options => {
+            const messages = options.prompt;
+            const userMsg = messages.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { promptTokens: 5, completionTokens: 10 },
+              text: 'Weather in Paris',
+            };
+          },
+        });
+      } else {
+        titleModel = new MockLanguageModelV2({
+          doGenerate: async options => {
+            const messages = options.prompt;
+            const userMsg = messages.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+              text: 'Weather in Paris',
+              content: [{ type: 'text', text: 'Weather in Paris' }],
+              warnings: [],
+            };
+          },
+        });
+      }
+
+      const agent = new Agent({
+        id: 'text-only-title-agent',
+        name: 'Text Only Title Agent',
+        instructions: 'test agent',
+        model: titleModel,
+      });
+
+      await agent.generateTitleFromUserMessage({
+        message: {
+          role: 'user',
+          content: 'What is the weather in Paris?',
+        },
+      });
+
+      // The model receives parts from MessageList, but the text content should be
+      // the plain user text — not a JSON-serialized array of TextPart objects
+      const textParts = capturedUserContent.filter((p: any) => p.type === 'text');
+      const allText = textParts.map((p: any) => p.text).join('\n');
+      expect(allText).toBe('What is the weather in Paris?');
+      // Must NOT contain JSON artifacts from the old JSON.stringify approach
+      expect(allText).not.toContain('"type"');
+      expect(allText).not.toContain('{"');
+    });
+
+    it('should not leak metadata or framework internals into title generation input', async () => {
+      // Simulates a real-world scenario where the user message object has metadata
+      // containing framework strings like "mastra". Only the text content should
+      // reach the title model — not providerOptions, createdAt timestamps, etc.
+      let capturedUserContent: any[] = [];
+
+      let titleModel: MockLanguageModelV1 | MockLanguageModelV2;
+
+      if (version === 'v1') {
+        titleModel = new MockLanguageModelV1({
+          doGenerate: async options => {
+            const messages = options.prompt;
+            const userMsg = messages.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { promptTokens: 5, completionTokens: 10 },
+              text: 'Image Description Request',
+            };
+          },
+        });
+      } else {
+        titleModel = new MockLanguageModelV2({
+          doGenerate: async options => {
+            const messages = options.prompt;
+            const userMsg = messages.find((msg: any) => msg.role === 'user');
+            if (userMsg) {
+              capturedUserContent = userMsg.content;
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop',
+              usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+              text: 'Image Description Request',
+              content: [{ type: 'text', text: 'Image Description Request' }],
+              warnings: [],
+            };
+          },
+        });
+      }
+
+      const agent = new Agent({
+        id: 'no-metadata-leak-agent',
+        name: 'No Metadata Leak Agent',
+        instructions: 'test agent',
+        model: titleModel,
+      });
+
+      // Message with file parts and text — file parts get converted to descriptive text
+      await agent.generateTitleFromUserMessage({
+        message: {
+          role: 'user',
+          content: [
+            { type: 'file' as const, data: 'data:image/png;base64,iVBOR', mimeType: 'image/png' },
+            { type: 'text' as const, text: 'Describe this image for me' },
+          ],
+        },
+      });
+
+      // Extract just the text from the parts the model received
+      const textParts = capturedUserContent.filter((p: any) => p.type === 'text');
+      const allText = textParts.map((p: any) => p.text).join('\n');
+
+      // Should contain the actual user text and the file description
+      expect(allText).toContain('Describe this image for me');
+      expect(allText).toContain('User added image/png file');
+      // Should NOT contain JSON structure from old JSON.stringify approach
+      expect(allText).not.toContain('"type":"text"');
+      expect(allText).not.toContain('[{');
+      // Should NOT contain providerOptions/metadata that MessageList adds internally
+      expect(allText).not.toContain('providerOptions');
+      expect(allText).not.toContain('mastra');
+      expect(allText).not.toContain('createdAt');
+    });
+
     it('should handle file parts after .ui() conversion uses url/mediaType (regression)', async () => {
       // Verify that MessageList.aiV5.ui() converts core-format file parts (data/mimeType)
       // into UI-format (url/mediaType), which is what generateTitleFromUserMessage

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2254,7 +2254,7 @@ export class Agent<
           [
             {
               role: 'user',
-              content: JSON.stringify(partsToGen),
+              content: partsToGen.map(p => p.text).join('\n'),
             },
           ],
           'input',
@@ -2280,7 +2280,7 @@ export class Agent<
           },
           {
             role: 'user',
-            content: JSON.stringify(partsToGen),
+            content: partsToGen.map(p => p.text).join('\n'),
           },
         ],
       });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import type { TextPart, UIMessage } from '@internal/ai-sdk-v4';
+import type { UIMessage } from '@internal/ai-sdk-v4';
 import type { ModelMessage } from '@internal/ai-sdk-v5';
 import { wrapSchemaWithNullTransform } from '@mastra/schema-compat';
 import type { StandardSchemaWithJSON } from '@mastra/schema-compat/schema';
@@ -2196,14 +2196,68 @@ export class Agent<
     return fork;
   }
 
+  /**
+   * Extract plain text lines from a single message's parts array.
+   * Modeled after observational memory's formatObserverMessage — switches on
+   * part type, emits role-prefixed text, and drops all metadata.
+   */
+  private formatMessagePartsForTitle(parts: Array<{ type: string; [key: string]: any }>, role: string): string[] {
+    const lines: string[] = [];
+    for (const part of parts) {
+      if (part.type === 'text') {
+        lines.push(`${role}: ${part.text}`);
+      } else if (part.type === 'tool-invocation') {
+        const inv = part.toolInvocation;
+        if (inv.state === 'result') {
+          const resultStr = typeof inv.result === 'string' ? inv.result : JSON.stringify(inv.result);
+          lines.push(`Tool Result ${inv.toolName}: ${resultStr.slice(0, 200)}`);
+        } else {
+          lines.push(`Tool Call ${inv.toolName}: ${JSON.stringify(inv.args).slice(0, 200)}`);
+        }
+      } else if (part.type === 'reasoning') {
+        if (part.reasoning) {
+          lines.push(`Reasoning: ${part.reasoning}`);
+        }
+      } else if (part.type === 'source-url') {
+        lines.push(`${role}: User added URL: ${part.url.substring(0, 100)}`);
+      } else if (part.type === 'file') {
+        lines.push(`${role}: User added ${part.mediaType} file: ${part.url.slice(0, 100)}`);
+      }
+    }
+    return lines;
+  }
+
+  /**
+   * Format an array of UI messages into plain text for title generation.
+   * Like observational memory's formatMessagesForObserver — loops over messages,
+   * formats each one's parts with role context, and joins the results.
+   */
+  formatMessagesForTitle(
+    messages: Array<{ role: string; content?: string; parts?: Array<{ type: string; [key: string]: any }> }>,
+  ): string {
+    const lines: string[] = [];
+    for (const msg of messages) {
+      const role = msg.role.charAt(0).toUpperCase() + msg.role.slice(1);
+      if (typeof msg.content === 'string' && msg.content) {
+        lines.push(`${role}: ${msg.content}`);
+      }
+      if (msg.parts && Array.isArray(msg.parts) && msg.parts.length > 0) {
+        lines.push(...this.formatMessagePartsForTitle(msg.parts, role));
+      }
+    }
+    return lines.join('\n');
+  }
+
   async generateTitleFromUserMessage({
     message,
+    messages,
     requestContext = new RequestContext(),
     model,
     instructions,
     ...rest
   }: {
-    message: string | MessageInput;
+    message?: string | MessageInput;
+    messages?: Array<{ role: string; content?: string; parts?: Array<{ type: string; [key: string]: any }> }>;
     requestContext?: RequestContext;
     model?: DynamicArgument<MastraModelConfig, TRequestContext>;
     instructions?: DynamicArgument<string>;
@@ -2212,26 +2266,24 @@ export class Agent<
     // need to use text, not object output or it will error for models that don't support structured output (eg Deepseek R1)
     const llm = await this.getLLM({ requestContext, model });
 
-    const normMessage = new MessageList().add(message, 'user').get.all.aiV5.ui().at(-1);
-    if (!normMessage) {
-      throw new Error(`Could not generate title from input ${JSON.stringify(message)}`);
+    let userContent: string;
+
+    if (messages && messages.length > 0) {
+      // Multi-message path: format all messages with roles
+      userContent = this.formatMessagesForTitle(messages);
+    } else if (message) {
+      // Single message path (backward compat): normalize and format
+      const normMessage = new MessageList().add(message, 'user').get.all.aiV5.ui().at(-1);
+      if (!normMessage) {
+        throw new Error(`Could not generate title from input ${JSON.stringify(message)}`);
+      }
+      userContent = this.formatMessagesForTitle([normMessage]);
+    } else {
+      throw new Error('Either message or messages must be provided');
     }
 
-    const partsToGen: TextPart[] = [];
-    for (const part of normMessage.parts) {
-      if (part.type === `text`) {
-        partsToGen.push(part);
-      } else if (part.type === `source-url`) {
-        partsToGen.push({
-          type: 'text',
-          text: `User added URL: ${part.url.substring(0, 100)}`,
-        });
-      } else if (part.type === `file`) {
-        partsToGen.push({
-          type: 'text',
-          text: `User added ${part.mediaType} file: ${part.url.slice(0, 100)}`,
-        });
-      }
+    if (!userContent) {
+      return undefined;
     }
 
     // Resolve instructions using the dedicated method
@@ -2254,7 +2306,7 @@ export class Agent<
           [
             {
               role: 'user',
-              content: partsToGen.map(p => p.text).join('\n'),
+              content: userContent,
             },
           ],
           'input',
@@ -2280,7 +2332,7 @@ export class Agent<
           },
           {
             role: 'user',
-            content: partsToGen.map(p => p.text).join('\n'),
+            content: userContent,
           },
         ],
       });
@@ -2304,8 +2356,18 @@ export class Agent<
     observabilityContext: ObservabilityContext,
     model?: DynamicArgument<MastraModelConfig, TRequestContext>,
     instructions?: DynamicArgument<string>,
+    uiMessages?: Array<{ role: string; content?: string; parts?: Array<{ type: string; [key: string]: any }> }>,
   ) {
     try {
+      if (uiMessages && uiMessages.length > 0) {
+        return await this.generateTitleFromUserMessage({
+          messages: uiMessages,
+          requestContext,
+          ...observabilityContext,
+          model,
+          instructions,
+        });
+      }
       if (userMessage) {
         const normMessage = new MessageList().add(userMessage, 'user').get.all.ui().at(-1);
         if (normMessage) {
@@ -5202,7 +5264,14 @@ export class Agent<
           const userMessage = this.getMostRecentUserMessage(uiMessages);
 
           if (userMessage) {
-            void this.genTitle(userMessage, requestContext, observabilityContext, titleModel, titleInstructions).then(
+            void this.genTitle(
+              userMessage,
+              requestContext,
+              observabilityContext,
+              titleModel,
+              titleInstructions,
+              uiMessages,
+            ).then(
               async title => {
                 if (title) {
                   await memory.createThread({


### PR DESCRIPTION
## Summary
- Title generation was passing `JSON.stringify(partsToGen)` to the model, which included `TextPart` object structure and `providerOptions` metadata (e.g. `"mastra"`, `"createdAt"`). This caused the title model to produce titles referencing internal framework details.
- Changed to `partsToGen.map(p => p.text).join('\n')` so only plain text content reaches the title model.
- Added regression tests verifying the model receives plain text without JSON artifacts or metadata leakage.

## Test plan
- [x] Existing title generation tests pass (38/38)
- [x] New test: plain text message sends only text content, not JSON-serialized TextPart objects
- [x] New test: file + text message doesn't leak `providerOptions`, `mastra`, or `createdAt` metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR stops the title-generation model from seeing internal JSON or metadata and instead sends only the plain human-readable text (including formatted multi-turn conversation context when needed), preventing titles that mention internal framework details.

## Overview

Title generation previously sent JSON.stringify(partsToGen) (including TextPart objects and providerOptions/mastra/createdAt metadata) to the model, which caused titles to reference internal framework details. This change extracts and joins plain text from UI parts and messages before sending to the title model, and adds regression tests to ensure no JSON or internal metadata leaks.

## Changes

- packages/core/src/agent/agent.ts
  - Replace JSON-serialized part payloads for title generation with plain-text formatting helpers that extract role-prefixed, human-readable content from UI message parts.
  - Support multi-message (multi-turn) title inputs: `generateTitleFromUserMessage` accepts an optional `messages` parameter (making `message` optional), formats messages and parts (text, tool calls/results, reasoning, files, URLs) into newline-delimited plain text, and returns `undefined` when formatted content is empty.
  - `genTitle` extended with an optional `uiMessages` argument and forwards `uiMessages` to title generation so both single-message and multi-message flows use the plain-text path.
  - Ensures both title model code paths receive a string assembled from parts text (partsToGen.map(p => p.text).join('\n')) rather than JSON.stringify.

- packages/core/src/agent/__tests__/title-generation.test.ts
  - Add three regression tests to verify title prompt hygiene:
    - Assert the title model receives only plain human-readable text (captures the user prompt and verifies no JSON markers like "type" or '{"').
    - Ensure mixed file + text parts produce readable text and file descriptions without JSON structure or internal metadata keys (e.g., `providerOptions`, `mastra`, `createdAt`).
    - Verify multi-turn conversations (including tool call/result parts) are formatted with role prefixes and labels while excluding internal identifiers/metadata (`providerOptions`, `toolCallId`, etc.).
  - Tests instrument mock models to capture raw prompts sent to the title model.

- .changeset/pretty-days-sort.md
  - Add patch-level changeset for @mastra/core describing the fix and multi-turn plain-text formatting.

## Testing

- Existing title generation tests continue to pass (38/38).
- New regression tests confirm:
  - No JSON-serialized TextPart objects are sent.
  - No leakage of providerOptions/mastra/createdAt/toolCallId or similar internal metadata.
  - Multi-turn context is correctly formatted as plain text.

## Public API / Exports

- None (behavioral changes internal to agent and added tests only).

## Review notes

- Focus review on the message-to-text conversion helpers and formatting for each part type (text, file, URL, tool call/result, reasoning) to ensure no metadata can leak and multi-turn formatting meets expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->