### PR TITLE
fix(core): filter tool calls during agentic loop steps

### DIFF
--- a/.changeset/quick-bags-tap.md
+++ b/.changeset/quick-bags-tap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added prompt-only processor context for agent loop messages so processors can reduce model prompt size without mutating canonical run history.

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -375,7 +375,7 @@ See the [`TokenLimiterProcessor` reference](/reference/processors/token-limiter-
 
 Removes tool calls and results from messages sent to the LLM, saving tokens on verbose tool interactions. Optionally exclude only specific tools. This filter only affects the LLM input, filtered messages are still saved to memory.
 
-By default, `ToolCallFilter` filters the initial input before the agent loop starts. Use `filterAfterToolSteps` to also filter during each loop step while preserving recent tool-producing steps.
+By default, `ToolCallFilter` filters the initial input before the agent loop starts. Use `filterAfterToolSteps` to also filter the next model prompt during each loop step while preserving recent tool-producing steps. Step filtering does not mutate canonical run history or remove final tool results.
 
 ```typescript
 new ToolCallFilter({

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -170,7 +170,7 @@ Most processor methods receive both `messages` and `messageList`. They point to 
 
 ### `messages` vs `messageList`
 
-- `messages`: A plain array of `MastraDBMessage` objects, scoped to the current stage. For `processInput` and `processInputStep` this excludes system messages. For `processOutputResult` and `processOutputStep` this includes the latest LLM response. The array is backed by `messageList`, so editing a message's `content.parts` in place is visible to downstream processors and to persistence.
+- `messages`: A plain array of `MastraDBMessage` objects, scoped to the current stage. For `processInput` this excludes system messages. For `processInputStep`, this is usually derived from `messageList`; after an earlier step processor returns `modelContextMessages`, it is the prompt-only message context for the current step. For `processOutputResult` and `processOutputStep` this includes the latest LLM response.
 - `messageList`: The live `MessageList` instance backing the run. It exposes filtered views (input, response, remembered, all), multiple output formats (db, ui, core), and methods for mutating the conversation.
 
 Use `messages` when you only need to read, map over, or lightly edit fields on the current stage's messages. Use `messageList` when you need to:
@@ -179,7 +179,9 @@ Use `messages` when you only need to read, map over, or lightly edit fields on t
 - Add, remove, or replace whole messages.
 - Convert to another format such as UI or core messages for a third-party API.
 
-`messages` is always derived from `messageList`, so mutating `messageList` is the canonical way to add, remove, or reorder messages. For in-place edits to a message's content (for example, rewriting `content.parts`), mutating `messages` directly is equivalent. If you return a new array from `messages`, Mastra reconciles it against `messageList` for the current stage.
+Except for prompt-only `modelContextMessages` during `processInputStep`, `messages` is derived from `messageList`, so mutating `messageList` is the canonical way to add, remove, or reorder messages. For in-place edits to a message's content (for example, rewriting `content.parts`), mutating `messages` directly is equivalent. If you return a new array from `messages`, Mastra reconciles it against `messageList` for the current stage.
+
+For `processInputStep`, return `modelContextMessages` when you want to change only the next model prompt. This does not mutate or persist canonical history. Later `processInputStep` processors in the same step receive those prompt-only messages as their `messages` argument.
 
 ### Persistence
 
@@ -450,6 +452,8 @@ processInputStep?<TTripwireMetadata = unknown>(
 - **`MastraDBMessage[]`** — return a transformed messages array; replaces the step's messages.
 - **`void` or `undefined`** — return nothing to leave the step unchanged.
 
+Use `modelContextMessages` instead of `messages` when the change should only affect the next model prompt. Returning both `messages` and `modelContextMessages` is an error.
+
 The object form can return any combination of these properties:
 
 <PropertiesTable
@@ -482,6 +486,13 @@ The object form can return any combination of these properties:
     name: 'messages',
     type: 'MastraDBMessage[]',
     description: 'Replace all messages. Cannot be used with messageList.',
+    isOptional: true,
+  },
+  {
+    name: 'modelContextMessages',
+    type: 'MastraDBMessage[]',
+    description:
+      'Replace the messages used for the next model prompt without mutating canonical MessageList history. Cannot be used with messages.',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/processors/tool-call-filter.mdx
+++ b/docs/src/content/en/reference/processors/tool-call-filter.mdx
@@ -7,7 +7,7 @@ packages:
 
 # ToolCallFilter
 
-The `ToolCallFilter` is an **input processor** that filters out tool calls and their results from the message history before sending to the model. This is useful when you want to exclude specific tool interactions from context or remove all tool calls entirely.
+The `ToolCallFilter` is an **input processor** that filters out tool calls and their results before sending messages to the model. This is useful when you want to exclude specific tool interactions from context or remove all tool calls entirely.
 
 ## Usage example
 
@@ -101,6 +101,8 @@ By default, `ToolCallFilter` filters only the initial input before the agent loo
 `filterAfterToolSteps` counts tool-producing steps. For example, `filterAfterToolSteps: 2` keeps tool calls and results from the two most recent tool-producing steps and filters older tool calls and results. Non-tool text remains in context.
 
 Set `filterAfterToolSteps: 0` to filter all previous tool calls and results on each step.
+
+Step filtering changes only the next model prompt by returning `modelContextMessages`; it does not mutate canonical run history or remove final tool results from persistence.
 
 ```typescript
 const filter = new ToolCallFilter({

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -89,6 +89,22 @@ const durableLLMOutputSchema = z.object({
   stepIndex: z.number().optional(),
 });
 
+function createModelContextMessageList(messageList: MessageList, messages: MastraDBMessage[]): MessageList {
+  const contextMessageList = new MessageList();
+  const sourceChecker = messageList.makeMessageSourceChecker();
+  contextMessageList.addSystem(messageList.getAllSystemMessages());
+  for (const message of messages) {
+    if (message.role === 'system') {
+      continue;
+    }
+    contextMessageList.add(
+      message,
+      sourceChecker.getSource(message) ?? (message.role === 'user' ? 'input' : 'response'),
+    );
+  }
+  return contextMessageList;
+}
+
 /**
  * Options for creating the durable LLM execution step
  */
@@ -191,6 +207,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             let currentTools = tools as unknown as ToolSet;
             let currentToolChoice = execOptions.toolChoice as ToolChoice<ToolSet> | undefined;
             let currentModelSettings = { temperature: execOptions.temperature };
+            let modelContextMessages: MastraDBMessage[] | undefined;
 
             // 6. Rebuild MODEL_GENERATION span from passed data
             // For durable execution, ONE model_generation span is created BEFORE the workflow starts
@@ -269,10 +286,14 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 ...currentModelSettings,
                 ...(processInputStepResult.modelSettings ?? {}),
               };
+              modelContextMessages = processInputStepResult.modelContextMessages;
             }
 
             // Get messages for LLM (using async llmPrompt for proper format conversion)
-            const inputMessages = (await messageList.get.all.aiV5.llmPrompt()) as LanguageModelV2Prompt;
+            const promptMessageList = modelContextMessages
+              ? createModelContextMessageList(messageList, modelContextMessages)
+              : messageList;
+            const inputMessages = (await promptMessageList.get.all.aiV5.llmPrompt()) as LanguageModelV2Prompt;
 
             // Enable defer mode - step-finish won't auto-close the step span
             // This allows us to export the step span and close it later after tool execution

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -4,7 +4,8 @@ import type { LanguageModelV2Usage } from '@ai-sdk/provider-v5';
 import { APICallError, generateId } from '@internal/ai-sdk-v5';
 import type { CallSettings, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import type { StructuredOutputOptions } from '../../../agent';
-import type { MessageList } from '../../../agent/message-list';
+import { MessageList } from '../../../agent/message-list';
+import type { MastraDBMessage } from '../../../agent/message-list';
 import { TripWire } from '../../../agent/trip-wire';
 import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../../../agent/utils';
 import { generateBackgroundTaskSystemPrompt } from '../../../background-tasks';
@@ -81,6 +82,22 @@ function buildResponseModelMetadata(
   }
 
   return Object.keys(metadata).length > 0 ? { metadata } : undefined;
+}
+
+function createModelContextMessageList(messageList: MessageList, messages: MastraDBMessage[]): MessageList {
+  const contextMessageList = new MessageList();
+  const sourceChecker = messageList.makeMessageSourceChecker();
+  contextMessageList.addSystem(messageList.getAllSystemMessages());
+  for (const message of messages) {
+    if (message.role === 'system') {
+      continue;
+    }
+    contextMessageList.add(
+      message,
+      sourceChecker.getSource(message) ?? (message.role === 'user' ? 'input' : 'response'),
+    );
+  }
+  return contextMessageList;
 }
 
 async function processOutputStream<OUTPUT = undefined>({
@@ -446,6 +463,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             providerOptions?: SharedProviderOptions | undefined;
             modelSettings?: Omit<CallSettings, 'abortSignal'> | undefined;
             structuredOutput?: StructuredOutputOptions<OUTPUT>;
+            modelContextMessages?: MastraDBMessage[];
             workspace?: Workspace;
           } = {
             messageId: currentMessageId,
@@ -678,7 +696,10 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             downloadConcurrency,
             supportedUrls: resolvedSupportedUrls,
           };
-          let inputMessages = await messageList.get.all.aiV5.llmPrompt(messageListPromptArgs);
+          const promptMessageList = currentStep.modelContextMessages
+            ? createModelContextMessageList(messageList, currentStep.modelContextMessages)
+            : messageList;
+          let inputMessages = await promptMessageList.get.all.aiV5.llmPrompt(messageListPromptArgs);
 
           if (autoResumeSuspendedTools) {
             const messages = messageList.get.all.db();

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -212,6 +212,11 @@ export type ProcessInputStepResult = {
 
   messages?: MastraDBMessage[];
   messageList?: MessageList;
+  /**
+   * Replace the messages used to build the next model prompt without mutating the canonical MessageList.
+   * Later processInputStep processors in the same step receive these messages as their `messages` argument.
+   */
+  modelContextMessages?: MastraDBMessage[];
   /** Replace all system messages with these */
   systemMessages?: CoreMessageV4[];
   providerOptions?: SharedProviderOptions;

--- a/packages/core/src/processors/process-input-step.test.ts
+++ b/packages/core/src/processors/process-input-step.test.ts
@@ -5,6 +5,7 @@ import { MessageList } from '../agent/message-list';
 import type { MastraDBMessage } from '../agent/message-list';
 import type { IMastraLogger } from '../logger';
 import { ProcessorRunner } from './runner';
+import { ProcessorStepOutputSchema } from './step-schema';
 import type { Processor } from './index';
 
 /**
@@ -1641,6 +1642,275 @@ describe('processInputStep', () => {
       expect(allMessages.map((m: MastraDBMessage) => m.id)).toEqual(
         expect.arrayContaining([expect.any(String), 'msg-from-p1', 'msg-from-p2']),
       );
+    });
+
+    it('should let processors set model context messages without mutating MessageList', async () => {
+      const seenByObserver: MastraDBMessage[][] = [];
+
+      const contextProcessor: Processor = {
+        id: 'context-processor',
+        processInputStep: async ({ messages }) => ({
+          modelContextMessages: messages.filter(message => message.id !== 'tool-result'),
+        }),
+      };
+
+      const observerProcessor: Processor = {
+        id: 'observer-processor',
+        processInputStep: async ({ messages }) => {
+          seenByObserver.push(messages);
+          return {};
+        },
+      };
+
+      const runner = new ProcessorRunner({
+        inputProcessors: [contextProcessor, observerProcessor],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      messageList.add([createMessage('User question')], 'input');
+      messageList.add(
+        [
+          {
+            id: 'tool-result',
+            role: 'assistant',
+            content: {
+              format: 2 as const,
+              parts: [
+                {
+                  type: 'tool-invocation' as const,
+                  toolInvocation: {
+                    state: 'result' as const,
+                    toolCallId: 'call-1',
+                    toolName: 'lookup',
+                    args: {},
+                    result: 'SECRET_RESULT',
+                  },
+                },
+              ],
+            },
+            createdAt: new Date(),
+            threadId: 'test-thread',
+          } as unknown as MastraDBMessage,
+        ],
+        'response',
+      );
+
+      const result = await runner.runProcessInputStep({
+        messageList,
+        stepNumber: 1,
+        model: createMockModel(),
+        steps: [],
+      });
+
+      expect(result.modelContextMessages?.map(message => message.id)).not.toContain('tool-result');
+      expect(seenByObserver[0]?.map(message => message.id)).not.toContain('tool-result');
+      expect(messageList.get.all.db().map(message => message.id)).toContain('tool-result');
+      expect(JSON.stringify(messageList.get.all.db())).toContain('SECRET_RESULT');
+    });
+
+    it('should isolate model context messages from canonical MessageList objects', async () => {
+      const contextProcessor: Processor = {
+        id: 'context-processor',
+        processInputStep: async ({ messages }) => ({ modelContextMessages: messages }),
+      };
+
+      const mutatingPromptProcessor: Processor = {
+        id: 'mutating-prompt-processor',
+        processInputStep: async ({ messages }) => {
+          const firstTextPart = messages[0]?.content.parts?.[0];
+          if (firstTextPart?.type === 'text') {
+            firstTextPart.text = 'Mutated prompt only';
+          }
+          return {};
+        },
+      };
+
+      const runner = new ProcessorRunner({
+        inputProcessors: [contextProcessor, mutatingPromptProcessor],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      messageList.add([createMessage('User question')], 'input');
+
+      const result = await runner.runProcessInputStep({
+        messageList,
+        stepNumber: 1,
+        model: createMockModel(),
+        steps: [],
+      });
+
+      expect(result.modelContextMessages?.[0]?.content.parts?.[0]).toMatchObject({ text: 'Mutated prompt only' });
+      expect(messageList.get.all.db()[0]?.content.parts?.[0]).toMatchObject({ text: 'User question' });
+    });
+
+    it('should reject messageList mutations after model context messages without a prompt context return', async () => {
+      const contextProcessor: Processor = {
+        id: 'context-processor',
+        processInputStep: async ({ messages }) => ({ modelContextMessages: messages }),
+      };
+
+      const mutatingProcessor: Processor = {
+        id: 'mutating-processor',
+        processInputStep: async ({ messageList }) => {
+          messageList.add([createMessage('Injected canonical message')], 'input');
+          return {};
+        },
+      };
+
+      const runner = new ProcessorRunner({
+        inputProcessors: [contextProcessor, mutatingProcessor],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      messageList.add([createMessage('User question')], 'input');
+
+      await expect(
+        runner.runProcessInputStep({
+          messageList,
+          stepNumber: 1,
+          model: createMockModel(),
+          steps: [],
+        }),
+      ).rejects.toThrow(/mutated messageList after a previous processor returned modelContextMessages/);
+    });
+
+    it('should reject workflow messageList mutations that only echo existing model context messages', async () => {
+      const contextProcessor: Processor = {
+        id: 'context-processor',
+        processInputStep: async ({ messages }) => ({ modelContextMessages: messages }),
+      };
+
+      const workflowProcessor = {
+        id: 'workflow-mutator',
+        inputSchema: z.any(),
+        outputSchema: z.any(),
+        execute: vi.fn(),
+        createRun: vi.fn(async () => ({
+          start: vi.fn(async ({ inputData }: any) => {
+            inputData.messageList.add([createMessage('Injected canonical message')], 'input');
+            return {
+              status: 'success',
+              steps: {},
+              result: {
+                phase: 'inputStep',
+                messages: inputData.messages,
+                modelContextMessages: inputData.modelContextMessages,
+              },
+            };
+          }),
+        })),
+      };
+
+      const runner = new ProcessorRunner({
+        inputProcessors: [contextProcessor, workflowProcessor as any],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      messageList.add([createMessage('User question')], 'input');
+
+      await expect(
+        runner.runProcessInputStep({
+          messageList,
+          stepNumber: 1,
+          model: createMockModel(),
+          steps: [],
+        }),
+      ).rejects.toThrow(/Processor workflow workflow-mutator mutated messageList/);
+    });
+
+    it('should reject workflow processors returning both messages and modelContextMessages', async () => {
+      const workflowProcessor = {
+        id: 'workflow-both-context',
+        inputSchema: z.any(),
+        outputSchema: z.any(),
+        execute: vi.fn(),
+        createRun: vi.fn(async () => ({
+          start: vi.fn(async ({ inputData }: any) => ({
+            status: 'success',
+            steps: {},
+            result: {
+              phase: 'inputStep',
+              messages: [
+                ...inputData.messages,
+                {
+                  ...createMessage('Changed canonical message'),
+                  id: 'changed-message',
+                },
+              ],
+              modelContextMessages: inputData.messages,
+            },
+          })),
+        })),
+      };
+
+      const runner = new ProcessorRunner({
+        inputProcessors: [workflowProcessor as any],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      messageList.add([createMessage('Hello')], 'input');
+
+      await expect(
+        runner.runProcessInputStep({
+          messageList,
+          stepNumber: 0,
+          model: createMockModel(),
+          steps: [],
+        }),
+      ).rejects.toThrow(/returned both messages and modelContextMessages/);
+    });
+
+    it('should preserve modelContextMessages through processor workflow schemas', () => {
+      const message = createMessage('User question');
+
+      const parsed = ProcessorStepOutputSchema.parse({
+        phase: 'inputStep',
+        messages: [message],
+        modelContextMessages: [message],
+      });
+
+      expect(parsed.modelContextMessages).toHaveLength(1);
+    });
+
+    it('should reject returning both messages and modelContextMessages together', async () => {
+      const processor: Processor = {
+        id: 'both-context-processor',
+        processInputStep: async ({ messages }) => ({ messages, modelContextMessages: messages }),
+      };
+
+      const runner = new ProcessorRunner({
+        inputProcessors: [processor],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      messageList.add([createMessage('Hello')], 'input');
+
+      await expect(
+        runner.runProcessInputStep({
+          messageList,
+          stepNumber: 0,
+          model: createMockModel(),
+          steps: [],
+        }),
+      ).rejects.toThrow(/returned both messages and modelContextMessages/);
     });
   });
 

--- a/packages/core/src/processors/processors/tool-call-filter.test.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.test.ts
@@ -964,6 +964,7 @@ describe('ToolCallFilter', () => {
       const result = await filter.processInputStep(mockStepArgs(messageList));
 
       expect(result.messages).toBeUndefined();
+      expect(result.modelContextMessages).toBeUndefined();
     });
 
     it('should filter tool calls from tool steps older than filterAfterToolSteps', async () => {
@@ -1035,8 +1036,8 @@ describe('ToolCallFilter', () => {
 
       const result = await filter.processInputStep(mockStepArgs(messageList, { stepNumber: 2, state }));
 
-      expect(result.messages).toBeDefined();
-      const toolParts = result.messages!.flatMap(message =>
+      expect(result.modelContextMessages).toBeDefined();
+      const toolParts = result.modelContextMessages!.flatMap(message =>
         typeof message.content === 'string'
           ? []
           : message.content.parts.filter((part: any) => part.type === 'tool-invocation'),
@@ -1097,8 +1098,8 @@ describe('ToolCallFilter', () => {
 
       const result = await filter.processInputStep(mockStepArgs(messageList));
 
-      expect(result.messages).toBeDefined();
-      const filteredMessages = result.messages!;
+      expect(result.modelContextMessages).toBeDefined();
+      const filteredMessages = result.modelContextMessages!;
       expect(filteredMessages).toHaveLength(2);
       expect(filteredMessages[0]!.id).toBe('msg-1');
 
@@ -1181,8 +1182,8 @@ describe('ToolCallFilter', () => {
 
       const result = await filter.processInputStep(mockStepArgs(messageList));
 
-      expect(result.messages).toBeDefined();
-      const filteredMessages = result.messages!;
+      expect(result.modelContextMessages).toBeDefined();
+      const filteredMessages = result.modelContextMessages!;
       expect(filteredMessages).toHaveLength(2);
 
       const assistantMsg = filteredMessages[1]!;
@@ -1234,8 +1235,7 @@ describe('ToolCallFilter', () => {
 
       const result = await filter.processInputStep(mockStepArgs(messageList));
 
-      expect(result.messages).toBeDefined();
-      expect(result.messages!).toHaveLength(2);
+      expect(result.modelContextMessages).toBeUndefined();
     });
   });
 
@@ -1406,6 +1406,7 @@ describe('ToolCallFilter', () => {
       expect(step3Prompt.some((msg: any) => msg.content?.some((p: any) => p.toolCallId === 'call-weather-2'))).toBe(
         true,
       );
+      expect(JSON.stringify(messageList.get.all.db())).toContain('call-weather-1');
     });
 
     it('should preserve the last two tool-call steps with filterAfterToolSteps 2', async () => {

--- a/packages/core/src/processors/processors/tool-call-filter.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.ts
@@ -64,9 +64,16 @@ export class ToolCallFilter implements Processor {
       return {};
     }
 
-    const { messageList } = args;
-    const messages = messageList.get.all.db();
-    return { messages: this.filterMessages(messages, this.getRecentToolStepToolCallIds(args)) };
+    const { messages } = args;
+    const filteredMessages = this.filterMessages(messages, this.getRecentToolStepToolCallIds(args));
+    if (
+      filteredMessages.length === messages.length &&
+      filteredMessages.every((message, index) => message === messages[index])
+    ) {
+      return {};
+    }
+
+    return { modelContextMessages: filteredMessages };
   }
 
   private getRecentToolStepToolCallIds(args: ProcessInputStepArgs): Set<string> {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -155,6 +155,14 @@ function areProcessorMessageArraysEqual(before: unknown[] | undefined, after: un
   );
 }
 
+function cloneModelContextMessages(messages: MastraDBMessage[]): MastraDBMessage[] {
+  return structuredClone(messages);
+}
+
+function hasRegularMessageListMutations(mutations: ReturnType<MessageList['stopRecording']>): boolean {
+  return mutations.some(mutation => mutation.type !== 'addSystem');
+}
+
 function buildProcessInputStepSpanInput(args: {
   messages: MastraDBMessage[];
   systemMessages: unknown[];
@@ -377,7 +385,10 @@ export class ProcessorRunner {
     }
 
     // Validate it has the expected ProcessorStepOutput shape
-    if (!('phase' in output) || !('messages' in output || 'part' in output || 'messageList' in output)) {
+    if (
+      !('phase' in output) ||
+      !('messages' in output || 'modelContextMessages' in output || 'part' in output || 'messageList' in output)
+    ) {
       throw new MastraError({
         category: 'USER',
         domain: 'AGENT',
@@ -1059,37 +1070,115 @@ export class ProcessorRunner {
 
     // Run through all input processors that have processInputStep
     for (const [index, processorOrWorkflow] of processors.entries()) {
-      const processableMessages: MastraDBMessage[] = messageList.get.all.db();
+      const processableMessages: MastraDBMessage[] = stepInput.modelContextMessages ?? messageList.get.all.db();
       const idsBeforeProcessing = processableMessages.map((m: MastraDBMessage) => m.id);
       const check = messageList.makeMessageSourceChecker();
 
       // Handle workflow as processor with inputStep phase
       if (isProcessorWorkflow(processorOrWorkflow)) {
         const currentSystemMessages = messageList.getAllSystemMessages();
-        const result = await this.executeWorkflowAsProcessor(
-          processorOrWorkflow,
-          {
-            phase: 'inputStep',
-            messages: processableMessages,
+        const hadModelContextMessages = stepInput.modelContextMessages !== undefined;
+        messageList.startRecording();
+        let recordingStopped = false;
+        try {
+          const result = await this.executeWorkflowAsProcessor(
+            processorOrWorkflow,
+            {
+              phase: 'inputStep',
+              messages: processableMessages,
+              messageList,
+              stepNumber,
+              steps,
+              systemMessages: currentSystemMessages,
+              rotateResponseMessageId: args.rotateResponseMessageId
+                ? () => {
+                    const nextMessageId = args.rotateResponseMessageId!();
+                    stepInput.messageId = nextMessageId;
+                    return nextMessageId;
+                  }
+                : undefined,
+              ...stepInput,
+            },
+            observabilityContext,
+            requestContext,
+            writer,
+            args.abortSignal,
+          );
+          const mutations = messageList.stopRecording();
+          recordingStopped = true;
+          const rawResult = result as RunProcessInputStepResult & { phase?: string };
+          const workflowMessages =
+            rawResult.messages && !areProcessorMessageArraysEqual(processableMessages, rawResult.messages)
+              ? rawResult.messages
+              : undefined;
+          const workflowModelContextMessages =
+            rawResult.modelContextMessages &&
+            !areProcessorMessageArraysEqual(stepInput.modelContextMessages, rawResult.modelContextMessages)
+              ? rawResult.modelContextMessages
+              : undefined;
+          if (workflowMessages && workflowModelContextMessages) {
+            throw new MastraError({
+              category: 'USER',
+              domain: 'AGENT',
+              id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+              text: `Processor workflow ${processorOrWorkflow.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
+            });
+          }
+          const workflowProcessInputStepResult: ProcessInputStepResult = {
+            ...rawResult,
+            messageList: undefined,
+            messages: workflowModelContextMessages === undefined ? workflowMessages : undefined,
+            modelContextMessages: workflowModelContextMessages,
+          };
+          delete (workflowProcessInputStepResult as { phase?: string }).phase;
+
+          const {
+            messages,
+            systemMessages,
+            modelContextMessages,
+            messageList: _messageList,
+            ...rest
+          } = await ProcessorRunner.validateAndFormatProcessInputStepResult(workflowProcessInputStepResult, {
             messageList,
+            processor: { id: processorOrWorkflow.id } as Processor,
             stepNumber,
-            steps,
-            systemMessages: currentSystemMessages,
-            rotateResponseMessageId: args.rotateResponseMessageId
-              ? () => {
-                  const nextMessageId = args.rotateResponseMessageId!();
-                  stepInput.messageId = nextMessageId;
-                  return nextMessageId;
-                }
-              : undefined,
-            ...stepInput,
-          },
-          observabilityContext,
-          requestContext,
-          writer,
-          args.abortSignal,
-        );
-        Object.assign(stepInput, result);
+          });
+
+          if (messages) {
+            if (stepInput.modelContextMessages || modelContextMessages) {
+              stepInput.modelContextMessages = cloneModelContextMessages(messages);
+            } else {
+              ProcessorRunner.applyMessagesToMessageList(messages, messageList, idsBeforeProcessing, check);
+            }
+          }
+          if (modelContextMessages) {
+            stepInput.modelContextMessages = cloneModelContextMessages(modelContextMessages);
+          }
+          if (systemMessages) {
+            messageList.replaceAllSystemMessages(systemMessages);
+          }
+          Object.assign(stepInput, rest);
+
+          if (
+            hadModelContextMessages &&
+            mutations.length > 0 &&
+            hasRegularMessageListMutations(mutations) &&
+            !messages &&
+            !modelContextMessages
+          ) {
+            throw new MastraError({
+              category: 'USER',
+              domain: 'AGENT',
+              id: 'PROCESSOR_MUTATED_MESSAGE_LIST_AFTER_MODEL_CONTEXT_MESSAGES',
+              text: `Processor workflow ${processorOrWorkflow.id} mutated messageList after a previous processor returned modelContextMessages. Return messages or modelContextMessages from this workflow so the next model prompt stays in sync with the mutation.`,
+            });
+          }
+        } catch (error) {
+          if (!recordingStopped) {
+            messageList.stopRecording();
+          }
+          throw error;
+        }
         continue;
       }
 
@@ -1183,6 +1272,7 @@ export class ProcessorRunner {
           abortSignal: args.abortSignal,
         };
 
+        const hadModelContextMessages = stepInput.modelContextMessages !== undefined;
         const result = await ProcessorRunner.validateAndFormatProcessInputStepResult(
           await processMethod(processMethodArgs),
           {
@@ -1191,9 +1281,16 @@ export class ProcessorRunner {
             stepNumber,
           },
         );
-        const { messages, systemMessages, ...rest } = result;
+        const { messages, systemMessages, modelContextMessages, ...rest } = result;
+        if (modelContextMessages) {
+          stepInput.modelContextMessages = cloneModelContextMessages(modelContextMessages);
+        }
         if (messages) {
-          ProcessorRunner.applyMessagesToMessageList(messages, messageList, idsBeforeProcessing, check);
+          if (stepInput.modelContextMessages) {
+            stepInput.modelContextMessages = cloneModelContextMessages(messages);
+          } else {
+            ProcessorRunner.applyMessagesToMessageList(messages, messageList, idsBeforeProcessing, check);
+          }
         }
         if (systemMessages) {
           messageList.replaceAllSystemMessages(systemMessages);
@@ -1202,6 +1299,20 @@ export class ProcessorRunner {
 
         // Stop recording and get mutations for this processor
         const mutations = messageList.stopRecording();
+        if (
+          hadModelContextMessages &&
+          mutations.length > 0 &&
+          hasRegularMessageListMutations(mutations) &&
+          !messages &&
+          !modelContextMessages
+        ) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_MUTATED_MESSAGE_LIST_AFTER_MODEL_CONTEXT_MESSAGES',
+            text: `Processor ${processor.id} mutated messageList after a previous processor returned modelContextMessages. Return messages or modelContextMessages from this processor so the next model prompt stays in sync with the mutation.`,
+          });
+        }
 
         processorSpan?.end({
           output: buildProcessInputStepSpanOutput({
@@ -1210,7 +1321,7 @@ export class ProcessorRunner {
             afterStepInput: stepInput,
             beforeMessages: inputData.messages,
             beforeSystemMessages: inputData.systemMessages,
-            messages: messageList.get.all.db(),
+            messages: stepInput.modelContextMessages ?? messageList.get.all.db(),
             systemMessages: messageList.getAllSystemMessages(),
           }),
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
@@ -1714,6 +1825,14 @@ export class ProcessorRunner {
           domain: 'AGENT',
           id: 'PROCESSOR_RETURNED_MESSAGES_AND_MESSAGE_LIST',
           text: `Processor ${processor.id} returned both messages and messageList. Only one of these is allowed.`,
+        });
+      }
+      if (result.messages && result.modelContextMessages) {
+        throw new MastraError({
+          category: 'USER',
+          domain: 'AGENT',
+          id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+          text: `Processor ${processor.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
         });
       }
       const { model: _model, ...rest } = result;

--- a/packages/core/src/processors/step-schema.ts
+++ b/packages/core/src/processors/step-schema.ts
@@ -113,6 +113,7 @@ export type ProcessorInputPhaseType = {
 export type ProcessorInputStepPhaseType = {
   phase: 'inputStep';
   messages: ProcessorMessageType[];
+  modelContextMessages?: ProcessorMessageType[];
   messageList: MessageList;
   stepNumber: number;
   systemMessages?: CoreMessageType[];
@@ -181,6 +182,7 @@ export type ProcessorStepInputType =
 export type ProcessorStepOutputType = {
   phase: 'input' | 'inputStep' | 'outputStream' | 'outputResult' | 'outputStep';
   messages?: ProcessorMessageType[];
+  modelContextMessages?: ProcessorMessageType[];
   messageList?: MessageList;
   systemMessages?: CoreMessageType[];
   stepNumber?: number;
@@ -525,6 +527,7 @@ export const ProcessorInputPhaseSchema = z.object({
 export const ProcessorInputStepPhaseSchema = z.object({
   phase: z.literal('inputStep'),
   messages: messagesSchema,
+  modelContextMessages: messagesSchema.optional(),
   messageList: messageListSchema,
   stepNumber: z.number().describe('The current step number (0-indexed)'),
   systemMessages: systemMessagesSchema.optional(),
@@ -639,6 +642,7 @@ export const ProcessorStepOutputSchema: z.ZodType<ProcessorStepOutputType> = z.o
 
   // Message-based fields (used by most phases)
   messages: messagesSchema.optional(),
+  modelContextMessages: messagesSchema.optional(),
   messageList: messageListSchema.optional(),
   systemMessages: systemMessagesSchema.optional(),
 

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -764,6 +764,7 @@ function createStepFromProcessor<TProcessorId extends string>(
       const {
         phase,
         messages,
+        modelContextMessages,
         messageList,
         stepNumber,
         systemMessages,
@@ -888,6 +889,16 @@ function createStepFromProcessor<TProcessorId extends string>(
               !areProcessorMessageArraysEqual(messages as unknown[] | undefined, payload.messages)
             ) {
               output.messages = payload.messages;
+            }
+
+            if (
+              Array.isArray(payload.modelContextMessages) &&
+              !areProcessorMessageArraysEqual(
+                modelContextMessages as unknown[] | undefined,
+                payload.modelContextMessages,
+              )
+            ) {
+              output.modelContextMessages = payload.modelContextMessages;
             }
 
             if (
@@ -1026,6 +1037,7 @@ function createStepFromProcessor<TProcessorId extends string>(
       // This enables processor workflows to use .then(), .parallel(), .branch(), etc.
       const passThrough = {
         phase,
+        modelContextMessages,
         // Auto-create MessageList from messages if not provided
         // This enables running processor workflows from the UI where messageList can't be serialized
         messageList:
@@ -1161,13 +1173,15 @@ function createStepFromProcessor<TProcessorId extends string>(
                 });
               }
 
+              const processableMessages = (modelContextMessages ?? messages) as MastraDBMessage[];
+
               // Create source checker before processing to preserve message sources
-              const idsBeforeProcessing = (messages as MastraDBMessage[]).map(m => m.id);
+              const idsBeforeProcessing = processableMessages.map(m => m.id);
               const check = passThrough.messageList.makeMessageSourceChecker();
 
               const result = await processor.processInputStep({
                 ...baseContext,
-                messages: messages as MastraDBMessage[],
+                messages: processableMessages,
                 messageList: passThrough.messageList,
                 stepNumber: stepNumber ?? 0,
                 systemMessages: (systemMessages ?? []) as CoreMessage[],
@@ -1191,12 +1205,20 @@ function createStepFromProcessor<TProcessorId extends string>(
               });
 
               if (validatedResult.messages) {
-                ProcessorRunner.applyMessagesToMessageList(
-                  validatedResult.messages,
-                  passThrough.messageList,
-                  idsBeforeProcessing,
-                  check,
-                );
+                if (modelContextMessages || validatedResult.modelContextMessages) {
+                  passThrough.modelContextMessages = validatedResult.messages;
+                } else {
+                  ProcessorRunner.applyMessagesToMessageList(
+                    validatedResult.messages,
+                    passThrough.messageList,
+                    idsBeforeProcessing,
+                    check,
+                  );
+                }
+              }
+
+              if (validatedResult.modelContextMessages) {
+                passThrough.modelContextMessages = validatedResult.modelContextMessages;
               }
 
               if (validatedResult.systemMessages) {
@@ -1205,12 +1227,20 @@ function createStepFromProcessor<TProcessorId extends string>(
 
               // Preserve messages in return - passThrough doesn't include messages,
               // so we must explicitly include it to avoid losing it for subsequent steps.
-              return {
+              const output = {
                 ...passThrough,
                 messages,
                 ...validatedResult,
                 ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
               };
+              if (
+                passThrough.modelContextMessages &&
+                validatedResult.messages &&
+                !validatedResult.modelContextMessages
+              ) {
+                output.messages = messages;
+              }
+              return output;
             }
             return { ...passThrough, messages };
           }

--- a/packages/core/src/workflows/processor-step.test.ts
+++ b/packages/core/src/workflows/processor-step.test.ts
@@ -259,6 +259,41 @@ describe('createStep with Processor', () => {
       );
     });
 
+    it('should pass modelContextMessages as messages to processInputStep processors', async () => {
+      const seenMessages: unknown[][] = [];
+      const processor: Processor = {
+        id: 'input-step-context-processor',
+        processInputStep: async ({ messages }) => {
+          seenMessages.push(messages);
+          return {};
+        },
+      };
+
+      const step = createStep(processor);
+      const messageList = createMockMessageList();
+      const canonicalMessages = [{ id: 'canonical', content: 'canonical' }] as any;
+      const modelContextMessages = [{ id: 'prompt-only', content: 'prompt-only' }] as any;
+
+      const result = await step.execute({
+        inputData: {
+          phase: 'inputStep' as const,
+          messages: canonicalMessages,
+          modelContextMessages,
+          messageList,
+          stepNumber: 5,
+          systemMessages: [],
+        },
+      } as any);
+
+      expect(seenMessages[0]).toEqual(modelContextMessages);
+      expect(result).toEqual(
+        expect.objectContaining({
+          messages: canonicalMessages,
+          modelContextMessages,
+        }),
+      );
+    });
+
     it('should call processOutputStream when phase is outputStream (messageList optional)', async () => {
       const processOutputStreamMock = async ({ part }) => {
         return { ...part, processed: true };

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -719,6 +719,7 @@ function createStepFromProcessor<TProcessorId extends string>(
       const {
         phase,
         messages,
+        modelContextMessages,
         messageList,
         stepNumber,
         systemMessages,
@@ -843,6 +844,16 @@ function createStepFromProcessor<TProcessorId extends string>(
               !areProcessorMessageArraysEqual(messages as unknown[] | undefined, payload.messages)
             ) {
               output.messages = payload.messages;
+            }
+
+            if (
+              Array.isArray(payload.modelContextMessages) &&
+              !areProcessorMessageArraysEqual(
+                modelContextMessages as unknown[] | undefined,
+                payload.modelContextMessages,
+              )
+            ) {
+              output.modelContextMessages = payload.modelContextMessages;
             }
 
             if (
@@ -994,6 +1005,7 @@ function createStepFromProcessor<TProcessorId extends string>(
       // This enables processor workflows to use .then(), .parallel(), .branch(), etc.
       const passThrough = {
         phase,
+        modelContextMessages,
         // Auto-create MessageList from messages if not provided
         // This enables running processor workflows from the UI where messageList can't be serialized
         messageList:
@@ -1134,14 +1146,15 @@ function createStepFromProcessor<TProcessorId extends string>(
 
               // Extract messageList after null check for proper type narrowing
               const checkedMessageList = passThrough.messageList;
+              const processableMessages = (modelContextMessages ?? messages) as MastraDBMessage[];
 
               // Create source checker before processing to preserve message sources
-              const idsBeforeProcessing = (messages as MastraDBMessage[]).map(m => m.id);
+              const idsBeforeProcessing = processableMessages.map(m => m.id);
               const check = checkedMessageList.makeMessageSourceChecker();
 
               const result = await processor.processInputStep({
                 ...baseContext,
-                messages: messages as MastraDBMessage[],
+                messages: processableMessages,
                 messageList: checkedMessageList,
                 stepNumber: stepNumber ?? 0,
                 systemMessages: (systemMessages ?? []) as CoreMessage[],
@@ -1165,12 +1178,20 @@ function createStepFromProcessor<TProcessorId extends string>(
               });
 
               if (validatedResult.messages) {
-                ProcessorRunner.applyMessagesToMessageList(
-                  validatedResult.messages,
-                  checkedMessageList,
-                  idsBeforeProcessing,
-                  check,
-                );
+                if (modelContextMessages || validatedResult.modelContextMessages) {
+                  passThrough.modelContextMessages = validatedResult.messages;
+                } else {
+                  ProcessorRunner.applyMessagesToMessageList(
+                    validatedResult.messages,
+                    checkedMessageList,
+                    idsBeforeProcessing,
+                    check,
+                  );
+                }
+              }
+
+              if (validatedResult.modelContextMessages) {
+                passThrough.modelContextMessages = validatedResult.modelContextMessages;
               }
 
               if (validatedResult.systemMessages) {
@@ -1179,12 +1200,20 @@ function createStepFromProcessor<TProcessorId extends string>(
 
               // Preserve messages in return - passThrough doesn't include messages,
               // so we must explicitly include it to avoid losing it for subsequent steps.
-              return {
+              const output = {
                 ...passThrough,
                 messages,
                 ...validatedResult,
                 ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
               };
+              if (
+                passThrough.modelContextMessages &&
+                validatedResult.messages &&
+                !validatedResult.modelContextMessages
+              ) {
+                output.messages = messages;
+              }
+              return output;
             }
             return { ...passThrough, messages };
           }


### PR DESCRIPTION
This fixes ToolCallFilter so it also runs during each agentic loop step, not only on the initial input. Filtering now uses prompt-only modelContextMessages, so older tool calls and results can be removed from the next model prompt without deleting canonical MessageList history, memory data, UI data, or final tool results. The latest completed tool step is preserved by default so the model can use fresh tool output once before it is pruned from later context.

It also adds validation for ambiguous processInputStep returns, covers markerless harness-style histories, and updates the processor reference docs.

Closes https://github.com/mastra-ai/mastra/issues/15811

Validated with focused core Vitest suites for ToolCallFilter, processInputStep, agent processors, and AI SDK v5/v6 message-list compatibility, plus core typecheck, core lint, docs validation, touched docs remark/prettier, and git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Old tool outputs kept piling into the model's prompts and made them huge. This PR makes the filter hide older tool outputs at every agent loop step (so prompts stay small) while keeping the full history intact and letting the latest tool output be seen once by default.

## Changes Overview
ToolCallFilter now runs during every agentic loop step via processInputStep and filters against a prompt-only context (modelContextMessages). This prunes prior tool outputs from the next model prompt without mutating canonical MessageList, memory, UI data, or final tool results.

## Key Features
- Step-aware filtering: ToolCallFilter.processInputStep executes on initial input and each agent loop step.
- Latest-step preservation: new preserveLatestStep option (default true) preserves the most recent completed tool step’s output for one model consumption; setting false removes it every step.
- Prompt-only context: processors can return modelContextMessages to produce a prompt-only message set used for the next model prompt; it does not persist to the MessageList.
- Stronger validation: rejects processor returns that include both messages and modelContextMessages and errors when a processor mutates MessageList after entering model-context-only mode.
- Broad compatibility: generalized filtering supports AI SDK v5/v6 part shapes and legacy toolInvocations; generic tool parts without toolName are not inferred for exclusion.

## Implementation Details
- Added optional modelContextMessages to ProcessInputStepResult, step types/schemas, and runtime validation.
- Runner/workflow: runProcessInputStep/workflow prefer stepInput.modelContextMessages as the prompt source and avoid applying returned messages to MessageList when modelContextMessages is active; validatedResult.messages are applied to MessageList only when not using modelContextMessages.
- ToolCallFilter: refactored to a unified filterMessages pipeline over "tool-like" parts, prunes content.toolInvocations, computes excluded tool-call IDs across parts and invocations, preserves IDs from the latest completed step (with step-start boundary logic), and trims orphan step markers.
- LLM step: llm-execution-step builds a derived MessageList from modelContextMessages (preserving system messages and source metadata) and uses it for aiV5.llmPrompt input when present.
- Provider & exports: ToolCallFilterOptions type added and exported; processor provider config accepts preserveLatestStep and includes processInputStep in available phases; ToolCallFilter constructor updated and processInputStep added.

## Documentation Updates
- Updated docs for processors, processor interface, and ToolCallFilter to document modelContextMessages, step-aware filtering, preserveLatestStep semantics, and agentic-loop behavior; usage examples and formatting adjusted.

## Testing & Validation
- Added/expanded Vitest coverage:
  - ToolCallFilter tests for processInput and processInputStep across v5/v6 part shapes, legacy toolInvocations, preserveLatestStep behavior, and markerless histories.
  - processInputStep tests for modelContextMessages propagation, isolation from MessageList, invalid-return guardrails, and mutation guards.
  - Agent/workflow/processor-step tests ensuring prompt-only context is used for LLM input and MessageList mutations are prevented.
  - agent-processor test validating prompt filtering while preserving final toolResults.
- CI checks updated: typecheck, lint, docs validation, remark/prettier formatting, and git diff --check.

## Public API Surface
- Added exported type: ToolCallFilterOptions.
- ToolCallFilter constructor signature updated and public processInputStep method added.
- Re-exported ToolCallFilterOptions from processors barrel.
- modelContextMessages fields added to processor step types/schemas.

## Resolves
Closes issue #15811: prevents repeated accumulation of prior tool call results across agent loop steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->