### PR TITLE
feat(azure): add AzureBlobStore for skill blob storage

### DIFF
--- a/.changeset/funny-monkeys-sing.md
+++ b/.changeset/funny-monkeys-sing.md
@@ -1,0 +1,16 @@
+---
+'@mastra/azure': minor
+---
+
+Added `AzureBlobStore`, a content-addressable blob store backed by Azure Blob Storage for skill versioning. Available alongside the existing `AzureBlobFilesystem` from `@mastra/azure/blob`.
+
+```typescript
+import { AzureBlobStore } from '@mastra/azure/blob';
+
+const blobs = new AzureBlobStore({
+  container: 'my-skill-blobs',
+  connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+});
+```
+
+Supports the same authentication methods as `AzureBlobFilesystem`: connection string, account key, SAS token, `DefaultAzureCredential`, and anonymous access. A matching `azureBlobStoreProvider` descriptor is also exported for MastraEditor.

--- a/examples/agent/src/mastra/agents/model-v2-agent.ts
+++ b/examples/agent/src/mastra/agents/model-v2-agent.ts
@@ -594,7 +594,7 @@ export const subscriptionOrchestratorAgent = new Agent({
   backgroundTasks: {
     tools: {
       cryptoResearchAgent: true,
-    }
+    },
   },
   memory: new Memory(),
   defaultOptions: {

--- a/workspaces/azure/README.md
+++ b/workspaces/azure/README.md
@@ -1,0 +1,79 @@
+# @mastra/azure
+
+Azure Blob Storage filesystem and content-addressable blob store provider for Mastra workspaces.
+
+## Installation
+
+```bash
+npm install @mastra/azure
+```
+
+## Usage
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { Workspace } from '@mastra/core/workspace';
+import { AzureBlobFilesystem } from '@mastra/azure/blob';
+
+const workspace = new Workspace({
+  filesystem: new AzureBlobFilesystem({
+    container: 'my-container',
+    connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+  }),
+});
+
+const agent = new Agent({
+  name: 'my-agent',
+  model: 'anthropic/claude-opus-4-5',
+  workspace,
+});
+```
+
+### Account key
+
+```typescript
+const filesystem = new AzureBlobFilesystem({
+  container: 'my-container',
+  accountName: process.env.AZURE_STORAGE_ACCOUNT_NAME,
+  accountKey: process.env.AZURE_STORAGE_ACCOUNT_KEY,
+});
+```
+
+### Shared access signature
+
+```typescript
+const filesystem = new AzureBlobFilesystem({
+  container: 'my-container',
+  accountName: process.env.AZURE_STORAGE_ACCOUNT_NAME,
+  sasToken: process.env.AZURE_STORAGE_SAS_TOKEN,
+});
+```
+
+### DefaultAzureCredential
+
+Requires `@azure/identity` to be installed.
+
+```typescript
+const filesystem = new AzureBlobFilesystem({
+  container: 'my-container',
+  accountName: process.env.AZURE_STORAGE_ACCOUNT_NAME,
+  useDefaultCredential: true,
+});
+```
+
+## Blob Store
+
+`AzureBlobStore` is a content-addressable blob store backed by Azure Blob Storage, used for skill versioning.
+
+```typescript
+import { AzureBlobStore } from '@mastra/azure/blob';
+
+const blobs = new AzureBlobStore({
+  container: 'my-skill-blobs',
+  connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+});
+```
+
+## Documentation
+
+For more information, see the [Mastra Workspaces documentation](https://mastra.ai/docs/workspace/overview).

--- a/workspaces/azure/src/blob/blob-store/index.test.ts
+++ b/workspaces/azure/src/blob/blob-store/index.test.ts
@@ -19,13 +19,18 @@ let lastServiceClientArgs: { url?: string; hasCredential?: boolean } | undefined
 vi.mock('@azure/storage-blob', () => {
   function makeBlockBlobClient(key: string) {
     return {
-      uploadData: vi.fn(async (buffer: Buffer, options: { blobHTTPHeaders?: { blobContentType?: string }; metadata?: Record<string, string> }) => {
-        mockContainer.set(key, {
-          body: Buffer.from(buffer),
-          metadata: options?.metadata ?? {},
-          contentType: options?.blobHTTPHeaders?.blobContentType ?? 'application/octet-stream',
-        });
-      }),
+      uploadData: vi.fn(
+        async (
+          buffer: Buffer,
+          options: { blobHTTPHeaders?: { blobContentType?: string }; metadata?: Record<string, string> },
+        ) => {
+          mockContainer.set(key, {
+            body: Buffer.from(buffer),
+            metadata: options?.metadata ?? {},
+            contentType: options?.blobHTTPHeaders?.blobContentType ?? 'application/octet-stream',
+          });
+        },
+      ),
       downloadToBuffer: vi.fn(async () => {
         const blob = mockContainer.get(key);
         if (!blob) {
@@ -107,7 +112,8 @@ function createEntry(hash: string, content: string, mimeType?: string): StorageB
 function createStore(opts?: { prefix?: string }) {
   return new AzureBlobStore({
     container: 'test-container',
-    connectionString: 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=key;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;',
+    connectionString:
+      'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=key;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;',
     ...(opts?.prefix !== undefined ? { prefix: opts.prefix } : {}),
   });
 }
@@ -333,7 +339,8 @@ describe('AzureBlobStore', () => {
     it('should use connectionString when provided', async () => {
       const store = new AzureBlobStore({
         container: 'test',
-        connectionString: 'DefaultEndpointsProtocol=https;AccountName=acc;AccountKey=key;EndpointSuffix=core.windows.net',
+        connectionString:
+          'DefaultEndpointsProtocol=https;AccountName=acc;AccountKey=key;EndpointSuffix=core.windows.net',
       });
 
       await store.has('trigger-client-creation');

--- a/workspaces/azure/src/blob/blob-store/index.test.ts
+++ b/workspaces/azure/src/blob/blob-store/index.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Azure Blob Store Unit Tests
+ *
+ * Tests AzureBlobStore functionality with a mocked Azure Storage Blob SDK.
+ */
+
+import type { StorageBlobEntry } from '@mastra/core/storage';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+interface MockBlob {
+  body: Buffer;
+  metadata: Record<string, string>;
+  contentType: string;
+}
+
+let mockContainer: Map<string, MockBlob>;
+let lastServiceClientArgs: { url?: string; hasCredential?: boolean } | undefined;
+
+vi.mock('@azure/storage-blob', () => {
+  function makeBlockBlobClient(key: string) {
+    return {
+      uploadData: vi.fn(async (buffer: Buffer, options: { blobHTTPHeaders?: { blobContentType?: string }; metadata?: Record<string, string> }) => {
+        mockContainer.set(key, {
+          body: Buffer.from(buffer),
+          metadata: options?.metadata ?? {},
+          contentType: options?.blobHTTPHeaders?.blobContentType ?? 'application/octet-stream',
+        });
+      }),
+      downloadToBuffer: vi.fn(async () => {
+        const blob = mockContainer.get(key);
+        if (!blob) {
+          const err = new Error('BlobNotFound') as Error & { statusCode?: number };
+          err.statusCode = 404;
+          throw err;
+        }
+        return blob.body;
+      }),
+      getProperties: vi.fn(async () => {
+        const blob = mockContainer.get(key);
+        if (!blob) {
+          const err = new Error('BlobNotFound') as Error & { statusCode?: number };
+          err.statusCode = 404;
+          throw err;
+        }
+        return { metadata: blob.metadata, contentType: blob.contentType };
+      }),
+      deleteIfExists: vi.fn(async () => {
+        const existed = mockContainer.has(key);
+        mockContainer.delete(key);
+        return { succeeded: existed };
+      }),
+    };
+  }
+
+  const containerClient = {
+    getBlockBlobClient: vi.fn((key: string) => makeBlockBlobClient(key)),
+    getBlobClient: vi.fn((name: string) => ({ name })),
+    getBlobBatchClient: vi.fn(() => ({
+      deleteBlobs: vi.fn(async (blobClients: Array<{ name: string }>) => {
+        for (const c of blobClients) mockContainer.delete(c.name);
+      }),
+    })),
+    listBlobsFlat: vi.fn(({ prefix }: { prefix: string }) => ({
+      async *[Symbol.asyncIterator]() {
+        for (const name of mockContainer.keys()) {
+          if (name.startsWith(prefix)) yield { name };
+        }
+      },
+    })),
+  };
+
+  const serviceClient = {
+    getContainerClient: vi.fn(() => containerClient),
+  };
+
+  return {
+    BlobServiceClient: Object.assign(
+      vi.fn().mockImplementation(function (url: string, credential?: unknown) {
+        lastServiceClientArgs = { url, hasCredential: credential !== undefined };
+        return serviceClient;
+      }),
+      {
+        fromConnectionString: vi.fn(() => {
+          lastServiceClientArgs = { url: 'connection-string' };
+          return serviceClient;
+        }),
+      },
+    ),
+    StorageSharedKeyCredential: vi.fn().mockImplementation(function () {
+      return {};
+    }),
+  };
+});
+
+import { AzureBlobStore } from './index';
+
+function createEntry(hash: string, content: string, mimeType?: string): StorageBlobEntry {
+  return {
+    hash,
+    content,
+    size: Buffer.byteLength(content, 'utf-8'),
+    mimeType,
+    createdAt: new Date('2025-01-01T00:00:00Z'),
+  };
+}
+
+function createStore(opts?: { prefix?: string }) {
+  return new AzureBlobStore({
+    container: 'test-container',
+    connectionString: 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=key;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;',
+    ...(opts?.prefix !== undefined ? { prefix: opts.prefix } : {}),
+  });
+}
+
+describe('AzureBlobStore', () => {
+  beforeEach(() => {
+    mockContainer = new Map();
+    lastServiceClientArgs = undefined;
+  });
+
+  describe('init', () => {
+    it('should be a no-op (Azure does not require table creation)', async () => {
+      const store = createStore();
+      await expect(store.init()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('put', () => {
+    it('should store a blob keyed by hash under the prefix', async () => {
+      const store = createStore();
+      const entry = createEntry('abc123', 'hello world', 'text/plain');
+
+      await store.put(entry);
+
+      const blob = mockContainer.get('mastra_skill_blobs/abc123');
+      expect(blob).toBeDefined();
+      expect(blob!.body.toString('utf-8')).toBe('hello world');
+      expect(blob!.contentType).toBe('text/plain');
+      expect(blob!.metadata.size).toBe(String(Buffer.byteLength('hello world', 'utf-8')));
+      expect(blob!.metadata.createdat).toBe('2025-01-01T00:00:00.000Z');
+    });
+
+    it('should use default content type when mimeType is not provided', async () => {
+      const store = createStore();
+      await store.put(createEntry('abc123', 'binary data'));
+
+      const blob = mockContainer.get('mastra_skill_blobs/abc123');
+      expect(blob!.contentType).toBe('application/octet-stream');
+    });
+
+    it('should use custom prefix', async () => {
+      const store = createStore({ prefix: 'custom/blobs' });
+      await store.put(createEntry('abc123', 'hello'));
+
+      expect(mockContainer.has('custom/blobs/abc123')).toBe(true);
+      expect(mockContainer.has('mastra_skill_blobs/abc123')).toBe(false);
+    });
+
+    it('should overwrite existing blob (idempotent for content-addressable storage)', async () => {
+      const store = createStore();
+      const entry = createEntry('abc123', 'hello world');
+
+      await store.put(entry);
+      await store.put(entry);
+
+      expect(mockContainer.size).toBe(1);
+    });
+  });
+
+  describe('get', () => {
+    it('should retrieve a stored blob', async () => {
+      const store = createStore();
+      const entry = createEntry('abc123', 'hello world', 'text/plain');
+      await store.put(entry);
+
+      const result = await store.get('abc123');
+
+      expect(result).not.toBeNull();
+      expect(result!.hash).toBe('abc123');
+      expect(result!.content).toBe('hello world');
+      expect(result!.mimeType).toBe('text/plain');
+      expect(result!.size).toBe(Buffer.byteLength('hello world', 'utf-8'));
+      expect(result!.createdAt).toEqual(new Date('2025-01-01T00:00:00Z'));
+    });
+
+    it('should return null for non-existent blob', async () => {
+      const store = createStore();
+
+      const result = await store.get('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should fall back to content length when metadata size is missing', async () => {
+      const store = createStore();
+      mockContainer.set('mastra_skill_blobs/abc123', {
+        body: Buffer.from('hello', 'utf-8'),
+        metadata: { createdat: '2025-01-01T00:00:00.000Z' },
+        contentType: 'text/plain',
+      });
+
+      const result = await store.get('abc123');
+
+      expect(result).not.toBeNull();
+      expect(result!.size).toBe(Buffer.byteLength('hello', 'utf-8'));
+    });
+  });
+
+  describe('has', () => {
+    it('should return true for existing blob', async () => {
+      const store = createStore();
+      await store.put(createEntry('abc123', 'hello'));
+
+      expect(await store.has('abc123')).toBe(true);
+    });
+
+    it('should return false for non-existent blob', async () => {
+      const store = createStore();
+
+      expect(await store.has('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete an existing blob and return true', async () => {
+      const store = createStore();
+      await store.put(createEntry('abc123', 'hello'));
+
+      const result = await store.delete('abc123');
+
+      expect(result).toBe(true);
+      expect(mockContainer.has('mastra_skill_blobs/abc123')).toBe(false);
+    });
+
+    it('should return false for non-existent blob', async () => {
+      const store = createStore();
+
+      const result = await store.delete('nonexistent');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('putMany', () => {
+    it('should store multiple blobs in parallel', async () => {
+      const store = createStore();
+      const entries = [
+        createEntry('hash1', 'content1', 'text/plain'),
+        createEntry('hash2', 'content2', 'text/markdown'),
+        createEntry('hash3', 'content3'),
+      ];
+
+      await store.putMany(entries);
+
+      expect(mockContainer.size).toBe(3);
+      expect(mockContainer.get('mastra_skill_blobs/hash1')!.body.toString('utf-8')).toBe('content1');
+      expect(mockContainer.get('mastra_skill_blobs/hash2')!.body.toString('utf-8')).toBe('content2');
+      expect(mockContainer.get('mastra_skill_blobs/hash3')!.body.toString('utf-8')).toBe('content3');
+    });
+
+    it('should handle empty array', async () => {
+      const store = createStore();
+
+      await store.putMany([]);
+
+      expect(mockContainer.size).toBe(0);
+    });
+  });
+
+  describe('getMany', () => {
+    it('should retrieve multiple blobs', async () => {
+      const store = createStore();
+      await store.put(createEntry('hash1', 'content1'));
+      await store.put(createEntry('hash2', 'content2'));
+
+      const result = await store.getMany(['hash1', 'hash2']);
+
+      expect(result.size).toBe(2);
+      expect(result.get('hash1')!.content).toBe('content1');
+      expect(result.get('hash2')!.content).toBe('content2');
+    });
+
+    it('should omit missing blobs', async () => {
+      const store = createStore();
+      await store.put(createEntry('hash1', 'content1'));
+
+      const result = await store.getMany(['hash1', 'missing']);
+
+      expect(result.size).toBe(1);
+      expect(result.has('hash1')).toBe(true);
+      expect(result.has('missing')).toBe(false);
+    });
+
+    it('should handle empty array', async () => {
+      const store = createStore();
+
+      const result = await store.getMany([]);
+
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('dangerouslyClearAll', () => {
+    it('should delete all blobs with the prefix', async () => {
+      const store = createStore();
+      await store.put(createEntry('hash1', 'content1'));
+      await store.put(createEntry('hash2', 'content2'));
+      await store.put(createEntry('hash3', 'content3'));
+
+      await store.dangerouslyClearAll();
+
+      expect(mockContainer.size).toBe(0);
+    });
+
+    it('should not delete objects outside the prefix', async () => {
+      const store = createStore();
+      await store.put(createEntry('hash1', 'content1'));
+
+      mockContainer.set('other/file.txt', {
+        body: Buffer.from('other'),
+        metadata: {},
+        contentType: 'text/plain',
+      });
+
+      await store.dangerouslyClearAll();
+
+      expect(mockContainer.size).toBe(1);
+      expect(mockContainer.has('other/file.txt')).toBe(true);
+    });
+  });
+
+  describe('auth strategy', () => {
+    it('should use connectionString when provided', async () => {
+      const store = new AzureBlobStore({
+        container: 'test',
+        connectionString: 'DefaultEndpointsProtocol=https;AccountName=acc;AccountKey=key;EndpointSuffix=core.windows.net',
+      });
+
+      await store.has('trigger-client-creation');
+
+      expect(lastServiceClientArgs?.url).toBe('connection-string');
+    });
+
+    it('should use accountName/accountKey when provided', async () => {
+      const store = new AzureBlobStore({
+        container: 'test',
+        accountName: 'myaccount',
+        accountKey: 'a2V5',
+      });
+
+      await store.has('trigger-client-creation');
+
+      expect(lastServiceClientArgs?.url).toBe('https://myaccount.blob.core.windows.net');
+      expect(lastServiceClientArgs?.hasCredential).toBe(true);
+    });
+
+    it('should throw when neither connectionString, accountName, nor endpoint is provided', async () => {
+      const store = new AzureBlobStore({ container: 'test' });
+
+      await expect(store.has('any')).rejects.toThrow(/connectionString.*accountName.*endpoint/);
+    });
+  });
+
+  describe('prefix handling', () => {
+    it('should default prefix to mastra_skill_blobs/', async () => {
+      const store = createStore();
+      await store.put(createEntry('abc', 'hello'));
+
+      expect(mockContainer.has('mastra_skill_blobs/abc')).toBe(true);
+    });
+
+    it('should trim slashes from custom prefix', async () => {
+      const store = createStore({ prefix: '/my/prefix/' });
+      await store.put(createEntry('abc', 'hello'));
+
+      expect(mockContainer.has('my/prefix/abc')).toBe(true);
+    });
+  });
+});

--- a/workspaces/azure/src/blob/blob-store/index.ts
+++ b/workspaces/azure/src/blob/blob-store/index.ts
@@ -1,0 +1,263 @@
+import { BlobServiceClient, StorageSharedKeyCredential } from '@azure/storage-blob';
+import type { ContainerClient } from '@azure/storage-blob';
+
+import { BlobStore } from '@mastra/core/storage';
+import type { StorageBlobEntry } from '@mastra/core/storage';
+
+/**
+ * Configuration for AzureBlobStore.
+ */
+export interface AzureBlobStoreOptions {
+  /** Azure Blob container name */
+  container: string;
+  /** Storage account name (required unless using connectionString) */
+  accountName?: string;
+  /** Storage account key */
+  accountKey?: string;
+  /** SAS token for authentication */
+  sasToken?: string;
+  /** Full connection string (takes priority over accountName/accountKey) */
+  connectionString?: string;
+  /**
+   * Use DefaultAzureCredential from @azure/identity for authentication.
+   * Requires @azure/identity to be installed as a peer dependency.
+   */
+  useDefaultCredential?: boolean;
+  /** Custom endpoint URL (e.g. for the Azurite emulator) */
+  endpoint?: string;
+  /**
+   * Key prefix for all blob objects.
+   * Defaults to 'mastra_skill_blobs/'.
+   */
+  prefix?: string;
+}
+
+/** Trim leading and trailing slashes. */
+function trimSlashes(s: string): string {
+  let start = 0;
+  let end = s.length;
+  while (start < end && s[start] === '/') start++;
+  while (end > start && s[end - 1] === '/') end--;
+  return s.slice(start, end);
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  return (error as { statusCode?: number }).statusCode === 404;
+}
+
+/** Azure metadata batch limit per request. */
+const BATCH_DELETE_SIZE = 256;
+
+/**
+ * Azure Blob Storage-backed content-addressable blob store for skill versioning.
+ *
+ * Each blob is stored as a block blob keyed by its SHA-256 hash. Metadata
+ * (size, mimeType, createdAt) is stored as Azure blob metadata.
+ *
+ * Since blobs are content-addressable, writes are idempotent — the same hash
+ * always maps to the same content, so overwrites are safe and equivalent to
+ * a no-op.
+ *
+ * @example Connection string
+ * ```typescript
+ * import { AzureBlobStore } from '@mastra/azure/blob';
+ *
+ * const blobs = new AzureBlobStore({
+ *   container: 'my-skill-blobs',
+ *   connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING!,
+ * });
+ * ```
+ *
+ * @example Account key
+ * ```typescript
+ * import { AzureBlobStore } from '@mastra/azure/blob';
+ *
+ * const blobs = new AzureBlobStore({
+ *   container: 'my-skill-blobs',
+ *   accountName: process.env.AZURE_STORAGE_ACCOUNT_NAME!,
+ *   accountKey: process.env.AZURE_STORAGE_ACCOUNT_KEY!,
+ * });
+ * ```
+ */
+export class AzureBlobStore extends BlobStore {
+  private readonly containerName: string;
+  private readonly accountName?: string;
+  private readonly accountKey?: string;
+  private readonly sasToken?: string;
+  private readonly connectionString?: string;
+  private readonly useDefaultCredential: boolean;
+  private readonly endpoint?: string;
+  private readonly prefix: string;
+
+  private _containerClient: ContainerClient | null = null;
+
+  constructor(options: AzureBlobStoreOptions) {
+    super();
+    this.containerName = options.container;
+    this.accountName = options.accountName;
+    this.accountKey = options.accountKey;
+    this.sasToken = options.sasToken;
+    this.connectionString = options.connectionString;
+    this.useDefaultCredential = options.useDefaultCredential ?? false;
+    this.endpoint = options.endpoint;
+    this.prefix = options.prefix ? trimSlashes(options.prefix) + '/' : 'mastra_skill_blobs/';
+  }
+
+  private async getContainerClient(): Promise<ContainerClient> {
+    if (this._containerClient) return this._containerClient;
+
+    let serviceClient: BlobServiceClient;
+
+    if (this.connectionString) {
+      serviceClient = BlobServiceClient.fromConnectionString(this.connectionString);
+    } else {
+      if (!this.endpoint && !this.accountName) {
+        throw new Error(
+          'Azure Blob Storage requires either a connectionString, or an accountName/endpoint. ' +
+            'Provide at least one of: connectionString, accountName, or endpoint.',
+        );
+      }
+      const baseUrl = this.endpoint ?? `https://${this.accountName}.blob.core.windows.net`;
+
+      if (this.accountName && this.accountKey) {
+        const credential = new StorageSharedKeyCredential(this.accountName, this.accountKey);
+        serviceClient = new BlobServiceClient(baseUrl, credential);
+      } else if (this.sasToken) {
+        const sas = this.sasToken.replace(/^\?+/, '');
+        const separator = baseUrl.includes('?') ? '&' : '?';
+        serviceClient = new BlobServiceClient(`${baseUrl}${separator}${sas}`);
+      } else if (this.useDefaultCredential) {
+        // Dynamically import @azure/identity to avoid requiring it when not used.
+        // Must use import() (not require()) because this package is ESM-first.
+        try {
+          const identity = await import('@azure/identity');
+          const credential = new identity.DefaultAzureCredential();
+          serviceClient = new BlobServiceClient(baseUrl, credential);
+        } catch {
+          throw new Error(
+            'DefaultAzureCredential requires @azure/identity to be installed. ' +
+              'Install it with: npm install @azure/identity',
+          );
+        }
+      } else {
+        // Anonymous access
+        serviceClient = new BlobServiceClient(baseUrl);
+      }
+    }
+
+    this._containerClient = serviceClient.getContainerClient(this.containerName);
+    return this._containerClient;
+  }
+
+  private toKey(hash: string): string {
+    return this.prefix + hash;
+  }
+
+  async init(): Promise<void> {
+    // Azure does not require table creation — the container is expected to exist.
+  }
+
+  async put(entry: StorageBlobEntry): Promise<void> {
+    const containerClient = await this.getContainerClient();
+    const blobClient = containerClient.getBlockBlobClient(this.toKey(entry.hash));
+    const now = entry.createdAt ?? new Date();
+    const buffer = Buffer.from(entry.content, 'utf-8');
+
+    await blobClient.uploadData(buffer, {
+      blobHTTPHeaders: {
+        blobContentType: entry.mimeType ?? 'application/octet-stream',
+      },
+      metadata: {
+        size: String(entry.size),
+        createdat: now.toISOString(),
+        ...(entry.mimeType ? { mimetype: entry.mimeType } : {}),
+      },
+    });
+  }
+
+  async get(hash: string): Promise<StorageBlobEntry | null> {
+    const containerClient = await this.getContainerClient();
+    const blobClient = containerClient.getBlockBlobClient(this.toKey(hash));
+
+    try {
+      const buffer = await blobClient.downloadToBuffer();
+      const properties = await blobClient.getProperties();
+      const metadata = properties.metadata ?? {};
+      const content = buffer.toString('utf-8');
+
+      return {
+        hash,
+        content,
+        size: metadata.size != null ? Number(metadata.size) : Buffer.byteLength(content, 'utf-8'),
+        mimeType: metadata.mimetype || properties.contentType || undefined,
+        createdAt: metadata.createdat ? new Date(metadata.createdat) : new Date(),
+      };
+    } catch (error: unknown) {
+      if (isNotFoundError(error)) return null;
+      throw error;
+    }
+  }
+
+  async has(hash: string): Promise<boolean> {
+    const containerClient = await this.getContainerClient();
+    const blobClient = containerClient.getBlockBlobClient(this.toKey(hash));
+
+    try {
+      await blobClient.getProperties();
+      return true;
+    } catch (error: unknown) {
+      if (isNotFoundError(error)) return false;
+      throw error;
+    }
+  }
+
+  async delete(hash: string): Promise<boolean> {
+    const containerClient = await this.getContainerClient();
+    const blobClient = containerClient.getBlockBlobClient(this.toKey(hash));
+    const response = await blobClient.deleteIfExists();
+    return response.succeeded;
+  }
+
+  async putMany(entries: StorageBlobEntry[]): Promise<void> {
+    if (entries.length === 0) return;
+    // Azure does not have a batch PUT, so we parallelize individual puts.
+    // Content-addressable means duplicate writes are idempotent.
+    await Promise.all(entries.map(entry => this.put(entry)));
+  }
+
+  async getMany(hashes: string[]): Promise<Map<string, StorageBlobEntry>> {
+    const result = new Map<string, StorageBlobEntry>();
+    if (hashes.length === 0) return result;
+
+    const entries = await Promise.all(hashes.map(hash => this.get(hash)));
+    for (const entry of entries) {
+      if (entry) {
+        result.set(entry.hash, entry);
+      }
+    }
+    return result;
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    const containerClient = await this.getContainerClient();
+    let batch: string[] = [];
+
+    for await (const blob of containerClient.listBlobsFlat({ prefix: this.prefix })) {
+      batch.push(blob.name);
+      if (batch.length >= BATCH_DELETE_SIZE) {
+        await this.deleteBlobBatch(containerClient, batch);
+        batch = [];
+      }
+    }
+
+    if (batch.length > 0) {
+      await this.deleteBlobBatch(containerClient, batch);
+    }
+  }
+
+  private async deleteBlobBatch(containerClient: ContainerClient, blobNames: string[]): Promise<void> {
+    const blobClients = blobNames.map(name => containerClient.getBlobClient(name));
+    await containerClient.getBlobBatchClient().deleteBlobs(blobClients);
+  }
+}

