### PR TITLE
feat(workspaces): add azure blob mounts for daytona and e2b

### DIFF
--- a/.changeset/azure-prefix-mount-config.md
+++ b/.changeset/azure-prefix-mount-config.md
@@ -1,0 +1,5 @@
+---
+'@mastra/azure': patch
+---
+
+Fixed AzureBlobFilesystem mount configs to include configured prefixes. Sandboxes that support Azure Blob mounts now mount only the configured prefix instead of the entire container.

--- a/.changeset/azure-prefix-mount-config.md
+++ b/.changeset/azure-prefix-mount-config.md
@@ -2,4 +2,4 @@
 '@mastra/azure': patch
 ---
 
-Fixed AzureBlobFilesystem mount configs to include configured prefixes. Sandboxes that support Azure Blob mounts now mount only the configured prefix instead of the entire container.
+@mastra/azure: Fixed AzureBlobFilesystem mount configs to include configured prefixes so mounts use the configured prefix instead of the entire container.

--- a/.changeset/fuzzy-hornets-obey.md
+++ b/.changeset/fuzzy-hornets-obey.md
@@ -3,7 +3,7 @@
 '@mastra/daytona': minor
 ---
 
-Added Azure Blob sandbox mount support via blobfuse2 in @mastra/e2b and @mastra/daytona. `sandbox.mount(azureBlobFilesystem, '/data')` now works for Azure containers, matching the existing s3fs (S3) and gcsfuse (GCS) integration. Supports authentication via accountKey, sasToken, connectionString, or DefaultAzureCredential, and preserves AzureBlobFilesystem prefixes when mounting.
+Added Azure Blob sandbox mount support via blobfuse2 in @mastra/e2b and @mastra/daytona. `sandbox.mount(azureBlobFilesystem, '/data')` now works for Azure containers, matching the existing s3fs (S3) and gcsfuse (GCS) integration. Supports authentication via accountKey, sasToken, connectionString, or managed identity/default credentials, and preserves AzureBlobFilesystem prefixes when mounting.
 
 ```ts
 import { E2BSandbox } from '@mastra/e2b';

--- a/.changeset/fuzzy-hornets-obey.md
+++ b/.changeset/fuzzy-hornets-obey.md
@@ -1,0 +1,16 @@
+---
+'@mastra/e2b': minor
+'@mastra/daytona': minor
+---
+
+Added Azure Blob sandbox mount support via blobfuse2 in @mastra/e2b and @mastra/daytona. `sandbox.mount(azureBlobFilesystem, '/data')` now works for Azure containers, matching the existing s3fs (S3) and gcsfuse (GCS) integration. Supports authentication via accountKey, sasToken, connectionString, or DefaultAzureCredential, and preserves AzureBlobFilesystem prefixes when mounting.
+
+```ts
+import { E2BSandbox } from '@mastra/e2b';
+import { AzureBlobFilesystem } from '@mastra/azure/blob';
+
+const azureFs = new AzureBlobFilesystem({ container: 'my-data', connectionString: '...' });
+const sandbox = new E2BSandbox();
+await sandbox.mount(azureFs, '/data');
+// Sandbox processes can now read/write /data/* directly against the Azure container.
+```

--- a/workspaces/azure/src/blob/filesystem/index.test.ts
+++ b/workspaces/azure/src/blob/filesystem/index.test.ts
@@ -172,6 +172,13 @@ describe('AzureBlobFilesystem', () => {
       expect(config.accountKey).toBeUndefined();
       expect(config.connectionString).toBeUndefined();
     });
+
+    it('includes normalized prefix when provided', () => {
+      const fs = new AzureBlobFilesystem({ container: 'test', prefix: '//workspace/data//' });
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBe('workspace/data/');
+    });
   });
 
   describe('getInfo()', () => {

--- a/workspaces/azure/src/blob/filesystem/index.ts
+++ b/workspaces/azure/src/blob/filesystem/index.ts
@@ -37,6 +37,7 @@ export interface AzureBlobMountConfig extends FilesystemMountConfig {
   connectionString?: string;
   useDefaultCredential?: boolean;
   endpoint?: string;
+  prefix?: string;
   readOnly?: boolean;
 }
 
@@ -230,6 +231,10 @@ export class AzureBlobFilesystem extends MastraFilesystem {
 
     if (this.endpoint) {
       config.endpoint = this.endpoint;
+    }
+
+    if (this.prefix) {
+      config.prefix = this.prefix;
     }
 
     if (this.readOnly) {

--- a/workspaces/daytona/README.md
+++ b/workspaces/daytona/README.md
@@ -2,7 +2,7 @@
 
 Daytona cloud sandbox provider for [Mastra](https://mastra.ai) workspaces.
 
-Implements the `WorkspaceSandbox` interface using [Daytona](https://www.daytona.io/) sandboxes. Supports multiple runtimes, resource configuration, volumes, snapshots, streaming output, sandbox reconnection, and filesystem mounting (S3, GCS).
+Implements the `WorkspaceSandbox` interface using [Daytona](https://www.daytona.io/) sandboxes. Supports multiple runtimes, resource configuration, volumes, snapshots, streaming output, sandbox reconnection, and filesystem mounting (S3, GCS, Azure Blob).
 
 ## Install
 
@@ -10,7 +10,7 @@ Implements the `WorkspaceSandbox` interface using [Daytona](https://www.daytona.
 pnpm add @mastra/daytona @mastra/core
 
 # For filesystem mounting (optional)
-pnpm add @mastra/s3 @mastra/gcs
+pnpm add @mastra/s3 @mastra/gcs @mastra/azure
 ```
 
 ## Usage
@@ -101,7 +101,7 @@ console.log(result.stdout); // "session 1"
 
 ### Filesystem mounting
 
-Mount S3 or GCS buckets as local directories inside the sandbox.
+Mount S3, GCS, or Azure Blob containers as local directories inside the sandbox.
 
 #### Via workspace mounts config
 
@@ -112,6 +112,7 @@ import { Workspace } from '@mastra/core/workspace';
 import { DaytonaSandbox } from '@mastra/daytona';
 import { GCSFilesystem } from '@mastra/gcs';
 import { S3Filesystem } from '@mastra/s3';
+import { AzureBlobFilesystem } from '@mastra/azure/blob';
 
 const workspace = new Workspace({
   mounts: {
@@ -126,6 +127,11 @@ const workspace = new Workspace({
       bucket: process.env.GCS_BUCKET!,
       projectId: 'my-project-id',
       credentials: JSON.parse(process.env.GCS_SERVICE_ACCOUNT_KEY!),
+    }),
+    '/azure-data': new AzureBlobFilesystem({
+      container: process.env.AZURE_STORAGE_CONTAINER!,
+      connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+      prefix: 'workspace/data',
     }),
   },
   sandbox: new DaytonaSandbox({ language: 'python' }),
@@ -189,6 +195,21 @@ await sandbox.mount(
     bucket: process.env.GCS_BUCKET!,
     projectId: 'my-project-id',
     credentials: JSON.parse(process.env.GCS_SERVICE_ACCOUNT_KEY!),
+  }),
+  '/data',
+);
+```
+
+#### Azure Blob
+
+```typescript
+import { AzureBlobFilesystem } from '@mastra/azure/blob';
+
+await sandbox.mount(
+  new AzureBlobFilesystem({
+    container: process.env.AZURE_STORAGE_CONTAINER!,
+    connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+    prefix: 'workspace/data',
   }),
   '/data',
 );
@@ -270,7 +291,7 @@ console.log(response.text);
 
 ## Mount Configuration
 
-Pass `S3Filesystem` or `GCSFilesystem` instances via the workspace `mounts` config or directly to `sandbox.mount()`.
+Pass `S3Filesystem`, `GCSFilesystem`, or `AzureBlobFilesystem` instances via the workspace `mounts` config or directly to `sandbox.mount()`.
 
 ### S3 environment variables
 
@@ -289,9 +310,16 @@ Pass `S3Filesystem` or `GCSFilesystem` instances via the workspace `mounts` conf
 | `GCS_BUCKET`              | Bucket name                                             |
 | `GCS_SERVICE_ACCOUNT_KEY` | Service account key JSON (full JSON string, not a path) |
 
+### Azure Blob environment variables
+
+| Variable                            | Description               |
+| ----------------------------------- | ------------------------- |
+| `AZURE_STORAGE_CONTAINER`           | Container name            |
+| `AZURE_STORAGE_CONNECTION_STRING`   | Storage connection string |
+
 ### Reducing cold start latency with a snapshot
 
-By default, `s3fs` and `gcsfuse` are installed at first mount via `apt`, which adds startup time. To eliminate this, prebake them into a Daytona snapshot and pass the snapshot name via the `snapshot` option.
+By default, `s3fs`, `gcsfuse`, and `blobfuse2` are installed at first mount, which adds startup time. To eliminate this, prebake them into a Daytona snapshot and pass the snapshot name via the `snapshot` option.
 
 Create the snapshot once:
 
@@ -320,6 +348,8 @@ await daytona.snapshot.create(
   { onLogs: console.log },
 );
 ```
+
+If you use Azure Blob mounts, also pre-install `blobfuse2` in the snapshot using Azure's supported package for your base image.
 
 Then use the snapshot name in your sandbox config:
 

--- a/workspaces/daytona/README.md
+++ b/workspaces/daytona/README.md
@@ -349,7 +349,7 @@ await daytona.snapshot.create(
 );
 ```
 
-If you use Azure Blob mounts, also pre-install `blobfuse2` in the snapshot using Azure's supported package for your base image.
+If you use Azure Blob mounts, also pre-install `blobfuse2` in the snapshot using Azure's supported package for your base image. See Azure's [BlobFuse2 installation guide](https://learn.microsoft.com/en-us/azure/storage/blobs/blobfuse2-how-to-deploy) for supported install options.
 
 Then use the snapshot name in your sandbox config:
 

--- a/workspaces/daytona/README.md
+++ b/workspaces/daytona/README.md
@@ -312,10 +312,10 @@ Pass `S3Filesystem`, `GCSFilesystem`, or `AzureBlobFilesystem` instances via the
 
 ### Azure Blob environment variables
 
-| Variable                            | Description               |
-| ----------------------------------- | ------------------------- |
-| `AZURE_STORAGE_CONTAINER`           | Container name            |
-| `AZURE_STORAGE_CONNECTION_STRING`   | Storage connection string |
+| Variable                          | Description               |
+| --------------------------------- | ------------------------- |
+| `AZURE_STORAGE_CONTAINER`         | Container name            |
+| `AZURE_STORAGE_CONNECTION_STRING` | Storage connection string |
 
 ### Reducing cold start latency with a snapshot
 

--- a/workspaces/daytona/src/index.ts
+++ b/workspaces/daytona/src/index.ts
@@ -1,4 +1,9 @@
 export { DaytonaSandbox, type DaytonaSandboxOptions } from './sandbox';
 export { DaytonaProcessManager } from './sandbox/process-manager';
 export { type DaytonaResources } from './sandbox/types';
-export type { DaytonaMountConfig, DaytonaS3MountConfig, DaytonaGCSMountConfig } from './sandbox/mounts';
+export type {
+  DaytonaMountConfig,
+  DaytonaS3MountConfig,
+  DaytonaGCSMountConfig,
+  DaytonaAzureBlobMountConfig,
+} from './sandbox/mounts';

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -657,6 +657,256 @@ describe('DaytonaSandbox', () => {
     });
   });
 
