### PR TITLE
paul/deved-266-channels-guide 

### DIFF
--- a/docs/src/content/en/docs/agents/channels.mdx
+++ b/docs/src/content/en/docs/agents/channels.mdx
@@ -79,7 +79,7 @@ Platform webhooks need a public URL to reach your local server. Use a tunnel to 
 ngrok http 4111
 
 # cloudflared
-cloudflared tunnel --url http://localhost:4111
+npx cloudflared tunnel --url http://localhost:4111
 ```
 
 Copy the generated URL and use it as the base for your webhook paths (e.g. `https://abc123.ngrok.io/api/agents/support-agent/channels/slack/webhook`).
@@ -175,6 +175,7 @@ See [Channels reference](/reference/agents/channels#inline-media) for all `inlin
 
 ## Related
 
+- [Guide: Building a Slack assistant](/guides/guide/slack-assistant)
 - [Agent overview](/docs/agents/overview)
 - [Tool approval](/docs/agents/agent-approval)
 - [Channels reference](/reference/agents/channels)

--- a/docs/src/content/en/guides/guide/slack-assistant.mdx
+++ b/docs/src/content/en/guides/guide/slack-assistant.mdx
@@ -129,7 +129,7 @@ The tunnel URL is for local development only. When you [deploy your application]
 
 ## Test the agent
 
-Before testing with Slack, you can refine your agent's behavior in [Studio](/docs/getting-started/studio). Open [http://localhost:4111/](http://localhost:4111/) to chat with your agent directly, adjust its instructions, and inspect traces to see how responses are generated.
+Before testing with Slack, you can refine your agent's behavior in [Studio](/docs/studio/overview). Open [http://localhost:4111/](http://localhost:4111/) to chat with your agent directly, adjust its instructions, and inspect traces to see how responses are generated.
 
 Once you're happy with the agent's responses, test the Slack integration. Invite the bot to a channel in Slack:
 
@@ -157,6 +157,6 @@ You can extend this agent to:
 Learn more:
 
 - [Channels overview](/docs/agents/channels)
-- [Studio](/docs/getting-started/studio)
+- [Studio](/docs/studio/overview)
 - [Deployment overview](/docs/deployment/overview)
 - [Chat SDK adapter docs](https://chat-sdk.dev)

--- a/docs/src/content/en/guides/guide/slack-assistant.mdx
+++ b/docs/src/content/en/guides/guide/slack-assistant.mdx
@@ -1,0 +1,162 @@
+---
+title: "Guide: Building a Slack assistant"
+description: Build a Mastra agent that responds to messages and mentions on Slack using the channel adapter.
+---
+
+# Building a Slack assistant
+
+In this guide, you'll build a Mastra agent that responds to messages and mentions on Slack. You'll learn how to configure a channel adapter, set up a Slack app with the right permissions, connect it to your agent via a webhook, and test the interaction.
+
+## Prerequisites
+
+- Node.js `v22.13.0` or later installed
+- An API key from a supported [Model Provider](/models)
+- An existing Mastra project. Follow the [installation guide](/guides/getting-started/quickstart) if needed.
+- A [Slack workspace](https://slack.com/) where you can create apps
+
+## Create the agent
+
+Install the Slack adapter:
+
+```bash npm2yarn
+npm install @chat-adapter/slack
+```
+
+Create a new file `src/mastra/agents/slack-agent.ts` and define your agent:
+
+```ts title="src/mastra/agents/slack-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { createSlackAdapter } from '@chat-adapter/slack'
+
+export const slackAgent = new Agent({
+  id: 'slack-agent',
+  name: 'Slack Agent',
+  instructions:
+    'You are a helpful assistant. Answer questions, help with tasks, and have natural conversations.',
+  model: 'anthropic/claude-opus-4-6',
+  channels: {
+    adapters: {
+      slack: createSlackAdapter(),
+    },
+  },
+})
+```
+
+The `channels` property tells Mastra to generate a webhook endpoint for each adapter. In this case, the Slack adapter handles event verification, signature validation, and message formatting automatically.
+
+Register the agent in your `src/mastra/index.ts` file:
+
+```ts title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+// highlight-next-line
+import { slackAgent } from './agents/slack-agent'
+
+export const mastra = new Mastra({
+  // highlight-next-line
+  agents: { slackAgent },
+})
+```
+
+## Create a Slack app
+
+You need a Slack app to connect your agent to a workspace.
+
+Go to [https://api.slack.com/apps](https://api.slack.com/apps) and select **Create New App** > **From scratch**. Give it a name and select your workspace.
+
+Navigate to **OAuth & Permissions** and scroll to **Bot Token Scopes**. Add the following scopes:
+
+- `app_mentions:read`
+- `channels:history`
+- `channels:read`
+- `chat:write`
+- `users:read`
+
+At the top of **OAuth & Permissions**, select **Install to Workspace**. Copy the **Bot User OAuth Token** (`xoxb-...`).
+
+Go to **Basic Information** > **App Credentials** and copy the **Signing Secret** (e.g. `c3a4...`).
+
+Ensure **Socket Mode** is turned **off** under **Settings** > **Socket Mode**.
+
+Add the credentials to your `.env` file:
+
+```bash title=".env"
+SLACK_SIGNING_SECRET=your-signing-secret
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+```
+
+The adapter reads these environment variables by default. See the [Chat SDK Slack adapter docs](https://chat-sdk.dev/adapters/slack) for more details.
+
+## Connect the webhook
+
+Slack delivers events to your agent via a webhook. Mastra generates this endpoint automatically for each channel adapter.
+
+Start the dev server:
+
+```bash npm2yarn
+npm run dev
+```
+
+During local development, Slack needs a public URL to reach your local server. Open a new terminal and start a tunnel:
+
+```bash
+npx cloudflared tunnel --url http://localhost:4111
+```
+
+This outputs a temporary public URL like `https://triple-arms-solutions-kit.trycloudflare.com`. The URL changes each time you restart the tunnel.
+
+In your Slack app settings, go to **Event Subscriptions** and toggle **Enable Events** to **On**.
+
+Set the **Request URL** to your tunnel URL with the agent webhook path:
+
+```text
+https://<your-tunnel-url>/api/agents/slack-agent/channels/slack/webhook
+```
+
+Slack sends a verification request. If your dev server is running, it responds with a green checkmark.
+
+Under **Subscribe to bot events**, add:
+
+- `app_mention`
+- `message.channels`
+
+Select **Save Changes**. Slack requires you to reinstall the app after changing event subscriptions. Go to **OAuth & Permissions** and select **Reinstall to Workspace** to apply the updated permissions.
+
+:::note
+
+The tunnel URL is for local development only. When you [deploy your application](/docs/deployment/overview), update the **Request URL** in your Slack app's **Event Subscriptions** to your production URL (e.g. `https://your-app.example.com/api/agents/slack-agent/channels/slack/webhook`).
+
+:::
+
+## Test the agent
+
+Before testing with Slack, you can refine your agent's behavior in [Studio](/docs/getting-started/studio). Open [http://localhost:4111/](http://localhost:4111/) to chat with your agent directly, adjust its instructions, and inspect traces to see how responses are generated.
+
+Once you're happy with the agent's responses, test the Slack integration. Invite the bot to a channel in Slack:
+
+```text
+/invite @your-bot-name
+```
+
+Mention the bot in the channel:
+
+```text
+@your-bot-name What can you help me with?
+```
+
+The agent responds in the thread. Output may vary depending on the model and instructions.
+
+## Next steps
+
+You can extend this agent to:
+
+- [Deploy your application](/docs/deployment/overview) and update the Slack **Request URL** to your production endpoint
+- Add more adapters (Discord, Telegram) to the same agent so it responds on multiple platforms
+- Configure [multimodal content](/docs/agents/channels#multimodal-content) to let your agent process images, video, and audio shared in chat
+- Add [tools](/docs/agents/using-tools) to give the agent access to external APIs and data
+
+Learn more:
+
+- [Channels overview](/docs/agents/channels)
+- [Studio](/docs/getting-started/studio)
+- [Deployment overview](/docs/deployment/overview)
+- [Chat SDK adapter docs](https://chat-sdk.dev)

--- a/docs/src/content/en/guides/sidebars.js
+++ b/docs/src/content/en/guides/sidebars.js
@@ -238,6 +238,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'guide/slack-assistant',
+          label: 'Channels: Slack Assistant',
+        },
+        {
+          type: 'doc',
           id: 'guide/whatsapp-chat-bot',
           label: 'WhatsApp Chat Bot',
         },


### PR DESCRIPTION
## Description

- add slack assistant guide

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a simple, step-by-step tutorial that shows developers how to build and connect an AI-powered Slack bot using Mastra—covering the code examples, Slack app settings, how to expose a local dev webhook, and how to test it.

## Changes

### Documentation
- New guide: docs/src/content/en/guides/guide/slack-assistant.mdx — full walkthrough for creating a Slack channel assistant with Mastra, including:
  - Installing and wiring the Slack adapter
  - Creating and exporting a `slackAgent` in example code (docs show `src/mastra/agents/slack-agent.ts`)
  - Registering the agent in `src/mastra/index.ts`
  - Slack app setup: OAuth scopes, signing secret and bot token env vars, disabling Socket Mode
  - Connecting Slack Event Subscriptions to Mastra’s auto-generated webhook endpoint (with tunnel instructions for local dev)
  - Required event subscriptions (`app_mention`, `message.channels`) and reinstallation step
  - Testing the bot via Studio and in Slack (invite/mention)
  - Next-step pointers: deployment, multi-adapter support, multimodal features, tools, and related docs

- Sidebar update: docs/src/content/en/guides/sidebars.js — adds a "Channels: Slack Assistant" entry under Guides → Tutorials.

- Channels docs tweak: docs/src/content/en/docs/agents/channels.mdx — updates cloudflared usage to `npx cloudflared tunnel --url http://localhost:4111` (uses npx) and adds a “Guide: Building a Slack assistant” link to the Related section.

### Code / Examples
- Example in the new guide shows exporting `export const slackAgent = new Agent({ ... })` in `src/mastra/agents/slack-agent.ts`. (Note: the repository does not contain an actual src/mastra/agents/slack-agent.ts file—this is an example added to the docs.)

## Other notes
- Commit message: docs: add missing npx to channels docs
- PR labeled Documentation; no related issues linked and checklist items are unchecked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->