--- a/workspaces/azure/src/blob/index.ts
+++ b/workspaces/azure/src/blob/index.ts
@@ -1,8 +1,9 @@
 /**
- * @mastra/azure/blob - Azure Blob Storage Filesystem Provider
+ * @mastra/azure/blob - Azure Blob Storage Filesystem & Blob Store Provider
  *
- * A filesystem implementation backed by Azure Blob Storage.
+ * A filesystem and content-addressable blob store backed by Azure Blob Storage.
  */
 
 export { AzureBlobFilesystem, type AzureBlobFilesystemOptions, type AzureBlobMountConfig } from './filesystem';
-export { azureBlobFilesystemProvider } from './provider';
+export { AzureBlobStore, type AzureBlobStoreOptions } from './blob-store';
+export { azureBlobFilesystemProvider, azureBlobStoreProvider } from './provider';

--- a/workspaces/azure/src/blob/provider.ts
+++ b/workspaces/azure/src/blob/provider.ts
@@ -1,4 +1,6 @@
-import type { FilesystemProvider } from '@mastra/core/editor';
+import type { BlobStoreProvider, FilesystemProvider } from '@mastra/core/editor';
+import { AzureBlobStore } from './blob-store';
+import type { AzureBlobStoreOptions } from './blob-store';
 import { AzureBlobFilesystem } from './filesystem';
 import type { AzureBlobFilesystemOptions } from './filesystem';
 
