### PR TITLE
feat(core): throttle background task progress output

### DIFF
--- a/.changeset/cool-pots-fall.md
+++ b/.changeset/cool-pots-fall.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': minor
+---
+
+Added `progressThrottleMs` to background task configuration so high-frequency progress output can be coalesced before it reaches pubsub and stream consumers.
+
+```ts
+const mastra = new Mastra({
+  backgroundTasks: {
+    enabled: true,
+    progressThrottleMs: 500,
+  },
+});
+```

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -884,6 +884,124 @@ describe('BackgroundTaskManager', () => {
       abortController.abort();
     });
 
+    it('emits every progress output chunk by default', async () => {
+      const abortController = new AbortController();
+      const stream = manager.stream({ abortSignal: abortController.signal });
+      const reader = stream.getReader();
+
+      const chunk = (output: string) => ({
+        type: 'tool-output',
+        runId: 'run-1',
+        from: 'AGENT',
+        payload: { output, toolCallId: 'c1', toolName: 'tool' },
+      });
+
+      const executeFn = vi.fn().mockImplementation(async (_args: any, opts: { onProgress?: (chunk: any) => void }) => {
+        await opts.onProgress?.(chunk('first'));
+        await opts.onProgress?.(chunk('second'));
+        await opts.onProgress?.(chunk('third'));
+        return 'done';
+      });
+
+      await manager.enqueue(
+        { toolName: 'tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' },
+        ctx(executeFn),
+      );
+
+      await tick();
+
+      await reader.read(); // running
+
+      const firstOutput = await reader.read();
+      expect(firstOutput.value).toMatchObject({
+        type: 'background-task-output',
+        payload: { payload: { payload: { output: 'first' } } },
+      });
+
+      const secondOutput = await reader.read();
+      expect(secondOutput.value).toMatchObject({
+        type: 'background-task-output',
+        payload: { payload: { payload: { output: 'second' } } },
+      });
+
+      const thirdOutput = await reader.read();
+      expect(thirdOutput.value).toMatchObject({
+        type: 'background-task-output',
+        payload: { payload: { payload: { output: 'third' } } },
+      });
+
+      const completed = await reader.read();
+      expect(completed.value).toMatchObject({
+        type: 'background-task-completed',
+        payload: { result: 'done' },
+      });
+
+      abortController.abort();
+    });
+
+    it('throttles progress output chunks while still emitting completion', async () => {
+      const isolatedPubsub = new EventEmitterPubSub();
+      const mgr = new BackgroundTaskManager({ enabled: true, progressThrottleMs: 100 });
+      mgr.__registerMastra(mastra);
+      await mgr.init(isolatedPubsub);
+
+      const abortController = new AbortController();
+      const stream = mgr.stream({ abortSignal: abortController.signal });
+      const reader = stream.getReader();
+      let now = 1_000;
+      const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now);
+
+      const chunk = (output: string) => ({
+        type: 'tool-output',
+        runId: 'run-1',
+        from: 'AGENT',
+        payload: { output, toolCallId: 'c1', toolName: 'tool' },
+      });
+
+      const executeFn = vi.fn().mockImplementation(async (_args: any, opts: { onProgress?: (chunk: any) => void }) => {
+        await opts.onProgress?.(chunk('first'));
+        now += 50;
+        await opts.onProgress?.(chunk('dropped'));
+        now += 100;
+        await opts.onProgress?.(chunk('third'));
+        return 'done';
+      });
+
+      try {
+        await mgr.enqueue(
+          { toolName: 'tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' },
+          ctx(executeFn),
+        );
+
+        await tick();
+
+        await reader.read(); // running
+
+        const firstOutput = await reader.read();
+        expect(firstOutput.value).toMatchObject({
+          type: 'background-task-output',
+          payload: { payload: { payload: { output: 'first' } } },
+        });
+
+        const thirdOutput = await reader.read();
+        expect(thirdOutput.value).toMatchObject({
+          type: 'background-task-output',
+          payload: { payload: { payload: { output: 'third' } } },
+        });
+
+        const completed = await reader.read();
+        expect(completed.value).toMatchObject({
+          type: 'background-task-completed',
+          payload: { result: 'done' },
+        });
+      } finally {
+        dateNow.mockRestore();
+        abortController.abort();
+        await mgr.shutdown();
+        await isolatedPubsub.close();
+      }
+    });
+
     it('emits cancel event with cancelled status', async () => {
       const abortController = new AbortController();
       const stream = manager.stream({ abortSignal: abortController.signal });

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -558,7 +558,20 @@ export class BackgroundTaskManager {
     try {
       void this.runLocalExecutionHook(runningTask!);
       // Build onProgress callback that forwards to the task context hook
+      const progressThrottleMs = this.config.progressThrottleMs;
+      const shouldThrottleProgress =
+        typeof progressThrottleMs === 'number' && Number.isFinite(progressThrottleMs) && progressThrottleMs > 0;
+      let lastProgressEmitMs: number | undefined;
+
       const onProgress = async (chunk: any) => {
+        if (shouldThrottleProgress) {
+          const now = Date.now();
+          if (lastProgressEmitMs !== undefined && now - lastProgressEmitMs < progressThrottleMs) {
+            return;
+          }
+          lastProgressEmitMs = now;
+        }
+
         await this.publishLifecycleEvent('task.output', {
           ...task,
           chunk,

--- a/packages/core/src/background-tasks/types.ts
+++ b/packages/core/src/background-tasks/types.ts
@@ -145,6 +145,11 @@ export interface BackgroundTaskManagerConfig {
   /** Cleanup configuration for old task records */
   cleanup?: CleanupConfig;
   /**
+   * Minimum delay between chunk-based progress output events for each task, in ms.
+   * Default: undefined (publish every progress chunk).
+   */
+  progressThrottleMs?: number;
+  /**
    * How long the agentic loop waits for a background task to complete before
    * moving on (in ms). If a task hasn't finished within this time, the loop
    * proceeds without setting isContinued — allowing it to end naturally.


### PR DESCRIPTION
Adds an optional progressThrottleMs setting to background task manager config so high-frequency progress output chunks can be coalesced before pubsub and stream consumers. Terminal completion and failure events are unchanged.

Example:

```ts
const mastra = new Mastra({
  backgroundTasks: {
    enabled: true,
    progressThrottleMs: 500,
  },
});
```

Closes #15803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Imagine a machine that works on tasks and keeps telling you how it's progressing. If it talks *really* fast (hundreds of times per second), that can overwhelm other systems listening to it. This PR adds a "slow down" setting that makes the machine only report progress once every X milliseconds, while always reporting when the task is finally done. It's like batching progress reports instead of sending them one-by-one.

## Changes Overview
This PR introduces a new `progressThrottleMs` configuration option to `BackgroundTaskManager` that applies optional rate-limiting to high-frequency progress output before it reaches pubsub and streaming consumers.

## Key Changes

**Configuration**
- Added `progressThrottleMs?: number` property to `BackgroundTaskManagerConfig` (optional, undefined by default to preserve existing behavior)

**Implementation**
- Modified the `onProgress` handler in `BackgroundTaskManager` to check if throttling is enabled and configured
- When throttling is active, intermediate progress chunks emitted within the throttle window are skipped
- The throttle uses a leading-edge strategy: the first chunk is always emitted, and subsequent chunks are dropped until the configured interval has elapsed
- Terminal events (`task.completed` and `task.failed`) remain unaffected and always emit immediately, regardless of throttle state

**Testing**
- Added comprehensive test coverage including:
  - Default behavior verification (no throttling) with three progress chunks and completion event
  - Throttled behavior verification using mocked timestamps to confirm intermediate chunks are suppressed while allowing chunks after the throttle window, and completion is always emitted

## Impact
Reduces pubsub and SSE churn for high-frequency progress-emitting tools (tens–hundreds of events/sec), lowering downstream load and smoothing client render loops while maintaining task completion reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->