### PR TITLE
fix(playground): persist Review tab comments across reload

### DIFF
--- a/.changeset/review-tab-comment-persistence.md
+++ b/.changeset/review-tab-comment-persistence.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed Review tab comments not persisting across page reload in the studio. Tags would survive a reload but typed comments would disappear, because the rehydrate path always reset the comment field to an empty string. Comments are now read back from the feedback store on load, matching how they are written when the textarea is blurred.

--- a/packages/playground/src/domains/agents/hooks/use-completed-items.ts
+++ b/packages/playground/src/domains/agents/hooks/use-completed-items.ts
@@ -2,6 +2,7 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import type { ReviewItem } from '../context/review-queue-context';
 import { useAgentExperiments } from './use-agent-experiments';
+import { fetchResultCommentsByExperiment } from '@/domains/review/utils/fetch-result-comments';
 
 /**
  * Loads completed review items (status='complete') for auditing.
@@ -18,7 +19,10 @@ export const useCompletedItems = (agentId: string) => {
       const allResults = await Promise.all(
         experiments.map(async exp => {
           try {
-            const { results } = await client.listDatasetExperimentResults(exp.datasetId, exp.id);
+            const [{ results }, comments] = await Promise.all([
+              client.listDatasetExperimentResults(exp.datasetId, exp.id),
+              fetchResultCommentsByExperiment(client, exp.id),
+            ]);
             return results
               .filter(r => r.status === 'complete')
               .map(r => ({
@@ -32,7 +36,7 @@ export const useCompletedItems = (agentId: string) => {
                 traceId: r.traceId ?? undefined,
                 scores: r.scores ? Object.fromEntries(r.scores.map(s => [s.scorerId, s.score ?? 0])) : {},
                 tags: r.tags ?? [],
-                comment: '',
+                comment: comments.get(r.id) ?? '',
               }));
           } catch {
             return [];

--- a/packages/playground/src/domains/agents/hooks/use-review-items.ts
+++ b/packages/playground/src/domains/agents/hooks/use-review-items.ts
@@ -2,6 +2,7 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import type { ReviewItem } from '../context/review-queue-context';
 import { useAgentExperiments } from './use-agent-experiments';
+import { fetchResultCommentsByExperiment } from '@/domains/review/utils/fetch-result-comments';
 
 /**
  * Loads persisted review items from experiment results with status='needs-review'.
@@ -19,7 +20,10 @@ export const useReviewItems = (agentId: string) => {
       const allResults = await Promise.all(
         experiments.map(async exp => {
           try {
-            const { results } = await client.listDatasetExperimentResults(exp.datasetId, exp.id);
+            const [{ results }, comments] = await Promise.all([
+              client.listDatasetExperimentResults(exp.datasetId, exp.id),
+              fetchResultCommentsByExperiment(client, exp.id),
+            ]);
             return results
               .filter(r => r.status === 'needs-review')
               .map(r => ({
@@ -33,7 +37,7 @@ export const useReviewItems = (agentId: string) => {
                 traceId: r.traceId ?? undefined,
                 scores: r.scores ? Object.fromEntries(r.scores.map(s => [s.scorerId, s.score ?? 0])) : {},
                 tags: r.tags ?? [],
-                comment: '',
+                comment: comments.get(r.id) ?? '',
               }));
           } catch {
             return [];

--- a/packages/playground/src/domains/review/hooks/use-dataset-review-items.ts
+++ b/packages/playground/src/domains/review/hooks/use-dataset-review-items.ts
@@ -1,6 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import type { ReviewItem } from '../components/review-item-card';
+import { fetchResultCommentsByExperiment } from '../utils/fetch-result-comments';
 import { useDatasetExperiments } from '@/domains/datasets/hooks/use-dataset-experiments';
 
 /**
@@ -20,7 +21,10 @@ export const useDatasetReviewItems = (datasetId: string) => {
         experiments.map(async exp => {
           if (!exp.datasetId) return [];
           try {
-            const { results } = await client.listDatasetExperimentResults(exp.datasetId, exp.id);
+            const [{ results }, comments] = await Promise.all([
+              client.listDatasetExperimentResults(exp.datasetId, exp.id),
+              fetchResultCommentsByExperiment(client, exp.id),
+            ]);
             return results
               .filter(r => r.status === 'needs-review')
               .map(r => ({
@@ -34,7 +38,7 @@ export const useDatasetReviewItems = (datasetId: string) => {
                 traceId: r.traceId ?? undefined,
                 scores: r.scores ? Object.fromEntries(r.scores.map(s => [s.scorerId, s.score ?? 0])) : {},
                 tags: r.tags ?? [],
-                comment: '',
+                comment: comments.get(r.id) ?? '',
               }));
           } catch {
             return [];
@@ -66,7 +70,10 @@ export const useDatasetCompletedItems = (datasetId: string) => {
         experiments.map(async exp => {
           if (!exp.datasetId) return [];
           try {
-            const { results } = await client.listDatasetExperimentResults(exp.datasetId, exp.id);
+            const [{ results }, comments] = await Promise.all([
+              client.listDatasetExperimentResults(exp.datasetId, exp.id),
+              fetchResultCommentsByExperiment(client, exp.id),
+            ]);
             return results
               .filter(r => r.status === 'complete')
               .map(r => ({
@@ -80,7 +87,7 @@ export const useDatasetCompletedItems = (datasetId: string) => {
                 traceId: r.traceId ?? undefined,
                 scores: r.scores ? Object.fromEntries(r.scores.map(s => [s.scorerId, s.score ?? 0])) : {},
                 tags: r.tags ?? [],
-                comment: '',
+                comment: comments.get(r.id) ?? '',
               }));
           } catch {
             return [];

--- a/packages/playground/src/domains/review/utils/fetch-result-comments.ts
+++ b/packages/playground/src/domains/review/utils/fetch-result-comments.ts
@@ -1,0 +1,31 @@
+import type { MastraClient } from '@mastra/client-js';
+
+/**
+ * Fetches the latest 'comment' feedback record for each experiment result
+ * and returns a map of result id (`sourceId`) → comment text.
+ *
+ * Comments are persisted via `client.createFeedback({ feedbackType: 'comment', sourceId: resultId, ... })`,
+ * so this is the read-side counterpart used to rehydrate the Review UI on page load.
+ */
+export async function fetchResultCommentsByExperiment(
+  client: MastraClient,
+  experimentId: string,
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  try {
+    const { feedback } = await client.listFeedback({
+      filters: { feedbackType: 'comment', experimentId },
+      pagination: { page: 0, perPage: 1000 },
+      orderBy: { field: 'timestamp', direction: 'DESC' },
+    });
+    for (const f of feedback) {
+      const sourceId = f.sourceId;
+      if (!sourceId || result.has(sourceId)) continue;
+      const text = f.comment ?? (typeof f.value === 'string' ? f.value : '');
+      if (text) result.set(sourceId, text);
+    }
+  } catch {
+    // Surface as "no comments" rather than blocking the rehydrate
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

On the studio Review tab, tags survive a page reload but typed comments disappear. The rehydrate hooks were hardcoding `comment: ''` when mapping experiment results into review items, so the comment that gets written to the feedback store on textarea blur was never read back.

## Fix

Comments are persisted via `client.createFeedback({ feedbackType: 'comment', sourceId: resultId, ... })` on blur. This PR adds the matching read path: a small helper that uses the existing `listFeedback` endpoint to fetch the latest comment-type feedback per experiment result, and wires it into the four rehydrate hooks.

- New `packages/playground/src/domains/review/utils/fetch-result-comments.ts` — one fetch per experiment, indexed by `sourceId`, latest-by-timestamp wins.
- Updated `use-review-items`, `use-completed-items` (agents) and `use-dataset-review-items` (both review and completed queries) to call the helper alongside `listDatasetExperimentResults` and populate `comment` from the returned map instead of the hardcoded `''`.

No schema or server changes; the write path is unchanged.

## Test plan

- [ ] Open Review tab on an agent, add a comment to an item, blur the textarea, reload — comment is restored.
- [ ] Same flow on the dataset Review tab.
- [ ] Same flow for a completed (Mark as complete) item — comment still shown read-only.
- [ ] Items with no comment continue to show an empty textarea.
- [ ] Items whose experiment has no traceId continue to work for tags/rating (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When you type a comment in the Review tab and refresh the page, your comment was disappearing—even though it was actually being saved. This PR fixes it by making sure comments are loaded back from storage when the page reloads, the same way other feedback (like tags) already were.

---

## Summary
This PR fixes a client-side rehydration bug in the playground's Review tab where typed comments were not being restored after a page reload. While comment writes were working correctly (saved via `client.createFeedback()` on textarea blur), the rehydrate/load hooks were hardcoding `comment: ''` instead of reading the saved comments back from the feedback store.

## Changes
- **New utility**: `packages/playground/src/domains/review/utils/fetch-result-comments.ts` — Exports `fetchResultCommentsByExperiment()`, which queries the existing `listFeedback` endpoint to retrieve all comment-type feedback for an experiment, returns the latest comment per result (keyed by `sourceId`, sorted by descending timestamp), and silently returns an empty `Map` on errors.

- **Updated rehydrate hooks** — Three hooks now call the new helper alongside `listDatasetExperimentResults` and populate `comment` from the fetched comments map instead of hardcoding empty strings:
  - `packages/playground/src/domains/agents/hooks/use-completed-items.ts`
  - `packages/playground/src/domains/agents/hooks/use-review-items.ts`
  - `packages/playground/src/domains/review/hooks/use-dataset-review-items.ts` (both review and completed query variants)

- **Changeset**: Documents the patch-level fix for `@internal/playground`.

## Impact
No schema or server changes. The feedback write path remains unchanged. Comments typed in Review tabs (agent and dataset) will now persist across page reloads, while completed items show read-only comments and items without comments display empty textareas as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->