@@ -26,4 +28,29 @@ export const azureBlobFilesystemProvider: FilesystemProvider<AzureBlobFilesystem
     },
   },
   createFilesystem: config => new AzureBlobFilesystem(config),
+};
+
+export const azureBlobStoreProvider: BlobStoreProvider<AzureBlobStoreOptions> = {
+  id: 'azure-blob',
+  name: 'Azure Blob Store',
+  description: 'Content-addressable blob storage backed by Azure Blob Storage',
+  configSchema: {
+    type: 'object',
+    required: ['container'],
+    properties: {
+      container: { type: 'string', description: 'Azure Blob container name' },
+      accountName: { type: 'string', description: 'Storage account name' },
+      accountKey: { type: 'string', description: 'Storage account key' },
+      sasToken: { type: 'string', description: 'Shared Access Signature token' },
+      connectionString: { type: 'string', description: 'Full connection string (overrides other auth options)' },
+      useDefaultCredential: {
+        type: 'boolean',
+        description: 'Use DefaultAzureCredential (requires @azure/identity)',
+        default: false,
+      },
+      prefix: { type: 'string', description: 'Key prefix for blob objects (default: mastra_skill_blobs/)' },
+      endpoint: { type: 'string', description: 'Custom endpoint URL (for Azurite emulator)' },
+    },
+  },
+  createBlobStore: config => new AzureBlobStore(config),
 };

