### PR TITLE
feat(core): add prompt-only model context

### DIFF
--- a/.changeset/common-hairs-count.md
+++ b/.changeset/common-hairs-count.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed prompt-only processor context so model prompt changes stay isolated from canonical history and API-error retries can update the failed prompt.

--- a/.changeset/every-dogs-fall.md
+++ b/.changeset/every-dogs-fall.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed processor middleware so output processors keep using the original prompt when provider options are cloned.

--- a/.changeset/five-rabbits-wash.md
+++ b/.changeset/five-rabbits-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed the processor execution endpoint so requests and responses cannot mix canonical messages with prompt-only model context.

--- a/.changeset/many-eyes-turn.md
+++ b/.changeset/many-eyes-turn.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': minor
+'@mastra/client-js': minor
+'@mastra/ai-sdk': minor
+'@mastra/server': minor
+---
+
+Added prompt-only model context support for input processors so processors can shape model prompts without mutating canonical messages.

--- a/client-sdks/ai-sdk/src/middleware.test.ts
+++ b/client-sdks/ai-sdk/src/middleware.test.ts
@@ -17,12 +17,33 @@ import type {
   ProcessOutputResultArgs,
   ProcessOutputStreamArgs,
 } from '@mastra/core/processors';
+import { MessageHistory } from '@mastra/core/processors';
 import type { MemoryStorage } from '@mastra/core/storage';
 import { LibSQLStore } from '@mastra/libsql';
