### PR TITLE
fix(auth): transparent server-side session refresh to eliminate 401 cascade

### DIFF
--- a/.changeset/fix-transparent-server-side-refresh.md
+++ b/.changeset/fix-transparent-server-side-refresh.md
@@ -7,11 +7,6 @@
 '@mastra/auth-studio': patch
 ---
 
-Fixed unexpected sign-outs caused by expired access tokens triggering a 401 cascade. The auth middleware now transparently refreshes sessions server-side when the auth provider implements `ISessionProvider`, so clients never receive a 401 for a recoverable token expiry. Only truly expired sessions (e.g. refresh token expired) return 401.
+Authentication now refreshes expired server-side sessions transparently, so recoverable token expiry no longer causes unexpected user sign-outs. Only truly expired sessions (e.g. refresh token dead) return a 401.
 
-**What changed**
-
-- `coreAuthMiddleware` detects when `authenticateToken()` returns null and the auth provider supports session refresh (`refreshSession`, `getSessionIdFromRequest`, `getSessionHeaders`). It refreshes the session, sets updated `Set-Cookie` headers on the response, and re-authenticates — all in a single request with no client-side retry needed.
-- `AuthResult` now carries an optional `headers` field so the middleware can pass `Set-Cookie` back through the server adapter.
-- All server adapters (Hono, Express, Fastify, Koa) propagate refresh headers on both standard and custom API routes.
-- `MastraAuthStudio` auth methods (`verifySessionCookie`, `handleCallback`, `refreshSession`, `verifyBearerToken`) now log errors instead of silently returning `null`, making SSO callback and session-validation failures diagnosable.
+Server adapters now forward refreshed session cookies consistently, and auth-studio logs session validation and refresh failures to improve diagnostics.

--- a/.changeset/fix-transparent-server-side-refresh.md
+++ b/.changeset/fix-transparent-server-side-refresh.md
@@ -1,0 +1,17 @@
+---
+'@mastra/server': patch
+'@mastra/hono': patch
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/koa': patch
+'@mastra/auth-studio': patch
+---
+
+Fixed unexpected sign-outs caused by expired access tokens triggering a 401 cascade. The auth middleware now transparently refreshes sessions server-side when the auth provider implements `ISessionProvider`, so clients never receive a 401 for a recoverable token expiry. Only truly expired sessions (e.g. refresh token expired) return 401.
+
+**What changed**
+
+- `coreAuthMiddleware` detects when `authenticateToken()` returns null and the auth provider supports session refresh (`refreshSession`, `getSessionIdFromRequest`, `getSessionHeaders`). It refreshes the session, sets updated `Set-Cookie` headers on the response, and re-authenticates — all in a single request with no client-side retry needed.
+- `AuthResult` now carries an optional `headers` field so the middleware can pass `Set-Cookie` back through the server adapter.
+- All server adapters (Hono, Express, Fastify, Koa) propagate refresh headers on both standard and custom API routes.
+- `MastraAuthStudio` auth methods (`verifySessionCookie`, `handleCallback`, `refreshSession`, `verifyBearerToken`) now log errors instead of silently returning `null`, making SSO callback and session-validation failures diagnosable.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -405,7 +405,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
 
       - name: Publish to npm
-        run: pnpm publish -r --filter '!@mastra/azure' --no-git-checks --tag ${{ env.FINAL_TAG }} --access public
+        run: pnpm publish -r --no-git-checks --tag ${{ env.FINAL_TAG }} --access public
         env:
           NPM_CONFIG_PROVENANCE: true
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -405,7 +405,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
 
       - name: Publish to npm
-        run: pnpm publish -r --no-git-checks --tag ${{ env.FINAL_TAG }} --access public
+        run: pnpm publish -r --filter '!@mastra/azure' --no-git-checks --tag ${{ env.FINAL_TAG }} --access public
         env:
           NPM_CONFIG_PROVENANCE: true
 

--- a/auth/studio/src/index.ts
+++ b/auth/studio/src/index.ts
@@ -170,8 +170,16 @@ export class MastraAuthStudio
     // The shared API already consumed the OAuth code and passes the sealed
     // session directly as the `code` parameter in the redirect to this callback.
     // Validate it to get user info.
+    this.logger.debug('SSO callback: validating sealed session via shared API', {
+      sharedApiUrl: this.sharedApiUrl,
+      codeLength: code?.length,
+    });
     const user = await this.verifySessionCookie(code);
     if (!user) {
+      this.logger.error('SSO callback: session validation failed — verifySessionCookie returned null', {
+        sharedApiUrl: this.sharedApiUrl,
+        codeLength: code?.length,
+      });
       throw new Error('Session validation failed');
     }
 
@@ -280,6 +288,10 @@ export class MastraAuthStudio
       });
 
       if (!res.ok) {
+        this.logger.warn('refreshSession: shared API refresh returned non-OK status', {
+          status: res.status,
+          url: `${this.sharedApiUrl}/auth/refresh`,
+        });
         // Refresh failed, fall back to validation (will likely also fail)
         return this.validateSession(sessionId);
       }
@@ -289,6 +301,7 @@ export class MastraAuthStudio
       const newSessionId = setCookie ? parseCookieFromHeader(setCookie, COOKIE_NAME) : null;
 
       if (!newSessionId) {
+        this.logger.warn('refreshSession: no Set-Cookie header in refresh response');
         // No new cookie returned, fall back to validation with original
         return this.validateSession(sessionId);
       }
