### PR TITLE
fix(core): isolate subagent tool results from supervisor context

### DIFF
--- a/.changeset/fifty-planets-refuse.md
+++ b/.changeset/fifty-planets-refuse.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed sub-agent delegation so nested tool results stay out of the parent model context by default while remaining available to application code. Set `delegation.includeSubAgentToolResultsInModelContext` to include the full subagent result in the parent model context.

--- a/docs/src/content/en/docs/agents/supervisor-agents.mdx
+++ b/docs/src/content/en/docs/agents/supervisor-agents.mdx
@@ -183,6 +183,22 @@ const stream = await supervisor.stream('Research AI trends', {
 
 The callback receives `messages` (the full conversation history), `primitiveId` (the subagent ID), and `prompt` (the delegation prompt). Return the filtered array of messages.
 
+## Subagent result context
+
+When a subagent completes, the supervisor model receives the subagent's text response in later iterations. Nested tool calls and subagent metadata, such as thread and resource IDs, are not added to the supervisor model context.
+
+Application code and UI integrations can still inspect the raw delegation result, including `subAgentToolResults`, from the tool result payload. This keeps debugging and display data available without sending nested tool arguments or outputs back into the supervisor's next model call.
+
+Set `includeSubAgentToolResultsInModelContext` to include the full subagent result, including nested tool results and subagent metadata, in the supervisor model context.
+
+```typescript title="src/mastra/agents/supervisor.ts"
+await supervisor.generate('Research AI trends', {
+  delegation: {
+    includeSubAgentToolResultsInModelContext: true,
+  },
+})
+```
+
 ## Iteration monitoring
 
 `onIterationComplete` is called after each iteration of the supervisor loop. Use it to log progress, inject feedback, or stop execution early.

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -3076,6 +3076,162 @@ describe('Supervisor Pattern - Message history transfer to sub-agents', () => {
     expect(promptStr).toContain('Do the task please');
   });
 
+  it('should hide sub-agent tool results from supervisor model context while preserving raw tool results', async () => {
+    const nestedToolArg = 'SECRET_NESTED_TOOL_ARG';
+    const nestedToolResult = 'SECRET_NESTED_TOOL_RESULT';
+    const rawSubAgentText = 'Task completed.';
+    const processedSubAgentText = 'Processed summary without nested tool details.';
+
+    const isTextPart = (part: unknown): part is { type: 'text'; text?: string } =>
+      typeof part === 'object' && part !== null && (part as { type?: unknown }).type === 'text';
+
+    const getAgentToolPayload = (
+      toolResult: unknown,
+    ): { toolName?: string; result?: { subAgentToolResults?: unknown } } | undefined => {
+      if (typeof toolResult !== 'object' || toolResult === null) return undefined;
+
+      const payload = (toolResult as { payload?: unknown }).payload;
+      if (typeof payload !== 'object' || payload === null) return undefined;
+
+      return payload as { toolName?: string; result?: { subAgentToolResults?: unknown } };
+    };
+
+    const textTransformProcessor: Processor<'text-transform'> = {
+      id: 'text-transform',
+      async processOutputResult(args: ProcessOutputResultArgs) {
+        return args.messages.map(msg => {
+          if (msg.role !== 'assistant') return msg;
+          const parts = msg.content?.parts ?? [];
+          return {
+            ...msg,
+            content: {
+              ...msg.content,
+              format: msg.content?.format ?? 2,
+              parts: parts.map(part => (isTextPart(part) ? { ...part, text: processedSubAgentText } : part)),
+            },
+          };
+        });
+      },
+    };
+
+    const subAgentTool = createTool({
+      id: 'lookup-secret',
+      description: 'Looks up private data',
+      inputSchema: z.object({
+        query: z.string(),
+      }),
+      execute: async ({ query }) => ({
+        query,
+        secret: nestedToolResult,
+        records: [{ id: 'private-record', value: nestedToolResult }],
+      }),
+    });
+
+    const runSupervisor = async (includeSubAgentToolResultsInModelContext?: boolean) => {
+      const supervisorPrompts: unknown[] = [];
+
+      const subAgent = new Agent({
+        id: 'context-isolation-sub-agent',
+        name: 'context-isolation-sub-agent',
+        description: 'A sub-agent that uses a nested tool',
+        instructions: 'Use lookupSecret, then summarize the result.',
+        model: makeSubAgentModelWithTool('lookupSecret', { query: nestedToolArg }),
+        tools: { lookupSecret: subAgentTool },
+        outputProcessors: [textTransformProcessor],
+      });
+
+      let supervisorCallCount = 0;
+      const supervisorAgent = new Agent({
+        id: 'context-isolation-supervisor',
+        name: 'context-isolation-supervisor',
+        instructions: 'Delegate to sub-agents.',
+        model: new MockLanguageModelV2({
+          doGenerate: async ({ prompt }) => {
+            supervisorCallCount++;
+            supervisorPrompts.push(prompt);
+
+            if (supervisorCallCount === 1) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                text: '',
+                content: [
+                  {
+                    type: 'tool-call' as const,
+                    toolCallId: 'call-1',
+                    toolName: 'agent-subAgent',
+                    input: JSON.stringify({ prompt: 'Research the private record', maxSteps: 3 }),
+                  },
+                ],
+                warnings: [],
+              };
+            }
+
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop' as const,
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              text: 'Done',
+              content: [{ type: 'text' as const, text: 'Done' }],
+              warnings: [],
+            };
+          },
+        }),
+        agents: { subAgent },
+        memory: new MockMemory(),
+      });
+
+      const delegation =
+        includeSubAgentToolResultsInModelContext === undefined ? {} : { includeSubAgentToolResultsInModelContext };
+
+      const result = await supervisorAgent.generate('Delegate this task', {
+        maxSteps: 5,
+        delegation,
+      });
+
+      expect(supervisorPrompts.length).toBeGreaterThanOrEqual(2);
+
+      return {
+        result,
+        supervisorContextAfterDelegation: JSON.stringify(supervisorPrompts[1]),
+      };
+    };
+
+    const assertTextOnlySupervisorContext = (supervisorContextAfterDelegation: string) => {
+      expect(supervisorContextAfterDelegation).toContain(processedSubAgentText);
+      expect(supervisorContextAfterDelegation).not.toContain(rawSubAgentText);
+      expect(supervisorContextAfterDelegation).not.toContain('subAgentToolResults');
+      expect(supervisorContextAfterDelegation).not.toContain(nestedToolArg);
+      expect(supervisorContextAfterDelegation).not.toContain(nestedToolResult);
+    };
+
+    const implicitDefaultRun = await runSupervisor();
+    assertTextOnlySupervisorContext(implicitDefaultRun.supervisorContextAfterDelegation);
+
+    const defaultRun = await runSupervisor(false);
+    const supervisorContextAfterDelegation = defaultRun.supervisorContextAfterDelegation;
+    assertTextOnlySupervisorContext(supervisorContextAfterDelegation);
+
+    const agentToolResult = defaultRun.result.toolResults
+      .map(getAgentToolPayload)
+      .find(payload => payload?.toolName === 'agent-subAgent')?.result;
+
+    expect(agentToolResult?.subAgentToolResults).toEqual([
+      expect.objectContaining({
+        toolName: 'lookupSecret',
+        args: { query: nestedToolArg },
+        result: expect.objectContaining({ secret: nestedToolResult }),
+      }),
+    ]);
+
+    const optInRun = await runSupervisor(true);
+    expect(optInRun.supervisorContextAfterDelegation).toContain(processedSubAgentText);
+    expect(optInRun.supervisorContextAfterDelegation).toContain('subAgentToolResults');
+    expect(optInRun.supervisorContextAfterDelegation).toContain(nestedToolArg);
+    expect(optInRun.supervisorContextAfterDelegation).toContain(nestedToolResult);
+  });
+
   it('should save only the last user message and response to sub-agent memory (not full supervisor context)', async () => {
     // The supervisor forwards ALL messages as context to the sub-agent (so it can see
     // the full conversation history), but only the immediate delegation prompt + response

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3261,8 +3261,8 @@ export class Agent<
               z.object({
                 toolName: z.string().describe('The name of the tool'),
                 toolCallId: z.string().describe('The ID of the tool call'),
-                result: z.any().describe('The result of the tool call'),
-                args: z.any().describe('The arguments of the tool call').optional(),
+                result: z.unknown().describe('The result of the tool call'),
+                args: z.unknown().describe('The arguments of the tool call').optional(),
                 isError: z.boolean().describe('Whether the tool call resulted in an error').optional(),
               }),
             )
@@ -3270,12 +3270,20 @@ export class Agent<
             .optional(),
         });
 
