### PR TITLE
ci: reuse prebuild outputs in vitest-changed

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -29,7 +29,7 @@ runs:
     - uses: pnpm/action-setup@v4
       name: Install pnpm
       with:
-        run_install: false
+        run_install: ${{ inputs.install-dependencies == 'true' && '[{"recursive":true,"args":["--frozen-lockfile","--ignore-scripts"]}]' || 'false' }}
         package_json_file: ${{ inputs.package-json-file || 'package.json' }}
         cache: ${{ inputs.package-manager-cache == 'true' }}
         cache_dependency_path: ${{ inputs.cache-dependency-path || 'pnpm-lock.yaml' }}
@@ -38,8 +38,3 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: 22.13.0
-
-    - name: Install dependencies
-      if: ${{ inputs.install-dependencies == 'true' }}
-      shell: bash
-      run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -42,4 +42,4 @@ runs:
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -96,7 +96,7 @@ jobs:
             -T prebuild-output-paths.txt
 
       - name: Upload build outputs
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: prebuild-outputs
           path: prebuild-outputs.tar.gz

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -41,7 +41,10 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: needs.changes.outputs.has_code == 'true' && github.repository == 'mastra-ai/mastra'
+    if: >-
+      needs.changes.outputs.has_code == 'true' &&
+      github.repository == 'mastra-ai/mastra' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -73,3 +73,28 @@ jobs:
 
       - name: Build
         run: pnpm turbo --filter "!./examples/**/*" --filter "!./docs/" --filter "!./explorations/**/*" build
+
+      - name: Archive build outputs
+        run: |
+          find . -type d \( -name dist -o -name .next \) \
+            ! -path '*/node_modules/*' \
+            ! -path '*/.next/cache*' \
+            | sed 's#^\./##' > prebuild-output-paths.txt
+
+          if [ ! -s prebuild-output-paths.txt ]; then
+            echo 'No build outputs found to archive.'
+            exit 1
+          fi
+
+          tar \
+            --exclude='*/.next/cache' \
+            --exclude='*/.next/cache/*' \
+            -czf prebuild-outputs.tar.gz \
+            -T prebuild-output-paths.txt
+
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v6
+        with:
+          name: prebuild-outputs
+          path: prebuild-outputs.tar.gz
+          retention-days: 1

--- a/.github/workflows/vitest-changed.yml
+++ b/.github/workflows/vitest-changed.yml
@@ -95,7 +95,7 @@ jobs:
           echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
 
       - name: Download prebuild outputs
-        uses: dawidd6/action-download-artifact@v10
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -192,7 +192,7 @@ jobs:
           echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
 
       - name: Download prebuild outputs
-        uses: dawidd6/action-download-artifact@v10
+        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -604,10 +604,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, e2e-test]
     if: always() && github.event.workflow_run.conclusion == 'success'
-    # Minimal permissions - read-only access
-    permissions:
-      actions: read
-      contents: read
 
     steps:
       - name: Checkout PR code

--- a/.github/workflows/vitest-changed.yml
+++ b/.github/workflows/vitest-changed.yml
@@ -17,7 +17,10 @@ jobs:
   set-pending-status:
     name: Set Pending Status
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'mastra-ai/mastra' && github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      github.repository == 'mastra-ai/mastra' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     permissions:
       contents: read
       statuses: write
