### PR TITLE
Add @mastra/x402station — pre-flight oracle for x402 endpoints

### DIFF
--- a/.changeset/x402station-integration.md
+++ b/.changeset/x402station-integration.md
@@ -1,0 +1,5 @@
+---
+'@mastra/x402station': minor
+---
+
+Add `@mastra/x402station` — pre-flight oracle tools for x402 endpoints. Six tools (`preflight`, `forensics`, `catalogDecoys`, `watchSubscribe`, `watchStatus`, `watchUnsubscribe`) wrap [x402station.io](https://x402station.io). Paid calls are auto-signed via `@x402/fetch` and settle in USDC on Base mainnet (`eip155:8453`) or Base Sepolia (`eip155:84532`). Returns `{ ok, warnings[], metadata, paymentReceipt }` so an agent can refuse to pay endpoints flagged decoy / zombie / dead. Defensive: HTTPS-only `webhookUrl`, canonical-host allow-list refuses to sign payments against any host other than `x402station.io` or localhost dev URLs, `AbortSignal.timeout(30s)` on every fetch, malformed payment receipts surface as `{ raw, malformed: true }` rather than a silent stub.

--- a/integrations/x402station/README.md
+++ b/integrations/x402station/README.md
@@ -1,0 +1,148 @@
+# @mastra/x402station
+
+Pre-flight oracle tools for [x402](https://x402.org) endpoints in [Mastra](https://mastra.ai) agents.
+Backed by [x402station.io](https://x402station.io) — an independent prober that scans every endpoint
+on `agentic.market` (≈ 25 950 active URLs across ≈ 549 services) every 10 minutes and exposes safety
+signals priced in USDC via x402 itself.
+
+## Why agents need this
+
+Agents that pay arbitrary x402 endpoints fall into three traps:
+
+- **Decoys.** ≈ 161 endpoints in the network are listed at ≥ $1 000 USDC; an agent paying one loses
+  its wallet. Most are anti-scraper "swarm" routes.
+- **Zombies.** Services 100% erroring in the last hour but still listed in the catalog. Invisible to
+  facilitator-based competitors because nobody calls them.
+- **Catalog concentration.** A single provider can be > 40% of the catalog under one billing
+  namespace — agents need this context before treating the network as diverse.
+
+x402station's prober sees these because it runs naked HTTP probes — no payment required to register
+a probe. This package wraps the public oracle as Mastra tools so an agent can preflight a URL before
+paying.
+
+## Installation
+
+```bash
+pnpm add @mastra/x402station
+```
+
+You'll also need a `viem`-compatible account holding USDC on Base mainnet (`eip155:8453`) or Base
+Sepolia (`eip155:84532`). USDC on Base mainnet:
+[`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`](https://basescan.org/token/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913).
+
+## Quick start
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { createX402StationTools } from '@mastra/x402station';
+
+const tools = createX402StationTools({
+  // 0x-prefixed 64-hex private key. Or pass `account: viemAccount` instead,
+  // or set X402STATION_PRIVATE_KEY in the environment.
+  privateKey: process.env.AGENT_PRIVATE_KEY,
+});
+
+const agent = new Agent({
+  id: 'shielded-x402-agent',
+  name: 'Shielded x402 agent',
+  instructions:
+    'Before paying any unfamiliar x402 URL, call x402station-preflight. ' +
+    'Refuse to pay when ok=false; warnings explain why.',
+  model: 'anthropic/claude-sonnet-4-6',
+  tools,
+});
+```
+
+`createX402StationTools` returns six tools:
+
+| Tool | Cost | Purpose |
+|---|---|---|
+| `x402StationPreflight` | $0.001 USDC | `{ok, warnings[], metadata}` for one URL. The fast path. |
+| `x402StationForensics` | $0.001 USDC | 7-day uptime, latency p50/p90/p99, status codes, decoy probability. |
+| `x402StationCatalogDecoys` | $0.005 USDC | Full known-bad list as one JSON. Cache as a blacklist. |
+| `x402StationWatchSubscribe` | $0.01 USDC | 30-day watch + 100 prepaid HMAC-signed alerts on state changes. |
+| `x402StationWatchStatus` | free | Status + recent alert deliveries (secret-gated). |
+| `x402StationWatchUnsubscribe` | free | Deactivate a watch (secret-gated). |
+
+Payments are auto-signed via `@x402/fetch` — every paid response includes a settled-payment receipt
+that decodes the on-chain transaction hash so the agent can audit spend.
+
+## Individual tools
+
+```typescript
+import {
+  createX402StationPreflightTool,
+  createX402StationForensicsTool,
+} from '@mastra/x402station';
+
+const preflight = createX402StationPreflightTool({ privateKey: process.env.AGENT_PK });
+const forensics = createX402StationForensicsTool({ privateKey: process.env.AGENT_PK });
+```
+
+### Preflight
+
+Posts the URL to `/api/v1/preflight` and returns
+`{ ok, warnings[], metadata }`.
+
+`ok` is `true` only when no critical signal fires. Critical set:
+
+- `dead` — endpoint failing in the last hour
+- `zombie` — listed but 100% erroring for the full hour
+- `decoy_price_extreme` — price ≥ $1 000 USDC
+
+Other signals (`slow`, `new_provider`, `unknown_endpoint`, …) appear in `warnings` but do not flip
+`ok` to false. See [signals.md](https://github.com/sF1nX/x402station-mcp/blob/main/docs/signals.md)
+for the full vocabulary.
+
+### Forensics
+
+Superset of preflight. Returns hourly uptime over 7 days, latency p50/p90/p99, status-code
+distribution, concentration-group stats (how crowded the provider's namespace is), and a
+`decoy_probability` score in `[0, 1]`.
+
+### Catalog decoys
+
+`{ generated_at, counts: { total, by_reason }, truncated, entries[] }`. Refreshed every ~10 min
+server-side. Pull periodically and cache locally; cheaper than preflighting every URL.
+
+### Watch subscribe / status / unsubscribe
+
+`watch.subscribe` pays $0.01 for a 30-day watch + 100 HMAC-SHA256-signed alerts. The response
+includes a 64-char hex `secret` — store it; it's the HMAC seed and is not retrievable later.
+
+`webhookUrl` is HTTPS-only at the schema level — HMAC-signed payloads must travel encrypted.
+
+`watch.status` and `watch.unsubscribe` are free, secret-gated. Wrong secret returns 404 (constant-
+time compare; an attacker scraping IDs cannot distinguish "exists with wrong secret" from "does
+not exist").
+
+## Configuration
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `account` | `viem.Account` | — | Pre-built viem account for signing. |
+| `privateKey` | `string` | `process.env.X402STATION_PRIVATE_KEY` | 0x-prefixed 64-hex key. Mutually exclusive with `account`. |
+| `baseUrl` | `string` | `https://x402station.io` | Override base URL. Only canonical or localhost dev URLs accepted. |
+| `fetchImpl` | `typeof fetch` | `globalThis.fetch` | Custom fetch. Mostly for tests. |
+| `timeoutMs` | `number` | `30000` | Per-call timeout. Aborts the underlying fetch on hang. |
+
+The `baseUrl` allow-list refuses anything other than `https://x402station.io` or
+`http(s)://localhost` / `127.0.0.1` / `[::1]` — a misconfigured agent cannot be tricked into
+signing x402 payments against an attacker-controlled host.
+
+## Networks
+
+Base mainnet (`eip155:8453`) and Base Sepolia (`eip155:84532`). The CDP facilitator
+(`https://x402.org/facilitator`) settles payments. Mainnet requires the receiver wallet to be
+funded — testnet is anonymous.
+
+## Discovery
+
+x402station also publishes its own discovery surfaces (`/.well-known/x402`, agent-card, OpenAPI,
+MCP server-card, `llms.txt`). It scores **5/5 ("Agent-Native")** on Cloudflare's
+[isitagentready.com](https://isitagentready.com/?url=https://x402station.io) scanner, with
+`isCommerce=true`.
+
+## License
+
+Apache-2.0

--- a/integrations/x402station/eslint.config.js
+++ b/integrations/x402station/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/integrations/x402station/package.json
+++ b/integrations/x402station/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@mastra/x402station",
+  "version": "0.1.0",
+  "description": "x402station pre-flight oracle tools for Mastra agents — preflight, forensics, decoy catalog, and webhook-watch alerts for x402 endpoints",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "mastra",
+    "x402",
+    "x402station",
+    "agent-payments",
+    "usdc",
+    "base",
+    "oracle",
+    "preflight",
+    "tools",
+    "ai-agent"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "integrations/x402station"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "homepage": "https://x402station.io",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "dependencies": {
+    "@x402/evm": "^2.10.0",
+    "@x402/fetch": "^2.10.0",
+    "viem": "^2.48.4"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "zod": ">=3.0.0 || >=4.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/integrations/x402station/src/__tests__/client.test.ts
+++ b/integrations/x402station/src/__tests__/client.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Bypass the @x402/fetch wrap so paid fetches surface our fetchImpl directly
+// in tests — we still want to assert request shape, but a real 402 round-trip
+// is out of scope here.
+vi.mock('@x402/fetch', () => ({
+  wrapFetchWithPaymentFromConfig: (impl: typeof fetch) => impl,
+}));
+vi.mock('@x402/evm', () => ({
+  ExactEvmScheme: class {
+    constructor(_: unknown) {}
+  },
+}));
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: (_pk: string) => ({
+    address: '0x30d2b1f9bcEdE5F13136b56Ff199A8ad6E4f50de',
+    signTypedData: () => Promise.resolve('0x' + '00'.repeat(65)),
+    signMessage: () => Promise.resolve('0x' + '00'.repeat(65)),
+    signTransaction: () => Promise.resolve('0x' + '00'.repeat(65)),
+  }),
+}));
+
+import { getX402StationClient  } from '../client.js';
+import type {X402StationClientOptions} from '../client.js';
+
+const VALID_PK = '0x' + 'a'.repeat(64);
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  body: string;
+  headers: Record<string, string>;
+}
+
+function buildFetchImpl(res: { status: number; bodyText: string; headers?: Record<string, string> }): {
+  fetchImpl: typeof fetch;
+  calls: CapturedCall[];
+} {
+  const calls: CapturedCall[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    let url: string;
+    let method: string;
+    let body: string;
+    let headers: Record<string, string>;
+    if (input instanceof Request) {
+      url = input.url;
+      method = input.method;
+      headers = Object.fromEntries(input.headers);
+      body = await input.clone().text();
+    } else {
+      url = typeof input === 'string' ? input : input.toString();
+      method = init?.method ?? 'GET';
+      const rawHeaders = init?.headers ?? {};
+      headers =
+        rawHeaders instanceof Headers
+          ? Object.fromEntries(rawHeaders)
+          : Array.isArray(rawHeaders)
+            ? Object.fromEntries(rawHeaders)
+            : (rawHeaders as Record<string, string>);
+      body = typeof init?.body === 'string' ? init.body : '';
+    }
+    calls.push({ url, method, body, headers });
+    return new Response(res.bodyText, { status: res.status, headers: new Headers(res.headers ?? {}) });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe('getX402StationClient — baseUrl allow-list', () => {
+  it('uses canonical https://x402station.io by default', () => {
+    const c = getX402StationClient({ privateKey: VALID_PK });
+    expect(c.baseUrl).toBe('https://x402station.io');
+  });
+
+  it('accepts explicit canonical host', () => {
+    const c = getX402StationClient({ privateKey: VALID_PK, baseUrl: 'https://x402station.io' });
+    expect(c.baseUrl).toBe('https://x402station.io');
+  });
+
+  it('strips trailing slashes', () => {
+    const c = getX402StationClient({ privateKey: VALID_PK, baseUrl: 'https://x402station.io///' });
+    expect(c.baseUrl).toBe('https://x402station.io');
+  });
+
+  it('accepts http://localhost dev URL', () => {
+    const c = getX402StationClient({ privateKey: VALID_PK, baseUrl: 'http://localhost:3002' });
+    expect(c.baseUrl).toBe('http://localhost:3002');
+  });
+
+  it('accepts IPv6 loopback dev URL [::1]', () => {
+    const c = getX402StationClient({ privateKey: VALID_PK, baseUrl: 'http://[::1]:3002' });
+    expect(c.baseUrl).toBe('http://[::1]:3002');
+  });
+
+  it('rejects non-canonical host', () => {
+    expect(() => getX402StationClient({ privateKey: VALID_PK, baseUrl: 'https://evil.example' })).toThrow(
+      /baseUrl must be/i,
+    );
+  });
+
+  it('rejects malformed URL', () => {
+    expect(() => getX402StationClient({ privateKey: VALID_PK, baseUrl: 'not a url' })).toThrow(/not a valid URL/i);
+  });
+
+  it('does not let a non-default port bypass the canonical check', () => {
+    // u.hostname strips port; u.host keeps it. Implementation must use u.host.
+    expect(() => getX402StationClient({ privateKey: VALID_PK, baseUrl: 'https://x402station.io:9999' })).toThrow(
+      /baseUrl must be/i,
+    );
+  });
+});
+
+describe('getX402StationClient — account resolution', () => {
+  const originalEnv = process.env.X402STATION_PRIVATE_KEY;
+  beforeEach(() => {
+    delete process.env.X402STATION_PRIVATE_KEY;
+  });
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.X402STATION_PRIVATE_KEY = originalEnv;
+    } else {
+      delete process.env.X402STATION_PRIVATE_KEY;
+    }
+  });
+
+  it('throws on first paid call when no account / privateKey / env var set', async () => {
+    const { fetchImpl } = buildFetchImpl({ status: 200, bodyText: '{}' });
+    const c = getX402StationClient({ fetchImpl } as X402StationClientOptions);
+    await expect(c.callPaid('/api/v1/preflight', {})).rejects.toThrow(/account.*required/i);
+  });
+
+  it('throws on malformed privateKey', async () => {
+    const { fetchImpl } = buildFetchImpl({ status: 200, bodyText: '{}' });
+    const c = getX402StationClient({ privateKey: 'not-a-hex-key', fetchImpl });
+    await expect(c.callPaid('/api/v1/preflight', {})).rejects.toThrow(/malformed/i);
+  });
+
+  it('falls back to X402STATION_PRIVATE_KEY env var', async () => {
+    process.env.X402STATION_PRIVATE_KEY = VALID_PK;
+    const { fetchImpl, calls } = buildFetchImpl({ status: 200, bodyText: '{}' });
+    const c = getX402StationClient({ fetchImpl });
+    await c.callPaid('/api/v1/preflight', { url: 'https://x' });
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe('callPaid — request shape and receipt decoding', () => {
+  it('POSTs to baseUrl + path with JSON body', async () => {
+    const { fetchImpl, calls } = buildFetchImpl({ status: 200, bodyText: '{"ok":true}' });
+    const c = getX402StationClient({ privateKey: VALID_PK, fetchImpl });
+    await c.callPaid('/api/v1/preflight', { url: 'https://target' });
+    expect(calls[0]!.url).toBe('https://x402station.io/api/v1/preflight');
+    expect(calls[0]!.method).toBe('POST');
+    expect(calls[0]!.headers['content-type']).toBe('application/json');
+    expect(JSON.parse(calls[0]!.body)).toEqual({ url: 'https://target' });
+  });
+
+  it('returns null paymentReceipt when header absent', async () => {
+    const { fetchImpl } = buildFetchImpl({ status: 200, bodyText: '{}' });
+    const c = getX402StationClient({ privateKey: VALID_PK, fetchImpl });
+    const out = await c.callPaid('/api/v1/preflight', {});
+    expect(out.paymentReceipt).toBeNull();
+  });
+
+  it('decodes the x-payment-response header into paymentReceipt', async () => {
+    const receipt = { transaction: '0xabc', network: 'eip155:8453' };
+    const headerVal = btoa(JSON.stringify(receipt));
+    const { fetchImpl } = buildFetchImpl({
+      status: 200,
+      bodyText: '{}',
+      headers: { 'x-payment-response': headerVal },
+    });
+    const c = getX402StationClient({ privateKey: VALID_PK, fetchImpl });
+    const out = await c.callPaid('/api/v1/preflight', {});
+    expect(out.paymentReceipt).toEqual(receipt);
+  });
+
+  it('flags malformed payment-response header with malformed:true', async () => {
+    const { fetchImpl } = buildFetchImpl({
+      status: 200,
+      bodyText: '{}',
+      headers: { 'x-payment-response': 'not-base64-and-not-json!!!' },
+    });
+    const c = getX402StationClient({ privateKey: VALID_PK, fetchImpl });
+    const out = await c.callPaid('/api/v1/preflight', {});
+    expect(out.paymentReceipt).toEqual({ raw: 'not-base64-and-not-json!!!', malformed: true });
+  });
+
+  it('throws a descriptive error on non-2xx', async () => {
+    const { fetchImpl } = buildFetchImpl({ status: 503, bodyText: 'upstream timeout' });
+    const c = getX402StationClient({ privateKey: VALID_PK, fetchImpl });
+    await expect(c.callPaid('/api/v1/preflight', {})).rejects.toThrow(/503.*upstream timeout/i);
+  });
+
+  it('throws when 200 body is not JSON (e.g. proxy returned HTML)', async () => {
+    const { fetchImpl } = buildFetchImpl({ status: 200, bodyText: '<!DOCTYPE html><html>...' });
+    const c = getX402StationClient({ privateKey: VALID_PK, fetchImpl });
+    await expect(c.callPaid('/api/v1/preflight', {})).rejects.toThrow(/non-JSON body/i);
+  });
+
+  it('aborts a hung fetch via AbortSignal.timeout', async () => {
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+      return new Promise<Response>((_resolve, reject) => {
+        if (!signal) return;
+        if (signal.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'));
+          return;
+        }
+        signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+      });
+    }) as unknown as typeof fetch;
+    const c = getX402StationClient({ privateKey: VALID_PK, fetchImpl, timeoutMs: 50 });
+    await expect(c.callPaid('/api/v1/preflight', {})).rejects.toThrow(/timed out after 50ms/);
+  });
+});
+
+describe('callFree — secret-gated GET / DELETE', () => {
+  it('GET sets x-x402station-secret header and no payment wrapper', async () => {
+    const { fetchImpl, calls } = buildFetchImpl({ status: 200, bodyText: '{"isActive":true}' });
+    const c = getX402StationClient({ privateKey: VALID_PK, fetchImpl });
+    const out = (await c.callFree('/api/v1/watch/abc', 'GET', 'a'.repeat(64))) as { isActive: boolean };
+    expect(out.isActive).toBe(true);
+    expect(calls[0]!.method).toBe('GET');
+    expect(calls[0]!.headers['x-x402station-secret']).toBe('a'.repeat(64));
+  });
+
+  it('DELETE issues DELETE method', async () => {
+    const { fetchImpl, calls } = buildFetchImpl({
+      status: 200,
+      bodyText: '{"watchId":"id","isActive":false,"message":"ok"}',
+    });
+    const c = getX402StationClient({ privateKey: VALID_PK, fetchImpl });
+    await c.callFree('/api/v1/watch/abc', 'DELETE', 'b'.repeat(64));
+    expect(calls[0]!.method).toBe('DELETE');
+  });
+
+  it('throws on 404 (wrong secret OR missing watch — server returns 404 for both)', async () => {
+    const { fetchImpl } = buildFetchImpl({ status: 404, bodyText: '{"error":"watch not found"}' });
+    const c = getX402StationClient({ privateKey: VALID_PK, fetchImpl });
+    await expect(c.callFree('/api/v1/watch/abc', 'GET', 'c'.repeat(64))).rejects.toThrow(/404.*watch not found/i);
+  });
+});

--- a/integrations/x402station/src/__tests__/decoys.test.ts
+++ b/integrations/x402station/src/__tests__/decoys.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@x402/fetch', () => ({
+  wrapFetchWithPaymentFromConfig: (impl: typeof fetch) => impl,
+}));
+vi.mock('@x402/evm', () => ({
+  ExactEvmScheme: class {
+    constructor(_: unknown) {}
+  },
+}));
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: (_pk: string) => ({ address: '0x30d2b1f9bcEdE5F13136b56Ff199A8ad6E4f50de' }),
+}));
+
+import { createX402StationCatalogDecoysTool } from '../decoys.js';
+
+const VALID_PK = '0x' + 'a'.repeat(64);
+
+describe('createX402StationCatalogDecoysTool', () => {
+  it('POSTs an empty body to /api/v1/catalog/decoys', async () => {
+    const calls: { url: string; body: string }[] = [];
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : typeof input === 'string' ? input : input.toString();
+      const body = input instanceof Request ? await input.clone().text() : (typeof init?.body === 'string' ? init.body : '');
+      calls.push({ url, body });
+      return new Response(
+        JSON.stringify({
+          generated_at: '2026-04-27T00:00:00Z',
+          counts: { total: 0, by_reason: {} },
+          truncated: false,
+          entries: [],
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const tool = createX402StationCatalogDecoysTool({ privateKey: VALID_PK, fetchImpl });
+    expect(tool.id).toBe('x402station-catalog-decoys');
+
+    await tool.execute!({}, {} as never);
+    expect(calls[0]!.url).toBe('https://x402station.io/api/v1/catalog/decoys');
+    expect(calls[0]!.body).toBe('{}');
+  });
+});

--- a/integrations/x402station/src/__tests__/forensics.test.ts
+++ b/integrations/x402station/src/__tests__/forensics.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@x402/fetch', () => ({
+  wrapFetchWithPaymentFromConfig: (impl: typeof fetch) => impl,
+}));
+vi.mock('@x402/evm', () => ({
+  ExactEvmScheme: class {
+    constructor(_: unknown) {}
+  },
+}));
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: (_pk: string) => ({ address: '0x30d2b1f9bcEdE5F13136b56Ff199A8ad6E4f50de' }),
+}));
+
+import { createX402StationForensicsTool } from '../forensics.js';
+
+const VALID_PK = '0x' + 'a'.repeat(64);
+
+describe('createX402StationForensicsTool', () => {
+  it('has correct id and is wired to /api/v1/forensics', async () => {
+    const calls: { url: string; body: string }[] = [];
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : typeof input === 'string' ? input : input.toString();
+      const body = input instanceof Request ? await input.clone().text() : (typeof init?.body === 'string' ? init.body : '');
+      calls.push({ url, body });
+      return new Response('{"ok":true,"warnings":[],"decoy_probability":0.1,"metadata":{"url":"https://x"}}', {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    const tool = createX402StationForensicsTool({ privateKey: VALID_PK, fetchImpl });
+    expect(tool.id).toBe('x402station-forensics');
+
+    await tool.execute!({ url: 'https://x' }, {} as never);
+    expect(calls[0]!.url).toBe('https://x402station.io/api/v1/forensics');
+    expect(JSON.parse(calls[0]!.body)).toEqual({ url: 'https://x' });
+  });
+});

--- a/integrations/x402station/src/__tests__/preflight.test.ts
+++ b/integrations/x402station/src/__tests__/preflight.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@x402/fetch', () => ({
+  wrapFetchWithPaymentFromConfig: (impl: typeof fetch) => impl,
+}));
+vi.mock('@x402/evm', () => ({
+  ExactEvmScheme: class {
+    constructor(_: unknown) {}
+  },
+}));
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: (_pk: string) => ({ address: '0x30d2b1f9bcEdE5F13136b56Ff199A8ad6E4f50de' }),
+}));
+
+import { createX402StationPreflightTool } from '../preflight.js';
+
+const VALID_PK = '0x' + 'a'.repeat(64);
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  body: string;
+}
+
+function buildFetchImpl(res: { status: number; bodyText: string }): {
+  fetchImpl: typeof fetch;
+  calls: CapturedCall[];
+} {
+  const calls: CapturedCall[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = input instanceof Request ? input.url : typeof input === 'string' ? input : input.toString();
+    const method = input instanceof Request ? input.method : (init?.method ?? 'GET');
+    const body = input instanceof Request ? await input.clone().text() : (typeof init?.body === 'string' ? init.body : '');
+    calls.push({ url, method, body });
+    return new Response(res.bodyText, { status: res.status });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe('createX402StationPreflightTool', () => {
+  it('has correct id, description, schemas', () => {
+    const tool = createX402StationPreflightTool({ privateKey: VALID_PK });
+    expect(tool.id).toBe('x402station-preflight');
+    expect(tool.description).toBeDefined();
+    expect(tool.description!.length).toBeGreaterThan(0);
+    expect(tool.inputSchema).toBeDefined();
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  it('POSTs the URL to /api/v1/preflight and returns parsed body', async () => {
+    const fakeBody = {
+      ok: false,
+      warnings: ['dead', 'zombie'],
+      metadata: { url: 'https://api.venice.ai/api/v1/chat/completions' },
+    };
+    const { fetchImpl, calls } = buildFetchImpl({ status: 200, bodyText: JSON.stringify(fakeBody) });
+    const tool = createX402StationPreflightTool({ privateKey: VALID_PK, fetchImpl });
+    const result = (await tool.execute!(
+      { url: 'https://api.venice.ai/api/v1/chat/completions' },
+      {} as never,
+    )) as { result: typeof fakeBody; paymentReceipt: unknown };
+
+    expect(result.result).toEqual(fakeBody);
+    expect(result.paymentReceipt).toBeNull();
+    expect(calls[0]!.url).toBe('https://x402station.io/api/v1/preflight');
+    expect(calls[0]!.method).toBe('POST');
+    expect(JSON.parse(calls[0]!.body)).toEqual({ url: 'https://api.venice.ai/api/v1/chat/completions' });
+  });
+
+  it('lets a 503 from the oracle propagate as a thrown error', async () => {
+    const { fetchImpl } = buildFetchImpl({ status: 503, bodyText: 'upstream timeout' });
+    const tool = createX402StationPreflightTool({ privateKey: VALID_PK, fetchImpl });
+    await expect(tool.execute!({ url: 'https://target' }, {} as never)).rejects.toThrow(/503/);
+  });
+});

--- a/integrations/x402station/src/__tests__/tools.test.ts
+++ b/integrations/x402station/src/__tests__/tools.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@x402/fetch', () => ({
+  wrapFetchWithPaymentFromConfig: (impl: typeof fetch) => impl,
+}));
+vi.mock('@x402/evm', () => ({
+  ExactEvmScheme: class {
+    constructor(_: unknown) {}
+  },
+}));
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: (_pk: string) => ({ address: '0x30d2b1f9bcEdE5F13136b56Ff199A8ad6E4f50de' }),
+}));
+
+import { createX402StationTools } from '../tools.js';
+
+const VALID_PK = '0x' + 'a'.repeat(64);
+
+describe('createX402StationTools', () => {
+  it('returns all six tools with correct ids', () => {
+    const tools = createX402StationTools({ privateKey: VALID_PK });
+    expect(tools.x402StationPreflight.id).toBe('x402station-preflight');
+    expect(tools.x402StationForensics.id).toBe('x402station-forensics');
+    expect(tools.x402StationCatalogDecoys.id).toBe('x402station-catalog-decoys');
+    expect(tools.x402StationWatchSubscribe.id).toBe('x402station-watch-subscribe');
+    expect(tools.x402StationWatchStatus.id).toBe('x402station-watch-status');
+    expect(tools.x402StationWatchUnsubscribe.id).toBe('x402station-watch-unsubscribe');
+  });
+
+  it('every tool has description, inputSchema, outputSchema', () => {
+    const tools = createX402StationTools({ privateKey: VALID_PK });
+    for (const tool of Object.values(tools)) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.outputSchema).toBeDefined();
+    }
+  });
+});

