### PR TITLE
fix(core): handle AbortError before logging at error level (#15844)

### DIFF
--- a/.changeset/abort-error-not-error-level.md
+++ b/.changeset/abort-error-not-error-level.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Stop logging client-disconnect aborts as `Error in LLM execution` at error level. The catch block in `agentic-execution/llm-execution-step.ts` now checks for `isAbortError(error)` first and exits via a `debug`-level log + the existing `onAbort` flow before the upstream-error / generic-error branches run. Closes #15844.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -884,6 +884,24 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           } catch (error) {
             const provider = model?.provider;
             const modelIdStr = model?.modelId;
+
+            // Handle abort first — a client-disconnect mid-stream is the
+            // expected exit path, not an error. Logging it at error level
+            // pollutes monitoring (see #15844 for the production
+            // numbers). Bail out with a debug log before the upstream /
+            // generic error branches so we never emit an
+            // `error`-level entry for an AbortError.
+            if (isAbortError(error) && options?.abortSignal?.aborted) {
+              logger?.debug?.('LLM execution aborted', { runId });
+              await options?.onAbort?.({
+                steps: inputData?.output?.steps ?? [],
+              });
+
+              safeEnqueue(controller, { type: 'abort', runId, from: ChunkFrom.AGENT, payload: {} });
+
+              return { callBail: true, outputStream, runState, stepTools: currentStep.tools };
+            }
+
             const isUpstreamError = APICallError.isInstance(error);
 
             if (isUpstreamError) {
@@ -902,16 +920,6 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                 ...(provider && { provider }),
                 ...(modelIdStr && { modelId: modelIdStr }),
               });
-            }
-
-            if (isAbortError(error) && options?.abortSignal?.aborted) {
-              await options?.onAbort?.({
-                steps: inputData?.output?.steps ?? [],
-              });
-
-              safeEnqueue(controller, { type: 'abort', runId, from: ChunkFrom.AGENT, payload: {} });
-
-              return { callBail: true, outputStream, runState, stepTools: currentStep.tools };
             }
 
             if (isLastModel) {


### PR DESCRIPTION
Closes #15844.

## Summary
The catch block in \`agentic-execution/llm-execution-step.ts\` logged \`'Error in LLM execution'\` (or the upstream-API-error variant) at **error level** *before* checking whether the caught error was actually an \`AbortError\`. Production users report ~100 of these noisy error-level entries per day per deployment for what is the *expected* graceful exit path when a client disconnects mid-stream — polluting alerting and hiding real LLM failures.

## Fix
Move the \`isAbortError(error) && options?.abortSignal?.aborted\` branch above the upstream-error and generic-error branches in the catch block. The abort path now logs at \`debug\` level via \`logger?.debug?.\` (optional-chained because some callers pass loggers without a \`debug\` method) and bails through the existing \`onAbort\` + \`safeEnqueue('abort')\` flow before any error-level log can fire.

```ts
} catch (error) {
    const provider = model?.provider;
    const modelIdStr = model?.modelId;

    if (isAbortError(error) && options?.abortSignal?.aborted) {
        logger?.debug?.('LLM execution aborted', { runId });
        await options?.onAbort?.({ steps: inputData?.output?.steps ?? [] });
        safeEnqueue(controller, { type: 'abort', runId, from: ChunkFrom.AGENT, payload: {} });
        return { callBail: true, outputStream, runState, stepTools: currentStep.tools };
    }

    const isUpstreamError = APICallError.isInstance(error);
    if (isUpstreamError) { /* ... unchanged ... */ }
    else { /* ... unchanged ... */ }
    ...
}
```

## Behavior
| Case | Before | After |
|---|---|---|
| `AbortError` + `abortSignal.aborted` | `error`-level + onAbort | `debug`-level + onAbort |
| `APICallError` | `error`-level (unchanged) | `error`-level (unchanged) |
| Any other error | `error`-level (unchanged) | `error`-level (unchanged) |

## Test plan
- [x] Logical reordering only — the abort branch was already terminal (`return { callBail: true ... }`), so moving it earlier is a no-op for non-abort cases. `APICallError` and generic errors keep their existing log lines, message text, and structured fields.
- [x] Patch-level changeset added under `.changeset/abort-error-not-error-level.md`.
- [ ] No new unit tests added: the existing test suite for `llm-execution-step.ts` does not exercise the catch block end-to-end (it stubs `doStream`), and adding a fresh AbortError-injected test would require a substantial scaffolding pass. Happy to follow up if maintainers want one.

## Notes
- Secondary issue raised in the bug report (\`error\` vs \`err\` logger key) is **not** addressed here — Pino's default key is \`err\`, but changing the field name is a public-log-shape change that warrants its own discussion. Filing a follow-up if the maintainers want it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When someone stops using the AI agent mid-conversation (like closing a browser), the system was logging it as a scary "error" that sent alerts. This PR fixes that by teaching the system to recognize when someone has just disconnected and log it as a normal debug message instead, so the alerts only show real problems.

## Overview
This PR addresses noisy error-level logs in LLM execution when clients disconnect mid-stream. The fix reorders the catch block in the LLM execution step to detect `AbortError` **before** performing error-level logging, preventing client disconnects from appearing as errors in monitoring systems.

## Changes
- **llm-execution-step.ts**: Reordered the catch block's error handling so that `isAbortError(error)` is checked first. When an abort is detected and the abort signal is marked aborted, the code now:
  - Logs at debug level (instead of error level): `'LLM execution aborted'`
  - Calls `options?.onAbort` with accumulated steps
  - Enqueues an abort chunk via `safeEnqueue`
  - Returns `{ callBail: true, ... }` immediately
  - Skips the upstream-error and generic-error logging branches entirely

- **.changeset/abort-error-not-error-level.md**: Added patch-level changeset for `@mastra/core` documenting that client-disconnect aborts are no longer logged at error level as "Error in LLM execution."

## Impact
- **Problem solved**: Client disconnects no longer generate spurious error-level logs (~100/day per deployment), reducing alert noise
- **Behavior unchanged for other errors**: APICallError and other exceptions retain their existing error-level logging and structured fields
- **No public API changes**: This is a pure logging-behavior fix with no impact on exported signatures or external interfaces

## Testing notes
No new unit tests were added. The author notes that existing tests stub `doStream` and would require additional scaffolding to exercise the catch path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->