@@ -304,7 +317,11 @@ export class MastraAuthStudio
         expiresAt: new Date(now.getTime() + 24 * 60 * 60 * 1000),
         createdAt: now,
       };
-    } catch {
+    } catch (error) {
+      this.logger.error('refreshSession: fetch to shared API failed', {
+        url: `${this.sharedApiUrl}/auth/refresh`,
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : String(error),
+      });
       // On error, fall back to validation
       return this.validateSession(sessionId);
     }
@@ -375,7 +392,14 @@ export class MastraAuthStudio
         },
       });
 
-      if (!res.ok) return null;
+      if (!res.ok) {
+        this.logger.warn('verifySessionCookie: shared API returned non-OK status', {
+          status: res.status,
+          statusText: res.statusText,
+          url: `${this.sharedApiUrl}/auth/me`,
+        });
+        return null;
+      }
 
       const data = (await res.json()) as {
         user: {
@@ -401,7 +425,11 @@ export class MastraAuthStudio
         permissions: data.permissions,
         memberOrgIds: data.memberOrgIds,
       };
-    } catch {
+    } catch (error) {
+      this.logger.error('verifySessionCookie: fetch to shared API failed', {
+        url: `${this.sharedApiUrl}/auth/me`,
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : String(error),
+      });
       return null;
     }
   }
@@ -418,7 +446,13 @@ export class MastraAuthStudio
         },
       });
 
-      if (!res.ok) return null;
+      if (!res.ok) {
+        this.logger.warn('verifyBearerToken: shared API returned non-OK status', {
+          status: res.status,
+          url: `${this.sharedApiUrl}/auth/verify`,
+        });
+        return null;
+      }
 
       const data = (await res.json()) as {
         user: {
@@ -440,7 +474,11 @@ export class MastraAuthStudio
         role: data.role,
         memberOrgIds: data.memberOrgIds,
       };
-    } catch {
+    } catch (error) {
+      this.logger.error('verifyBearerToken: fetch to shared API failed', {
+        url: `${this.sharedApiUrl}/auth/verify`,
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : String(error),
+      });
       return null;
     }
   }

--- a/examples/voice/interactive-story/next-env.d.ts
+++ b/examples/voice/interactive-story/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/voice/voice-memo-app/next-env.d.ts
+++ b/examples/voice/voice-memo-app/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/server/src/server/auth/helpers.test.ts
+++ b/packages/server/src/server/auth/helpers.test.ts
@@ -706,4 +706,258 @@ describe('auth helpers', () => {
       expect(requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBeUndefined();
     });
   });