--- a/integrations/x402station/src/__tests__/watch.test.ts
+++ b/integrations/x402station/src/__tests__/watch.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@x402/fetch', () => ({
+  wrapFetchWithPaymentFromConfig: (impl: typeof fetch) => impl,
+}));
+vi.mock('@x402/evm', () => ({
+  ExactEvmScheme: class {
+    constructor(_: unknown) {}
+  },
+}));
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: (_pk: string) => ({ address: '0x30d2b1f9bcEdE5F13136b56Ff199A8ad6E4f50de' }),
+}));
+
+import { WatchSubscribeInputSchema } from '../schemas.js';
+import {
+  createX402StationWatchStatusTool,
+  createX402StationWatchSubscribeTool,
+  createX402StationWatchUnsubscribeTool,
+} from '../watch.js';
+
+const VALID_PK = '0x' + 'a'.repeat(64);
+const VALID_ID = '0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11';
+const VALID_SECRET = 'a'.repeat(64);
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  body: string;
+  headers: Record<string, string>;
+}
+
+function buildFetchImpl(res: { status: number; bodyText: string }): {
+  fetchImpl: typeof fetch;
+  calls: CapturedCall[];
+} {
+  const calls: CapturedCall[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    let url: string;
+    let method: string;
+    let body: string;
+    let headers: Record<string, string>;
+    if (input instanceof Request) {
+      url = input.url;
+      method = input.method;
+      headers = Object.fromEntries(input.headers);
+      body = await input.clone().text();
+    } else {
+      url = typeof input === 'string' ? input : input.toString();
+      method = init?.method ?? 'GET';
+      const rawHeaders = init?.headers ?? {};
+      headers =
+        rawHeaders instanceof Headers
+          ? Object.fromEntries(rawHeaders)
+          : Array.isArray(rawHeaders)
+            ? Object.fromEntries(rawHeaders)
+            : (rawHeaders as Record<string, string>);
+      body = typeof init?.body === 'string' ? init.body : '';
+    }
+    calls.push({ url, method, body, headers });
+    return new Response(res.bodyText, { status: res.status });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe('createX402StationWatchSubscribeTool', () => {
+  it('omits signals from POST body when not provided', async () => {
+    const { fetchImpl, calls } = buildFetchImpl({ status: 200, bodyText: '{}' });
+    const tool = createX402StationWatchSubscribeTool({ privateKey: VALID_PK, fetchImpl });
+    await tool.execute!({ url: 'https://target', webhookUrl: 'https://hook.example' }, {} as never);
+    const body = JSON.parse(calls[0]!.body);
+    expect(body).toEqual({ url: 'https://target', webhookUrl: 'https://hook.example' });
+    expect(body).not.toHaveProperty('signals');
+  });
+
+  it('includes signals in POST body when provided', async () => {
+    const { fetchImpl, calls } = buildFetchImpl({ status: 200, bodyText: '{}' });
+    const tool = createX402StationWatchSubscribeTool({ privateKey: VALID_PK, fetchImpl });
+    await tool.execute!(
+      { url: 'https://target', webhookUrl: 'https://hook.example', signals: ['zombie', 'decoy_price_extreme'] },
+      {} as never,
+    );
+    const body = JSON.parse(calls[0]!.body);
+    expect(body.signals).toEqual(['zombie', 'decoy_price_extreme']);
+  });
+
+  it('rejects http:// webhookUrl at the schema level (HMAC payloads must travel encrypted)', () => {
+    const result = WatchSubscribeInputSchema.safeParse({
+      url: 'https://target',
+      webhookUrl: 'http://insecure-webhook.example',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]!.message).toMatch(/HTTPS/);
+    }
+  });
+
+  it('rejects an unknown signal at the schema level', () => {
+    const result = WatchSubscribeInputSchema.safeParse({
+      url: 'https://target',
+      webhookUrl: 'https://hook.example',
+      signals: ['bogus' as never],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('createX402StationWatchStatusTool', () => {
+  it('GET /api/v1/watch/{id} with secret header (no payment wrapper)', async () => {
+    const fullStatus = {
+      watchId: VALID_ID,
+      endpointUrl: 'https://target',
+      webhookUrl: 'https://hook.example',
+      signals: [],
+      createdAt: '2026-04-27T00:00:00Z',
+      expiresAt: '2026-05-27T00:00:00Z',
+      alertsPaid: 100,
+      alertsSent: 0,
+      alertsRemaining: 100,
+      lastState: null,
+      isActive: true,
+      expired: false,
+      recentAlerts: [],
+    };
+    const { fetchImpl, calls } = buildFetchImpl({
+      status: 200,
+      bodyText: JSON.stringify(fullStatus),
+    });
+    const tool = createX402StationWatchStatusTool({ privateKey: VALID_PK, fetchImpl });
+    const out = (await tool.execute!({ watchId: VALID_ID, secret: VALID_SECRET }, {} as never)) as {
+      isActive: boolean;
+      alertsRemaining: number;
+    };
+    expect(out.isActive).toBe(true);
+    expect(out.alertsRemaining).toBe(100);
+    expect(calls[0]!.url).toBe(`https://x402station.io/api/v1/watch/${VALID_ID}`);
+    expect(calls[0]!.method).toBe('GET');
+    expect(calls[0]!.headers['x-x402station-secret']).toBe(VALID_SECRET);
+  });
+});
+
+describe('createX402StationWatchUnsubscribeTool', () => {
+  it('issues DELETE', async () => {
+    const { fetchImpl, calls } = buildFetchImpl({
+      status: 200,
+      bodyText: JSON.stringify({ watchId: VALID_ID, isActive: false, message: 'unsubscribed' }),
+    });
+    const tool = createX402StationWatchUnsubscribeTool({ privateKey: VALID_PK, fetchImpl });
+    await tool.execute!({ watchId: VALID_ID, secret: VALID_SECRET }, {} as never);
+    expect(calls[0]!.method).toBe('DELETE');
+  });
+});

--- a/integrations/x402station/src/client.ts
+++ b/integrations/x402station/src/client.ts
@@ -1,0 +1,209 @@
+import { ExactEvmScheme } from '@x402/evm';
+import { wrapFetchWithPaymentFromConfig } from '@x402/fetch';
+import type { LocalAccount } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import type { PaymentReceipt } from './types.js';
+
+const DEFAULT_BASE_URL = 'https://x402station.io';
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Validates the configured base URL points at the canonical x402station
+ * host (or a local-dev URL on `localhost` / `127.0.0.1` / `[::1]`). Any
+ * other host throws so a misconfigured agent can't be tricked into
+ * signing x402 payments against an attacker-controlled URL. Mirrors the
+ * allow-list shipped in the official `x402station-mcp` npm package.
+ *
+ * - `u.host` (NOT `u.hostname`) — `https://x402station.io:9999`.hostname
+ *   strips the port, but `.host` keeps it. Without this a non-default
+ *   port silently bypasses the canonical check.
+ * - `[::1]` (IPv6 loopback) — included so dual-stack dev machines that
+ *   bind their oracle to `::1` work. URL parsing returns it as the
+ *   bracketed form `[::1]:3002`, which the `startsWith` check matches.
+ */
+function resolveBaseUrl(raw: string | undefined): string {
+  const value = (raw ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+  let u: URL;
+  try {
+    u = new URL(value);
+  } catch {
+    throw new Error(`@mastra/x402station: baseUrl is not a valid URL: ${value}`);
+  }
+  const isCanonical = u.host === 'x402station.io' && u.protocol === 'https:';
+  const isLocalDev =
+    (u.host.startsWith('localhost') || u.host.startsWith('127.0.0.1') || u.host.startsWith('[::1]')) &&
+    (u.protocol === 'http:' || u.protocol === 'https:');
+  if (!isCanonical && !isLocalDev) {
+    throw new Error(
+      `@mastra/x402station: baseUrl must be https://x402station.io or a localhost dev URL; got "${value}". ` +
+        'Refusing to sign x402 payments against an unknown host.',
+    );
+  }
+  return value;
+}
+
+/**
+ * Decodes the settled-payment receipt header. When the header is present
+ * but the body fails decode (non-base64, non-JSON, or a stripped proxy
+ * mangled it), returns `{ raw, malformed: true }` so spend-auditing code
+ * can branch on `malformed` rather than silently consuming a stub
+ * object.
+ */
+function decodeReceipt(headers: Headers): PaymentReceipt | null {
+  const raw = headers.get('x-payment-response') ?? headers.get('payment-response');
+  if (!raw) return null;
+  try {
+    return JSON.parse(atob(raw)) as PaymentReceipt;
+  } catch {
+    return { raw, malformed: true };
+  }
+}
+
+function resolveAccount(config: X402StationClientOptions): LocalAccount {
+  if (config.account) return config.account;
+  const pk = config.privateKey ?? process.env.X402STATION_PRIVATE_KEY;
+  if (!pk) {
+    throw new Error(
+      '@mastra/x402station: a viem `account` (or `privateKey` / X402STATION_PRIVATE_KEY env var) is required. ' +
+        'x402station charges $0.001–$0.01 USDC per call via x402; the client needs a wallet to sign 402 challenges. ' +
+        'Provide a Base mainnet account holding USDC at 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913.',
+    );
+  }
+  if (!/^0x[0-9a-fA-F]{64}$/.test(pk)) {
+    throw new Error('@mastra/x402station: privateKey is malformed — expected 0x + 64 hex chars.');
+  }
+  return privateKeyToAccount(pk as `0x${string}`);
+}
+
+export interface X402StationClientOptions {
+  /**
+   * Pre-built viem `LocalAccount` that signs EIP-712 X-PAYMENT
+   * challenges. Mutually exclusive with `privateKey`. If neither is
+   * provided, `X402STATION_PRIVATE_KEY` is read from the environment.
+   */
+  account?: LocalAccount;
+  /** 0x-prefixed 64-hex private key. Convenience over `account`. */
+  privateKey?: string;
+  /**
+   * Override base URL. Only `https://x402station.io` (canonical) or
+   * `http(s)://localhost` / `127.0.0.1` / `[::1]` (dev) are accepted.
+   */
+  baseUrl?: string;
+  /** Custom fetch (mostly for tests). Default: global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /**
+   * Per-call timeout in ms. Aborts the underlying fetch if the oracle
+   * takes longer — without it a stalled network turns into a stuck
+   * agent step. Default: 30 000.
+   */
+  timeoutMs?: number;
+}
+
+export interface X402StationClient {
+  baseUrl: string;
+  timeoutMs: number;
+  /**
+   * POST a paid x402 endpoint. Wraps fetch with `@x402/fetch` so the
+   * 402 challenge is auto-signed and retried. Returns the parsed JSON
+   * body plus the decoded payment receipt (or `null` if the receipt
+   * header is missing).
+   */
+  callPaid<T = unknown>(path: string, body: unknown): Promise<{ result: T; paymentReceipt: PaymentReceipt | null }>;
+  /**
+   * Issue a free, secret-gated request (used for `watch.status` and
+   * `watch.unsubscribe`). The secret travels in the
+   * `x-x402station-secret` header.
+   */
+  callFree<T = unknown>(path: string, method: 'GET' | 'DELETE', secret: string): Promise<T>;
+}
+
+/**
+ * Build a configured x402station client. Tools defer this call until
+ * first execution so importing `@mastra/x402station` doesn't fail when
+ * an account hasn't been wired up yet.
+ */
+export function getX402StationClient(config: X402StationClientOptions = {}): X402StationClient {
+  const baseUrl = resolveBaseUrl(config.baseUrl);
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchFree = (config.fetchImpl ?? globalThis.fetch).bind(globalThis);
+
+  let cachedPaid: typeof fetch | null = null;
+  function getFetchPaid(): typeof fetch {
+    if (cachedPaid) return cachedPaid;
+    const account = resolveAccount(config);
+    const scheme = new ExactEvmScheme(account);
+    cachedPaid = wrapFetchWithPaymentFromConfig(config.fetchImpl ?? globalThis.fetch, {
+      schemes: [
+        { network: 'eip155:8453', client: scheme }, // Base mainnet
+        { network: 'eip155:84532', client: scheme }, // Base Sepolia
+      ],
+    });
+    return cachedPaid;
+  }
+
+  async function callPaid<T>(path: string, body: unknown): Promise<{ result: T; paymentReceipt: PaymentReceipt | null }> {
+    const f = getFetchPaid();
+    let res: Response;
+    try {
+      res = await f(`${baseUrl}${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body ?? {}),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (err) {
+      const e = err as { name?: string };
+      if (e.name === 'AbortError' || e.name === 'TimeoutError') {
+        throw new Error(`@mastra/x402station: ${path} timed out after ${timeoutMs}ms`);
+      }
+      throw err;
+    }
+    const paymentReceipt = decodeReceipt(res.headers);
+    const raw = await res.text();
+    if (!res.ok) {
+      const snippet = raw.length > 200 ? `${raw.slice(0, 200)}…` : raw;
+      throw new Error(`@mastra/x402station: ${path} returned ${res.status}: ${snippet}`);
+    }
+    let result: T;
+    try {
+      result = JSON.parse(raw) as T;
+    } catch {
+      throw new Error(
+        `@mastra/x402station: ${path} returned 200 with non-JSON body (first 200 chars): ${raw.slice(0, 200)}`,
+      );
+    }
+    return { result, paymentReceipt };
+  }
+
+  async function callFree<T>(path: string, method: 'GET' | 'DELETE', secret: string): Promise<T> {
+    let res: Response;
+    try {
+      res = await fetchFree(`${baseUrl}${path}`, {
+        method,
+        headers: { 'x-x402station-secret': secret },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (err) {
+      const e = err as { name?: string };
+      if (e.name === 'AbortError' || e.name === 'TimeoutError') {
+        throw new Error(`@mastra/x402station: ${method} ${path} timed out after ${timeoutMs}ms`);
+      }
+      throw err;
+    }
+    const raw = await res.text();
+    if (!res.ok) {
+      const snippet = raw.length > 200 ? `${raw.slice(0, 200)}…` : raw;
+      throw new Error(`@mastra/x402station: ${method} ${path} returned ${res.status}: ${snippet}`);
+    }
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      throw new Error(
+        `@mastra/x402station: ${method} ${path} returned 200 with non-JSON body (first 200 chars): ${raw.slice(0, 200)}`,
+      );
+    }
+  }
+
+  return { baseUrl, timeoutMs, callPaid, callFree };
+}

--- a/integrations/x402station/src/decoys.ts
+++ b/integrations/x402station/src/decoys.ts
@@ -1,0 +1,39 @@
+import { createTool } from '@mastra/core/tools';
+
+import { getX402StationClient   } from './client.js';
+import type {X402StationClient, X402StationClientOptions} from './client.js';
+import { CatalogDecoysInputSchema, CatalogDecoysOutputSchema } from './schemas.js';
+import type { CatalogDecoysResponse } from './types.js';
+
+/**
+ * Decoy / zombie blacklist tool. Pulls every active x402 endpoint
+ * currently flagged `decoy_price_extreme` / `zombie` / `dead_7d` /
+ * `mostly_dead` in one JSON payload, plus per-reason counts.
+ *
+ * **Cost: $0.005 USDC.** Refreshed every ~10 min server-side. Pull
+ * periodically (hourly/daily) and cache locally as a blacklist —
+ * cheaper than preflighting every URL the agent encounters.
+ */
+export function createX402StationCatalogDecoysTool(config: X402StationClientOptions = {}) {
+  let client: X402StationClient | null = null;
+  function getClient(): X402StationClient {
+    if (!client) client = getX402StationClient(config);
+    return client;
+  }
+
+  return createTool({
+    id: 'x402station-catalog-decoys',
+    description:
+      'Returns every active x402 endpoint currently flagged decoy_price_extreme / zombie / dead_7d / ' +
+      'mostly_dead in one JSON payload, plus per-reason counts. Costs $0.005 USDC. Refreshed every ~10 ' +
+      'min server-side. Pull periodically (hourly/daily) and cache locally as a blacklist — cheaper than ' +
+      'preflighting every URL.',
+    inputSchema: CatalogDecoysInputSchema,
+    outputSchema: CatalogDecoysOutputSchema,
+    execute: async () => {
+      const c = getClient();
+      const out = await c.callPaid<CatalogDecoysResponse>('/api/v1/catalog/decoys', {});
+      return out;
+    },
+  });
+}

--- a/integrations/x402station/src/forensics.ts
+++ b/integrations/x402station/src/forensics.ts
@@ -1,0 +1,38 @@
+import { createTool } from '@mastra/core/tools';
+
+import { getX402StationClient   } from './client.js';
+import type {X402StationClient, X402StationClientOptions} from './client.js';
+import { ForensicsInputSchema, ForensicsOutputSchema } from './schemas.js';
+import type { ForensicsResponse } from './types.js';
+
+/**
+ * Deep 7-day forensics tool. Posts a target URL to
+ * `https://x402station.io/api/v1/forensics` and returns hourly uptime,
+ * latency p50/p90/p99, status-code distribution, concentration-group
+ * stats, and a `decoy_probability` score in `[0, 1]`.
+ *
+ * **Cost: $0.001 USDC.** Superset of preflight — if you're running
+ * forensics you don't also need preflight on the same URL.
+ */
+export function createX402StationForensicsTool(config: X402StationClientOptions = {}) {
+  let client: X402StationClient | null = null;
+  function getClient(): X402StationClient {
+    if (!client) client = getX402StationClient(config);
+    return client;
+  }
+
+  return createTool({
+    id: 'x402station-forensics',
+    description:
+      'Deep 7-day report on one x402 endpoint: hourly uptime, latency p50/p90/p99, status-code distribution, ' +
+      'concentration-group stats (how crowded the provider namespace is), and a decoy_probability score [0,1]. ' +
+      'Costs $0.001 USDC. Superset of preflight — running forensics removes the need to also preflight.',
+    inputSchema: ForensicsInputSchema,
+    outputSchema: ForensicsOutputSchema,
+    execute: async ({ url }) => {
+      const c = getClient();
+      const out = await c.callPaid<ForensicsResponse>('/api/v1/forensics', { url });
+      return out;
+    },
+  });
+}

--- a/integrations/x402station/src/index.ts
+++ b/integrations/x402station/src/index.ts
@@ -1,0 +1,40 @@
+export { getX402StationClient, type X402StationClient, type X402StationClientOptions } from './client.js';
+export { createX402StationPreflightTool } from './preflight.js';
+export { createX402StationForensicsTool } from './forensics.js';
+export { createX402StationCatalogDecoysTool } from './decoys.js';
+export {
+  createX402StationWatchSubscribeTool,
+  createX402StationWatchStatusTool,
+  createX402StationWatchUnsubscribeTool,
+} from './watch.js';
+export { createX402StationTools } from './tools.js';
+
+export {
+  SignalSchema,
+  PreflightInputSchema,
+  ForensicsInputSchema,
+  CatalogDecoysInputSchema,
+  WatchSubscribeInputSchema,
+  WatchSecretInputSchema,
+  type PreflightInput,
+  type ForensicsInput,
+  type CatalogDecoysInput,
+  type WatchSubscribeInput,
+  type WatchSecretInput,
+} from './schemas.js';
+
+export type {
+  Signal,
+  PaymentReceipt,
+  EndpointMetadata,
+  PreflightResponse,
+  ForensicsResponse,
+  ForensicsHourBucket,
+  CatalogDecoysResponse,
+  CatalogDecoyEntry,
+  WatchSubscribeResponse,
+  WatchStatusResponse,
+  WatchUnsubscribeResponse,
+  WatchAlertSnapshot,
+  PaidResponse,
+} from './types.js';

--- a/integrations/x402station/src/preflight.ts
+++ b/integrations/x402station/src/preflight.ts
@@ -1,0 +1,44 @@
+import { createTool } from '@mastra/core/tools';
+
+import { getX402StationClient   } from './client.js';
+import type {X402StationClient, X402StationClientOptions} from './client.js';
+import { PreflightInputSchema, PreflightOutputSchema } from './schemas.js';
+import type { PreflightResponse } from './types.js';
+
+/**
+ * Pre-flight safety check tool. Posts a target URL to
+ * `https://x402station.io/api/v1/preflight` and returns
+ * `{ ok, warnings[], metadata }` plus the settled-payment receipt.
+ *
+ * **Cost: $0.001 USDC** (auto-signed via `@x402/fetch`). The CDP
+ * facilitator settles before this tool's `execute` returns. `ok` is
+ * `true` only when no critical signal fires (`dead`, `zombie`,
+ * `decoy_price_extreme`).
+ *
+ * Agents should call this BEFORE any other paid x402 request to avoid
+ * decoys (price ≥ $1k traps), zombie services (100% errors but still
+ * listed), and dead endpoints.
+ */
+export function createX402StationPreflightTool(config: X402StationClientOptions = {}) {
+  let client: X402StationClient | null = null;
+  function getClient(): X402StationClient {
+    if (!client) client = getX402StationClient(config);
+    return client;
+  }
+
+  return createTool({
+    id: 'x402station-preflight',
+    description:
+      'Ask x402station whether a given x402 URL is safe to pay. Returns {ok, warnings[], metadata}. ' +
+      'Costs $0.001 USDC, settled via x402. Call this BEFORE paying an unfamiliar x402 endpoint to avoid ' +
+      'decoys (price ≥ $1k), zombie services (100% errors), and dead endpoints. ok:true only when no ' +
+      'critical warning fires.',
+    inputSchema: PreflightInputSchema,
+    outputSchema: PreflightOutputSchema,
+    execute: async ({ url }) => {
+      const c = getClient();
+      const out = await c.callPaid<PreflightResponse>('/api/v1/preflight', { url });
+      return out;
+    },
+  });
+}

--- a/integrations/x402station/src/schemas.ts
+++ b/integrations/x402station/src/schemas.ts
@@ -1,0 +1,160 @@
+import { z } from 'zod';
+
+/**
+ * Whitelist of signal names accepted by `watch.subscribe`. Catching a
+ * typo here saves the agent the round-trip cost of finding out via 400.
+ */
+export const SignalSchema = z.enum([
+  'unknown_endpoint',
+  'no_history',
+  'dead',
+  'zombie',
+  'decoy_price_extreme',
+  'suspicious_high_price',
+  'slow',
+  'new_provider',
+  'dead_7d',
+  'mostly_dead',
+  'slow_p99',
+  'price_outlier_high',
+  'high_concentration',
+]);
+
+export const PreflightInputSchema = z.object({
+  url: z.string().url().describe('The full URL of the x402 endpoint the agent is about to pay.'),
+});
+
+export const ForensicsInputSchema = z.object({
+  url: z.string().url().describe('The full URL of the x402 endpoint to analyse.'),
+});
+
+export const CatalogDecoysInputSchema = z.object({});
+
+export const WatchSubscribeInputSchema = z.object({
+  url: z.string().url().describe('The x402 endpoint URL to watch.'),
+  webhookUrl: z
+    .string()
+    .url()
+    .refine(u => u.startsWith('https://'), {
+      message: 'webhookUrl must use HTTPS — HMAC-signed alert payloads must not travel in clear text',
+    })
+    .describe(
+      'Where x402station should POST alert payloads. Must be HTTPS (HMAC-signed payloads must travel encrypted) and reachable from the public internet.',
+    ),
+  signals: z
+    .array(SignalSchema)
+    .min(1)
+    .max(20)
+    .optional()
+    .describe(
+      "Signal names to alert on. Defaults server-side to ['dead', 'zombie', 'decoy_price_extreme'].",
+    ),
+});
+
+export const WatchSecretInputSchema = z.object({
+  watchId: z.string().uuid().describe('The watchId UUID returned by watch_subscribe.'),
+  secret: z
+    .string()
+    .length(64)
+    .regex(/^[0-9a-f]{64}$/i, 'secret must be 64 hex chars')
+    .describe('The 64-char hex secret returned by watch_subscribe.'),
+});
+
+export const PaymentReceiptSchema = z
+  .object({
+    transaction: z.string().optional(),
+    network: z.string().optional(),
+    payer: z.string().optional(),
+    raw: z.string().optional(),
+    malformed: z.boolean().optional(),
+  })
+  .passthrough()
+  .nullable();
+
+export const EndpointMetadataSchema = z
+  .object({
+    url: z.string(),
+    service: z.string().optional(),
+    service_id: z.string().optional(),
+    provider: z.string().nullable().optional(),
+    price_usdc: z.string().nullable().optional(),
+    currency: z.string().nullable().optional(),
+    is_active: z.boolean().optional(),
+    uptime_1h_pct: z.number().nullable().optional(),
+    avg_latency_ms: z.number().nullable().optional(),
+    endpoint_first_seen: z.string().optional(),
+    service_first_seen: z.string().optional(),
+  })
+  .passthrough();
+
+export const PreflightOutputSchema = z.object({
+  result: z.object({
+    ok: z.boolean(),
+    warnings: z.array(SignalSchema),
+    metadata: EndpointMetadataSchema,
+  }),
+  paymentReceipt: PaymentReceiptSchema,
+});
+
+export const ForensicsOutputSchema = z.object({
+  result: z
+    .object({
+      ok: z.boolean(),
+      warnings: z.array(SignalSchema),
+      decoy_probability: z.number(),
+      metadata: EndpointMetadataSchema,
+    })
+    .passthrough(),
+  paymentReceipt: PaymentReceiptSchema,
+});
+
+export const CatalogDecoysOutputSchema = z.object({
+  result: z
+    .object({
+      generated_at: z.string(),
+      counts: z.object({
+        total: z.number(),
+        by_reason: z.record(z.string(), z.number()),
+      }),
+      truncated: z.boolean(),
+      entries: z.array(z.unknown()),
+    })
+    .passthrough(),
+  paymentReceipt: PaymentReceiptSchema,
+});
+
+export const WatchSubscribeOutputSchema = z.object({
+  result: z
+    .object({
+      watchId: z.string(),
+      secret: z.string(),
+      expiresAt: z.string(),
+      signals: z.array(SignalSchema),
+      alertsPaid: z.number(),
+      alertsRemaining: z.number(),
+    })
+    .passthrough(),
+  paymentReceipt: PaymentReceiptSchema,
+});
+
+export const WatchStatusOutputSchema = z
+  .object({
+    watchId: z.string(),
+    endpointUrl: z.string(),
+    isActive: z.boolean(),
+    expired: z.boolean(),
+    alertsRemaining: z.number(),
+  })
+  .passthrough();
+
+export const WatchUnsubscribeOutputSchema = z.object({
+  watchId: z.string(),
+  isActive: z.literal(false),
+  message: z.string(),
+});
+
+export type PreflightInput = z.infer<typeof PreflightInputSchema>;
+export type ForensicsInput = z.infer<typeof ForensicsInputSchema>;
+export type CatalogDecoysInput = z.infer<typeof CatalogDecoysInputSchema>;
+export type WatchSubscribeInput = z.infer<typeof WatchSubscribeInputSchema>;
+export type WatchSecretInput = z.infer<typeof WatchSecretInputSchema>;

--- a/integrations/x402station/src/tools.ts
+++ b/integrations/x402station/src/tools.ts
@@ -1,0 +1,40 @@
+import type { X402StationClientOptions } from './client.js';
+import { createX402StationCatalogDecoysTool } from './decoys.js';
+import { createX402StationForensicsTool } from './forensics.js';
+import { createX402StationPreflightTool } from './preflight.js';
+import {
+  createX402StationWatchStatusTool,
+  createX402StationWatchSubscribeTool,
+  createX402StationWatchUnsubscribeTool,
+} from './watch.js';
+
+/**
+ * Build all six x402station tools in one call. Pass a single
+ * configuration (account / privateKey / baseUrl / fetchImpl /
+ * timeoutMs) and every tool inherits it.
+ *
+ * @example
+ * ```ts
+ * import { Agent } from '@mastra/core/agent';
+ * import { createX402StationTools } from '@mastra/x402station';
+ *
+ * const tools = createX402StationTools({ privateKey: process.env.AGENT_PK });
+ *
+ * const agent = new Agent({
+ *   id: 'shielded-x402-agent',
+ *   instructions: 'Always preflight URLs before paying x402. Refuse if ok=false.',
+ *   model: 'anthropic/claude-sonnet-4-6',
+ *   tools,
+ * });
+ * ```
+ */
+export function createX402StationTools(config: X402StationClientOptions = {}) {
+  return {
+    x402StationPreflight: createX402StationPreflightTool(config),
+    x402StationForensics: createX402StationForensicsTool(config),
+    x402StationCatalogDecoys: createX402StationCatalogDecoysTool(config),
+    x402StationWatchSubscribe: createX402StationWatchSubscribeTool(config),
+    x402StationWatchStatus: createX402StationWatchStatusTool(config),
+    x402StationWatchUnsubscribe: createX402StationWatchUnsubscribeTool(config),
+  };
+}

--- a/integrations/x402station/src/types.ts
+++ b/integrations/x402station/src/types.ts
@@ -1,0 +1,192 @@
+/**
+ * Signal vocabulary returned by x402station's preflight + forensics
+ * endpoints. Critical signals (the ones that flip `ok` to `false`) are
+ * marked in the inline comments. Full reference:
+ * https://x402station.io/.well-known/x402.
+ */
+export type Signal =
+  | 'unknown_endpoint'
+  | 'no_history'
+  | 'dead' // critical
+  | 'zombie' // critical
+  | 'decoy_price_extreme' // critical
+  | 'suspicious_high_price'
+  | 'slow'
+  | 'new_provider'
+  | 'dead_7d' // critical (forensics-only)
+  | 'mostly_dead' // critical (forensics-only)
+  | 'slow_p99'
+  | 'price_outlier_high'
+  | 'high_concentration';
+
+/**
+ * Settled-payment receipt. Returned alongside every paid tool response
+ * so the agent can audit on-chain spend. Decoded from the
+ * `x-payment-response` (or `payment-response`) header that x402's
+ * facilitator attaches once a 402 challenge has been settled.
+ *
+ * If the header is present but the body fails base64 / JSON decode (e.g.
+ * a misconfigured proxy stripped the encoding) the client surfaces
+ * `{ raw, malformed: true }` rather than silently returning a stub —
+ * spend-auditing branches can detect the mismatch instead of silently
+ * consuming a stub object that satisfies the type but lacks
+ * `transaction` / `network` / `payer`.
+ */
+export interface PaymentReceipt {
+  transaction?: string;
+  network?: string;
+  payer?: string;
+  /** Raw header value, populated only when decode failed. */
+  raw?: string;
+  /** True when the receipt header was present but couldn't be decoded. */
+  malformed?: boolean;
+  [key: string]: unknown;
+}
+
+export interface EndpointMetadata {
+  url: string;
+  service?: string;
+  service_id?: string;
+  provider?: string | null;
+  price_usdc?: string | null;
+  currency?: string | null;
+  is_active?: boolean;
+  uptime_1h_pct?: number | null;
+  avg_latency_ms?: number | null;
+  endpoint_first_seen?: string;
+  service_first_seen?: string;
+  [key: string]: unknown;
+}
+
+export interface PreflightResponse {
+  ok: boolean;
+  warnings: Signal[];
+  metadata: EndpointMetadata;
+  [key: string]: unknown;
+}
+
+export interface ForensicsHourBucket {
+  bucket: string;
+  probes: number;
+  healthy: number;
+  avg_latency_ms: number | null;
+}
+
+export interface ForensicsResponse {
+  ok: boolean;
+  warnings: Signal[];
+  decoy_probability: number;
+  metadata: EndpointMetadata;
+  uptime: {
+    probes_7d: number;
+    healthy_7d: number;
+    errors_7d: number;
+    uptime_7d_pct: number;
+    uptime_1h_pct: number;
+    avg_latency_1h_ms: number | null;
+    hourly: ForensicsHourBucket[];
+  };
+  latency: {
+    p50_ms: number | null;
+    p90_ms: number | null;
+    p99_ms: number | null;
+    max_ms: number | null;
+  };
+  status_codes: Record<string, number>;
+  concentration: {
+    group_size: number;
+    catalog_total: number;
+    concentration_pct: number;
+    group_median_price_usdc: string | null;
+    group_p90_price_usdc: string | null;
+    price_ratio_to_median: number | null;
+  };
+  [key: string]: unknown;
+}
+
+export interface CatalogDecoyEntry {
+  url: string;
+  service_id: string;
+  service_name: string;
+  provider: string | null;
+  price_usdc: string | null;
+  currency: string | null;
+  reasons: Array<'decoy_price_extreme' | 'zombie' | 'dead_7d' | 'mostly_dead'>;
+  probes_7d: number;
+  healthy_7d: number;
+  uptime_7d_pct: number | null;
+  last_probe_at: string | null;
+}
+
+export interface CatalogDecoysResponse {
+  generated_at: string;
+  counts: {
+    total: number;
+    by_reason: Record<string, number>;
+  };
+  truncated: boolean;
+  entries: CatalogDecoyEntry[];
+  [key: string]: unknown;
+}
+
+export interface WatchSubscribeResponse {
+  watchId: string;
+  /** 64-char hex secret. Returned ONCE — store it. HMAC seed for verifying delivery payloads. */
+  secret: string;
+  expiresAt: string;
+  signals: Signal[];
+  alertsPaid: number;
+  alertsRemaining: number;
+  endpointKnown: boolean;
+  deliveryFormat: {
+    method: string;
+    headers: Record<string, string>;
+    signatureScheme: string;
+    retryPolicy: string;
+    examplePayload: unknown;
+  };
+  statusUrl: string;
+  unsubscribeUrl: string;
+  [key: string]: unknown;
+}
+
+export interface WatchAlertSnapshot {
+  id: string;
+  firedSignals: Signal[];
+  clearedSignals: Signal[];
+  currentState: unknown;
+  createdAt: string;
+  deliveredAt: string | null;
+  deliveryStatus: 'pending' | 'delivered' | 'failed' | 'skipped_quota_exceeded';
+  deliveryAttempts: number;
+  deliveryResponseCode: number | null;
+}
+
+export interface WatchStatusResponse {
+  watchId: string;
+  endpointUrl: string;
+  webhookUrl: string;
+  signals: Signal[];
+  createdAt: string;
+  expiresAt: string;
+  alertsPaid: number;
+  alertsSent: number;
+  alertsRemaining: number;
+  lastState: unknown;
+  isActive: boolean;
+  expired: boolean;
+  recentAlerts: WatchAlertSnapshot[];
+  [key: string]: unknown;
+}
+
+export interface WatchUnsubscribeResponse {
+  watchId: string;
+  isActive: false;
+  message: string;
+}
+
+/** Wraps a paid response with its payment receipt for spend auditing. */
+export interface PaidResponse<T> {
+  result: T;
+  paymentReceipt: PaymentReceipt | null;
+}

--- a/integrations/x402station/src/watch.ts
+++ b/integrations/x402station/src/watch.ts
@@ -1,0 +1,96 @@
+import { createTool } from '@mastra/core/tools';
+
+import { getX402StationClient   } from './client.js';
+import type {X402StationClient, X402StationClientOptions} from './client.js';
+import {
+  WatchSecretInputSchema,
+  WatchStatusOutputSchema,
+  WatchSubscribeInputSchema,
+  WatchSubscribeOutputSchema,
+  WatchUnsubscribeOutputSchema,
+} from './schemas.js';
+import type { WatchStatusResponse, WatchSubscribeResponse, WatchUnsubscribeResponse } from './types.js';
+
+function makeClient(config: X402StationClientOptions): () => X402StationClient {
+  let client: X402StationClient | null = null;
+  return () => {
+    if (!client) client = getX402StationClient(config);
+    return client;
+  };
+}
+
+/**
+ * Watch-subscribe tool. Pays $0.01 USDC for a 30-day watch + 100
+ * prepaid HMAC-SHA256-signed alerts on one x402 endpoint. Returns
+ * `watchId` + `secret` — STORE THE SECRET, it's the HMAC seed for
+ * verifying delivery payloads and is not retrievable later.
+ *
+ * `webhookUrl` is HTTPS-only at the schema level: HMAC-signed payloads
+ * must not travel in clear text.
+ */
+export function createX402StationWatchSubscribeTool(config: X402StationClientOptions = {}) {
+  const getClient = makeClient(config);
+  return createTool({
+    id: 'x402station-watch-subscribe',
+    description:
+      'Pay $0.01 USDC for a 30-day watch + 100 prepaid HMAC-SHA256-signed alerts on one x402 endpoint. ' +
+      'When subscribed signals fire or clear (e.g. endpoint goes zombie, price flips to decoy_price_extreme), ' +
+      'x402station POSTs a JSON payload signed with HMAC-SHA256 to your webhookUrl. Returns watchId + ' +
+      'secret — STORE THE SECRET, it is the HMAC seed and is not retrievable later. signals defaults to ' +
+      "{dead, zombie, decoy_price_extreme}; pass other names to subscribe to non-critical signals too.",
+    inputSchema: WatchSubscribeInputSchema,
+    outputSchema: WatchSubscribeOutputSchema,
+    execute: async ({ url, webhookUrl, signals }) => {
+      const c = getClient();
+      const body: Record<string, unknown> = { url, webhookUrl };
+      if (signals && signals.length > 0) body.signals = signals;
+      const out = await c.callPaid<WatchSubscribeResponse>('/api/v1/watch', body);
+      return out;
+    },
+  });
+}
+
+/**
+ * Free, secret-gated tool that returns the current state of a watch:
+ * active/expired flag, alerts remaining (out of 100 prepaid), the last
+ * 10 alert deliveries with their `delivery_status`, and the last
+ * computed signal snapshot.
+ */
+export function createX402StationWatchStatusTool(config: X402StationClientOptions = {}) {
+  const getClient = makeClient(config);
+  return createTool({
+    id: 'x402station-watch-status',
+    description:
+      'Read the current state of an active watch: isActive/expired, alertsRemaining, last 10 alert ' +
+      'deliveries with delivery_status, and last computed signal snapshot. Free — no payment required, ' +
+      'secret-gated. The secret is the one returned by watch_subscribe.',
+    inputSchema: WatchSecretInputSchema,
+    outputSchema: WatchStatusOutputSchema,
+    execute: async ({ watchId, secret }) => {
+      const c = getClient();
+      return c.callFree<WatchStatusResponse>(`/api/v1/watch/${watchId}`, 'GET', secret);
+    },
+  });
+}
+
+/**
+ * Free, secret-gated tool that deactivates a watch — no further alerts
+ * are queued or delivered. The subscription row + alert history is
+ * retained for audit. There is no refund for unused prepaid alerts.
+ */
+export function createX402StationWatchUnsubscribeTool(config: X402StationClientOptions = {}) {
+  const getClient = makeClient(config);
+  return createTool({
+    id: 'x402station-watch-unsubscribe',
+    description:
+      'Deactivate a watch — no further alerts are queued or delivered. The subscription is set to ' +
+      'is_active=false but the row + alert history is retained for audit. Free — no payment required, ' +
+      'secret-gated. There is no refund for unused prepaid alerts.',
+    inputSchema: WatchSecretInputSchema,
+    outputSchema: WatchUnsubscribeOutputSchema,
+    execute: async ({ watchId, secret }) => {
+      const c = getClient();
+      return c.callFree<WatchUnsubscribeResponse>(`/api/v1/watch/${watchId}`, 'DELETE', secret);
+    },
+  });
+}

--- a/integrations/x402station/tsconfig.build.json
+++ b/integrations/x402station/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/x402station/tsconfig.json
+++ b/integrations/x402station/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/x402station/tsup.config.ts
+++ b/integrations/x402station/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/integrations/x402station/turbo.json
+++ b/integrations/x402station/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/integrations/x402station/vitest.config.ts
+++ b/integrations/x402station/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:integrations/x402station',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1530,6 +1530,40 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
 
+  integrations/x402station:
+    dependencies:
+      '@x402/evm':
+        specifier: ^2.10.0
+        version: 2.10.0(bufferutil@4.1.0)(typescript@5.9.3)
+      '@x402/fetch':
+        specifier: ^2.10.0
+        version: 2.10.0(bufferutil@4.1.0)(typescript@5.9.3)
+      viem:
+        specifier: ^2.48.4
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(zod@4.3.6)
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+
   mastracode:
     dependencies:
       '@ai-sdk/anthropic':
@@ -7170,6 +7204,9 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
   '@ai-sdk/amazon-bedrock@3.0.93':
     resolution: {integrity: sha512-57cP3Ume6DdQP05xPYl2g554EqPrQgKRW/eE3BGm1ktK1k71e35HGzNl1GZHIYKct82QrY/iQuheanSonI88Dg==}
     engines: {node: '>=18'}
@@ -11823,9 +11860,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/ciphers@2.0.1':
     resolution: {integrity: sha512-xHK3XHPUW8DTAobU+G0XT+/w+JLM7/8k1UFdB5xg/zTFPnFCobhftzw8wl4Lw2aq/Rvir5pxfZV5fEazmeCJ2g==}
     engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -14397,6 +14442,15 @@ packages:
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -16495,6 +16549,15 @@ packages:
     resolution: {integrity: sha512-lbLP1y8MHWL1Op9athZ3SrzKLcL0+xBVpADCMQLI39mPgSQj+/lopVdOx0Cku96hYnJBOJTLVTK3Zox4FbZl4A==}
     engines: {node: '>=20.0.0'}
 
+  '@x402/core@2.10.0':
+    resolution: {integrity: sha512-n9Exnt1HN4LFaINaPYhk6Cy3ICBt0e46XN1Uo5i6efIZfIoqP6pY8ONSX/M9bU4F1fpvMj0JZ3xdcBZCiGInfw==}
+
+  '@x402/evm@2.10.0':
+    resolution: {integrity: sha512-iEGIgW5K3qM3d2S1wuBSGJ1Kfdctd+0LAN8l+33dbYZgdkvCvTDwBPjbojVJ9mXI0Zk2bt4hUpcoOgsdmr79BA==}
+
+  '@x402/fetch@2.10.0':
+    resolution: {integrity: sha512-Rpe7JL0wzsdRmUfzULCjWI+yq5dkEtYFdE7qbtL81VMdOjq3E50fxJd3dcg/U+Lam+CAHQA5FZkcjP932Xyk0A==}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -16527,6 +16590,17 @@ packages:
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: ^5.9.3
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
   abort-controller-x@0.5.0:
     resolution: {integrity: sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==}
@@ -20006,6 +20080,7 @@ packages:
   inngest@3.52.7:
     resolution: {integrity: sha512-Bj4LttRrNUfVz745MVxQio34QwHzwG7dHiAI6DmRIZqfRjQ6tdV4mg70xzbRmwsaXgN+iboa+SXP6ILkziUf4g==}
     engines: {node: '>=20'}
+    deprecated: 'CRITICAL SECURITY: upgrade to >=3.54.0'
     peerDependencies:
       '@sveltejs/kit': '>=1.27.3'
       '@vercel/node': '>=2.15.9'
@@ -20393,6 +20468,11 @@ packages:
 
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
 
@@ -22071,6 +22151,14 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  ox@0.14.20:
+    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
+    peerDependencies:
+      typescript: ^5.9.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   oxc-parser@0.118.0:
     resolution: {integrity: sha512-RWcTXXw9rsdlGxPwaL2hVKDtgudMBAUlwqPNl1WhgWQNlp/RZ/XeFHuG8HolZM2dMjLJeD4b2Ywo7/a988X4MQ==}
@@ -25479,6 +25567,14 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
+  viem@2.48.4:
+    resolution: {integrity: sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==}
+    peerDependencies:
+      typescript: ^5.9.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-plugin-dts@4.5.4:
     resolution: {integrity: sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==}
     peerDependencies:
@@ -25903,6 +25999,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -26103,6 +26211,8 @@ snapshots:
       - supports-color
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@ai-sdk/amazon-bedrock@3.0.93(zod@4.3.6)':
     dependencies:
@@ -32434,7 +32544,13 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
   '@noble/ciphers@2.0.1': {}
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.4.0': {}
 
@@ -35688,6 +35804,19 @@ snapshots:
 
   '@scarf/scarf@1.4.0': {}
 
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@segment/analytics-core@1.8.2':
@@ -38170,6 +38299,30 @@ snapshots:
       iron-webcrypto: 2.0.0
       jose: 6.2.1
 
+  '@x402/core@2.10.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@x402/evm@2.10.0(bufferutil@4.1.0)(typescript@5.9.3)':
+    dependencies:
+      '@x402/core': 2.10.0
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@x402/fetch@2.10.0(bufferutil@4.1.0)(typescript@5.9.3)':
+    dependencies:
+      '@x402/core': 2.10.0
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -38209,6 +38362,16 @@ snapshots:
   a-sync-waterfall@1.0.1: {}
 
   abbrev@2.0.0: {}
+
+  abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 3.25.76
+
+  abitype@1.2.3(typescript@5.9.3)(zod@4.3.6):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.3.6
 
   abort-controller-x@0.5.0: {}
 
@@ -42853,6 +43016,10 @@ snapshots:
     dependencies:
       ws: 8.20.0(bufferutil@4.1.0)
 
+  isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)):
+    dependencies:
+      ws: 8.18.3(bufferutil@4.1.0)
+
   isstream@0.1.2: {}
 
   istanbul-lib-coverage@3.2.2: {}
@@ -45105,6 +45272,36 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  ox@0.14.20(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.20(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
 
   oxc-parser@0.118.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0):
     dependencies:
@@ -49511,6 +49708,40 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0))
+      ox: 0.14.20(typescript@5.9.3)(zod@3.25.76)
+      ws: 8.18.3(bufferutil@4.1.0)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0))
+      ox: 0.14.20(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.18.3(bufferutil@4.1.0)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite-plugin-dts@4.5.4(@types/node@22.19.15)(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@microsoft/api-extractor': 7.57.7(@types/node@22.19.15)
@@ -50099,6 +50330,10 @@ snapshots:
       bufferutil: 4.1.0
 
   ws@8.18.0(bufferutil@4.1.0):
+    optionalDependencies:
+      bufferutil: 4.1.0
+
+  ws@8.18.3(bufferutil@4.1.0):
     optionalDependencies:
       bufferutil: 4.1.0
 


### PR DESCRIPTION
## Summary

Adds `@mastra/x402station` — six tools (`preflight`, `forensics`, `catalogDecoys`, `watchSubscribe`, `watchStatus`, `watchUnsubscribe`) that wrap [x402station.io](https://x402station.io)'s pre-flight oracle. Paid calls are auto-signed through `@x402/fetch` and settle in USDC on Base mainnet (`eip155:8453`) or Base Sepolia (`eip155:84532`).

## Why

[x402](https://x402.org) lets agents pay HTTP endpoints, but the network already has shape problems an agent can't see at the facilitator layer:

- ~161 endpoints listed at ≥ $1 000 USDC. Most are anti-scraper "swarm" routes — an agent paying one loses its wallet.
- ~10 services 100 % erroring in the last hour but still listed in the catalog. Invisible to facilitator-based scanners because nobody calls them.
- One provider can be > 40 % of the catalog under a single billing namespace — agents need this context before treating the network as diverse.

x402station independently probes every endpoint on `agentic.market` (≈ 25 950 active URLs across ≈ 549 services) every 10 minutes and exposes safety signals priced in USDC via x402 itself. This package surfaces those signals as Mastra tools so an agent can refuse to pay endpoints flagged `decoy` / `zombie` / `dead`.

## Surface

| Tool | Cost | Purpose |
|---|---|---|
| `x402StationPreflight` | $0.001 USDC | `{ ok, warnings[], metadata }` for one URL. The fast path. |
| `x402StationForensics` | $0.001 USDC | 7-day uptime, latency p50/p90/p99, status codes, decoy probability. |
| `x402StationCatalogDecoys` | $0.005 USDC | Full known-bad list as one JSON. Cache as a blacklist. |
| `x402StationWatchSubscribe` | $0.01 USDC | 30-day watch + 100 prepaid HMAC-signed alerts on state changes. |
| `x402StationWatchStatus` | free | Status + recent alert deliveries (secret-gated). |
| `x402StationWatchUnsubscribe` | free | Deactivate a watch (secret-gated). |

`createX402StationTools({ privateKey })` returns the whole bundle; individual factories are also exported.

## Defensive defaults

- **Canonical-host allow-list** refuses to sign x402 payments against any host other than `https://x402station.io` or `http(s)://localhost` / `127.0.0.1` / `[::1]` — a misconfigured agent cannot be tricked into signing payments against an attacker-controlled URL. `u.host` (not `u.hostname`) so a non-default port can't bypass the check.
- **`webhookUrl` is HTTPS-only at the zod schema level** — HMAC-SHA256-signed alert payloads must not travel in clear text.
- **`AbortSignal.timeout(30 s)`** on every fetch (paid + free) so a stalled oracle does not hang the agent step.
- **Malformed payment receipts** surface as `{ raw, malformed: true }` rather than a silent stub object that satisfies the type but lacks `transaction` / `network` / `payer` — spend-auditing branches can detect the mismatch.

## Test plan

- [x] `pnpm test` — 34/34 passing (vitest, 6 files: client allow-list, paid request shape, receipt decoding, http://-webhookUrl rejection, secret-gated free endpoints, abort-on-timeout, factory parity)
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build:lib` — esm + cjs + d.ts emitted

## Networks / fees

Base mainnet (`eip155:8453`) and Base Sepolia (`eip155:84532`). The CDP facilitator (`https://x402.org/facilitator`) settles. Mainnet requires the agent's wallet to hold USDC at `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`. Testnet is anonymous.

## Notes

- The same package is published as `x402station-mcp` (MCP transport) and shipped as separate integrations to [coinbase/agentkit#1154](https://github.com/coinbase/agentkit/pull/1154) and [daydreamsai/lucid-agents#1629](https://github.com/daydreamsai/lucid-agents/pull/1629). Greptile review on the Lucid PR caught one P1 + three P2 (HTTPS-only webhook, IPv6 [::1] dev host, `AbortSignal.timeout`, malformed-receipt fallback) — those four fixes are baked into this Mastra version from the start, not bolted on.
- License: Apache-2.0, matching the Mastra default.
- A changeset is included.

## Discovery

x402station scores **5/5 ("Agent-Native")** on Cloudflare's [isitagentready.com](https://isitagentready.com/?url=https://x402station.io) scanner, with `isCommerce=true`. Discovery surfaces published: `/.well-known/x402`, `agent-card.json`, `mcp/server-card.json`, OpenAPI 3.1, `llms.txt`, RFC 8414/9728 OAuth metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a safety-check tool for AI agents called `@mastra/x402station`. Think of it like a bouncer at a club who quickly checks if a guest (website/endpoint) is legitimate before letting the agent interact with it — some checks are free, others cost a tiny bit of money (paid in USDC crypto), and the tool refuses to work with known fakes or broken endpoints.

---

## What's New

Introduces the `@mastra/x402station` Mastra integration package, which wraps six oracle tools from x402station.io for pre-flight endpoint validation:

**Paid tools (USDC settlement on Base mainnet/Sepolia):**
- **x402StationPreflight** — $0.001 USDC: Quick `{ ok, warnings[], metadata }` check for one URL
- **x402StationForensics** — $0.001 USDC: 7-day uptime, latency percentiles (p50/p90/p99), status codes, decoy probability
- **x402StationCatalogDecoys** — $0.005 USDC: Full JSON list of known-bad endpoints (cacheable)
- **x402StationWatchSubscribe** — $0.01 USDC: 30-day watch subscription with 100 prepaid HMAC-signed alerts

**Free, secret-gated tools:**
- **x402StationWatchStatus**: Retrieve watch state, recent alert deliveries
- **x402StationWatchUnsubscribe**: Deactivate a watch

All paid calls are automatically signed via `@x402/fetch` using a private key or `X402STATION_PRIVATE_KEY` env var.

---

## Key Implementation Details

**Client layer** (`getX402StationClient`):
- Validates `baseUrl` against a canonical-host allow-list (only `https://x402station.io` or localhost dev URLs including 127.0.0.1 and [::1])
- Resolves signing account from `account`/`privateKey`/`X402STATION_PRIVATE_KEY` (throws if none available)
- Implements `callPaid<T>` (POST with payment wrapper, decodes optional `x-payment-response` header) and `callFree<T>` (GET/DELETE with `x-x402station-secret` header)
- Enforces `AbortSignal.timeout(30s)` on all fetches
- Returns malformed payment receipts as `{ raw, malformed: true }` instead of failing silently
- Provides structured error messages for timeouts, non-2xx responses, and invalid JSON bodies

**Schemas** (Zod validation):
- `webhookUrl` enforced as HTTPS at schema level
- Watch signal values validated against approved enum
- Watch subscribe signals array limited to 1–20 entries
- Watch secret (UUID + 64-hex characters) validated

**Tool factory API:**
- `createX402StationTools({ privateKey })` returns all six tools as a bundle
- Individual factories exported for standalone tool creation
- Each tool lazily initializes and caches a client instance

---

## Defensive Defaults & Safety Features

- **Canonical-host allow-list** restricts signing to x402station.io only (prevents port-bypass and SSRF)
- **HTTPS-only webhooks** validated at schema level to prevent credential leakage
- **30-second timeouts** on all requests (paid + free) to prevent agent hangs
- **Malformed receipt handling** surfaces payment inconsistencies instead of silent fallback
- **Environment variable fallback** (`X402STATION_PRIVATE_KEY`) for account resolution without hardcoding

---

## Integration & Discovery

x402station.io scores 5/5 on Cloudflare's isitagentready.com and publishes:
- `/.well-known/x402` discovery endpoint
- agent-card.json, mcp/server-card.json
- OpenAPI 3.1, llms.txt, OAuth metadata

The tool bundle surfaces x402station's real-time safety signals (~25,950 URLs across ~549 services probed every 10 minutes), enabling agents to auto-refuse endpoints flagged `decoy`, `zombie`, or `dead`.

---

## Package Structure & Quality

- **All exports** documented in barrel module (`src/index.ts`); client, tool factories, schemas, and types all public
- **Test coverage**: 34/34 vitest passing, covering client URL validation, account resolution, payment receipt decoding, tool execution paths, and schema constraints
- **Build artifacts**: ESM/CJS outputs with TypeScript `.d.ts`, sourcemaps
- **Code quality**: `tsc --noEmit` clean, `eslint` clean
- **Config**: TurboRepo pipeline, tsup builder, vitest unit tests, ESLint flat-config
- **License**: Apache-2.0
- **Node requirement**: >= 22.13.0
- **Changeset included** for version management

---

## Dependencies

- **Runtime**: `@x402/evm`, `@x402/fetch`, `viem` (payment signing and EVM scheme)
- **Peer**: `@mastra/core`, `zod`
- **Dev**: Shared workspace tooling (typescript, vitest, eslint, tsup, etc.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->