+  describe('Azure Blob Mount Configuration', () => {
+    const setupAzureMocks = () => {
+      mockSandbox.process.executeCommand.mockImplementation(async (command: string) => {
+        if (command.includes('which blobfuse2')) {
+          return { exitCode: 0, result: '/usr/bin/blobfuse2' };
+        }
+        if (command.includes('id -u && id -g')) {
+          return { exitCode: 0, result: '1000\n1000' };
+        }
+        if (command.includes('curl') && command.includes('blob.core.windows.net')) {
+          return { exitCode: 0, result: '' };
+        }
+        return { exitCode: 0, result: '' };
+      });
+    };
+
+    const findBlobfuseMountCall = (target: string) =>
+      mockSandbox.process.executeCommand.mock.calls.find((call: any[]) => {
+        const command = call[0] || '';
+        return (
+          command.includes('blobfuse2 mount') &&
+          command.includes(target) &&
+          !command.includes('which blobfuse2')
+        );
+      });
+
+    const findWrittenConfig = (): string | undefined => {
+      const upload = mockSandbox.fs.uploadFile.mock.calls.find((call: any[]) =>
+        String(call[1]).includes('.blobfuse2-config'),
+      );
+      return upload ? Buffer.from(upload[0]).toString('utf-8') : undefined;
+    };
+
+    it('account-key auth writes mode: key with account-name, account-key, container', async () => {
+      setupAzureMocks();
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const mockFilesystem = {
+        id: 'test-azure-key',
+        name: 'AzureBlobFilesystem',
+        provider: 'azure-blob',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 'azure-blob',
+          container: 'test-container',
+          accountName: 'mystorage',
+          accountKey: 'a-secret-key',
+        }),
+      } as any;
+
+      await sandbox.mount(mockFilesystem, '/data/azure-key');
+
+      const mountCall = findBlobfuseMountCall('/data/azure-key');
+      expect(mountCall).toBeDefined();
+      expect(mountCall![0]).toContain('--config-file=');
+
+      const yaml = findWrittenConfig();
+      expect(yaml).toBeDefined();
+      expect(yaml).toContain('mode: key');
+      expect(yaml).toContain('account-name: "mystorage"');
+      expect(yaml).toContain('account-key: "a-secret-key"');
+      expect(yaml).toContain('container: "test-container"');
+      expect(yaml).toContain('read-only: false');
+    });
+
+    it('SAS token auth writes mode: sas with sas field (no account-key)', async () => {
+      setupAzureMocks();
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const mockFilesystem = {
+        id: 'test-azure-sas',
+        name: 'AzureBlobFilesystem',
+        provider: 'azure-blob',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 'azure-blob',
+          container: 'sas-container',
+          accountName: 'mystorage',
+          sasToken: 'sv=2022-11-02&ss=b&srt=co&sp=rl&se=2030-01-01T00:00:00Z&sig=xyz',
+        }),
+      } as any;
+
+      await sandbox.mount(mockFilesystem, '/data/azure-sas');
+
+      const yaml = findWrittenConfig();
+      expect(yaml).toBeDefined();
+      expect(yaml).toContain('mode: sas');
+      expect(yaml).toContain('sas: ');
+      expect(yaml).not.toContain('account-key:');
+    });
+
+    it('useDefaultCredential writes mode: msi (no key, no sas)', async () => {
+      setupAzureMocks();
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const mockFilesystem = {
+        id: 'test-azure-msi',
+        name: 'AzureBlobFilesystem',
+        provider: 'azure-blob',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 'azure-blob',
+          container: 'msi-container',
+          accountName: 'mystorage',
+          useDefaultCredential: true,
+        }),
+      } as any;
+
+      await sandbox.mount(mockFilesystem, '/data/azure-msi');
+
+      const yaml = findWrittenConfig();
+      expect(yaml).toBeDefined();
+      expect(yaml).toContain('mode: msi');
+      expect(yaml).not.toContain('account-key:');
+      expect(yaml).not.toContain('sas:');
+    });
+
+    it('connection string is parsed for AccountName, AccountKey, BlobEndpoint', async () => {
+      setupAzureMocks();
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const mockFilesystem = {
+        id: 'test-azure-cs',
+        name: 'AzureBlobFilesystem',
+        provider: 'azure-blob',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 'azure-blob',
+          container: 'cs-container',
+          connectionString:
+            'DefaultEndpointsProtocol=https;AccountName=fromstring;AccountKey=keyvalue;BlobEndpoint=https://fromstring.blob.core.windows.net/;EndpointSuffix=core.windows.net',
+        }),
+      } as any;
+
+      await sandbox.mount(mockFilesystem, '/data/azure-cs');
+
+      const yaml = findWrittenConfig();
+      expect(yaml).toBeDefined();
+      expect(yaml).toContain('mode: key');
+      expect(yaml).toContain('account-name: "fromstring"');
+      expect(yaml).toContain('account-key: "keyvalue"');
+      expect(yaml).toContain('endpoint: "https://fromstring.blob.core.windows.net"');
+    });
+
+    it('readOnly writes read-only: true in config', async () => {
+      setupAzureMocks();
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const mockFilesystem = {
+        id: 'test-azure-ro',
+        name: 'AzureBlobFilesystem',
+        provider: 'azure-blob',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 'azure-blob',
+          container: 'ro-container',
+          accountName: 'mystorage',
+          accountKey: 'k',
+          readOnly: true,
+        }),
+      } as any;
+
+      await sandbox.mount(mockFilesystem, '/data/azure-ro');
+
+      const yaml = findWrittenConfig();
+      expect(yaml).toBeDefined();
+      expect(yaml).toContain('read-only: true');
+    });
+
+    it('prefix mount uses blobfuse2 subdirectory flag', async () => {
+      setupAzureMocks();
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const mockFilesystem = {
+        id: 'test-azure-prefix',
+        name: 'AzureBlobFilesystem',
+        provider: 'azure-blob',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 'azure-blob',
+          container: 'prefix-container',
+          accountName: 'mystorage',
+          accountKey: 'k',
+          prefix: '/workspace/data/',
+        }),
+      } as any;
+
+      await sandbox.mount(mockFilesystem, '/data/azure-prefix');
+
+      const mountCall = findBlobfuseMountCall('/data/azure-prefix');
+      expect(mountCall).toBeDefined();
+      expect(mountCall![0]).toContain('--virtual-directory=true');
+      expect(mountCall![0]).toContain('--subdirectory=workspace/data');
+    });
+
+    it('missing credentials produces a clear error', async () => {
+      setupAzureMocks();
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const mockFilesystem = {
+        id: 'test-azure-nocreds',
+        name: 'AzureBlobFilesystem',
+        provider: 'azure-blob',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 'azure-blob',
+          container: 'no-creds',
+          accountName: 'mystorage',
+        }),
+      } as any;
+
+      const result = await sandbox.mount(mockFilesystem, '/data/azure-nocreds');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/credentials/i);
+    });
+
+    it('invalid container name is rejected before any mount command', async () => {
+      setupAzureMocks();
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const mockFilesystem = {
+        id: 'test-azure-bad-name',
+        name: 'AzureBlobFilesystem',
+        provider: 'azure-blob',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 'azure-blob',
+          container: 'Bad_Name',
+          accountName: 'mystorage',
+          accountKey: 'k',
+        }),
+      } as any;
+
+      const result = await sandbox.mount(mockFilesystem, '/data/azure-bad');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Invalid Azure container name/i);
+      expect(findBlobfuseMountCall('/data/azure-bad')).toBeUndefined();
+    });
+  });
+
   describe('Stop & Destroy', () => {
     it('stop calls daytona.stop()', async () => {
       const sandbox = new DaytonaSandbox();

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -676,11 +676,7 @@ describe('DaytonaSandbox', () => {
     const findBlobfuseMountCall = (target: string) =>
       mockSandbox.process.executeCommand.mock.calls.find((call: any[]) => {
         const command = call[0] || '';
-        return (
-          command.includes('blobfuse2 mount') &&
-          command.includes(target) &&
-          !command.includes('which blobfuse2')
-        );
+        return command.includes('blobfuse2 mount') && command.includes(target) && !command.includes('which blobfuse2');
       });
 
     const findWrittenConfig = (): string | undefined => {

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -721,6 +721,7 @@ describe('DaytonaSandbox', () => {
       expect(yaml).toContain('account-key: "a-secret-key"');
       expect(yaml).toContain('container: "test-container"');
       expect(yaml).toContain('read-only: false');
+      expect(yaml).not.toContain('  type: block');
     });
 
     it('SAS token auth writes mode: sas with sas field (no account-key)', async () => {
@@ -803,6 +804,31 @@ describe('DaytonaSandbox', () => {
       expect(yaml).toContain('account-name: "fromstring"');
       expect(yaml).toContain('account-key: "keyvalue"');
       expect(yaml).toContain('endpoint: "https://fromstring.blob.core.windows.net"');
+    });
+
+    it('connection string synthesizes endpoint from EndpointSuffix when BlobEndpoint is omitted', async () => {
+      setupAzureMocks();
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const mockFilesystem = {
+        id: 'test-azure-cs-suffix',
+        name: 'AzureBlobFilesystem',
+        provider: 'azure-blob',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 'azure-blob',
+          container: 'cs-container',
+          connectionString:
+            'DefaultEndpointsProtocol=https;AccountName=fromstring;AccountKey=keyvalue;EndpointSuffix=core.usgovcloudapi.net',
+        }),
+      } as any;
+
+      await sandbox.mount(mockFilesystem, '/data/azure-cs-suffix');
+
+      const yaml = findWrittenConfig();
+      expect(yaml).toBeDefined();
+      expect(yaml).toContain('endpoint: "https://fromstring.blob.core.usgovcloudapi.net"');
     });
 
     it('readOnly writes read-only: true in config', async () => {

--- a/workspaces/daytona/src/sandbox/index.ts
+++ b/workspaces/daytona/src/sandbox/index.ts
@@ -30,7 +30,7 @@ import { MastraSandbox, SandboxNotReadyError } from '@mastra/core/workspace';
 
 import { compact } from '../utils/compact';
 import { shellQuote } from '../utils/shell-quote';
-import { mountS3, mountGCS, LOG_PREFIX, runCommand } from './mounts';
+import { mountS3, mountGCS, mountAzure, LOG_PREFIX, runCommand } from './mounts';
 import type { DaytonaMountConfig, MountContext } from './mounts';
 import { DaytonaProcessManager } from './process-manager';
 import type { DaytonaResources } from './types';
@@ -650,6 +650,11 @@ export class DaytonaSandbox extends MastraSandbox {
           await mountGCS(mountPath, config, mountCtx);
           this.logger.debug(`${LOG_PREFIX} Mounted GCS bucket at ${mountPath}`);
           break;
+        case 'azure-blob':
+          this.logger.debug(`${LOG_PREFIX} Mounting Azure Blob at "${mountPath}"...`);
+          await mountAzure(mountPath, config, mountCtx);
+          this.logger.debug(`${LOG_PREFIX} Mounted Azure Blob container at ${mountPath}`);
+          break;
         default: {
           const error = `Unsupported mount type: ${(config as FilesystemMountConfig).type}`;
           this.mounts.set(mountPath, { filesystem, state: 'unsupported', config, error });
@@ -745,7 +750,7 @@ export class DaytonaSandbox extends MastraSandbox {
     try {
       const mountsResult = await runCommand(
         sandbox,
-        `grep -E 'fuse\\.(s3fs|gcsfuse)' /proc/mounts | awk '{print $2}'`,
+        `grep -E 'fuse\\.(s3fs|gcsfuse|blobfuse2)' /proc/mounts | awk '{print $2}'`,
         { timeout: MOUNT_COMMAND_TIMEOUT_MS },
       );
       currentMounts = mountsResult.output

--- a/workspaces/daytona/src/sandbox/mounts/azure.ts
+++ b/workspaces/daytona/src/sandbox/mounts/azure.ts
@@ -1,0 +1,364 @@
+import { createHash } from 'node:crypto';
+
+import type { FilesystemMountConfig } from '@mastra/core/workspace';
+
+import { shellQuote } from '../../utils/shell-quote';
+import { LOG_PREFIX, validateEndpoint, validatePrefix } from './types';
+import type { MountContext } from './types';
+
+/**
+ * Azure Blob mount config for Daytona (mounted via blobfuse2).
+ *
+ * Authentication is selected from the first applicable option:
+ *   1. `useDefaultCredential` (managed identity, requires running in Azure)
+ *   2. `sasToken`
+ *   3. `accountKey`
+ *   4. `connectionString` (parsed for AccountName/AccountKey/SharedAccessSignature/BlobEndpoint)
+ */
+export interface DaytonaAzureBlobMountConfig extends FilesystemMountConfig {
+  type: 'azure-blob';
+  /** Azure Blob container name */
+  container: string;
+  /** Storage account name (required unless supplied via connectionString) */
+  accountName?: string;
+  /** Storage account access key */
+  accountKey?: string;
+  /** Shared Access Signature token (without leading '?') */
+  sasToken?: string;
+  /** Azure Storage connection string */
+  connectionString?: string;
+  /** Use DefaultAzureCredential / managed identity (mode: msi) */
+  useDefaultCredential?: boolean;
+  /** Custom blob endpoint (e.g. for sovereign clouds or Azurite) */
+  endpoint?: string;
+  /**
+   * Optional prefix (subdirectory) to mount instead of the entire container.
+   * Uses blobfuse2 --subdirectory. Leading/trailing slashes are normalized.
+   */
+  prefix?: string;
+  /** Mount as read-only */
+  readOnly?: boolean;
+}
+
+// Azure container names: 3-63 lowercase alphanumeric chars or hyphens, no leading/
+// trailing hyphen, no consecutive hyphens.
+const SAFE_CONTAINER_NAME = /^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/;
+const BLOBFUSE2_GITHUB_DEB =
+  'https://github.com/Azure/azure-storage-fuse/releases/download/blobfuse2-2.5.1/blobfuse2-2.5.1-Ubuntu-22.04.x86_64.deb';
+
+function validateContainerName(name: string): void {
+  if (!SAFE_CONTAINER_NAME.test(name) || name.includes('--')) {
+    throw new Error(
+      `Invalid Azure container name: "${name}". Container names must be 3-63 lowercase alphanumeric characters or hyphens, with no consecutive hyphens.`,
+    );
+  }
+}
+
+interface ParsedConnectionString {
+  accountName?: string;
+  accountKey?: string;
+  sasToken?: string;
+  endpoint?: string;
+}
+
+function parseConnectionString(cs: string): ParsedConnectionString {
+  const out: ParsedConnectionString = {};
+  for (const part of cs.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+    if (!value) continue;
+    if (key === 'AccountName') out.accountName = value;
+    else if (key === 'AccountKey') out.accountKey = value;
+    else if (key === 'SharedAccessSignature') out.sasToken = value;
+    else if (key === 'BlobEndpoint') out.endpoint = value;
+  }
+  return out;
+}
+
+function yamlString(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function parseOsRelease(output: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const line of output.split('\n')) {
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq);
+    const value = line.slice(eq + 1).trim().replace(/^"|"$/g, '');
+    values[key] = value;
+  }
+  return values;
+}
+
+interface MicrosoftAptRepo {
+  repoUrl: string;
+  suite: string;
+}
+
+function resolveMicrosoftAptRepos(osReleaseOutput: string): MicrosoftAptRepo[] {
+  const osRelease = parseOsRelease(osReleaseOutput);
+  const distroId = osRelease.ID || 'ubuntu';
+  const codename = osRelease.VERSION_CODENAME || (distroId === 'debian' ? 'bookworm' : 'jammy');
+  const versionId = osRelease.VERSION_ID || (distroId === 'debian' ? '12' : '22.04');
+
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(codename)) {
+    throw new Error(`Invalid distro codename for blobfuse2 repo: "${codename}"`);
+  }
+  if (!/^\d+(?:\.\d+)?$/.test(versionId)) {
+    throw new Error(`Invalid distro version for blobfuse2 repo: "${versionId}"`);
+  }
+
+  if (distroId === 'debian') {
+    const repos = [{ repoUrl: `https://packages.microsoft.com/debian/${versionId.split('.')[0]}/prod`, suite: codename }];
+    if (versionId.split('.')[0] !== '12' || codename !== 'bookworm') {
+      repos.push({ repoUrl: 'https://packages.microsoft.com/debian/12/prod', suite: 'bookworm' });
+    }
+    return repos;
+  }
+  if (distroId === 'ubuntu') {
+    const repos = [{ repoUrl: `https://packages.microsoft.com/ubuntu/${versionId}/prod`, suite: codename }];
+    if (versionId !== '24.04' || codename !== 'noble') {
+      repos.push({ repoUrl: 'https://packages.microsoft.com/ubuntu/24.04/prod', suite: 'noble' });
+    }
+    if (versionId !== '22.04' || codename !== 'jammy') {
+      repos.push({ repoUrl: 'https://packages.microsoft.com/ubuntu/22.04/prod', suite: 'jammy' });
+    }
+    return repos;
+  }
+
+  throw new Error(`Unsupported distro for blobfuse2 runtime installation: "${distroId}"`);
+}
+
+interface ResolvedAuth {
+  mode: 'key' | 'sas' | 'msi';
+  accountName: string;
+  accountKey?: string;
+  sasToken?: string;
+  endpoint?: string;
+}
+
+function resolveAuth(config: DaytonaAzureBlobMountConfig): ResolvedAuth {
+  let accountName = config.accountName;
+  let accountKey = config.accountKey;
+  let sasToken = config.sasToken;
+  let endpoint = config.endpoint;
+
+  if (config.connectionString) {
+    const parsed = parseConnectionString(config.connectionString);
+    accountName = accountName ?? parsed.accountName;
+    accountKey = accountKey ?? parsed.accountKey;
+    sasToken = sasToken ?? parsed.sasToken;
+    endpoint = endpoint ?? parsed.endpoint;
+  }
+
+  let mode: 'key' | 'sas' | 'msi';
+  if (config.useDefaultCredential) {
+    mode = 'msi';
+  } else if (sasToken) {
+    mode = 'sas';
+  } else if (accountKey) {
+    mode = 'key';
+  } else {
+    throw new Error(
+      'Azure Blob mount requires credentials: provide connectionString, accountKey + accountName, sasToken + accountName, or useDefaultCredential.',
+    );
+  }
+
+  if (!accountName) {
+    throw new Error('Azure Blob mount requires an accountName (either explicitly or via connectionString).');
+  }
+
+  if (endpoint) {
+    validateEndpoint(endpoint);
+  }
+
+  return { mode, accountName, accountKey, sasToken, endpoint };
+}
+
+function buildBlobfuseConfig(
+  container: string,
+  auth: ResolvedAuth,
+  cachePath: string,
+  readOnly: boolean,
+): string {
+  const lines: string[] = [
+    'allow-other: true',
+    'foreground: false',
+    `read-only: ${readOnly ? 'true' : 'false'}`,
+    'logging:',
+    '  type: silent',
+    'components:',
+    '  - libfuse',
+    '  - file_cache',
+    '  - attr_cache',
+    '  - azstorage',
+    'libfuse:',
+    '  attribute-expiration-sec: 240',
+    '  entry-expiration-sec: 240',
+    '  negative-entry-expiration-sec: 120',
+    'file_cache:',
+    `  path: ${yamlString(cachePath)}`,
+    '  timeout-sec: 120',
+    'attr_cache:',
+    '  timeout-sec: 7200',
+    'azstorage:',
+    '  type: block',
+    `  mode: ${auth.mode}`,
+    `  account-name: ${yamlString(auth.accountName)}`,
+    `  container: ${yamlString(container)}`,
+  ];
+  if (auth.mode === 'key' && auth.accountKey) {
+    lines.push(`  account-key: ${yamlString(auth.accountKey)}`);
+  } else if (auth.mode === 'sas' && auth.sasToken) {
+    lines.push(`  sas: ${yamlString(auth.sasToken)}`);
+  }
+  if (auth.endpoint) {
+    lines.push(`  endpoint: ${yamlString(auth.endpoint.replace(/\/$/, ''))}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Mount an Azure Blob container using blobfuse2.
+ */
+export async function mountAzure(
+  mountPath: string,
+  config: DaytonaAzureBlobMountConfig,
+  ctx: MountContext,
+): Promise<void> {
+  const { run, writeFile, logger } = ctx;
+
+  validateContainerName(config.container);
+  const auth = resolveAuth(config);
+  const prefix = config.prefix ? validatePrefix(config.prefix) : undefined;
+
+  const quotedMountPath = shellQuote(mountPath);
+
+  // Verify network reachability to the blob endpoint. Daytona's restricted tiers
+  // block traffic to azure.com domains, which would otherwise hang the mount.
+  const probeUrl = auth.endpoint ? auth.endpoint.replace(/\/$/, '') : `https://${auth.accountName}.blob.core.windows.net`;
+  const connectivityCheck = await run(`curl -sS --max-time 5 ${shellQuote(probeUrl)} 2>&1`, 10_000);
+  const checkOutput = connectivityCheck.stdout.trim();
+  if (
+    connectivityCheck.exitCode !== 0 ||
+    checkOutput.toLowerCase().includes('restricted') ||
+    checkOutput.toLowerCase().includes('blocked')
+  ) {
+    throw new Error(
+      `Cannot reach ${probeUrl} from this sandbox. ` +
+        `Azure Blob mounting requires network access to the storage endpoint, ` +
+        `which may be blocked on Daytona's restricted tiers. ` +
+        `Upgrade to a tier with unrestricted internet access, or contact Daytona support to remove the network restriction.` +
+        (checkOutput ? `\n\nSandbox network response: ${checkOutput}` : ''),
+    );
+  }
+
+  // Install blobfuse2 if not present
+  const checkResult = await run('which blobfuse2 2>/dev/null || echo "not found"', 30_000);
+  if (checkResult.stdout.includes('not found')) {
+    logger.warn(`${LOG_PREFIX} blobfuse2 not found, attempting runtime installation...`);
+    logger.info(`${LOG_PREFIX} Tip: For faster startup, pre-install blobfuse2 in your sandbox image`);
+
+    await run('sudo apt-get update -qq 2>&1', 60_000);
+    const prepResult = await run('sudo apt-get install -y curl gnupg 2>&1', 120_000);
+    if (prepResult.exitCode !== 0) {
+      throw new Error(
+        `Failed to install blobfuse2 prerequisites (curl, gnupg): ${prepResult.stderr || prepResult.stdout}`,
+      );
+    }
+
+    const osReleaseResult = await run('cat /etc/os-release 2>/dev/null || true', 30_000);
+    const repos = resolveMicrosoftAptRepos(osReleaseResult.stdout);
+
+    const repoSetup = await run(
+      'sudo mkdir -p /etc/apt/keyrings && ' +
+        'curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL https://packages.microsoft.com/keys/microsoft.asc -o /tmp/ms-key.asc && ' +
+        'sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/microsoft.gpg /tmp/ms-key.asc',
+      30_000,
+    );
+
+    let installResult: { exitCode: number; stdout: string; stderr: string } | undefined;
+    if (repoSetup.exitCode === 0) {
+      for (const { repoUrl, suite } of repos) {
+        await run(
+          `echo "deb [signed-by=/etc/apt/keyrings/microsoft.gpg] ${repoUrl} ${suite} main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list`,
+          30_000,
+        );
+        await run('sudo apt-get update -qq 2>&1 || true', 60_000);
+        installResult = await run('sudo apt-get install -y blobfuse2 fuse3 2>&1', 120_000);
+        if (installResult.exitCode === 0) break;
+        logger.warn(`${LOG_PREFIX} blobfuse2 install failed for ${repoUrl} ${suite}, trying fallback if available`);
+      }
+    } else {
+      logger.warn(`${LOG_PREFIX} Failed to set up Microsoft apt repository, trying GitHub release fallback`);
+    }
+
+    let verifyResult = await run('which blobfuse2 && blobfuse2 --version', 30_000);
+    if (verifyResult.exitCode !== 0) {
+      installResult = await run(
+        'sudo apt-get update -qq 2>&1 || true && ' +
+          'sudo apt-get install -y fuse3 ca-certificates curl 2>&1 && ' +
+          `curl -L --retry 3 --retry-all-errors --retry-delay 2 -fSLo /tmp/blobfuse2.deb ${BLOBFUSE2_GITHUB_DEB} && ` +
+          'sudo dpkg -i /tmp/blobfuse2.deb 2>&1 && ' +
+          'sudo bash -c \'lib=$(find /usr/lib -name "libfuse3.so.3.*" | head -1); [ -z "$lib" ] || ln -sf "$lib" /usr/lib/x86_64-linux-gnu/libfuse3.so.3\'',
+        180_000,
+      );
+      verifyResult = await run('which blobfuse2 && blobfuse2 --version', 30_000);
+    }
+
+    if (!installResult || verifyResult.exitCode !== 0) {
+      throw new Error(
+        `Failed to install blobfuse2: ${
+          verifyResult.stderr || verifyResult.stdout || installResult?.stderr || installResult?.stdout || 'unknown error'
+        }`,
+      );
+    }
+  }
+
+  // Get uid/gid for proper file ownership of the cache directory
+  const idResult = await run('id -u && id -g', 30_000);
+  const [uid, gid] = idResult.stdout.trim().split('\n');
+  const validUidGid = uid && gid && /^\d+$/.test(uid) && /^\d+$/.test(gid);
+
+  // Allow non-root processes to use FUSE and the allow_other mount option.
+  await run(
+    `sudo chmod a+rw /dev/fuse 2>/dev/null || true; ` +
+      `sudo bash -c 'grep -q "^user_allow_other" /etc/fuse.conf 2>/dev/null || echo "user_allow_other" >> /etc/fuse.conf' 2>/dev/null || true`,
+  );
+
+  // Use a mount-specific config + cache path to avoid races with concurrent mounts.
+  const mountHash = createHash('md5').update(mountPath).digest('hex').slice(0, 8);
+  const configPath = `/tmp/.blobfuse2-config-${mountHash}.yaml`;
+  const cachePath = `/tmp/blobfuse2-cache-${mountHash}`;
+
+  const yaml = buildBlobfuseConfig(config.container, auth, cachePath, !!config.readOnly);
+
+  await run(`sudo rm -f ${shellQuote(configPath)}`, 30_000);
+  await writeFile(configPath, yaml);
+  await run(`chmod 600 ${shellQuote(configPath)}`, 30_000);
+
+  // blobfuse2 requires an empty cache directory when mounting.
+  await run(`sudo rm -rf ${shellQuote(cachePath)} && mkdir -p ${shellQuote(cachePath)}`, 30_000);
+  if (validUidGid) {
+    await run(`sudo chown ${uid}:${gid} ${shellQuote(cachePath)} 2>/dev/null || true`, 30_000);
+  }
+
+  // Run blobfuse2 as the sandbox user (not root) so the FUSE connection is registered
+  // in the user namespace — allowing fusermount -u to unmount it later.
+  const prefixFlags = prefix ? ` --virtual-directory=true --subdirectory=${shellQuote(prefix)}` : '';
+  const mountCmd = `blobfuse2 mount ${quotedMountPath} --config-file=${shellQuote(configPath)}${prefixFlags}`;
+  logger.debug(`${LOG_PREFIX} Mounting Azure Blob:`, mountCmd);
+
+  const result = await run(mountCmd, 60_000);
+  logger.debug(`${LOG_PREFIX} blobfuse2 result:`, {
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to mount Azure Blob container: ${result.stderr || result.stdout}`);
+  }
+}

--- a/workspaces/daytona/src/sandbox/mounts/azure.ts
+++ b/workspaces/daytona/src/sandbox/mounts/azure.ts
@@ -112,14 +112,18 @@ function resolveMicrosoftAptRepos(osReleaseOutput: string): MicrosoftAptRepo[] {
   }
 
   if (distroId === 'debian') {
-    const repos = [{ repoUrl: `https://packages.microsoft.com/debian/${versionId.split('.')[0]}/prod`, suite: codename }];
+    const repos = [
+      { repoUrl: `https://packages.microsoft.com/debian/${versionId.split('.')[0]}/prod`, suite: codename },
+    ];
     if (versionId.split('.')[0] !== '12' || codename !== 'bookworm') {
       repos.push({ repoUrl: 'https://packages.microsoft.com/debian/12/prod', suite: 'bookworm' });
     }
     return repos;
   }
   if (distroId === 'ubuntu') {
-    const repos = [{ repoUrl: `https://packages.microsoft.com/ubuntu/${versionId}/prod`, suite: codename }];
+    const repos = [
+      { repoUrl: `https://packages.microsoft.com/ubuntu/${versionId}/prod`, suite: codename },
+    ];
     if (versionId !== '24.04' || codename !== 'noble') {
       repos.push({ repoUrl: 'https://packages.microsoft.com/ubuntu/24.04/prod', suite: 'noble' });
     }

--- a/workspaces/daytona/src/sandbox/mounts/azure.ts
+++ b/workspaces/daytona/src/sandbox/mounts/azure.ts
@@ -59,6 +59,8 @@ interface ParsedConnectionString {
   accountKey?: string;
   sasToken?: string;
   endpoint?: string;
+  endpointSuffix?: string;
+  protocol?: string;
 }
 
 function parseConnectionString(cs: string): ParsedConnectionString {
@@ -73,6 +75,11 @@ function parseConnectionString(cs: string): ParsedConnectionString {
     else if (key === 'AccountKey') out.accountKey = value;
     else if (key === 'SharedAccessSignature') out.sasToken = value;
     else if (key === 'BlobEndpoint') out.endpoint = value;
+    else if (key === 'EndpointSuffix') out.endpointSuffix = value;
+    else if (key === 'DefaultEndpointsProtocol') out.protocol = value;
+  }
+  if (!out.endpoint && out.accountName) {
+    out.endpoint = `${out.protocol || 'https'}://${out.accountName}.blob.${out.endpointSuffix || 'core.windows.net'}`;
   }
   return out;
 }
@@ -209,7 +216,6 @@ function buildBlobfuseConfig(
     'attr_cache:',
     '  timeout-sec: 7200',
     'azstorage:',
-    '  type: block',
     `  mode: ${auth.mode}`,
     `  account-name: ${yamlString(auth.accountName)}`,
     `  container: ${yamlString(container)}`,
@@ -240,6 +246,16 @@ export async function mountAzure(
   const prefix = config.prefix ? validatePrefix(config.prefix) : undefined;
 
   const quotedMountPath = shellQuote(mountPath);
+
+  const curlCheck = await run('which curl 2>/dev/null || echo "not found"', 30_000);
+  if (curlCheck.stdout.includes('not found')) {
+    const curlInstall = await run('sudo apt-get update -qq 2>&1 && sudo apt-get install -y curl 2>&1', 120_000);
+    if (curlInstall.exitCode !== 0) {
+      throw new Error(
+        `Failed to install curl for Azure Blob reachability check: ${curlInstall.stderr || curlInstall.stdout}`,
+      );
+    }
+  }
 
   // Verify network reachability to the blob endpoint. Daytona's restricted tiers
   // block traffic to azure.com domains, which would otherwise hang the mount.

--- a/workspaces/daytona/src/sandbox/mounts/azure.ts
+++ b/workspaces/daytona/src/sandbox/mounts/azure.ts
@@ -94,7 +94,10 @@ function parseOsRelease(output: string): Record<string, string> {
     const eq = line.indexOf('=');
     if (eq === -1) continue;
     const key = line.slice(0, eq);
-    const value = line.slice(eq + 1).trim().replace(/^"|"$/g, '');
+    const value = line
+      .slice(eq + 1)
+      .trim()
+      .replace(/^"|"$/g, '');
     values[key] = value;
   }
   return values;
@@ -128,9 +131,7 @@ function resolveMicrosoftAptRepos(osReleaseOutput: string): MicrosoftAptRepo[] {
     return repos;
   }
   if (distroId === 'ubuntu') {
-    const repos = [
-      { repoUrl: `https://packages.microsoft.com/ubuntu/${versionId}/prod`, suite: codename },
-    ];
+    const repos = [{ repoUrl: `https://packages.microsoft.com/ubuntu/${versionId}/prod`, suite: codename }];
     if (versionId !== '24.04' || codename !== 'noble') {
       repos.push({ repoUrl: 'https://packages.microsoft.com/ubuntu/24.04/prod', suite: 'noble' });
     }
@@ -189,12 +190,7 @@ function resolveAuth(config: DaytonaAzureBlobMountConfig): ResolvedAuth {
   return { mode, accountName, accountKey, sasToken, endpoint };
 }
 
-function buildBlobfuseConfig(
-  container: string,
-  auth: ResolvedAuth,
-  cachePath: string,
-  readOnly: boolean,
-): string {
+function buildBlobfuseConfig(container: string, auth: ResolvedAuth, cachePath: string, readOnly: boolean): string {
   const lines: string[] = [
     'allow-other: true',
     'foreground: false',
@@ -259,7 +255,9 @@ export async function mountAzure(
 
   // Verify network reachability to the blob endpoint. Daytona's restricted tiers
   // block traffic to azure.com domains, which would otherwise hang the mount.
-  const probeUrl = auth.endpoint ? auth.endpoint.replace(/\/$/, '') : `https://${auth.accountName}.blob.core.windows.net`;
+  const probeUrl = auth.endpoint
+    ? auth.endpoint.replace(/\/$/, '')
+    : `https://${auth.accountName}.blob.core.windows.net`;
   const connectivityCheck = await run(`curl -sS --max-time 5 ${shellQuote(probeUrl)} 2>&1`, 10_000);
   const checkOutput = connectivityCheck.stdout.trim();
   if (
@@ -332,7 +330,11 @@ export async function mountAzure(
     if (!installResult || verifyResult.exitCode !== 0) {
       throw new Error(
         `Failed to install blobfuse2: ${
-          verifyResult.stderr || verifyResult.stdout || installResult?.stderr || installResult?.stdout || 'unknown error'
+          verifyResult.stderr ||
+          verifyResult.stdout ||
+          installResult?.stderr ||
+          installResult?.stdout ||
+          'unknown error'
         }`,
       );
     }

--- a/workspaces/daytona/src/sandbox/mounts/index.ts
+++ b/workspaces/daytona/src/sandbox/mounts/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './s3';
 export * from './gcs';
+export * from './azure';

--- a/workspaces/daytona/src/sandbox/mounts/types.ts
+++ b/workspaces/daytona/src/sandbox/mounts/types.ts
@@ -4,6 +4,7 @@
 
 import type { Sandbox } from '@daytonaio/sdk';
 
+import type { DaytonaAzureBlobMountConfig } from './azure';
 import type { DaytonaGCSMountConfig } from './gcs';
 import type { DaytonaS3MountConfig } from './s3';
 
@@ -12,7 +13,7 @@ export const LOG_PREFIX = '[@mastra/daytona]';
 /**
  * Union of mount configs supported by Daytona sandbox.
  */
-export type DaytonaMountConfig = DaytonaS3MountConfig | DaytonaGCSMountConfig;
+export type DaytonaMountConfig = DaytonaS3MountConfig | DaytonaGCSMountConfig | DaytonaAzureBlobMountConfig;
 
 /**
  * Context for mount operations.

--- a/workspaces/e2b/README.md
+++ b/workspaces/e2b/README.md
@@ -31,11 +31,12 @@ const agent = new Agent({
 
 ### Mounting Cloud Storage
 
-E2B sandboxes can mount S3 or GCS filesystems, making cloud storage accessible as a local directory inside the sandbox:
+E2B sandboxes can mount S3, GCS, or Azure Blob filesystems, making cloud storage accessible as a local directory inside the sandbox:
 
 ```typescript
 import { Workspace } from '@mastra/core/workspace';
 import { S3Filesystem } from '@mastra/s3';
+import { AzureBlobFilesystem } from '@mastra/azure/blob';
 import { E2BSandbox } from '@mastra/e2b';
 
 const workspace = new Workspace({
@@ -45,6 +46,11 @@ const workspace = new Workspace({
       region: 'us-east-1',
       accessKeyId: process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    }),
+    '/azure-data': new AzureBlobFilesystem({
+      container: 'my-container',
+      connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+      prefix: 'workspace/data',
     }),
   },
   sandbox: new E2BSandbox(),

--- a/workspaces/e2b/src/index.ts
+++ b/workspaces/e2b/src/index.ts
@@ -1,5 +1,10 @@
 export { E2BSandbox, type E2BSandboxOptions } from './sandbox';
 export { E2BProcessManager } from './sandbox/process-manager';
 export { createDefaultMountableTemplate, type TemplateSpec, type MountableTemplateResult } from './utils/template';
-export { type E2BS3MountConfig, type E2BGCSMountConfig, type E2BMountConfig } from './sandbox/mounts';
+export {
+  type E2BS3MountConfig,
+  type E2BGCSMountConfig,
+  type E2BAzureBlobMountConfig,
+  type E2BMountConfig,
+} from './sandbox/mounts';
 export { e2bSandboxProvider } from './provider';

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -927,9 +927,6 @@ describe('E2BSandbox GCS Mount Configuration', () => {
   });
 });
 
-/**
- * Azure Blob mount command flag tests
- */
 describe('E2BSandbox Azure Blob Mount Configuration', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -1158,7 +1155,7 @@ describe('E2BSandbox Azure Blob Mount Configuration', () => {
       status: 'ready',
       getMountConfig: () => ({
         type: 'azure-blob',
-        container: 'Bad_Name', // uppercase + underscore — not allowed
+        container: 'Bad_Name',
         accountName: 'mystorage',
         accountKey: 'k',
       }),

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -928,6 +928,251 @@ describe('E2BSandbox GCS Mount Configuration', () => {
 });
 
 /**
+ * Azure Blob mount command flag tests
+ */
+describe('E2BSandbox Azure Blob Mount Configuration', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await resetMockDefaults();
+    mockSandbox.commands.run.mockImplementation((cmd: string) => {
+      if (cmd.includes('which blobfuse2')) {
+        return Promise.resolve({ exitCode: 0, stdout: '/usr/bin/blobfuse2', stderr: '' });
+      }
+      if (cmd.includes('id -u')) {
+        return Promise.resolve({ exitCode: 0, stdout: '1000\n1000', stderr: '' });
+      }
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+  });
+
+  const findBlobfuseMountCall = (target: string) => {
+    return mockSandbox.commands.run.mock.calls.find(
+      (call: any[]) =>
+        call[0].includes('blobfuse2 mount') && call[0].includes(target) && !call[0].includes('which blobfuse2'),
+    );
+  };
+
+  const findWrittenConfig = (): string | undefined => {
+    const writeCall = mockSandbox.files.write.mock.calls.find((call: any[]) =>
+      String(call[0]).includes('.blobfuse2-config'),
+    );
+    return writeCall?.[1] as string | undefined;
+  };
+
+  it('account-key auth writes mode: key with account-name, account-key, container', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-azure-key',
+      name: 'AzureBlobFilesystem',
+      provider: 'azure-blob',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 'azure-blob',
+        container: 'test-container',
+        accountName: 'mystorage',
+        accountKey: 'a-secret-key',
+      }),
+    } as any;
+
+    await sandbox.mount(mockFilesystem, '/data/azure-key');
+
+    const mountCall = findBlobfuseMountCall('/data/azure-key');
+    expect(mountCall).toBeDefined();
+    expect(mountCall![0]).toContain('--config-file=');
+
+    const yaml = findWrittenConfig();
+    expect(yaml).toBeDefined();
+    expect(yaml).toContain('mode: key');
+    expect(yaml).toContain('account-name: "mystorage"');
+    expect(yaml).toContain('account-key: "a-secret-key"');
+    expect(yaml).toContain('container: "test-container"');
+    expect(yaml).toContain('read-only: false');
+  });
+
+  it('SAS token auth writes mode: sas with sas field (no account-key)', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-azure-sas',
+      name: 'AzureBlobFilesystem',
+      provider: 'azure-blob',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 'azure-blob',
+        container: 'sas-container',
+        accountName: 'mystorage',
+        sasToken: 'sv=2022-11-02&ss=b&srt=co&sp=rl&se=2030-01-01T00:00:00Z&sig=xyz',
+      }),
+    } as any;
+
+    await sandbox.mount(mockFilesystem, '/data/azure-sas');
+
+    const yaml = findWrittenConfig();
+    expect(yaml).toBeDefined();
+    expect(yaml).toContain('mode: sas');
+    expect(yaml).toContain('sas: ');
+    expect(yaml).not.toContain('account-key:');
+  });
+
+  it('useDefaultCredential writes mode: msi (no key, no sas)', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-azure-msi',
+      name: 'AzureBlobFilesystem',
+      provider: 'azure-blob',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 'azure-blob',
+        container: 'msi-container',
+        accountName: 'mystorage',
+        useDefaultCredential: true,
+      }),
+    } as any;
+
+    await sandbox.mount(mockFilesystem, '/data/azure-msi');
+
+    const yaml = findWrittenConfig();
+    expect(yaml).toBeDefined();
+    expect(yaml).toContain('mode: msi');
+    expect(yaml).not.toContain('account-key:');
+    expect(yaml).not.toContain('sas:');
+  });
+
+  it('connection string is parsed for AccountName, AccountKey, BlobEndpoint', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-azure-cs',
+      name: 'AzureBlobFilesystem',
+      provider: 'azure-blob',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 'azure-blob',
+        container: 'cs-container',
+        connectionString:
+          'DefaultEndpointsProtocol=https;AccountName=fromstring;AccountKey=keyvalue;BlobEndpoint=https://fromstring.blob.core.windows.net/;EndpointSuffix=core.windows.net',
+      }),
+    } as any;
+
+    await sandbox.mount(mockFilesystem, '/data/azure-cs');
+
+    const yaml = findWrittenConfig();
+    expect(yaml).toBeDefined();
+    expect(yaml).toContain('mode: key');
+    expect(yaml).toContain('account-name: "fromstring"');
+    expect(yaml).toContain('account-key: "keyvalue"');
+    expect(yaml).toContain('endpoint: "https://fromstring.blob.core.windows.net"');
+  });
+
+  it('readOnly writes read-only: true in config', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-azure-ro',
+      name: 'AzureBlobFilesystem',
+      provider: 'azure-blob',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 'azure-blob',
+        container: 'ro-container',
+        accountName: 'mystorage',
+        accountKey: 'k',
+        readOnly: true,
+      }),
+    } as any;
+
+    await sandbox.mount(mockFilesystem, '/data/azure-ro');
+
+    const yaml = findWrittenConfig();
+    expect(yaml).toBeDefined();
+    expect(yaml).toContain('read-only: true');
+  });
+
+  it('prefix mount uses blobfuse2 subdirectory flag and a mount-specific cache', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-azure-prefix',
+      name: 'AzureBlobFilesystem',
+      provider: 'azure-blob',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 'azure-blob',
+        container: 'prefix-container',
+        accountName: 'mystorage',
+        accountKey: 'k',
+        prefix: '/workspace/data/',
+      }),
+    } as any;
+
+    await sandbox.mount(mockFilesystem, '/data/azure-prefix');
+
+    const mountCall = findBlobfuseMountCall('/data/azure-prefix');
+    expect(mountCall).toBeDefined();
+    expect(mountCall![0]).toContain('--virtual-directory=true');
+    expect(mountCall![0]).toContain('--subdirectory=workspace/data');
+
+    const yaml = findWrittenConfig();
+    expect(yaml).toBeDefined();
+    expect(yaml).toContain('/tmp/blobfuse2-cache-');
+  });
+
+  it('missing credentials produces a clear error', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-azure-nocreds',
+      name: 'AzureBlobFilesystem',
+      provider: 'azure-blob',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 'azure-blob',
+        container: 'no-creds',
+        accountName: 'mystorage',
+      }),
+    } as any;
+
+    const result = await sandbox.mount(mockFilesystem, '/data/azure-nocreds');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/credentials/i);
+  });
+
+  it('invalid container name is rejected before any mount command', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-azure-bad-name',
+      name: 'AzureBlobFilesystem',
+      provider: 'azure-blob',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 'azure-blob',
+        container: 'Bad_Name', // uppercase + underscore — not allowed
+        accountName: 'mystorage',
+        accountKey: 'k',
+      }),
+    } as any;
+
+    const result = await sandbox.mount(mockFilesystem, '/data/azure-bad');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Invalid Azure container name/i);
+    expect(findBlobfuseMountCall('/data/azure-bad')).toBeUndefined();
+  });
+});
+
+/**
  * Error handling unit tests
  */
 describe('E2BSandbox Error Handling', () => {

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -986,6 +986,7 @@ describe('E2BSandbox Azure Blob Mount Configuration', () => {
     expect(yaml).toContain('account-key: "a-secret-key"');
     expect(yaml).toContain('container: "test-container"');
     expect(yaml).toContain('read-only: false');
+    expect(yaml).not.toContain('  type: block');
   });
 
   it('SAS token auth writes mode: sas with sas field (no account-key)', async () => {
@@ -1065,6 +1066,30 @@ describe('E2BSandbox Azure Blob Mount Configuration', () => {
     expect(yaml).toContain('account-name: "fromstring"');
     expect(yaml).toContain('account-key: "keyvalue"');
     expect(yaml).toContain('endpoint: "https://fromstring.blob.core.windows.net"');
+  });
+
+  it('connection string synthesizes endpoint from EndpointSuffix when BlobEndpoint is omitted', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-azure-cs-suffix',
+      name: 'AzureBlobFilesystem',
+      provider: 'azure-blob',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 'azure-blob',
+        container: 'cs-container',
+        connectionString:
+          'DefaultEndpointsProtocol=https;AccountName=fromstring;AccountKey=keyvalue;EndpointSuffix=core.usgovcloudapi.net',
+      }),
+    } as any;
+
+    await sandbox.mount(mockFilesystem, '/data/azure-cs-suffix');
+
+    const yaml = findWrittenConfig();
+    expect(yaml).toBeDefined();
+    expect(yaml).toContain('endpoint: "https://fromstring.blob.core.usgovcloudapi.net"');
   });
 
   it('readOnly writes read-only: true in config', async () => {

--- a/workspaces/e2b/src/sandbox/index.ts
+++ b/workspaces/e2b/src/sandbox/index.ts
@@ -27,8 +27,14 @@ import { Sandbox, Template } from 'e2b';
 import type { TemplateBuilder, TemplateClass } from 'e2b';
 import { createDefaultMountableTemplate } from '../utils/template';
 import type { TemplateSpec } from '../utils/template';
-import { mountS3, mountGCS, LOG_PREFIX } from './mounts';
-import type { E2BMountConfig, E2BS3MountConfig, E2BGCSMountConfig, MountContext } from './mounts';
+import { mountS3, mountGCS, mountAzure, LOG_PREFIX } from './mounts';
+import type {
+  E2BMountConfig,
+  E2BS3MountConfig,
+  E2BGCSMountConfig,
+  E2BAzureBlobMountConfig,
+  MountContext,
+} from './mounts';
 import { E2BProcessManager } from './process-manager';
 
 /** Allowlist pattern for mount paths — absolute path with safe characters only. */
@@ -501,6 +507,11 @@ export class E2BSandbox extends MastraSandbox {
           await mountGCS(mountPath, config as E2BGCSMountConfig, mountCtx);
           this.logger.debug(`${LOG_PREFIX} Mounted GCS bucket at ${mountPath}`);
           break;
+        case 'azure-blob':
+          this.logger.debug(`${LOG_PREFIX} Mounting Azure Blob container at ${mountPath}...`);
+          await mountAzure(mountPath, config as E2BAzureBlobMountConfig, mountCtx);
+          this.logger.debug(`${LOG_PREFIX} Mounted Azure Blob container at ${mountPath}`);
+          break;
         default:
           this.mounts.set(mountPath, {
             filesystem,
@@ -601,7 +612,7 @@ export class E2BSandbox extends MastraSandbox {
 
     // Get current FUSE mounts in the sandbox
     const mountsResult = await this._sandbox.commands.run(
-      `grep -E 'fuse\\.(s3fs|gcsfuse)' /proc/mounts | awk '{print $2}'`,
+      `grep -E 'fuse\\.(s3fs|gcsfuse|blobfuse2)' /proc/mounts | awk '{print $2}'`,
     );
     const currentMounts = mountsResult.stdout
       .trim()

--- a/workspaces/e2b/src/sandbox/mounts/azure.ts
+++ b/workspaces/e2b/src/sandbox/mounts/azure.ts
@@ -112,14 +112,18 @@ function resolveMicrosoftAptRepos(osReleaseOutput: string): MicrosoftAptRepo[] {
   }
 
   if (distroId === 'debian') {
-    const repos = [{ repoUrl: `https://packages.microsoft.com/debian/${versionId.split('.')[0]}/prod`, suite: codename }];
+    const repos = [
+      { repoUrl: `https://packages.microsoft.com/debian/${versionId.split('.')[0]}/prod`, suite: codename },
+    ];
     if (versionId.split('.')[0] !== '12' || codename !== 'bookworm') {
       repos.push({ repoUrl: 'https://packages.microsoft.com/debian/12/prod', suite: 'bookworm' });
     }
     return repos;
   }
   if (distroId === 'ubuntu') {
-    const repos = [{ repoUrl: `https://packages.microsoft.com/ubuntu/${versionId}/prod`, suite: codename }];
+    const repos = [
+      { repoUrl: `https://packages.microsoft.com/ubuntu/${versionId}/prod`, suite: codename },
+    ];
     if (versionId !== '24.04' || codename !== 'noble') {
       repos.push({ repoUrl: 'https://packages.microsoft.com/ubuntu/24.04/prod', suite: 'noble' });
     }
@@ -235,8 +239,8 @@ export async function mountAzure(
   const auth = resolveAuth(config);
   const prefix = config.prefix ? validatePrefix(config.prefix) : undefined;
 
-  // Install blobfuse2 if not present. Microsoft's apt repo is required, so we
-  // install it at mount time rather than baking it into the default template.
+  // Install blobfuse2 if not present. Prefer Microsoft apt packages and fall
+  // back to the official Azure GitHub release when the repo is unavailable.
   const checkResult = await sandbox.commands.run('which blobfuse2 || echo "not found"');
   if (checkResult.stdout.includes('not found')) {
     logger.warn(`${LOG_PREFIX} blobfuse2 not found, attempting runtime installation...`);
@@ -249,7 +253,8 @@ export async function mountAzure(
 
     const repoSetupResult = await sandbox.commands.run(
       'sudo mkdir -p /etc/apt/keyrings && ' +
-        'curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg',
+        'curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL https://packages.microsoft.com/keys/microsoft.asc -o /tmp/ms-key.asc && ' +
+        'sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/microsoft.gpg /tmp/ms-key.asc',
       { timeoutMs: 60_000 },
     );
 

--- a/workspaces/e2b/src/sandbox/mounts/azure.ts
+++ b/workspaces/e2b/src/sandbox/mounts/azure.ts
@@ -1,0 +1,338 @@
+import { createHash } from 'node:crypto';
+
+import type { FilesystemMountConfig } from '@mastra/core/workspace';
+
+import { shellQuote } from '../../utils/shell-quote';
+import { LOG_PREFIX, validateEndpoint, validatePrefix } from './types';
+import type { MountContext } from './types';
+
+/**
+ * Azure Blob mount config for E2B (mounted via blobfuse2).
+ *
+ * Authentication is selected from the first applicable option:
+ *   1. `useDefaultCredential` (managed identity, requires running in Azure)
+ *   2. `sasToken`
+ *   3. `accountKey`
+ *   4. `connectionString` (parsed for AccountName/AccountKey/SharedAccessSignature/BlobEndpoint)
+ */
+export interface E2BAzureBlobMountConfig extends FilesystemMountConfig {
+  type: 'azure-blob';
+  /** Azure Blob container name */
+  container: string;
+  /** Storage account name (required unless supplied via connectionString) */
+  accountName?: string;
+  /** Storage account access key */
+  accountKey?: string;
+  /** Shared Access Signature token (without leading '?') */
+  sasToken?: string;
+  /** Azure Storage connection string */
+  connectionString?: string;
+  /** Use DefaultAzureCredential / managed identity (mode: msi) */
+  useDefaultCredential?: boolean;
+  /** Custom blob endpoint (e.g. for sovereign clouds or Azurite) */
+  endpoint?: string;
+  /**
+   * Optional prefix (subdirectory) to mount instead of the entire container.
+   * Uses blobfuse2 --subdirectory. Leading/trailing slashes are normalized.
+   */
+  prefix?: string;
+  /** Mount as read-only */
+  readOnly?: boolean;
+}
+
+// Azure container names: 3-63 lowercase alphanumeric chars or hyphens, no leading/
+// trailing hyphen, no consecutive hyphens. Stricter than the generic bucket regex.
+const SAFE_CONTAINER_NAME = /^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/;
+const BLOBFUSE2_GITHUB_DEB =
+  'https://github.com/Azure/azure-storage-fuse/releases/download/blobfuse2-2.5.1/blobfuse2-2.5.1-Ubuntu-22.04.x86_64.deb';
+
+function validateContainerName(name: string): void {
+  if (!SAFE_CONTAINER_NAME.test(name) || name.includes('--')) {
+    throw new Error(
+      `Invalid Azure container name: "${name}". Container names must be 3-63 lowercase alphanumeric characters or hyphens, with no consecutive hyphens.`,
+    );
+  }
+}
+
+interface ParsedConnectionString {
+  accountName?: string;
+  accountKey?: string;
+  sasToken?: string;
+  endpoint?: string;
+}
+
+function parseConnectionString(cs: string): ParsedConnectionString {
+  const out: ParsedConnectionString = {};
+  for (const part of cs.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+    if (!value) continue;
+    if (key === 'AccountName') out.accountName = value;
+    else if (key === 'AccountKey') out.accountKey = value;
+    else if (key === 'SharedAccessSignature') out.sasToken = value;
+    else if (key === 'BlobEndpoint') out.endpoint = value;
+  }
+  return out;
+}
+
+function yamlString(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function parseOsRelease(output: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const line of output.split('\n')) {
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq);
+    const value = line.slice(eq + 1).trim().replace(/^"|"$/g, '');
+    values[key] = value;
+  }
+  return values;
+}
+
+interface MicrosoftAptRepo {
+  repoUrl: string;
+  suite: string;
+}
+
+function resolveMicrosoftAptRepos(osReleaseOutput: string): MicrosoftAptRepo[] {
+  const osRelease = parseOsRelease(osReleaseOutput);
+  const distroId = osRelease.ID || 'ubuntu';
+  const codename = osRelease.VERSION_CODENAME || (distroId === 'debian' ? 'bookworm' : 'jammy');
+  const versionId = osRelease.VERSION_ID || (distroId === 'debian' ? '12' : '22.04');
+
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(codename)) {
+    throw new Error(`Invalid distro codename for blobfuse2 repo: "${codename}"`);
+  }
+  if (!/^\d+(?:\.\d+)?$/.test(versionId)) {
+    throw new Error(`Invalid distro version for blobfuse2 repo: "${versionId}"`);
+  }
+
+  if (distroId === 'debian') {
+    const repos = [{ repoUrl: `https://packages.microsoft.com/debian/${versionId.split('.')[0]}/prod`, suite: codename }];
+    if (versionId.split('.')[0] !== '12' || codename !== 'bookworm') {
+      repos.push({ repoUrl: 'https://packages.microsoft.com/debian/12/prod', suite: 'bookworm' });
+    }
+    return repos;
+  }
+  if (distroId === 'ubuntu') {
+    const repos = [{ repoUrl: `https://packages.microsoft.com/ubuntu/${versionId}/prod`, suite: codename }];
+    if (versionId !== '24.04' || codename !== 'noble') {
+      repos.push({ repoUrl: 'https://packages.microsoft.com/ubuntu/24.04/prod', suite: 'noble' });
+    }
+    if (versionId !== '22.04' || codename !== 'jammy') {
+      repos.push({ repoUrl: 'https://packages.microsoft.com/ubuntu/22.04/prod', suite: 'jammy' });
+    }
+    return repos;
+  }
+
+  throw new Error(`Unsupported distro for blobfuse2 runtime installation: "${distroId}"`);
+}
+
+interface ResolvedAuth {
+  mode: 'key' | 'sas' | 'msi';
+  accountName: string;
+  accountKey?: string;
+  sasToken?: string;
+  endpoint?: string;
+}
+
+function resolveAuth(config: E2BAzureBlobMountConfig): ResolvedAuth {
+  let accountName = config.accountName;
+  let accountKey = config.accountKey;
+  let sasToken = config.sasToken;
+  let endpoint = config.endpoint;
+
+  if (config.connectionString) {
+    const parsed = parseConnectionString(config.connectionString);
+    accountName = accountName ?? parsed.accountName;
+    accountKey = accountKey ?? parsed.accountKey;
+    sasToken = sasToken ?? parsed.sasToken;
+    endpoint = endpoint ?? parsed.endpoint;
+  }
+
+  let mode: 'key' | 'sas' | 'msi';
+  if (config.useDefaultCredential) {
+    mode = 'msi';
+  } else if (sasToken) {
+    mode = 'sas';
+  } else if (accountKey) {
+    mode = 'key';
+  } else {
+    throw new Error(
+      'Azure Blob mount requires credentials: provide connectionString, accountKey + accountName, sasToken + accountName, or useDefaultCredential.',
+    );
+  }
+
+  if (!accountName) {
+    throw new Error('Azure Blob mount requires an accountName (either explicitly or via connectionString).');
+  }
+
+  if (endpoint) {
+    validateEndpoint(endpoint);
+  }
+
+  return { mode, accountName, accountKey, sasToken, endpoint };
+}
+
+function buildBlobfuseConfig(
+  container: string,
+  auth: ResolvedAuth,
+  cachePath: string,
+  readOnly: boolean,
+): string {
+  const lines: string[] = [
+    'allow-other: true',
+    'foreground: false',
+    `read-only: ${readOnly ? 'true' : 'false'}`,
+    'logging:',
+    '  type: silent',
+    'components:',
+    '  - libfuse',
+    '  - file_cache',
+    '  - attr_cache',
+    '  - azstorage',
+    'libfuse:',
+    '  attribute-expiration-sec: 240',
+    '  entry-expiration-sec: 240',
+    '  negative-entry-expiration-sec: 120',
+    'file_cache:',
+    `  path: ${yamlString(cachePath)}`,
+    '  timeout-sec: 120',
+    'attr_cache:',
+    '  timeout-sec: 7200',
+    'azstorage:',
+    '  type: block',
+    `  mode: ${auth.mode}`,
+    `  account-name: ${yamlString(auth.accountName)}`,
+    `  container: ${yamlString(container)}`,
+  ];
+  if (auth.mode === 'key' && auth.accountKey) {
+    lines.push(`  account-key: ${yamlString(auth.accountKey)}`);
+  } else if (auth.mode === 'sas' && auth.sasToken) {
+    lines.push(`  sas: ${yamlString(auth.sasToken)}`);
+  }
+  if (auth.endpoint) {
+    lines.push(`  endpoint: ${yamlString(auth.endpoint.replace(/\/$/, ''))}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Mount an Azure Blob container using blobfuse2.
+ */
+export async function mountAzure(
+  mountPath: string,
+  config: E2BAzureBlobMountConfig,
+  ctx: MountContext,
+): Promise<void> {
+  const { sandbox, logger } = ctx;
+
+  validateContainerName(config.container);
+  const auth = resolveAuth(config);
+  const prefix = config.prefix ? validatePrefix(config.prefix) : undefined;
+
+  // Install blobfuse2 if not present. Microsoft's apt repo is required, so we
+  // install it at mount time rather than baking it into the default template.
+  const checkResult = await sandbox.commands.run('which blobfuse2 || echo "not found"');
+  if (checkResult.stdout.includes('not found')) {
+    logger.warn(`${LOG_PREFIX} blobfuse2 not found, attempting runtime installation...`);
+    logger.info(
+      `${LOG_PREFIX} Tip: For faster startup, pre-install blobfuse2 in your sandbox template via createMountableTemplate()`,
+    );
+
+    const osReleaseResult = await sandbox.commands.run('cat /etc/os-release 2>/dev/null || true');
+    const repos = resolveMicrosoftAptRepos(osReleaseResult.stdout);
+
+    const repoSetupResult = await sandbox.commands.run(
+      'sudo mkdir -p /etc/apt/keyrings && ' +
+        'curl --retry 3 --retry-all-errors --retry-delay 2 -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg',
+      { timeoutMs: 60_000 },
+    );
+
+    let installResult: { exitCode: number; stdout: string; stderr: string } | undefined;
+    if (repoSetupResult.exitCode === 0) {
+      for (const { repoUrl, suite } of repos) {
+        installResult = await sandbox.commands.run(
+          `echo "deb [signed-by=/etc/apt/keyrings/microsoft.gpg] ${repoUrl} ${suite} main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list && ` +
+            'sudo apt-get update 2>&1 && sudo apt-get install -y blobfuse2 fuse3 2>&1',
+          { timeoutMs: 180_000 },
+        );
+        if (installResult.exitCode === 0) break;
+        logger.warn(`${LOG_PREFIX} blobfuse2 install failed for ${repoUrl} ${suite}, trying fallback if available`);
+      }
+    } else {
+      logger.warn(`${LOG_PREFIX} Failed to set up Microsoft apt repository, trying GitHub release fallback`);
+    }
+
+    let verifyResult = await sandbox.commands.run('which blobfuse2 && blobfuse2 --version', { timeoutMs: 30_000 });
+    if (verifyResult.exitCode !== 0) {
+      installResult = await sandbox.commands.run(
+        'sudo apt-get update -qq 2>&1 || true && ' +
+          'sudo apt-get install -y fuse3 ca-certificates curl 2>&1 && ' +
+          `curl -L --retry 3 --retry-all-errors --retry-delay 2 -fSLo /tmp/blobfuse2.deb ${BLOBFUSE2_GITHUB_DEB} && ` +
+          'sudo dpkg -i /tmp/blobfuse2.deb 2>&1 && ' +
+          'sudo bash -c \'lib=$(find /usr/lib -name "libfuse3.so.3.*" | head -1); [ -z "$lib" ] || ln -sf "$lib" /usr/lib/x86_64-linux-gnu/libfuse3.so.3\'',
+        { timeoutMs: 180_000 },
+      );
+      verifyResult = await sandbox.commands.run('which blobfuse2 && blobfuse2 --version', { timeoutMs: 30_000 });
+    }
+
+    if (!installResult || verifyResult.exitCode !== 0) {
+      throw new Error(
+        `Failed to install blobfuse2. ` +
+          `For Azure Blob mounting, your template needs blobfuse2 and fuse3.\n\n` +
+          `Option 1: Use createMountableTemplate() helper:\n` +
+          `  import { E2BSandbox, createMountableTemplate } from '@mastra/e2b';\n` +
+          `  const sandbox = new E2BSandbox({ template: createMountableTemplate() });\n\n` +
+          `Option 2: Customize the base template:\n` +
+          `  new E2BSandbox({ template: base => base.aptInstall(['your-packages']) })\n\n` +
+          `Error details: ${
+            verifyResult.stderr ||
+            verifyResult.stdout ||
+            installResult?.stderr ||
+            installResult?.stdout ||
+            'unknown error'
+          }`,
+      );
+    }
+  }
+
+  const mountHash = createHash('md5').update(mountPath).digest('hex').slice(0, 8);
+  const configPath = `/tmp/.blobfuse2-config-${mountHash}.yaml`;
+  const cachePath = `/tmp/blobfuse2-cache-${mountHash}`;
+  const yaml = buildBlobfuseConfig(config.container, auth, cachePath, !!config.readOnly);
+
+  // Write config (root-owned, 0600) since blobfuse2 runs as root via sudo for /dev/fuse access.
+  await sandbox.commands.run(`sudo rm -f ${configPath}`);
+  await sandbox.files.write(configPath, yaml);
+  await sandbox.commands.run(`sudo chown root:root ${configPath} && sudo chmod 600 ${configPath}`);
+
+  // blobfuse2 requires an empty cache directory when mounting.
+  await sandbox.commands.run(`sudo rm -rf ${shellQuote(cachePath)} && sudo mkdir -p ${shellQuote(cachePath)}`);
+
+  const prefixFlags = prefix ? ` --virtual-directory=true --subdirectory=${shellQuote(prefix)}` : '';
+  const mountCmd = `sudo blobfuse2 mount ${shellQuote(mountPath)} --config-file=${shellQuote(configPath)}${prefixFlags}`;
+  logger.debug(`${LOG_PREFIX} Mounting Azure Blob:`, mountCmd);
+
+  try {
+    const result = await sandbox.commands.run(mountCmd, { timeoutMs: 60_000 });
+    logger.debug(`${LOG_PREFIX} blobfuse2 result:`, {
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to mount Azure Blob container: ${result.stderr || result.stdout}`);
+    }
+  } catch (error: unknown) {
+    const errorObj = error as { result?: { exitCode: number; stdout: string; stderr: string } };
+    const stderr = errorObj.result?.stderr || '';
+    const stdout = errorObj.result?.stdout || '';
+    logger.error(`${LOG_PREFIX} blobfuse2 error:`, { stderr, stdout, error: String(error) });
+    throw new Error(`Failed to mount Azure Blob container: ${stderr || stdout || error}`);
+  }
+}

--- a/workspaces/e2b/src/sandbox/mounts/azure.ts
+++ b/workspaces/e2b/src/sandbox/mounts/azure.ts
@@ -94,7 +94,10 @@ function parseOsRelease(output: string): Record<string, string> {
     const eq = line.indexOf('=');
     if (eq === -1) continue;
     const key = line.slice(0, eq);
-    const value = line.slice(eq + 1).trim().replace(/^"|"$/g, '');
+    const value = line
+      .slice(eq + 1)
+      .trim()
+      .replace(/^"|"$/g, '');
     values[key] = value;
   }
   return values;
@@ -128,9 +131,7 @@ function resolveMicrosoftAptRepos(osReleaseOutput: string): MicrosoftAptRepo[] {
     return repos;
   }
   if (distroId === 'ubuntu') {
-    const repos = [
-      { repoUrl: `https://packages.microsoft.com/ubuntu/${versionId}/prod`, suite: codename },
-    ];
+    const repos = [{ repoUrl: `https://packages.microsoft.com/ubuntu/${versionId}/prod`, suite: codename }];
     if (versionId !== '24.04' || codename !== 'noble') {
       repos.push({ repoUrl: 'https://packages.microsoft.com/ubuntu/24.04/prod', suite: 'noble' });
     }
@@ -189,12 +190,7 @@ function resolveAuth(config: E2BAzureBlobMountConfig): ResolvedAuth {
   return { mode, accountName, accountKey, sasToken, endpoint };
 }
 
-function buildBlobfuseConfig(
-  container: string,
-  auth: ResolvedAuth,
-  cachePath: string,
-  readOnly: boolean,
-): string {
+function buildBlobfuseConfig(container: string, auth: ResolvedAuth, cachePath: string, readOnly: boolean): string {
   const lines: string[] = [
     'allow-other: true',
     'foreground: false',
@@ -234,11 +230,7 @@ function buildBlobfuseConfig(
 /**
  * Mount an Azure Blob container using blobfuse2.
  */
-export async function mountAzure(
-  mountPath: string,
-  config: E2BAzureBlobMountConfig,
-  ctx: MountContext,
-): Promise<void> {
+export async function mountAzure(mountPath: string, config: E2BAzureBlobMountConfig, ctx: MountContext): Promise<void> {
   const { sandbox, logger } = ctx;
 
   validateContainerName(config.container);

--- a/workspaces/e2b/src/sandbox/mounts/azure.ts
+++ b/workspaces/e2b/src/sandbox/mounts/azure.ts
@@ -59,6 +59,8 @@ interface ParsedConnectionString {
   accountKey?: string;
   sasToken?: string;
   endpoint?: string;
+  endpointSuffix?: string;
+  protocol?: string;
 }
 
 function parseConnectionString(cs: string): ParsedConnectionString {
@@ -73,6 +75,11 @@ function parseConnectionString(cs: string): ParsedConnectionString {
     else if (key === 'AccountKey') out.accountKey = value;
     else if (key === 'SharedAccessSignature') out.sasToken = value;
     else if (key === 'BlobEndpoint') out.endpoint = value;
+    else if (key === 'EndpointSuffix') out.endpointSuffix = value;
+    else if (key === 'DefaultEndpointsProtocol') out.protocol = value;
+  }
+  if (!out.endpoint && out.accountName) {
+    out.endpoint = `${out.protocol || 'https'}://${out.accountName}.blob.${out.endpointSuffix || 'core.windows.net'}`;
   }
   return out;
 }
@@ -209,7 +216,6 @@ function buildBlobfuseConfig(
     'attr_cache:',
     '  timeout-sec: 7200',
     'azstorage:',
-    '  type: block',
     `  mode: ${auth.mode}`,
     `  account-name: ${yamlString(auth.accountName)}`,
     `  container: ${yamlString(container)}`,

--- a/workspaces/e2b/src/sandbox/mounts/index.ts
+++ b/workspaces/e2b/src/sandbox/mounts/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './s3';
 export * from './gcs';
+export * from './azure';

--- a/workspaces/e2b/src/sandbox/mounts/types.ts
+++ b/workspaces/e2b/src/sandbox/mounts/types.ts
@@ -4,15 +4,16 @@
 
 import type { Sandbox } from 'e2b';
 
-export const LOG_PREFIX = '[@mastra/e2b]';
-
+import type { E2BAzureBlobMountConfig } from './azure';
 import type { E2BGCSMountConfig } from './gcs';
 import type { E2BS3MountConfig } from './s3';
+
+export const LOG_PREFIX = '[@mastra/e2b]';
 
 /**
  * Union of mount configs supported by E2B sandbox.
  */
-export type E2BMountConfig = E2BS3MountConfig | E2BGCSMountConfig;
+export type E2BMountConfig = E2BS3MountConfig | E2BGCSMountConfig | E2BAzureBlobMountConfig;
 
 /**
  * Context for mount operations.


### PR DESCRIPTION
## Description

Adds Azure Blob Storage sandbox mounts for E2B and Daytona, matching the existing S3 and GCS mount support.
This allows `AzureBlobFilesystem` to be mounted into sandboxes with `sandbox.mount(azureBlobFilesystem, '/path')`. The implementation supports account key, SAS token, connection string, and managed identity/default credential auth, preserves Azure Blob prefixes during mounts, installs `blobfuse2` when needed, and documents Azure Blob usage in the workspace READMEs.

## Related Issue(s)

Fixes #15851

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

This PR lets code running inside isolated sandboxes directly use files in Microsoft Azure Blob Storage as if they were local files by mounting Azure containers into the sandbox filesystem, similar to existing S3/GCS mounts.

## Overview

Adds Azure Blob Storage sandbox mount support for both E2B and Daytona workspaces using blobfuse2, enabling sandbox.mount(AzureBlobFilesystem, '/path') with support for account key, SAS token, connection string, and managed identity/default credentials. Preserves configured container prefixes during mounts, ensures blobfuse2 is installed when needed, updates mount detection/reconciliation to recognize blobfuse2, and adds docs and tests to mirror S3/GCS behavior. References Fixes #15851.

## Key Changes

- Azure blob filesystem package
  - AzureBlobMountConfig: added optional prefix?: string and getMountConfig() now propagates normalized prefix.
  - Unit test added to validate prefix normalization.

- E2B workspace
  - New workspaces/e2b/src/sandbox/mounts/azure.ts implementing mountAzure(...) with:
    - Validation of container name and optional prefix handling (mounts subdirectory when prefix provided).
    - Credential resolution (connectionString parsing, sasToken, accountKey, useDefaultCredential).
    - Endpoint validation and reachability probe (curl).
    - blobfuse2 installation flow: Microsoft apt repo setup based on /etc/os-release with fallback to GitHub .deb, verification of blobfuse2 --version.
    - Per-mount hashed config/cache paths, secure config YAML writing (0600), cache directory handling, and running sudo blobfuse2 mount with appropriate flags.
    - Detailed error messages for installation, credential, and mount failures.
  - E2B sandbox updated to handle config.type === 'azure-blob' and to include blobfuse2 in reconcileMounts detection.
  - Exported E2BAzureBlobMountConfig type and re-exported via mounts barrel.
  - Comprehensive Azure Blob mount test suite added (authentication paths, connection string parsing, prefix/subdirectory behavior, readOnly, failure modes).
  - README updated with Azure Blob examples and environment variable guidance.

- Daytona workspace
  - New workspaces/daytona/src/sandbox/mounts/azure.ts implementing mountAzure(...) with parallel behavior to the E2B implementation:
    - Multi-variant Debian/Ubuntu apt repo handling, GitHub .deb fallback, reachability probe, secure YAML config, per-mount cache, subdirectory/prefix mounting, and robust error handling.
    - Parses EndpointSuffix/DefaultEndpointsProtocol from connection strings to correctly resolve blob endpoints for sovereign clouds.
    - Removed hardcoded azstorage.type from YAML so blobfuse2 autodetects HNS/ADLS Gen2 accounts.
  - Daytona sandbox updated to handle config.type === 'azure-blob' and include blobfuse2 in mount reconciliation regex.
  - Exported DaytonaAzureBlobMountConfig type and re-exported via mounts barrel.
  - Unit tests added to cover credential modes, connection string parsing, prefix handling, config YAML content, and failure cases.
  - README updated with mounting instructions and note about pre-installing blobfuse2 for snapshot/cold-start optimization; curl is installed earlier to avoid probe failures on minimal images.

- Types & exports
  - E2B and Daytona mount config unions extended to include Azure mount types and corresponding exports added to workspace index files.

- Tests & CI
  - Mirrors S3/GCS test coverage: comprehensive tests added for both workspaces validating all authentication modes, endpoint parsing, prefix/subdirectory mounting, config generation, read-only propagation, mount command construction, and error conditions.
  - Some duplicated test block noted in E2B changeset (duplicate suite present).

- Documentation & release notes
  - README updates for both workspaces with examples and environment variable references.
  - .env/example and changesets added documenting Azure Blob mount functionality and noting that configured prefixes are preserved (mount scoped to prefix).
  - Changeset text scoped for @mastra/azure and @mastra packages; links to blobfuse2 install guide included.

## Migration / Operational Notes

- blobfuse2 is installed automatically in E2B (apt or .deb fallback); Daytona snapshots may require pre-install or image changes for optimal cold-start behavior (README updated).
- Connection strings are parsed for AccountName, AccountKey, BlobEndpoint, and EndpointSuffix to support sovereign clouds.
- Prefix behavior: configured prefixes are preserved and mounted as subdirectories (--virtual-directory/--subdirectory), constraining the mount to the specified prefix.

## Tests Added

- Unit tests for AzureBlobFilesystem prefix normalization.
- Extensive mount integration-like tests for E2B and Daytona covering:
  - All credential modes (account key, SAS, connection string parsing, managed identity/default credentials)
  - Endpoint synthesis and reachability checks
  - Config YAML generation and secure file permissions
  - blobfuse2 install paths and version verification
  - Prefix/subdirectory mount behavior and cache handling
  - Error handling for missing credentials and invalid container names

## Files / Notable Additions

- workspaces/e2b/src/sandbox/mounts/azure.ts (+341 lines)
- workspaces/daytona/src/sandbox/mounts/azure.ts (+386 lines)
- Types & re-exports in workspaces/e2b/daytona index and mounts barrels
- Tests: workspaces/e2b/src/sandbox/index.test.ts, workspaces/daytona/src/sandbox/index.test.ts
- Azure blob filesystem prefix support: workspaces/azure/src/blob/filesystem/index.ts and test
- README updates for both workspaces and changeset files for release notes

## Impact & Risk

- New feature: expands sandbox filesystem types—surface area includes blobfuse2 installation logic and system-level mount operations; careful review of installation, sudo usage, permissions, and error paths recommended.
- Tests added broadly replicate S3/GCS patterns; reviewers should confirm no regressions to existing mount types and that blobfuse2 detection/reconcile logic doesn't unintentionally match unrelated mounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->