+
+  describe('coreAuthMiddleware - transparent session refresh', () => {
+    const user = { id: 'user-123', email: 'test@example.com' };
+
+    function createMockMastra() {
+      return {
+        getServer: () => ({}),
+        getLogger: () => null,
+      } as any;
+    }
+
+    function createRequestContext() {
+      const store = new Map<string, unknown>();
+      return {
+        get: (key: string) => store.get(key),
+        set: (key: string, value: unknown) => store.set(key, value),
+        _store: store,
+      };
+    }
+
+    function createRawRequest() {
+      return new Request('http://localhost/api/agents', {
+        method: 'GET',
+        headers: { Cookie: 'wos-session=expired-token' },
+      });
+    }
+
+    const baseCtx = {
+      path: '/api/agents',
+      method: 'GET',
+      getHeader: () => undefined,
+      token: 'valid-token',
+      buildAuthorizeContext: () => null,
+    };
+
+    it('should transparently refresh expired session and proceed', async () => {
+      let callCount = 0;
+      const requestContext = createRequestContext();
+
+      const authConfig: any = {
+        protected: ['/api/*'],
+        // First call: returns null (expired). Second call (with refreshed cookie): returns user.
+        authenticateToken: async (_token: string, req: any) => {
+          callCount++;
+          if (callCount === 1) return null;
+          // Second call should have the refreshed cookie
+          const cookie = req?.headers?.get?.('Cookie') || '';
+          if (cookie.includes('wos-session=refreshed-token')) return user;
+          return null;
+        },
+        // ISessionProvider methods
+        getSessionIdFromRequest: (req: Request) => {
+          const cookie = req.headers.get('Cookie') || '';
+          const match = cookie.match(/wos-session=([^;]+)/);
+          return match ? match[1] : null;
+        },
+        refreshSession: async (_sessionId: string) => ({
+          id: 'refreshed-token',
+          userId: user.id,
+          expiresAt: new Date(Date.now() + 86400000),
+          createdAt: new Date(),
+        }),
+        getSessionHeaders: (session: any) => ({
+          'Set-Cookie': `wos-session=${session.id}; HttpOnly; SameSite=Lax; Path=/; Max-Age=86400`,
+        }),
+      };
+
+      const result = await coreAuthMiddleware({
+        ...baseCtx,
+        mastra: createMockMastra(),
+        authConfig,
+        requestContext,
+        rawRequest: createRawRequest(),
+      });
+
+      expect(result.action).toBe('next');
+      expect(result).toHaveProperty('headers');
+      expect((result as any).headers['Set-Cookie']).toContain('wos-session=refreshed-token');
+      expect(requestContext.get('user')).toBe(user);
+      expect(callCount).toBe(2); // authenticateToken called twice
+    });
+
+    it('should set new session cookie headers after refresh', async () => {
+      let callCount = 0;
+      const requestContext = createRequestContext();
+
+      const authConfig: any = {
+        protected: ['/api/*'],
+        authenticateToken: async (_token: string, req: any) => {
+          callCount++;
+          if (callCount === 1) return null;
+          const cookie = req?.headers?.get?.('Cookie') || '';
+          if (cookie.includes('new-session')) return user;
+          return null;
+        },
+        getSessionIdFromRequest: () => 'old-session',
+        refreshSession: async () => ({
+          id: 'new-session',
+          userId: user.id,
+          expiresAt: new Date(Date.now() + 86400000),
+          createdAt: new Date(),
+        }),
+        getSessionHeaders: (session: any) => ({
+          'Set-Cookie': `wos-session=${session.id}; HttpOnly; Secure; Domain=.example.com`,
+        }),
+      };
+
+      const result = await coreAuthMiddleware({
+        ...baseCtx,
+        mastra: createMockMastra(),
+        authConfig,
+        requestContext,
+        rawRequest: createRawRequest(),
+      });
+
+      expect(result.action).toBe('next');
+      const headers = (result as any).headers;
+      expect(headers).toBeDefined();
+      expect(headers['Set-Cookie']).toContain('wos-session=new-session');
+      expect(headers['Set-Cookie']).toContain('Secure');
+      expect(headers['Set-Cookie']).toContain('Domain=.example.com');
+    });
+
+    it('should return 401 when refresh token is also expired', async () => {
+      const requestContext = createRequestContext();
+
+      const authConfig: any = {
+        protected: ['/api/*'],
+        authenticateToken: async () => null,
+        getSessionIdFromRequest: () => 'expired-session',
+        refreshSession: async () => null, // Refresh failed
+        getSessionHeaders: () => ({}),
+      };
+
+      const result = await coreAuthMiddleware({
+        ...baseCtx,
+        mastra: createMockMastra(),
+        authConfig,
+        requestContext,
+        rawRequest: createRawRequest(),
+      });
+
+      expect(result).toEqual({
+        action: 'error',
+        status: 401,
+        body: { error: 'Invalid or expired token' },
+      });
+    });
+
+    it('should return 401 when refresh throws an error', async () => {
+      const requestContext = createRequestContext();
+
+      const authConfig: any = {
+        protected: ['/api/*'],
+        authenticateToken: async () => null,
+        getSessionIdFromRequest: () => 'some-session',
+        refreshSession: async () => {
+          throw new Error('Network error during refresh');
+        },
+        getSessionHeaders: () => ({}),
+      };
+
+      const result = await coreAuthMiddleware({
+        ...baseCtx,
+        mastra: createMockMastra(),
+        authConfig,
+        requestContext,
+        rawRequest: createRawRequest(),
+      });
+
+      expect(result).toEqual({
+        action: 'error',
+        status: 401,
+        body: { error: 'Invalid or expired token' },
+      });
+    });
+
+    it('should not attempt refresh when auth provider lacks ISessionProvider methods', async () => {
+      const requestContext = createRequestContext();
+
+      const authConfig: any = {
+        protected: ['/api/*'],
+        authenticateToken: async () => null,
+        // No getSessionIdFromRequest, refreshSession, or getSessionHeaders
+      };
+
+      const result = await coreAuthMiddleware({
+        ...baseCtx,
+        mastra: createMockMastra(),
+        authConfig,
+        requestContext,
+        rawRequest: createRawRequest(),
+      });
+
+      expect(result).toEqual({
+        action: 'error',
+        status: 401,
+        body: { error: 'Invalid or expired token' },
+      });
+    });
+
+    it('should not attempt refresh when no session ID found in request', async () => {
+      const requestContext = createRequestContext();
+
+      const authConfig: any = {
+        protected: ['/api/*'],
+        authenticateToken: async () => null,
+        getSessionIdFromRequest: () => null, // No session cookie
+        refreshSession: async () => {
+          throw new Error('Should not be called');
+        },
+        getSessionHeaders: () => ({}),
+      };
+
+      const result = await coreAuthMiddleware({
+        ...baseCtx,
+        mastra: createMockMastra(),
+        authConfig,
+        requestContext,
+        rawRequest: createRawRequest(),
+      });
+
+      expect(result).toEqual({
+        action: 'error',
+        status: 401,
+        body: { error: 'Invalid or expired token' },
+      });
+    });
+
+    it('should not return refresh headers when valid on first try (no refresh needed)', async () => {
+      const requestContext = createRequestContext();
+
+      const authConfig: any = {
+        protected: ['/api/*'],
+        authenticateToken: async () => user,
+        getSessionIdFromRequest: () => 'valid-session',
+        refreshSession: async () => {
+          throw new Error('Should not be called');
+        },
+        getSessionHeaders: () => ({}),
+      };
+
+      const result = await coreAuthMiddleware({
+        ...baseCtx,
+        mastra: createMockMastra(),
+        authConfig,
+        requestContext,
+        rawRequest: createRawRequest(),
+      });
+
+      expect(result).toEqual({ action: 'next' });
+      expect(result).not.toHaveProperty('headers');
+    });
+  });
 });

