### PR TITLE
feat(mcp): forward jsonSchemaValidator into underlying SDK Client/Server

### DIFF
--- a/.changeset/big-loops-watch.md
+++ b/.changeset/big-loops-watch.md
@@ -1,0 +1,28 @@
+---
+'@mastra/mcp': minor
+---
+
+Added `jsonSchemaValidator` pass-through option on `MCPClient` server entries and `MCPServer`. Forward this option from `@modelcontextprotocol/sdk` to opt into a non-default validator. Pass `CfWorkerJsonSchemaValidator` from `@modelcontextprotocol/sdk/validation/cfworker` to make tools with `outputSchema` work in Cloudflare Workers / V8 isolates, where the default Ajv validator's `new Function(...)` compile path is blocked.
+
+```typescript
+import { MCPClient, MCPServer } from '@mastra/mcp';
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker';
+
+const mcp = new MCPClient({
+  servers: {
+    upstream: {
+      url: new URL('https://example/mcp'),
+      jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+    },
+  },
+});
+
+const server = new MCPServer({
+  name: 'My Server',
+  version: '1.0.0',
+  tools: { ... },
+  jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+});
+```
+
+Closes #15862.

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -106,6 +106,48 @@ async function setupTestServer(withSessionManagement: boolean) {
   return { httpServer, mcpServer, serverTransport: undefined as any, baseUrl };
 }
 