+        const toModelOutput = delegation?.includeSubAgentToolResultsInModelContext
+          ? undefined
+          : (output: z.infer<typeof agentOutputSchema>) => ({
+              type: 'text' as const,
+              value: output.text,
+            });
+
         const toolObj = createTool({
           id: `agent-${agentName}`,
           description: agent.getDescription() || `Agent: ${agentName}`,
           inputSchema: agentInputSchema,
           outputSchema: agentOutputSchema,
           mastra: this.#mastra,
+          ...(toModelOutput ? { toModelOutput } : {}),
           // manually wrap agent tools with tracing, so that we can pass the
           // current tool span onto the agent to maintain continuity of the trace
           execute: async (inputData: z.infer<typeof agentInputSchema>, context) => {

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -274,6 +274,15 @@ export interface DelegationConfig {
   onDelegationComplete?: OnDelegationCompleteHandler;
 
   /**
+   * Include the full subagent result in the supervisor model context.
+   *
+   * By default, the supervisor model receives only the subagent's text response
+   * in later iterations. Set this to true to also include nested subagent tool
+   * results in the supervisor model context.
+   */
+  includeSubAgentToolResultsInModelContext?: boolean;
+
+  /**
    * Callback that controls which parent messages are passed to each subagent as conversation
    * context. Receives the full parent message history along with delegation metadata, and
    * returns the messages that should be forwarded.


### PR DESCRIPTION
Fixes #15823.

## Summary

This keeps subagent nested tool results out of the supervisor model context by default. The supervisor still receives the subagent text for later iterations, while application and UI code can keep reading the raw delegation result, including `subAgentToolResults`, from the tool result payload.

This also adds an explicit escape hatch for workflows that intentionally want the full subagent result in the supervisor model context:

```ts
delegation: {
  includeSubAgentToolResultsInModelContext: true,
}
```

## Why

Subagent tool results can contain large intermediate payloads, nested tool arguments, and implementation details that are useful to application code but usually harmful as implicit supervisor prompt context. Sending only the subagent text by default keeps the next supervisor model call focused and avoids accidental context bloat.

The opt-in keeps compatibility for prompt-organization workflows that depend on the supervisor model seeing the full raw subagent result.

## Changes

- Adds text-only `toModelOutput` for subagent delegation tools by default.
- Adds `delegation.includeSubAgentToolResultsInModelContext` to restore full raw subagent result context when needed.
- Preserves raw nested tool results in `result.toolResults` for application and UI consumers.
- Adds regression coverage for both default isolation and opt-in behavior with output processors.
- Updates supervisor-agent docs and the `@mastra/core` changeset.

## Validation

- `pnpm --filter ./packages/core exec vitest run src/agent/__tests__/supervisor-integration.test.ts src/harness/subagent-tool.test.ts src/harness/display-state.test.ts src/agent/message-list/tests/message-list-v5.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm --dir docs validate`
- `pnpm --dir docs exec remark --no-stdout --frail --quiet --ext mdx src/content/en/docs/agents/supervisor-agents.mdx`
- `pnpm --dir docs exec prettier --check src/content/en/docs/agents/supervisor-agents.mdx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

Subagents used to pour all their internal steps into the supervisor's brain and make it cluttered. This PR keeps only the subagent's final text in the supervisor's context by default, while still saving the full raw subagent result separately for apps/UIs; you can opt-in to include the full raw result in the supervisor context if needed.

---

## Summary of Changes

Fixes #15823 by preventing nested subagent tool results from being merged into the supervisor model context by default while preserving the raw delegation payload for application/UI consumption.

### Key changes
- Code
  - packages/core/src/agent/agent.types.ts
    - Adds DelegationConfig.includeSubAgentToolResultsInModelContext?: boolean to let callers opt in to including full subagent results in the supervisor model context.
  - packages/core/src/agent/agent.ts
    - Tightens sub-agent wrapper typings (subAgentToolResults[].result and .args typed as unknown).
    - Conditionally injects a toModelOutput adapter for subagent delegation tools: when includeSubAgentToolResultsInModelContext is false/absent, only the subagent's processed text is converted into model-context shape; when true, the adapter is omitted so the full raw subagent result (including nested subAgentToolResults and metadata) is visible to the supervisor model.
    - Ensures raw nested tool results remain available under result.toolResults for application/UI inspection.
- Tests
  - packages/core/src/agent/__tests__/supervisor-integration.test.ts
    - New regression tests asserting default isolation (supervisor prompt receives only subagent text; nested tool args/results excluded from model context) and opt-in behavior (supervisor prompt includes subAgentToolResults and nested tool artifacts when the flag is true). Verifies raw results remain present on the tool result payload.
- Docs & release notes
  - docs/src/content/en/docs/agents/supervisor-agents.mdx
    - Documents default behavior (only subagent text is merged into supervisor context), how to access raw delegation payload, and usage of includeSubAgentToolResultsInModelContext to opt into full inclusion.
  - .changeset/fifty-planets-refuse.md
    - Adds a changeset entry describing the behavior change and the new configuration flag.
- Validation
  - Ran selected vitest tests, TypeScript checks, linting, and docs validation/formatting as part of branch validation.

### Impact and compatibility
- Default: supervisor model context remains clean—only the subagent's final assistant text is included; nested tool calls and subAgentToolResults are excluded to avoid context pollution.
- Backwards compatibility: callers that need full nested results can opt in by setting delegation.includeSubAgentToolResultsInModelContext: true.
- Observers: reviewers requested an opt-in/opt-out surface; this PR implements an explicit opt-in flag to address that concern.

### Files changed (high-level)
- Modified: packages/core/src/agent/agent.types.ts, packages/core/src/agent/agent.ts
- Added tests: packages/core/src/agent/__tests__/supervisor-integration.test.ts
- Docs: docs/src/content/en/docs/agents/supervisor-agents.mdx
- Changeset: .changeset/fifty-planets-refuse.md
<!-- end of auto-generated comment: release notes by coderabbit.ai -->