### PR TITLE
fix(core): pass requestContext and workspace to needsApprovalFn in network loop

### DIFF
--- a/.changeset/metal-bottles-serve.md
+++ b/.changeset/metal-bottles-serve.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': patch
+---
+
+Fixed: `requireApproval` predicate now receives `{ requestContext, workspace }` as the second argument when invoked from the network loop, matching the existing behavior in the agentic-execution path. Function predicates can now gate approval on user role, workspace tier, or other request-scoped state regardless of whether the tool runs in `agent.network()` or the standard agentic loop.
+
+```ts
+createTool({
+  id: 'delete-account',
+  requireApproval: (input, { requestContext, workspace }) => {
+    return requestContext.role !== 'admin';
+  },
+  execute: async () => { /* ... */ },
+});
+```

--- a/packages/core/src/loop/network/index.test.ts
+++ b/packages/core/src/loop/network/index.test.ts
@@ -5,7 +5,7 @@ import type { Processor } from '../../processors';
 import { RequestContext } from '../../request-context';
 import { createTool } from '../../tools';
 import { createWorkflow } from '../../workflows';
-import { getLastMessage, getRoutingAgent } from './index';
+import { evaluateNetworkToolApproval, getLastMessage, getRoutingAgent } from './index';
 
 describe('getLastMessage', () => {
   it('returns string directly', () => {
@@ -356,5 +356,132 @@ describe('getRoutingAgent', () => {
     // listInputProcessors should NOT be called - only listConfiguredInputProcessors
     expect(mockAgent.listInputProcessors).not.toHaveBeenCalled();
     expect(mockAgent.listConfiguredInputProcessors).toHaveBeenCalled();
+  });
+});
+
+describe('evaluateNetworkToolApproval', () => {
+  const makeAgent = (workspace: any = { id: 'ws-1' }) =>
+    ({
+      getWorkspace: vi.fn().mockResolvedValue(workspace),
+    }) as any;
+
+  const makeRequestContext = (entries: Record<string, unknown> = {}) => {
+    const rc = new RequestContext();
+    for (const [k, v] of Object.entries(entries)) {
+      rc.set(k, v);
+    }
+    return rc;
+  };
+
+  const makeLogger = () => ({ error: vi.fn() });
+
+  it('returns the boolean requireApproval when no needsApprovalFn is set', async () => {
+    const result = await evaluateNetworkToolApproval({
+      tool: { requireApproval: true },
+      inputData: { x: 1 },
+      requestContext: makeRequestContext(),
+      agent: makeAgent(),
+      toolId: 'plain-tool',
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns undefined when neither requireApproval nor needsApprovalFn is set', async () => {
+    const result = await evaluateNetworkToolApproval({
+      tool: {},
+      inputData: { x: 1 },
+      requestContext: makeRequestContext(),
+      agent: makeAgent(),
+      toolId: 'no-approval-tool',
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('passes inputData and { requestContext, workspace } to needsApprovalFn', async () => {
+    const needsApprovalFn = vi.fn().mockReturnValue(true);
+    const requestContext = makeRequestContext({ role: 'admin', tier: 'pro' });
+    const workspace = { id: 'ws-42' };
+    const agent = makeAgent(workspace);
+    const inputData = { action: 'delete' };
+
+    await evaluateNetworkToolApproval({
+      tool: { needsApprovalFn },
+      inputData,
+      requestContext,
+      agent,
+      toolId: 'ctx-tool',
+    });
+
+    expect(needsApprovalFn).toHaveBeenCalledTimes(1);
+    expect(needsApprovalFn).toHaveBeenCalledWith(inputData, {
+      requestContext: { role: 'admin', tier: 'pro' },
+      workspace,
+    });
+    expect(agent.getWorkspace).toHaveBeenCalledWith({ requestContext });
+  });
+
+  it('returns the predicate result when needsApprovalFn resolves to false', async () => {
+    const needsApprovalFn = vi.fn().mockResolvedValue(false);
+
+    const result = await evaluateNetworkToolApproval({
+      tool: { needsApprovalFn },
+      inputData: {},
+      requestContext: makeRequestContext(),
+      agent: makeAgent(),
+      toolId: 'skip-approval-tool',
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns the predicate result when needsApprovalFn resolves to true', async () => {
+    const needsApprovalFn = vi.fn().mockResolvedValue(true);
+
+    const result = await evaluateNetworkToolApproval({
+      tool: { needsApprovalFn },
+      inputData: {},
+      requestContext: makeRequestContext(),
+      agent: makeAgent(),
+      toolId: 'require-approval-tool',
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('defaults to true and logs when needsApprovalFn throws', async () => {
+    const error = new Error('predicate failed');
+    const needsApprovalFn = vi.fn().mockRejectedValue(error);
+    const logger = makeLogger();
+
+    const result = await evaluateNetworkToolApproval({
+      tool: { needsApprovalFn },
+      inputData: {},
+      requestContext: makeRequestContext(),
+      agent: makeAgent(),
+      logger,
+      toolId: 'throwing-tool',
+    });
+
+    expect(result).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('throwing-tool'), error);
+  });
+
+  it('passes workspace as undefined when getWorkspace rejects', async () => {
+    const needsApprovalFn = vi.fn().mockReturnValue(true);
+    const agent = {
+      getWorkspace: vi.fn().mockRejectedValue(new Error('no workspace configured')),
+    } as any;
+
+    await evaluateNetworkToolApproval({
+      tool: { needsApprovalFn },
+      inputData: {},
+      requestContext: makeRequestContext(),
+      agent,
+      toolId: 'no-workspace-tool',
+    });
+
+    expect(needsApprovalFn).toHaveBeenCalledWith({}, expect.objectContaining({ workspace: undefined }));
   });
 });

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -472,6 +472,47 @@ async function saveFinalResultIfProvided({
   }
 }
 
+/**
+ * Evaluate a tool's `requireApproval` predicate inside the network loop.
+ * Mirrors the agentic-execution path in `loop/workflows/agentic-execution/tool-call-step.ts`
+ * by passing `{ requestContext, workspace }` as the second argument so predicates
+ * can gate approval on user role, workspace tier, or other request-scoped state.
+ *
+ * Exported for unit testing; not part of the public API.
+ */
+export async function evaluateNetworkToolApproval({
+  tool,
+  inputData,
+  requestContext,
+  agent,
+  logger,
+  toolId,
+}: {
+  tool: any;
+  inputData: unknown;
+  requestContext: RequestContext;
+  agent: Agent;
+  logger?: { error: (...args: any[]) => void };
+  toolId: string;
+}): Promise<boolean | undefined> {
+  let toolRequiresApproval = tool.requireApproval;
+  if (tool.needsApprovalFn) {
+    try {
+      const needsApprovalResult = await tool.needsApprovalFn(inputData, {
+        requestContext: requestContext ? Object.fromEntries(requestContext.entries()) : {},
+        workspace: await agent.getWorkspace({ requestContext }).catch(() => undefined),
+      });
+      toolRequiresApproval = needsApprovalResult;
+    } catch (error) {
+      // Log error to help developers debug faulty needsApprovalFn implementations
+      logger?.error(`Error evaluating needsApprovalFn for tool ${toolId}:`, error);
+      // On error, default to requiring approval to be safe
+      toolRequiresApproval = true;
+    }
+  }
+  return toolRequiresApproval;
+}
+
 export async function createNetworkLoop({
   networkName,
   requestContext,
@@ -1524,24 +1565,18 @@ export async function createNetworkLoop({
         runId,
       });
 
-      // Check if approval is required
-      // requireApproval can be:
-      // - boolean (from Mastra createTool or mapped from AI SDK needsApproval: true)
-      // - undefined (no approval needed)
-      // If needsApprovalFn exists, evaluate it with the tool args
-      let toolRequiresApproval = (tool as any).requireApproval;
-      if ((tool as any).needsApprovalFn) {
-        // Evaluate the function with the parsed args
-        try {
-          const needsApprovalResult = await (tool as any).needsApprovalFn(inputDataToUse);
-          toolRequiresApproval = needsApprovalResult;
-        } catch (error) {
-          // Log error to help developers debug faulty needsApprovalFn implementations
-          logger?.error(`Error evaluating needsApprovalFn for tool ${toolId}:`, error);
-          // On error, default to requiring approval to be safe
-          toolRequiresApproval = true;
-        }
-      }
+      // Check if approval is required.
+      // `requireApproval` can be a boolean or a function (stored as `needsApprovalFn`
+      // by the tool builder). Function predicates receive `{ requestContext, workspace }`
+      // as the second argument, matching the agentic-execution path.
+      const toolRequiresApproval = await evaluateNetworkToolApproval({
+        tool,
+        inputData: inputDataToUse,
+        requestContext,
+        agent,
+        logger,
+        toolId,
+      });
 
       if (toolRequiresApproval) {
         // Check if abort fired before writing approval metadata or suspending


### PR DESCRIPTION
Fixes #15799.

The `requireApproval` predicate's type signature already declares an optional second argument (`{ requestContext, workspace }`), and the agentic-execution path at `loop/workflows/agentic-execution/tool-call-step.ts:293` passes it. The network loop at `loop/network/index.ts:1536` was still calling with only the input — function predicates running through `agent.network()` could not gate approval on user role / workspace tier.

This brings the two paths into agreement.

Before:

```ts
const needsApprovalResult = await (tool as any).needsApprovalFn(inputDataToUse);
```

After:

```ts
const toolRequiresApproval = await evaluateNetworkToolApproval({
  tool,
  inputData: inputDataToUse,
  requestContext,
  agent,
  logger,
  toolId,
});
```

`evaluateNetworkToolApproval` is a small exported helper that mirrors the agentic-execution shape and gives us a clean unit-test surface (the network loop's `toolStep` is otherwise internal). `agent.getWorkspace({ requestContext })` is wrapped in `.catch(() => undefined)` so predicate evaluation never throws on workspace lookup failure — the type already declares `workspace?:` optional.

Tests cover: boolean-only `requireApproval`, missing predicate, predicate input/ctx shape, true/false returns, predicate throwing (defaults to requiring approval), and workspace fallback when `getWorkspace` rejects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The network execution path in Mastra wasn't giving approval predicates the same information that the regular agentic execution path was giving them. This meant predicates couldn't make approval decisions based on who was making the request or what workspace they were using. This PR fixes that by making both paths pass the same context information to approval predicates.

## Changes

**Changeset Documentation**
- Added release note documenting the observable behavioral change: `requireApproval` predicates evaluated in `agent.network()` now receive `{ requestContext, workspace }` as the second argument, matching the agentic-execution behavior. This enables approval gating based on user role, workspace tier, or other request-scoped state.

**New Exported Function**
- Added `evaluateNetworkToolApproval()` in `packages/core/src/loop/network/index.ts` — a reusable helper that evaluates approval predicates with proper context. It accepts tool configuration, input data, request context, agent instance, logger, and tool ID. Returns `Promise<boolean | undefined>`.

**Implementation Details**
- The function passes `{ requestContext, workspace }` to `needsApprovalFn`, where workspace is retrieved via `agent.getWorkspace({ requestContext })` 
- Wraps the workspace lookup in `.catch(() => undefined)` so failures don't throw; the predicate still runs with `workspace: undefined`
- Defaults to requiring approval (`true`) if the predicate throws or rejects, with errors logged via `logger.error` including the tool ID
- Simplified the tool-execution step's approval-check control flow to use the new helper instead of inline predicate evaluation

**Test Coverage**
- Added comprehensive test suite covering:
  - Boolean-only `requireApproval: true` returning `true` when no predicate exists
  - Missing predicate returning `undefined`
  - Predicate receiving correct argument shape: `(inputData, { requestContext, workspace })`
  - Boolean predicate results (`true`/`false`) being propagated correctly
  - Predicate errors/rejections defaulting to approval required with error logging
  - Workspace lookup failures allowing predicate to run with `workspace: undefined`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->