### PR TITLE
fix(posthog): upgrade posthog-node from v4 to v5

### DIFF
--- a/.changeset/silent-rats-call.md
+++ b/.changeset/silent-rats-call.md
@@ -1,0 +1,5 @@
+---
+'@mastra/posthog': patch
+---
+
+Updated `posthog-node` from v4 to v5 to pick up the latest fixes and LLM analytics improvements. Resolves [#15858](https://github.com/mastra-ai/mastra/issues/15858).

--- a/observability/posthog/package.json
+++ b/observability/posthog/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@mastra/observability": "workspace:*",
-    "posthog-node": "^4.18.0"
+    "posthog-node": "^5.30.6"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2192,8 +2192,8 @@ importers:
         specifier: workspace:*
         version: link:../mastra
       posthog-node:
-        specifier: ^4.18.0
-        version: 4.18.0
+        specifier: ^5.30.6
+        version: 5.30.6(rxjs@7.8.1)
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -13234,6 +13234,9 @@ packages:
   '@posthog/core@1.27.1':
     resolution: {integrity: sha512-130F5zAmGoY0KAqdT2FYfU79mk54z0wTWfCMkyzXmkKz2eg23694O2ofaAf4NuIdI8e6LFNHyaZ7aWbatUeW5A==}
 
+  '@posthog/core@1.27.7':
+    resolution: {integrity: sha512-6rzOZajUkhuezgPeF+ReMMly0D9oiwIZtMQrsJtZcS/mwi5OtvuYgxeaohgP9PKOhkK1c7cvGskX0Y2YUtBYCw==}
+
   '@posthog/core@1.7.1':
     resolution: {integrity: sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==}
 
@@ -13249,6 +13252,9 @@ packages:
 
   '@posthog/types@1.371.2':
     resolution: {integrity: sha512-Ak3kuGMPBTjuoK6Ki0kQbq9eROk7LRJ3GBkbQINCZBT9FPlHvlXRwQr0/OVsi4xYPSMSGxWjRDMPFsR9Px66Cg==}
+
+  '@posthog/types@1.372.3':
+    resolution: {integrity: sha512-4mkXC9AhsquJnvogWtWsCi+ReODj/jbK0d3fkwCNLLTOpaiAF125FJ6OJyRFax2u+dEKXAPA/dCTGx1S2WF0nw==}
 
   '@prisma/instrumentation@7.4.2':
     resolution: {integrity: sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==}
@@ -22990,16 +22996,21 @@ packages:
   posthog-js@1.371.2:
     resolution: {integrity: sha512-2cd4NqsFbBUiBAXLRCcM8De4lA/x2ZmNI7ii3BegpQItMKZUk2w1HY/91pLvvwEyShWa2WGloBJSCBJAVo/hWg==}
 
-  posthog-node@4.18.0:
-    resolution: {integrity: sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==}
-    engines: {node: '>=15.0.0'}
-
   posthog-node@5.17.2:
     resolution: {integrity: sha512-lz3YJOr0Nmiz0yHASaINEDHqoV+0bC3eD8aZAG+Ky292dAnVYul+ga/dMX8KCBXg8hHfKdxw0SztYD5j6dgUqQ==}
     engines: {node: '>=20'}
 
   posthog-node@5.28.3:
     resolution: {integrity: sha512-kcnEgBW4o3oSqr+oHy54+w0o5Ww91bp6I3iEe7jvr6Nd7mAyWLbAMIILnSbDJpn2129WXhMCCbVP//VlfBtCNA==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
+  posthog-node@5.30.6:
+    resolution: {integrity: sha512-deZuSiLkpdEipiywkww1FhQoKpVVFmJP6SAVQcZcMbugTLwJRYSGjgm+qV0Y91xghf2yP6Nr5Plfl52i9Qj15Q==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       rxjs: ^7.0.0
@@ -34251,6 +34262,10 @@ snapshots:
     dependencies:
       '@posthog/types': 1.371.2
 
+  '@posthog/core@1.27.7':
+    dependencies:
+      '@posthog/types': 1.372.3
+
   '@posthog/core@1.7.1':
     dependencies:
       cross-spawn: 7.0.6
@@ -34263,6 +34278,8 @@ snapshots:
       '@types/react': 19.2.14
 
   '@posthog/types@1.371.2': {}
+
+  '@posthog/types@1.372.3': {}
 
   '@prisma/instrumentation@7.4.2(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -46146,12 +46163,6 @@ snapshots:
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.1.0
 
-  posthog-node@4.18.0:
-    dependencies:
-      axios: 1.15.0
-    transitivePeerDependencies:
-      - debug
-
   posthog-node@5.17.2:
     dependencies:
       '@posthog/core': 1.7.1
@@ -46159,6 +46170,12 @@ snapshots:
   posthog-node@5.28.3(rxjs@7.8.1):
     dependencies:
       '@posthog/core': 1.23.4
+    optionalDependencies:
+      rxjs: 7.8.1
+
+  posthog-node@5.30.6(rxjs@7.8.1):
+    dependencies:
+      '@posthog/core': 1.27.7
     optionalDependencies:
       rxjs: 7.8.1
 


### PR DESCRIPTION
Bumps `posthog-node` in `@mastra/posthog` from `^4.18.0` to `^5.30.6`. Closes #15858.

The exporter only uses `PostHog`, `EventMessage`, `capture`, `flush`, `shutdown`, and `privacyMode` — all unchanged in v5. The v5 breaking changes (native fetch + Node 20+, gzip-by-default, removal of `captureMode`/`personProperties`/`groupProperties`/`is_simple_flag`) don't affect us. Mastra already requires Node `>=22.13.0`, and sibling packages (`packages/cli`, `packages/create-mastra`) are already on v5.

```diff
-    "posthog-node": "^4.18.0"
+    "posthog-node": "^5.30.6"
```

Tests, typecheck, lint, and build all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates a tool that Mastra uses to track user analytics from an old version (v4) to a newer version (v5). Think of it like updating an app on your phone to get the latest features and bug fixes. The update was needed because the old version was flagged as outdated and might have been missing some data points for tracking AI model analytics.

## Changes

The PR makes minimal changes to update the PostHog SDK:

1. **package.json** - Updates the `posthog-node` dependency from `^4.18.0` to `^5.30.6` in the `observability/posthog` package
2. **Changeset metadata** - Adds a `.changeset/silent-rats-call.md` file to document the patch release and link it to issue #15858

## Compatibility

The PR author confirms that the exported APIs used by this codebase (PostHog, EventMessage, capture, flush, shutdown, and privacyMode) remain unchanged in v5. While v5 has breaking changes, they do not affect this codebase because:

- v5 requires Node 20+ with native fetch support, but Mastra already requires Node >=22.13.0
- v5 has gzip compression enabled by default and removes certain deprecated properties (captureMode, personProperties, groupProperties, is_simple_flag), but sibling packages are already on v5

## Closes

- Issue #15858 - Updates outdated PostHog SDK to restore analytics visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->