### PR TITLE
ci(lint): gate heavy lint jobs behind alpha PR / ci:full label

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,9 @@ name: Quality assurance
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
     branches: [main, 0.x]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -20,6 +21,7 @@ jobs:
     outputs:
       has_code: ${{ steps.filter.outputs.has_code }}
       has_examples: ${{ steps.filter.outputs.has_examples }}
+      run_full_suite: ${{ steps.full.outputs.run_full_suite }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -29,6 +31,13 @@ jobs:
       - name: Check for code changes
         id: filter
         run: |
+          # On workflow_dispatch there is no PR context — assume everything changed.
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "has_code=true" >> $GITHUB_OUTPUT
+            echo "has_examples=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           ALL=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
 
           CODE=$(echo "$ALL" | grep -vE '^(docs/|examples/|\.changeset/|explorations/)' || true)
@@ -44,6 +53,31 @@ jobs:
           else
             echo "has_examples=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Determine if full suite should run
+        id: full
+        env:
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          # Run the full lint suite on:
+          # - manual workflow_dispatch
+          # - the dane-ai-mastra bot's "version packages" PR (final gate before publish)
+          # - any PR with the "ci:full" label
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run_full_suite=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [[ "$PR_USER" == "dane-ai-mastra"* ]] && [[ "$PR_TITLE" == "chore: version packages"* ]]; then
+            echo "run_full_suite=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if echo "$LABELS" | grep -q '"ci:full"'; then
+            echo "run_full_suite=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "run_full_suite=false" >> $GITHUB_OUTPUT
 
   lint:
     name: Lint
@@ -75,7 +109,9 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: needs.changes.outputs.has_code == 'true' && github.repository == 'mastra-ai/mastra'
+    # Heavy: full repo build + bundle test. Only run on the alpha "version packages"
+    # PR, on PRs labeled "ci:full", or on manual dispatch. Day-to-day PRs skip this.
+    if: needs.changes.outputs.run_full_suite == 'true' && needs.changes.outputs.has_code == 'true' && github.repository == 'mastra-ai/mastra'
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -149,10 +185,13 @@ jobs:
 
   peerdeps-check:
     name: Validate peer dependencies
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Run on main repository or for trusted bot PRs
-    if: ${{ github.repository == 'mastra-ai/mastra' }}
+    # Heavy: runs `changeset version` then validates peer deps. Only run on the
+    # alpha "version packages" PR (where peerdep drift actually matters before
+    # publish), on PRs labeled "ci:full", or on manual dispatch.
+    if: needs.changes.outputs.run_full_suite == 'true' && github.repository == 'mastra-ai/mastra'
     permissions:
       pull-requests: read
 


### PR DESCRIPTION
## Summary

Speeds up CI for day-to-day PRs by gating the two heaviest jobs in the `Quality assurance` workflow (`.github/workflows/lint.yml`) so they only run when their output actually matters:

- **`check-bundle`** — does a full repo `turbo build` then runs the `e2e-tests/pkg-outputs` bundle test. The longest single job in the lint workflow.
- **`peerdeps-check`** — runs `changeset version` then validates peer-dependency drift via `scripts/validate-peerdeps.mjs`. The result only matters on the alpha publish PR.

Both jobs now run only when a new `run_full_suite` output is true. That happens in three cases:

1. The workflow is dispatched manually (`workflow_dispatch`).
2. The PR is the `dane-ai-mastra` bot's `chore: version packages` PR — i.e. the alpha gate, which is the same signal already used by `secrets.test-combined-stores.yml` and `npm-publish.yml`.
3. The PR carries the `ci:full` label. The `pull_request` trigger now also fires on `labeled`, so adding the label re-runs the workflow with the heavy jobs enabled.

Day-to-day PRs continue to run `lint`, `validator`, `agents-md-check`, and `validate-pkg-json` (all fast).

## Why

Real CI timing across ~200 successful runs put `check-bundle` and the surrounding lint jobs as one of the longer legs of the per-PR critical path while catching issues that, in practice, only need to fail before publish — not on every push. `peerdeps-check` is similar: the alpha "version packages" PR is the natural gate.

## Test plan

- [x] YAML parses cleanly
- [x] `actionlint` reports zero errors / zero warnings (only pre-existing `info`-level `SC2086` notes, unchanged in style from the rest of the file)
- [ ] This PR itself: confirm `check-bundle` and `peerdeps-check` are **skipped** on the default run
- [ ] Apply the `ci:full` label to this PR and confirm both jobs **run**
- [ ] Remove the label, push a no-op commit, confirm they are **skipped** again
- [ ] Trigger via `workflow_dispatch` from the Actions tab and confirm both **run**

## Branch protection note

If `Validate build outputs` (`check-bundle`) is currently a required status check, it will need to be removed from the required list — or this PR should be followed up with a stub job that always reports success when the heavy suite is skipped. Worth confirming on this PR's own checks before rolling out further gating to the post-prebuild workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the team's CI process faster for everyday pull requests by skipping the heaviest tests (full builds and peer-dependency checks) unless they're actually needed. These tests only run when doing a release, when someone marks a PR with `ci:full`, or when manually triggered—saving time and resources on regular code reviews.

## Changes

The `lint.yml` workflow has been modified to intelligently gate heavy CI jobs:

### New Trigger Events
- Added `workflow_dispatch` to allow manual triggering
- Extended `pull_request` event to include `labeled` type, enabling workflow reruns when labels are added

### New Logic for Full Suite Detection
Added a "Determine if full suite should run" step in the `changes` job that outputs `run_full_suite=true` when any of these conditions are met:
- Manual workflow dispatch (via `workflow_dispatch` event)
- dane-ai-mastra bot performing the "chore: version packages" PR (alpha release gate)
- PR has the `ci:full` label

### Filter Job Enhancement
The "Check for code changes" step now assumes all code and examples have changed when triggered via `workflow_dispatch`, since there is no PR context in that scenario.

### Heavy Jobs Gating
- **lint** job: Continues running on `has_code` (unchanged behavior for lighter linting tasks)
- **check-bundle** job: Now requires both `run_full_suite == 'true'` AND `has_code == 'true'` (full repo build + bundle tests skipped on regular PRs)
- **peerdeps-check** job: Now requires only `run_full_suite == 'true'` and added `needs: changes` to access the new output (peer-dependency validation skipped except on release/full suite runs)

### Regular PR Jobs
The following jobs continue to run on all PRs with code changes and are not affected by the gating:
- `lint` (code formatting and linting)
- `validator` (examples validation)
- `agents-md-check` (AGENTS.md validation)
- `validate-pkg-json` (package.json validation)

### Breaking Changes Note
If `check-bundle` is configured as a required status check in branch protection, it must be removed or replaced with a stub since the job will be skipped by default on regular PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->