### PR TITLE
fix peerdep version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -121,6 +121,8 @@ jobs:
           install-dependencies: false
 
       - name: Install dependencies
+        env:
+          npm_config_trust_policy: no-check
         run: pnpm add -w --no-lockfile globby
 
       - name: Run examples validator
@@ -171,6 +173,8 @@ jobs:
           install-dependencies: false
 
       - name: Install dependencies
+        env:
+          npm_config_trust_policy: no-check
         run: pnpm add -w --no-lockfile semver
 
       - name: bump versions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -121,9 +121,7 @@ jobs:
           install-dependencies: false
 
       - name: Install dependencies
-        env:
-          npm_config_trust_policy: no-check
-        run: pnpm add -w --no-lockfile globby
+        run: pnpm --config.trust-policy=no-check add -w --no-lockfile globby
 
       - name: Run examples validator
         run: node .github/scripts/validate-examples.js
@@ -173,9 +171,7 @@ jobs:
           install-dependencies: false
 
       - name: Install dependencies
-        env:
-          npm_config_trust_policy: no-check
-        run: pnpm add -w --no-lockfile semver
+        run: pnpm --config.trust-policy=no-check add -w --no-lockfile semver
 
       - name: bump versions
         run: npx changeset version

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -38,6 +38,8 @@ jobs:
         uses: ./.github/actions/setup-pnpm-node
 
       - name: Install dependencies
+        env:
+          npm_config_trust_policy: no-check
         run: pnpm add -w --no-lockfile @octokit/rest fs-extra dotenv --no-lockfile
 
       - name: Run Template Sync Script

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -38,9 +38,7 @@ jobs:
         uses: ./.github/actions/setup-pnpm-node
 
       - name: Install dependencies
-        env:
-          npm_config_trust_policy: no-check
-        run: pnpm add -w --no-lockfile @octokit/rest fs-extra dotenv --no-lockfile
+        run: pnpm --config.trust-policy=no-check add -w --no-lockfile @octokit/rest fs-extra dotenv
 
       - name: Run Template Sync Script
         env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

CI workflow steps were failing to temporarily install small helper packages because pnpm refused to "trust" them; this change tells pnpm to skip the trust check for those ad-hoc installs so the workflows can proceed.

## Changes

- Updated .github/workflows/lint.yml:
  - Modified the "Install dependencies" steps in the validator and peerdeps-check jobs to run pnpm with an explicit trust-policy flag: `pnpm --config.trust-policy=no-check add -w --no-lockfile globby` and `pnpm --config.trust-policy=no-check add -w --no-lockfile semver`.

- Updated .github/workflows/sync-templates.yml:
  - Changed the "Install dependencies" step to use `pnpm --config.trust-policy=no-check add -w --no-lockfile @octokit/rest fs-extra dotenv` (removed a duplicate `--no-lockfile` and added `--config.trust-policy=no-check`).

## Impact

- Unblocks CI workflow steps that perform temporary dependency installs by disabling pnpm's package trust check for those commands.
- No changes to application code or exported/public APIs.
- Low-risk configuration change limited to GitHub Actions workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->