### PR TITLE
Fix deployer generated server entry bundling

### DIFF
--- a/.changeset/swift-jokes-say.md
+++ b/.changeset/swift-jokes-say.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed deployer bundling for generated server entries.

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -223,7 +223,7 @@ export abstract class Bundler extends MastraBundler {
       },
       { sourcemap: enableSourcemap, workspaceRoot, projectRoot, enableEsmShim, externalsPreset: externals === true },
     );
-    const isVirtual = serverFile.includes('\n') || existsSync(serverFile);
+    const isVirtual = serverFile.includes('\n') || !existsSync(serverFile);
 
     const toolsInputOptions = await this.listToolsInputOptions(toolsPaths);
 


### PR DESCRIPTION
## Summary
- Fix deployer bundling for generated server entries by treating missing server entry paths as virtual files.
- Add a patch changeset for @mastra/deployer.

## Why
Generated server entries can be passed as content or paths that do not exist on disk yet. These entries need to be handled as virtual modules so the deployer can bundle them correctly.

## Test plan
- pnpm --filter @mastra/deployer lint
- pnpm --filter @mastra/deployer test -- --runInBand
- pnpm exec tsc --noEmit -p packages/deployer/tsconfig.json