--- a/workspaces/azure/src/index.ts
+++ b/workspaces/azure/src/index.ts
@@ -2,5 +2,8 @@ export {
   AzureBlobFilesystem,
   type AzureBlobFilesystemOptions,
   type AzureBlobMountConfig,
+  AzureBlobStore,
+  type AzureBlobStoreOptions,
   azureBlobFilesystemProvider,
+  azureBlobStoreProvider,
 } from './blob';


### PR DESCRIPTION
## Description

Adds `AzureBlobStore`, a content-addressable blob store backed by Azure Blob Storage, used by Mastra core's skill versioning. This closes the parity gap with `@mastra/s3` (which already exports `S3BlobStore`) so Azure-first teams can keep skill blob storage native to Azure. Also adds the package's missing README to match `@mastra/s3` and `@mastra/gcs`.

## Related Issue(s)

Related to #15217

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds Azure Blob Storage support so Mastra can store and version skill blobs in Azure just like it already does with S3. It includes the implementation, tests, provider wiring for the editor, and documentation so teams using Azure can keep everything native to their cloud.

## Overview

Adds AzureBlobStore — a content-addressable blob store backed by Azure Blob Storage — providing parity with @mastra/s3 and complementing the existing AzureBlobFilesystem. Exposes a provider for MastraEditor and documents usage and auth options.