--- a/packages/server/src/server/auth/helpers.ts
+++ b/packages/server/src/server/auth/helpers.ts
@@ -240,7 +240,7 @@ export interface AuthMiddlewareContext {
 
 export type AuthResult =
   | { action: 'next'; headers?: Record<string, string> }
-  | { action: 'error'; status: number; body: Record<string, unknown> };
+  | { action: 'error'; status: number; body: Record<string, unknown>; headers?: Record<string, string> };
 
 const pass: AuthResult = { action: 'next' };
 
@@ -343,7 +343,14 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
                 headers: new Headers(rawRequest.headers),
               });
               refreshedRequest.headers.set('Cookie', refreshedCookie);
-              user = await authConfig.authenticateToken(token ?? '', refreshedRequest as any);
+              // Pass the refreshed cookie value as the token so authenticateToken
+              // picks up the new session instead of the stale original.
+              // Auth providers typically read cookies from the request object, but
+              // some may also inspect the token parameter directly.
+              const cookieValue = refreshedCookie.includes('=')
+                ? refreshedCookie.split('=').slice(1).join('=')
+                : refreshedCookie;
+              user = await authConfig.authenticateToken(cookieValue, refreshedRequest as any);
             }
             if (!user) {
               refreshHeaders = undefined;
@@ -359,7 +366,7 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
     }
 
     if (!user) {
-      return { action: 'error', status: 401, body: { error: 'Invalid or expired token' } };
+      return { action: 'error', status: 401, body: { error: 'Invalid or expired token' }, headers: refreshHeaders };
     }
 
     requestContext.set('user', user);
@@ -374,7 +381,12 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
         mastra.getLogger()?.error('mapUserToResourceId failed', {
           error: mapError instanceof Error ? { message: mapError.message, stack: mapError.stack } : mapError,
         });
-        return { action: 'error', status: 500, body: { error: 'Failed to map authenticated user to a resource ID' } };
+        return {
+          action: 'error',
+          status: 500,
+          body: { error: 'Failed to map authenticated user to a resource ID' },
+          headers: refreshHeaders,
+        };
       }
     }
 
@@ -402,7 +414,7 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
     mastra.getLogger()?.error('Authentication error', {
       error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
     });
-    return { action: 'error', status: 401, body: { error: 'Invalid or expired token' } };
+    return { action: 'error', status: 401, body: { error: 'Invalid or expired token' }, headers: refreshHeaders };
   }
 
   // ── Authorization ──
@@ -412,13 +424,13 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
       const isAuthorized = await authConfig.authorizeUser(user, rawRequest as any);
 
       if (!isAuthorized) {
-        return { action: 'error', status: 403, body: { error: 'Access denied' } };
+        return { action: 'error', status: 403, body: { error: 'Access denied' }, headers: refreshHeaders };
       }
     } catch (err) {
       mastra.getLogger()?.error('Authorization error in authorizeUser', {
         error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
       });
-      return { action: 'error', status: 500, body: { error: 'Authorization error' } };
+      return { action: 'error', status: 500, body: { error: 'Authorization error' }, headers: refreshHeaders };
     }
   } else if ('authorize' in authConfig && typeof authConfig.authorize === 'function') {
     try {
@@ -426,7 +438,7 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
       const isAuthorized = await authConfig.authorize(path, method, user, authorizeCtx as any);
 
       if (!isAuthorized) {
-        return { action: 'error', status: 403, body: { error: 'Access denied' } };
+        return { action: 'error', status: 403, body: { error: 'Access denied' }, headers: refreshHeaders };
       }
     } catch (err) {
       mastra.getLogger()?.error('Authorization error in authorize', {
@@ -434,13 +446,13 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
         path,
         method,
       });
-      return { action: 'error', status: 500, body: { error: 'Authorization error' } };
+      return { action: 'error', status: 500, body: { error: 'Authorization error' }, headers: refreshHeaders };
     }
   } else if ('rules' in authConfig && authConfig.rules && authConfig.rules.length > 0) {
     const isAuthorized = await checkRules(authConfig.rules, path, method, user);
 
     if (!isAuthorized) {
-      return { action: 'error', status: 403, body: { error: 'Access denied' } };
+      return { action: 'error', status: 403, body: { error: 'Access denied' }, headers: refreshHeaders };
     }
   } else {
     // No explicit authorization configured (authorizeUser, authorize, or rules)
@@ -452,10 +464,10 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
         const isAuthorized = await checkRules(defaultAuthConfig.rules, path, method, user);
 
         if (!isAuthorized) {
-          return { action: 'error', status: 403, body: { error: 'Access denied' } };
+          return { action: 'error', status: 403, body: { error: 'Access denied' }, headers: refreshHeaders };
         }
       } else {
-        return { action: 'error', status: 403, body: { error: 'Access denied' } };
+        return { action: 'error', status: 403, body: { error: 'Access denied' }, headers: refreshHeaders };
       }
     }
   }

--- a/packages/server/src/server/auth/helpers.ts
+++ b/packages/server/src/server/auth/helpers.ts
@@ -1,7 +1,7 @@
 import type { ISessionProvider } from '@mastra/core/auth';
 import type { IRBACProvider, EEUser } from '@mastra/core/auth/ee';
 import type { Mastra } from '@mastra/core/mastra';
-import type { MastraAuthConfig } from '@mastra/core/server';
+import type { MastraAuthConfig, MastraAuthProvider } from '@mastra/core/server';
 import type { HonoRequest } from 'hono';
 
 import { MASTRA_RESOURCE_ID_KEY } from '../constants';
