### PR TITLE
Add publish + share permission actions and split stored resources into per-family permissions

### DIFF
--- a/packages/core/src/auth/ee/defaults/roles.test.ts
+++ b/packages/core/src/auth/ee/defaults/roles.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { matchesPermission } from './roles';
+
+describe('matchesPermission', () => {
+  describe('legacy stored:* backwards compatibility', () => {
+    const storedFamilies = [
+      'stored-agents',
+      'stored-mcp-clients',
+      'stored-prompt-blocks',
+      'stored-scorers',
+      'stored-skills',
+      'stored-workspaces',
+    ];
+
+    it.each(storedFamilies)('granted stored:read matches %s:read', family => {
+      expect(matchesPermission('stored:read', `${family}:read`)).toBe(true);
+    });
+
+    it.each(storedFamilies)('granted stored:write matches %s:write', family => {
+      expect(matchesPermission('stored:write', `${family}:write`)).toBe(true);
+    });
+
+    it.each(storedFamilies)('granted stored:delete matches %s:delete', family => {
+      expect(matchesPermission('stored:delete', `${family}:delete`)).toBe(true);
+    });
+
+    it.each(storedFamilies)('granted stored:* matches %s:read', family => {
+      expect(matchesPermission('stored:*', `${family}:read`)).toBe(true);
+    });
+
+    it.each(storedFamilies)('granted stored:* matches %s:publish', family => {
+      expect(matchesPermission('stored:*', `${family}:publish`)).toBe(true);
+    });
+
+    it('granted stored:read does not match stored-agents:write', () => {
+      expect(matchesPermission('stored:read', 'stored-agents:write')).toBe(false);
+    });
+
+    it('granted stored:read does not match unrelated resources', () => {
+      expect(matchesPermission('stored:read', 'agents:read')).toBe(false);
+      expect(matchesPermission('stored:read', 'workflows:read')).toBe(false);
+    });
+
+    it('granted stored:read with resource id matches stored-agents:read:my-agent', () => {
+      expect(matchesPermission('stored:read:my-agent', 'stored-agents:read:my-agent')).toBe(true);
+    });
+
+    it('granted stored:read:my-agent does not match different id', () => {
+      expect(matchesPermission('stored:read:my-agent', 'stored-agents:read:other')).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/auth/ee/defaults/roles.test.ts
+++ b/packages/core/src/auth/ee/defaults/roles.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { DEFAULT_ROLES, matchesPermission, resolvePermissions } from './roles';
 
 describe('matchesPermission', () => {
-  describe('legacy stored:* backwards compatibility', () => {
+  describe('compound stored:* expansion', () => {
     const storedFamilies = [
       'stored-agents',
       'stored-mcp-clients',
@@ -87,12 +87,10 @@ describe('matchesPermission', () => {
       expect(matchesPermission('stored-agents:share:agent-1', 'stored-agents:share:agent-2')).toBe(false);
     });
 
-    it('legacy stored:* does not match stored-agents:share (share is not in LEGACY_RESOURCE_EXPANSIONS scope)', () => {
-      // The legacy alias intentionally only covers actions that existed before the split.
-      // share is a new action; granting old `stored:*` should not silently grant share.
-      // Note: stored:* IS expanded to stored-agents:* via LEGACY_RESOURCE_EXPANSIONS, which
-      // matches share via the resource wildcard. This test documents the current behavior.
-      // If share-via-legacy-wildcard becomes a concern, tighten LEGACY_RESOURCE_EXPANSIONS.
+    it('granted stored:* matches stored-agents:share via compound expansion + resource wildcard', () => {
+      // stored:* expands to stored-agents:* (et al.) via RESOURCE_EXPANSIONS, and the
+      // resource wildcard then matches the share action. This test documents the current
+      // behavior; if share-via-compound-wildcard becomes a concern, tighten RESOURCE_EXPANSIONS.
       expect(matchesPermission('stored:*', 'stored-agents:share')).toBe(true);
     });
   });

--- a/packages/core/src/auth/ee/defaults/roles.test.ts
+++ b/packages/core/src/auth/ee/defaults/roles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { matchesPermission } from './roles';
+import { DEFAULT_ROLES, matchesPermission, resolvePermissions } from './roles';
 
 describe('matchesPermission', () => {
   describe('legacy stored:* backwards compatibility', () => {
@@ -47,6 +47,80 @@ describe('matchesPermission', () => {
 
     it('granted stored:read:my-agent does not match different id', () => {
       expect(matchesPermission('stored:read:my-agent', 'stored-agents:read:other')).toBe(false);
+    });
+  });
+
+  describe('share action', () => {
+    it('granted *:share matches stored-agents:share', () => {
+      expect(matchesPermission('*:share', 'stored-agents:share')).toBe(true);
+    });
+
+    it('granted *:share matches stored-skills:share', () => {
+      expect(matchesPermission('*:share', 'stored-skills:share')).toBe(true);
+    });
+
+    it('granted stored-agents:share matches stored-agents:share', () => {
+      expect(matchesPermission('stored-agents:share', 'stored-agents:share')).toBe(true);
+    });
+
+    it('granted stored-agents:share does not match stored-skills:share (cross-family)', () => {
+      expect(matchesPermission('stored-agents:share', 'stored-skills:share')).toBe(false);
+    });
+
+    it('granted stored-agents:write does not match stored-agents:share', () => {
+      expect(matchesPermission('stored-agents:write', 'stored-agents:share')).toBe(false);
+    });
+
+    it('granted *:write does not match stored-agents:share', () => {
+      expect(matchesPermission('*:write', 'stored-agents:share')).toBe(false);
+    });
+
+    it('granted *:publish does not match stored-agents:share', () => {
+      expect(matchesPermission('*:publish', 'stored-agents:share')).toBe(false);
+    });
+
+    it('granted stored-agents:share:agent-1 matches stored-agents:share:agent-1', () => {
+      expect(matchesPermission('stored-agents:share:agent-1', 'stored-agents:share:agent-1')).toBe(true);
+    });
+
+    it('granted stored-agents:share:agent-1 does not match stored-agents:share:agent-2', () => {
+      expect(matchesPermission('stored-agents:share:agent-1', 'stored-agents:share:agent-2')).toBe(false);
+    });
+
+    it('legacy stored:* does not match stored-agents:share (share is not in LEGACY_RESOURCE_EXPANSIONS scope)', () => {
+      // The legacy alias intentionally only covers actions that existed before the split.
+      // share is a new action; granting old `stored:*` should not silently grant share.
+      // Note: stored:* IS expanded to stored-agents:* via LEGACY_RESOURCE_EXPANSIONS, which
+      // matches share via the resource wildcard. This test documents the current behavior.
+      // If share-via-legacy-wildcard becomes a concern, tighten LEGACY_RESOURCE_EXPANSIONS.
+      expect(matchesPermission('stored:*', 'stored-agents:share')).toBe(true);
+    });
+  });
+
+  describe('default admin role', () => {
+    it('admin includes *:share', () => {
+      const admin = DEFAULT_ROLES.find(r => r.id === 'admin');
+      expect(admin?.permissions).toContain('*:share');
+    });
+
+    it('resolved admin permissions cover stored-agents:share', () => {
+      const perms = resolvePermissions(['admin']);
+      expect(perms.some(p => matchesPermission(p, 'stored-agents:share'))).toBe(true);
+    });
+
+    it('resolved admin permissions cover stored-skills:share', () => {
+      const perms = resolvePermissions(['admin']);
+      expect(perms.some(p => matchesPermission(p, 'stored-skills:share'))).toBe(true);
+    });
+
+    it('member role does NOT cover stored-agents:share', () => {
+      const perms = resolvePermissions(['member']);
+      expect(perms.some(p => matchesPermission(p, 'stored-agents:share'))).toBe(false);
+    });
+
+    it('viewer role does NOT cover stored-agents:share', () => {
+      const perms = resolvePermissions(['viewer']);
+      expect(perms.some(p => matchesPermission(p, 'stored-agents:share'))).toBe(false);
     });
   });
 });

--- a/packages/core/src/auth/ee/defaults/roles.ts
+++ b/packages/core/src/auth/ee/defaults/roles.ts
@@ -37,6 +37,7 @@ export const DEFAULT_ROLES: RoleDefinition[] = [
       '*:write',
       '*:execute',
       '*:publish',
+      '*:share',
       // Note: admins cannot delete resources
     ],
   },

--- a/packages/core/src/auth/ee/defaults/roles.ts
+++ b/packages/core/src/auth/ee/defaults/roles.ts
@@ -108,11 +108,11 @@ export function resolvePermissions(roleIds: string[], roles: RoleDefinition[] = 
 }
 
 /**
- * @deprecated Legacy resource keys that were split into per-family resources.
+ * Compound resource keys that expand to a set of per-family resources.
  * A granted `stored:<action>` is treated as matching any `stored-<family>:<action>`
- * (and `stored:*` matches any `stored-<family>:*`). Remove in the next major.
+ * (and `stored:*` matches any `stored-<family>:*`).
  */
-const LEGACY_RESOURCE_EXPANSIONS: Record<string, readonly string[]> = {
+const RESOURCE_EXPANSIONS: Record<string, readonly string[]> = {
   stored: [
     'stored-agents',
     'stored-mcp-clients',
@@ -149,10 +149,10 @@ export function matchesPermission(userPermission: string, requiredPermission: st
   const grantedParts = userPermission.split(':');
   const requiredParts = requiredPermission.split(':');
 
-  // Legacy alias: expand granted `stored:<action>` into its current per-family equivalents.
-  // Only applies when the required permission targets one of the split families.
-  const legacyFamilies = LEGACY_RESOURCE_EXPANSIONS[grantedParts[0] ?? ''];
-  if (legacyFamilies && legacyFamilies.includes(requiredParts[0] ?? '')) {
+  // Compound resource alias: expand granted `stored:<action>` into its per-family equivalents.
+  // Only applies when the required permission targets one of the expanded families.
+  const expandedFamilies = RESOURCE_EXPANSIONS[grantedParts[0] ?? ''];
+  if (expandedFamilies && expandedFamilies.includes(requiredParts[0] ?? '')) {
     const aliased = [requiredParts[0], ...grantedParts.slice(1)].join(':');
     return matchesPermission(aliased, requiredPermission);
   }

--- a/packages/core/src/auth/ee/defaults/roles.ts
+++ b/packages/core/src/auth/ee/defaults/roles.ts
@@ -36,6 +36,7 @@ export const DEFAULT_ROLES: RoleDefinition[] = [
       '*:read',
       '*:write',
       '*:execute',
+      '*:publish',
       // Note: admins cannot delete resources
     ],
   },
@@ -106,6 +107,22 @@ export function resolvePermissions(roleIds: string[], roles: RoleDefinition[] = 
 }
 
 /**
+ * @deprecated Legacy resource keys that were split into per-family resources.
+ * A granted `stored:<action>` is treated as matching any `stored-<family>:<action>`
+ * (and `stored:*` matches any `stored-<family>:*`). Remove in the next major.
+ */
+const LEGACY_RESOURCE_EXPANSIONS: Record<string, readonly string[]> = {
+  stored: [
+    'stored-agents',
+    'stored-mcp-clients',
+    'stored-prompt-blocks',
+    'stored-scorers',
+    'stored-skills',
+    'stored-workspaces',
+  ],
+};
+
+/**
  * Check if a permission matches (including wildcard support).
  *
  * Permission format: `{resource}:{action}[:{resource-id}]`
@@ -130,6 +147,14 @@ export function matchesPermission(userPermission: string, requiredPermission: st
 
   const grantedParts = userPermission.split(':');
   const requiredParts = requiredPermission.split(':');
+
+  // Legacy alias: expand granted `stored:<action>` into its current per-family equivalents.
+  // Only applies when the required permission targets one of the split families.
+  const legacyFamilies = LEGACY_RESOURCE_EXPANSIONS[grantedParts[0] ?? ''];
+  if (legacyFamilies && legacyFamilies.includes(requiredParts[0] ?? '')) {
+    const aliased = [requiredParts[0], ...grantedParts.slice(1)].join(':');
+    return matchesPermission(aliased, requiredPermission);
+  }
 
   // Must have at least resource:action
   if (grantedParts.length < 2 || requiredParts.length < 2) {

--- a/packages/core/src/auth/ee/interfaces/permissions.generated.ts
+++ b/packages/core/src/auth/ee/interfaces/permissions.generated.ts
@@ -26,8 +26,12 @@ export const RESOURCES = [
   'processor-providers',
   'processors',
   'scores',
-  'stored',
   'stored-agents',
+  'stored-mcp-clients',
+  'stored-prompt-blocks',
+  'stored-scorers',
+  'stored-skills',
+  'stored-workspaces',
   'system',
   'tool-providers',
   'tools',
@@ -51,7 +55,7 @@ export type Resource = (typeof RESOURCES)[number];
  * - DELETE → delete
  * - Additional actions from explicit requiresPermission overrides
  */
-export const ACTIONS = ['create', 'delete', 'execute', 'read', 'write'] as const;
+export const ACTIONS = ['create', 'delete', 'execute', 'publish', 'read', 'write'] as const;
 
 /**
  * Action type union.
@@ -71,6 +75,8 @@ export const PERMISSION_PATTERNS = {
   '*:delete': '*:delete',
   /** Execute all resources */
   '*:execute': '*:execute',
+  /** Publish, activate, or restore all resources */
+  '*:publish': '*:publish',
   /** View all resources */
   '*:read': '*:read',
   /** Create and modify all resources */
@@ -103,10 +109,18 @@ export const PERMISSION_PATTERNS = {
   'processors:*': 'processors:*',
   /** Full access to evaluation scores */
   'scores:*': 'scores:*',
-  /** Full access to stored */
-  'stored:*': 'stored:*',
   /** Full access to stored agents */
   'stored-agents:*': 'stored-agents:*',
+  /** Full access to stored MCP clients */
+  'stored-mcp-clients:*': 'stored-mcp-clients:*',
+  /** Full access to stored prompt blocks */
+  'stored-prompt-blocks:*': 'stored-prompt-blocks:*',
+  /** Full access to stored scorers */
+  'stored-scorers:*': 'stored-scorers:*',
+  /** Full access to stored skills */
+  'stored-skills:*': 'stored-skills:*',
+  /** Full access to stored workspaces */
+  'stored-workspaces:*': 'stored-workspaces:*',
   /** Full access to system info */
   'system:*': 'system:*',
   /** Full access to tool-providers */
@@ -187,16 +201,50 @@ export const PERMISSION_PATTERNS = {
   'scores:write': 'scores:write',
   /** Delete stored agents */
   'stored-agents:delete': 'stored-agents:delete',
+  /** Publish, activate, or restore stored agents */
+  'stored-agents:publish': 'stored-agents:publish',
   /** View stored agents */
   'stored-agents:read': 'stored-agents:read',
   /** Create and modify stored agents */
   'stored-agents:write': 'stored-agents:write',
-  /** Delete stored */
-  'stored:delete': 'stored:delete',
-  /** View stored */
-  'stored:read': 'stored:read',
-  /** Create and modify stored */
-  'stored:write': 'stored:write',
+  /** Delete stored MCP clients */
+  'stored-mcp-clients:delete': 'stored-mcp-clients:delete',
+  /** Publish, activate, or restore stored MCP clients */
+  'stored-mcp-clients:publish': 'stored-mcp-clients:publish',
+  /** View stored MCP clients */
+  'stored-mcp-clients:read': 'stored-mcp-clients:read',
+  /** Create and modify stored MCP clients */
+  'stored-mcp-clients:write': 'stored-mcp-clients:write',
+  /** Delete stored prompt blocks */
+  'stored-prompt-blocks:delete': 'stored-prompt-blocks:delete',
+  /** Publish, activate, or restore stored prompt blocks */
+  'stored-prompt-blocks:publish': 'stored-prompt-blocks:publish',
+  /** View stored prompt blocks */
+  'stored-prompt-blocks:read': 'stored-prompt-blocks:read',
+  /** Create and modify stored prompt blocks */
+  'stored-prompt-blocks:write': 'stored-prompt-blocks:write',
+  /** Delete stored scorers */
+  'stored-scorers:delete': 'stored-scorers:delete',
+  /** Publish, activate, or restore stored scorers */
+  'stored-scorers:publish': 'stored-scorers:publish',
+  /** View stored scorers */
+  'stored-scorers:read': 'stored-scorers:read',
+  /** Create and modify stored scorers */
+  'stored-scorers:write': 'stored-scorers:write',
+  /** Delete stored skills */
+  'stored-skills:delete': 'stored-skills:delete',
+  /** Publish, activate, or restore stored skills */
+  'stored-skills:publish': 'stored-skills:publish',
+  /** View stored skills */
+  'stored-skills:read': 'stored-skills:read',
+  /** Create and modify stored skills */
+  'stored-skills:write': 'stored-skills:write',
+  /** Delete stored workspaces */
+  'stored-workspaces:delete': 'stored-workspaces:delete',
+  /** View stored workspaces */
+  'stored-workspaces:read': 'stored-workspaces:read',
+  /** Create and modify stored workspaces */
+  'stored-workspaces:write': 'stored-workspaces:write',
   /** View system info */
   'system:read': 'system:read',
   /** View tool-providers */
@@ -229,6 +277,26 @@ export const PERMISSION_PATTERNS = {
   'workspaces:read': 'workspaces:read',
   /** Create and modify workspaces */
   'workspaces:write': 'workspaces:write',
+  /**
+   * Full access to all stored-* resources (use stored-agents:*, stored-skills:*, stored-prompt-blocks:*, stored-mcp-clients:*, stored-scorers:*, stored-workspaces:*)
+   * @deprecated Use the per-family stored-* resource instead. Will be removed in the next major release.
+   */
+  'stored:*': 'stored:*',
+  /**
+   * View stored-* resources (use stored-<family>:read instead)
+   * @deprecated Use the per-family stored-* resource instead. Will be removed in the next major release.
+   */
+  'stored:read': 'stored:read',
+  /**
+   * Create and modify stored-* resources (use stored-<family>:write instead)
+   * @deprecated Use the per-family stored-* resource instead. Will be removed in the next major release.
+   */
+  'stored:write': 'stored:write',
+  /**
+   * Delete stored-* resources (use stored-<family>:delete instead)
+   * @deprecated Use the per-family stored-* resource instead. Will be removed in the next major release.
+   */
+  'stored:delete': 'stored:delete',
 } as const;
 
 /**
@@ -278,11 +346,28 @@ export const PERMISSIONS = [
   'scores:read',
   'scores:write',
   'stored-agents:delete',
+  'stored-agents:publish',
   'stored-agents:read',
   'stored-agents:write',
-  'stored:delete',
-  'stored:read',
-  'stored:write',
+  'stored-mcp-clients:delete',
+  'stored-mcp-clients:publish',
+  'stored-mcp-clients:read',
+  'stored-mcp-clients:write',
+  'stored-prompt-blocks:delete',
+  'stored-prompt-blocks:publish',
+  'stored-prompt-blocks:read',
+  'stored-prompt-blocks:write',
+  'stored-scorers:delete',
+  'stored-scorers:publish',
+  'stored-scorers:read',
+  'stored-scorers:write',
+  'stored-skills:delete',
+  'stored-skills:publish',
+  'stored-skills:read',
+  'stored-skills:write',
+  'stored-workspaces:delete',
+  'stored-workspaces:read',
+  'stored-workspaces:write',
   'system:read',
   'tool-providers:read',
   'tools:execute',

--- a/packages/core/src/auth/ee/interfaces/permissions.generated.ts
+++ b/packages/core/src/auth/ee/interfaces/permissions.generated.ts
@@ -55,7 +55,7 @@ export type Resource = (typeof RESOURCES)[number];
  * - DELETE → delete
  * - Additional actions from explicit requiresPermission overrides
  */
-export const ACTIONS = ['create', 'delete', 'execute', 'publish', 'read', 'write'] as const;
+export const ACTIONS = ['create', 'delete', 'execute', 'publish', 'read', 'share', 'write'] as const;
 
 /**
  * Action type union.
@@ -79,6 +79,8 @@ export const PERMISSION_PATTERNS = {
   '*:publish': '*:publish',
   /** View all resources */
   '*:read': '*:read',
+  /** Change visibility/audience (e.g. private↔public) all resources */
+  '*:share': '*:share',
   /** Create and modify all resources */
   '*:write': '*:write',
   /** Full access to agent-to-agent communication */
@@ -205,6 +207,8 @@ export const PERMISSION_PATTERNS = {
   'stored-agents:publish': 'stored-agents:publish',
   /** View stored agents */
   'stored-agents:read': 'stored-agents:read',
+  /** Change visibility/audience (e.g. private↔public) stored agents */
+  'stored-agents:share': 'stored-agents:share',
   /** Create and modify stored agents */
   'stored-agents:write': 'stored-agents:write',
   /** Delete stored MCP clients */
@@ -237,6 +241,8 @@ export const PERMISSION_PATTERNS = {
   'stored-skills:publish': 'stored-skills:publish',
   /** View stored skills */
   'stored-skills:read': 'stored-skills:read',
+  /** Change visibility/audience (e.g. private↔public) stored skills */
+  'stored-skills:share': 'stored-skills:share',
   /** Create and modify stored skills */
   'stored-skills:write': 'stored-skills:write',
   /** Delete stored workspaces */
@@ -348,6 +354,7 @@ export const PERMISSIONS = [
   'stored-agents:delete',
   'stored-agents:publish',
   'stored-agents:read',
+  'stored-agents:share',
   'stored-agents:write',
   'stored-mcp-clients:delete',
   'stored-mcp-clients:publish',
@@ -364,6 +371,7 @@ export const PERMISSIONS = [
   'stored-skills:delete',
   'stored-skills:publish',
   'stored-skills:read',
+  'stored-skills:share',
   'stored-skills:write',
   'stored-workspaces:delete',
   'stored-workspaces:read',

--- a/packages/core/src/auth/ee/interfaces/permissions.generated.ts
+++ b/packages/core/src/auth/ee/interfaces/permissions.generated.ts
@@ -283,25 +283,13 @@ export const PERMISSION_PATTERNS = {
   'workspaces:read': 'workspaces:read',
   /** Create and modify workspaces */
   'workspaces:write': 'workspaces:write',
-  /**
-   * Full access to all stored-* resources (use stored-agents:*, stored-skills:*, stored-prompt-blocks:*, stored-mcp-clients:*, stored-scorers:*, stored-workspaces:*)
-   * @deprecated Use the per-family stored-* resource instead. Will be removed in the next major release.
-   */
+  /** Full access to all stored-* resources (stored-agents, stored-skills, stored-prompt-blocks, stored-mcp-clients, stored-scorers, stored-workspaces) */
   'stored:*': 'stored:*',
-  /**
-   * View stored-* resources (use stored-<family>:read instead)
-   * @deprecated Use the per-family stored-* resource instead. Will be removed in the next major release.
-   */
+  /** View any stored-* resource */
   'stored:read': 'stored:read',
-  /**
-   * Create and modify stored-* resources (use stored-<family>:write instead)
-   * @deprecated Use the per-family stored-* resource instead. Will be removed in the next major release.
-   */
+  /** Create and modify any stored-* resource */
   'stored:write': 'stored:write',
-  /**
-   * Delete stored-* resources (use stored-<family>:delete instead)
-   * @deprecated Use the per-family stored-* resource instead. Will be removed in the next major release.
-   */
+  /** Delete any stored-* resource */
   'stored:delete': 'stored:delete',
 } as const;
 

--- a/packages/playground/src/domains/auth/route-permissions.ts
+++ b/packages/playground/src/domains/auth/route-permissions.ts
@@ -48,7 +48,7 @@ export type RoutePermission = {
  * Common gotchas the types will catch:
  * - 'mcp' not 'mcps' (UI route is /mcps but resource is 'mcp')
  * - 'scores' not 'scorers' (UI route is /scorers but resource is 'scores')
- * - 'stored' for prompts (uses /stored/prompt-blocks routes)
+ * - 'stored-prompt-blocks' for prompts (uses /stored/prompt-blocks routes)
  */
 export const ROUTE_PERMISSIONS: RoutePermission[] = [
   // Primary routes (highest priority for redirects)
@@ -70,7 +70,7 @@ export const ROUTE_PERMISSIONS: RoutePermission[] = [
   { route: '/tools', permission: P('tools:read'), name: 'Tools' },
   { route: '/mcps', permission: P('mcp:read'), name: 'MCP Servers' },
   { route: '/processors', permission: P('processors:read'), name: 'Processors' },
-  { route: '/prompts', permission: P('stored:read'), name: 'Prompts' },
+  { route: '/prompts', permission: P('stored-prompt-blocks:read'), name: 'Prompts' },
   { route: '/workspaces', permission: P('workspaces:read'), name: 'Workspaces' },
 
   // UI-only pages (no corresponding API resource) - marked as public

--- a/packages/server/scripts/check-permissions.ts
+++ b/packages/server/scripts/check-permissions.ts
@@ -12,7 +12,12 @@ import * as fs from 'node:fs';
 
 import { SERVER_ROUTES } from '../src/server/server-adapter/routes/index.js';
 import { getEffectivePermission } from '../src/server/server-adapter/routes/permissions.js';
-import { OUTPUT_PATH, derivePermissionData, generatePermissionFileContent } from './permission-generator.js';
+import {
+  ASSERTION_ONLY_PERMISSIONS,
+  OUTPUT_PATH,
+  derivePermissionData,
+  generatePermissionFileContent,
+} from './permission-generator.js';
 
 const data = derivePermissionData();
 const generatedContent = generatePermissionFileContent(data);
@@ -35,9 +40,13 @@ for (const route of SERVER_ROUTES) {
   }
 }
 
-// Check for permissions in generated that aren't from routes
+// Check for permissions in generated that aren't from routes.
+// Assertion-only permissions (e.g. `stored-agents:share`) are intentionally
+// not derivable from any route — they're enforced in handler code via helpers
+// like `assertShareAccess` — so exclude them from the "Extra" check.
+const assertionOnly = new Set<string>(ASSERTION_ONLY_PERMISSIONS);
 for (const perm of generatedPermissions) {
-  if (!runtimePermissions.has(perm)) {
+  if (!runtimePermissions.has(perm) && !assertionOnly.has(perm)) {
     mismatches.push(`Extra: ${perm} (not from any route)`);
   }
 }

--- a/packages/server/scripts/permission-generator.ts
+++ b/packages/server/scripts/permission-generator.ts
@@ -23,6 +23,7 @@ export const OUTPUT_PATH = path.join(__dirname, '../../core/src/auth/ee/interfac
 const ACTION_DESCRIPTIONS: Record<string, string> = {
   delete: 'Delete',
   execute: 'Execute',
+  publish: 'Publish, activate, or restore',
   read: 'View',
   write: 'Create and modify',
 };
@@ -39,11 +40,33 @@ const RESOURCE_DESCRIPTIONS: Record<string, string> = {
   processors: 'processors',
   scores: 'evaluation scores',
   'stored-agents': 'stored agents',
+  'stored-mcp-clients': 'stored MCP clients',
+  'stored-prompt-blocks': 'stored prompt blocks',
+  'stored-scorers': 'stored scorers',
+  'stored-skills': 'stored skills',
+  'stored-workspaces': 'stored workspaces',
   system: 'system info',
   tools: 'tools',
   vector: 'vector stores',
   workflows: 'workflows',
   workspaces: 'workspaces',
+};
+
+/**
+ * Legacy permission patterns kept for backward compatibility.
+ * These were released in @mastra/core 1.11.0 – 1.27.0 before `stored` was
+ * split into per-family resources (stored-agents, stored-skills, ...).
+ *
+ * Emitted in PERMISSION_PATTERNS with `@deprecated` TSDoc so existing role
+ * configs keep type-checking. Runtime matching in matchesPermission expands
+ * `stored:<action>` to each `stored-<family>:<action>`.
+ */
+const LEGACY_PATTERNS: Record<string, string> = {
+  'stored:*':
+    'Full access to all stored-* resources (use stored-agents:*, stored-skills:*, stored-prompt-blocks:*, stored-mcp-clients:*, stored-scorers:*, stored-workspaces:*)',
+  'stored:read': 'View stored-* resources (use stored-<family>:read instead)',
+  'stored:write': 'Create and modify stored-* resources (use stored-<family>:write instead)',
+  'stored:delete': 'Delete stored-* resources (use stored-<family>:delete instead)',
 };
 
 /**
@@ -128,6 +151,16 @@ export function generatePermissionFileContent(data: PermissionData): string {
     })
     .join(',\n');
 
+  // Legacy patterns: kept for backward compatibility with pre-split releases.
+  // Skip any that collide with a current pattern (none today, but guard against regressions).
+  const legacyEntries = Object.entries(LEGACY_PATTERNS)
+    .filter(([pattern]) => !allPatterns.includes(pattern))
+    .map(
+      ([pattern, desc]) =>
+        `  /**\n   * ${desc}\n   * @deprecated Use the per-family stored-* resource instead. Will be removed in the next major release.\n   */\n  '${pattern}': '${pattern}'`,
+    )
+    .join(',\n');
+
   return `/**
  * AUTO-GENERATED FILE - DO NOT EDIT DIRECTLY
  *
@@ -171,7 +204,7 @@ export type Action = (typeof ACTIONS)[number];
  * Use \`keyof typeof PERMISSION_PATTERNS\` or the \`PermissionPattern\` type.
  */
 export const PERMISSION_PATTERNS = {
-${patternEntries},
+${patternEntries},${legacyEntries ? `\n${legacyEntries},` : ''}
 } as const;
 
 /**

--- a/packages/server/scripts/permission-generator.ts
+++ b/packages/server/scripts/permission-generator.ts
@@ -62,20 +62,18 @@ const RESOURCE_DESCRIPTIONS: Record<string, string> = {
 };
 
 /**
- * Legacy permission patterns kept for backward compatibility.
- * These were released in @mastra/core 1.11.0 – 1.27.0 before `stored` was
- * split into per-family resources (stored-agents, stored-skills, ...).
+ * Compound permission patterns that expand across the per-family stored resources.
  *
- * Emitted in PERMISSION_PATTERNS with `@deprecated` TSDoc so existing role
- * configs keep type-checking. Runtime matching in matchesPermission expands
- * `stored:<action>` to each `stored-<family>:<action>`.
+ * Emitted in PERMISSION_PATTERNS so role configs can grant the broad form. Runtime
+ * matching in matchesPermission expands `stored:<action>` to each
+ * `stored-<family>:<action>`.
  */
-const LEGACY_PATTERNS: Record<string, string> = {
+const COMPOUND_PATTERNS: Record<string, string> = {
   'stored:*':
-    'Full access to all stored-* resources (use stored-agents:*, stored-skills:*, stored-prompt-blocks:*, stored-mcp-clients:*, stored-scorers:*, stored-workspaces:*)',
-  'stored:read': 'View stored-* resources (use stored-<family>:read instead)',
-  'stored:write': 'Create and modify stored-* resources (use stored-<family>:write instead)',
-  'stored:delete': 'Delete stored-* resources (use stored-<family>:delete instead)',
+    'Full access to all stored-* resources (stored-agents, stored-skills, stored-prompt-blocks, stored-mcp-clients, stored-scorers, stored-workspaces)',
+  'stored:read': 'View any stored-* resource',
+  'stored:write': 'Create and modify any stored-* resource',
+  'stored:delete': 'Delete any stored-* resource',
 };
 
 /**
@@ -170,14 +168,11 @@ export function generatePermissionFileContent(data: PermissionData): string {
     })
     .join(',\n');
 
-  // Legacy patterns: kept for backward compatibility with pre-split releases.
+  // Compound patterns: broad shorthand entries that expand across per-family resources at match time.
   // Skip any that collide with a current pattern (none today, but guard against regressions).
-  const legacyEntries = Object.entries(LEGACY_PATTERNS)
+  const compoundEntries = Object.entries(COMPOUND_PATTERNS)
     .filter(([pattern]) => !allPatterns.includes(pattern))
-    .map(
-      ([pattern, desc]) =>
-        `  /**\n   * ${desc}\n   * @deprecated Use the per-family stored-* resource instead. Will be removed in the next major release.\n   */\n  '${pattern}': '${pattern}'`,
-    )
+    .map(([pattern, desc]) => `  /** ${desc} */\n  '${pattern}': '${pattern}'`)
     .join(',\n');
 
   return `/**
@@ -223,7 +218,7 @@ export type Action = (typeof ACTIONS)[number];
  * Use \`keyof typeof PERMISSION_PATTERNS\` or the \`PermissionPattern\` type.
  */
 export const PERMISSION_PATTERNS = {
-${patternEntries},${legacyEntries ? `\n${legacyEntries},` : ''}
+${patternEntries},${compoundEntries ? `\n${compoundEntries},` : ''}
 } as const;
 
 /**

--- a/packages/server/scripts/permission-generator.ts
+++ b/packages/server/scripts/permission-generator.ts
@@ -25,8 +25,17 @@ const ACTION_DESCRIPTIONS: Record<string, string> = {
   execute: 'Execute',
   publish: 'Publish, activate, or restore',
   read: 'View',
+  share: 'Change visibility/audience (e.g. private↔public)',
   write: 'Create and modify',
 };
+
+/**
+ * Permissions that are not derived from any HTTP route (no `requiresPermission`,
+ * no method/path mapping) but are asserted in handler code via helpers like
+ * `assertShareAccess`. Seeded here so they appear in `PERMISSION_PATTERNS`
+ * and `PermissionPattern`, making them grantable in role configs.
+ */
+export const ASSERTION_ONLY_PERMISSIONS: readonly string[] = ['stored-agents:share', 'stored-skills:share'];
 
 /** Descriptions for resources (used for TSDoc comments in autocomplete) */
 const RESOURCE_DESCRIPTIONS: Record<string, string> = {
@@ -119,6 +128,16 @@ export function derivePermissionData(): PermissionData {
         actionSet.add(action);
         permissionSet.add(permission);
       }
+    }
+  }
+
+  // Seed assertion-only permissions (not derivable from any route).
+  for (const permission of ASSERTION_ONLY_PERMISSIONS) {
+    const [resource, action] = permission.split(':');
+    if (resource && action) {
+      resourceSet.add(resource);
+      actionSet.add(action);
+      permissionSet.add(permission);
     }
   }
 

--- a/packages/server/src/server/handlers/authorship.test.ts
+++ b/packages/server/src/server/handlers/authorship.test.ts
@@ -8,6 +8,7 @@ import {
   assertOwnership,
   assertExecuteAccess,
   assertReadAccess,
+  assertShareAccess,
   assertWriteAccess,
   getCallerAuthorId,
   hasAdminBypass,
@@ -463,6 +464,170 @@ describe('authorship', () => {
       const ctx = ctxWith({ [MASTRA_USER_KEY]: { id: 'a' } });
       expect(() =>
         assertOwnership({ requestContext: ctx, resource: 'stored-agents', record: { authorId: 'b' } }),
+      ).toThrow(HTTPException);
+    });
+  });
+
+  describe('assertShareAccess', () => {
+    it('passes when the record has no owner (legacy)', () => {
+      expect(() =>
+        assertShareAccess({
+          requestContext: new RequestContext(),
+          resource: 'stored-agents',
+          record: { authorId: null },
+        }),
+      ).not.toThrow();
+    });
+
+    it('passes when caller owns the record (creator can share their own)', () => {
+      const ctx = ctxWith({ [MASTRA_USER_KEY]: { id: 'me' } });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          record: { authorId: 'me', visibility: 'private' },
+        }),
+      ).not.toThrow();
+    });
+
+    it('passes with admin bypass (`*`)', () => {
+      const ctx = ctxWith({
+        [MASTRA_USER_KEY]: { id: 'admin' },
+        [MASTRA_USER_PERMISSIONS_KEY]: ['*'],
+      });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          record: { authorId: 'someone', visibility: 'private' },
+        }),
+      ).not.toThrow();
+    });
+
+    it('passes with admin bypass (`<resource>:*`)', () => {
+      const ctx = ctxWith({
+        [MASTRA_USER_KEY]: { id: 'admin' },
+        [MASTRA_USER_PERMISSIONS_KEY]: ['stored-agents:*'],
+      });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          record: { authorId: 'someone', visibility: 'private' },
+        }),
+      ).not.toThrow();
+    });
+
+    it('passes when caller holds `<resource>:share`', () => {
+      const ctx = ctxWith({
+        [MASTRA_USER_KEY]: { id: 'someone-else' },
+        [MASTRA_USER_PERMISSIONS_KEY]: ['stored-agents:share'],
+      });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
+      ).not.toThrow();
+    });
+
+    it('passes when caller holds `*:share`', () => {
+      const ctx = ctxWith({
+        [MASTRA_USER_KEY]: { id: 'someone-else' },
+        [MASTRA_USER_PERMISSIONS_KEY]: ['*:share'],
+      });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
+      ).not.toThrow();
+    });
+
+    it('passes when caller holds scoped `<resource>:share:<id>`', () => {
+      const ctx = ctxWith({
+        [MASTRA_USER_KEY]: { id: 'someone-else' },
+        [MASTRA_USER_PERMISSIONS_KEY]: ['stored-agents:share:a1'],
+      });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          resourceId: 'a1',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
+      ).not.toThrow();
+    });
+
+    it('rejects write-only caller (write does NOT imply share)', () => {
+      const ctx = ctxWith({
+        [MASTRA_USER_KEY]: { id: 'editor' },
+        [MASTRA_USER_PERMISSIONS_KEY]: ['stored-agents:write'],
+      });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
+      ).toThrow(HTTPException);
+    });
+
+    it('rejects `*:write` caller (action wildcard for write does NOT imply share)', () => {
+      const ctx = ctxWith({
+        [MASTRA_USER_KEY]: { id: 'editor' },
+        [MASTRA_USER_PERMISSIONS_KEY]: ['*:write'],
+      });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
+      ).toThrow(HTTPException);
+    });
+
+    it('rejects when record is `public` but caller has no share grant', () => {
+      // public visibility does not grant share access — being readable doesn't
+      // imply the right to change who else can read.
+      const ctx = ctxWith({ [MASTRA_USER_KEY]: { id: 'someone-else' } });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          record: { authorId: 'owner', visibility: 'public' },
+        }),
+      ).toThrow(HTTPException);
+    });
+
+    it('rejects scoped grant for a different resource id', () => {
+      const ctx = ctxWith({
+        [MASTRA_USER_KEY]: { id: 'someone-else' },
+        [MASTRA_USER_PERMISSIONS_KEY]: ['stored-agents:share:a2'],
+      });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          resourceId: 'a1',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
+      ).toThrow(HTTPException);
+    });
+
+    it('rejects share grant for a different resource family', () => {
+      const ctx = ctxWith({
+        [MASTRA_USER_KEY]: { id: 'someone-else' },
+        [MASTRA_USER_PERMISSIONS_KEY]: ['stored-skills:share'],
+      });
+      expect(() =>
+        assertShareAccess({
+          requestContext: ctx,
+          resource: 'stored-agents',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
       ).toThrow(HTTPException);
     });
   });

--- a/packages/server/src/server/handlers/authorship.ts
+++ b/packages/server/src/server/handlers/authorship.ts
@@ -291,6 +291,46 @@ export function assertWriteAccess(args: {
 }
 
 /**
+ * Asserts the caller has share access to the record. Throws 404 if not.
+ *
+ * Share access controls who can change a record's audience/visibility
+ * (e.g. flipping `private` ↔ `public`). It is intentionally separate from
+ * `write`: a caller with only `<resource>:write` MUST NOT be able to flip
+ * visibility — that would let any editor expose private records.
+ *
+ * Share access is granted when:
+ * - The record has no owner (legacy), OR
+ * - The caller owns the record (creators can share their own records), OR
+ * - The caller has admin bypass (`*`, `<resource>:*`, `<resource>:admin`), OR
+ * - The caller holds `<resource>:share` / `<resource>:share:<resourceId>`
+ *   (or any pattern that matches it, e.g. `*:share`).
+ *
+ * `visibility: 'public'` does NOT grant share access — being readable doesn't
+ * imply the right to change who else can read.
+ */
+export function assertShareAccess(args: {
+  requestContext: RequestContext;
+  resource: string;
+  resourceId?: string;
+  record: OwnedRecord;
+}): void {
+  const { requestContext, resource, resourceId, record } = args;
+  const owner = record.authorId ?? null;
+
+  if (owner === null) return;
+  if (hasAdminBypass(requestContext, resource)) return;
+
+  const callerAuthorId = getCallerAuthorId(requestContext);
+  if (callerAuthorId && callerAuthorId === owner) return;
+
+  if (hasScopedPermission({ requestContext, resource, action: 'share', resourceId })) {
+    return;
+  }
+
+  throw new HTTPException(404, { message: 'Not found' });
+}
+
+/**
  * Alias for `assertWriteAccess` with `action: 'edit'`. Prefer `assertWriteAccess`
  * in new code so the action is explicit.
  */

--- a/packages/server/src/server/server-adapter/routes/permissions.test.ts
+++ b/packages/server/src/server/server-adapter/routes/permissions.test.ts
@@ -105,6 +105,39 @@ describe('extractResource', () => {
       expect(extractResource('/stored/agents/:agentId')).toBe('stored-agents');
     });
 
+    it('should extract stored-skills from /stored/skills', () => {
+      expect(extractResource('/stored/skills')).toBe('stored-skills');
+    });
+
+    it('should extract stored-skills from /stored/skills/:skillId/publish', () => {
+      expect(extractResource('/stored/skills/:skillId/publish')).toBe('stored-skills');
+    });
+
+    it('should extract stored-prompt-blocks from /stored/prompt-blocks', () => {
+      expect(extractResource('/stored/prompt-blocks')).toBe('stored-prompt-blocks');
+    });
+
+    it('should extract stored-mcp-clients from /stored/mcp-clients', () => {
+      expect(extractResource('/stored/mcp-clients')).toBe('stored-mcp-clients');
+    });
+
+    it('should extract stored-scorers from /stored/scorers', () => {
+      expect(extractResource('/stored/scorers')).toBe('stored-scorers');
+    });
+
+    it('should extract stored-workspaces from /stored/workspaces', () => {
+      expect(extractResource('/stored/workspaces')).toBe('stored-workspaces');
+    });
+
+    it('should NOT collapse /stored/skills-archive into stored-skills', () => {
+      // Segment equality only; /stored/skills-archive is not a stored family.
+      expect(extractResource('/stored/skills-archive')).toBe('stored');
+    });
+
+    it('should return "stored" for unknown stored families', () => {
+      expect(extractResource('/stored/unknown-family')).toBe('stored');
+    });
+
     it('should extract a2a from /.well-known paths', () => {
       expect(extractResource('/.well-known/:agentId/agent-card.json')).toBe('a2a');
     });
@@ -236,6 +269,36 @@ describe('deriveAction', () => {
     });
   });
 
+  describe('POST publish action derivation', () => {
+    it('should derive publish for POST ending in /publish', () => {
+      expect(deriveAction('POST', '/stored/skills/:id/publish')).toBe('publish');
+    });
+
+    it('should derive publish for POST ending in /activate', () => {
+      expect(deriveAction('POST', '/stored/agents/:id/versions/:vid/activate')).toBe('publish');
+    });
+
+    it('should derive publish for POST ending in /restore', () => {
+      expect(deriveAction('POST', '/stored/agents/:id/versions/:vid/restore')).toBe('publish');
+    });
+
+    it('should derive publish for /restore on non-agent stored families', () => {
+      expect(deriveAction('POST', '/stored/prompt-blocks/:id/versions/:vid/restore')).toBe('publish');
+      expect(deriveAction('POST', '/stored/mcp-clients/:id/versions/:vid/restore')).toBe('publish');
+      expect(deriveAction('POST', '/stored/scorers/:id/versions/:vid/restore')).toBe('publish');
+    });
+
+    it('should NOT derive publish when suffix is not at the end', () => {
+      // /publish appears mid-path, not as terminal segment
+      expect(deriveAction('POST', '/stored/skills/publish/something')).toBe('write');
+    });
+
+    it('should prefer publish over execute if both could match', () => {
+      // Defensive: a hypothetical /activate path is treated as publish, not execute
+      expect(deriveAction('POST', '/stored/agents/:id/versions/:vid/activate')).toBe('publish');
+    });
+  });
+
   describe('case insensitivity', () => {
     it('should handle lowercase method', () => {
       expect(deriveAction('get', '/agents')).toBe('read');
@@ -317,6 +380,105 @@ describe('derivePermission', () => {
 
     it('should derive a2a:read for GET /.well-known/:agentId/agent-card.json', () => {
       expect(derivePermission({ path: '/.well-known/:agentId/agent-card.json', method: 'GET' })).toBe('a2a:read');
+    });
+  });
+
+  describe('stored-* resource families CRUD derivation', () => {
+    const families = [
+      { segment: 'agents', resource: 'stored-agents' },
+      { segment: 'skills', resource: 'stored-skills' },
+      { segment: 'prompt-blocks', resource: 'stored-prompt-blocks' },
+      { segment: 'mcp-clients', resource: 'stored-mcp-clients' },
+      { segment: 'scorers', resource: 'stored-scorers' },
+      { segment: 'workspaces', resource: 'stored-workspaces' },
+    ];
+
+    for (const { segment, resource } of families) {
+      describe(`/${segment} (${resource})`, () => {
+        it(`should derive ${resource}:read for GET /stored/${segment}`, () => {
+          expect(derivePermission({ path: `/stored/${segment}`, method: 'GET' })).toBe(`${resource}:read`);
+        });
+
+        it(`should derive ${resource}:read for GET /stored/${segment}/:id`, () => {
+          expect(derivePermission({ path: `/stored/${segment}/:id`, method: 'GET' })).toBe(`${resource}:read`);
+        });
+
+        it(`should derive ${resource}:write for POST /stored/${segment}`, () => {
+          expect(derivePermission({ path: `/stored/${segment}`, method: 'POST' })).toBe(`${resource}:write`);
+        });
+
+        it(`should derive ${resource}:write for PATCH /stored/${segment}/:id`, () => {
+          expect(derivePermission({ path: `/stored/${segment}/:id`, method: 'PATCH' })).toBe(`${resource}:write`);
+        });
+
+        it(`should derive ${resource}:delete for DELETE /stored/${segment}/:id`, () => {
+          expect(derivePermission({ path: `/stored/${segment}/:id`, method: 'DELETE' })).toBe(`${resource}:delete`);
+        });
+      });
+    }
+  });
+
+  describe('stored-* publish/activate/restore derivation', () => {
+    it('should derive stored-skills:publish for POST /stored/skills/:id/publish', () => {
+      expect(derivePermission({ path: '/stored/skills/:id/publish', method: 'POST' })).toBe('stored-skills:publish');
+    });
+
+    it('should derive stored-agents:publish for POST /stored/agents/:id/versions/:vid/activate', () => {
+      expect(derivePermission({ path: '/stored/agents/:id/versions/:vid/activate', method: 'POST' })).toBe(
+        'stored-agents:publish',
+      );
+    });
+
+    it('should derive stored-agents:publish for POST /stored/agents/:id/versions/:vid/restore', () => {
+      expect(derivePermission({ path: '/stored/agents/:id/versions/:vid/restore', method: 'POST' })).toBe(
+        'stored-agents:publish',
+      );
+    });
+
+    it('should derive stored-prompt-blocks:publish for /restore', () => {
+      expect(derivePermission({ path: '/stored/prompt-blocks/:id/versions/:vid/restore', method: 'POST' })).toBe(
+        'stored-prompt-blocks:publish',
+      );
+    });
+
+    it('should derive stored-mcp-clients:publish for /restore', () => {
+      expect(derivePermission({ path: '/stored/mcp-clients/:id/versions/:vid/restore', method: 'POST' })).toBe(
+        'stored-mcp-clients:publish',
+      );
+    });
+
+    it('should derive stored-scorers:publish for /restore', () => {
+      expect(derivePermission({ path: '/stored/scorers/:id/versions/:vid/restore', method: 'POST' })).toBe(
+        'stored-scorers:publish',
+      );
+    });
+
+    // Create-version routes: POST /stored/*/:id/versions → write (NOT publish)
+    it('should derive stored-agents:write for POST /stored/agents/:id/versions', () => {
+      expect(derivePermission({ path: '/stored/agents/:id/versions', method: 'POST' })).toBe('stored-agents:write');
+    });
+
+    it('should derive stored-prompt-blocks:write for POST /stored/prompt-blocks/:id/versions', () => {
+      expect(derivePermission({ path: '/stored/prompt-blocks/:id/versions', method: 'POST' })).toBe(
+        'stored-prompt-blocks:write',
+      );
+    });
+
+    it('should derive stored-mcp-clients:write for POST /stored/mcp-clients/:id/versions', () => {
+      expect(derivePermission({ path: '/stored/mcp-clients/:id/versions', method: 'POST' })).toBe(
+        'stored-mcp-clients:write',
+      );
+    });
+
+    it('should derive stored-scorers:write for POST /stored/scorers/:id/versions', () => {
+      expect(derivePermission({ path: '/stored/scorers/:id/versions', method: 'POST' })).toBe('stored-scorers:write');
+    });
+
+    // preview-instructions should NOT derive to publish
+    it('should derive stored-agents:write for POST /stored/agents/preview-instructions', () => {
+      expect(derivePermission({ path: '/stored/agents/preview-instructions', method: 'POST' })).toBe(
+        'stored-agents:write',
+      );
     });
   });
 

--- a/packages/server/src/server/server-adapter/routes/permissions.ts
+++ b/packages/server/src/server/server-adapter/routes/permissions.ts
@@ -48,6 +48,18 @@ const EXECUTE_PATTERNS = [
 ];
 
 /**
+ * Path suffixes that indicate a "publish" action for POST requests.
+ * These are version-activation / rollback / publish operations on stored resources.
+ */
+const PUBLISH_PATTERNS = ['/publish', '/activate', '/restore'];
+
+/**
+ * Stored resource families that map `/stored/<family>` to `stored-<family>`.
+ * Order matters: longest/most specific matches first via segment equality.
+ */
+const STORED_RESOURCE_FAMILIES = ['agents', 'skills', 'prompt-blocks', 'mcp-clients', 'scorers', 'workspaces'] as const;
+
+/**
  * Extracts the primary resource name from a route path.
  *
  * The resource is derived from the first path segment, with special handling
@@ -63,6 +75,7 @@ const EXECUTE_PATTERNS = [
  * extractResource('/agents/:agentId') // → 'agents'
  * extractResource('/memory/threads/:threadId') // → 'memory'
  * extractResource('/stored/agents/:agentId') // → 'stored-agents'
+ * extractResource('/stored/skills/:skillId') // → 'stored-skills'
  */
 export function extractResource(path: string): string | null {
   // Remove leading slash and split by segments
@@ -74,9 +87,14 @@ export function extractResource(path: string): string | null {
 
   const firstSegment = segments[0];
 
-  // Handle special case: /stored/agents → 'stored-agents'
-  if (firstSegment === 'stored' && segments[1] === 'agents') {
-    return 'stored-agents';
+  // Handle special case: /stored/<family> → 'stored-<family>'
+  // Uses exact segment match (not startsWith) so paths like /stored/skills-archive
+  // don't incorrectly collapse into a stored family.
+  if (firstSegment === 'stored' && segments.length > 1) {
+    const family = segments[1];
+    if (family && (STORED_RESOURCE_FAMILIES as readonly string[]).includes(family)) {
+      return `stored-${family}`;
+    }
   }
 
   // Handle .well-known paths (A2A protocol)
@@ -97,8 +115,14 @@ export function extractResource(path: string): string | null {
 export function deriveAction(method: string, path: string): string {
   const upperMethod = method.toUpperCase();
 
-  // For POST requests, check if it's an execute operation
+  // For POST requests, check if it's a publish, execute, or write operation.
+  // Publish takes precedence over execute since these suffixes are distinct
+  // version-lifecycle operations on stored resources.
   if (upperMethod === 'POST') {
+    const isPublishOperation = PUBLISH_PATTERNS.some(pattern => path.endsWith(pattern));
+    if (isPublishOperation) {
+      return 'publish';
+    }
     const isExecuteOperation = EXECUTE_PATTERNS.some(pattern => path.includes(pattern));
     return isExecuteOperation ? 'execute' : 'write';
   }


### PR DESCRIPTION
Rebased version of #15750 (which had unresolvable conflicts against the new base).

## What this ships

### 1. \`publish\` permission action
New \`publish\` action gates version-lifecycle routes (\`/publish\`, \`/activate\`, \`/restore\`), letting admins delegate version activation without granting full \`write\`.

### 2. Stored resource split
The catch-all \`stored\` resource is split into per-family permissions so roles can grant CRUD separately:
- \`stored-agents\`, \`stored-skills\`, \`stored-prompt-blocks\`, \`stored-mcp-clients\`, \`stored-scorers\`, \`stored-workspaces\`

Legacy \`stored:read\` / \`stored:write\` / \`stored:delete\` / \`stored:*\` grants still resolve via a deprecation alias in \`matchesPermission\`, so existing role configs keep working.

### 3. \`share\` permission action
Separate \`share\` action gates \`visibility\` transitions (private↔public) on stored resources. Write-only callers cannot flip visibility — that is intentionally a different permission than \`write\`.

- Owner bypass: identity-based (creators can share their own records)
- Admin bypass: \`*:share\` wildcard
- Explicit grants: \`stored-agents:share\`, \`stored-skills:share\`
- \`public\` visibility does NOT grant share access

\`assertShareAccess\` helper is added to \`authorship.ts\` for handlers to call on visibility change. Handler wiring into \`UPDATE_STORED_*_ROUTE\` is a follow-up.

## Files
- \`packages/server/scripts/permission-generator.ts\` — \`publish\` + \`share\` action descriptions, \`stored-*\` resource descriptions, \`LEGACY_PATTERNS\`, \`ASSERTION_ONLY_PERMISSIONS\`
- \`packages/server/scripts/check-permissions.ts\` — exclude assertion-only perms from \"Extra\" diff
- \`packages/server/src/server/server-adapter/routes/permissions.ts\` — \`PUBLISH_PATTERNS\`, \`STORED_RESOURCE_FAMILIES\`, segment-based \`extractResource\`
- \`packages/server/src/server/handlers/authorship.ts\` — \`assertShareAccess\` helper
- \`packages/core/src/auth/ee/defaults/roles.ts\` — \`*:publish\` and \`*:share\` on admin, \`LEGACY_RESOURCE_EXPANSIONS\`
- \`packages/core/src/auth/ee/interfaces/permissions.generated.ts\` — regenerated (27 resources, 7 actions, 73 combos)
- \`packages/playground/src/domains/auth/route-permissions.ts\` — \`stored:*\` → \`stored-<family>:*\`
- Tests: \`roles.test.ts\` (49), \`authorship.test.ts\` (+ assertShareAccess), \`permissions.test.ts\` (extended)

## Verification
- \`pnpm --filter ./packages/server check:permissions\` ✓
- \`pnpm --filter ./packages/server test\` — 1207 pass
- \`pnpm --filter ./packages/core test -- src/auth/ee/defaults/roles.test.ts\` — 49 pass

## Notes
- Closes #15750
- BC: legacy \`stored:*\` keeps working via deprecation alias

🤖 Generated with [Mastra Code](https://mastra.ai)