## What changed

- New core implementation
  - workspaces/azure/src/blob/blob-store/index.ts
    - Added AzureBlobStore (extends BlobStore) and AzureBlobStoreOptions.
    - Blobs stored as block blobs keyed by SHA-256 hash with configurable prefix (default "mastra_skill_blobs/").
    - Public methods: init, put, get, has, delete, putMany, getMany, dangerouslyClearAll.
    - Metadata preserved in blob metadata (size, createdAt, mimetype) and content-type handling.
    - Idempotent writes (content-addressable).
    - Container client initialization supports: connection string, accountName+accountKey (shared key), SAS token, DefaultAzureCredential (optional @azure/identity), custom endpoint, and anonymous access. Container client is cached.
    - Batch deletion in chunks (BATCH_DELETE_SIZE = 256) for dangerouslyClearAll.
    - 404 responses mapped to not-found (get returns null, has returns false).

- Provider & exports
  - workspaces/azure/src/blob/provider.ts
    - Added azureBlobStoreProvider: BlobStoreProvider<AzureBlobStoreOptions> with config schema matching supported auth and prefix/endpoint options.
  - workspaces/azure/src/blob/index.ts and workspaces/azure/src/index.ts
    - Export AzureBlobStore, AzureBlobStoreOptions, and azureBlobStoreProvider alongside existing exports.