@@ -272,9 +272,9 @@ export const getAuthenticatedUser = async <TUser = unknown>({
  * Check if an auth config object supports transparent session refresh.
  * Returns true if the auth provider implements the necessary ISessionProvider methods.
  */
-function supportsSessionRefresh(
-  authConfig: MastraAuthConfig,
-): authConfig is MastraAuthConfig &
+export function supportsSessionRefresh(
+  authConfig: MastraAuthConfig | MastraAuthProvider,
+): authConfig is (MastraAuthConfig | MastraAuthProvider) &
   Pick<ISessionProvider, 'refreshSession' | 'getSessionIdFromRequest' | 'getSessionHeaders'> {
   return (
     typeof (authConfig as any).getSessionIdFromRequest === 'function' &&

--- a/packages/server/src/server/auth/helpers.ts
+++ b/packages/server/src/server/auth/helpers.ts
@@ -1,3 +1,4 @@
+import type { ISessionProvider } from '@mastra/core/auth';
 import type { IRBACProvider, EEUser } from '@mastra/core/auth/ee';
 import type { Mastra } from '@mastra/core/mastra';
 import type { MastraAuthConfig } from '@mastra/core/server';
@@ -237,7 +238,9 @@ export interface AuthMiddlewareContext {
   buildAuthorizeContext: () => unknown;
 }
 
-export type AuthResult = { action: 'next' } | { action: 'error'; status: number; body: Record<string, unknown> };
+export type AuthResult =
+  | { action: 'next'; headers?: Record<string, string> }
+  | { action: 'error'; status: number; body: Record<string, unknown> };
 
 const pass: AuthResult = { action: 'next' };
 
@@ -264,6 +267,21 @@ export const getAuthenticatedUser = async <TUser = unknown>({
 
   return (await authConfig.authenticateToken(normalizedToken, request as any)) as TUser | null;
 };
+
+/**
+ * Check if an auth config object supports transparent session refresh.
+ * Returns true if the auth provider implements the necessary ISessionProvider methods.
+ */
+function supportsSessionRefresh(
+  authConfig: MastraAuthConfig,
+): authConfig is MastraAuthConfig &
+  Pick<ISessionProvider, 'refreshSession' | 'getSessionIdFromRequest' | 'getSessionHeaders'> {
+  return (
+    typeof (authConfig as any).getSessionIdFromRequest === 'function' &&
+    typeof (authConfig as any).refreshSession === 'function' &&
+    typeof (authConfig as any).getSessionHeaders === 'function'
+  );
+}
 
 /**
  * Single auth middleware: authenticate → authorize.
@@ -293,12 +311,51 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
   // ── Authentication ──
 
   let user: unknown;
+  let refreshHeaders: Record<string, string> | undefined;
 
   try {
     if (typeof authConfig.authenticateToken === 'function') {
       user = await authConfig.authenticateToken(token ?? '', rawRequest as any);
     } else {
       throw new Error('No token verification method configured');
+    }
+
+    // If authentication failed, attempt transparent session refresh before returning 401.
+    // This handles expired access tokens without requiring client-side refresh logic.
+    if (!user && supportsSessionRefresh(authConfig) && rawRequest instanceof Request) {
+      try {
+        const sessionId = authConfig.getSessionIdFromRequest(rawRequest);
+        if (sessionId) {
+          const newSession = await authConfig.refreshSession(sessionId);
+          if (newSession) {
+            // Refresh succeeded — build updated session headers and re-authenticate.
+            // We create a synthetic request with the new session cookie so
+            // authenticateToken (which reads cookies from the request) picks up
+            // the refreshed session instead of the expired one.
+            refreshHeaders = authConfig.getSessionHeaders(newSession);
+            const refreshedCookie = Object.entries(refreshHeaders)
+              .filter(([k]) => k.toLowerCase() === 'set-cookie')
+              .map(([, v]) => v.split(';')[0]) // Extract name=value before attributes
+              .join('; ');
+            if (refreshedCookie) {
+              const refreshedRequest = new Request(rawRequest.url, {
+                method: rawRequest.method,
+                headers: new Headers(rawRequest.headers),
+              });
+              refreshedRequest.headers.set('Cookie', refreshedCookie);
+              user = await authConfig.authenticateToken(token ?? '', refreshedRequest as any);
+            }
+            if (!user) {
+              refreshHeaders = undefined;
+            }
+          }
+        }
+      } catch (refreshErr) {
+        refreshHeaders = undefined;
+        mastra.getLogger()?.debug('Session refresh failed, falling back to 401', {
+          error: refreshErr instanceof Error ? { message: refreshErr.message } : refreshErr,
+        });
+      }
     }
 
     if (!user) {
@@ -403,7 +460,7 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
     }
   }
 
-  return pass;
+  return refreshHeaders ? { action: 'next', headers: refreshHeaders } : pass;
 };
 
 // Check authorization rules

--- a/packages/server/src/server/handlers/auth.ts
+++ b/packages/server/src/server/handlers/auth.ts
@@ -18,6 +18,7 @@ import type {
 import type { IRBACProvider, EEUser } from '@mastra/core/auth/ee';
 import type { MastraAuthProvider } from '@mastra/core/server';
 
+import { supportsSessionRefresh } from '../auth/helpers';
 import { HTTPException } from '../http-exception';
 import {
   capabilitiesResponseSchema,
@@ -143,12 +144,58 @@ export const GET_AUTH_CAPABILITIES_ROUTE = createPublicRoute({
       }
       const capabilities = await buildCapabilities(auth, request, { rbac, apiPrefix: routePrefix });
 
+      // If capabilities came back without a user, the session may have expired.
+      // Attempt a transparent refresh (same logic as coreAuthMiddleware) and retry.
+      if (!('user' in capabilities) && supportsSessionRefresh(auth)) {
+        try {
+          const sessionId = await auth.getSessionIdFromRequest(request);
+          if (sessionId) {
+            const refreshedSession = await auth.refreshSession(sessionId);
+            if (refreshedSession) {
+              const sessionHeaders = await auth.getSessionHeaders(refreshedSession);
+              const cookieValue = extractCookieFromHeaders(sessionHeaders);
+              if (cookieValue) {
+                // Rebuild capabilities with the refreshed cookie
+                const refreshedRequest = new Request(request.url, {
+                  method: request.method,
+                  headers: new Headers(request.headers),
+                });
+                refreshedRequest.headers.set('Cookie', cookieValue);
+                const refreshedCapabilities = await buildCapabilities(auth, refreshedRequest, {
+                  rbac,
+                  apiPrefix: routePrefix,
+                });
+
+                // Attach refresh headers so the adapter can set the new cookie
+                if ('user' in refreshedCapabilities) {
+                  (refreshedCapabilities as any).__refreshHeaders = sessionHeaders;
+                }
+                return refreshedCapabilities;
+              }
+            }
+          }
+        } catch {
+          // Refresh failed — return original unauthenticated capabilities
+        }
+      }
+
       return capabilities;
     } catch (error) {
       return handleError(error, 'Error getting auth capabilities');
     }
   },
 });
+
+/**
+ * Extract a full cookie string from session headers (e.g. Set-Cookie → Cookie).
+ */
+function extractCookieFromHeaders(headers: Record<string, string>): string | null {
+  const setCookie = headers['Set-Cookie'] || headers['set-cookie'];
+  if (!setCookie) return null;
+  // Set-Cookie value is "name=value; Path=/; ..." — extract "name=value"
+  const match = setCookie.match(/^([^;]+)/);
+  return match ? (match[1] ?? null) : null;
+}
 
 // ============================================================================
 // GET /auth/me

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -418,7 +418,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
 
     // Translate AuthResult error to the {status, error} format adapters expect
     const errorBody = result.body as { error?: string } | undefined;
-    return { status: result.status, error: errorBody?.error ?? 'Access denied' };
+    return { status: result.status, error: errorBody?.error ?? 'Access denied', headers: result.headers };
   }
 
   /**

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -373,7 +373,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
       /** Build framework-specific context for authorize() callback */
       buildAuthorizeContext?: () => unknown;
     },
-  ): Promise<{ status: number; error: string } | null> {
+  ): Promise<{ status: number; error: string; headers?: Record<string, string> } | null> {
     const authConfig = this.mastra.getServer()?.auth;
 
     // No auth config means no auth required
@@ -409,6 +409,10 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     });
 
     if (result.action === 'next') {
+      // Pass through any refresh headers (e.g. Set-Cookie from transparent session refresh)
+      if (result.headers) {
+        return { status: 200, error: '', headers: result.headers };
+      }
       return null;
     }
 

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -280,6 +280,15 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
   ): Promise<void> {
     const resolvedPrefix = prefix ?? this.prefix ?? '';
 
+    // Apply refresh headers from transparent session refresh (e.g. Set-Cookie after token refresh)
+    if (result && typeof result === 'object' && '__refreshHeaders' in result) {
+      const refreshHeaders = (result as any).__refreshHeaders as Record<string, string>;
+      for (const [key, value] of Object.entries(refreshHeaders)) {
+        response.setHeader(key, value);
+      }
+      delete (result as any).__refreshHeaders;
+    }
+
     if (route.responseType === 'json') {
       response.json(result);
     } else if (route.responseType === 'stream') {

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -425,7 +425,17 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
         });
 
         if (authError) {
-          return res.status(authError.status).json({ error: authError.error });
+          // Apply any refresh headers (e.g. Set-Cookie from transparent session refresh)
+          if (authError.headers) {
+            for (const [key, value] of Object.entries(authError.headers)) {
+              res.setHeader(key, value);
+            }
+          }
+
+          // If this is an auth error (not just a success-with-headers), return error response
+          if (authError.error) {
+            return res.status(authError.status).json({ error: authError.error });
+          }
         }
 
         const params = await this.getParams(route, req);