+describe('InternalMastraMCPClient - jsonSchemaValidator pass-through', () => {
+  it('should forward jsonSchemaValidator to the underlying SDK Client', () => {
+    const customValidator = {
+      getValidator: vi.fn(() => (input: unknown) => ({
+        valid: true as const,
+        data: input,
+        errorMessage: undefined,
+      })),
+    };
+
+    const client = new InternalMastraMCPClient({
+      name: 'validator-pass-through-client',
+      server: {
+        url: new URL('http://127.0.0.1:0/mcp'),
+        jsonSchemaValidator: customValidator,
+      },
+    });
+
+    // @ts-expect-error - accessing internal SDK property for testing
+    const sdkClient = client.client as Client;
+
+    // @ts-expect-error - accessing internal SDK property for testing
+    expect(sdkClient._jsonSchemaValidator).toBe(customValidator);
+  });
+
+  it('should leave the SDK Client default validator in place when omitted', () => {
+    const client = new InternalMastraMCPClient({
+      name: 'default-validator-client',
+      server: {
+        url: new URL('http://127.0.0.1:0/mcp'),
+      },
+    });
+
+    // @ts-expect-error - accessing internal SDK property for testing
+    const sdkClient = client.client as Client;
+
+    // SDK falls back to its built-in default (AJV) when nothing is forwarded
+    // @ts-expect-error - accessing internal SDK property for testing
+    expect(sdkClient._jsonSchemaValidator).not.toBeUndefined();
+  });
+});
+
 describe('MastraMCPClient with Streamable HTTP', () => {
   let testServer: {
     httpServer: HttpServer;

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -174,6 +174,7 @@ export class InternalMastraMCPClient extends MastraBase {
       },
       {
         capabilities: clientCapabilities,
+        ...(server.jsonSchemaValidator ? { jsonSchemaValidator: server.jsonSchemaValidator } : {}),
       },
     );
 

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -11,6 +11,7 @@ import type {
   LoggingLevel,
   ProgressNotification,
 } from '@modelcontextprotocol/sdk/types.js';
+import type { jsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/types.js';
 
 /**
  * Extended fetch function type that receives the current request context as a third argument.
@@ -171,6 +172,31 @@ export type BaseServerOptions = {
    * ```
    */
   requireToolApproval?: RequireToolApproval;
+  /**
+   * Optional custom JSON Schema validator forwarded to the underlying MCP SDK
+   * client. Use this to opt into a non-default validator implementation.
+   *
+   * Pass `CfWorkerJsonSchemaValidator` (from
+   * `@modelcontextprotocol/sdk/validation/cfworker`) when running in
+   * Cloudflare Workers / V8 isolates: the default `AjvJsonSchemaValidator`
+   * compiles validators with `new Function(...)`, which workerd refuses to
+   * evaluate when a tool advertises an `outputSchema`.
+   *
+   * @example
+   * ```typescript
+   * import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker';
+   *
+   * const mcp = new MCPClient({
+   *   servers: {
+   *     upstream: {
+   *       url: new URL('https://example/mcp'),
+   *       jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+   *     },
+   *   },
+   * });
+   * ```
+   */
+  jsonSchemaValidator?: jsonSchemaValidator;
   /**
    * List of filesystem roots to expose to the MCP server.
    *

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -251,6 +251,38 @@ describe('MCPServer', () => {
       // @ts-expect-error - accessing internal for testing - accessing private property for testing
       expect(sdkServer._instructions).toBe(instructions);
     });
+
+    it('should forward jsonSchemaValidator to underlying SDK Server', () => {
+      const customValidator = {
+        getValidator: vi.fn(() => (input: unknown) => ({
+          valid: true as const,
+          data: input,
+          errorMessage: undefined,
+        })),
+      };
+
+      const server = new MCPServer({
+        ...minimalConfig,
+        jsonSchemaValidator: customValidator,
+      });
+
+      const sdkServer = server.getServer();
+
+      // @ts-expect-error - accessing internal SDK property for testing
+      expect(sdkServer._jsonSchemaValidator).toBe(customValidator);
+    });
+
+    it('should not set jsonSchemaValidator on the SDK Server when omitted', () => {
+      const server = new MCPServer(minimalConfig);
+      const sdkServer = server.getServer();
+
+      // When omitted, the SDK falls back to its default (AJV) validator. The
+      // important assertion is that we do not pass undefined through, which
+      // would force a default-import of the AJV provider in environments
+      // (Cloudflare Workers) that cannot evaluate it.
+      // @ts-expect-error - accessing internal SDK property for testing
+      expect(sdkServer._jsonSchemaValidator).not.toBeUndefined();
+    });
   });
 
   describe('getServerInfo()', () => {

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -46,6 +46,7 @@ import type {
   ElicitRequest,
   LoggingLevel,
 } from '@modelcontextprotocol/sdk/types.js';
+import type { jsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/types.js';
 import type { SSEStreamingApi } from 'hono/streaming';
 import { streamSSE } from 'hono/streaming';
 import { SSETransport } from 'hono-mcp-server-sse-transport';
@@ -96,6 +97,7 @@ export class MCPServer extends MCPServerBase {
   private resourceOptions?: MCPServerResources;
   private definedPrompts?: MastraPrompt[];
   private promptOptions?: MCPServerPrompts;
+  private jsonSchemaValidator?: jsonSchemaValidator;
   private subscriptions: Set<string> = new Set();
   private currentLoggingLevel: LoggingLevel | undefined;
 
@@ -236,10 +238,42 @@ export class MCPServer extends MCPServerBase {
    * });
    * ```
    */
-  constructor(opts: MCPServerConfig & { resources?: MCPServerResources; prompts?: MCPServerPrompts }) {
+  constructor(
+    opts: MCPServerConfig & {
+      resources?: MCPServerResources;
+      prompts?: MCPServerPrompts;
+      /**
+       * Optional custom JSON Schema validator forwarded to the underlying MCP
+       * SDK server. Use this to opt into a non-default validator
+       * implementation.
+       *
+       * Pass `CfWorkerJsonSchemaValidator` (from
+       * `@modelcontextprotocol/sdk/validation/cfworker`) when running in
+       * Cloudflare Workers / V8 isolates: the default
+       * `AjvJsonSchemaValidator` compiles validators with `new Function(...)`,
+       * which workerd refuses to evaluate when a registered tool has an
+       * `outputSchema`.
+       *
+       * @example
+       * ```typescript
+       * import { MCPServer } from '@mastra/mcp';
+       * import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker';
+       *
+       * const server = new MCPServer({
+       *   name: 'My Server',
+       *   version: '1.0.0',
+       *   tools: { ... },
+       *   jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+       * });
+       * ```
+       */
+      jsonSchemaValidator?: jsonSchemaValidator;
+    },
+  ) {
     super(opts);
     this.resourceOptions = opts.resources;
     this.promptOptions = opts.prompts;
+    this.jsonSchemaValidator = opts.jsonSchemaValidator;
 
     const capabilities: ServerCapabilities = {
       tools: {},
@@ -262,6 +296,7 @@ export class MCPServer extends MCPServerBase {
       {
         capabilities,
         ...(this.instructions ? { instructions: this.instructions } : {}),
+        ...(this.jsonSchemaValidator ? { jsonSchemaValidator: this.jsonSchemaValidator } : {}),
       },
     );
 
@@ -399,6 +434,7 @@ export class MCPServer extends MCPServerBase {
       {
         capabilities,
         ...(this.instructions ? { instructions: this.instructions } : {}),
+        ...(this.jsonSchemaValidator ? { jsonSchemaValidator: this.jsonSchemaValidator } : {}),
       },
     );
 


### PR DESCRIPTION
## Summary

- Allow callers to opt into a custom MCP SDK JSON Schema validator via both `MCPClient` server entries and `MCPServer`. The option is forwarded into the underlying `@modelcontextprotocol/sdk` `Client` / `Server` constructors (and into the per-request `Server` instances created in serverless mode).
- This unblocks running tools with `outputSchema` inside Cloudflare Workers / V8 isolates by passing `CfWorkerJsonSchemaValidator` from `@modelcontextprotocol/sdk/validation/cfworker`. The default Ajv validator calls `ajv.compile(schema)` (via `new Function(...)`), which workerd refuses to evaluate.
- Zero behavior change when the option is omitted — the SDK falls back to its built-in default validator.

```ts
import { MCPClient, MCPServer } from '@mastra/mcp';
import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker';

const mcp = new MCPClient({
  servers: {
    upstream: {
      url: new URL('https://example/mcp'),
      jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
    },
  },
});

const server = new MCPServer({
  name: 'My Server',
  version: '1.0.0',
  tools: { /* ... */ },
  jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
});
```

Closes #15862.

## Test plan

- [x] `pnpm --filter ./packages/mcp build:lib` — builds clean
- [x] `pnpm lint` (in `packages/mcp`) — passes
- [x] New unit tests cover both pass-through and default behavior on both client and server (4 new tests, all passing)
- [x] Verified the 3 pre-existing client filesystem-roots failures and 1 pre-existing server stdio failure reproduce on `main` with this branch's changes stashed — unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets developers tell the MCP client and server to use a different validation system instead of the default one. This is useful for Cloudflare Workers (a special hosting environment) where the normal validator doesn't work, so developers can now plug in a special worker-friendly validator instead.

## Changes

### Type Updates
- Updated `BaseServerOptions` in `packages/mcp/src/client/types.ts` to add an optional `jsonSchemaValidator` property, typed to the MCP SDK's `jsonSchemaValidator` interface. This allows callers to pass a custom validator through the MCPClient configuration.
- Updated `MCPServer` constructor signature in `packages/mcp/src/server/server.ts` to accept an optional `jsonSchemaValidator` parameter.

### Runtime Implementation
- Modified `packages/mcp/src/client/client.ts` to forward the custom `jsonSchemaValidator` from `server.jsonSchemaValidator` into the underlying SDK client's capabilities/options when provided.
- Modified `packages/mcp/src/server/server.ts` to accept, store, and forward the optional `jsonSchemaValidator` parameter into the underlying `@modelcontextprotocol/sdk/server` configuration for both the main Server instance and per-request Server instances created in serverless (HTTP) mode.

### Testing
- Added two tests in `packages/mcp/src/client/client.test.ts` to verify that custom validators are forwarded unchanged to the SDK client and that the SDK default validator is used when a custom validator is omitted.
- Added two tests in `packages/mcp/src/server/server.test.ts` to verify that custom validators provided via the MCPServer constructor are forwarded to the SDK server's internal `_jsonSchemaValidator`, and that the SDK server receives a valid default validator when the option is omitted.

### Documentation
- Added a changeset in `.changeset/big-loops-watch.md` documenting the new feature, including a note about using `CfWorkerJsonSchemaValidator` from `@modelcontextprotocol/sdk/validation/cfworker` for Cloudflare Workers/V8 isolate compatibility, and a TypeScript usage snippet showing how to pass the validator in both client and server construction.

## Behavior
The change is fully backwards compatible. When `jsonSchemaValidator` is not provided, the MCP SDK falls back to its default validator. The feature enables overriding the default validator to support runtimes like Cloudflare Workers where code generation from strings (used by Ajv's compile method) is blocked, allowing tools with `outputSchema` to function properly in such environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->