-import { ObservationalMemory } from '@mastra/memory/processors';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createProcessorMiddleware, withMastra } from './middleware';
+
+function createDbMessage(text: string, role: 'user' | 'assistant' | 'system' = 'user'): MastraDBMessage {
+  return {
+    id: `${role}-${text}`,
+    role,
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text }],
+    },
+    createdAt: new Date(0),
+    threadId: 'test-thread',
+  };
+}
+
+function getDbMessageText(message: MastraDBMessage): string {
+  return (
+    (typeof message.content.content === 'string' ? message.content.content : undefined) ??
+    message.content.parts?.map(part => ('text' in part && typeof part.text === 'string' ? part.text : '')).join('') ??
+    ''
+  );
+}
 
 // Helper to create a mock model with a specific response
 function createMockModel(response: string = 'Test response') {
@@ -121,6 +142,202 @@ describe('withMastra middleware', () => {
 
       expect(processedInputs).toContain('Hello world');
       expect(result.text).toBe('Test response');
+    });
+
+    it('should use modelContextMessages for the model prompt only', async () => {
+      let promptSeenByModel = '';
+      const promptOnlyMessage = createDbMessage('prompt-only input');
+      const captureModel = new MockLanguageModelV2({
+        doGenerate: async ({ prompt }) => {
+          promptSeenByModel = JSON.stringify(prompt);
+          return {
+            content: [{ type: 'text', text: 'OK' }],
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        },
+      });
+
+      const processor: InputProcessor = {
+        id: 'prompt-only',
+        async processInput() {
+          return { modelContextMessages: [promptOnlyMessage] };
+        },
+      };
+
+      const model = withMastra(captureModel, {
+        inputProcessors: [processor],
+      });
+
+      const result = await generateText({
+        model,
+        prompt: 'canonical input',
+      });
+
+      expect(result.text).toBe('OK');
+      expect(promptSeenByModel).toContain('prompt-only input');
+      expect(promptSeenByModel).not.toContain('canonical input');
+    });
+
+    it('should reject input processor results that include both messages and modelContextMessages keys', async () => {
+      const promptOnlyMessage = createDbMessage('prompt-only input');
+      const processor: InputProcessor = {
+        id: 'invalid-present-keys',
+        async processInput() {
+          return {
+            messages: undefined,
+            modelContextMessages: [promptOnlyMessage],
+          } as never;
+        },
+      };
+
+      const model = withMastra(createMockModel('OK'), {
+        inputProcessors: [processor],
+      });
+
+      await expect(
+        generateText({
+          model,
+          prompt: 'canonical input',
+        }),
+      ).rejects.toThrow('returned both messages and modelContextMessages');
+    });
+
+    it('should keep prompt-only messages out of output processor canonical messages', async () => {
+      const promptOnlyMessage = createDbMessage('prompt-only input');
+      let messagesSeenByOutputProcessor: MastraDBMessage[] = [];
+
+      const inputProcessor: InputProcessor = {
+        id: 'prompt-only',
+        async processInput() {
+          return { modelContextMessages: [promptOnlyMessage] };
+        },
+      };
+      const outputProcessor: OutputProcessor = {
+        id: 'output-capture',
+        async processOutputResult(args) {
+          messagesSeenByOutputProcessor = args.messages;
+          return args.messageList;
+        },
+      };
+
+      const model = withMastra(createMockModel('OK'), {
+        inputProcessors: [inputProcessor],
+        outputProcessors: [outputProcessor],
+      });
+
+      await generateText({
+        model,
+        prompt: 'canonical input',
+      });
+
+      const outputTexts = messagesSeenByOutputProcessor.map(getDbMessageText);
+      expect(outputTexts).toContain('canonical input');
+      expect(outputTexts).not.toContain('prompt-only input');
+    });
+
+    it('should reject messageList mutation while returning prompt-only model context', async () => {
+      const promptOnlyMessage = createDbMessage('prompt-only input');
+
+      const inputProcessor: InputProcessor = {
+        id: 'invalid-prompt-only-mutation',
+        async processInput({ messageList }) {
+          messageList.add([createDbMessage('canonical mutation')], 'input');
+          return { modelContextMessages: [promptOnlyMessage] };
+        },
+      };
+
+      const model = withMastra(createMockModel('OK'), {
+        inputProcessors: [inputProcessor],
+      });
+
+      await expect(
+        generateText({
+          model,
+          prompt: 'canonical input',
+        }),
+      ).rejects.toThrow('mutated messageList and returned modelContextMessages');
+    });
+
+    it('should reject messageList mutation after prompt-only mode starts', async () => {
+      const promptOnlyMessage = createDbMessage('prompt-only input');
+
+      const promptOnlyProcessor: InputProcessor = {
+        id: 'prompt-only',
+        async processInput() {
+          return { modelContextMessages: [promptOnlyMessage] };
+        },
+      };
+      const mutatingProcessor: InputProcessor = {
+        id: 'invalid-canonical-mutation',
+        async processInput({ messageList }) {
+          messageList.add([createDbMessage('canonical mutation')], 'input');
+          return undefined;
+        },
+      };
+
+      const model = withMastra(createMockModel('OK'), {
+        inputProcessors: [promptOnlyProcessor, mutatingProcessor],
+      });
+
+      await expect(
+        generateText({
+          model,
+          prompt: 'canonical input',
+        }),
+      ).rejects.toThrow('mutated messageList after prompt-only model context was set');
+    });
+
+    it('should ignore system-role modelContextMessages and keep canonical system prompts', async () => {
+      let promptSeenByModel = '';
+      const promptOnlySystemMessage = createDbMessage('prompt-only system', 'system');
+      let messagesSeenByOutputProcessor: MastraDBMessage[] = [];
+      const captureModel = new MockLanguageModelV2({
+        doGenerate: async ({ prompt }) => {
+          promptSeenByModel = JSON.stringify(prompt);
+          return {
+            content: [{ type: 'text', text: 'OK' }],
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        },
+      });
+
+      const inputProcessor: InputProcessor = {
+        id: 'prompt-only-system',
+        async processInput() {
+          return { modelContextMessages: [promptOnlySystemMessage, createDbMessage('prompt-only input')] };
+        },
+      };
+      const outputProcessor: OutputProcessor = {
+        id: 'output-capture',
+        async processOutputResult(args) {
+          messagesSeenByOutputProcessor = args.messages;
+          return args.messageList;
+        },
+      };
+
+      const model = withMastra(captureModel, {
+        inputProcessors: [inputProcessor],
+        outputProcessors: [outputProcessor],
+      });
+
+      await generateText({
+        model,
+        system: 'canonical system',
+        prompt: 'canonical input',
+      });
+
+      expect(promptSeenByModel).toContain('canonical system');
+      expect(promptSeenByModel).not.toContain('prompt-only system');
+
+      const outputTexts = messagesSeenByOutputProcessor.map(getDbMessageText);
+      expect(outputTexts).toContain('canonical input');
+      expect(outputTexts).not.toContain('prompt-only system');
     });
 
     it('should accept LanguageModelV3 models', async () => {
@@ -819,12 +1036,8 @@ describe('withMastra middleware', () => {
       expect(texts).toContain('The answer is 42.');
     });
 
-    it('should save messages via observational memory after streaming completes', async () => {
-      const observationalMemory = new ObservationalMemory({
-        storage: memoryStore,
-        observation: { messageTokens: 100000, model: 'test-model', bufferTokens: false },
-        reflection: { observationTokens: 200000, model: 'test-model' },
-      });
+    it('should save messages via MessageHistory after streaming completes', async () => {
+      const messageHistory = new MessageHistory({ storage: memoryStore });
 
       const model = withMastra(createMockModel(), {
         memory: {
@@ -833,8 +1046,7 @@ describe('withMastra middleware', () => {
           resourceId,
           lastMessages: false,
         },
-        inputProcessors: [observationalMemory],
-        outputProcessors: [observationalMemory],
+        outputProcessors: [messageHistory],
       });
 
       const { messages: initialMessages } = await memoryStore.listMessages({ threadId });

--- a/client-sdks/ai-sdk/src/middleware.test.ts
+++ b/client-sdks/ai-sdk/src/middleware.test.ts
@@ -20,7 +20,7 @@ import type {
 import { MessageHistory } from '@mastra/core/processors';
 import type { MemoryStorage } from '@mastra/core/storage';
 import { LibSQLStore } from '@mastra/libsql';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createProcessorMiddleware, withMastra } from './middleware';
 
@@ -236,6 +236,168 @@ describe('withMastra middleware', () => {
       const outputTexts = messagesSeenByOutputProcessor.map(getDbMessageText);
       expect(outputTexts).toContain('canonical input');
       expect(outputTexts).not.toContain('prompt-only input');
+    });
+
+    it('should keep original prompt state when provider options are cloned before output processing', async () => {
+      const promptOnlyMessage = createDbMessage('prompt-only input');
+      let messagesSeenByOutputProcessor: MastraDBMessage[] = [];
+
+      const middleware = createProcessorMiddleware({
+        inputProcessors: [
+          {
+            id: 'prompt-only',
+            async processInput() {
+              return { modelContextMessages: [promptOnlyMessage] };
+            },
+          },
+        ],
+        outputProcessors: [
+          {
+            id: 'output-capture',
+            async processOutputResult(args) {
+              messagesSeenByOutputProcessor = args.messages;
+              return args.messageList;
+            },
+          },
+        ],
+      });
+
+      const transformedParams = await (middleware as any).transformParams({
+        params: {
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'canonical input' }] }],
+          providerOptions: {},
+        },
+      });
+      const clonedParams = {
+        ...transformedParams,
+        providerOptions: structuredClone(transformedParams.providerOptions),
+      };
+
+      await (middleware as any).wrapGenerate({
+        params: clonedParams,
+        doGenerate: async () => ({
+          content: [{ type: 'text', text: 'OK' }],
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          rawCall: { rawPrompt: [], rawSettings: {} },
+          warnings: [],
+        }),
+      });
+
+      const outputTexts = messagesSeenByOutputProcessor.map(getDbMessageText);
+      expect(outputTexts).toContain('canonical input');
+      expect(outputTexts).not.toContain('prompt-only input');
+    });
+
+    it('should throw instead of falling back to transformed prompt when original prompt state is missing', async () => {
+      const middleware = createProcessorMiddleware({
+        outputProcessors: [
+          {
+            id: 'output-capture',
+            async processOutputResult(args) {
+              return args.messageList;
+            },
+          },
+        ],
+      });
+
+      await expect(
+        (middleware as any).wrapGenerate({
+          params: {
+            prompt: [{ role: 'user', content: [{ type: 'text', text: 'transformed prompt' }] }],
+            providerOptions: {
+              mastraProcessors: {
+                originalInputCount: 1,
+                originalPromptRunId: 'missing-run-id',
+              },
+            },
+          },
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'OK' }],
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          }),
+        }),
+      ).rejects.toThrow('missing original prompt');
+    });
+
+    it('should clean up original prompt state when the request aborts before output processing', async () => {
+      const abortController = new AbortController();
+      const middleware = createProcessorMiddleware({
+        outputProcessors: [
+          {
+            id: 'output-capture',
+            async processOutputResult(args) {
+              return args.messageList;
+            },
+          },
+        ],
+      });
+
+      const transformedParams = await (middleware as any).transformParams({
+        params: {
+          prompt: [{ role: 'user', content: [{ type: 'text', text: 'canonical input' }] }],
+          providerOptions: {},
+          abortSignal: abortController.signal,
+        },
+      });
+
+      abortController.abort();
+
+      await expect(
+        (middleware as any).wrapGenerate({
+          params: transformedParams,
+          doGenerate: async () => ({
+            content: [{ type: 'text', text: 'OK' }],
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          }),
+        }),
+      ).rejects.toThrow('missing original prompt');
+    });
+
+    it('should bound original prompt state lifetime when output processing is abandoned', async () => {
+      vi.useFakeTimers();
+      try {
+        const middleware = createProcessorMiddleware({
+          outputProcessors: [
+            {
+              id: 'output-capture',
+              async processOutputResult(args) {
+                return args.messageList;
+              },
+            },
+          ],
+        });
+
+        const transformedParams = await (middleware as any).transformParams({
+          params: {
+            prompt: [{ role: 'user', content: [{ type: 'text', text: 'canonical input' }] }],
+            providerOptions: {},
+          },
+        });
+
+        vi.advanceTimersByTime(30 * 60 * 1000);
+
+        await expect(
+          (middleware as any).wrapGenerate({
+            params: transformedParams,
+            doGenerate: async () => ({
+              content: [{ type: 'text', text: 'OK' }],
+              finishReason: 'stop',
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              rawCall: { rawPrompt: [], rawSettings: {} },
+              warnings: [],
+            }),
+          }),
+        ).rejects.toThrow('missing original prompt');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should reject messageList mutation while returning prompt-only model context', async () => {

--- a/client-sdks/ai-sdk/src/middleware.ts
+++ b/client-sdks/ai-sdk/src/middleware.ts
@@ -1,5 +1,6 @@
 import { ReadableStream, TransformStream } from 'node:stream/web';
 import type {
+  JSONValue,
   LanguageModelV2,
   LanguageModelV2Middleware,
   LanguageModelV2Prompt,
@@ -92,6 +93,39 @@ export interface WithMastraOptions {
   inputProcessors?: InputProcessor[];
   /** Output processors to run on the LLM response */
   outputProcessors?: OutputProcessor[];
+}
+
+function applyMessagesToMessageList(messages: MastraDBMessage[], messageList: MessageList): void {
+  const idsBeforeProcessing = messageList.get.input.db().map(message => message.id);
+  const deletedIds = idsBeforeProcessing.filter(id => !messages.some(message => message.id === id));
+  if (deletedIds.length) {
+    messageList.removeByIds(deletedIds);
+  }
+
+  const check = messageList.makeMessageSourceChecker();
+  for (const message of messages) {
+    messageList.removeByIds([message.id]);
+    if (message.role === 'system') {
+      const systemText =
+        (message.content.content as string | undefined) ??
+        message.content.parts?.map(part => (part.type === 'text' ? part.text : '')).join('\n') ??
+        '';
+      messageList.addSystem(systemText);
+    } else {
+      messageList.add(message, check.getSource(message) || 'input');
+    }
+  }
+}
+
+function createPromptOnlyMessageList(messageList: MessageList, messages: MastraDBMessage[]): MessageList {
+  const promptMessageList = new MessageList().deserialize(messageList.serialize());
+  promptMessageList.clear.all.db();
+  promptMessageList.replaceAllSystemMessages(messageList.getAllSystemMessages());
+  promptMessageList.add(
+    messages.filter(message => message.role !== 'system'),
+    'input',
+  );
+  return promptMessageList;
 }
 
 /**
@@ -262,6 +296,67 @@ interface ProcessorMiddlewareState {
   tripwire?: boolean;
   reason?: string;
   originalInputCount?: number;
+}
+
+const originalPromptsByState = new WeakMap<ProcessorMiddlewareState, LanguageModelV2Prompt>();
+
+function storeOriginalPrompt(processorState: ProcessorMiddlewareState, prompt: LanguageModelV2Prompt): void {
+  originalPromptsByState.set(processorState, prompt);
+}
+
+function getOriginalPrompt(processorState?: ProcessorMiddlewareState): LanguageModelV2Prompt | undefined {
+  return processorState ? originalPromptsByState.get(processorState) : undefined;
+}
+
+function deleteOriginalPrompt(processorState?: ProcessorMiddlewareState): void {
+  if (processorState) {
+    originalPromptsByState.delete(processorState);
+  }
+}
+
+function snapshotMessageList(messageList: MessageList): string {
+  return JSON.stringify(messageList.serialize());
+}
+
+function assertPromptOnlyMessageListMutation({
+  processorId,
+  messageList,
+  snapshotBefore,
+  promptOnlyAlreadyActive,
+  returnedPromptOnly,
+}: {
+  processorId: string;
+  messageList: MessageList;
+  snapshotBefore: string;
+  promptOnlyAlreadyActive: boolean;
+  returnedPromptOnly: boolean;
+}): void {
+  if (snapshotMessageList(messageList) === snapshotBefore) {
+    return;
+  }
+
+  if (promptOnlyAlreadyActive) {
+    throw new Error(
+      `Processor ${processorId} mutated messageList after prompt-only model context was set. Mutate canonical messages before returning modelContextMessages, or return messages to update the prompt-only context.`,
+    );
+  }
+
+  if (returnedPromptOnly) {
+    throw new Error(
+      `Processor ${processorId} mutated messageList and returned modelContextMessages. Prompt-only model context cannot be combined with canonical messageList mutations.`,
+    );
+  }
+}
+
+function serializeProcessorState(
+  processorState: ProcessorMiddlewareState,
+): ProcessorMiddlewareState & Record<string, JSONValue> {
+  const serialized: ProcessorMiddlewareState & Record<string, JSONValue> = {};
+  if (processorState.tripwire !== undefined) serialized.tripwire = processorState.tripwire;
+  if (processorState.reason !== undefined) serialized.reason = processorState.reason;
+  if (processorState.originalInputCount !== undefined)
+    serialized.originalInputCount = processorState.originalInputCount;
+  return serialized;
 }
 
 interface TextPart {
@@ -489,22 +584,85 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
       }
 
       const originalInputCount = params.prompt.filter(msg => msg.role !== 'system').length;
+      let modelContextMessages: MastraDBMessage[] | undefined;
 
       // Run each input processor
       for (const processor of inputProcessors) {
         if (processor.processInput) {
           try {
-            // Processors modify messageList in place. Array returns are supported
-            // but the messageList reference takes precedence for preserving source info.
-            await processor.processInput({
-              messages: messageList.get.input.db(),
+            const snapshotBeforeProcessor = snapshotMessageList(messageList);
+            const result = await processor.processInput({
+              messages: modelContextMessages ?? messageList.get.input.db(),
               systemMessages: messageList.getAllSystemMessages(),
               messageList,
               requestContext,
+              state: {},
+              retryCount: 0,
               abort: (reason?: string): never => {
                 throw new TripWire(reason || 'Aborted by processor');
               },
             } as ProcessInputArgs);
+
+            if (Array.isArray(result)) {
+              assertPromptOnlyMessageListMutation({
+                processorId: processor.id,
+                messageList,
+                snapshotBefore: snapshotBeforeProcessor,
+                promptOnlyAlreadyActive: !!modelContextMessages,
+                returnedPromptOnly: false,
+              });
+              if (modelContextMessages) {
+                modelContextMessages = result;
+              } else {
+                applyMessagesToMessageList(result, messageList);
+              }
+            } else if (result instanceof MessageList) {
+              if (result !== messageList) {
+                throw new Error(
+                  `Processor ${processor.id} returned a MessageList instance other than the one passed in.`,
+                );
+              }
+              assertPromptOnlyMessageListMutation({
+                processorId: processor.id,
+                messageList,
+                snapshotBefore: snapshotBeforeProcessor,
+                promptOnlyAlreadyActive: !!modelContextMessages,
+                returnedPromptOnly: false,
+              });
+            } else if (result) {
+              if ('messages' in result && 'modelContextMessages' in result) {
+                throw new Error(
+                  `Processor ${processor.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
+                );
+              }
+              assertPromptOnlyMessageListMutation({
+                processorId: processor.id,
+                messageList,
+                snapshotBefore: snapshotBeforeProcessor,
+                promptOnlyAlreadyActive: !!modelContextMessages,
+                returnedPromptOnly: !!result.modelContextMessages,
+              });
+              if (result.systemMessages) {
+                messageList.replaceAllSystemMessages(result.systemMessages);
+              }
+              if (result.modelContextMessages) {
+                modelContextMessages = result.modelContextMessages;
+              } else if (result.messages) {
+                if (modelContextMessages) {
+                  modelContextMessages = result.messages;
+                } else {
+                  applyMessagesToMessageList(result.messages, messageList);
+                }
+              }
+            } else {
+              assertPromptOnlyMessageListMutation({
+                processorId: processor.id,
+                messageList,
+                snapshotBefore: snapshotBeforeProcessor,
+                promptOnlyAlreadyActive: !!modelContextMessages,
+                returnedPromptOnly: false,
+              });
+            }
           } catch (error) {
             if (error instanceof TripWire) {
               // Store tripwire in providerOptions for wrapGenerate/wrapStream to handle
@@ -515,7 +673,7 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
                   mastraProcessors: {
                     tripwire: true,
                     reason: error.message,
-                  } satisfies ProcessorMiddlewareState,
+                  },
                 },
               };
             }
@@ -526,17 +684,30 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
 
       // Convert back to AI SDK prompt format using built-in MessageList methods
       // get.all.aiV5.prompt() returns ModelMessage[], then convert to LanguageModelV2Prompt
-      const newPrompt: LanguageModelV2Prompt = messageList.get.all.aiV5.prompt().map(aiV5ModelMessageToV2PromptMessage);
+      const originalPrompt: LanguageModelV2Prompt = messageList.get.all.aiV5
+        .prompt()
+        .map(aiV5ModelMessageToV2PromptMessage);
+      const promptMessageList = modelContextMessages
+        ? createPromptOnlyMessageList(messageList, modelContextMessages)
+        : messageList;
+      const newPrompt: LanguageModelV2Prompt = promptMessageList.get.all.aiV5
+        .prompt()
+        .map(aiV5ModelMessageToV2PromptMessage);
+      const processorState: ProcessorMiddlewareState = {
+        ...(params.providerOptions?.mastraProcessors as ProcessorMiddlewareState | undefined),
+        originalInputCount,
+      };
+      const serializedProcessorState = serializeProcessorState(processorState);
+      if (outputProcessors.length) {
+        storeOriginalPrompt(serializedProcessorState, originalPrompt);
+      }
 
       return {
         ...params,
         prompt: newPrompt,
         providerOptions: {
           ...params.providerOptions,
-          mastraProcessors: {
-            ...(params.providerOptions?.mastraProcessors as ProcessorMiddlewareState | undefined),
-            originalInputCount,
-          } satisfies ProcessorMiddlewareState,
+          mastraProcessors: serializedProcessorState,
         },
       };
     },
@@ -553,9 +724,18 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
         };
       }
 
-      const result = await doGenerate();
+      let result: Awaited<ReturnType<typeof doGenerate>>;
+      try {
+        result = await doGenerate();
+      } catch (error) {
+        deleteOriginalPrompt(processorState);
+        throw error;
+      }
 
-      if (!outputProcessors.length) return result;
+      if (!outputProcessors.length) {
+        deleteOriginalPrompt(processorState);
+        return result;
+      }
 
       // Create a fresh MessageList for output processing
       // The transformed prompt from transformParams contains all input messages
@@ -568,11 +748,12 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
       // so output processors don't re-persist them.
       const originalInputCount =
         processorState?.originalInputCount ?? params.prompt.filter(m => m.role !== 'system').length;
-      const nonSystemTotal = params.prompt.filter(m => m.role !== 'system').length;
+      const promptForOutputProcessors = getOriginalPrompt(processorState) ?? params.prompt;
+      const nonSystemTotal = promptForOutputProcessors.filter(m => m.role !== 'system').length;
       const memoryCount = nonSystemTotal - originalInputCount;
 
       let nonSystemIndex = 0;
-      for (const msg of params.prompt) {
+      for (const msg of promptForOutputProcessors) {
         if (msg.role === 'system') {
           messageList.addSystem(msg.content);
         } else {
@@ -623,6 +804,7 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
             } as ProcessOutputResultArgs);
           } catch (error) {
             if (error instanceof TripWire) {
+              deleteOriginalPrompt(processorState);
               return {
                 content: [{ type: 'text' as const, text: error.message }],
                 finishReason: 'stop' as const,
@@ -630,6 +812,7 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
                 warnings: [{ type: 'other' as const, message: `Output blocked: ${error.message}` }],
               };
             }
+            deleteOriginalPrompt(processorState);
             throw error;
           }
         }
@@ -641,10 +824,14 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
         .map(m => extractTextFromMastraMessage(m))
         .join('');
 
-      return {
-        ...result,
-        content: [{ type: 'text' as const, text: processedText }],
-      };
+      try {
+        return {
+          ...result,
+          content: [{ type: 'text' as const, text: processedText }],
+        };
+      } finally {
+        deleteOriginalPrompt(processorState);
+      }
     },
     async wrapStream({ doStream, params }) {
       // Check for tripwire from transformParams
@@ -656,9 +843,19 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
         };
       }
 
-      const { stream, ...rest } = await doStream();
+      let streamResult: Awaited<ReturnType<typeof doStream>>;
+      try {
+        streamResult = await doStream();
+      } catch (error) {
+        deleteOriginalPrompt(processorState);
+        throw error;
+      }
+      const { stream, ...rest } = streamResult;
 
-      if (!outputProcessors.length) return { stream, ...rest };
+      if (!outputProcessors.length) {
+        deleteOriginalPrompt(processorState);
+        return { stream, ...rest };
+      }
 
       // Transform stream through output processors
       const outputResultProcessors = outputProcessors.filter(processor => processor.processOutputResult);
@@ -667,6 +864,13 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
       const runId = crypto.randomUUID();
       let streamAborted = false;
       let sawFinish = false;
+      let cleanedUpOriginalPrompt = false;
+      const cleanupOriginalPrompt = () => {
+        if (!cleanedUpOriginalPrompt) {
+          deleteOriginalPrompt(processorState);
+          cleanedUpOriginalPrompt = true;
+        }
+      };
 
       const transformedStream = stream.pipeThrough(
         new TransformStream<LanguageModelV2StreamPart, LanguageModelV2StreamPart>({
@@ -717,9 +921,11 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
                       type: 'error',
                       error: new Error(error.message),
                     });
+                    cleanupOriginalPrompt();
                     controller.terminate();
                     return;
                   }
+                  cleanupOriginalPrompt();
                   throw error;
                 }
               }
@@ -744,6 +950,7 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
           },
           async flush(controller) {
             if (!streamAccumulator || streamAborted || !sawFinish) {
+              cleanupOriginalPrompt();
               return;
             }
 
@@ -755,11 +962,12 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
             // Tag historical messages as 'memory' so output processors don't re-persist them.
             const flushOriginalInputCount =
               processorState?.originalInputCount ?? params.prompt.filter(m => m.role !== 'system').length;
-            const flushNonSystemTotal = params.prompt.filter(m => m.role !== 'system').length;
+            const promptForOutputProcessors = getOriginalPrompt(processorState) ?? params.prompt;
+            const flushNonSystemTotal = promptForOutputProcessors.filter(m => m.role !== 'system').length;
             const flushMemoryCount = flushNonSystemTotal - flushOriginalInputCount;
 
             let flushNonSystemIndex = 0;
-            for (const msg of params.prompt) {
+            for (const msg of promptForOutputProcessors) {
               if (msg.role === 'system') {
                 messageList.addSystem(msg.content);
               } else {
@@ -808,11 +1016,14 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
                     type: 'error',
                     error: new Error(error.message),
                   });
+                  cleanupOriginalPrompt();
                   return;
                 }
+                cleanupOriginalPrompt();
                 throw error;
               }
             }
+            cleanupOriginalPrompt();
           },
         }),
       );

--- a/client-sdks/ai-sdk/src/middleware.ts
+++ b/client-sdks/ai-sdk/src/middleware.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { ReadableStream, TransformStream } from 'node:stream/web';
 import type {
   JSONValue,
@@ -13,7 +14,14 @@ import { MessageList, TripWire, aiV5ModelMessageToV2PromptMessage } from '@mastr
 import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent';
 import { RequestContext } from '@mastra/core/di';
 import type { MemoryConfig, SemanticRecall as SemanticRecallConfig } from '@mastra/core/memory';
-import { MessageHistory, SemanticRecall, WorkingMemory } from '@mastra/core/processors';
+import {
+  createPromptOnlyMessageList,
+  MessageHistory,
+  normalizePromptOnlyMessages,
+  SemanticRecall,
+  snapshotMessageList,
+  WorkingMemory,
+} from '@mastra/core/processors';
 import type {
   InputProcessor,
   OutputProcessor,
@@ -115,17 +123,6 @@ function applyMessagesToMessageList(messages: MastraDBMessage[], messageList: Me
       messageList.add(message, check.getSource(message) || 'input');
     }
   }
-}
-
-function createPromptOnlyMessageList(messageList: MessageList, messages: MastraDBMessage[]): MessageList {
-  const promptMessageList = new MessageList().deserialize(messageList.serialize());
-  promptMessageList.clear.all.db();
-  promptMessageList.replaceAllSystemMessages(messageList.getAllSystemMessages());
-  promptMessageList.add(
-    messages.filter(message => message.role !== 'system'),
-    'input',
-  );
-  return promptMessageList;
 }
 
 /**
@@ -296,26 +293,65 @@ interface ProcessorMiddlewareState {
   tripwire?: boolean;
   reason?: string;
   originalInputCount?: number;
+  originalPromptRunId?: string;
 }
 
-const originalPromptsByState = new WeakMap<ProcessorMiddlewareState, LanguageModelV2Prompt>();
+const ORIGINAL_PROMPT_CLEANUP_TIMEOUT_MS = 30 * 60 * 1000;
+const originalPromptsByRunId = new Map<string, LanguageModelV2Prompt>();
+const originalPromptCleanupsByRunId = new Map<
+  string,
+  {
+    abortListener?: () => void;
+    abortSignal?: AbortSignal;
+    timeout: ReturnType<typeof setTimeout>;
+  }
+>();
 
-function storeOriginalPrompt(processorState: ProcessorMiddlewareState, prompt: LanguageModelV2Prompt): void {
-  originalPromptsByState.set(processorState, prompt);
+function storeOriginalPrompt(prompt: LanguageModelV2Prompt, options?: { abortSignal?: AbortSignal }): string {
+  const runId = randomUUID();
+  originalPromptsByRunId.set(runId, prompt);
+
+  const cleanup = () => deleteOriginalPrompt({ originalPromptRunId: runId });
+  const abortSignal = options?.abortSignal;
+  let abortListener: (() => void) | undefined;
+
+  if (abortSignal) {
+    if (abortSignal.aborted) {
+      cleanup();
+      return runId;
+    }
+
+    abortListener = cleanup;
+    abortSignal.addEventListener('abort', abortListener, { once: true });
+  }
+
+  const timeout = setTimeout(cleanup, ORIGINAL_PROMPT_CLEANUP_TIMEOUT_MS);
+  timeout.unref?.();
+  originalPromptCleanupsByRunId.set(runId, { abortListener, abortSignal, timeout });
+
+  return runId;
 }
 
 function getOriginalPrompt(processorState?: ProcessorMiddlewareState): LanguageModelV2Prompt | undefined {
-  return processorState ? originalPromptsByState.get(processorState) : undefined;
+  return processorState?.originalPromptRunId
+    ? originalPromptsByRunId.get(processorState.originalPromptRunId)
+    : undefined;
 }
 
 function deleteOriginalPrompt(processorState?: ProcessorMiddlewareState): void {
-  if (processorState) {
-    originalPromptsByState.delete(processorState);
-  }
-}
+  const runId = processorState?.originalPromptRunId;
+  if (runId) {
+    originalPromptsByRunId.delete(runId);
 
-function snapshotMessageList(messageList: MessageList): string {
-  return JSON.stringify(messageList.serialize());
+    const cleanup = originalPromptCleanupsByRunId.get(runId);
+    if (cleanup) {
+      clearTimeout(cleanup.timeout);
+      if (cleanup.abortListener) {
+        cleanup.abortSignal?.removeEventListener('abort', cleanup.abortListener);
+      }
+      originalPromptCleanupsByRunId.delete(runId);
+    }
+  }
 }
 
 function assertPromptOnlyMessageListMutation({
@@ -356,6 +392,8 @@ function serializeProcessorState(
   if (processorState.reason !== undefined) serialized.reason = processorState.reason;
   if (processorState.originalInputCount !== undefined)
     serialized.originalInputCount = processorState.originalInputCount;
+  if (processorState.originalPromptRunId !== undefined)
+    serialized.originalPromptRunId = processorState.originalPromptRunId;
   return serialized;
 }
 
@@ -608,11 +646,11 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
                 processorId: processor.id,
                 messageList,
                 snapshotBefore: snapshotBeforeProcessor,
-                promptOnlyAlreadyActive: !!modelContextMessages,
+                promptOnlyAlreadyActive: modelContextMessages !== undefined,
                 returnedPromptOnly: false,
               });
-              if (modelContextMessages) {
-                modelContextMessages = result;
+              if (modelContextMessages !== undefined) {
+                modelContextMessages = normalizePromptOnlyMessages(result);
               } else {
                 applyMessagesToMessageList(result, messageList);
               }
@@ -626,7 +664,7 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
                 processorId: processor.id,
                 messageList,
                 snapshotBefore: snapshotBeforeProcessor,
-                promptOnlyAlreadyActive: !!modelContextMessages,
+                promptOnlyAlreadyActive: modelContextMessages !== undefined,
                 returnedPromptOnly: false,
               });
             } else if (result) {
@@ -639,17 +677,17 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
                 processorId: processor.id,
                 messageList,
                 snapshotBefore: snapshotBeforeProcessor,
-                promptOnlyAlreadyActive: !!modelContextMessages,
-                returnedPromptOnly: !!result.modelContextMessages,
+                promptOnlyAlreadyActive: modelContextMessages !== undefined,
+                returnedPromptOnly: 'modelContextMessages' in result,
               });
               if (result.systemMessages) {
                 messageList.replaceAllSystemMessages(result.systemMessages);
               }
-              if (result.modelContextMessages) {
-                modelContextMessages = result.modelContextMessages;
+              if ('modelContextMessages' in result) {
+                modelContextMessages = normalizePromptOnlyMessages(result.modelContextMessages ?? []);
               } else if (result.messages) {
-                if (modelContextMessages) {
-                  modelContextMessages = result.messages;
+                if (modelContextMessages !== undefined) {
+                  modelContextMessages = normalizePromptOnlyMessages(result.messages);
                 } else {
                   applyMessagesToMessageList(result.messages, messageList);
                 }
@@ -659,7 +697,7 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
                 processorId: processor.id,
                 messageList,
                 snapshotBefore: snapshotBeforeProcessor,
-                promptOnlyAlreadyActive: !!modelContextMessages,
+                promptOnlyAlreadyActive: modelContextMessages !== undefined,
                 returnedPromptOnly: false,
               });
             }
@@ -687,9 +725,13 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
       const originalPrompt: LanguageModelV2Prompt = messageList.get.all.aiV5
         .prompt()
         .map(aiV5ModelMessageToV2PromptMessage);
-      const promptMessageList = modelContextMessages
-        ? createPromptOnlyMessageList(messageList, modelContextMessages)
-        : messageList;
+      const promptMessageList =
+        modelContextMessages !== undefined
+          ? createPromptOnlyMessageList({
+              canonicalMessageList: messageList,
+              modelContextMessages,
+            })
+          : messageList;
       const newPrompt: LanguageModelV2Prompt = promptMessageList.get.all.aiV5
         .prompt()
         .map(aiV5ModelMessageToV2PromptMessage);
@@ -697,10 +739,12 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
         ...(params.providerOptions?.mastraProcessors as ProcessorMiddlewareState | undefined),
         originalInputCount,
       };
-      const serializedProcessorState = serializeProcessorState(processorState);
       if (outputProcessors.length) {
-        storeOriginalPrompt(serializedProcessorState, originalPrompt);
+        processorState.originalPromptRunId = storeOriginalPrompt(originalPrompt, {
+          abortSignal: (params as { abortSignal?: AbortSignal }).abortSignal,
+        });
       }
+      const serializedProcessorState = serializeProcessorState(processorState);
 
       return {
         ...params,
@@ -748,7 +792,10 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
       // so output processors don't re-persist them.
       const originalInputCount =
         processorState?.originalInputCount ?? params.prompt.filter(m => m.role !== 'system').length;
-      const promptForOutputProcessors = getOriginalPrompt(processorState) ?? params.prompt;
+      const promptForOutputProcessors = getOriginalPrompt(processorState);
+      if (!promptForOutputProcessors) {
+        throw new Error('Mastra processor middleware missing original prompt for output processors.');
+      }
       const nonSystemTotal = promptForOutputProcessors.filter(m => m.role !== 'system').length;
       const memoryCount = nonSystemTotal - originalInputCount;
 
@@ -962,7 +1009,11 @@ export function createProcessorMiddleware(options: ProcessorMiddlewareOptions): 
             // Tag historical messages as 'memory' so output processors don't re-persist them.
             const flushOriginalInputCount =
               processorState?.originalInputCount ?? params.prompt.filter(m => m.role !== 'system').length;
-            const promptForOutputProcessors = getOriginalPrompt(processorState) ?? params.prompt;
+            const promptForOutputProcessors = getOriginalPrompt(processorState);
+            if (!promptForOutputProcessors) {
+              cleanupOriginalPrompt();
+              throw new Error('Mastra processor middleware missing original prompt for output processors.');
+            }
             const flushNonSystemTotal = promptForOutputProcessors.filter(m => m.role !== 'system').length;
             const flushMemoryCount = flushNonSystemTotal - flushOriginalInputCount;
 

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -2056,6 +2056,7 @@ export interface ExecuteProcessorResponse {
   success: boolean;
   phase: string;
   messages?: MastraDBMessage[];
+  modelContextMessages?: MastraDBMessage[];
   messageList?: {
     messages: MastraDBMessage[];
   };

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -174,7 +174,9 @@ export class CustomInputProcessor implements Processor {
 }
 ```
 
-The `processInput()` method receives `messages`, `systemMessages`, and an `abort()` function. Return a `MastraDBMessage[]` to replace messages, or `{ messages, systemMessages }` to also modify system messages.
+The `processInput()` method receives `messages`, `systemMessages`, and an `abort()` function. Return a `MastraDBMessage[]` to replace canonical messages, or `{ messages, systemMessages }` to also modify system messages.
+
+Return `{ modelContextMessages }` when you want to change the next model prompt without changing canonical messages. Later input processors receive that prompt-only list as `messages`, but Mastra does not persist it to memory.
 
 See the [`Processor` reference](/reference/processors/processor-interface#processinput) for all available arguments and return types.
 

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -176,7 +176,7 @@ export class CustomInputProcessor implements Processor {
 
 The `processInput()` method receives `messages`, `systemMessages`, and an `abort()` function. Return a `MastraDBMessage[]` to replace canonical messages, or `{ messages, systemMessages }` to also modify system messages.
 
-Return `{ modelContextMessages }` when you want to change the next model prompt without changing canonical messages. Later input processors receive that prompt-only list as `messages`, but Mastra does not persist it to memory.
+Return `{ modelContextMessages }` when you want to change the next model prompt without changing canonical messages. Later input processors receive that prompt-only list as `messages`, but Mastra does not persist it to memory. Return `{ modelContextMessages: [] }` to clear the prompt-only non-system messages for the next model call.
 
 See the [`Processor` reference](/reference/processors/processor-interface#processinput) for all available arguments and return types.
 

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -277,7 +277,7 @@ processInput?(args: ProcessInputArgs): Promise<ProcessInputResult> | ProcessInpu
 
 #### `ProcessInputResult`
 
-The method can return one of three types:
+The method can return one of these types:
 
 <PropertiesTable
   content={[
@@ -296,8 +296,24 @@ The method can return one of three types:
     type: 'object',
     description: 'Object with both transformed messages and modified system messages.',
   },
+  {
+    name: '{ modelContextMessages }',
+    type: 'object',
+    description:
+      'Prompt-only messages for the next model call. These messages do not mutate canonical messages or persist to memory. Cannot be used with messages.',
+  },
+  {
+    name: '{ modelContextMessages, systemMessages }',
+    type: 'object',
+    description:
+      'Prompt-only messages plus system prompt changes for the next model call. The prompt-only messages are not saved to memory. The system messages affect the model prompt, not canonical memory.',
+  },
 ]}
 />
+
+When one processor returns `modelContextMessages`, prompt-only mode begins. Later input processors receive that prompt-only list as `messages` and through `messageList`. Canonical messages remain unchanged.
+
+In prompt-only mode, return `messages` from a later processor to keep transforming the prompt-only list. Do not include system-role messages in `modelContextMessages`. Use `systemMessages` for system prompt changes.
 
 ---
 
@@ -471,7 +487,14 @@ The object form can return any combination of these properties:
   {
     name: 'messages',
     type: 'MastraDBMessage[]',
-    description: 'Replace all messages. Cannot be used with messageList.',
+    description: 'Replace all messages. Cannot be used with messageList or modelContextMessages.',
+    isOptional: true,
+  },
+  {
+    name: 'modelContextMessages',
+    type: 'MastraDBMessage[]',
+    description:
+      'Prompt-only messages for the next model call. These messages do not mutate canonical messages or persist to memory. Cannot be used with messages.',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -311,9 +311,9 @@ The method can return one of these types:
 ]}
 />
 
-When one processor returns `modelContextMessages`, prompt-only mode begins. Later input processors receive that prompt-only list as `messages` and through `messageList`. Canonical messages remain unchanged.
+When one processor returns `modelContextMessages`, prompt-only mode begins. Later input processors receive that prompt-only list as `messages`. The `messageList` argument still represents canonical history, and canonical messages remain unchanged.
 
-In prompt-only mode, return `messages` from a later processor to keep transforming the prompt-only list. Do not include system-role messages in `modelContextMessages`. Use `systemMessages` for system prompt changes.
+In prompt-only mode, return `messages` from a later processor to keep transforming the prompt-only list. Return `modelContextMessages: []` to clear the prompt-only non-system messages for the next model call. Do not include system-role messages in `modelContextMessages`. Use `systemMessages` for system prompt changes.
 
 ---
 

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -47,6 +47,17 @@ import type {
 
 import { resolveThreadIdFromArgs } from './utils';
 
+function createModelContextMessageList(messageList: MessageList, messages: MastraDBMessage[]): MessageList {
+  const contextMessageList = new MessageList().deserialize(messageList.serialize());
+  contextMessageList.clear.all.db();
+  contextMessageList.replaceAllSystemMessages(messageList.getAllSystemMessages());
+  contextMessageList.add(
+    messages.filter(message => message.role !== 'system'),
+    'input',
+  );
+  return contextMessageList;
+}
+
 /**
  * Interface for accessing Agent methods needed by the legacy handler.
  * This allows the legacy handler to work with Agent without directly accessing private members.
@@ -114,6 +125,7 @@ export interface AgentLegacyCapabilities {
     } & ObservabilityContext,
   ): Promise<{
     messageList: MessageList;
+    modelContextMessages?: MastraDBMessage[];
     tripwire?: {
       reason: string;
       retry?: boolean;
@@ -127,9 +139,11 @@ export interface AgentLegacyCapabilities {
       requestContext: RequestContext;
       messageList: MessageList;
       stepNumber?: number;
+      modelContextMessages?: MastraDBMessage[];
     },
   ): Promise<{
     messageList: MessageList;
+    modelContextMessages?: MastraDBMessage[];
     tripwire?: {
       reason: string;
       retry?: boolean;
@@ -310,11 +324,17 @@ export class AgentLegacyHandler {
 
         if (!memory || (!threadId && !resourceId)) {
           messageList.add(messages, 'user');
-          const { tripwire } = await this.capabilities.__runInputProcessors({
+          const {
+            messageList: processedMessageList,
+            tripwire,
+            modelContextMessages,
+          } = await this.capabilities.__runInputProcessors({
             requestContext,
             ...innerObservabilityContext,
             messageList,
           });
+          messageList = processedMessageList;
+          let currentModelContextMessages = modelContextMessages;
           // Run processInputStep for step 0 (legacy path compatibility)
           if (!tripwire) {
             const inputStepResult = await this.capabilities.__runProcessInputStep({
@@ -322,7 +342,10 @@ export class AgentLegacyHandler {
               ...innerObservabilityContext,
               messageList,
               stepNumber: 0,
+              modelContextMessages: currentModelContextMessages,
             });
+            messageList = inputStepResult.messageList;
+            currentModelContextMessages = inputStepResult.modelContextMessages;
             if (inputStepResult.tripwire) {
               return {
                 messageObjects: [],
@@ -335,8 +358,11 @@ export class AgentLegacyHandler {
               };
             }
           }
+          const promptMessageList = currentModelContextMessages
+            ? createModelContextMessageList(messageList, currentModelContextMessages)
+            : messageList;
           return {
-            messageObjects: tripwire ? [] : messageList.get.all.prompt(),
+            messageObjects: tripwire ? [] : promptMessageList.get.all.prompt(),
             convertedTools,
             threadExists: false,
             thread: undefined,
@@ -402,12 +428,17 @@ export class AgentLegacyHandler {
         // Historical messages, semantic recall, and working memory will be added by input processors
         messageList.add(messages, 'user');
 
-        const { messageList: processedMessageList, tripwire } = await this.capabilities.__runInputProcessors({
+        const {
+          messageList: processedMessageList,
+          tripwire,
+          modelContextMessages,
+        } = await this.capabilities.__runInputProcessors({
           requestContext,
           ...innerObservabilityContext,
           messageList,
         });
         messageList = processedMessageList;
+        let currentModelContextMessages = modelContextMessages;
 
         // Run processInputStep phase for step 0 (legacy path compatibility).
         // The v5 agentic loop runs this per-step in llm-execution-step, but the legacy
@@ -419,7 +450,10 @@ export class AgentLegacyHandler {
             ...innerObservabilityContext,
             messageList,
             stepNumber: 0,
+            modelContextMessages: currentModelContextMessages,
           });
+          messageList = inputStepResult.messageList;
+          currentModelContextMessages = inputStepResult.modelContextMessages;
           if (inputStepResult.tripwire) {
             return {
               convertedTools,
@@ -435,7 +469,10 @@ export class AgentLegacyHandler {
 
         // Messages are already processed by __runInputProcessors and __runProcessInputStep above
         // which includes memory processors (WorkingMemory, MessageHistory, OM, etc.)
-        const processedList = messageList.get.all.prompt();
+        const promptMessageList = currentModelContextMessages
+          ? createModelContextMessageList(messageList, currentModelContextMessages)
+          : messageList;
+        const processedList = promptMessageList.get.all.prompt();
 
         return {
           convertedTools,

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -29,6 +29,7 @@ import {
   resolveObservabilityContext,
 } from '../observability';
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors/index';
+import { createPromptOnlyMessageList } from '../processors/index';
 import { RequestContext, MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context';
 import type { ChunkType } from '../stream/types';
 import type { CoreTool } from '../tools/types';
@@ -46,17 +47,6 @@ import type {
 } from './types';
 
 import { resolveThreadIdFromArgs } from './utils';
-
-function createModelContextMessageList(messageList: MessageList, messages: MastraDBMessage[]): MessageList {
-  const contextMessageList = new MessageList().deserialize(messageList.serialize());
-  contextMessageList.clear.all.db();
-  contextMessageList.replaceAllSystemMessages(messageList.getAllSystemMessages());
-  contextMessageList.add(
-    messages.filter(message => message.role !== 'system'),
-    'input',
-  );
-  return contextMessageList;
-}
 
 /**
  * Interface for accessing Agent methods needed by the legacy handler.
@@ -359,7 +349,10 @@ export class AgentLegacyHandler {
             }
           }
           const promptMessageList = currentModelContextMessages
-            ? createModelContextMessageList(messageList, currentModelContextMessages)
+            ? createPromptOnlyMessageList({
+                canonicalMessageList: messageList,
+                modelContextMessages: currentModelContextMessages,
+              })
             : messageList;
           return {
             messageObjects: tripwire ? [] : promptMessageList.get.all.prompt(),
@@ -470,7 +463,10 @@ export class AgentLegacyHandler {
         // Messages are already processed by __runInputProcessors and __runProcessInputStep above
         // which includes memory processors (WorkingMemory, MessageHistory, OM, etc.)
         const promptMessageList = currentModelContextMessages
-          ? createModelContextMessageList(messageList, currentModelContextMessages)
+          ? createPromptOnlyMessageList({
+              canonicalMessageList: messageList,
+              modelContextMessages: currentModelContextMessages,
+            })
           : messageList;
         const processedList = promptMessageList.get.all.prompt();
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2723,6 +2723,7 @@ export class Agent<
     processorStates?: Map<string, ProcessorState>;
   } & ObservabilityContext): Promise<{
     messageList: MessageList;
+    modelContextMessages?: MastraDBMessage[];
     tripwire?: {
       reason: string;
       retry?: boolean;
@@ -2731,6 +2732,7 @@ export class Agent<
     };
   }> {
     let tripwire: { reason: string; retry?: boolean; metadata?: unknown; processorId?: string } | undefined;
+    let modelContextMessages: MastraDBMessage[] | undefined;
 
     if (
       inputProcessorOverrides?.length ||
@@ -2747,7 +2749,12 @@ export class Agent<
         processorStates,
       });
       try {
-        messageList = await runner.runInputProcessors(messageList, observabilityContext, requestContext, 0);
+        ({ messageList, modelContextMessages } = await runner.runInputProcessors(
+          messageList,
+          observabilityContext,
+          requestContext,
+          0,
+        ));
       } catch (error) {
         if (error instanceof TripWire) {
           tripwire = {
@@ -2778,6 +2785,7 @@ export class Agent<
 
     return {
       messageList,
+      modelContextMessages,
       tripwire,
     };
   }
@@ -2793,10 +2801,12 @@ export class Agent<
       requestContext: RequestContext;
       messageList: MessageList;
       stepNumber?: number;
+      modelContextMessages?: MastraDBMessage[];
       processorStates?: Map<string, ProcessorState>;
     },
   ): Promise<{
     messageList: MessageList;
+    modelContextMessages?: MastraDBMessage[];
     tripwire?: {
       reason: string;
       retry?: boolean;
@@ -2804,10 +2814,11 @@ export class Agent<
       processorId?: string;
     };
   }> {
-    const { requestContext, messageList, stepNumber = 0, processorStates, ...rest } = args;
+    const { requestContext, messageList, stepNumber = 0, modelContextMessages, processorStates, ...rest } = args;
     const observabilityContext = resolveObservabilityContext(rest);
 
     let tripwire: { reason: string; retry?: boolean; metadata?: unknown; processorId?: string } | undefined;
+    let nextModelContextMessages = modelContextMessages;
 
     if (this.#inputProcessors || this.#memory) {
       const runner = await this.getProcessorRunner({
@@ -2817,7 +2828,7 @@ export class Agent<
       try {
         const llm = await this.getLLM({ requestContext });
         const model = llm.getModel();
-        await runner.runProcessInputStep({
+        const inputStepResult = await runner.runProcessInputStep({
           messageList,
           stepNumber,
           steps: [],
@@ -2826,8 +2837,10 @@ export class Agent<
           // Cast needed: legacy v1 models return LanguageModelV1 which doesn't satisfy MastraLanguageModel.
           // OM's processInputStep doesn't use the model parameter, so this is safe.
           model: model as MastraLanguageModel,
+          modelContextMessages: nextModelContextMessages,
           retryCount: 0,
         });
+        nextModelContextMessages = inputStepResult.modelContextMessages;
       } catch (error) {
         if (error instanceof TripWire) {
           tripwire = {
@@ -2858,6 +2871,7 @@ export class Agent<
 
     return {
       messageList,
+      modelContextMessages: nextModelContextMessages,
       tripwire,
     };
   }

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -351,6 +351,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
         ...(options.modelSettings || {}),
       },
       messageList: memoryData.messageList!,
+      modelContextMessages: memoryData.modelContextMessages,
       maxProcessorRetries: options.maxProcessorRetries,
       // IsTaskComplete scoring for supervisor patterns
       isTaskComplete: options.isTaskComplete,

--- a/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
@@ -10,6 +10,7 @@ import type { RequestContext } from '../../../request-context';
 import { createStep } from '../../../workflows';
 import type { InnerAgentExecutionOptions } from '../../agent.types';
 import { MessageList } from '../../message-list';
+import type { MastraDBMessage } from '../../message-list';
 import type { AgentMethodType } from '../../types';
 import type { AgentCapabilities } from './schema';
 import { prepareMemoryStepOutputSchema } from './schema';
@@ -96,8 +97,9 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
         // workflow snapshot. Running processors on an empty messageList would cause
         // processors like TokenLimiterProcessor to throw a TripWire.
         let tripwire;
+        let modelContextMessages: MastraDBMessage[] | undefined;
         if (!isResume) {
-          ({ tripwire } = await capabilities.runInputProcessors({
+          ({ tripwire, modelContextMessages } = await capabilities.runInputProcessors({
             requestContext,
             ...observabilityContext,
             messageList,
@@ -110,6 +112,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
           threadExists: false,
           thread: thread as StorageThreadType | undefined,
           messageList,
+          modelContextMessages,
           processorStates,
           tripwire,
         };
@@ -176,8 +179,9 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
       // workflow snapshot. Running processors on an empty messageList would cause
       // processors like TokenLimiterProcessor to throw a TripWire.
       let tripwire;
+      let modelContextMessages: MastraDBMessage[] | undefined;
       if (!isResume) {
-        ({ tripwire } = await capabilities.runInputProcessors({
+        ({ tripwire, modelContextMessages } = await capabilities.runInputProcessors({
           requestContext,
           ...observabilityContext,
           messageList,
@@ -189,6 +193,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
       return {
         thread: threadObject,
         messageList: messageList,
+        modelContextMessages,
         processorStates,
         tripwire,
         threadExists: !!existingThread,

--- a/packages/core/src/agent/workflows/prepare-stream/schema.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/schema.ts
@@ -11,7 +11,23 @@ import type {
 import type { RequestContext } from '../../../request-context';
 import type { Agent } from '../../agent';
 import { MessageList } from '../../message-list';
+import type { MastraDBMessage } from '../../message-list';
 import type { AgentExecuteOnFinishOptions } from '../../types';
+
+const mastraDBMessageSchema = z.object({
+  id: z.string(),
+  role: z.enum(['user', 'assistant', 'system', 'tool']),
+  createdAt: z.date(),
+  threadId: z.string().optional(),
+  resourceId: z.string().optional(),
+  type: z.string().optional(),
+  content: z
+    .object({
+      format: z.literal(2),
+      parts: z.array(z.unknown()),
+    })
+    .passthrough(),
+}) as z.ZodType<MastraDBMessage>;
 
 export type AgentCapabilities = {
   agent: Agent<any, any, any, any>;
@@ -74,6 +90,9 @@ export const prepareMemoryStepOutputSchema = z.object({
   threadExists: z.boolean(),
   thread: storageThreadSchema.optional(),
   messageList: z.instanceof(MessageList),
+  modelContextMessages: z
+    .array(z.custom<MastraDBMessage>(value => mastraDBMessageSchema.safeParse(value).success))
+    .optional(),
   /** Shared processor states map that persists across loop iterations for both input and output processors */
   processorStates: z.instanceof(Map<string, ProcessorState>),
   /** Tripwire data when input processor triggered abort */

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -132,6 +132,7 @@ export class MastraLLMVNext extends MastraBase {
     isTaskComplete,
     onIterationComplete,
     workspace,
+    modelContextMessages,
     ...rest
   }: ModelLoopStreamArgs<Tools, OUTPUT>): MastraModelOutput<OUTPUT> {
     const observabilityContext = resolveObservabilityContext(rest);
@@ -220,6 +221,7 @@ export class MastraLLMVNext extends MastraBase {
         isTaskComplete,
         onIterationComplete,
         workspace,
+        modelContextMessages,
         ...observabilityContext,
         options: {
           ...options,

--- a/packages/core/src/llm/model/model.loop.types.ts
+++ b/packages/core/src/llm/model/model.loop.types.ts
@@ -8,7 +8,7 @@ import type {
   UIMessage,
 } from '@internal/ai-sdk-v5';
 import type { JSONSchema7 } from 'json-schema';
-import type { MessageList } from '../../agent';
+import type { MastraDBMessage, MessageList } from '../../agent';
 import type { LoopOptions } from '../../loop/types';
 import type { ObservabilityContext } from '../../observability';
 import type { OutputProcessorOrWorkflow } from '../../processors';
@@ -42,6 +42,7 @@ export type ModelLoopStreamArgs<TOOLS extends ToolSet, OUTPUT = undefined> = {
   threadId?: string;
   returnScorerData?: boolean;
   messageList: MessageList;
+  modelContextMessages?: MastraDBMessage[];
 } & ObservabilityContext &
   Omit<LoopOptions<TOOLS, OUTPUT>, 'models' | 'messageList'>;
 

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -9,7 +9,7 @@ import type {
 import type { StopCondition as StopConditionV6 } from '@internal/ai-v6';
 import { z } from 'zod/v4';
 import type { IsTaskCompleteConfig, OnIterationCompleteHandler } from '../agent/agent.types';
-import type { MessageInput, MessageList } from '../agent/message-list';
+import type { MastraDBMessage, MessageInput, MessageList } from '../agent/message-list';
 import type { SaveQueueManager } from '../agent/save-queue';
 import type { StructuredOutputOptions } from '../agent/types';
 import type { AgentBackgroundConfig, BackgroundTaskManager, BackgroundTaskManagerConfig } from '../background-tasks';
@@ -177,6 +177,10 @@ export type LoopOptions<TOOLS extends ToolSet = ToolSet, OUTPUT = undefined> = {
    * Keyed by processor ID.
    */
   processorStates?: Map<string, ProcessorState>;
+  /**
+   * Prompt-only messages for the next model call. These do not mutate or persist canonical messages.
+   */
+  modelContextMessages?: MastraDBMessage[];
 } & Partial<ObservabilityContext>;
 
 export type LoopRun<Tools extends ToolSet = ToolSet, OUTPUT = undefined> = LoopOptions<Tools, OUTPUT> & {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Mock } from 'vitest';
 import { z } from 'zod/v4';
 import { MessageList } from '../../../agent/message-list';
+import type { MastraDBMessage } from '../../../agent/message-list';
 import { RequestContext } from '../../../request-context';
 import { ToolStream } from '../../../tools/stream';
 import { createTool } from '../../../tools/tool';
@@ -35,6 +36,7 @@ type IterationData = {
   processorRetryCount?: number;
   fallbackModelIndex?: number;
   processorRetryFeedback?: string;
+  modelContextMessages?: MastraDBMessage[];
 };
 
 describe('createLLMExecutionStep gateway provider tools', () => {
@@ -103,6 +105,153 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     messageList.add({ role: 'user', content: 'Find the latest AI agent news' }, 'input');
 
     bail = vi.fn(data => data);
+  });
+
+  it('uses prompt-only model context for the model prompt without mutating canonical messages', async () => {
+    const doStream = vi.fn(async () => ({
+      stream: convertArrayToReadableStream([
+        {
+          type: 'response-metadata',
+          id: 'resp-1',
+          modelId: 'mock-model-id',
+          timestamp: new Date(0),
+        },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: testUsage,
+        },
+      ]),
+      request: {},
+      response: {
+        headers: undefined,
+      },
+      warnings: [],
+    }));
+    const promptOnlyUserMessage: MastraDBMessage = {
+      id: 'prompt-only-user',
+      role: 'user',
+      content: {
+        format: 2,
+        parts: [{ type: 'text', text: 'prompt-only input' }],
+      },
+      createdAt: new Date(0),
+      threadId: 'test-thread',
+    };
+    const promptOnlySystemMessage: MastraDBMessage = {
+      id: 'prompt-only-system',
+      role: 'system',
+      content: {
+        format: 2,
+        parts: [{ type: 'text', text: 'prompt-only system should be ignored' }],
+      },
+      createdAt: new Date(0),
+      threadId: 'test-thread',
+    };
+
+    messageList.addSystem('canonical system');
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      modelContextMessages: [promptOnlySystemMessage, promptOnlyUserMessage],
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream,
+          },
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+        threadId: 'thread-123',
+        resourceId: 'resource-456',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+    } as unknown as OuterLLMRun<{}>);
+
+    const firstInput = createIterationInput();
+    firstInput.stepResult.isContinued = false;
+
+    await llmExecutionStep.execute(createExecuteParams(firstInput));
+
+    expect(doStream).toHaveBeenCalledOnce();
+    expect(doStream.mock.calls[0]?.[0]?.prompt).toEqual([
+      expect.objectContaining({ role: 'system', content: 'canonical system' }),
+      expect.objectContaining({
+        role: 'user',
+        content: [expect.objectContaining({ type: 'text', text: 'prompt-only input' })],
+      }),
+    ]);
+    expect(JSON.stringify(doStream.mock.calls[0]?.[0]?.prompt)).not.toContain('Find the latest AI agent news');
+    expect(JSON.stringify(doStream.mock.calls[0]?.[0]?.prompt)).not.toContain('prompt-only system should be ignored');
+    expect(messageList.get.input.db()).toHaveLength(1);
+    expect(messageList.get.input.db()[0]?.id).not.toBe('prompt-only-user');
+
+    doStream.mockClear();
+    const retryInput = createIterationInput();
+    retryInput.stepResult.isContinued = false;
+    retryInput.output.steps = [{}];
+    retryInput.processorRetryCount = 1;
+
+    await llmExecutionStep.execute(createExecuteParams(retryInput));
+
+    expect(doStream).toHaveBeenCalledOnce();
+    expect(JSON.stringify(doStream.mock.calls[0]?.[0]?.prompt)).toContain('Find the latest AI agent news');
+    expect(JSON.stringify(doStream.mock.calls[0]?.[0]?.prompt)).not.toContain('prompt-only input');
+
+    doStream.mockClear();
+    const explicitRetryInput = createIterationInput();
+    explicitRetryInput.stepResult.isContinued = false;
+    explicitRetryInput.output.steps = [{}];
+    explicitRetryInput.processorRetryCount = 1;
+    explicitRetryInput.modelContextMessages = [promptOnlySystemMessage, promptOnlyUserMessage];
+
+    await llmExecutionStep.execute(createExecuteParams(explicitRetryInput));
+
+    expect(doStream).toHaveBeenCalledOnce();
+    expect(doStream.mock.calls[0]?.[0]?.prompt).toEqual([
+      expect.objectContaining({ role: 'system', content: 'canonical system' }),
+      expect.objectContaining({
+        role: 'user',
+        content: [expect.objectContaining({ type: 'text', text: 'prompt-only input' })],
+      }),
+    ]);
+
+    doStream.mockClear();
+    const resetRetryInput = createIterationInput();
+    resetRetryInput.stepResult.isContinued = false;
+    resetRetryInput.output.steps = [{}];
+    resetRetryInput.processorRetryCount = 1;
+    resetRetryInput.modelContextMessages = undefined;
+
+    await llmExecutionStep.execute(createExecuteParams(resetRetryInput));
+
+    expect(doStream).toHaveBeenCalledOnce();
+    expect(JSON.stringify(doStream.mock.calls[0]?.[0]?.prompt)).toContain('Find the latest AI agent news');
+    expect(JSON.stringify(doStream.mock.calls[0]?.[0]?.prompt)).not.toContain('prompt-only input');
   });
 
   it('should infer providerExecuted for gateway tools and not merge streamed results onto toolCalls', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -4,7 +4,8 @@ import type { LanguageModelV2Usage } from '@ai-sdk/provider-v5';
 import { APICallError, generateId } from '@internal/ai-sdk-v5';
 import type { CallSettings, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import type { StructuredOutputOptions } from '../../../agent';
-import type { MessageList } from '../../../agent/message-list';
+import type { MastraDBMessage, MessageList } from '../../../agent/message-list';
+import { MessageList as MessageListClass } from '../../../agent/message-list';
 import { TripWire } from '../../../agent/trip-wire';
 import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../../../agent/utils';
 import { generateBackgroundTaskSystemPrompt } from '../../../background-tasks';
@@ -62,6 +63,17 @@ type ProcessOutputStreamOptions<OUTPUT = undefined> = {
   transportRef?: StreamTransportRef;
   transportResolver?: () => StreamTransport | undefined;
 };
+
+function createModelContextMessageList(messageList: MessageList, messages: MastraDBMessage[]): MessageList {
+  const contextMessageList = new MessageListClass().deserialize(messageList.serialize());
+  contextMessageList.clear.all.db();
+  contextMessageList.replaceAllSystemMessages(messageList.getAllSystemMessages());
+  contextMessageList.add(
+    messages.filter(message => message.role !== 'system'),
+    'input',
+  );
+  return contextMessageList;
+}
 
 function buildResponseModelMetadata(
   runState: AgenticRunState,
@@ -357,6 +369,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
   autoResumeSuspendedTools,
   maxProcessorRetries,
   workspace,
+  modelContextMessages,
   outputWriter,
 }: OuterLLMRun<TOOLS, OUTPUT>) {
   const initialSystemMessages = messageList.getAllSystemMessages();
@@ -390,6 +403,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       let rawResponse: any;
       let activeFallbackModelIndex = inputData.fallbackModelIndex || 0;
       let executedStepModel: string | undefined;
+      let executedModelContextMessages: MastraDBMessage[] | undefined;
       const maxErrorProcessorRetries = maxProcessorRetries ?? (errorProcessors?.length ? 10 : undefined);
       const { outputStream, callBail, runState, stepTools, stepWorkspace, processAPIErrorRetry } =
         await executeStreamWithFallbackModels<{
@@ -431,6 +445,12 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             messageList.addSystem(inputData.processorRetryFeedback, 'processor-retry-feedback');
           }
 
+          const hasExplicitModelContextMessages = Object.prototype.hasOwnProperty.call(
+            inputData,
+            'modelContextMessages',
+          );
+          const shouldSeedModelContextMessages =
+            (inputData.output?.steps?.length || 0) === 0 && !hasExplicitModelContextMessages;
           const currentStep: {
             messageId: string;
             model: MastraLanguageModel;
@@ -441,6 +461,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             modelSettings?: Omit<CallSettings, 'abortSignal'> | undefined;
             structuredOutput?: StructuredOutputOptions<OUTPUT>;
             workspace?: Workspace;
+            modelContextMessages?: MastraDBMessage[];
           } = {
             messageId: currentMessageId,
             model,
@@ -451,6 +472,9 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             modelSettings,
             structuredOutput,
             workspace,
+            modelContextMessages: shouldSeedModelContextMessages
+              ? modelContextMessages
+              : inputData.modelContextMessages,
           };
 
           const inputStepProcessors = [
@@ -500,6 +524,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                 providerOptions,
                 modelSettings,
                 structuredOutput,
+                modelContextMessages: currentStep.modelContextMessages,
                 retryCount: inputData.processorRetryCount || 0,
                 writer: inputStepWriter,
                 abortSignal: options?.abortSignal,
@@ -663,7 +688,11 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             downloadConcurrency,
             supportedUrls: resolvedSupportedUrls,
           };
-          let inputMessages = await messageList.get.all.aiV5.llmPrompt(messageListPromptArgs);
+          const promptMessageList = currentStep.modelContextMessages
+            ? createModelContextMessageList(messageList, currentStep.modelContextMessages)
+            : messageList;
+          executedModelContextMessages = currentStep.modelContextMessages;
+          let inputMessages = await promptMessageList.get.all.aiV5.llmPrompt(messageListPromptArgs);
 
           if (autoResumeSuspendedTools) {
             const messages = messageList.get.all.db();
@@ -1158,6 +1187,9 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           },
           messages,
           processorRetryCount: nextProcessorRetryCount,
+          // API-error retries re-run the same model attempt, so preserve the exact
+          // prompt-only context that was executed instead of reseeding from canonical messages.
+          ...(executedModelContextMessages ? { modelContextMessages: executedModelContextMessages } : {}),
           ...(activeFallbackModelIndex > 0 ? { fallbackModelIndex: activeFallbackModelIndex } : {}),
         };
       }
@@ -1410,6 +1442,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         // Track processor retry count for next iteration
         processorRetryCount: nextProcessorRetryCount,
         processorRetryFeedback: retryFeedbackText,
+        ...(shouldRetry && executedModelContextMessages ? { modelContextMessages: executedModelContextMessages } : {}),
         ...(nextFallbackModelIndex > 0 ? { fallbackModelIndex: nextFallbackModelIndex } : {}),
       };
     },

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -5,7 +5,6 @@ import { APICallError, generateId } from '@internal/ai-sdk-v5';
 import type { CallSettings, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import type { StructuredOutputOptions } from '../../../agent';
 import type { MastraDBMessage, MessageList } from '../../../agent/message-list';
-import { MessageList as MessageListClass } from '../../../agent/message-list';
 import { TripWire } from '../../../agent/trip-wire';
 import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../../../agent/utils';
 import { generateBackgroundTaskSystemPrompt } from '../../../background-tasks';
@@ -18,6 +17,7 @@ import { ConsoleLogger } from '../../../logger';
 import { createObservabilityContext, SpanType } from '../../../observability';
 import { executeWithContextSync } from '../../../observability/utils';
 import type { ProcessorStreamWriter } from '../../../processors/index';
+import { createPromptOnlyMessageList } from '../../../processors/index';
 import { PrepareStepProcessor } from '../../../processors/processors/prepare-step';
 import { ProcessorRunner } from '../../../processors/runner';
 import { RequestContext } from '../../../request-context';
@@ -63,17 +63,6 @@ type ProcessOutputStreamOptions<OUTPUT = undefined> = {
   transportRef?: StreamTransportRef;
   transportResolver?: () => StreamTransport | undefined;
 };
-
-function createModelContextMessageList(messageList: MessageList, messages: MastraDBMessage[]): MessageList {
-  const contextMessageList = new MessageListClass().deserialize(messageList.serialize());
-  contextMessageList.clear.all.db();
-  contextMessageList.replaceAllSystemMessages(messageList.getAllSystemMessages());
-  contextMessageList.add(
-    messages.filter(message => message.role !== 'system'),
-    'input',
-  );
-  return contextMessageList;
-}
 
 function buildResponseModelMetadata(
   runState: AgenticRunState,
@@ -689,7 +678,10 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             supportedUrls: resolvedSupportedUrls,
           };
           const promptMessageList = currentStep.modelContextMessages
-            ? createModelContextMessageList(messageList, currentStep.modelContextMessages)
+            ? createPromptOnlyMessageList({
+                canonicalMessageList: messageList,
+                modelContextMessages: currentStep.modelContextMessages,
+              })
             : messageList;
           executedModelContextMessages = currentStep.modelContextMessages;
           let inputMessages = await promptMessageList.get.all.aiV5.llmPrompt(messageListPromptArgs);
@@ -984,7 +976,10 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
 
               const errorResult = await processorRunner.runProcessAPIError({
                 error,
-                messages: messageList.get.all.db(),
+                messages: executedModelContextMessages ?? messageList.get.all.db(),
+                ...(executedModelContextMessages !== undefined
+                  ? { modelContextMessages: executedModelContextMessages }
+                  : {}),
                 messageList,
                 stepNumber: inputData.output?.steps?.length || 0,
                 steps: inputData.output?.steps || [],
@@ -1004,6 +999,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               });
 
               if (errorResult.retry && canRetryError) {
+                executedModelContextMessages = errorResult.modelContextMessages ?? executedModelContextMessages;
                 // Signal retry - store on runState so it's handled after the callback returns
                 runState.setState({
                   hasErrored: false,
@@ -1121,7 +1117,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
 
         const errorResult = await processorRunner.runProcessAPIError({
           error: runState.state.apiError,
-          messages: messageList.get.all.db(),
+          messages: executedModelContextMessages ?? messageList.get.all.db(),
+          ...(executedModelContextMessages !== undefined ? { modelContextMessages: executedModelContextMessages } : {}),
           messageList,
           stepNumber: inputData.output?.steps?.length || 0,
           steps: inputData.output?.steps || [],
@@ -1140,6 +1137,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         });
 
         if (errorResult.retry && canRetryError) {
+          executedModelContextMessages = errorResult.modelContextMessages ?? executedModelContextMessages;
           apiErrorRetryResult = errorResult;
           // Clear error state for retry
           runState.setState({
@@ -1189,7 +1187,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           processorRetryCount: nextProcessorRetryCount,
           // API-error retries re-run the same model attempt, so preserve the exact
           // prompt-only context that was executed instead of reseeding from canonical messages.
-          ...(executedModelContextMessages ? { modelContextMessages: executedModelContextMessages } : {}),
+          ...(executedModelContextMessages !== undefined ? { modelContextMessages: executedModelContextMessages } : {}),
           ...(activeFallbackModelIndex > 0 ? { fallbackModelIndex: activeFallbackModelIndex } : {}),
         };
       }
@@ -1442,7 +1440,9 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         // Track processor retry count for next iteration
         processorRetryCount: nextProcessorRetryCount,
         processorRetryFeedback: retryFeedbackText,
-        ...(shouldRetry && executedModelContextMessages ? { modelContextMessages: executedModelContextMessages } : {}),
+        ...(shouldRetry && executedModelContextMessages !== undefined
+          ? { modelContextMessages: executedModelContextMessages }
+          : {}),
         ...(nextFallbackModelIndex > 0 ? { fallbackModelIndex: nextFallbackModelIndex } : {}),
       };
     },

--- a/packages/core/src/loop/workflows/schema.ts
+++ b/packages/core/src/loop/workflows/schema.ts
@@ -20,6 +20,22 @@ import type {
   GeneratedFile,
 } from '@internal/ai-sdk-v5';
 import { z } from 'zod/v4';
+import type { MastraDBMessage } from '../../agent/message-list';
+
+const mastraDBMessageSchema = z.object({
+  id: z.string(),
+  role: z.enum(['user', 'assistant', 'system', 'tool']),
+  createdAt: z.date(),
+  threadId: z.string().optional(),
+  resourceId: z.string().optional(),
+  type: z.string().optional(),
+  content: z
+    .object({
+      format: z.literal(2),
+      parts: z.array(z.unknown()),
+    })
+    .passthrough(),
+}) as z.ZodType<MastraDBMessage>;
 
 // Type definitions for the workflow data
 export interface LLMIterationStepResult {
@@ -87,6 +103,7 @@ export interface LLMIterationData<Tools extends ToolSet = ToolSet, OUTPUT = unde
    */
   fallbackModelIndex?: number;
   processorRetryFeedback?: string;
+  modelContextMessages?: MastraDBMessage[];
   /**
    * True when a background task result was injected and the LLM needs another
    * iteration to process it. When set, isTaskCompleteStep is skipped.
@@ -158,6 +175,7 @@ export const llmIterationOutputSchema = z.object({
   processorRetryCount: z.number().optional(),
   fallbackModelIndex: z.number().optional(),
   processorRetryFeedback: z.string().optional(),
+  modelContextMessages: z.array(mastraDBMessageSchema).optional(),
   isTaskCompleteCheckFailed: z.boolean().optional(), //true if the isTaskComplete check failed and LLM has to run again
   backgroundTaskPending: z.boolean().optional(), // true if a background task result was injected and LLM needs to process it
 });

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -84,13 +84,27 @@ export interface ProcessorMessageContext<TTripwireMetadata = unknown> extends Pr
   messageList: MessageList;
 }
 
+type ProcessInputSystemMessages = {
+  /** Replace all system messages with these. */
+  systemMessages?: CoreMessageV4[];
+};
+
 /**
- * Return type for processInput that includes modified system messages
+ * Return type for processInput that can modify canonical messages, prompt-only model input, and/or system messages.
  */
-export interface ProcessInputResultWithSystemMessages {
-  messages: MastraDBMessage[];
-  systemMessages: CoreMessageV4[];
-}
+export type ProcessInputResultObject = ProcessInputSystemMessages &
+  (
+    | {
+        /** Replace canonical messages. */
+        messages?: MastraDBMessage[];
+        modelContextMessages?: never;
+      }
+    | {
+        messages?: never;
+        /** Replace the model prompt messages for the next model call without mutating canonical messages. */
+        modelContextMessages?: MastraDBMessage[];
+      }
+  );
 
 /**
  * Return type for message-based processor methods
@@ -102,7 +116,7 @@ export type ProcessorMessageResult = Promise<MessageList | MastraDBMessage[]> | 
 /**
  * Possible return types from processInput
  */
-export type ProcessInputResult = MessageList | MastraDBMessage[] | ProcessInputResultWithSystemMessages;
+export type ProcessInputResult = MessageList | MastraDBMessage[] | ProcessInputResultObject;
 
 /**
  * Arguments for processInput method
@@ -192,6 +206,7 @@ export type RunProcessInputStepArgs = Omit<
 > & {
   messageId?: string;
   rotateResponseMessageId?: () => string;
+  modelContextMessages?: MastraDBMessage[];
   retryCount?: number;
 };
 
@@ -201,7 +216,17 @@ export type RunProcessInputStepArgs = Omit<
  * Note: structuredOutput.schema is typed as StandardSchemaWithJSON (not the specific OUTPUT type) because
  * processors can modify it dynamically, and the actual type is only known at runtime.
  */
-export type ProcessInputStepResult = {
+type ProcessInputStepMessageResult =
+  | {
+      messages?: MastraDBMessage[];
+      modelContextMessages?: never;
+    }
+  | {
+      messages?: never;
+      modelContextMessages?: MastraDBMessage[];
+    };
+
+export type ProcessInputStepResult = ProcessInputStepMessageResult & {
   model?: LanguageModelV2 | ModelRouterModelId | OpenAICompatibleConfig | MastraLanguageModel;
   /** Override the active assistant response message ID for this step */
   messageId?: string;
@@ -209,8 +234,6 @@ export type ProcessInputStepResult = {
   tools?: Record<string, unknown>;
   toolChoice?: ToolChoice<any>;
   activeTools?: string[];
-
-  messages?: MastraDBMessage[];
   messageList?: MessageList;
   /** Replace all system messages with these */
   systemMessages?: CoreMessageV4[];

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -305,6 +305,8 @@ export interface ProcessOutputStepArgs<TTripwireMetadata = unknown> extends Proc
  * This is distinct from network errors or retryable server errors (which are handled by p-retry).
  */
 export interface ProcessAPIErrorArgs<TTripwireMetadata = unknown> extends ProcessorMessageContext<TTripwireMetadata> {
+  /** Prompt-only messages used for the failed model call, when input processors changed the model context. */
+  modelContextMessages?: MastraDBMessage[];
   /** The error that occurred during the LLM API call */
   error: unknown;
   /** The current step number (0-indexed) */
@@ -327,6 +329,8 @@ export interface ProcessAPIErrorArgs<TTripwireMetadata = unknown> extends Proces
 export type ProcessAPIErrorResult = {
   /** Whether to retry the LLM call after applying modifications */
   retry: boolean;
+  /** Replace the prompt-only messages used for the retry without mutating canonical history. */
+  modelContextMessages?: MastraDBMessage[];
 };
 
 /**
@@ -554,6 +558,17 @@ export { PrefillErrorHandler } from './prefill-error-handler';
 export { ProviderHistoryCompat, anthropicToolIdFormat } from './provider-history-compat';
 export type { CompatRule } from './provider-history-compat';
 export { ProcessorState, ProcessorRunner } from './runner';
+export {
+  createPromptOnlyMessageList,
+  normalizePromptOnlyMessages,
+  snapshotMessageList,
+  stripPromptOnlySystemMessages,
+} from './prompt-view';
+export {
+  validateAndFormatProcessInputResult,
+  validateAndFormatProcessInputStepResult,
+  validateProcessorResultExclusivity,
+} from './validate-result';
 export * from './memory';
 export type { TripWireOptions } from '../agent/trip-wire';
 export {

--- a/packages/core/src/processors/prompt-view.ts
+++ b/packages/core/src/processors/prompt-view.ts
@@ -1,0 +1,47 @@
+import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
+import type { MastraDBMessage } from '../agent/message-list';
+import { MessageList } from '../agent/message-list';
+
+export function stripPromptOnlySystemMessages(messages: readonly MastraDBMessage[]): MastraDBMessage[] {
+  return messages.filter(message => message.role !== 'system');
+}
+
+export function normalizePromptOnlyMessages(
+  messages: readonly MastraDBMessage[],
+  { clone = true }: { clone?: boolean } = {},
+): MastraDBMessage[] {
+  const nonSystemMessages = stripPromptOnlySystemMessages(messages);
+
+  if (!clone) {
+    return nonSystemMessages;
+  }
+
+  return nonSystemMessages.map(message => structuredClone(message));
+}
+
+export function createPromptOnlyMessageList({
+  canonicalMessageList,
+  modelContextMessages,
+  systemMessages,
+  cloneMessages = true,
+}: {
+  canonicalMessageList: MessageList;
+  modelContextMessages: readonly MastraDBMessage[];
+  systemMessages?: CoreMessageV4[];
+  cloneMessages?: boolean;
+}): MessageList {
+  const promptOnlyMessageList = new MessageList().deserialize(canonicalMessageList.serialize());
+  promptOnlyMessageList.clear.all.db();
+
+  const nonSystemMessages = normalizePromptOnlyMessages(modelContextMessages, { clone: cloneMessages });
+  if (nonSystemMessages.length > 0) {
+    promptOnlyMessageList.add(nonSystemMessages, 'input');
+  }
+
+  promptOnlyMessageList.replaceAllSystemMessages(systemMessages ?? canonicalMessageList.getAllSystemMessages());
+  return promptOnlyMessageList;
+}
+
+export function snapshotMessageList(messageList: MessageList): string {
+  return JSON.stringify(messageList.serialize());
+}

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -1,15 +1,18 @@
 import type { TextPart } from '@internal/ai-sdk-v4';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MessageList } from '../agent/message-list';
+import type { MastraDBMessage } from '../agent/message-list';
 import { TripWire } from '../agent/trip-wire';
+import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { IMastraLogger } from '../logger';
 import type { ChunkType } from '../stream';
 import { ChunkFrom } from '../stream/types';
 import { ProcessorRunner } from './runner';
-import type { Processor } from './index';
+import type { ProcessorStepOutput } from './step-schema';
+import type { Processor, ProcessorWorkflow } from './index';
 
 // Helper to create a message
-const createMessage = (content: string, role: 'user' | 'assistant' = 'user') => ({
+const createMessage = (content: string, role: 'user' | 'assistant' | 'system' = 'user'): MastraDBMessage => ({
   id: `msg-${Math.random()}`,
   role,
   content: {
@@ -32,6 +35,36 @@ const mockLogger: IMastraLogger = {
   listLogsByRunId: vi.fn(() => []),
 } as any;
 
+const createMockModel = (): MastraLanguageModel =>
+  ({
+    modelId: 'test-model',
+    specificationVersion: 'v2',
+    provider: 'test',
+    defaultObjectGenerationMode: 'json',
+    supportsImageUrls: false,
+    supportsStructuredOutputs: true,
+    doGenerate: async () => ({}),
+    doStream: async () => ({}),
+  }) as unknown as MastraLanguageModel;
+
+const createProcessorWorkflow = (
+  id: string,
+  handler: (input: ProcessorStepOutput) => ProcessorStepOutput | Promise<ProcessorStepOutput>,
+): ProcessorWorkflow =>
+  ({
+    id,
+    inputSchema: {},
+    outputSchema: {},
+    execute: async () => undefined,
+    createRun: async () => ({
+      start: async ({ inputData }: { inputData: ProcessorStepOutput }) => ({
+        status: 'success' as const,
+        result: await handler(inputData),
+        steps: {},
+      }),
+    }),
+  }) as unknown as ProcessorWorkflow;
+
 describe('ProcessorRunner', () => {
   let messageList: MessageList;
   let runner: ProcessorRunner;
@@ -47,6 +80,182 @@ describe('ProcessorRunner', () => {
   });
 
   describe('Input Processors', () => {
+    it('should allow processInput to return prompt-only model context without mutating canonical messages', async () => {
+      const canonicalMessage = createMessage('canonical input', 'user');
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+
+      messageList.add([canonicalMessage], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'prompt-only',
+            processInput: async () => ({
+              modelContextMessages: [promptOnlyMessage],
+            }),
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const result = await runner.runInputProcessors(messageList);
+
+      expect(result.messageList.get.input.db()).toEqual([canonicalMessage]);
+      expect(result.modelContextMessages).toEqual([promptOnlyMessage]);
+    });
+
+    it('should pass prompt-only messages to later processInput processors and keep canonical messages intact', async () => {
+      const canonicalMessage = createMessage('canonical input', 'user');
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+      const trimmedPromptMessage = createMessage('trimmed prompt input', 'user');
+      const seenMessages: string[][] = [];
+
+      messageList.add([canonicalMessage], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'inject',
+            processInput: async ({ messages }) => {
+              seenMessages.push(messages.map(message => (message.content.parts?.[0] as TextPart).text));
+              return { modelContextMessages: [promptOnlyMessage] };
+            },
+          },
+          {
+            id: 'trim',
+            processInput: async ({ messages }) => {
+              seenMessages.push(messages.map(message => (message.content.parts?.[0] as TextPart).text));
+              return [trimmedPromptMessage];
+            },
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const result = await runner.runInputProcessors(messageList);
+
+      expect(seenMessages).toEqual([['canonical input'], ['prompt-only input']]);
+      expect(result.messageList.get.input.db()).toEqual([canonicalMessage]);
+      expect(result.modelContextMessages).toEqual([trimmedPromptMessage]);
+    });
+
+    it('should reject processInput results that return messages and modelContextMessages together', async () => {
+      messageList.add([createMessage('canonical input', 'user')], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'invalid',
+            processInput: async ({ messages }) => ({
+              messages,
+              modelContextMessages: messages,
+            }),
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await expect(runner.runInputProcessors(messageList)).rejects.toThrow(
+        'returned both messages and modelContextMessages',
+      );
+    });
+
+    it('should reject processInput results that include both messages and modelContextMessages keys', async () => {
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+      messageList.add([createMessage('canonical input', 'user')], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'invalid-present-keys',
+            processInput: async () =>
+              ({
+                messages: undefined,
+                modelContextMessages: [promptOnlyMessage],
+              }) as never,
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await expect(runner.runInputProcessors(messageList)).rejects.toThrow(
+        'returned both messages and modelContextMessages',
+      );
+    });
+
+    it('should reject processInput object results that return messages and messageList together', async () => {
+      messageList.add([createMessage('canonical input', 'user')], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'invalid-message-list-object',
+            processInput: async ({ messages, messageList }) =>
+              ({
+                messages,
+                messageList,
+              }) as never,
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await expect(runner.runInputProcessors(messageList)).rejects.toThrow('returned both messages and messageList');
+    });
+
+    it('should reject mutating messageList while returning prompt-only model context', async () => {
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+      messageList.add([createMessage('canonical input', 'user')], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'invalid-mutation',
+            processInput: async ({ messageList }) => {
+              messageList.add([createMessage('canonical mutation', 'user')], 'input');
+              return { modelContextMessages: [promptOnlyMessage] };
+            },
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await expect(runner.runInputProcessors(messageList)).rejects.toThrow(
+        'mutated messageList and returned modelContextMessages',
+      );
+    });
+
+    it('should reject workflow messageList mutations while returning prompt-only model context', async () => {
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+      messageList.add([createMessage('canonical input', 'user')], 'user');
+
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          createProcessorWorkflow('invalid-workflow-mutation', input => {
+            if (!input.messageList) throw new Error('missing messageList');
+            input.messageList.add([createMessage('canonical mutation', 'user')], 'input');
+            return {
+              phase: 'input',
+              modelContextMessages: [promptOnlyMessage],
+            };
+          }),
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await expect(runner.runInputProcessors(messageList)).rejects.toThrow(
+        'mutated messageList and returned modelContextMessages',
+      );
+    });
+
     it('should run input processors in order', async () => {
       const executionOrder: string[] = [];
       const inputProcessors: Processor[] = [
@@ -81,7 +290,7 @@ describe('ProcessorRunner', () => {
       const result = await runner.runInputProcessors(messageList);
 
       expect(executionOrder).toEqual(['processor1', 'processor2']);
-      const messages = await result.get.all.prompt();
+      const messages = await result.messageList.get.all.prompt();
       expect(messages).toHaveLength(3);
       expect((messages[0].content[0] as TextPart).text).toBe('original message');
       expect((messages[1].content[0] as TextPart).text).toBe('processed by 1');
@@ -260,7 +469,7 @@ describe('ProcessorRunner', () => {
       const result = await runner.runInputProcessors(messageList);
 
       expect(executionOrder).toEqual(['processor1', 'processor3']);
-      const messages = await result.get.all.prompt();
+      const messages = await result.messageList.get.all.prompt();
       expect(messages).toHaveLength(3);
       expect((messages[0].content[0] as TextPart).text).toBe('original');
       expect((messages[1].content[0] as TextPart).text).toBe('from processor 1');
@@ -370,7 +579,7 @@ describe('ProcessorRunner', () => {
         const result = await runner.runInputProcessors(messageList);
 
         // After processing, the system messages should be modified
-        const allMessages = await result.get.all.aiV5.prompt();
+        const allMessages = await result.messageList.get.all.aiV5.prompt();
         const systemMessages = allMessages.filter((m: any) => m.role === 'system');
 
         // Verify system messages were trimmed
@@ -418,7 +627,7 @@ describe('ProcessorRunner', () => {
         const result = await runner.runInputProcessors(messageList);
 
         // Verify the system message was added
-        const allMessages = await result.get.all.aiV5.prompt();
+        const allMessages = await result.messageList.get.all.aiV5.prompt();
         const systemMessages = allMessages.filter((m: any) => m.role === 'system');
 
         expect(systemMessages).toHaveLength(1);
@@ -431,7 +640,206 @@ describe('ProcessorRunner', () => {
     });
   });
 
+  describe('Input Step Processors', () => {
+    it('should pass prompt-only messages to later processInputStep processors and keep canonical messages intact', async () => {
+      const canonicalMessage = createMessage('canonical input', 'user');
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+      const trimmedPromptMessage = createMessage('trimmed prompt input', 'user');
+      const seenMessages: string[][] = [];
+
+      messageList.add([canonicalMessage], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'inject-step',
+            processInputStep: async ({ messages }) => {
+              seenMessages.push(messages.map(message => (message.content.parts?.[0] as TextPart).text));
+              return { modelContextMessages: [promptOnlyMessage] };
+            },
+          },
+          {
+            id: 'trim-step',
+            processInputStep: async ({ messages }) => {
+              seenMessages.push(messages.map(message => (message.content.parts?.[0] as TextPart).text));
+              return [trimmedPromptMessage];
+            },
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const result = await runner.runProcessInputStep({
+        messageList,
+        stepNumber: 0,
+        steps: [],
+        model: createMockModel(),
+      });
+
+      expect(seenMessages).toEqual([['canonical input'], ['prompt-only input']]);
+      expect(messageList.get.all.db()).toEqual([canonicalMessage]);
+      expect(result.modelContextMessages).toEqual([trimmedPromptMessage]);
+    });
+
+    it('should reject canonical messageList mutations after processInputStep prompt-only mode starts', async () => {
+      const canonicalMessage = createMessage('canonical input', 'user');
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+      const mutationMessage = createMessage('canonical mutation', 'assistant');
+
+      messageList.add([canonicalMessage], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'canonical-step-mutation',
+            processInputStep: async ({ messageList }) => {
+              messageList.add([mutationMessage], 'response');
+            },
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await expect(
+        runner.runProcessInputStep({
+          messageList,
+          modelContextMessages: [promptOnlyMessage],
+          stepNumber: 0,
+          steps: [],
+          model: createMockModel(),
+        }),
+      ).rejects.toThrow('mutated messageList after prompt-only model context was set');
+    });
+
+    it('should reject workflow messageList mutations after processInputStep prompt-only mode starts', async () => {
+      const canonicalMessage = createMessage('canonical input', 'user');
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+      const mutationMessage = createMessage('canonical mutation', 'assistant');
+
+      messageList.add([canonicalMessage], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          createProcessorWorkflow('canonical-step-workflow-mutation', input => {
+            if (!input.messageList) throw new Error('missing messageList');
+            input.messageList.add([mutationMessage], 'response');
+            return { phase: 'inputStep' };
+          }),
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await expect(
+        runner.runProcessInputStep({
+          messageList,
+          modelContextMessages: [promptOnlyMessage],
+          stepNumber: 0,
+          steps: [],
+          model: createMockModel(),
+        }),
+      ).rejects.toThrow('mutated messageList after prompt-only model context was set');
+    });
+
+    it('should reject mutating messageList while returning prompt-only model context from processInputStep', async () => {
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+      messageList.add([createMessage('canonical input', 'user')], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'invalid-step-mutation',
+            processInputStep: async ({ messageList }) => {
+              messageList.add([createMessage('canonical mutation', 'assistant')], 'response');
+              return { modelContextMessages: [promptOnlyMessage] };
+            },
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await expect(
+        runner.runProcessInputStep({
+          messageList,
+          stepNumber: 0,
+          steps: [],
+          model: createMockModel(),
+        }),
+      ).rejects.toThrow('mutated messageList and returned modelContextMessages');
+    });
+
+    it('should reject processInputStep results that return messages and modelContextMessages together', async () => {
+      messageList.add([createMessage('canonical input', 'user')], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'invalid-step',
+            processInputStep: async ({ messages }) => ({
+              messages,
+              modelContextMessages: messages,
+            }),
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await expect(
+        runner.runProcessInputStep({
+          messageList,
+          stepNumber: 0,
+          steps: [],
+          model: createMockModel(),
+        }),
+      ).rejects.toThrow('returned both messages and modelContextMessages');
+    });
+  });
+
   describe('Output Processors', () => {
+    it('should keep prompt-only input context out of output processors', async () => {
+      const canonicalMessage = createMessage('canonical input', 'user');
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+      const responseMessage = createMessage('canonical response', 'assistant');
+      let messagesSeenByOutputProcessor: string[] = [];
+
+      messageList.add([canonicalMessage], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'prompt-only-input',
+            processInput: async () => ({
+              modelContextMessages: [promptOnlyMessage],
+            }),
+          },
+        ],
+        outputProcessors: [
+          {
+            id: 'memory-like-output',
+            processOutputResult: async ({ messageList }) => {
+              messagesSeenByOutputProcessor = messageList.get.all
+                .db()
+                .map(message => (message.content.parts?.[0] as TextPart).text);
+              return messageList;
+            },
+          },
+        ],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const inputResult = await runner.runInputProcessors(messageList);
+      inputResult.messageList.add([responseMessage], 'response');
+
+      await runner.runOutputProcessors(inputResult.messageList);
+
+      expect(messagesSeenByOutputProcessor).toEqual(['canonical input', 'canonical response']);
+      expect(messagesSeenByOutputProcessor).not.toContain('prompt-only input');
+    });
+
     it('should run output processors in order', async () => {
       const outputProcessors: Processor[] = [
         {

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -141,6 +141,64 @@ describe('ProcessorRunner', () => {
       expect(result.modelContextMessages).toEqual([trimmedPromptMessage]);
     });
 
+    it('should isolate prompt-only messages from later deep mutations', async () => {
+      const canonicalMessage = createMessage('canonical input', 'user');
+
+      messageList.add([canonicalMessage], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'prompt-only-from-canonical',
+            processInput: async ({ messages }) => ({
+              modelContextMessages: messages,
+            }),
+          },
+          {
+            id: 'deep-mutator',
+            processInput: async ({ messages }) => {
+              (messages[0]!.content.parts![0] as TextPart).text = 'mutated prompt-only input';
+              return undefined;
+            },
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const result = await runner.runInputProcessors(messageList);
+
+      expect((result.messageList.get.input.db()[0]!.content.parts![0] as TextPart).text).toBe('canonical input');
+      expect((result.modelContextMessages![0]!.content.parts![0] as TextPart).text).toBe('mutated prompt-only input');
+    });
+
+    it('should treat an empty modelContextMessages array as an intentional prompt-only clear', async () => {
+      const canonicalMessage = createMessage('canonical input', 'user');
+      const promptOnlyMessage = createMessage('prompt-only input', 'user');
+
+      messageList.add([canonicalMessage], 'user');
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'prompt-only',
+            processInput: async () => ({ modelContextMessages: [promptOnlyMessage] }),
+          },
+          {
+            id: 'clear-prompt-only',
+            processInput: async () => ({ modelContextMessages: [] }),
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const result = await runner.runInputProcessors(messageList);
+
+      expect(result.messageList.get.input.db()).toEqual([canonicalMessage]);
+      expect(result.modelContextMessages).toEqual([]);
+    });
+
     it('should reject processInput results that return messages and modelContextMessages together', async () => {
       messageList.add([createMessage('canonical input', 'user')], 'user');
       runner = new ProcessorRunner({
@@ -2623,6 +2681,44 @@ describe('ProcessorRunner', () => {
         }),
       );
       expect(result).toEqual({ retry: true });
+    });
+
+    it('should pass and update prompt-only model context for API-error retries', async () => {
+      const executedPromptMessage = createMessage('executed prompt-only input', 'user');
+      const repairedPromptMessage = createMessage('repaired prompt-only input', 'user');
+      const processAPIError = vi.fn().mockReturnValue({
+        retry: true,
+        modelContextMessages: [repairedPromptMessage],
+      });
+
+      runner = new ProcessorRunner({
+        inputProcessors: [{ id: 'error-handler', processAPIError }],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const canonicalInputMessage = createMessage('canonical input', 'user');
+      messageList.add(canonicalInputMessage, 'user');
+
+      const result = await runner.runProcessAPIError({
+        error: new Error('API error'),
+        messages: [executedPromptMessage],
+        modelContextMessages: [executedPromptMessage],
+        messageList,
+        stepNumber: 0,
+        steps: [],
+        retryCount: 0,
+      });
+
+      expect(processAPIError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [executedPromptMessage],
+          modelContextMessages: [executedPromptMessage],
+        }),
+      );
+      expect(result).toEqual({ retry: true, modelContextMessages: [repairedPromptMessage] });
+      expect(messageList.get.input.db()).toEqual([canonicalInputMessage]);
     });
 
     it('should skip processors that do not implement processAPIError', async () => {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -1,3 +1,4 @@
+import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
 import type { StepResult } from '@internal/ai-sdk-v5';
 import type { MastraDBMessage, MessageInput } from '../agent/message-list';
 import { MessageList, messagesAreEqual } from '../agent/message-list';
@@ -26,6 +27,7 @@ import { isProcessorWorkflow } from './index';
 import type {
   ErrorProcessorOrWorkflow,
   OutputResult,
+  ProcessInputResult,
   ProcessInputStepResult,
   Processor,
   ProcessorMessageResult,
@@ -35,6 +37,19 @@ import type {
   RunProcessInputStepResult,
   ToolCallInfo,
 } from './index';
+
+export type RunInputProcessorsResult = {
+  messageList: MessageList;
+  modelContextMessages?: MastraDBMessage[];
+};
+
+function snapshotMessageList(messageList: MessageList): string {
+  return JSON.stringify(messageList.serialize());
+}
+
+function didMessageListChange(messageList: MessageList, snapshotBefore: string): boolean {
+  return snapshotMessageList(messageList) !== snapshotBefore;
+}
 
 /**
  * Implementation of processor state management
@@ -357,13 +372,21 @@ export class ProcessorRunner {
       return input;
     }
 
-    // Validate it has the expected ProcessorStepOutput shape
-    if (!('phase' in output) || !('messages' in output || 'part' in output || 'messageList' in output)) {
+    if (!('phase' in output)) {
       throw new MastraError({
         category: 'USER',
         domain: 'AGENT',
         id: 'PROCESSOR_WORKFLOW_INVALID_OUTPUT',
         text: `Processor workflow ${workflow.id} returned invalid output format. Expected ProcessorStepOutput.`,
+      });
+    }
+
+    if (output.messages !== undefined && output.modelContextMessages !== undefined) {
+      throw new MastraError({
+        category: 'USER',
+        domain: 'AGENT',
+        id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+        text: `Processor workflow ${workflow.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
       });
     }
 
@@ -778,27 +801,74 @@ export class ProcessorRunner {
     observabilityContext?: ObservabilityContext,
     requestContext?: RequestContext,
     retryCount: number = 0,
-  ): Promise<MessageList> {
+  ): Promise<RunInputProcessorsResult> {
+    let modelContextMessages: MastraDBMessage[] | undefined;
+
     for (const [index, processorOrWorkflow] of this.inputProcessors.entries()) {
-      let processableMessages: MastraDBMessage[] = messageList.get.input.db();
-      const inputIds = processableMessages.map((m: MastraDBMessage) => m.id);
+      let processableMessages: MastraDBMessage[] = modelContextMessages ?? messageList.get.input.db();
+      const inputIds = messageList.get.input.db().map((m: MastraDBMessage) => m.id);
       const check = messageList.makeMessageSourceChecker();
 
       // Handle workflow as processor
       if (isProcessorWorkflow(processorOrWorkflow)) {
         const currentSystemMessages = messageList.getAllSystemMessages();
-        await this.executeWorkflowAsProcessor(
+        const messageListBeforeWorkflow = snapshotMessageList(messageList);
+        const result = await this.executeWorkflowAsProcessor(
           processorOrWorkflow,
           {
             phase: 'input',
             messages: processableMessages,
             messageList,
+            modelContextMessages,
             systemMessages: currentSystemMessages,
             retryCount,
           },
           observabilityContext,
           requestContext,
         );
+        const workflowMutatedMessageList = didMessageListChange(messageList, messageListBeforeWorkflow);
+        if (result.messages !== undefined && result.modelContextMessages !== undefined) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+            text: `Processor workflow ${processorOrWorkflow.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
+          });
+        }
+        if (modelContextMessages && workflowMutatedMessageList) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_MUTATED_MESSAGE_LIST_AFTER_MODEL_CONTEXT',
+            text: `Processor workflow ${processorOrWorkflow.id} mutated messageList after prompt-only model context was set. Mutate canonical messages before returning modelContextMessages, or return messages to update the prompt-only context.`,
+          });
+        }
+        if (result.modelContextMessages !== undefined && workflowMutatedMessageList) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_MUTATED_MESSAGE_LIST_WITH_MODEL_CONTEXT_MESSAGES',
+            text: `Processor workflow ${processorOrWorkflow.id} mutated messageList and returned modelContextMessages. Prompt-only model context cannot be combined with canonical messageList mutations.`,
+          });
+        }
+        if (result.systemMessages) {
+          messageList.replaceAllSystemMessages(result.systemMessages as CoreMessageV4[]);
+        }
+        if (result.modelContextMessages) {
+          modelContextMessages = result.modelContextMessages as MastraDBMessage[];
+        } else if (result.messages) {
+          if (modelContextMessages) {
+            modelContextMessages = result.messages as MastraDBMessage[];
+          } else {
+            ProcessorRunner.applyMessagesToMessageList(
+              result.messages as MastraDBMessage[],
+              messageList,
+              inputIds,
+              check,
+            );
+            processableMessages = messageList.get.input.db();
+          }
+        }
         continue;
       }
 
@@ -844,115 +914,69 @@ export class ProcessorRunner {
         // Get per-processor state that persists across all method calls within this request
         const processorState = this.getProcessorState(processor.id);
 
-        const result = await processMethod({
-          messages: processableMessages,
-          systemMessages: currentSystemMessages,
-          state: processorState.customState,
-          abort,
-          ...createObservabilityContext({ currentSpan: processorSpan }),
-          messageList,
-          requestContext,
-          retryCount,
-        });
+        const result = await ProcessorRunner.validateAndFormatProcessInputResult(
+          await processMethod({
+            messages: processableMessages,
+            systemMessages: currentSystemMessages,
+            state: processorState.customState,
+            abort,
+            ...createObservabilityContext({ currentSpan: processorSpan }),
+            messageList,
+            requestContext,
+            retryCount,
+          }),
+          {
+            messageList,
+            processor,
+          },
+        );
 
-        // Handle MessageList, MastraDBMessage[], or { messages, systemMessages } return types
-        let mutations: Array<{
-          type: 'add' | 'addSystem' | 'removeByIds' | 'clear';
-          source?: string;
-          count?: number;
-          ids?: string[];
-          text?: string;
-          tag?: string;
-          message?: any;
-        }>;
+        // Stop recording and capture mutations before applying internal plumbing changes.
+        const mutations = messageList.stopRecording();
 
-        if (result instanceof MessageList) {
-          if (result !== messageList) {
+        if (modelContextMessages && mutations.length > 0) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_MUTATED_MESSAGE_LIST_AFTER_MODEL_CONTEXT',
+            text: `Processor ${processor.id} mutated messageList after prompt-only model context was set. Mutate canonical messages before returning modelContextMessages, or return messages to update the prompt-only context.`,
+          });
+        }
+
+        if ('modelContextMessages' in result && mutations.length > 0) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_MUTATED_MESSAGE_LIST_WITH_MODEL_CONTEXT_MESSAGES',
+            text: `Processor ${processor.id} mutated messageList and returned modelContextMessages. Prompt-only model context cannot be combined with canonical messageList mutations.`,
+          });
+        }
+
+        if (result.systemMessages) {
+          messageList.replaceAllSystemMessages(result.systemMessages);
+        }
+
+        if (result.modelContextMessages) {
+          modelContextMessages = result.modelContextMessages;
+          processableMessages = modelContextMessages;
+        } else if (result.messages) {
+          if (modelContextMessages) {
+            modelContextMessages = result.messages;
+            processableMessages = modelContextMessages;
+          } else {
+            ProcessorRunner.applyMessagesToMessageList(result.messages, messageList, inputIds, check);
+            processableMessages = messageList.get.input.db();
+          }
+        } else if (result.messageList) {
+          if (modelContextMessages) {
             throw new MastraError({
               category: 'USER',
               domain: 'AGENT',
-              id: 'PROCESSOR_RETURNED_EXTERNAL_MESSAGE_LIST',
-              text: `Processor ${processor.id} returned a MessageList instance other than the one that was passed in as an argument. New external message list instances are not supported. Use the messageList argument instead.`,
+              id: 'PROCESSOR_RETURNED_MESSAGE_LIST_AFTER_MODEL_CONTEXT',
+              text: `Processor ${processor.id} returned messageList after prompt-only model context was set. Return messages to update the prompt-only context instead.`,
             });
           }
-          // Stop recording and capture mutations
-          mutations = messageList.stopRecording();
           if (mutations.length > 0) {
-            // Processor returned a MessageList - it has been modified in place
-            // Update processableMessages to reflect ALL current messages for next processor
-            processableMessages = messageList.get.input.db();
-          }
-        } else if (this.isProcessInputResultWithSystemMessages(result)) {
-          // Processor returned { messages, systemMessages } - handle both
-          mutations = messageList.stopRecording();
-
-          // Replace system messages with the modified ones
-          messageList.replaceAllSystemMessages(result.systemMessages);
-
-          // Handle regular messages
-          const regularMessages = result.messages;
-          if (regularMessages) {
-            const deletedIds = inputIds.filter(i => !regularMessages.some(m => m.id === i));
-            if (deletedIds.length) {
-              messageList.removeByIds(deletedIds);
-            }
-
-            // Separate any new system messages from other messages (backward compat)
-            const newSystemMessages = regularMessages.filter(m => m.role === 'system');
-            const nonSystemMessages = regularMessages.filter(m => m.role !== 'system');
-
-            // Add any new system messages from the messages array
-            for (const sysMsg of newSystemMessages) {
-              const systemText =
-                (sysMsg.content.content as string | undefined) ??
-                sysMsg.content.parts?.map(p => (p.type === 'text' ? p.text : '')).join('\n') ??
-                '';
-              messageList.addSystem(systemText);
-            }
-
-            // Add non-system messages normally
-            if (nonSystemMessages.length > 0) {
-              for (const message of nonSystemMessages) {
-                messageList.removeByIds([message.id]);
-                messageList.add(message, check.getSource(message) || 'input');
-              }
-            }
-          }
-
-          processableMessages = messageList.get.input.db();
-        } else {
-          // Processor returned an array - stop recording before clear/add (that's just internal plumbing)
-          mutations = messageList.stopRecording();
-
-          if (result) {
-            // Clear and re-add since processor worked with array. clear all messages, the new result array is all messages in the list (new input but also any messages added by other processors, memory for ex)
-            const deletedIds = inputIds.filter(i => !result.some(m => m.id === i));
-            if (deletedIds.length) {
-              messageList.removeByIds(deletedIds);
-            }
-
-            // Separate system messages from other messages since they need different handling
-            const systemMessages = result.filter(m => m.role === 'system');
-            const nonSystemMessages = result.filter(m => m.role !== 'system');
-
-            // Add system messages using addSystem
-            for (const sysMsg of systemMessages) {
-              const systemText =
-                (sysMsg.content.content as string | undefined) ??
-                sysMsg.content.parts?.map(p => (p.type === 'text' ? p.text : '')).join('\n') ??
-                '';
-              messageList.addSystem(systemText);
-            }
-
-            // Add non-system messages normally
-            if (nonSystemMessages.length > 0) {
-              for (const message of nonSystemMessages) {
-                messageList.removeByIds([message.id]);
-                messageList.add(message, check.getSource(message) || 'input');
-              }
-            }
-
-            // Use messageList.get.input.db() for consistency with MessageList return type
             processableMessages = messageList.get.input.db();
           }
         }
@@ -962,6 +986,7 @@ export class ProcessorRunner {
             ...(!areProcessorMessageArraysEqual(inputMessagesBefore, processableMessages)
               ? { messages: processableMessages }
               : {}),
+            ...(modelContextMessages ? { modelContextMessages } : {}),
             ...(!areProcessorMessageArraysEqual(inputSystemMessagesBefore, messageList.getAllSystemMessages())
               ? { systemMessages: messageList.getAllSystemMessages() }
               : {}),
@@ -991,7 +1016,7 @@ export class ProcessorRunner {
       }
     }
 
-    return messageList;
+    return { messageList, modelContextMessages };
   }
 
   /**
@@ -1026,6 +1051,7 @@ export class ProcessorRunner {
       providerOptions: args.providerOptions,
       modelSettings: args.modelSettings,
       structuredOutput: args.structuredOutput,
+      modelContextMessages: args.modelContextMessages,
       retryCount: args.retryCount ?? 0,
     };
 
@@ -1037,13 +1063,14 @@ export class ProcessorRunner {
 
     // Run through all input processors that have processInputStep
     for (const [index, processorOrWorkflow] of processors.entries()) {
-      const processableMessages: MastraDBMessage[] = messageList.get.all.db();
-      const idsBeforeProcessing = processableMessages.map((m: MastraDBMessage) => m.id);
+      const processableMessages: MastraDBMessage[] = stepInput.modelContextMessages ?? messageList.get.all.db();
+      const idsBeforeProcessing = messageList.get.all.db().map((m: MastraDBMessage) => m.id);
       const check = messageList.makeMessageSourceChecker();
 
       // Handle workflow as processor with inputStep phase
       if (isProcessorWorkflow(processorOrWorkflow)) {
         const currentSystemMessages = messageList.getAllSystemMessages();
+        const messageListBeforeWorkflow = snapshotMessageList(messageList);
         const result = await this.executeWorkflowAsProcessor(
           processorOrWorkflow,
           {
@@ -1067,7 +1094,50 @@ export class ProcessorRunner {
           writer,
           args.abortSignal,
         );
-        Object.assign(stepInput, result);
+        const workflowMutatedMessageList = didMessageListChange(messageList, messageListBeforeWorkflow);
+        if (result.messages !== undefined && result.modelContextMessages !== undefined) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+            text: `Processor workflow ${processorOrWorkflow.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
+          });
+        }
+        if (stepInput.modelContextMessages && workflowMutatedMessageList) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_MUTATED_MESSAGE_LIST_AFTER_MODEL_CONTEXT',
+            text: `Processor workflow ${processorOrWorkflow.id} mutated messageList after prompt-only model context was set. Mutate canonical messages before returning modelContextMessages, or return messages to update the prompt-only context.`,
+          });
+        }
+        if (result.modelContextMessages !== undefined && workflowMutatedMessageList) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_MUTATED_MESSAGE_LIST_WITH_MODEL_CONTEXT_MESSAGES',
+            text: `Processor workflow ${processorOrWorkflow.id} mutated messageList and returned modelContextMessages. Prompt-only model context cannot be combined with canonical messageList mutations.`,
+          });
+        }
+        const { messages, systemMessages, modelContextMessages, ...rest } = result;
+        if (systemMessages) {
+          messageList.replaceAllSystemMessages(systemMessages as CoreMessageV4[]);
+        }
+        if (modelContextMessages) {
+          stepInput.modelContextMessages = modelContextMessages as MastraDBMessage[];
+        } else if (messages) {
+          if (stepInput.modelContextMessages) {
+            stepInput.modelContextMessages = messages as MastraDBMessage[];
+          } else {
+            ProcessorRunner.applyMessagesToMessageList(
+              messages as MastraDBMessage[],
+              messageList,
+              idsBeforeProcessing,
+              check,
+            );
+          }
+        }
+        Object.assign(stepInput, rest);
         continue;
       }
 
@@ -1142,8 +1212,20 @@ export class ProcessorRunner {
         };
 
         const processMethodArgs = {
+          messages: processableMessages,
           messageList,
-          ...inputData,
+          stepNumber,
+          steps,
+          messageId: stepInput.messageId,
+          systemMessages: currentSystemMessages,
+          tools: stepInput.tools,
+          toolChoice: stepInput.toolChoice,
+          model: stepInput.model!,
+          activeTools: stepInput.activeTools,
+          providerOptions: stepInput.providerOptions,
+          modelSettings: stepInput.modelSettings,
+          structuredOutput: stepInput.structuredOutput,
+          requestContext,
           state: processorState.customState,
           abort,
           ...(args.rotateResponseMessageId
@@ -1169,17 +1251,44 @@ export class ProcessorRunner {
             stepNumber,
           },
         );
-        const { messages, systemMessages, ...rest } = result;
+        const returnedModelContextMessages = 'modelContextMessages' in result;
+        const { messages, systemMessages, modelContextMessages, ...rest } = result;
+
+        // Stop recording and get mutations for this processor
+        const mutations = messageList.stopRecording();
+
+        if (stepInput.modelContextMessages && mutations.length > 0) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_MUTATED_MESSAGE_LIST_AFTER_MODEL_CONTEXT',
+            text: `Processor ${processor.id} mutated messageList after prompt-only model context was set. Mutate canonical messages before returning modelContextMessages, or return messages to update the prompt-only context.`,
+          });
+        }
+
+        if (returnedModelContextMessages && mutations.length > 0) {
+          throw new MastraError({
+            category: 'USER',
+            domain: 'AGENT',
+            id: 'PROCESSOR_MUTATED_MESSAGE_LIST_WITH_MODEL_CONTEXT_MESSAGES',
+            text: `Processor ${processor.id} mutated messageList and returned modelContextMessages. Prompt-only model context cannot be combined with canonical messageList mutations.`,
+          });
+        }
+
         if (messages) {
-          ProcessorRunner.applyMessagesToMessageList(messages, messageList, idsBeforeProcessing, check);
+          if (stepInput.modelContextMessages) {
+            stepInput.modelContextMessages = messages;
+          } else {
+            ProcessorRunner.applyMessagesToMessageList(messages, messageList, idsBeforeProcessing, check);
+          }
+        }
+        if (modelContextMessages) {
+          stepInput.modelContextMessages = modelContextMessages;
         }
         if (systemMessages) {
           messageList.replaceAllSystemMessages(systemMessages);
         }
         Object.assign(stepInput, rest);
-
-        // Stop recording and get mutations for this processor
-        const mutations = messageList.stopRecording();
 
         processorSpan?.end({
           output: buildProcessInputStepSpanOutput({
@@ -1188,7 +1297,7 @@ export class ProcessorRunner {
             afterStepInput: stepInput,
             beforeMessages: inputData.messages,
             beforeSystemMessages: inputData.systemMessages,
-            messages: messageList.get.all.db(),
+            messages: stepInput.modelContextMessages ?? messageList.get.all.db(),
             systemMessages: messageList.getAllSystemMessages(),
           }),
           attributes: mutations.length > 0 ? { messageListMutations: mutations } : undefined,
@@ -1217,22 +1326,6 @@ export class ProcessorRunner {
     }
 
     return stepInput;
-  }
-
-  /**
-   * Type guard to check if result is { messages, systemMessages }
-   */
-  private isProcessInputResultWithSystemMessages(
-    result: unknown,
-  ): result is { messages: MastraDBMessage[]; systemMessages: unknown[] } {
-    return (
-      result !== null &&
-      typeof result === 'object' &&
-      'messages' in result &&
-      'systemMessages' in result &&
-      Array.isArray((result as any).messages) &&
-      Array.isArray((result as any).systemMessages)
-    );
   }
 
   /**
@@ -1646,6 +1739,73 @@ export class ProcessorRunner {
     }
   }
 
+  static validateAndFormatProcessInputResult(
+    result: ProcessInputResult | undefined | void,
+    {
+      messageList,
+      processor,
+    }: {
+      messageList: MessageList;
+      processor: Processor;
+    },
+  ): {
+    messages?: MastraDBMessage[];
+    messageList?: MessageList;
+    modelContextMessages?: MastraDBMessage[];
+    systemMessages?: CoreMessageV4[];
+  } {
+    if (result instanceof MessageList) {
+      if (result !== messageList) {
+        throw new MastraError({
+          category: 'USER',
+          domain: 'AGENT',
+          id: 'PROCESSOR_RETURNED_EXTERNAL_MESSAGE_LIST',
+          text: `Processor ${processor.id} returned a MessageList instance other than the one that was passed in as an argument. New external message list instances are not supported. Use the messageList argument instead.`,
+        });
+      }
+      return {
+        messageList: result,
+      };
+    } else if (Array.isArray(result)) {
+      return {
+        messages: result,
+      };
+    } else if (result) {
+      const resultWithMessageList = result as typeof result & { messageList?: MessageList };
+      if (
+        'messageList' in resultWithMessageList &&
+        resultWithMessageList.messageList &&
+        resultWithMessageList.messageList !== messageList
+      ) {
+        throw new MastraError({
+          category: 'USER',
+          domain: 'AGENT',
+          id: 'PROCESSOR_RETURNED_EXTERNAL_MESSAGE_LIST',
+          text: `Processor ${processor.id} returned a MessageList instance other than the one that was passed in as an argument. New external message list instances are not supported. Use the messageList argument instead.`,
+        });
+      }
+      if ('messages' in result && 'messageList' in resultWithMessageList) {
+        throw new MastraError({
+          category: 'USER',
+          domain: 'AGENT',
+          id: 'PROCESSOR_RETURNED_MESSAGES_AND_MESSAGE_LIST',
+          text: `Processor ${processor.id} returned both messages and messageList. Only one of these is allowed.`,
+        });
+      }
+      if ('messages' in result && 'modelContextMessages' in result) {
+        throw new MastraError({
+          category: 'USER',
+          domain: 'AGENT',
+          id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+          text: `Processor ${processor.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
+        });
+      }
+      return result;
+    }
+
+    return {};
+  }
+
   static async validateAndFormatProcessInputStepResult(
     result: ProcessInputStepResult | Awaited<ProcessorMessageResult> | undefined | void,
     {
@@ -1675,7 +1835,7 @@ export class ProcessorRunner {
         messages: result,
       };
     } else if (result) {
-      if (result.messageList && result.messageList !== messageList) {
+      if ('messageList' in result && result.messageList && result.messageList !== messageList) {
         throw new MastraError({
           category: 'USER',
           domain: 'AGENT',
@@ -1683,12 +1843,20 @@ export class ProcessorRunner {
           text: `Processor ${processor.id} returned a MessageList instance other than the one that was passed in as an argument. New external message list instances are not supported. Use the messageList argument instead.`,
         });
       }
-      if (result.messages && result.messageList) {
+      if ('messages' in result && 'messageList' in result) {
         throw new MastraError({
           category: 'USER',
           domain: 'AGENT',
           id: 'PROCESSOR_RETURNED_MESSAGES_AND_MESSAGE_LIST',
           text: `Processor ${processor.id} returned both messages and messageList. Only one of these is allowed.`,
+        });
+      }
+      if ('messages' in result && 'modelContextMessages' in result) {
+        throw new MastraError({
+          category: 'USER',
+          domain: 'AGENT',
+          id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+          text: `Processor ${processor.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
         });
       }
       const { model: _model, ...rest } = result;

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -4,9 +4,7 @@ import type { MastraDBMessage, MessageInput } from '../agent/message-list';
 import { MessageList, messagesAreEqual } from '../agent/message-list';
 import { TripWire } from '../agent/trip-wire';
 import type { TripWireOptions } from '../agent/trip-wire';
-import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../agent/utils';
 import { MastraError } from '../error';
-import { resolveModelConfig } from '../llm';
 import type { IMastraLogger } from '../logger';
 import { EntityType, SpanType, createObservabilityContext, resolveObservabilityContext } from '../observability';
 import type { ObservabilityContext, Span } from '../observability';
@@ -14,6 +12,7 @@ import type { RequestContext } from '../request-context';
 import type { ChunkType } from '../stream';
 import type { MastraModelOutput } from '../stream/base/output';
 import type { LanguageModelUsage } from '../stream/types';
+import { normalizePromptOnlyMessages, snapshotMessageList } from './prompt-view';
 import {
   summarizeActiveToolsForSpan,
   summarizeProcessorModelForSpan,
@@ -23,6 +22,11 @@ import {
 } from './span-payload';
 import type { ProcessorStepOutput } from './step-schema';
 import { isMaybeClaude46, TrailingAssistantGuard } from './trailing-assistant-guard';
+import {
+  validateAndFormatProcessInputResult,
+  validateAndFormatProcessInputStepResult,
+  validateProcessorResultExclusivity,
+} from './validate-result';
 import { isProcessorWorkflow } from './index';
 import type {
   ErrorProcessorOrWorkflow,
@@ -43,12 +47,18 @@ export type RunInputProcessorsResult = {
   modelContextMessages?: MastraDBMessage[];
 };
 
-function snapshotMessageList(messageList: MessageList): string {
-  return JSON.stringify(messageList.serialize());
-}
-
 function didMessageListChange(messageList: MessageList, snapshotBefore: string): boolean {
   return snapshotMessageList(messageList) !== snapshotBefore;
+}
+
+function stripUndefinedMessageContextFields<T extends Record<string, unknown>>(result: T): T {
+  if ('messages' in result && result.messages === undefined) {
+    delete result.messages;
+  }
+  if ('modelContextMessages' in result && result.modelContextMessages === undefined) {
+    delete result.modelContextMessages;
+  }
+  return result;
 }
 
 /**
@@ -365,7 +375,10 @@ export class ProcessorRunner {
     }
 
     // Extract and validate the output from the workflow result
-    const output = result.result;
+    const output =
+      result.result && typeof result.result === 'object'
+        ? stripUndefinedMessageContextFields(result.result as ProcessorStepOutput)
+        : result.result;
 
     if (!output || typeof output !== 'object') {
       // No output means no changes - return input unchanged
@@ -381,14 +394,7 @@ export class ProcessorRunner {
       });
     }
 
-    if (output.messages !== undefined && output.modelContextMessages !== undefined) {
-      throw new MastraError({
-        category: 'USER',
-        domain: 'AGENT',
-        id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
-        text: `Processor workflow ${workflow.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
-      });
-    }
+    validateProcessorResultExclusivity({ result: output, processorId: workflow.id });
 
     return output as ProcessorStepOutput;
   }
@@ -827,15 +833,8 @@ export class ProcessorRunner {
           requestContext,
         );
         const workflowMutatedMessageList = didMessageListChange(messageList, messageListBeforeWorkflow);
-        if (result.messages !== undefined && result.modelContextMessages !== undefined) {
-          throw new MastraError({
-            category: 'USER',
-            domain: 'AGENT',
-            id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
-            text: `Processor workflow ${processorOrWorkflow.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
-          });
-        }
-        if (modelContextMessages && workflowMutatedMessageList) {
+        validateProcessorResultExclusivity({ result, processorId: processorOrWorkflow.id });
+        if (modelContextMessages !== undefined && workflowMutatedMessageList) {
           throw new MastraError({
             category: 'USER',
             domain: 'AGENT',
@@ -854,11 +853,11 @@ export class ProcessorRunner {
         if (result.systemMessages) {
           messageList.replaceAllSystemMessages(result.systemMessages as CoreMessageV4[]);
         }
-        if (result.modelContextMessages) {
-          modelContextMessages = result.modelContextMessages as MastraDBMessage[];
+        if ('modelContextMessages' in result) {
+          modelContextMessages = normalizePromptOnlyMessages((result.modelContextMessages ?? []) as MastraDBMessage[]);
         } else if (result.messages) {
-          if (modelContextMessages) {
-            modelContextMessages = result.messages as MastraDBMessage[];
+          if (modelContextMessages !== undefined) {
+            modelContextMessages = normalizePromptOnlyMessages(result.messages as MastraDBMessage[]);
           } else {
             ProcessorRunner.applyMessagesToMessageList(
               result.messages as MastraDBMessage[],
@@ -934,7 +933,7 @@ export class ProcessorRunner {
         // Stop recording and capture mutations before applying internal plumbing changes.
         const mutations = messageList.stopRecording();
 
-        if (modelContextMessages && mutations.length > 0) {
+        if (modelContextMessages !== undefined && mutations.length > 0) {
           throw new MastraError({
             category: 'USER',
             domain: 'AGENT',
@@ -956,19 +955,19 @@ export class ProcessorRunner {
           messageList.replaceAllSystemMessages(result.systemMessages);
         }
 
-        if (result.modelContextMessages) {
-          modelContextMessages = result.modelContextMessages;
+        if ('modelContextMessages' in result) {
+          modelContextMessages = normalizePromptOnlyMessages(result.modelContextMessages ?? []);
           processableMessages = modelContextMessages;
         } else if (result.messages) {
-          if (modelContextMessages) {
-            modelContextMessages = result.messages;
+          if (modelContextMessages !== undefined) {
+            modelContextMessages = normalizePromptOnlyMessages(result.messages);
             processableMessages = modelContextMessages;
           } else {
             ProcessorRunner.applyMessagesToMessageList(result.messages, messageList, inputIds, check);
             processableMessages = messageList.get.input.db();
           }
         } else if (result.messageList) {
-          if (modelContextMessages) {
+          if (modelContextMessages !== undefined) {
             throw new MastraError({
               category: 'USER',
               domain: 'AGENT',
@@ -986,7 +985,7 @@ export class ProcessorRunner {
             ...(!areProcessorMessageArraysEqual(inputMessagesBefore, processableMessages)
               ? { messages: processableMessages }
               : {}),
-            ...(modelContextMessages ? { modelContextMessages } : {}),
+            ...(modelContextMessages !== undefined ? { modelContextMessages } : {}),
             ...(!areProcessorMessageArraysEqual(inputSystemMessagesBefore, messageList.getAllSystemMessages())
               ? { systemMessages: messageList.getAllSystemMessages() }
               : {}),
@@ -1095,15 +1094,8 @@ export class ProcessorRunner {
           args.abortSignal,
         );
         const workflowMutatedMessageList = didMessageListChange(messageList, messageListBeforeWorkflow);
-        if (result.messages !== undefined && result.modelContextMessages !== undefined) {
-          throw new MastraError({
-            category: 'USER',
-            domain: 'AGENT',
-            id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
-            text: `Processor workflow ${processorOrWorkflow.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
-          });
-        }
-        if (stepInput.modelContextMessages && workflowMutatedMessageList) {
+        validateProcessorResultExclusivity({ result, processorId: processorOrWorkflow.id });
+        if (stepInput.modelContextMessages !== undefined && workflowMutatedMessageList) {
           throw new MastraError({
             category: 'USER',
             domain: 'AGENT',
@@ -1123,11 +1115,13 @@ export class ProcessorRunner {
         if (systemMessages) {
           messageList.replaceAllSystemMessages(systemMessages as CoreMessageV4[]);
         }
-        if (modelContextMessages) {
-          stepInput.modelContextMessages = modelContextMessages as MastraDBMessage[];
+        if ('modelContextMessages' in result) {
+          stepInput.modelContextMessages = normalizePromptOnlyMessages(
+            (modelContextMessages ?? []) as MastraDBMessage[],
+          );
         } else if (messages) {
-          if (stepInput.modelContextMessages) {
-            stepInput.modelContextMessages = messages as MastraDBMessage[];
+          if (stepInput.modelContextMessages !== undefined) {
+            stepInput.modelContextMessages = normalizePromptOnlyMessages(messages as MastraDBMessage[]);
           } else {
             ProcessorRunner.applyMessagesToMessageList(
               messages as MastraDBMessage[],
@@ -1257,7 +1251,7 @@ export class ProcessorRunner {
         // Stop recording and get mutations for this processor
         const mutations = messageList.stopRecording();
 
-        if (stepInput.modelContextMessages && mutations.length > 0) {
+        if (stepInput.modelContextMessages !== undefined && mutations.length > 0) {
           throw new MastraError({
             category: 'USER',
             domain: 'AGENT',
@@ -1276,14 +1270,14 @@ export class ProcessorRunner {
         }
 
         if (messages) {
-          if (stepInput.modelContextMessages) {
-            stepInput.modelContextMessages = messages;
+          if (stepInput.modelContextMessages !== undefined) {
+            stepInput.modelContextMessages = normalizePromptOnlyMessages(messages);
           } else {
             ProcessorRunner.applyMessagesToMessageList(messages, messageList, idsBeforeProcessing, check);
           }
         }
-        if (modelContextMessages) {
-          stepInput.modelContextMessages = modelContextMessages;
+        if (returnedModelContextMessages) {
+          stepInput.modelContextMessages = normalizePromptOnlyMessages(modelContextMessages ?? []);
         }
         if (systemMessages) {
           messageList.replaceAllSystemMessages(systemMessages);
@@ -1559,6 +1553,7 @@ export class ProcessorRunner {
     args: {
       error: unknown;
       messages: MastraDBMessage[];
+      modelContextMessages?: MastraDBMessage[];
       messageList: MessageList;
       stepNumber: number;
       steps: Array<StepResult<any>>;
@@ -1569,7 +1564,7 @@ export class ProcessorRunner {
       abortSignal?: AbortSignal;
       rotateResponseMessageId?: () => string;
     } & Partial<ObservabilityContext>,
-  ): Promise<{ retry: boolean }> {
+  ): Promise<{ retry: boolean; modelContextMessages?: MastraDBMessage[] }> {
     const { error, messageList, stepNumber, steps, requestContext, retryCount = 0, writer, abortSignal } = args;
     const observabilityContext = resolveObservabilityContext(args);
 
@@ -1596,7 +1591,7 @@ export class ProcessorRunner {
         throw new TripWire(reason || `Tripwire triggered by ${processor.id}`, options, processor.id);
       };
 
-      const processableMessages: MastraDBMessage[] = messageList.get.all.db();
+      const processableMessages: MastraDBMessage[] = args.modelContextMessages ?? messageList.get.all.db();
       const systemMessagesBefore = messageList.getAllSystemMessages();
       const messageIdBefore = args.messageId;
       let messageIdAfter = args.messageId;
@@ -1630,6 +1625,7 @@ export class ProcessorRunner {
       try {
         const result = await processMethod({
           messages: processableMessages,
+          ...(args.modelContextMessages !== undefined ? { modelContextMessages: processableMessages } : {}),
           messageList,
           stepNumber,
           steps,
@@ -1679,7 +1675,14 @@ export class ProcessorRunner {
         });
 
         if (result?.retry) {
-          return { retry: true };
+          return {
+            retry: true,
+            ...(result.modelContextMessages !== undefined
+              ? { modelContextMessages: normalizePromptOnlyMessages(result.modelContextMessages) }
+              : args.modelContextMessages !== undefined
+                ? { modelContextMessages: args.modelContextMessages }
+                : {}),
+          };
         }
       } catch (processorError) {
         // Stop recording on error
@@ -1754,56 +1757,7 @@ export class ProcessorRunner {
     modelContextMessages?: MastraDBMessage[];
     systemMessages?: CoreMessageV4[];
   } {
-    if (result instanceof MessageList) {
-      if (result !== messageList) {
-        throw new MastraError({
-          category: 'USER',
-          domain: 'AGENT',
-          id: 'PROCESSOR_RETURNED_EXTERNAL_MESSAGE_LIST',
-          text: `Processor ${processor.id} returned a MessageList instance other than the one that was passed in as an argument. New external message list instances are not supported. Use the messageList argument instead.`,
-        });
-      }
-      return {
-        messageList: result,
-      };
-    } else if (Array.isArray(result)) {
-      return {
-        messages: result,
-      };
-    } else if (result) {
-      const resultWithMessageList = result as typeof result & { messageList?: MessageList };
-      if (
-        'messageList' in resultWithMessageList &&
-        resultWithMessageList.messageList &&
-        resultWithMessageList.messageList !== messageList
-      ) {
-        throw new MastraError({
-          category: 'USER',
-          domain: 'AGENT',
-          id: 'PROCESSOR_RETURNED_EXTERNAL_MESSAGE_LIST',
-          text: `Processor ${processor.id} returned a MessageList instance other than the one that was passed in as an argument. New external message list instances are not supported. Use the messageList argument instead.`,
-        });
-      }
-      if ('messages' in result && 'messageList' in resultWithMessageList) {
-        throw new MastraError({
-          category: 'USER',
-          domain: 'AGENT',
-          id: 'PROCESSOR_RETURNED_MESSAGES_AND_MESSAGE_LIST',
-          text: `Processor ${processor.id} returned both messages and messageList. Only one of these is allowed.`,
-        });
-      }
-      if ('messages' in result && 'modelContextMessages' in result) {
-        throw new MastraError({
-          category: 'USER',
-          domain: 'AGENT',
-          id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
-          text: `Processor ${processor.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
-        });
-      }
-      return result;
-    }
-
-    return {};
+    return validateAndFormatProcessInputResult(result, { messageList, processor });
   }
 
   static async validateAndFormatProcessInputStepResult(
@@ -1818,69 +1772,6 @@ export class ProcessorRunner {
       stepNumber: number;
     },
   ): Promise<RunProcessInputStepResult> {
-    if (result instanceof MessageList) {
-      if (result !== messageList) {
-        throw new MastraError({
-          category: 'USER',
-          domain: 'AGENT',
-          id: 'PROCESSOR_RETURNED_EXTERNAL_MESSAGE_LIST',
-          text: `Processor ${processor.id} returned a MessageList instance other than the one that was passed in as an argument. New external message list instances are not supported. Use the messageList argument instead.`,
-        });
-      }
-      return {
-        messageList: result,
-      };
-    } else if (Array.isArray(result)) {
-      return {
-        messages: result,
-      };
-    } else if (result) {
-      if ('messageList' in result && result.messageList && result.messageList !== messageList) {
-        throw new MastraError({
-          category: 'USER',
-          domain: 'AGENT',
-          id: 'PROCESSOR_RETURNED_EXTERNAL_MESSAGE_LIST',
-          text: `Processor ${processor.id} returned a MessageList instance other than the one that was passed in as an argument. New external message list instances are not supported. Use the messageList argument instead.`,
-        });
-      }
-      if ('messages' in result && 'messageList' in result) {
-        throw new MastraError({
-          category: 'USER',
-          domain: 'AGENT',
-          id: 'PROCESSOR_RETURNED_MESSAGES_AND_MESSAGE_LIST',
-          text: `Processor ${processor.id} returned both messages and messageList. Only one of these is allowed.`,
-        });
-      }
-      if ('messages' in result && 'modelContextMessages' in result) {
-        throw new MastraError({
-          category: 'USER',
-          domain: 'AGENT',
-          id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
-          text: `Processor ${processor.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
-        });
-      }
-      const { model: _model, ...rest } = result;
-      if (result.model) {
-        const resolvedModel = await resolveModelConfig(result.model);
-        const isSupported = isSupportedLanguageModel(resolvedModel);
-        if (!isSupported) {
-          throw new MastraError({
-            category: 'USER',
-            domain: 'AGENT',
-            id: 'PROCESSOR_RETURNED_UNSUPPORTED_MODEL',
-            text: `Processor ${processor.id} returned an unsupported model version ${resolvedModel.specificationVersion} in step ${stepNumber}. Only ${supportedLanguageModelSpecifications.join(', ')} models are supported in processInputStep.`,
-          });
-        }
-
-        return {
-          model: resolvedModel,
-          ...rest,
-        };
-      }
-
-      return rest;
-    }
-
-    return {};
+    return validateAndFormatProcessInputStepResult(result, { messageList, processor, stepNumber });
   }
 }

--- a/packages/core/src/processors/step-schema.ts
+++ b/packages/core/src/processors/step-schema.ts
@@ -105,6 +105,7 @@ export type ProcessorStepToolsConfig = ToolSet | Record<string, unknown>;
 export type ProcessorInputPhaseType = {
   phase: 'input';
   messages: ProcessorMessageType[];
+  modelContextMessages?: ProcessorMessageType[];
   messageList: MessageList;
   systemMessages?: CoreMessageType[];
   retryCount?: number;
@@ -113,6 +114,7 @@ export type ProcessorInputPhaseType = {
 export type ProcessorInputStepPhaseType = {
   phase: 'inputStep';
   messages: ProcessorMessageType[];
+  modelContextMessages?: ProcessorMessageType[];
   messageList: MessageList;
   stepNumber: number;
   systemMessages?: CoreMessageType[];
@@ -181,6 +183,7 @@ export type ProcessorStepInputType =
 export type ProcessorStepOutputType = {
   phase: 'input' | 'inputStep' | 'outputStream' | 'outputResult' | 'outputStep';
   messages?: ProcessorMessageType[];
+  modelContextMessages?: ProcessorMessageType[];
   messageList?: MessageList;
   systemMessages?: CoreMessageType[];
   stepNumber?: number;
@@ -512,6 +515,7 @@ const retryCountSchema = z.number().optional();
 export const ProcessorInputPhaseSchema = z.object({
   phase: z.literal('input'),
   messages: messagesSchema,
+  modelContextMessages: messagesSchema.optional(),
   messageList: messageListSchema,
   systemMessages: systemMessagesSchema.optional(),
   retryCount: retryCountSchema,
@@ -525,6 +529,7 @@ export const ProcessorInputPhaseSchema = z.object({
 export const ProcessorInputStepPhaseSchema = z.object({
   phase: z.literal('inputStep'),
   messages: messagesSchema,
+  modelContextMessages: messagesSchema.optional(),
   messageList: messageListSchema,
   stepNumber: z.number().describe('The current step number (0-indexed)'),
   systemMessages: systemMessagesSchema.optional(),
@@ -639,6 +644,7 @@ export const ProcessorStepOutputSchema: z.ZodType<ProcessorStepOutputType> = z.o
 
   // Message-based fields (used by most phases)
   messages: messagesSchema.optional(),
+  modelContextMessages: messagesSchema.optional(),
   messageList: messageListSchema.optional(),
   systemMessages: systemMessagesSchema.optional(),
 

--- a/packages/core/src/processors/validate-result.ts
+++ b/packages/core/src/processors/validate-result.ts
@@ -1,0 +1,172 @@
+import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
+import { MessageList } from '../agent/message-list';
+import type { MastraDBMessage } from '../agent/message-list';
+import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../agent/utils';
+import { MastraError } from '../error';
+import { resolveModelConfig } from '../llm';
+import type {
+  ProcessInputResult,
+  ProcessInputStepResult,
+  Processor,
+  ProcessorMessageResult,
+  RunProcessInputStepResult,
+} from './index';
+
+export type ProcessInputValidationResult = {
+  messages?: MastraDBMessage[];
+  messageList?: MessageList;
+  modelContextMessages?: MastraDBMessage[];
+  systemMessages?: CoreMessageV4[];
+};
+
+export function validateProcessorResultExclusivity({
+  result,
+  processorId,
+  domain = 'AGENT',
+}: {
+  result: object;
+  processorId: string;
+  domain?: 'AGENT' | 'MASTRA_WORKFLOW';
+}): void {
+  if ('messages' in result && 'modelContextMessages' in result) {
+    throw new MastraError({
+      category: 'USER',
+      domain,
+      id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+      text: `Processor ${processorId} returned both messages and modelContextMessages. Only one of these is allowed.`,
+    });
+  }
+}
+
+function assertReturnedMessageListIsLocal({
+  returnedMessageList,
+  messageList,
+  processorId,
+}: {
+  returnedMessageList: MessageList;
+  messageList: MessageList;
+  processorId: string;
+}): void {
+  if (returnedMessageList !== messageList) {
+    throw new MastraError({
+      category: 'USER',
+      domain: 'AGENT',
+      id: 'PROCESSOR_RETURNED_EXTERNAL_MESSAGE_LIST',
+      text: `Processor ${processorId} returned a MessageList instance other than the one that was passed in as an argument. New external message list instances are not supported. Use the messageList argument instead.`,
+    });
+  }
+}
+
+export function validateAndFormatProcessInputResult(
+  result: ProcessInputResult | undefined | void,
+  {
+    messageList,
+    processor,
+  }: {
+    messageList: MessageList;
+    processor: Processor;
+  },
+): ProcessInputValidationResult {
+  if (result instanceof MessageList) {
+    assertReturnedMessageListIsLocal({
+      returnedMessageList: result as MessageList,
+      messageList,
+      processorId: processor.id,
+    });
+    return {
+      messageList: result as MessageList,
+    };
+  } else if (Array.isArray(result)) {
+    return {
+      messages: result,
+    };
+  } else if (result) {
+    const resultWithMessageList = result as typeof result & { messageList?: MessageList };
+    if ('messageList' in resultWithMessageList && resultWithMessageList.messageList) {
+      assertReturnedMessageListIsLocal({
+        returnedMessageList: resultWithMessageList.messageList,
+        messageList,
+        processorId: processor.id,
+      });
+    }
+    if ('messages' in result && 'messageList' in resultWithMessageList) {
+      throw new MastraError({
+        category: 'USER',
+        domain: 'AGENT',
+        id: 'PROCESSOR_RETURNED_MESSAGES_AND_MESSAGE_LIST',
+        text: `Processor ${processor.id} returned both messages and messageList. Only one of these is allowed.`,
+      });
+    }
+    validateProcessorResultExclusivity({ result, processorId: processor.id });
+    return result;
+  }
+
+  return {};
+}
+
+export async function validateAndFormatProcessInputStepResult(
+  result: ProcessInputStepResult | Awaited<ProcessorMessageResult> | undefined | void,
+  {
+    messageList,
+    processor,
+    stepNumber,
+  }: {
+    messageList: MessageList;
+    processor: Processor;
+    stepNumber: number;
+  },
+): Promise<RunProcessInputStepResult> {
+  if (result instanceof MessageList) {
+    assertReturnedMessageListIsLocal({
+      returnedMessageList: result as MessageList,
+      messageList,
+      processorId: processor.id,
+    });
+    return {
+      messageList: result as MessageList,
+    };
+  } else if (Array.isArray(result)) {
+    return {
+      messages: result,
+    };
+  } else if (result) {
+    if ('messageList' in result && result.messageList) {
+      assertReturnedMessageListIsLocal({
+        returnedMessageList: result.messageList,
+        messageList,
+        processorId: processor.id,
+      });
+    }
+    if ('messages' in result && 'messageList' in result) {
+      throw new MastraError({
+        category: 'USER',
+        domain: 'AGENT',
+        id: 'PROCESSOR_RETURNED_MESSAGES_AND_MESSAGE_LIST',
+        text: `Processor ${processor.id} returned both messages and messageList. Only one of these is allowed.`,
+      });
+    }
+    validateProcessorResultExclusivity({ result, processorId: processor.id });
+    const { model: _model, ...rest } = result;
+    if (result.model) {
+      const resolvedModel = await resolveModelConfig(result.model);
+      const isSupported = isSupportedLanguageModel(resolvedModel);
+      if (!isSupported) {
+        throw new MastraError({
+          category: 'USER',
+          domain: 'AGENT',
+          id: 'PROCESSOR_RETURNED_UNSUPPORTED_MODEL',
+          text: `Processor ${processor.id} returned an unsupported model version ${resolvedModel.specificationVersion} in step ${stepNumber}. Only ${supportedLanguageModelSpecifications.join(', ')} models are supported in processInputStep.`,
+        });
+      }
+
+      return {
+        model: resolvedModel,
+        ...rest,
+      };
+    }
+
+    return rest;
+  }
+
+  return {};
+}

--- a/packages/core/src/tool-loop-agent/__tests__/tool-loop-agent.test.ts
+++ b/packages/core/src/tool-loop-agent/__tests__/tool-loop-agent.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { MockLanguageModelV3, convertArrayToReadableStreamV3 } from '../../agent/__tests__/mock-model';
 import { Agent } from '../../agent/agent';
+import { MessageList } from '../../agent/message-list';
+import type { MastraDBMessage } from '../../agent/message-list';
+import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import { Mastra } from '../../mastra';
 import { toolLoopAgentToMastraAgent, isToolLoopAgentLike, getSettings } from '../index';
 import { ToolLoopAgentProcessor } from '../tool-loop-processor';
@@ -48,6 +51,19 @@ function createCapturingMockModel(onCapture?: (options: any) => void) {
       };
     },
   });
+}
+
+function createDbMessage(id: string, text: string): MastraDBMessage {
+  return {
+    id,
+    role: 'user',
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text }],
+    },
+    createdAt: new Date(0),
+    threadId: 'test-thread',
+  };
 }
 
 /**
@@ -729,6 +745,45 @@ describe('ToolLoopAgent to Mastra Agent', () => {
       // Note: The steps array is populated after each step completes.
       // Due to workflow state management, step data may not be available immediately
       // on the next iteration in all scenarios. This is a known limitation.
+    });
+
+    it('should pass prepareCall prompt-only message overrides to prepareStep', async () => {
+      const canonicalMessage = createDbMessage('canonical', 'canonical input');
+      const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');
+      let prepareStepMessages: Array<unknown> = [];
+
+      const agentLike = {
+        version: 'agent-v1',
+        settings: {
+          id: 'test-agent',
+          model: MODEL,
+          prepareCall: () => ({
+            modelContextMessages: [promptOnlyMessage],
+          }),
+          prepareStep: ({ messages }: { messages: Array<unknown> }) => {
+            prepareStepMessages = messages;
+            return {};
+          },
+        },
+      };
+      const processor = new ToolLoopAgentProcessor(agentLike);
+
+      await processor.processInputStep({
+        messages: [canonicalMessage],
+        messageList: new MessageList().add([canonicalMessage], 'input'),
+        stepNumber: 0,
+        steps: [],
+        systemMessages: [],
+        state: {},
+        abort: (reason?: string): never => {
+          throw new Error(reason ?? 'aborted');
+        },
+        model: createCapturingMockModel() as unknown as MastraLanguageModel,
+        retryCount: 0,
+      });
+
+      expect(prepareStepMessages).toHaveLength(1);
+      expect((prepareStepMessages[0] as MastraDBMessage).id).toBe('prompt-only');
     });
 
     it('should receive model override from prepareCall in prepareStep', async () => {

--- a/packages/core/src/tool-loop-agent/__tests__/tool-loop-agent.test.ts
+++ b/packages/core/src/tool-loop-agent/__tests__/tool-loop-agent.test.ts
@@ -786,6 +786,42 @@ describe('ToolLoopAgent to Mastra Agent', () => {
       expect((prepareStepMessages[0] as MastraDBMessage).id).toBe('prompt-only');
     });
 
+    it('should reject prepareCall and prepareStep results that merge messages with modelContextMessages', async () => {
+      const canonicalMessage = createDbMessage('canonical', 'canonical input');
+      const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');
+
+      const agentLike = {
+        version: 'agent-v1',
+        settings: {
+          id: 'test-agent',
+          model: MODEL,
+          prepareCall: () => ({
+            messages: [canonicalMessage],
+          }),
+          prepareStep: () => ({
+            modelContextMessages: [promptOnlyMessage],
+          }),
+        },
+      };
+      const processor = new ToolLoopAgentProcessor(agentLike);
+
+      await expect(
+        processor.processInputStep({
+          messages: [canonicalMessage],
+          messageList: new MessageList().add([canonicalMessage], 'input'),
+          stepNumber: 0,
+          steps: [],
+          systemMessages: [],
+          state: {},
+          abort: (reason?: string): never => {
+            throw new Error(reason ?? 'aborted');
+          },
+          model: createCapturingMockModel() as unknown as MastraLanguageModel,
+          retryCount: 0,
+        }),
+      ).rejects.toThrow('returned both messages and modelContextMessages');
+    });
+
     it('should receive model override from prepareCall in prepareStep', async () => {
       // Create models with distinct modelIds so we can identify which one was passed
       const originalModel = new MockLanguageModelV3({

--- a/packages/core/src/tool-loop-agent/tool-loop-processor.ts
+++ b/packages/core/src/tool-loop-agent/tool-loop-processor.ts
@@ -6,7 +6,7 @@ import type {
   ToolLoopAgentSettings,
 } from '@internal/ai-v6';
 import { isSupportedLanguageModel } from '../agent';
-import type { AgentExecutionOptions, AgentInstructions } from '../agent';
+import type { AgentExecutionOptions, AgentInstructions, MastraDBMessage } from '../agent';
 import { resolveModelConfig } from '../llm/model/resolve-model';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { ProcessInputStepArgs, ProcessInputStepResult, Processor } from '../processors';
@@ -220,7 +220,37 @@ export class ToolLoopAgentProcessor implements Processor<'tool-loop-agent-proces
       stepResult.messages = result.messages as any;
     }
 
+    const modelContextResult = result as { modelContextMessages?: unknown };
+    if (
+      modelContextResult.modelContextMessages !== undefined &&
+      !Array.isArray(modelContextResult.modelContextMessages)
+    ) {
+      throw new Error('prepareCall/prepareStep modelContextMessages must be an array when provided.');
+    }
+    if (modelContextResult.modelContextMessages) {
+      stepResult.modelContextMessages = modelContextResult.modelContextMessages as MastraDBMessage[];
+    }
+
     return stepResult;
+  }
+
+  private mergeProcessInputStepResult(
+    current: ProcessInputStepResult,
+    next: ProcessInputStepResult,
+  ): ProcessInputStepResult {
+    const merged = { ...current, ...next };
+
+    if (next.modelContextMessages) {
+      const { messages: _messages, ...rest } = merged;
+      return rest as ProcessInputStepResult;
+    }
+
+    if (next.messages) {
+      const { modelContextMessages: _modelContextMessages, ...rest } = merged;
+      return rest as ProcessInputStepResult;
+    }
+
+    return merged as ProcessInputStepResult;
   }
 
   private async handlePrepareCall(args: ProcessInputStepArgs) {
@@ -264,7 +294,7 @@ export class ToolLoopAgentProcessor implements Processor<'tool-loop-agent-proces
 
   private async handlePrepareStep(args: ProcessInputStepArgs, currentResult: ProcessInputStepResult) {
     if (this.settings.prepareStep) {
-      const { messages, steps, stepNumber } = args;
+      const { steps, stepNumber } = args;
 
       let model = args.model;
       if (currentResult.model) {
@@ -274,6 +304,8 @@ export class ToolLoopAgentProcessor implements Processor<'tool-loop-agent-proces
         }
         model = resolvedModel;
       }
+
+      const preparedMessages = currentResult.modelContextMessages ?? currentResult.messages ?? args.messages;
 
       // Use the model from currentResult if prepareCall overrode it, otherwise use args.model
 
@@ -305,7 +337,7 @@ export class ToolLoopAgentProcessor implements Processor<'tool-loop-agent-proces
       } = {
         model,
         // Messages are in Mastra format (MastraDBMessage[])
-        messages: messages as any,
+        messages: preparedMessages as unknown as Array<ModelMessage>,
         // Steps may have minor type differences in usage properties (inputTokenDetails/outputTokenDetails)
         steps: steps as any,
         stepNumber,
@@ -330,7 +362,7 @@ export class ToolLoopAgentProcessor implements Processor<'tool-loop-agent-proces
     if (this.prepareCallResult) {
       const mappedResult = this.mapToProcessInputStepResult(this.prepareCallResult);
       if (Object.keys(mappedResult).length > 0) {
-        result = { ...result, ...mappedResult };
+        result = this.mergeProcessInputStepResult(result, mappedResult);
       }
     }
 
@@ -341,7 +373,7 @@ export class ToolLoopAgentProcessor implements Processor<'tool-loop-agent-proces
       if (prepareStepResult) {
         const mappedResult = this.mapToProcessInputStepResult(prepareStepResult as any);
         // prepareStep overrides prepareCall for this step
-        result = { ...result, ...mappedResult };
+        result = this.mergeProcessInputStepResult(result, mappedResult);
       }
     }
 

--- a/packages/core/src/tool-loop-agent/tool-loop-processor.ts
+++ b/packages/core/src/tool-loop-agent/tool-loop-processor.ts
@@ -9,6 +9,7 @@ import { isSupportedLanguageModel } from '../agent';
 import type { AgentExecutionOptions, AgentInstructions, MastraDBMessage } from '../agent';
 import { resolveModelConfig } from '../llm/model/resolve-model';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
+import { validateProcessorResultExclusivity } from '../processors';
 import type { ProcessInputStepArgs, ProcessInputStepResult, Processor } from '../processors';
 import { getSettings as getToolLoopAgentSettings } from './utils';
 import type { ToolLoopAgentLike } from './utils';
@@ -227,7 +228,7 @@ export class ToolLoopAgentProcessor implements Processor<'tool-loop-agent-proces
     ) {
       throw new Error('prepareCall/prepareStep modelContextMessages must be an array when provided.');
     }
-    if (modelContextResult.modelContextMessages) {
+    if (modelContextResult.modelContextMessages !== undefined) {
       stepResult.modelContextMessages = modelContextResult.modelContextMessages as MastraDBMessage[];
     }
 
@@ -240,15 +241,10 @@ export class ToolLoopAgentProcessor implements Processor<'tool-loop-agent-proces
   ): ProcessInputStepResult {
     const merged = { ...current, ...next };
 
-    if (next.modelContextMessages) {
-      const { messages: _messages, ...rest } = merged;
-      return rest as ProcessInputStepResult;
-    }
-
-    if (next.messages) {
-      const { modelContextMessages: _modelContextMessages, ...rest } = merged;
-      return rest as ProcessInputStepResult;
-    }
+    validateProcessorResultExclusivity({
+      result: merged,
+      processorId: this.id,
+    });
 
     return merged as ProcessInputStepResult;
   }

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -678,6 +678,27 @@ function createStepFromProcessor<TProcessorId extends string>(
   unknown,
   DefaultEngineType
 > {
+  const stripPromptOnlySystemMessages = (messages: MastraDBMessage[]): MastraDBMessage[] =>
+    messages.filter(message => message.role !== 'system');
+
+  const createPromptOnlyProcessorMessageList = ({
+    canonicalMessageList,
+    modelContextMessages,
+    systemMessages,
+  }: {
+    canonicalMessageList: MessageList;
+    modelContextMessages: MastraDBMessage[];
+    systemMessages?: CoreMessage[];
+  }): MessageList => {
+    const promptOnlyMessageList = new MessageList();
+    const nonSystemMessages = stripPromptOnlySystemMessages(modelContextMessages);
+    if (nonSystemMessages.length > 0) {
+      promptOnlyMessageList.add(nonSystemMessages, 'input');
+    }
+    promptOnlyMessageList.replaceAllSystemMessages(systemMessages ?? canonicalMessageList.getAllSystemMessages());
+    return promptOnlyMessageList;
+  };
+
   // Helper to map phase to entity type
   const getProcessorEntityType = (phase: string): EntityType => {
     switch (phase) {
@@ -775,6 +796,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         structuredOutput,
         steps,
         usage,
+        modelContextMessages,
         messageId,
         rotateResponseMessageId,
         // Shared processor states map for accessing persisted state
@@ -801,12 +823,13 @@ function createStepFromProcessor<TProcessorId extends string>(
         finishReason: 'unknown',
         steps: [],
       };
+      const processableMessages = (modelContextMessages ?? messages ?? []) as MastraDBMessage[];
 
       const buildProcessorSpanInput = () => {
         switch (phase) {
           case 'input':
             return {
-              messages: (messages as MastraDBMessage[]) ?? [],
+              messages: processableMessages,
               ...(systemMessages ? { systemMessages } : {}),
               ...(retryCount !== undefined ? { retryCount } : {}),
             };
@@ -817,7 +840,7 @@ function createStepFromProcessor<TProcessorId extends string>(
             const summarizedActiveTools = summarizeActiveToolsForSpan(activeTools, tools);
 
             return {
-              messages: (messages as MastraDBMessage[]) ?? [],
+              messages: processableMessages,
               ...(systemMessages ? { systemMessages } : {}),
               ...(stepNumber !== undefined ? { stepNumber } : {}),
               ...(currentMessageId ? { messageId: currentMessageId } : {}),
@@ -1045,6 +1068,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         structuredOutput,
         steps,
         usage,
+        modelContextMessages,
         messageId: currentMessageId,
         rotateResponseMessageId: rotateCurrentResponseMessageId,
       };
@@ -1082,20 +1106,52 @@ function createStepFromProcessor<TProcessorId extends string>(
                 });
               }
 
-              // Create source checker before processing to preserve message sources
-              const idsBeforeProcessing = (messages as MastraDBMessage[]).map(m => m.id);
-              const check = passThrough.messageList.makeMessageSourceChecker();
+              const checkedMessageList = passThrough.messageList;
+              const processorMessageList = passThrough.modelContextMessages
+                ? createPromptOnlyProcessorMessageList({
+                    canonicalMessageList: checkedMessageList,
+                    modelContextMessages: passThrough.modelContextMessages as MastraDBMessage[],
+                    systemMessages: systemMessages as CoreMessage[] | undefined,
+                  })
+                : checkedMessageList;
 
-              const result = await processor.processInput({
-                ...baseContext,
-                messages: messages as MastraDBMessage[],
-                messageList: passThrough.messageList,
-                systemMessages: (systemMessages ?? []) as CoreMessage[],
-              });
+              // Create source checker before processing to preserve message sources
+              const idsBeforeProcessing = processableMessages.map(m => m.id);
+              const check = checkedMessageList.makeMessageSourceChecker();
+
+              processorMessageList.startRecording();
+              let result: Awaited<ReturnType<NonNullable<typeof processor.processInput>>>;
+              let mutations: ReturnType<MessageList['stopRecording']>;
+              try {
+                result = await processor.processInput({
+                  ...baseContext,
+                  messages: processableMessages,
+                  messageList: processorMessageList,
+                  systemMessages: processorMessageList.getAllSystemMessages(),
+                });
+                mutations = processorMessageList.stopRecording();
+              } catch (error) {
+                processorMessageList.stopRecording();
+                throw error;
+              }
 
               if (result instanceof MessageList) {
+                if (passThrough.modelContextMessages) {
+                  if (result !== processorMessageList) {
+                    throw new MastraError({
+                      category: ErrorCategory.USER,
+                      domain: ErrorDomain.MASTRA_WORKFLOW,
+                      id: 'PROCESSOR_RETURNED_EXTERNAL_MESSAGE_LIST',
+                      text: `Processor ${processor.id} returned a MessageList instance other than the one passed in. Use the messageList argument instead.`,
+                    });
+                  }
+                  return {
+                    ...passThrough,
+                    modelContextMessages: stripPromptOnlySystemMessages(result.get.all.db()),
+                  };
+                }
                 // Validate same instance
-                if (result !== passThrough.messageList) {
+                if (result !== checkedMessageList) {
                   throw new MastraError({
                     category: ErrorCategory.USER,
                     domain: ErrorDomain.MASTRA_WORKFLOW,
@@ -1109,31 +1165,96 @@ function createStepFromProcessor<TProcessorId extends string>(
                   systemMessages: result.getAllSystemMessages(),
                 };
               } else if (Array.isArray(result)) {
+                if (passThrough.modelContextMessages) {
+                  return {
+                    ...passThrough,
+                    modelContextMessages: stripPromptOnlySystemMessages(result as MastraDBMessage[]),
+                  };
+                }
                 // Processor returned an array of messages
                 ProcessorRunner.applyMessagesToMessageList(
                   result as MastraDBMessage[],
-                  passThrough.messageList,
+                  checkedMessageList,
                   idsBeforeProcessing,
                   check,
                   'input',
                 );
                 return { ...passThrough, messages: result };
-              } else if (result && 'messages' in result && 'systemMessages' in result) {
-                // Processor returned { messages, systemMessages }
-                const typedResult = result as { messages: MastraDBMessage[]; systemMessages: CoreMessage[] };
-                ProcessorRunner.applyMessagesToMessageList(
-                  typedResult.messages,
-                  passThrough.messageList,
-                  idsBeforeProcessing,
-                  check,
-                  'input',
-                );
-                passThrough.messageList.replaceAllSystemMessages(typedResult.systemMessages);
-                return {
-                  ...passThrough,
-                  messages: typedResult.messages,
-                  systemMessages: typedResult.systemMessages,
-                };
+              } else if (result) {
+                if ('messages' in result && 'modelContextMessages' in result) {
+                  throw new MastraError({
+                    category: ErrorCategory.USER,
+                    domain: ErrorDomain.MASTRA_WORKFLOW,
+                    id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+                    text: `Processor ${processor.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
+                  });
+                }
+                if ('modelContextMessages' in result && mutations.length > 0) {
+                  throw new MastraError({
+                    category: ErrorCategory.USER,
+                    domain: ErrorDomain.MASTRA_WORKFLOW,
+                    id: 'PROCESSOR_MUTATED_MESSAGE_LIST_WITH_MODEL_CONTEXT_MESSAGES',
+                    text: `Processor ${processor.id} mutated messageList and returned modelContextMessages. Prompt-only model context cannot be combined with canonical messageList mutations.`,
+                  });
+                }
+                if (result.systemMessages) {
+                  checkedMessageList.replaceAllSystemMessages(result.systemMessages as CoreMessage[]);
+                }
+                if (result.modelContextMessages) {
+                  return {
+                    ...passThrough,
+                    modelContextMessages: stripPromptOnlySystemMessages(
+                      result.modelContextMessages as MastraDBMessage[],
+                    ),
+                    ...(result.systemMessages ? { systemMessages: result.systemMessages } : {}),
+                  };
+                }
+                if (result.messages) {
+                  if (passThrough.modelContextMessages) {
+                    return {
+                      ...passThrough,
+                      modelContextMessages: stripPromptOnlySystemMessages(result.messages as MastraDBMessage[]),
+                      ...(result.systemMessages ? { systemMessages: result.systemMessages } : {}),
+                    };
+                  }
+                  ProcessorRunner.applyMessagesToMessageList(
+                    result.messages as MastraDBMessage[],
+                    checkedMessageList,
+                    idsBeforeProcessing,
+                    check,
+                    'input',
+                  );
+                  return {
+                    ...passThrough,
+                    messages: result.messages,
+                    ...(result.systemMessages ? { systemMessages: result.systemMessages } : {}),
+                  };
+                }
+                if (result.systemMessages) {
+                  return passThrough.modelContextMessages
+                    ? {
+                        ...passThrough,
+                        ...(mutations.length > 0
+                          ? {
+                              modelContextMessages: stripPromptOnlySystemMessages(processorMessageList.get.all.db()),
+                            }
+                          : {}),
+                        systemMessages: result.systemMessages,
+                      }
+                    : {
+                        ...passThrough,
+                        messages,
+                        systemMessages: result.systemMessages,
+                      };
+                }
+              }
+              if (passThrough.modelContextMessages) {
+                return mutations.length > 0
+                  ? {
+                      ...passThrough,
+                      modelContextMessages: stripPromptOnlySystemMessages(processorMessageList.get.all.db()),
+                    }
+                  : { ...passThrough };
               }
               return { ...passThrough, messages };
             }
@@ -1151,53 +1272,133 @@ function createStepFromProcessor<TProcessorId extends string>(
                 });
               }
 
-              // Create source checker before processing to preserve message sources
-              const idsBeforeProcessing = (messages as MastraDBMessage[]).map(m => m.id);
-              const check = passThrough.messageList.makeMessageSourceChecker();
+              const checkedMessageList = passThrough.messageList;
+              const processorMessageList = passThrough.modelContextMessages
+                ? createPromptOnlyProcessorMessageList({
+                    canonicalMessageList: checkedMessageList,
+                    modelContextMessages: passThrough.modelContextMessages as MastraDBMessage[],
+                    systemMessages: systemMessages as CoreMessage[] | undefined,
+                  })
+                : checkedMessageList;
 
-              const result = await processor.processInputStep({
-                ...baseContext,
-                messages: messages as MastraDBMessage[],
-                messageList: passThrough.messageList,
-                stepNumber: stepNumber ?? 0,
-                systemMessages: (systemMessages ?? []) as CoreMessage[],
-                // Pass model/tools configuration fields - types match ProcessInputStepArgs
-                model: model!,
-                tools,
-                toolChoice,
-                activeTools,
-                providerOptions,
-                modelSettings,
-                structuredOutput,
-                steps: steps ?? [],
-                messageId: currentMessageId,
-                rotateResponseMessageId: rotateCurrentResponseMessageId,
-              });
+              // Create source checker before processing to preserve message sources
+              const idsBeforeProcessing = processableMessages.map(m => m.id);
+              const check = checkedMessageList.makeMessageSourceChecker();
+
+              processorMessageList.startRecording();
+              let result: Awaited<ReturnType<NonNullable<typeof processor.processInputStep>>>;
+              let mutations: ReturnType<MessageList['stopRecording']>;
+              try {
+                result = await processor.processInputStep({
+                  ...baseContext,
+                  messages: processableMessages,
+                  messageList: processorMessageList,
+                  stepNumber: stepNumber ?? 0,
+                  systemMessages: processorMessageList.getAllSystemMessages(),
+                  // Pass model/tools configuration fields - types match ProcessInputStepArgs
+                  model: model!,
+                  tools,
+                  toolChoice,
+                  activeTools,
+                  providerOptions,
+                  modelSettings,
+                  structuredOutput,
+                  steps: steps ?? [],
+                  messageId: currentMessageId,
+                  rotateResponseMessageId: rotateCurrentResponseMessageId,
+                });
+                mutations = processorMessageList.stopRecording();
+              } catch (error) {
+                processorMessageList.stopRecording();
+                throw error;
+              }
 
               const validatedResult = await ProcessorRunner.validateAndFormatProcessInputStepResult(result, {
-                messageList: passThrough.messageList,
+                messageList: processorMessageList,
                 processor,
                 stepNumber: stepNumber ?? 0,
               });
 
-              if (validatedResult.messages) {
+              if ('messages' in validatedResult && 'modelContextMessages' in validatedResult) {
+                throw new MastraError({
+                  category: ErrorCategory.USER,
+                  domain: ErrorDomain.MASTRA_WORKFLOW,
+                  id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+                  text: `Processor ${processor.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
+                });
+              }
+              if ('modelContextMessages' in validatedResult && mutations.length > 0) {
+                throw new MastraError({
+                  category: ErrorCategory.USER,
+                  domain: ErrorDomain.MASTRA_WORKFLOW,
+                  id: 'PROCESSOR_MUTATED_MESSAGE_LIST_WITH_MODEL_CONTEXT_MESSAGES',
+                  text: `Processor ${processor.id} mutated messageList and returned modelContextMessages. Prompt-only model context cannot be combined with canonical messageList mutations.`,
+                });
+              }
+
+              if (validatedResult.messages && !passThrough.modelContextMessages) {
                 ProcessorRunner.applyMessagesToMessageList(
                   validatedResult.messages,
-                  passThrough.messageList,
+                  checkedMessageList,
                   idsBeforeProcessing,
                   check,
                 );
               }
+              if (validatedResult.messages && passThrough.modelContextMessages) {
+                validatedResult.modelContextMessages = stripPromptOnlySystemMessages(validatedResult.messages);
+                delete validatedResult.messages;
+              }
+              if (validatedResult.messageList && passThrough.modelContextMessages) {
+                validatedResult.modelContextMessages = stripPromptOnlySystemMessages(processorMessageList.get.all.db());
+                delete validatedResult.messageList;
+              }
+              if (validatedResult.modelContextMessages) {
+                validatedResult.modelContextMessages = stripPromptOnlySystemMessages(
+                  validatedResult.modelContextMessages,
+                );
+              }
 
               if (validatedResult.systemMessages) {
-                passThrough.messageList!.replaceAllSystemMessages(validatedResult.systemMessages as CoreMessage[]);
+                checkedMessageList.replaceAllSystemMessages(validatedResult.systemMessages as CoreMessage[]);
+              }
+
+              const returnPassThrough = { ...passThrough };
+              let returnMessages = validatedResult.modelContextMessages ?? messages;
+              if (
+                !('messages' in validatedResult) &&
+                !('modelContextMessages' in validatedResult) &&
+                mutations.length > 0
+              ) {
+                if (passThrough.modelContextMessages) {
+                  validatedResult.modelContextMessages = stripPromptOnlySystemMessages(
+                    processorMessageList.get.all.db(),
+                  );
+                  returnMessages = validatedResult.modelContextMessages;
+                } else {
+                  delete returnPassThrough.modelContextMessages;
+                  returnMessages = checkedMessageList.get.all.db();
+                }
               }
 
               // Preserve messages in return - passThrough doesn't include messages,
               // so we must explicitly include it to avoid losing it for subsequent steps.
+              if (validatedResult.modelContextMessages) {
+                return {
+                  ...returnPassThrough,
+                  ...validatedResult,
+                  ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
+                };
+              }
+              if (returnPassThrough.modelContextMessages) {
+                return {
+                  ...returnPassThrough,
+                  ...validatedResult,
+                  ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
+                };
+              }
               return {
-                ...passThrough,
-                messages,
+                ...returnPassThrough,
+                messages: returnMessages,
                 ...validatedResult,
                 ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
               };

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -17,7 +17,14 @@ import { EntityType, SpanType, createObservabilityContext, resolveObservabilityC
 import type { ObservabilityContext } from '../../observability';
 import { executeWithContext } from '../../observability/utils';
 import type { OutputResult, Processor } from '../../processors';
-import { ProcessorRunner, ProcessorState, ProcessorStepOutputSchema, ProcessorStepSchema } from '../../processors';
+import {
+  createPromptOnlyMessageList as createPromptOnlyProcessorMessageList,
+  normalizePromptOnlyMessages as stripPromptOnlySystemMessages,
+  ProcessorRunner,
+  ProcessorState,
+  ProcessorStepOutputSchema,
+  ProcessorStepSchema,
+} from '../../processors';
 import {
   summarizeActiveToolsForSpan,
   summarizeProcessorModelForSpan,
@@ -678,27 +685,6 @@ function createStepFromProcessor<TProcessorId extends string>(
   unknown,
   DefaultEngineType
 > {
-  const stripPromptOnlySystemMessages = (messages: MastraDBMessage[]): MastraDBMessage[] =>
-    messages.filter(message => message.role !== 'system');
-
-  const createPromptOnlyProcessorMessageList = ({
-    canonicalMessageList,
-    modelContextMessages,
-    systemMessages,
-  }: {
-    canonicalMessageList: MessageList;
-    modelContextMessages: MastraDBMessage[];
-    systemMessages?: CoreMessage[];
-  }): MessageList => {
-    const promptOnlyMessageList = new MessageList();
-    const nonSystemMessages = stripPromptOnlySystemMessages(modelContextMessages);
-    if (nonSystemMessages.length > 0) {
-      promptOnlyMessageList.add(nonSystemMessages, 'input');
-    }
-    promptOnlyMessageList.replaceAllSystemMessages(systemMessages ?? canonicalMessageList.getAllSystemMessages());
-    return promptOnlyMessageList;
-  };
-
   // Helper to map phase to entity type
   const getProcessorEntityType = (phase: string): EntityType => {
     switch (phase) {
@@ -1136,7 +1122,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               }
 
               if (result instanceof MessageList) {
-                if (passThrough.modelContextMessages) {
+                if (passThrough.modelContextMessages !== undefined) {
                   if (result !== processorMessageList) {
                     throw new MastraError({
                       category: ErrorCategory.USER,
@@ -1165,7 +1151,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                   systemMessages: result.getAllSystemMessages(),
                 };
               } else if (Array.isArray(result)) {
-                if (passThrough.modelContextMessages) {
+                if (passThrough.modelContextMessages !== undefined) {
                   return {
                     ...passThrough,
                     modelContextMessages: stripPromptOnlySystemMessages(result as MastraDBMessage[]),
@@ -1200,17 +1186,17 @@ function createStepFromProcessor<TProcessorId extends string>(
                 if (result.systemMessages) {
                   checkedMessageList.replaceAllSystemMessages(result.systemMessages as CoreMessage[]);
                 }
-                if (result.modelContextMessages) {
+                if ('modelContextMessages' in result) {
                   return {
                     ...passThrough,
                     modelContextMessages: stripPromptOnlySystemMessages(
-                      result.modelContextMessages as MastraDBMessage[],
+                      (result.modelContextMessages ?? []) as MastraDBMessage[],
                     ),
                     ...(result.systemMessages ? { systemMessages: result.systemMessages } : {}),
                   };
                 }
                 if (result.messages) {
-                  if (passThrough.modelContextMessages) {
+                  if (passThrough.modelContextMessages !== undefined) {
                     return {
                       ...passThrough,
                       modelContextMessages: stripPromptOnlySystemMessages(result.messages as MastraDBMessage[]),
@@ -1231,7 +1217,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                   };
                 }
                 if (result.systemMessages) {
-                  return passThrough.modelContextMessages
+                  return passThrough.modelContextMessages !== undefined
                     ? {
                         ...passThrough,
                         ...(mutations.length > 0
@@ -1248,7 +1234,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                       };
                 }
               }
-              if (passThrough.modelContextMessages) {
+              if (passThrough.modelContextMessages !== undefined) {
                 return mutations.length > 0
                   ? {
                       ...passThrough,
@@ -1336,7 +1322,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                 });
               }
 
-              if (validatedResult.messages && !passThrough.modelContextMessages) {
+              if (validatedResult.messages && passThrough.modelContextMessages === undefined) {
                 ProcessorRunner.applyMessagesToMessageList(
                   validatedResult.messages,
                   checkedMessageList,
@@ -1344,15 +1330,15 @@ function createStepFromProcessor<TProcessorId extends string>(
                   check,
                 );
               }
-              if (validatedResult.messages && passThrough.modelContextMessages) {
+              if (validatedResult.messages && passThrough.modelContextMessages !== undefined) {
                 validatedResult.modelContextMessages = stripPromptOnlySystemMessages(validatedResult.messages);
                 delete validatedResult.messages;
               }
-              if (validatedResult.messageList && passThrough.modelContextMessages) {
+              if (validatedResult.messageList && passThrough.modelContextMessages !== undefined) {
                 validatedResult.modelContextMessages = stripPromptOnlySystemMessages(processorMessageList.get.all.db());
                 delete validatedResult.messageList;
               }
-              if (validatedResult.modelContextMessages) {
+              if (validatedResult.modelContextMessages !== undefined) {
                 validatedResult.modelContextMessages = stripPromptOnlySystemMessages(
                   validatedResult.modelContextMessages,
                 );
@@ -1369,7 +1355,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                 !('modelContextMessages' in validatedResult) &&
                 mutations.length > 0
               ) {
-                if (passThrough.modelContextMessages) {
+                if (passThrough.modelContextMessages !== undefined) {
                   validatedResult.modelContextMessages = stripPromptOnlySystemMessages(
                     processorMessageList.get.all.db(),
                   );

--- a/packages/core/src/workflows/processor-step.test.ts
+++ b/packages/core/src/workflows/processor-step.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { Agent } from '../agent';
-import type { MastraDBMessage, MessageList } from '../agent/message-list';
+import { MessageList } from '../agent/message-list';
+import type { MastraDBMessage } from '../agent/message-list';
 import { TripWire } from '../agent/trip-wire';
 import type { Processor } from '../processors';
 import { ProcessorStepInputSchema, ProcessorStepOutputSchema, ProcessorStepSchema } from '../processors/step-schema';
@@ -26,6 +27,25 @@ function createMockMessageList(messages: MastraDBMessage[] = []): MessageList {
   } as unknown as MessageList;
   return mockMessageList;
 }
+
+const createDbMessage = (
+  id: string,
+  text: string,
+  role: 'user' | 'assistant' | 'system' = 'user',
+): MastraDBMessage => ({
+  id,
+  role,
+  content: {
+    format: 2,
+    parts: [{ type: 'text', text }],
+  },
+  createdAt: new Date(),
+});
+
+const getDbMessageText = (message: MastraDBMessage): string => {
+  const part = message.content.parts?.[0];
+  return part && 'text' in part ? String(part.text) : '';
+};
 
 describe('isProcessor', () => {
   it('should return true for object with processInput method', () => {
@@ -257,6 +277,216 @@ describe('createStep with Processor', () => {
           messages: [{ id: '1', content: 'test', step: 5 }],
         }),
       );
+    });
+
+    it('should pass prompt-only messages through both messages and messageList in processInput', async () => {
+      const canonicalMessage = createDbMessage('canonical', 'canonical input');
+      const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');
+      const messageList = new MessageList().add([canonicalMessage], 'input');
+      const seen = {
+        messages: [] as string[],
+        messageList: [] as string[],
+      };
+
+      const processor: Processor = {
+        id: 'prompt-only-input-view',
+        processInput: async ({ messages, messageList }) => {
+          seen.messages = messages.map(getDbMessageText);
+          seen.messageList = messageList.get.all.db().map(getDbMessageText);
+          return;
+        },
+      };
+
+      const step = createStep(processor);
+      const result = await step.execute({
+        inputData: {
+          phase: 'input' as const,
+          messages: [canonicalMessage],
+          modelContextMessages: [promptOnlyMessage],
+          messageList,
+          systemMessages: [],
+        },
+      } as Parameters<typeof step.execute>[0]);
+
+      expect(seen).toEqual({
+        messages: ['prompt-only input'],
+        messageList: ['prompt-only input'],
+      });
+      expect(result).toEqual(
+        expect.objectContaining({
+          modelContextMessages: [promptOnlyMessage],
+        }),
+      );
+      expect(result).not.toHaveProperty('messages');
+      expect(messageList.get.all.db()).toEqual([canonicalMessage]);
+    });
+
+    it('should keep prompt-only mode when processInput returns only systemMessages', async () => {
+      const canonicalMessage = createDbMessage('canonical', 'canonical input');
+      const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');
+      const messageList = new MessageList().add([canonicalMessage], 'input');
+
+      const processor: Processor = {
+        id: 'prompt-only-system-update',
+        processInput: async () => ({
+          systemMessages: [{ role: 'system' as const, content: 'new system' }],
+        }),
+      };
+
+      const step = createStep(processor);
+      const result = await step.execute({
+        inputData: {
+          phase: 'input' as const,
+          messages: [canonicalMessage],
+          modelContextMessages: [promptOnlyMessage],
+          messageList,
+          systemMessages: [],
+        },
+      } as Parameters<typeof step.execute>[0]);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          modelContextMessages: [promptOnlyMessage],
+          systemMessages: [{ role: 'system', content: 'new system' }],
+        }),
+      );
+      expect(result).not.toHaveProperty('messages');
+    });
+
+    it('should preserve prompt-only MessageList mutations when processInput returns only systemMessages', async () => {
+      const canonicalMessage = createDbMessage('canonical', 'canonical input');
+      const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');
+      const trimmedPromptMessage = createDbMessage('trimmed-prompt', 'trimmed prompt input');
+      const messageList = new MessageList().add([canonicalMessage], 'input');
+
+      const processor: Processor = {
+        id: 'prompt-only-system-update-with-mutation',
+        processInput: async ({ messageList }) => {
+          messageList.clear.all.db();
+          messageList.add([trimmedPromptMessage], 'input');
+          return {
+            systemMessages: [{ role: 'system' as const, content: 'new system' }],
+          };
+        },
+      };
+
+      const step = createStep(processor);
+      const result = await step.execute({
+        inputData: {
+          phase: 'input' as const,
+          messages: [canonicalMessage],
+          modelContextMessages: [promptOnlyMessage],
+          messageList,
+          systemMessages: [],
+        },
+      } as Parameters<typeof step.execute>[0]);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          modelContextMessages: [trimmedPromptMessage],
+          systemMessages: [{ role: 'system', content: 'new system' }],
+        }),
+      );
+      expect(result).not.toHaveProperty('messages');
+      expect(messageList.get.all.db()).toEqual([canonicalMessage]);
+    });
+
+    it('should keep canonical system messages visible in prompt-only processInput MessageList views', async () => {
+      const canonicalMessage = createDbMessage('canonical', 'canonical input');
+      const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');
+      const messageList = new MessageList().add([canonicalMessage], 'input');
+      messageList.addSystem('canonical system');
+      let seenSystemMessages: string[] = [];
+      let seenMessageListSystemMessages: string[] = [];
+
+      const processor: Processor = {
+        id: 'prompt-only-canonical-system-view',
+        processInput: async ({ messageList, systemMessages }) => {
+          seenSystemMessages = systemMessages.map(message => String(message.content));
+          seenMessageListSystemMessages = messageList.getAllSystemMessages().map(message => String(message.content));
+        },
+      };
+
+      const step = createStep(processor);
+      await step.execute({
+        inputData: {
+          phase: 'input' as const,
+          messages: [canonicalMessage],
+          modelContextMessages: [promptOnlyMessage],
+          messageList,
+        },
+      } as Parameters<typeof step.execute>[0]);
+
+      expect(seenSystemMessages).toEqual(['canonical system']);
+      expect(seenMessageListSystemMessages).toEqual(['canonical system']);
+      expect(messageList.get.all.db()).toEqual([canonicalMessage]);
+    });
+
+    it('should strip system-role messages from prompt-only processInput results', async () => {
+      const canonicalMessage = createDbMessage('canonical', 'canonical input');
+      const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');
+      const promptOnlySystemMessage = createDbMessage('prompt-only-system', 'ignored system', 'system');
+      const messageList = new MessageList().add([canonicalMessage], 'input');
+
+      const processor: Processor = {
+        id: 'prompt-only-system-strip',
+        processInput: async () => ({
+          modelContextMessages: [promptOnlySystemMessage, promptOnlyMessage],
+        }),
+      };
+
+      const step = createStep(processor);
+      const result = await step.execute({
+        inputData: {
+          phase: 'input' as const,
+          messages: [canonicalMessage],
+          messageList,
+          systemMessages: [],
+        },
+      } as Parameters<typeof step.execute>[0]);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          modelContextMessages: [promptOnlyMessage],
+        }),
+      );
+    });
+
+    it('should keep prompt-only processInputStep MessageList mutations prompt-only', async () => {
+      const canonicalMessage = createDbMessage('canonical', 'canonical input');
+      const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');
+      const trimmedPromptMessage = createDbMessage('trimmed-prompt', 'trimmed prompt input');
+      const messageList = new MessageList().add([canonicalMessage], 'input');
+
+      const processor: Processor = {
+        id: 'prompt-only-step-message-list',
+        processInputStep: async ({ messageList }) => {
+          messageList.clear.all.db();
+          messageList.add([trimmedPromptMessage], 'input');
+          return messageList;
+        },
+      };
+
+      const step = createStep(processor);
+      const result = await step.execute({
+        inputData: {
+          phase: 'inputStep' as const,
+          messages: [canonicalMessage],
+          modelContextMessages: [promptOnlyMessage],
+          messageList,
+          stepNumber: 0,
+          systemMessages: [],
+        },
+      } as Parameters<typeof step.execute>[0]);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          modelContextMessages: [trimmedPromptMessage],
+        }),
+      );
+      expect(result).not.toHaveProperty('messages');
+      expect(result.messageList).toBe(messageList);
+      expect(messageList.get.all.db()).toEqual([canonicalMessage]);
     });
 
     it('should call processOutputStream when phase is outputStream (messageList optional)', async () => {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -641,6 +641,27 @@ function createStepFromProcessor<TProcessorId extends string>(
   unknown,
   DefaultEngineType
 > {
+  const stripPromptOnlySystemMessages = (messages: MastraDBMessage[]): MastraDBMessage[] =>
+    messages.filter(message => message.role !== 'system');
+
+  const createPromptOnlyProcessorMessageList = ({
+    canonicalMessageList,
+    modelContextMessages,
+    systemMessages,
+  }: {
+    canonicalMessageList: MessageList;
+    modelContextMessages: MastraDBMessage[];
+    systemMessages?: CoreMessage[];
+  }): MessageList => {
+    const promptOnlyMessageList = new MessageList();
+    const nonSystemMessages = stripPromptOnlySystemMessages(modelContextMessages);
+    if (nonSystemMessages.length > 0) {
+      promptOnlyMessageList.add(nonSystemMessages, 'input');
+    }
+    promptOnlyMessageList.replaceAllSystemMessages(systemMessages ?? canonicalMessageList.getAllSystemMessages());
+    return promptOnlyMessageList;
+  };
+
   // Helper to map phase to entity type
   const getProcessorEntityType = (phase: string): EntityType => {
     switch (phase) {
@@ -735,6 +756,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         structuredOutput,
         steps,
         usage,
+        modelContextMessages,
         messageId,
         rotateResponseMessageId,
         // Shared processor states map for accessing persisted state
@@ -761,12 +783,13 @@ function createStepFromProcessor<TProcessorId extends string>(
         finishReason: 'unknown',
         steps: [],
       };
+      const processableMessages = (modelContextMessages ?? messages ?? []) as MastraDBMessage[];
 
       const buildProcessorSpanInput = () => {
         switch (phase) {
           case 'input':
             return {
-              messages: (messages as MastraDBMessage[]) ?? [],
+              messages: processableMessages,
               ...(systemMessages ? { systemMessages } : {}),
               ...(retryCount !== undefined ? { retryCount } : {}),
             };
@@ -777,7 +800,7 @@ function createStepFromProcessor<TProcessorId extends string>(
             const summarizedActiveTools = summarizeActiveToolsForSpan(activeTools, tools);
 
             return {
-              messages: (messages as MastraDBMessage[]) ?? [],
+              messages: processableMessages,
               ...(systemMessages ? { systemMessages } : {}),
               ...(stepNumber !== undefined ? { stepNumber } : {}),
               ...(currentMessageId ? { messageId: currentMessageId } : {}),
@@ -1018,6 +1041,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         structuredOutput,
         steps,
         usage,
+        modelContextMessages,
         messageId: currentMessageId,
         rotateResponseMessageId: rotateCurrentResponseMessageId,
       };
@@ -1057,19 +1081,49 @@ function createStepFromProcessor<TProcessorId extends string>(
 
               // Extract messageList after null check for proper type narrowing
               const checkedMessageList = passThrough.messageList;
+              const processorMessageList = passThrough.modelContextMessages
+                ? createPromptOnlyProcessorMessageList({
+                    canonicalMessageList: checkedMessageList,
+                    modelContextMessages: passThrough.modelContextMessages as MastraDBMessage[],
+                    systemMessages: systemMessages as CoreMessage[] | undefined,
+                  })
+                : checkedMessageList;
 
               // Create source checker before processing to preserve message sources
-              const idsBeforeProcessing = (messages as MastraDBMessage[]).map(m => m.id);
+              const idsBeforeProcessing = processableMessages.map(m => m.id);
               const check = checkedMessageList.makeMessageSourceChecker();
 
-              const result = await processor.processInput({
-                ...baseContext,
-                messages: messages as MastraDBMessage[],
-                messageList: checkedMessageList,
-                systemMessages: (systemMessages ?? []) as CoreMessage[],
-              });
+              processorMessageList.startRecording();
+              let result: Awaited<ReturnType<NonNullable<typeof processor.processInput>>>;
+              let mutations: ReturnType<MessageList['stopRecording']>;
+              try {
+                result = await processor.processInput({
+                  ...baseContext,
+                  messages: processableMessages,
+                  messageList: processorMessageList,
+                  systemMessages: processorMessageList.getAllSystemMessages(),
+                });
+                mutations = processorMessageList.stopRecording();
+              } catch (error) {
+                processorMessageList.stopRecording();
+                throw error;
+              }
 
               if (result instanceof MessageList) {
+                if (passThrough.modelContextMessages) {
+                  if (result !== processorMessageList) {
+                    throw new MastraError({
+                      category: ErrorCategory.USER,
+                      domain: ErrorDomain.MASTRA_WORKFLOW,
+                      id: 'PROCESSOR_RETURNED_EXTERNAL_MESSAGE_LIST',
+                      text: `Processor ${processor.id} returned a MessageList instance other than the one passed in. Use the messageList argument instead.`,
+                    });
+                  }
+                  return {
+                    ...passThrough,
+                    modelContextMessages: stripPromptOnlySystemMessages(result.get.all.db()),
+                  };
+                }
                 // Validate same instance
                 if (result !== checkedMessageList) {
                   throw new MastraError({
@@ -1085,6 +1139,12 @@ function createStepFromProcessor<TProcessorId extends string>(
                   systemMessages: result.getAllSystemMessages(),
                 };
               } else if (Array.isArray(result)) {
+                if (passThrough.modelContextMessages) {
+                  return {
+                    ...passThrough,
+                    modelContextMessages: stripPromptOnlySystemMessages(result as MastraDBMessage[]),
+                  };
+                }
                 // Processor returned an array of messages
                 ProcessorRunner.applyMessagesToMessageList(
                   result as MastraDBMessage[],
@@ -1094,22 +1154,81 @@ function createStepFromProcessor<TProcessorId extends string>(
                   'input',
                 );
                 return { ...passThrough, messages: result };
-              } else if (result && 'messages' in result && 'systemMessages' in result) {
-                // Processor returned { messages, systemMessages }
-                const typedResult = result as { messages: MastraDBMessage[]; systemMessages: CoreMessage[] };
-                ProcessorRunner.applyMessagesToMessageList(
-                  typedResult.messages,
-                  checkedMessageList,
-                  idsBeforeProcessing,
-                  check,
-                  'input',
-                );
-                checkedMessageList.replaceAllSystemMessages(typedResult.systemMessages);
-                return {
-                  ...passThrough,
-                  messages: typedResult.messages,
-                  systemMessages: typedResult.systemMessages,
-                };
+              } else if (result) {
+                if ('messages' in result && 'modelContextMessages' in result) {
+                  throw new MastraError({
+                    category: ErrorCategory.USER,
+                    domain: ErrorDomain.MASTRA_WORKFLOW,
+                    id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+                    text: `Processor ${processor.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
+                  });
+                }
+                if ('modelContextMessages' in result && mutations.length > 0) {
+                  throw new MastraError({
+                    category: ErrorCategory.USER,
+                    domain: ErrorDomain.MASTRA_WORKFLOW,
+                    id: 'PROCESSOR_MUTATED_MESSAGE_LIST_WITH_MODEL_CONTEXT_MESSAGES',
+                    text: `Processor ${processor.id} mutated messageList and returned modelContextMessages. Prompt-only model context cannot be combined with canonical messageList mutations.`,
+                  });
+                }
+                if (result.systemMessages) {
+                  checkedMessageList.replaceAllSystemMessages(result.systemMessages as CoreMessage[]);
+                }
+                if (result.modelContextMessages) {
+                  return {
+                    ...passThrough,
+                    modelContextMessages: stripPromptOnlySystemMessages(
+                      result.modelContextMessages as MastraDBMessage[],
+                    ),
+                    ...(result.systemMessages ? { systemMessages: result.systemMessages } : {}),
+                  };
+                }
+                if (result.messages) {
+                  if (passThrough.modelContextMessages) {
+                    return {
+                      ...passThrough,
+                      modelContextMessages: stripPromptOnlySystemMessages(result.messages as MastraDBMessage[]),
+                      ...(result.systemMessages ? { systemMessages: result.systemMessages } : {}),
+                    };
+                  }
+                  ProcessorRunner.applyMessagesToMessageList(
+                    result.messages as MastraDBMessage[],
+                    checkedMessageList,
+                    idsBeforeProcessing,
+                    check,
+                    'input',
+                  );
+                  return {
+                    ...passThrough,
+                    messages: result.messages,
+                    ...(result.systemMessages ? { systemMessages: result.systemMessages } : {}),
+                  };
+                }
+                if (result.systemMessages) {
+                  return passThrough.modelContextMessages
+                    ? {
+                        ...passThrough,
+                        ...(mutations.length > 0
+                          ? {
+                              modelContextMessages: stripPromptOnlySystemMessages(processorMessageList.get.all.db()),
+                            }
+                          : {}),
+                        systemMessages: result.systemMessages,
+                      }
+                    : {
+                        ...passThrough,
+                        messages,
+                        systemMessages: result.systemMessages,
+                      };
+                }
+              }
+              if (passThrough.modelContextMessages) {
+                return mutations.length > 0
+                  ? {
+                      ...passThrough,
+                      modelContextMessages: stripPromptOnlySystemMessages(processorMessageList.get.all.db()),
+                    }
+                  : { ...passThrough };
               }
               return { ...passThrough, messages };
             }
@@ -1129,37 +1248,70 @@ function createStepFromProcessor<TProcessorId extends string>(
 
               // Extract messageList after null check for proper type narrowing
               const checkedMessageList = passThrough.messageList;
+              const processorMessageList = passThrough.modelContextMessages
+                ? createPromptOnlyProcessorMessageList({
+                    canonicalMessageList: checkedMessageList,
+                    modelContextMessages: passThrough.modelContextMessages as MastraDBMessage[],
+                    systemMessages: systemMessages as CoreMessage[] | undefined,
+                  })
+                : checkedMessageList;
 
               // Create source checker before processing to preserve message sources
-              const idsBeforeProcessing = (messages as MastraDBMessage[]).map(m => m.id);
+              const idsBeforeProcessing = processableMessages.map(m => m.id);
               const check = checkedMessageList.makeMessageSourceChecker();
 
-              const result = await processor.processInputStep({
-                ...baseContext,
-                messages: messages as MastraDBMessage[],
-                messageList: checkedMessageList,
-                stepNumber: stepNumber ?? 0,
-                systemMessages: (systemMessages ?? []) as CoreMessage[],
-                // Pass model/tools configuration fields - types match ProcessInputStepArgs
-                model: model!,
-                tools,
-                toolChoice,
-                activeTools,
-                providerOptions,
-                modelSettings,
-                structuredOutput,
-                steps: steps ?? [],
-                messageId: currentMessageId,
-                rotateResponseMessageId: rotateCurrentResponseMessageId,
-              });
+              processorMessageList.startRecording();
+              let result: Awaited<ReturnType<NonNullable<typeof processor.processInputStep>>>;
+              let mutations: ReturnType<MessageList['stopRecording']>;
+              try {
+                result = await processor.processInputStep({
+                  ...baseContext,
+                  messages: processableMessages,
+                  messageList: processorMessageList,
+                  stepNumber: stepNumber ?? 0,
+                  systemMessages: processorMessageList.getAllSystemMessages(),
+                  // Pass model/tools configuration fields - types match ProcessInputStepArgs
+                  model: model!,
+                  tools,
+                  toolChoice,
+                  activeTools,
+                  providerOptions,
+                  modelSettings,
+                  structuredOutput,
+                  steps: steps ?? [],
+                  messageId: currentMessageId,
+                  rotateResponseMessageId: rotateCurrentResponseMessageId,
+                });
+                mutations = processorMessageList.stopRecording();
+              } catch (error) {
+                processorMessageList.stopRecording();
+                throw error;
+              }
 
               const validatedResult = await ProcessorRunner.validateAndFormatProcessInputStepResult(result, {
-                messageList: checkedMessageList,
+                messageList: processorMessageList,
                 processor,
                 stepNumber: stepNumber ?? 0,
               });
 
-              if (validatedResult.messages) {
+              if ('messages' in validatedResult && 'modelContextMessages' in validatedResult) {
+                throw new MastraError({
+                  category: ErrorCategory.USER,
+                  domain: ErrorDomain.MASTRA_WORKFLOW,
+                  id: 'PROCESSOR_RETURNED_MESSAGES_AND_MODEL_CONTEXT_MESSAGES',
+                  text: `Processor ${processor.id} returned both messages and modelContextMessages. Only one of these is allowed.`,
+                });
+              }
+              if ('modelContextMessages' in validatedResult && mutations.length > 0) {
+                throw new MastraError({
+                  category: ErrorCategory.USER,
+                  domain: ErrorDomain.MASTRA_WORKFLOW,
+                  id: 'PROCESSOR_MUTATED_MESSAGE_LIST_WITH_MODEL_CONTEXT_MESSAGES',
+                  text: `Processor ${processor.id} mutated messageList and returned modelContextMessages. Prompt-only model context cannot be combined with canonical messageList mutations.`,
+                });
+              }
+
+              if (validatedResult.messages && !passThrough.modelContextMessages) {
                 ProcessorRunner.applyMessagesToMessageList(
                   validatedResult.messages,
                   checkedMessageList,
@@ -1167,16 +1319,61 @@ function createStepFromProcessor<TProcessorId extends string>(
                   check,
                 );
               }
+              if (validatedResult.messages && passThrough.modelContextMessages) {
+                validatedResult.modelContextMessages = stripPromptOnlySystemMessages(validatedResult.messages);
+                delete validatedResult.messages;
+              }
+              if (validatedResult.messageList && passThrough.modelContextMessages) {
+                validatedResult.modelContextMessages = stripPromptOnlySystemMessages(processorMessageList.get.all.db());
+                delete validatedResult.messageList;
+              }
+              if (validatedResult.modelContextMessages) {
+                validatedResult.modelContextMessages = stripPromptOnlySystemMessages(
+                  validatedResult.modelContextMessages,
+                );
+              }
 
               if (validatedResult.systemMessages) {
                 checkedMessageList.replaceAllSystemMessages(validatedResult.systemMessages as CoreMessage[]);
               }
 
+              const returnPassThrough = { ...passThrough };
+              let returnMessages = validatedResult.modelContextMessages ?? messages;
+              if (
+                !('messages' in validatedResult) &&
+                !('modelContextMessages' in validatedResult) &&
+                mutations.length > 0
+              ) {
+                if (passThrough.modelContextMessages) {
+                  validatedResult.modelContextMessages = stripPromptOnlySystemMessages(
+                    processorMessageList.get.all.db(),
+                  );
+                  returnMessages = validatedResult.modelContextMessages;
+                } else {
+                  delete returnPassThrough.modelContextMessages;
+                  returnMessages = checkedMessageList.get.all.db();
+                }
+              }
+
               // Preserve messages in return - passThrough doesn't include messages,
               // so we must explicitly include it to avoid losing it for subsequent steps.
+              if (validatedResult.modelContextMessages) {
+                return {
+                  ...returnPassThrough,
+                  ...validatedResult,
+                  ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
+                };
+              }
+              if (returnPassThrough.modelContextMessages) {
+                return {
+                  ...returnPassThrough,
+                  ...validatedResult,
+                  ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
+                };
+              }
               return {
-                ...passThrough,
-                messages,
+                ...returnPassThrough,
+                messages: returnMessages,
                 ...validatedResult,
                 ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
               };

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -27,7 +27,12 @@ import {
   resolveObservabilityContext,
 } from '../observability';
 import { executeWithContext } from '../observability/utils';
-import { ProcessorRunner, ProcessorState } from '../processors';
+import {
+  createPromptOnlyMessageList as createPromptOnlyProcessorMessageList,
+  normalizePromptOnlyMessages as stripPromptOnlySystemMessages,
+  ProcessorRunner,
+  ProcessorState,
+} from '../processors';
 import type { OutputResult, Processor, ProcessorStreamWriter } from '../processors';
 import {
   summarizeActiveToolsForSpan,
@@ -641,27 +646,6 @@ function createStepFromProcessor<TProcessorId extends string>(
   unknown,
   DefaultEngineType
 > {
-  const stripPromptOnlySystemMessages = (messages: MastraDBMessage[]): MastraDBMessage[] =>
-    messages.filter(message => message.role !== 'system');
-
-  const createPromptOnlyProcessorMessageList = ({
-    canonicalMessageList,
-    modelContextMessages,
-    systemMessages,
-  }: {
-    canonicalMessageList: MessageList;
-    modelContextMessages: MastraDBMessage[];
-    systemMessages?: CoreMessage[];
-  }): MessageList => {
-    const promptOnlyMessageList = new MessageList();
-    const nonSystemMessages = stripPromptOnlySystemMessages(modelContextMessages);
-    if (nonSystemMessages.length > 0) {
-      promptOnlyMessageList.add(nonSystemMessages, 'input');
-    }
-    promptOnlyMessageList.replaceAllSystemMessages(systemMessages ?? canonicalMessageList.getAllSystemMessages());
-    return promptOnlyMessageList;
-  };
-
   // Helper to map phase to entity type
   const getProcessorEntityType = (phase: string): EntityType => {
     switch (phase) {
@@ -1110,7 +1094,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               }
 
               if (result instanceof MessageList) {
-                if (passThrough.modelContextMessages) {
+                if (passThrough.modelContextMessages !== undefined) {
                   if (result !== processorMessageList) {
                     throw new MastraError({
                       category: ErrorCategory.USER,
@@ -1139,7 +1123,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                   systemMessages: result.getAllSystemMessages(),
                 };
               } else if (Array.isArray(result)) {
-                if (passThrough.modelContextMessages) {
+                if (passThrough.modelContextMessages !== undefined) {
                   return {
                     ...passThrough,
                     modelContextMessages: stripPromptOnlySystemMessages(result as MastraDBMessage[]),
@@ -1174,17 +1158,17 @@ function createStepFromProcessor<TProcessorId extends string>(
                 if (result.systemMessages) {
                   checkedMessageList.replaceAllSystemMessages(result.systemMessages as CoreMessage[]);
                 }
-                if (result.modelContextMessages) {
+                if ('modelContextMessages' in result) {
                   return {
                     ...passThrough,
                     modelContextMessages: stripPromptOnlySystemMessages(
-                      result.modelContextMessages as MastraDBMessage[],
+                      (result.modelContextMessages ?? []) as MastraDBMessage[],
                     ),
                     ...(result.systemMessages ? { systemMessages: result.systemMessages } : {}),
                   };
                 }
                 if (result.messages) {
-                  if (passThrough.modelContextMessages) {
+                  if (passThrough.modelContextMessages !== undefined) {
                     return {
                       ...passThrough,
                       modelContextMessages: stripPromptOnlySystemMessages(result.messages as MastraDBMessage[]),
@@ -1205,7 +1189,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                   };
                 }
                 if (result.systemMessages) {
-                  return passThrough.modelContextMessages
+                  return passThrough.modelContextMessages !== undefined
                     ? {
                         ...passThrough,
                         ...(mutations.length > 0
@@ -1222,7 +1206,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                       };
                 }
               }
-              if (passThrough.modelContextMessages) {
+              if (passThrough.modelContextMessages !== undefined) {
                 return mutations.length > 0
                   ? {
                       ...passThrough,
@@ -1311,7 +1295,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                 });
               }
 
-              if (validatedResult.messages && !passThrough.modelContextMessages) {
+              if (validatedResult.messages && passThrough.modelContextMessages === undefined) {
                 ProcessorRunner.applyMessagesToMessageList(
                   validatedResult.messages,
                   checkedMessageList,
@@ -1319,15 +1303,15 @@ function createStepFromProcessor<TProcessorId extends string>(
                   check,
                 );
               }
-              if (validatedResult.messages && passThrough.modelContextMessages) {
+              if (validatedResult.messages && passThrough.modelContextMessages !== undefined) {
                 validatedResult.modelContextMessages = stripPromptOnlySystemMessages(validatedResult.messages);
                 delete validatedResult.messages;
               }
-              if (validatedResult.messageList && passThrough.modelContextMessages) {
+              if (validatedResult.messageList && passThrough.modelContextMessages !== undefined) {
                 validatedResult.modelContextMessages = stripPromptOnlySystemMessages(processorMessageList.get.all.db());
                 delete validatedResult.messageList;
               }
-              if (validatedResult.modelContextMessages) {
+              if (validatedResult.modelContextMessages !== undefined) {
                 validatedResult.modelContextMessages = stripPromptOnlySystemMessages(
                   validatedResult.modelContextMessages,
                 );
@@ -1344,7 +1328,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                 !('modelContextMessages' in validatedResult) &&
                 mutations.length > 0
               ) {
-                if (passThrough.modelContextMessages) {
+                if (passThrough.modelContextMessages !== undefined) {
                   validatedResult.modelContextMessages = stripPromptOnlySystemMessages(
                     processorMessageList.get.all.db(),
                   );

--- a/packages/server/src/server/handlers/processors.test.ts
+++ b/packages/server/src/server/handlers/processors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { EXECUTE_PROCESSOR_ROUTE } from './processors';
+
+const message = {
+  id: 'message-1',
+  role: 'user' as const,
+  content: {
+    format: 2,
+    parts: [{ type: 'text', text: 'hello' }],
+  },
+};
+
+describe('processor handlers', () => {
+  it('should reject processor results with both messages and modelContextMessages', async () => {
+    const processor = {
+      id: 'invalid-processor',
+      processInput: () => ({
+        messages: [message],
+        modelContextMessages: [message],
+      }),
+    };
+
+    const mastra = {
+      getProcessorById: () => processor,
+      listProcessors: () => ({ [processor.id]: processor }),
+    };
+
+    await expect(
+      EXECUTE_PROCESSOR_ROUTE.handler({
+        mastra,
+        processorId: processor.id,
+        phase: 'input',
+        messages: [message],
+      } as never),
+    ).rejects.toThrow('returned both messages and modelContextMessages');
+  });
+});

--- a/packages/server/src/server/handlers/processors.ts
+++ b/packages/server/src/server/handlers/processors.ts
@@ -332,11 +332,15 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
           // Extract output from workflow result
           const output = result.result;
           let outputMessages = messages;
+          let modelContextMessages;
 
           if (output && typeof output === 'object') {
-            if ('messages' in output && Array.isArray(output.messages)) {
+            if ('modelContextMessages' in output && Array.isArray(output.modelContextMessages)) {
+              modelContextMessages = output.modelContextMessages;
+            }
+            if (!modelContextMessages && 'messages' in output && Array.isArray(output.messages)) {
               outputMessages = output.messages;
-            } else if ('messageList' in output && output.messageList instanceof MessageList) {
+            } else if (!modelContextMessages && 'messageList' in output && output.messageList instanceof MessageList) {
               outputMessages = output.messageList.get.all.db();
             }
           }
@@ -345,6 +349,7 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
             success: true,
             phase,
             messages: outputMessages,
+            modelContextMessages,
             messageList: {
               messages: outputMessages,
             },
@@ -461,6 +466,7 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
 
         // Process the result
         let outputMessages = messages;
+        let modelContextMessages;
         if (result) {
           if (Array.isArray(result)) {
             outputMessages = result;
@@ -470,12 +476,16 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
           } else if (result.messages) {
             outputMessages = result.messages;
           }
+          if (result.modelContextMessages) {
+            modelContextMessages = result.modelContextMessages;
+          }
         }
 
         return {
           success: true,
           phase,
           messages: outputMessages,
+          modelContextMessages,
           messageList: {
             messages: outputMessages,
           },

--- a/packages/server/src/server/handlers/processors.ts
+++ b/packages/server/src/server/handlers/processors.ts
@@ -1,6 +1,6 @@
 import { MessageList } from '@mastra/core/agent';
-import type { MessageInput } from '@mastra/core/agent/message-list';
-import { isProcessorWorkflow } from '@mastra/core/processors';
+import type { MastraDBMessage, MessageInput } from '@mastra/core/agent/message-list';
+import { isProcessorWorkflow, ProcessorRunner, validateProcessorResultExclusivity } from '@mastra/core/processors';
 import type { Processor, ProcessorWorkflow } from '@mastra/core/processors';
 
 import { HTTPException } from '../http-exception';
@@ -200,7 +200,8 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, processorId, ...bodyParams }) => {
     try {
-      const { phase, messages } = bodyParams;
+      const { phase, messages, modelContextMessages } = bodyParams;
+      const rawInputMessages = modelContextMessages ?? messages;
 
       if (!processorId) {
         throw new HTTPException(400, { message: 'Processor ID is required' });
@@ -210,9 +211,11 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'Phase is required' });
       }
 
-      if (!messages || !Array.isArray(messages)) {
-        throw new HTTPException(400, { message: 'Messages array is required' });
+      if (!Array.isArray(rawInputMessages)) {
+        throw new HTTPException(400, { message: 'Messages or modelContextMessages array is required' });
       }
+
+      const inputMessages = rawInputMessages as unknown as MastraDBMessage[];
 
       // Get the processor from Mastra's registered processors
       let processor;
@@ -229,7 +232,7 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
       }
 
       const messageList = new MessageList();
-      messageList.add(messages as unknown as MessageInput[], 'input');
+      messageList.add(inputMessages as unknown as MessageInput[], 'input');
 
       // Check if this is a workflow processor
       if (isProcessorWorkflow(processor)) {
@@ -238,11 +241,12 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
           // Build inputData based on phase - each phase has different required fields
           const baseInputData = {
             phase: phase as 'input' | 'inputStep' | 'outputStream' | 'outputResult' | 'outputStep',
-            messages: messageList.get.all.db(),
+            messages: inputMessages,
             messageList,
+            ...(modelContextMessages !== undefined ? { modelContextMessages } : {}),
             retryCount: 0,
           };
-          let inputData: typeof baseInputData & Record<string, unknown> = baseInputData;
+          let inputData: Record<string, unknown> = baseInputData;
 
           // Add phase-specific fields
           switch (phase) {
@@ -272,7 +276,7 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
                 ...inputData,
                 state: {},
                 result: {
-                  text: extractTextFromMessages(messages),
+                  text: extractTextFromMessages(inputMessages),
                   usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
                   finishReason: 'unknown',
                   steps: [],
@@ -287,7 +291,7 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
                 steps: [],
                 finishReason: 'stop',
                 toolCalls: [],
-                text: extractTextFromMessages(messages),
+                text: extractTextFromMessages(inputMessages),
               };
               break;
             case 'outputStream':
@@ -302,7 +306,7 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
 
           const run = await processor.createRun();
           const result = await run.start({
-            inputData,
+            inputData: inputData as any,
           });
 
           // Check for tripwire status
@@ -315,9 +319,9 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
                 reason: result.tripwire.reason || `Tripwire triggered in workflow ${processor.id}`,
                 metadata: result.tripwire.metadata,
               },
-              messages,
+              messages: inputMessages,
               messageList: {
-                messages,
+                messages: inputMessages,
               },
             };
           }
@@ -331,16 +335,16 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
 
           // Extract output from workflow result
           const output = result.result;
-          let outputMessages = messages;
-          let modelContextMessages;
+          let outputMessages: MastraDBMessage[] = inputMessages;
+          let outputModelContextMessages: MastraDBMessage[] | undefined;
 
           if (output && typeof output === 'object') {
+            validateProcessorResultExclusivity({ result: output, processorId: processor.id });
             if ('modelContextMessages' in output && Array.isArray(output.modelContextMessages)) {
-              modelContextMessages = output.modelContextMessages;
-            }
-            if (!modelContextMessages && 'messages' in output && Array.isArray(output.messages)) {
-              outputMessages = output.messages;
-            } else if (!modelContextMessages && 'messageList' in output && output.messageList instanceof MessageList) {
+              outputModelContextMessages = output.modelContextMessages as MastraDBMessage[];
+            } else if ('messages' in output && Array.isArray(output.messages)) {
+              outputMessages = output.messages as MastraDBMessage[];
+            } else if ('messageList' in output && output.messageList instanceof MessageList) {
               outputMessages = output.messageList.get.all.db();
             }
           }
@@ -348,8 +352,9 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
           return {
             success: true,
             phase,
-            messages: outputMessages,
-            modelContextMessages,
+            ...(outputModelContextMessages !== undefined
+              ? { modelContextMessages: outputModelContextMessages }
+              : { messages: outputMessages }),
             messageList: {
               messages: outputMessages,
             },
@@ -382,7 +387,7 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
       const baseContext = {
         abort,
         retryCount: 0,
-        messages: messageList.get.all.db(),
+        messages: inputMessages,
         messageList,
         state: {},
       };
@@ -430,7 +435,7 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
               ...baseContext,
               state: {},
               result: {
-                text: extractTextFromMessages(messages),
+                text: extractTextFromMessages(inputMessages),
                 usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
                 finishReason: 'unknown',
                 steps: [],
@@ -449,7 +454,7 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
               steps: [],
               finishReason: 'stop',
               toolCalls: [],
-              text: extractTextFromMessages(messages),
+              text: extractTextFromMessages(inputMessages),
               usage: { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined },
             });
             break;
@@ -465,27 +470,56 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
         }
 
         // Process the result
-        let outputMessages = messages;
-        let modelContextMessages;
+        let outputMessages: MastraDBMessage[] = inputMessages;
+        let outputModelContextMessages: MastraDBMessage[] | undefined;
         if (result) {
-          if (Array.isArray(result)) {
-            outputMessages = result;
-          } else if (result.get && result.get.all && typeof result.get.all.db === 'function') {
-            // It's a MessageList
-            outputMessages = result.get.all.db();
-          } else if (result.messages) {
-            outputMessages = result.messages;
-          }
-          if (result.modelContextMessages) {
-            modelContextMessages = result.modelContextMessages;
+          if (phase === 'input') {
+            const validatedResult = ProcessorRunner.validateAndFormatProcessInputResult(result, {
+              messageList,
+              processor,
+            });
+            if ('modelContextMessages' in validatedResult) {
+              outputModelContextMessages = validatedResult.modelContextMessages as MastraDBMessage[] | undefined;
+            } else if (validatedResult.messages) {
+              outputMessages = validatedResult.messages;
+            } else if (validatedResult.messageList) {
+              outputMessages = validatedResult.messageList.get.all.db();
+            }
+          } else if (phase === 'inputStep') {
+            const validatedResult = await ProcessorRunner.validateAndFormatProcessInputStepResult(result, {
+              messageList,
+              processor,
+              stepNumber: 0,
+            });
+            if ('modelContextMessages' in validatedResult) {
+              outputModelContextMessages = validatedResult.modelContextMessages;
+            } else if (validatedResult.messages) {
+              outputMessages = validatedResult.messages;
+            } else if (validatedResult.messageList) {
+              outputMessages = validatedResult.messageList.get.all.db();
+            }
+          } else {
+            if (typeof result === 'object' && !Array.isArray(result) && !(result instanceof MessageList)) {
+              validateProcessorResultExclusivity({ result, processorId: processor.id });
+            }
+            if (Array.isArray(result)) {
+              outputMessages = result as MastraDBMessage[];
+            } else if (result instanceof MessageList) {
+              outputMessages = result.get.all.db();
+            } else if (result.messages) {
+              outputMessages = result.messages as MastraDBMessage[];
+            } else if ('modelContextMessages' in result) {
+              outputModelContextMessages = result.modelContextMessages as MastraDBMessage[];
+            }
           }
         }
 
         return {
           success: true,
           phase,
-          messages: outputMessages,
-          modelContextMessages,
+          ...(outputModelContextMessages !== undefined
+            ? { modelContextMessages: outputModelContextMessages }
+            : { messages: outputMessages }),
           messageList: {
             messages: outputMessages,
           },
@@ -501,9 +535,9 @@ export const EXECUTE_PROCESSOR_ROUTE = createRoute({
               reason: tripwireReason || error.message?.replace('TRIPWIRE:', ''),
               metadata: tripwireMetadata,
             },
-            messages,
+            messages: inputMessages,
             messageList: {
-              messages,
+              messages: inputMessages,
             },
           };
         }

--- a/packages/server/src/server/schemas/processors.test.ts
+++ b/packages/server/src/server/schemas/processors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { executeProcessorBodySchema, executeProcessorResponseSchema } from './processors';
+
+const message = {
+  id: 'message-1',
+  role: 'user' as const,
+  content: {
+    format: 2,
+    parts: [{ type: 'text', text: 'hello' }],
+  },
+};
+
+describe('processor schemas', () => {
+  it('should reject execute requests with both messages and modelContextMessages', () => {
+    const result = executeProcessorBodySchema.safeParse({
+      phase: 'input',
+      messages: [message],
+      modelContextMessages: [message],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept execute requests with modelContextMessages only', () => {
+    const result = executeProcessorBodySchema.safeParse({
+      phase: 'input',
+      modelContextMessages: [message],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject execute responses with both messages and modelContextMessages', () => {
+    const result = executeProcessorResponseSchema.safeParse({
+      success: true,
+      phase: 'input',
+      messages: [message],
+      modelContextMessages: [message],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/server/src/server/schemas/processors.ts
+++ b/packages/server/src/server/schemas/processors.ts
@@ -101,6 +101,7 @@ export const executeProcessorResponseSchema = z.object({
   success: z.boolean(),
   phase: z.string(),
   messages: z.array(processorMessageSchema).optional(),
+  modelContextMessages: z.array(processorMessageSchema).optional(),
   messageList: z
     .object({
       messages: z.array(processorMessageSchema),

--- a/packages/server/src/server/schemas/processors.ts
+++ b/packages/server/src/server/schemas/processors.ts
@@ -78,12 +78,30 @@ const processorMessageSchema = z
 /**
  * Body schema for executing a processor
  */
-export const executeProcessorBodySchema = z.object({
-  phase: z.enum(['input', 'inputStep', 'outputStream', 'outputResult', 'outputStep']),
-  messages: z.array(processorMessageSchema),
-  agentId: z.string().optional(),
-  requestContext: z.record(z.string(), z.any()).optional(),
-});
+export const executeProcessorBodySchema = z
+  .object({
+    phase: z.enum(['input', 'inputStep', 'outputStream', 'outputResult', 'outputStep']),
+    messages: z.array(processorMessageSchema).optional(),
+    modelContextMessages: z.array(processorMessageSchema).optional(),
+    agentId: z.string().optional(),
+    requestContext: z.record(z.string(), z.any()).optional(),
+  })
+  .superRefine((body, ctx) => {
+    if ('messages' in body && 'modelContextMessages' in body) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Provide either messages or modelContextMessages, not both.',
+        path: ['modelContextMessages'],
+      });
+    }
+    if (!('messages' in body) && !('modelContextMessages' in body)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Provide messages or modelContextMessages.',
+        path: ['messages'],
+      });
+    }
+  });
 
 /**
  * Schema for tripwire result
@@ -97,16 +115,26 @@ const tripwireSchema = z.object({
 /**
  * Response schema for processor execution
  */
-export const executeProcessorResponseSchema = z.object({
-  success: z.boolean(),
-  phase: z.string(),
-  messages: z.array(processorMessageSchema).optional(),
-  modelContextMessages: z.array(processorMessageSchema).optional(),
-  messageList: z
-    .object({
-      messages: z.array(processorMessageSchema),
-    })
-    .optional(),
-  tripwire: tripwireSchema.optional(),
-  error: z.string().optional(),
-});
+export const executeProcessorResponseSchema = z
+  .object({
+    success: z.boolean(),
+    phase: z.string(),
+    messages: z.array(processorMessageSchema).optional(),
+    modelContextMessages: z.array(processorMessageSchema).optional(),
+    messageList: z
+      .object({
+        messages: z.array(processorMessageSchema),
+      })
+      .optional(),
+    tripwire: tripwireSchema.optional(),
+    error: z.string().optional(),
+  })
+  .superRefine((body, ctx) => {
+    if ('messages' in body && 'modelContextMessages' in body) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Processor response cannot include both messages and modelContextMessages.',
+        path: ['modelContextMessages'],
+      });
+    }
+  });


### PR DESCRIPTION
## Description

Adds `modelContextMessages` as a prompt-only input channel for Mastra processors.

Processors can already return `messages` when they intentionally replace canonical conversation state. This PR adds a separate path for processors that only need to change the next model prompt, without changing what memory, persistence, OM, output processors, stream state, or future turns treat as the saved conversation.

```ts
return {
  modelContextMessages: shapedMessages,
};
```

This is useful for token limiting, tool-call filtering, context compression, retrieval/context preload, and other prompt-shaping processors. Those processors can now change what the model sees for one call while preserving canonical history.

The boundary is:

```ts
messages              // durable conversation state
modelContextMessages  // next model call only
systemMessages        // system prompt changes
```

The implementation threads this through initial input processing, step input processing, workflow processors, tool-loop execution, retries, legacy execution, server/client schemas, and AI SDK middleware. It also rejects ambiguous behavior like returning both `messages` and `modelContextMessages`, or mutating canonical `messageList` after prompt-only mode begins.

## Related Issue(s)

Fixes #15846

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're having a conversation with an AI assistant, but you want to inject some temporary context just for the next response without actually changing your permanent conversation history. This PR adds that ability—letting processors modify what the AI sees as its prompt (via `modelContextMessages`) while keeping the real conversation record untouched.

---

## Overview

This PR introduces **prompt-only model context** (`modelContextMessages`) to Mastra's processor system, enabling input processors to modify the next model call's prompt without mutating the canonical conversation state. The feature establishes a clear three-channel messaging model:
- **`messages`**: Durable canonical conversation state (persisted to memory)
- **`modelContextMessages`**: Transient prompt-only context (affects only the next model invocation)
- **`systemMessages`**: System prompt changes (applied to canonical state)

The implementation enforces strict invariants: processors cannot return both `messages` and `modelContextMessages` in the same result, system-role entries in prompt-only context are filtered out, and the canonical message list is never mutated after prompt-only mode begins.

---

## Scope of Changes

### Core Framework Updates

**Processor Interface & Validation** (`packages/core/src/processors/`)
- Added `ProcessInputResultObject` type supporting mutually exclusive `messages` vs `modelContextMessages` returns
- Updated `ProcessInputResult` union to enforce exclusivity constraints
- Extended `RunProcessInputStepArgs` and `ProcessInputStepResult` to support prompt-only messaging
- Enhanced `ProcessorRunner` to track and validate two-track message flow (canonical mutations vs. prompt-only context)
- New validation functions ensure processors cannot return both canonical and prompt-only messages

**Message List Management**
- Added `createModelContextMessageList` helper to reconstruct prompt from prompt-only context while preserving canonical system messages
- Implemented snapshot-based mutation detection to prevent canonical list tampering after prompt-only mode activation
- Added `startRecording`/`stopRecording` APIs for detecting unauthorized mutations

**Agent & Workflow Execution** (`packages/core/src/agent/`, `packages/core/src/workflows/`)
- Updated `AgentLegacyCapabilities` to thread `modelContextMessages` through legacy input processing and step pipelines
- Modified workflow processors (`evented/workflow.ts`, `workflow.ts`) to:
  - Derive processor message inputs from `modelContextMessages ?? messages`
  - Create dedicated prompt-only `MessageList` instances with system-message filtering
  - Enforce mutual-exclusivity constraints and mutation detection
  - Map validated results back into `modelContextMessages` when in prompt-only mode

**Loop Execution** (`packages/core/src/loop/`)
- Updated `createLLMExecutionStep` to accept and thread `modelContextMessages` parameter
- Modified prompt construction to use prompt-only context when present, with automatic system-message preservation
- Added `executedModelContextMessages` recording for accurate retry payloads (prevents re-seeding from canonical on API-error and processor retries)
- Extended `ModelLoopStreamArgs` and `LoopOptions` types to carry `modelContextMessages`

**Tool-Loop Processing** (`packages/core/src/tool-loop-agent/`)
- Added support for `prepareCall`/`prepareStep` overrides returning `modelContextMessages`
- Implemented `mergeProcessInputStepResult` to enforce mutual exclusivity when successive hook outputs are merged

### AI SDK Middleware Integration

**`client-sdks/ai-sdk/src/middleware.ts`** — High-effort changes
- Added `modelContextMessages` buffer tracking alongside canonical messages
- Implemented dual-path prompt construction: canonical `MessageList` for output processors, prompt-only `MessageList` derived on-demand for model calls
- Snapshots `messageList` before each processor to detect mutations
- Throws if processors mutate canonical messages after prompt-only mode is activated
- Throws if processors return both `messages` and `modelContextMessages`
- Enhanced output-processor memory tagging to use `getOriginalPrompt(processorState)` instead of always using `params.prompt`
- Added comprehensive cleanup of stored `originalPrompt` on all completion paths (normal returns, TripWire returns, errors in `doGenerate`/`doStream`, and stream transform exit handlers)

**Middleware Tests** — Extended with ~200 LOC validating:
- Prompt-only messages affect only the LLM prompt, not output processor's canonical `args.messages`
- Canonical system messages remain present while system-role entries in `modelContextMessages` are filtered
- Errors when processors mutate canonical `messageList` while returning `modelContextMessages`
- Streaming persistence now uses `MessageHistory` instead of `ObservationalMemory`

### Type & Schema Updates

- **Client SDK** (`client-sdks/client-js/src/types.ts`): Added `modelContextMessages?: MastraDBMessage[]` to `ExecuteProcessorResponse`
- **Core Schemas** (`packages/core/src/`):
  - `loop/workflows/schema.ts`: Extended `LLMIterationData` and `llmIterationOutputSchema`
  - `processors/step-schema.ts`: Added `modelContextMessages` to `ProcessorInputPhaseType`, `ProcessorInputStepPhaseType`, and `ProcessorStepOutputType` with corresponding Zod validators
  - `agent/workflows/prepare-stream/schema.ts`: Added validation for `modelContextMessages` in `prepareMemoryStepOutputSchema`
- **Server Schema** (`packages/server/src/server/schemas/processors.ts`): Extended `executeProcessorResponseSchema` with optional `modelContextMessages`

### Server-Side Processor Handling

**`packages/server/src/server/handlers/processors.ts`**
- Updated workflow and individual processor execution response parsing to capture and return `modelContextMessages`
- When present, `modelContextMessages` prevents legacy `messages`/`messageList` override logic from running

### Documentation

- **`docs/src/content/en/docs/agents/processors.mdx`**: Documented `modelContextMessages` return shape with semantics (prompt-only, not persisted)
- **`docs/src/content/en/reference/processors/processor-interface.mdx`**: Extended processor interface documentation showing `modelContextMessages` option for both `processInput` and `processInputStep`, with mutual-exclusivity constraints

### Packaging & Release

- **`.changeset/many-eyes-turn.md`**: Marks `@mastra/core`, `@mastra/client-js`, `@mastra/ai-sdk`, and `@mastra/server` for minor version bumps

---

## Test Coverage

- **AI SDK Middleware Tests**: ~200 LOC verifying prompt-only context handling, system-message filtering, mutation detection, and persistence behavior
- **Processor Runner Tests**: ~390 LOC of new assertions covering:
  - Output processors only see canonical messages (not prompt-only injected context)
  - Mutual-exclusivity enforcement (rejects processors returning both `messages` and `modelContextMessages`)
  - Mutation detection across workflows and processors
- **LLM Execution Step Tests**: ~136 LOC end-to-end validation of:
  - Prompt composition from prompt-only context with canonical system messages preserved
  - Canonical `messageList` remains unmodified (no prompt-only message IDs added)
  - Retry scenarios maintain prompt-only context
  - Context removal reverts to canonical messages
- **Workflow Processor Step Tests**: ~162 LOC validating:
  - `processInput` visibility of prompt-only content
  - System-role message filtering from prompt-only context
  - Prompt-only persistence across processor returns with only `systemMessages`
  - `processInputStep` mutations preserved while `messages` omitted in prompt-only mode

---

## Key Implementation Details

**Invariant Enforcement**
- Processors cannot return both `messages` and `modelContextMessages` (throws `MastraError`)
- Processors cannot return an external `MessageList` instance when in prompt-only mode
- Processors cannot mutate canonical `messageList` after prompt-only mode is active
- System-role entries in `modelContextMessages` are automatically filtered and not persisted

**Transience Guarantees**
- Prompt-only messages are never persisted to memory or written into canonical message rows
- System-role changes in `modelContextMessages` do not override canonical system messages; `systemMessages` channel is required for system prompt changes
- Output processors only receive canonical `messageList`, never prompt-only injected context

**Retry & Recovery**
- `modelContextMessages` is preserved across API-error retries using `executedModelContextMessages` (prevents re-seeding from canonical)
- Tool-loop `prepareCall`/`prepareStep` hook results merge with mutual-exclusivity enforcement
- Processor input retries maintain the exact prompt-only context initially sent to the model

**Prompt Composition Logic**
- When `modelContextMessages` is present, the model receives a prompt reconstructed from:
  - Canonical system messages (preserved as-is)
  - Non-system entries from `modelContextMessages` (injected as `input` role)
- Canonical user messages are excluded from the prompt when in prompt-only mode
- System-role entries in `modelContextMessages` are stripped before injection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->