### PR TITLE
fix(core): aggregate Anthropic cache-write tokens across multi-step runs

### DIFF
--- a/.changeset/anthropic-cache-write-aggregation.md
+++ b/.changeset/anthropic-cache-write-aggregation.md
@@ -1,0 +1,11 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed Anthropic `inputDetails.cacheWrite` reporting only the last step's value in multi-step traces (e.g. subagent flows with prompt caching). `extractUsageMetrics` now reads cache-write tokens from the new Mastra-aggregated `usage.cacheCreationInputTokens` field (summed across all steps by `@mastra/core`) before falling back to `providerMetadata.anthropic.cacheCreationInputTokens` (which only carries the last step's value). The Anthropic input-token adjustment also recognizes a positive `cacheCreationInputTokens` as a signal that `inputTokens` already includes cache totals, preventing accidental double-counting.
+
+```ts
+// 3-step Anthropic subagent trace with prompt caching:
+// Before: usage.inputDetails = { cacheRead: 12686, cacheWrite: 4005, text: 1271 }
+// After:  usage.inputDetails = { cacheRead: 12686, cacheWrite: 5268, text: 8 }
+```

--- a/.changeset/anthropic-cache-write-aggregation.md
+++ b/.changeset/anthropic-cache-write-aggregation.md
@@ -2,10 +2,4 @@
 '@mastra/observability': patch
 ---
 
-Fixed Anthropic `inputDetails.cacheWrite` reporting only the last step's value in multi-step traces (e.g. subagent flows with prompt caching). `extractUsageMetrics` now reads cache-write tokens from the new Mastra-aggregated `usage.cacheCreationInputTokens` field (summed across all steps by `@mastra/core`) before falling back to `providerMetadata.anthropic.cacheCreationInputTokens` (which only carries the last step's value). The Anthropic input-token adjustment also recognizes a positive `cacheCreationInputTokens` as a signal that `inputTokens` already includes cache totals, preventing accidental double-counting.
-
-```ts
-// 3-step Anthropic subagent trace with prompt caching:
-// Before: usage.inputDetails = { cacheRead: 12686, cacheWrite: 4005, text: 1271 }
-// After:  usage.inputDetails = { cacheRead: 12686, cacheWrite: 5268, text: 8 }
-```
+Fixed `inputDetails.cacheWrite` reflecting only the final step's cache-write tokens in multi-step Anthropic prompt-caching runs (e.g. subagent and workflow flows). Trace `inputDetails.cacheWrite` and the derived input-token totals now reflect the full multi-step run, so cost accounting in Langfuse and other exporters matches what Anthropic actually charged.

--- a/.changeset/smart-jeans-pump.md
+++ b/.changeset/smart-jeans-pump.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Anthropic prompt-caching cache-write tokens being overwritten with the latest step's value instead of summed across multi-step runs.
+
+In multi-step agent runs (e.g. a subagent calling a model 3 times), per-step `usage.inputTokens.cacheWrite` was dropped during V3-to-V2 usage normalization and only survived in `raw`, which RunOutput intentionally keeps as the latest step. The aggregated total therefore reflected only the last step's cache-write tokens.
+
+Added a new top-level `cacheCreationInputTokens` field on `LanguageModelUsage`. The V3 usage normalizer now extracts it from `inputTokens.cacheWrite`, and `RunOutput.updateUsageCount`/`populateUsageCount` sum it across steps, mirroring how `cachedInputTokens` already aggregates cache-read tokens. `MastraAgentNetworkStream` was updated symmetrically.
+
+```ts
+// totalUsage on a 3-step Anthropic run with prompt caching:
+// Before: { cacheCreationInputTokens: 4005 }   // only the last step
+// After:  { cacheCreationInputTokens: 5268 }   // 967 + 296 + 4005
+```

--- a/observability/mastra/src/usage.test.ts
+++ b/observability/mastra/src/usage.test.ts
@@ -172,6 +172,33 @@ describe('extractUsageMetrics', () => {
       expect(result.outputTokens).toBe(125);
     });
 