@@ -43,7 +46,10 @@ jobs:
     name: UNIT Test (Shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: [set-pending-status]
-    if: ${{ github.repository == 'mastra-ai/mastra' && github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      github.repository == 'mastra-ai/mastra' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -128,7 +134,10 @@ jobs:
     name: E2E Test (${{ matrix.project }})
     runs-on: ubuntu-latest
     needs: [set-pending-status]
-    if: ${{ github.repository == 'mastra-ai/mastra' && github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      github.repository == 'mastra-ai/mastra' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/vitest-changed.yml
+++ b/.github/workflows/vitest-changed.yml
@@ -55,6 +55,7 @@ jobs:
       TURBO_CACHE: remote:r
     # Minimal permissions - read-only access
     permissions:
+      actions: read
       contents: read
 
     steps:
@@ -87,13 +88,19 @@ jobs:
           BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref // "main"')
           echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
 
+      - name: Download prebuild outputs
+        uses: dawidd6/action-download-artifact@v10
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: prebuild-outputs
+          path: prebuild-artifact
+
+      - name: Extract prebuild outputs
+        run: tar -xzf prebuild-artifact/prebuild-outputs.tar.gz
+
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Build packages
-        run: pnpm turbo build --filter "!./examples/**/*" --filter "!./docs/" --filter "!./explorations/**/*"
-        env:
-          NODE_OPTIONS: '--max_old_space_size=8192'
 
       - name: Run changed tests (Shard ${{ matrix.shard }}/4)
         run: |
@@ -143,6 +150,7 @@ jobs:
       TURBO_CACHE: remote:r
     # Minimal permissions - read-only access
     permissions:
+      actions: read
       contents: read
     steps:
       - name: Checkout PR code
@@ -174,13 +182,19 @@ jobs:
           BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref // "main"')
           echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
 
+      - name: Download prebuild outputs
+        uses: dawidd6/action-download-artifact@v10
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: prebuild-outputs
+          path: prebuild-artifact
+
+      - name: Extract prebuild outputs
+        run: tar -xzf prebuild-artifact/prebuild-outputs.tar.gz
+
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Build packages
-        run: pnpm turbo build --filter "!./examples/**/*" --filter "!./docs/" --filter "!./explorations/**/*"
-        env:
-          NODE_OPTIONS: '--max_old_space_size=8192'
 
       - name: Normalize project name
         id: normalize
@@ -583,6 +597,7 @@ jobs:
     if: always() && github.event.workflow_run.conclusion == 'success'
     # Minimal permissions - read-only access
     permissions:
+      actions: read
       contents: read
 
     steps:


### PR DESCRIPTION
## Summary
- upload prebuild dist/.next outputs as a reusable artifact
- restore that artifact in vitest-changed unit shards and e2e jobs
- remove the duplicate vitest-changed repo build that was rerunning after Prebuild

## Test Plan
- actionlint .github/workflows/prebuild.yml .github/workflows/vitest-changed.yml
- node - <<'NODE'
  const fs = require('fs');
  const yaml = require('js-yaml');
  for (const path of ['.github/workflows/prebuild.yml', '.github/workflows/vitest-changed.yml']) {
    yaml.load(fs.readFileSync(path, 'utf8'));
    console.log(`YAML OK: ${path}`);
  }
  NODE
- git diff --check -- .github/workflows/prebuild.yml .github/workflows/vitest-changed.yml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Tests now reuse the build outputs the Prebuild job already made instead of rebuilding everything, so CI runs faster and uses fewer resources.

## Summary
Add uploading of prebuilt dist/.next outputs from the Prebuild workflow and restore those outputs in vitest-changed jobs so unit and e2e shards consume the prebuilt artifact instead of performing a duplicate repository build; tighten workflow-run origin checks and move shared pnpm install responsibility into the pnpm setup action.

### .github/workflows/prebuild.yml
- Require PR head repository to equal github.repository in addition to existing has_code == 'true' and repository checks.
- After pnpm turbo build, locate dist and .next directories (exclude node_modules and .next/cache*), fail if none are found, package them into prebuild-outputs.tar.gz, and upload as artifact prebuild-outputs (actions/upload-artifact) with 1-day retention.

### .github/workflows/vitest-changed.yml
- Restrict set-pending-status, test, and e2e-test jobs to workflow_run.conclusion == 'success' and workflow_run.head_repository.full_name == github.repository so only trusted runs from the main repo trigger downstream jobs.
- test and e2e-test download the prebuild-outputs artifact tied to the triggering workflow_run.id and extract prebuild-outputs.tar.gz instead of running a full pnpm turbo build, removing the duplicate build step.
- Explicit minimal permissions (actions: read, contents: read) are requested where needed for artifact access.

### .github/actions/setup-pnpm-node/action.yaml
- Stop running pnpm install in the composite action shell step; delegate installation to pnpm/action-setup by setting run_install based on inputs.install-dependencies. When enabled, installs are executed recursively with --frozen-lockfile and --ignore-scripts (suppresses lifecycle/package scripts).

## Commit note
One commit: "ci: move shared install into pnpm setup action" — delegate pnpm install to pnpm/action-setup with the same frozen-lockfile and add --ignore-scripts when enabled. Co-Authored-By: Mastra Code (openai/gpt-5.4).

## Rationale
Reusing Prebuild artifacts removes redundant rebuilds, speeds CI, reduces resource use, and narrows artifact consumption to trusted workflow runs while preventing untrusted package lifecycle scripts during installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->