- Tests
  - workspaces/azure/src/blob/blob-store/index.test.ts
    - Comprehensive Vitest suite (mocking @azure/storage-blob with an in-memory Map).
    - Covers init/auth paths (connection string vs account/endpoint vs missing creds), put/get/has/delete, putMany/getMany behavior, prefix handling (including trimming), content-type/metadata mapping and fallbacks, idempotent overwrites, missing-blob handling (404 -> null/false), and dangerouslyClearAll batch deletion.

- Documentation & changelog
  - workspaces/azure/README.md
    - Installation, examples for AzureBlobFilesystem and AzureBlobStore, and authentication examples for connection string, account key, SAS token, and DefaultAzureCredential (notes dependency on @azure/identity).
  - .changeset/funny-monkeys-sing.md
    - Changeset entry documenting addition of AzureBlobStore and available auth methods; minor bump for @mastra/azure.

- Minor example tweak
  - examples/agent/src/mastra/agents/model-v2-agent.ts
    - Small formatting/brace placement edit (no behavioral change).

## Public API surface added
- Type: AzureBlobStoreOptions { container, accountName?, accountKey?, sasToken?, connectionString?, useDefaultCredential?, endpoint?, prefix? }
- Class: AzureBlobStore extends BlobStore with methods: init(), put(entry), get(hash), has(hash), delete(hash), putMany(entries), getMany(hashes), dangerouslyClearAll()
- Exported provider: azureBlobStoreProvider

## Tests & docs
- Tests added and exercise auth branches, I/O semantics, metadata handling, bulk operations, and error handling.
- README and changeset added to match other storage packages.

## Notes / Outstanding
- PR checklist notes coderabbit comments not fully addressed (per PR description).
- Type and runtime behavior assume peer dependency @azure/identity only when useDefaultCredential is true; README documents this.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->