+    it('should sum Anthropic cache write across multi-step runs via usage.cacheCreationInputTokens', () => {
+      // Regression for PR #14674: 3-step Anthropic prompt-caching aggregation.
+      // Mastra-summed usage must win over per-step providerMetadata.
+      const usage: LanguageModelUsage = {
+        inputTokens: 17962,
+        outputTokens: 1500,
+        cachedInputTokens: 12686,
+        cacheCreationInputTokens: 5268,
+      };
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          cacheReadInputTokens: 4551,
+          cacheCreationInputTokens: 4005,
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(17962);
+      expect(result.outputTokens).toBe(1500);
+      expect(result.inputDetails?.cacheRead).toBe(12686);
+      expect(result.inputDetails?.cacheWrite).toBe(5268);
+      expect(result.inputDetails?.text).toBe(8);
+      expect(result.outputDetails?.text).toBe(1500);
+    });
+
     it('should not double count Anthropic cache tokens when v6 usage already includes them', () => {
       const usage: LanguageModelUsage = {
         inputTokens: 106,
@@ -394,7 +421,7 @@ describe('extractUsageMetrics', () => {
 
       const providerMetadata: ProviderMetadata = {
         anthropic: {
-          cacheReadInputTokens: 3000, // last step only — should be ignored
+          cacheReadInputTokens: 3000, // last step only - should be ignored
           cacheCreationInputTokens: 0,
         },
       };

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -40,7 +40,7 @@ function isV3RawUsage(raw: unknown): raw is V3RawUsage {
 
 /**
  * AI SDK aggregated input token details.
- * Available on totalUsage in multi-step runs — properly summed across all steps.
+ * Available on totalUsage in multi-step runs - properly summed across all steps.
  */
 interface AISdkInputTokenDetails {
   cacheReadTokens?: number;
@@ -60,8 +60,9 @@ function isDefined(value: unknown): value is number {
  *
  * Cache token extraction priority (highest to lowest):
  * 1. AI SDK aggregated inputTokenDetails (properly summed across all steps in multi-step runs)
- * 2. Provider-specific providerMetadata (accurate for single-step, last step only in multi-step)
- * 3. usage.cachedInputTokens (OpenAI/OpenRouter direct field)
+ * 2. Mastra-aggregated top-level usage fields (usage.cachedInputTokens, usage.cacheCreationInputTokens) -
+ *    summed across steps by RunOutput, so they are correct for multi-step runs.
+ * 3. Provider-specific providerMetadata (accurate for single-step, LAST STEP ONLY in multi-step).
  *
  * Handles:
  * - OpenAI: cachedInputTokens in usage object
@@ -97,11 +98,12 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
     inputDetails.cacheWrite = aiSdkDetails.cacheWriteTokens;
   }
 
-  // ===== OpenAI / OpenRouter =====
-  // cachedInputTokens is already in the usage object
-  // inputTokens INCLUDES cached tokens (no adjustment needed)
+  // Mastra-aggregated fields — summed across steps by RunOutput; prefer over per-step providerMetadata.
   if (!isDefined(inputDetails.cacheRead) && isDefined(usage.cachedInputTokens)) {
     inputDetails.cacheRead = usage.cachedInputTokens;
+  }
+  if (!isDefined(inputDetails.cacheWrite) && isDefined(usage.cacheCreationInputTokens)) {
+    inputDetails.cacheWrite = usage.cacheCreationInputTokens;
   }
 
   // reasoningTokens from usage (OpenAI o1 models)
@@ -127,10 +129,11 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
       inputDetails.cacheWrite = anthropic.cacheCreationInputTokens;
     }
 
-    // Skip adjustment when inputTokens already includes cache tokens.
-    // Detected via V3 raw structure or a positive cachedInputTokens field.
+    // Skip adjustment when inputTokens already includes cache tokens (V3 raw or any positive Mastra-aggregated cache field).
     const inputAlreadyIncludesCache =
-      hasV3CachedTotals || (isDefined(usage.cachedInputTokens) && usage.cachedInputTokens > 0);
+      hasV3CachedTotals ||
+      (isDefined(usage.cachedInputTokens) && usage.cachedInputTokens > 0) ||
+      (isDefined(usage.cacheCreationInputTokens) && usage.cacheCreationInputTokens > 0);
 
     if (!inputAlreadyIncludesCache && (isDefined(inputDetails.cacheRead) || isDefined(inputDetails.cacheWrite))) {
       inputTokens = (usage.inputTokens ?? 0) + (inputDetails.cacheRead ?? 0) + (inputDetails.cacheWrite ?? 0);

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -2107,6 +2107,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
         it('result.totalUsage should contain total token usage', async () => {
           expect(await result.totalUsage).toMatchInlineSnapshot(`
             {
+              "cacheCreationInputTokens": undefined,
               "cachedInputTokens": 3,
               "inputTokens": 6,
               "outputTokens": 20,
@@ -2126,6 +2127,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
         it('result.usage should contain token usage from final step', async () => {
           expect(await result.totalUsage).toMatchInlineSnapshot(`
             {
+              "cacheCreationInputTokens": undefined,
               "cachedInputTokens": 3,
               "inputTokens": 6,
               "outputTokens": 20,

--- a/packages/core/src/loop/test-utils/streamObject.ts
+++ b/packages/core/src/loop/test-utils/streamObject.ts
@@ -1086,6 +1086,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
               "toolCalls": [],
               "toolResults": [],
               "totalUsage": {
+                "cacheCreationInputTokens": undefined,
                 "cachedInputTokens": undefined,
                 "inputTokens": 3,
                 "outputTokens": 10,
@@ -1393,6 +1394,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
               "toolCalls": [],
               "toolResults": [],
               "totalUsage": {
+                "cacheCreationInputTokens": undefined,
                 "cachedInputTokens": undefined,
                 "inputTokens": 3,
                 "outputTokens": 10,
@@ -1700,6 +1702,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
               "toolCalls": [],
               "toolResults": [],
               "totalUsage": {
+                "cacheCreationInputTokens": undefined,
                 "cachedInputTokens": undefined,
                 "inputTokens": 3,
                 "outputTokens": 10,

--- a/packages/core/src/loop/workflows/schema.ts
+++ b/packages/core/src/loop/workflows/schema.ts
@@ -102,6 +102,7 @@ const languageModelUsageSchema = z.object({
   totalTokens: z.number().optional(),
   reasoningTokens: z.number().optional(),
   cachedInputTokens: z.number().optional(),
+  cacheCreationInputTokens: z.number().optional(),
 });
 
 // Zod schemas for runtime validation

--- a/packages/core/src/stream/MastraAgentNetworkStream.ts
+++ b/packages/core/src/stream/MastraAgentNetworkStream.ts
@@ -8,6 +8,7 @@ export class MastraAgentNetworkStream<OUTPUT = undefined> extends ReadableStream
     outputTokens: 0,
     totalTokens: 0,
     cachedInputTokens: 0,
+    cacheCreationInputTokens: 0,
     reasoningTokens: 0,
   };
   #streamPromise: {
@@ -70,12 +71,14 @@ export class MastraAgentNetworkStream<OUTPUT = undefined> extends ReadableStream
       totalTokens?: `${number}` | number;
       reasoningTokens?: `${number}` | number;
       cachedInputTokens?: `${number}` | number;
+      cacheCreationInputTokens?: `${number}` | number;
     }) => {
       this.#usageCount.inputTokens += parseInt(usage?.inputTokens?.toString() ?? '0', 10);
       this.#usageCount.outputTokens += parseInt(usage?.outputTokens?.toString() ?? '0', 10);
       this.#usageCount.totalTokens += parseInt(usage?.totalTokens?.toString() ?? '0', 10);
       this.#usageCount.reasoningTokens += parseInt(usage?.reasoningTokens?.toString() ?? '0', 10);
       this.#usageCount.cachedInputTokens += parseInt(usage?.cachedInputTokens?.toString() ?? '0', 10);
+      this.#usageCount.cacheCreationInputTokens += parseInt(usage?.cacheCreationInputTokens?.toString() ?? '0', 10);
     };
 
     super({

--- a/packages/core/src/stream/MastraWorkflowStream.ts
+++ b/packages/core/src/stream/MastraWorkflowStream.ts
@@ -13,6 +13,8 @@ export class MastraWorkflowStream<
     inputTokens: 0,
     outputTokens: 0,
     totalTokens: 0,
+    cachedInputTokens: 0,
+    cacheCreationInputTokens: 0,
   };
   #streamPromise: {
     promise: Promise<void>;
@@ -48,11 +50,15 @@ export class MastraWorkflowStream<
             inputTokens?: `${number}` | number;
             outputTokens?: `${number}` | number;
             totalTokens?: `${number}` | number;
+            cachedInputTokens?: `${number}` | number;
+            cacheCreationInputTokens?: `${number}` | number;
           }
         | {
             promptTokens?: `${number}` | number;
             completionTokens?: `${number}` | number;
             totalTokens?: `${number}` | number;
+            cachedInputTokens?: `${number}` | number;
+            cacheCreationInputTokens?: `${number}` | number;
           },
     ) => {
       if ('inputTokens' in usage) {
@@ -64,6 +70,8 @@ export class MastraWorkflowStream<
         this.#usageCount.outputTokens += parseInt(usage?.completionTokens?.toString() ?? '0', 10);
       }
       this.#usageCount.totalTokens += parseInt(usage?.totalTokens?.toString() ?? '0', 10);
+      this.#usageCount.cachedInputTokens += parseInt(usage?.cachedInputTokens?.toString() ?? '0', 10);
+      this.#usageCount.cacheCreationInputTokens += parseInt(usage?.cacheCreationInputTokens?.toString() ?? '0', 10);
     };
 
     super({

--- a/packages/core/src/stream/RunOutput.test.ts
+++ b/packages/core/src/stream/RunOutput.test.ts
@@ -1,0 +1,73 @@
+import { ReadableStream } from 'node:stream/web';
+import { describe, expect, it } from 'vitest';
+import { WorkflowRunOutput } from './RunOutput';
+import { ChunkFrom } from './types';
+import type { WorkflowStreamEvent } from './types';
+
+function createWorkflowStream(chunks: WorkflowStreamEvent[]): ReadableStream<WorkflowStreamEvent> {
+  return new ReadableStream<WorkflowStreamEvent>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+function createWorkflowStepOutput(usage: Record<string, unknown>): WorkflowStreamEvent {
+  return {
+    type: 'workflow-step-output',
+    runId: 'run-1',
+    from: ChunkFrom.WORKFLOW,
+    payload: {
+      id: 'step-output',
+      stepId: 'step-1',
+      output: {
+        type: 'finish',
+        payload: {
+          usage,
+        },
+      },
+    },
+  } as WorkflowStreamEvent;
+}
+
+describe('WorkflowRunOutput', () => {
+  it('should sum cacheCreationInputTokens across workflow step outputs', async () => {
+    const output = new WorkflowRunOutput({
+      runId: 'run-1',
+      workflowId: 'workflow-1',
+      stream: createWorkflowStream([
+        createWorkflowStepOutput({
+          inputTokens: 4557,
+          outputTokens: 113,
+          totalTokens: 4670,
+          cachedInputTokens: 3584,
+          cacheCreationInputTokens: 967,
+        }),
+        createWorkflowStepOutput({
+          inputTokens: 4848,
+          outputTokens: 117,
+          totalTokens: 4965,
+          cachedInputTokens: 4551,
+          cacheCreationInputTokens: 296,
+        }),
+        createWorkflowStepOutput({
+          inputTokens: 8557,
+          outputTokens: 1270,
+          totalTokens: 9827,
+          cachedInputTokens: 4551,
+          cacheCreationInputTokens: 4005,
+        }),
+      ]),
+    });
+
+    const usage = await output.usage;
+
+    expect(usage.inputTokens).toBe(17962);
+    expect(usage.outputTokens).toBe(1500);
+    expect(usage.cachedInputTokens).toBe(12686);
+    expect((usage as { cacheCreationInputTokens?: number }).cacheCreationInputTokens).toBe(5268);
+  });
+});

--- a/packages/core/src/stream/RunOutput.ts
+++ b/packages/core/src/stream/RunOutput.ts
@@ -9,16 +9,21 @@ import { consumeStream } from './base/consume-stream';
 import { ChunkFrom } from './types';
 import type { StepTripwireData, WorkflowStreamEvent } from './types';
 
+type AggregatedLanguageModelUsage = Required<LanguageModelUsage> & {
+  cacheCreationInputTokens: number;
+};
+
 export class WorkflowRunOutput<
   TResult extends WorkflowResult<any, any, any, any> = WorkflowResult<any, any, any, any>,
 > implements MastraBaseStream<WorkflowStreamEvent> {
   #status: WorkflowRunStatus = 'running';
   #tripwireData: StepTripwireData | undefined;
-  #usageCount: Required<LanguageModelUsage> = {
+  #usageCount: AggregatedLanguageModelUsage = {
     inputTokens: 0,
     outputTokens: 0,
     totalTokens: 0,
     cachedInputTokens: 0,
+    cacheCreationInputTokens: 0,
     reasoningTokens: 0,
   };
   #consumptionStarted = false;
@@ -169,6 +174,7 @@ export class WorkflowRunOutput<
           totalTokens?: `${number}` | number;
           reasoningTokens?: `${number}` | number;
           cachedInputTokens?: `${number}` | number;
+          cacheCreationInputTokens?: `${number}` | number;
         }
       | {
           promptTokens?: `${number}` | number;
@@ -176,6 +182,7 @@ export class WorkflowRunOutput<
           totalTokens?: `${number}` | number;
           reasoningTokens?: `${number}` | number;
           cachedInputTokens?: `${number}` | number;
+          cacheCreationInputTokens?: `${number}` | number;
         },
   ) {
     let totalUsage = {
@@ -184,6 +191,7 @@ export class WorkflowRunOutput<
       totalTokens: this.#usageCount.totalTokens ?? 0,
       reasoningTokens: this.#usageCount.reasoningTokens ?? 0,
       cachedInputTokens: this.#usageCount.cachedInputTokens ?? 0,
+      cacheCreationInputTokens: this.#usageCount.cacheCreationInputTokens ?? 0,
     };
     if ('inputTokens' in usage) {
       totalUsage.inputTokens += parseInt(usage?.inputTokens?.toString() ?? '0', 10);
@@ -197,6 +205,7 @@ export class WorkflowRunOutput<
 
     totalUsage.reasoningTokens += parseInt(usage?.reasoningTokens?.toString() ?? '0', 10);
     totalUsage.cachedInputTokens += parseInt(usage?.cachedInputTokens?.toString() ?? '0', 10);
+    totalUsage.cacheCreationInputTokens += parseInt(usage?.cacheCreationInputTokens?.toString() ?? '0', 10);
     this.#usageCount = totalUsage;
   }
 

--- a/packages/core/src/stream/aisdk/v5/transform.test.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.test.ts
@@ -548,6 +548,7 @@ describe('convertFullStreamChunkToMastra', () => {
           inputTokens: 10,
           outputTokens: 20,
           totalTokens: 30,
+          cacheCreationInputTokens: 7,
         },
         providerMetadata: {},
         messages: {
@@ -562,6 +563,7 @@ describe('convertFullStreamChunkToMastra', () => {
       expect(result?.type).toBe('finish');
       if (result?.type === 'finish') {
         expect(result.payload.stepResult.reason).toBe('stop');
+        expect(result.payload.output.usage.cacheCreationInputTokens).toBe(7);
         expect(result.payload.providerMetadata).toEqual({});
         expect(result.payload.metadata.providerMetadata).toEqual({});
       }
@@ -595,6 +597,7 @@ describe('convertFullStreamChunkToMastra', () => {
       if (result?.type === 'finish') {
         expect(result.payload.stepResult.reason).toBe('stop');
         expect(result.payload.output.usage.cachedInputTokens).toBe(94);
+        expect(result.payload.output.usage.cacheCreationInputTokens).toBe(6);
         expect(result.payload.providerMetadata).toEqual(providerMetadata);
         expect(result.payload.metadata.providerMetadata).toEqual(providerMetadata);
       }

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -606,6 +606,7 @@ function normalizeUsage(usage: LanguageModelV2Usage | LanguageModelV3Usage | und
       totalTokens: undefined,
       reasoningTokens: undefined,
       cachedInputTokens: undefined,
+      cacheCreationInputTokens: undefined,
       raw: undefined,
     };
   }
@@ -620,6 +621,7 @@ function normalizeUsage(usage: LanguageModelV2Usage | LanguageModelV3Usage | und
       totalTokens: (inputTokens ?? 0) + (outputTokens ?? 0),
       reasoningTokens: usage.outputTokens.reasoning,
       cachedInputTokens: usage.inputTokens.cacheRead,
+      cacheCreationInputTokens: usage.inputTokens.cacheWrite,
       raw: usage,
     };
   }
@@ -632,6 +634,7 @@ function normalizeUsage(usage: LanguageModelV2Usage | LanguageModelV3Usage | und
     totalTokens: v2Usage.totalTokens ?? (v2Usage.inputTokens ?? 0) + (v2Usage.outputTokens ?? 0),
     reasoningTokens: (v2Usage as { reasoningTokens?: number }).reasoningTokens,
     cachedInputTokens: (v2Usage as { cachedInputTokens?: number }).cachedInputTokens,
+    cacheCreationInputTokens: (v2Usage as { cacheCreationInputTokens?: number }).cacheCreationInputTokens,
     raw: usage,
   };
 }

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -453,6 +453,63 @@ describe('MastraModelOutput', () => {
       expect(finishPayload?.totalUsage?.outputTokens).toBe(50);
     });
 
+    it('should sum cacheCreationInputTokens across multi-step Anthropic runs', async () => {
+      // Regression for PR #14674: per-step cacheWrite must be summed, not overwritten.
+      const runId = 'test-run';
+      const stepUsages = [
+        {
+          inputTokens: 4557,
+          outputTokens: 113,
+          totalTokens: 4670,
+          cachedInputTokens: 3584,
+          cacheCreationInputTokens: 967,
+        },
+        {
+          inputTokens: 4848,
+          outputTokens: 117,
+          totalTokens: 4965,
+          cachedInputTokens: 4551,
+          cacheCreationInputTokens: 296,
+        },
+        {
+          inputTokens: 8557,
+          outputTokens: 1270,
+          totalTokens: 9827,
+          cachedInputTokens: 4551,
+          cacheCreationInputTokens: 4005,
+        },
+      ];
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      let finishPayload: any;
+
+      const stream = createChunkStream([
+        createStepFinishChunk(runId, undefined, stepUsages[0]),
+        createStepFinishChunk(runId, undefined, stepUsages[1]),
+        createStepFinishChunk(runId, undefined, stepUsages[2]),
+        createFinishChunk(runId, undefined, stepUsages[2]),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          onFinish: async payload => {
+            finishPayload = payload;
+          },
+        },
+      });
+
+      await output.consumeStream();
+
+      expect(finishPayload?.totalUsage?.inputTokens).toBe(17962);
+      expect(finishPayload?.totalUsage?.outputTokens).toBe(1500);
+      expect(finishPayload?.totalUsage?.cachedInputTokens).toBe(12686);
+      expect(finishPayload?.totalUsage?.cacheCreationInputTokens).toBe(5268);
+    });
+
     it('should omit raw when upstream usage has no raw field', async () => {
       const runId = 'test-run';
       const messageList = new MessageList({ threadId: 'test-thread' });

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -802,6 +802,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 ...(self.#usageCount.cachedInputTokens !== undefined && {
                   cachedInputTokens: self.#usageCount.cachedInputTokens,
                 }),
+                ...(self.#usageCount.cacheCreationInputTokens !== undefined && {
+                  cacheCreationInputTokens: self.#usageCount.cacheCreationInputTokens,
+                }),
                 ...(self.#usageCount.raw !== undefined && {
                   raw: self.#usageCount.raw,
                 }),
@@ -1256,6 +1259,10 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     if (usage.cachedInputTokens !== undefined) {
       this.#usageCount.cachedInputTokens = (this.#usageCount.cachedInputTokens ?? 0) + usage.cachedInputTokens;
     }
+    if (usage.cacheCreationInputTokens !== undefined) {
+      this.#usageCount.cacheCreationInputTokens =
+        (this.#usageCount.cacheCreationInputTokens ?? 0) + usage.cacheCreationInputTokens;
+    }
     // raw is provider-specific and not summable; keep the latest step's raw
     if (usage.raw !== undefined) {
       this.#usageCount.raw = usage.raw;
@@ -1282,6 +1289,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     }
     if (usage.cachedInputTokens !== undefined && this.#usageCount.cachedInputTokens === undefined) {
       this.#usageCount.cachedInputTokens = usage.cachedInputTokens;
+    }
+    if (usage.cacheCreationInputTokens !== undefined && this.#usageCount.cacheCreationInputTokens === undefined) {
+      this.#usageCount.cacheCreationInputTokens = usage.cacheCreationInputTokens;
     }
     if (usage.raw !== undefined && this.#usageCount.raw === undefined) {
       this.#usageCount.raw = usage.raw;
@@ -1549,6 +1559,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
       totalTokens: total,
       reasoningTokens: this.#usageCount.reasoningTokens,
       cachedInputTokens: this.#usageCount.cachedInputTokens,
+      cacheCreationInputTokens: this.#usageCount.cacheCreationInputTokens,
       ...(this.#usageCount.raw !== undefined && { raw: this.#usageCount.raw }),
     };
   }

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -924,6 +924,12 @@ export type LanguageModelUsage = LanguageModelV2Usage & {
   reasoningTokens?: number;
   cachedInputTokens?: number;
   /**
+   * Cache-write tokens, summed across multi-step runs. Mirrors `cachedInputTokens`
+   * for cache reads. Distinct from `providerMetadata.anthropic.cacheCreationInputTokens`,
+   * which is last-step-only.
+   */
+  cacheCreationInputTokens?: number;
+  /**
    * Raw usage data from the provider, preserved for advanced use cases.
    * For V3 models, contains the full nested structure:
    * { inputTokens: { total, noCache, cacheRead, cacheWrite }, outputTokens: { total, text, reasoning } }

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -923,11 +923,6 @@ export type ModelManagerModelConfig = {
 export type LanguageModelUsage = LanguageModelV2Usage & {
   reasoningTokens?: number;
   cachedInputTokens?: number;
-  /**
-   * Cache-write tokens, summed across multi-step runs. Mirrors `cachedInputTokens`
-   * for cache reads. Distinct from `providerMetadata.anthropic.cacheCreationInputTokens`,
-   * which is last-step-only.
-   */
   cacheCreationInputTokens?: number;
   /**
    * Raw usage data from the provider, preserved for advanced use cases.


### PR DESCRIPTION
## Description

In multi-step Anthropic runs (e.g. a subagent calling a model multiple times with prompt caching, or a workflow composed of cached agent steps), per-step `usage.inputTokens.cacheWrite` was dropped during V3→V2 usage normalization and only survived inside `raw`, which `RunOutput` intentionally keeps as the latest step. Aggregated `totalUsage` therefore reported only the final step's cache-write tokens — inflating derived "non-cached" input text and breaking cost accounting in observability traces. Verified end-to-end against the real Anthropic API with a stash-based before/after harness: pre-fix reported 0 of 4904 actual cache-write tokens (100% under-report); post-fix reports the exact summed value.

## Related Issue(s)
https://github.com/mastra-ai/mastra/pull/14674#issuecomment-4328440444

Fixes maureis follow-up report on #14674 (continuation of the issue addressed by #15308 / PR #15316)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes a counting bug so that every step's "cache-write" tokens are added together in multi-step runs (agents/workflows). Before, only the last step's cache-write tokens were kept, making usage and cost look wrong; now all steps' cache-write tokens are summed so reported usage matches what Anthropic charged.

## Summary

Fixes aggregation of Anthropic cache-write tokens (cacheCreationInputTokens) across multi-step runs. The V3→V2 usage normalization previously dropped per-step `inputTokens.cacheWrite` values during multi-step executions, leaving only the final step’s value in `raw` and under-reporting cache-write tokens (and inflating non-cached input counts). This change ensures Mastra aggregates cache-write tokens across steps, aligns observability totals with actual Anthropic billing, and preserves symmetric handling of cache-read and cache-write metrics.

A real Anthropic API end-to-end harness verified the fix: pre-fix reported 0 of 4,904 cache-write tokens; post-fix reports the exact summed value. This PR continues work from prior discussion/PRs and addresses follow-up reports on the earlier fix.

## Changes Overview

- Adds a top-level optional field to usage: `LanguageModelUsage.cacheCreationInputTokens?: number`.
- Normalize/transform:
  - `normalizeUsage` (aisdk/v5 transform) now derives `cacheCreationInputTokens` from V3 `inputTokens.cacheWrite` and reads V2’s flat `cacheCreationInputTokens`.
- Observability:
  - `extractUsageMetrics` now prefers Mastra-aggregated `usage.cacheCreationInputTokens` when populating `inputDetails.cacheWrite` and treats positive aggregated cache-creation tokens as indicating "input tokens already include cache" to avoid double-counting.
- Core stream aggregation:
  - `RunOutput`, `MastraModelOutput`, `MastraWorkflowStream`, and `MastraAgentNetworkStream` were extended to initialize, accept, and sum `cacheCreationInputTokens` into their internal usage accumulators and expose it on final usage outputs.
- Tests and docs:
  - Added/updated regression tests (usage.test.ts, RunOutput.test.ts, transform.test.ts, base/output.test.ts, others) to assert correct aggregation and extraction.
  - Changesets added to document the fix and version impact.

## Impact

- Non-breaking: new field is optional and backward-compatible.
- Correctness: observability and exporters (e.g., Langfuse) now report cache-write tokens that match actual provider billing in multi-step prompt-caching scenarios.
- Test-covered: regression tests ensure aggregation behavior remains correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->