@@ -583,7 +593,14 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
         });
 
         if (authError) {
-          return res.status(authError.status).json({ error: authError.error });
+          if (authError.headers) {
+            for (const [key, value] of Object.entries(authError.headers)) {
+              res.setHeader(key, value);
+            }
+          }
+          if (authError.error) {
+            return res.status(authError.status).json({ error: authError.error });
+          }
         }
 
         const authConfig = this.mastra.getServer()?.auth;

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -457,7 +457,17 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
       });
 
       if (authError) {
-        return reply.status(authError.status).send({ error: authError.error });
+        // Apply any refresh headers (e.g. Set-Cookie from transparent session refresh)
+        if (authError.headers) {
+          for (const [key, value] of Object.entries(authError.headers)) {
+            void reply.header(key, value);
+          }
+        }
+
+        // If this is an auth error (not just a success-with-headers), return error response
+        if (authError.error) {
+          return reply.status(authError.status).send({ error: authError.error });
+        }
       }
 
       const params = await this.getParams(route, request);
@@ -652,7 +662,14 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         });
 
         if (authError) {
-          return reply.status(authError.status).send({ error: authError.error });
+          if (authError.headers) {
+            for (const [key, value] of Object.entries(authError.headers)) {
+              void reply.header(key, value);
+            }
+          }
+          if (authError.error) {
+            return reply.status(authError.status).send({ error: authError.error });
+          }
         }
 
         const authConfig = this.mastra.getServer()?.auth;

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -309,6 +309,15 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
   ): Promise<void> {
     const resolvedPrefix = prefix ?? this.prefix ?? '';
 
+    // Apply refresh headers from transparent session refresh (e.g. Set-Cookie after token refresh)
+    if (result && typeof result === 'object' && '__refreshHeaders' in result) {
+      const refreshHeaders = (result as any).__refreshHeaders as Record<string, string>;
+      for (const [key, value] of Object.entries(refreshHeaders)) {
+        reply.header(key, value);
+      }
+      delete (result as any).__refreshHeaders;
+    }
+
     if (route.responseType === 'json') {
       await reply.send(result);
     } else if (route.responseType === 'stream') {

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -383,7 +383,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
       ...middlewares,
       async (c: Context) => {
         // Check route-level authentication/authorization
-        const authError = await this.checkRouteAuth(route, {
+        const authResult = await this.checkRouteAuth(route, {
           path: c.req.path,
           method: c.req.method,
           getHeader: name => c.req.header(name),
@@ -393,8 +393,18 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           buildAuthorizeContext: () => c,
         });
 
-        if (authError) {
-          return c.json({ error: authError.error }, authError.status as any);
+        if (authResult) {
+          // Apply any refresh headers (e.g. Set-Cookie from transparent session refresh)
+          if (authResult.headers) {
+            for (const [key, value] of Object.entries(authResult.headers)) {
+              c.header(key, value as string);
+            }
+          }
+
+          // If this is an auth error (not just a success-with-headers), return error response
+          if (authResult.error) {
+            return c.json({ error: authResult.error }, authResult.status as any);
+          }
         }
 
         const params = await this.getParams(route, c.req);
@@ -585,7 +595,14 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
         });
 
         if (authError) {
-          return c.json({ error: authError.error }, authError.status as any);
+          if (authError.headers) {
+            for (const [key, value] of Object.entries(authError.headers)) {
+              c.header(key, value as string);
+            }
+          }
+          if (authError.error) {
+            return c.json({ error: authError.error }, authError.status as any);
+          }
         }
 
         const authConfig = this.mastra.getServer()?.auth;

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -286,6 +286,15 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
   async sendResponse(route: ServerRoute, response: Context, result: unknown, prefix?: string): Promise<any> {
     const resolvedPrefix = prefix ?? this.prefix ?? '';
 
+    // Apply refresh headers from transparent session refresh (e.g. Set-Cookie after token refresh)
+    if (result && typeof result === 'object' && '__refreshHeaders' in result) {
+      const refreshHeaders = (result as any).__refreshHeaders as Record<string, string>;
+      for (const [key, value] of Object.entries(refreshHeaders)) {
+        response.header(key, value);
+      }
+      delete (result as any).__refreshHeaders;
+    }
+
     if (route.responseType === 'json') {
       return response.json(result as any, 200);
     } else if (route.responseType === 'stream') {

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -400,6 +400,15 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
   async sendResponse(route: ServerRoute, ctx: Context, result: unknown, prefix?: string): Promise<void> {
     const resolvedPrefix = prefix ?? this.prefix ?? '';
 
+    // Apply refresh headers from transparent session refresh (e.g. Set-Cookie after token refresh)
+    if (result && typeof result === 'object' && '__refreshHeaders' in result) {
+      const refreshHeaders = (result as any).__refreshHeaders as Record<string, string>;
+      for (const [key, value] of Object.entries(refreshHeaders)) {
+        ctx.set(key, value);
+      }
+      delete (result as any).__refreshHeaders;
+    }
+
     if (route.responseType === 'json') {
       // Explicitly set content-type and handle null/undefined to ensure proper JSON response
       // Koa sets 204 No Content when body is null, but we want to return JSON null

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -562,9 +562,19 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       });
 
       if (authError) {
-        ctx.status = authError.status;
-        ctx.body = { error: authError.error };
-        return;
+        // Apply any refresh headers (e.g. Set-Cookie from transparent session refresh)
+        if (authError.headers) {
+          for (const [key, value] of Object.entries(authError.headers)) {
+            ctx.set(key, value);
+          }
+        }
+
+        // If this is an auth error (not just a success-with-headers), return error response
+        if (authError.error) {
+          ctx.status = authError.status;
+          ctx.body = { error: authError.error };
+          return;
+        }
       }
 
       const params = await this.getParams(route, ctx);
@@ -764,9 +774,16 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         });
 
         if (authError) {
-          ctx.status = authError.status;
-          ctx.body = { error: authError.error };
-          return;
+          if (authError.headers) {
+            for (const [key, value] of Object.entries(authError.headers)) {
+              ctx.set(key, value);
+            }
+          }
+          if (authError.error) {
+            ctx.status = authError.status;
+            ctx.body = { error: authError.error };
+            return;
+          }
         }
 
         const authConfig = this.mastra.getServer()?.auth;


### PR DESCRIPTION
## Summary

When an access token expires, deployed Studios return a 401 to the browser and rely on client-side `fetchWithRefresh` logic to call `/auth/refresh`, retry the request, and hope the QueryCache error handler doesn't nuke auth state first. This race condition is the primary cause of users being unexpectedly signed out.

This PR moves session refresh into the server-side auth middleware so it happens transparently in a single request. Clients never see a 401 for a recoverable token expiry — only truly dead sessions (refresh token expired) produce a 401.

## Changes

- **`@mastra/server` — `coreAuthMiddleware`**: When `authenticateToken()` returns null and the auth provider implements `ISessionProvider` (`refreshSession`, `getSessionIdFromRequest`, `getSessionHeaders`), the middleware now refreshes the session, builds updated `Set-Cookie` headers, re-authenticates with the refreshed session, and returns the headers in a new optional `headers` field on `AuthResult`.
- **All server adapters (Hono, Express, Fastify, Koa)**: Propagate refresh headers from `AuthResult` onto the HTTP response for both standard and custom API routes.
- **`@mastra/auth-studio` — diagnostic logging**: Replaced silent `catch { return null }` blocks in `verifySessionCookie`, `handleCallback`, `refreshSession`, and `verifyBearerToken` with structured logging so SSO callback and session-validation failures are diagnosable instead of silently swallowed.

## Test Plan

- Added 2 new tests to `packages/server/src/server/auth/helpers.test.ts`:
  - "transparently refreshes expired session and proceeds" — mocks expired token → refresh success → re-auth success
  - "returns 401 when refresh token is also expired" — mocks expired token → refresh returns null → 401
- All 1049 server tests pass (`pnpm test:server`)
- All 82 `@mastra/auth-studio` tests pass
- All adapter auth-middleware tests pass (Hono, Express)
- TypeScript compilation clean across all changed packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When your login cookie briefly expires, the server now quietly refreshes it and gives the browser the new cookie so you stay signed in instead of getting kicked out.

## Overview

Implements transparent server-side session refresh to avoid 401 cascades from recoverable access-token expiry. If an auth provider implements ISessionProvider (refreshSession, getSessionIdFromRequest, getSessionHeaders), core middleware will attempt a refresh, return refreshed Set-Cookie headers to the client, and re-run authentication; only an expired refresh token results in a 401.

## Changes

### Core Authentication Middleware
- AuthResult extended to optionally include headers: `headers?: Record<string,string>` for both success (`action: 'next'`) and error responses.
- Added `supportsSessionRefresh(authConfig)` type guard.
- coreAuthMiddleware now:
  - When `authenticateToken()` returns null and provider supports session refresh (and the raw request is a Request), attempts `getSessionIdFromRequest()` → `refreshSession()` → `getSessionHeaders()`.
  - Synthesizes a new Request with the refreshed Cookie, re-runs `authenticateToken()`, and returns the refreshed headers on success (`action: 'next'`) or on error responses when present.
  - Logs refresh failures (debug) and falls back to existing unauthenticated/authorization flows; refresh failures that indicate expired refresh tokens lead to 401s.

### /auth/capabilities handler
- For the public capabilities route (which bypasses coreAuthMiddleware), the handler will attempt a best-effort refresh when the capabilities response has no `user` and the provider supports session refresh; if successful, it attaches `__refreshHeaders` to the capabilities response so adapters can set cookies.

### Server Adapters
- Hono, Express, Fastify, and Koa adapters:
  - Propagate refresh Set-Cookie headers (via `authResult.headers` or internal `__refreshHeaders`) onto HTTP responses for both standard and custom API routes.
  - Apply headers before conditionally emitting JSON error bodies so refreshed cookies reach clients even when an auth error is returned or when the auth flow yields headers-only.

### Diagnostic Logging (@mastra/auth-studio)
- Replaced silent `catch { return null }` patterns with structured logging:
  - `handleCallback` logs debug on entry and error on session validation failures.
  - `refreshSession`, `verifySessionCookie`, and `verifyBearerToken` log warnings on non-OK shared-API responses and errors with contextual details on fetch exceptions.
- `refreshSession()` now uses POST and warns when expected Set-Cookie is missing.

### Types & API surface
- Added exported `supportsSessionRefresh` helper.
- Updated exported `AuthResult` union to include optional `headers` on both success and error shapes.

### Tests & Verification
- Added tests verifying:
  - Successful transparent refresh → middleware re-authenticates, returns `action: 'next'` and refresh headers (Set-Cookie).
  - Refresh failure → middleware returns 401 with `{ error: 'Invalid or expired token' }`.
  - No refresh attempted when provider lacks ISessionProvider methods or when no session ID is present.
  - No-refresh-needed when initial `authenticateToken` succeeds.
- Reported verification: all server tests (1049) pass, all `@mastra/auth-studio` tests (82) pass, adapter auth-middleware tests pass, and TypeScript compiles clean across changed packages.
- Added a Changeset release note documenting behavior change.

## User-facing effect

Recoverable access-token expiry is handled server-side and transparently sets refreshed session cookies for clients so browsers do not experience unexpected sign-outs; only truly expired refresh tokens result in an HTTP 401.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->