### PR TITLE
fix(core): pass resourceId when executing workflow as tool

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4196,7 +4196,7 @@ export class Agent<
                 resourceId,
               });
 
-              const run = await workflow.createRun({ runId: runIdToUse });
+              const run = await workflow.createRun({ runId: runIdToUse, resourceId });
               const { resumeData, suspend } = context?.agent ?? {};
 
               let result: WorkflowResult<any, any, any, any> | undefined = undefined;


### PR DESCRIPTION
## Description

## Problem

When an agent executes a workflow through the generated `workflow-*` tool, `Agent.listWorkflows()` resolves and logs `resourceId`, but does not pass it to `workflow.createRun()`.

As a result, workflow runs created via workflow tools are persisted with `resourceId: null`, even though the resource ID is available in the execution context.

## Fix

Pass the resolved `resourceId` into `workflow.createRun()`.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

When an agent runs a workflow as a tool, the system knows who's running it (the `resourceId`), but it was forgetting to tell the workflow about it. This fix makes sure the system remembers to pass that information along so the workflow run is properly tagged with who created it.

## Summary

This PR fixes a bug where workflow runs created by agents executing workflows as tools were missing the `resourceId` attribute, even though it was available in the execution context.

### Changes

**`packages/core/src/agent/agent.ts`**

Updated the `listWorkflowTools` method to pass the resolved `resourceId` parameter to `workflow.createRun()`. Previously, only the `runId` was being passed; now both `runId` and `resourceId` are included:

```
- const run = await workflow.createRun({ runId: runIdToUse });
+ const run = await workflow.createRun({ runId: runIdToUse, resourceId });
```

The `resourceId` is already available in the method's execution context and is being logged in debug statements, but was not being forwarded to the workflow run creation. This change ensures workflow runs are properly persisted with the correct resource ID for audit, tracking, and multi-tenancy purposes.

### Impact

- **Type**: Bug fix (non-breaking)
- **Lines changed**: +1/-1
- **API changes**: None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->