### PR TITLE
ci: harden prerelease recovery workflows

### DIFF
--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   alpha-version:
-    if: ${{ github.repository == 'mastra-ai/mastra' }}
+    if: ${{ github.repository == 'mastra-ai/mastra' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Initial checkout
@@ -104,4 +104,6 @@ jobs:
         run: |
           git add -A
           git commit -m "chore: version packages"
-          git push
+          git fetch origin "${GITHUB_REF_NAME}"
+          git rebase "origin/${GITHUB_REF_NAME}"
+          git push origin HEAD:"${GITHUB_REF_NAME}"

--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -64,7 +64,9 @@ jobs:
           pnpm changeset-cli pre enter alpha
           git add .changeset/pre.json
           git commit -m "chore: version - enter prerelease mode" --no-verify
-          git push
+          git fetch origin "${GITHUB_REF_NAME}"
+          git rebase "origin/${GITHUB_REF_NAME}"
+          git push origin HEAD:"${GITHUB_REF_NAME}"
           echo "restored=true" >> "$GITHUB_OUTPUT"
 
       - name: Version packages (alpha prerelease)

--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   schedule:
     - cron: '0 4,16 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: alpha-prerelease-main
@@ -39,7 +40,35 @@ jobs:
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
 
+      - name: Ensure alpha prerelease mode
+        id: ensure-prerelease
+        env:
+          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+          HUSKY: 0
+        run: |
+          if [ -f .changeset/pre.json ]; then
+            node <<'NODE'
+          const { readFileSync } = require('node:fs');
+          const pre = JSON.parse(readFileSync('.changeset/pre.json', 'utf8'));
+          if (pre.mode !== 'pre' || pre.tag !== 'alpha') {
+            console.error(`Expected .changeset/pre.json to be in alpha pre mode, got mode=${pre.mode} tag=${pre.tag}`);
+            process.exit(1);
+          }
+          NODE
+            echo "Already in alpha prerelease mode"
+            echo "restored=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Missing .changeset/pre.json; restoring alpha prerelease mode"
+          pnpm changeset-cli pre enter alpha
+          git add .changeset/pre.json
+          git commit -m "chore: version - enter prerelease mode" --no-verify
+          git push
+          echo "restored=true" >> "$GITHUB_OUTPUT"
+
       - name: Version packages (alpha prerelease)
+        if: steps.ensure-prerelease.outputs.restored != 'true'
         env:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           HUSKY: 0
@@ -47,6 +76,7 @@ jobs:
 
       - name: Check for changes
         id: check-changes
+        if: steps.ensure-prerelease.outputs.restored != 'true'
         run: |
           if git diff --quiet && git diff --cached --quiet; then
             echo "No version changes detected"
@@ -58,14 +88,14 @@ jobs:
           fi
 
       - name: Bump mcp-docs-server prerelease version
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.ensure-prerelease.outputs.restored != 'true' && steps.check-changes.outputs.has_changes == 'true'
         run: |
           cd packages/mcp-docs-server
           pnpm version prerelease --preid alpha --no-git-tag-version
           cd ../..
 
       - name: Commit and push version changes
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.ensure-prerelease.outputs.restored != 'true' && steps.check-changes.outputs.has_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
           HUSKY: 0

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -83,13 +83,32 @@ jobs:
             .trim()
             .split('\n')
             .filter(Boolean);
-          const hasAlphaVersion = packageJsons.some(file => {
-            const packageJson = JSON.parse(readFileSync(file, 'utf8'));
-            return typeof packageJson.version === 'string' && packageJson.version.includes('-alpha.');
+          const publishablePackages = packageJsons
+            .map(file => ({ file, packageJson: JSON.parse(readFileSync(file, 'utf8')) }))
+            .filter(({ packageJson }) => packageJson.name && packageJson.version && packageJson.private !== true);
+          const alphaPackages = publishablePackages.filter(({ packageJson }) => packageJson.version.includes('-alpha.'));
+
+          if (alphaPackages.length === 0) {
+            console.error('No publishable package versions contain -alpha.; refusing to publish stable versions to the alpha tag.');
+            process.exit(1);
+          }
+
+          const unpublishedStablePackages = publishablePackages.filter(({ packageJson }) => {
+            if (packageJson.version.includes('-alpha.')) return false;
+
+            try {
+              execSync(`npm view ${packageJson.name}@${packageJson.version} version`, { stdio: 'ignore' });
+              return false;
+            } catch {
+              return true;
+            }
           });
 
-          if (!hasAlphaVersion) {
-            console.error('No package.json versions contain -alpha.; refusing to publish stable versions to the alpha tag.');
+          if (unpublishedStablePackages.length > 0) {
+            console.error('Refusing to publish unpublished stable package versions to the alpha tag:');
+            for (const { file, packageJson } of unpublishedStablePackages) {
+              console.error(`- ${packageJson.name}@${packageJson.version} (${file})`);
+            }
             process.exit(1);
           }
           NODE

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -62,6 +62,38 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      - name: Verify alpha prerelease state
+        run: |
+          if [ ! -f .changeset/pre.json ]; then
+            echo "::error::.changeset/pre.json is missing. Run the Cron Alpha Version workflow first to restore alpha prerelease mode."
+            exit 1
+          fi
+
+          node <<'NODE'
+          const { readFileSync } = require('node:fs');
+          const { execSync } = require('node:child_process');
+
+          const pre = JSON.parse(readFileSync('.changeset/pre.json', 'utf8'));
+          if (pre.mode !== 'pre' || pre.tag !== 'alpha') {
+            console.error(`Expected .changeset/pre.json to be in alpha pre mode, got mode=${pre.mode} tag=${pre.tag}`);
+            process.exit(1);
+          }
+
+          const packageJsons = execSync('git ls-files "**/package.json" package.json', { encoding: 'utf8' })
+            .trim()
+            .split('\n')
+            .filter(Boolean);
+          const hasAlphaVersion = packageJsons.some(file => {
+            const packageJson = JSON.parse(readFileSync(file, 'utf8'));
+            return typeof packageJson.version === 'string' && packageJson.version.includes('-alpha.');
+          });
+
+          if (!hasAlphaVersion) {
+            console.error('No package.json versions contain -alpha.; refusing to publish stable versions to the alpha tag.');
+            process.exit(1);
+          }
+          NODE
+
       - name: Ensure npm 11.5.1+ for OIDC
         run: npm install -g npm@latest
 
@@ -396,7 +428,14 @@ jobs:
       - name: Build
         run: pnpm turbo --filter "!./examples/**/*" --filter "!./docs/" build
 
+      - name: Check for pre.json file existence
+        id: check-snapshot-pre-json
+        uses: andstor/file-existence-action@v3.0.0
+        with:
+          files: '.changeset/pre.json'
+
       - name: Run Changeset Pre Exit
+        if: steps.check-snapshot-pre-json.outputs.files_exists == 'true'
         run: pnpm changeset-cli pre exit
 
       - name: Run Changeset Version Snapshot


### PR DESCRIPTION
This hardens the alpha/release workflows around the post-stable state where `main` can be outside Changesets prerelease mode.

`Cron Alpha Version` now only runs on `main`, can be manually dispatched, and restores alpha prerelease mode if `.changeset/pre.json` is missing. The recovery commit is rebased before pushing, then package versioning is skipped for that run. Normal alpha versioning still runs when prerelease mode is already valid, and its version commit also rebases before pushing.

`Publish to npm` now fails prerelease publishes unless the repo is in alpha prerelease mode and has alpha package versions. It also blocks unpublished stable package versions from being published to the `alpha` tag. Snapshot publishes now skip `changeset pre exit` when the branch is already outside prerelease mode.

Test plan:
- Validated updated workflow YAML parses locally with Ruby YAML.
- Ran `git diff --check`.
- Reviewed the full workflow diff and PR review comments; current CodeRabbit inline findings are outdated after the latest fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR makes the alpha-release automation safer: if the repo has lost the "alpha prerelease" marker it will recreate that marker and push a recovery commit without doing any versioning/publishing in the same run, and it blocks accidental publishing of stable package versions to the alpha tag.

## Changes

**File: .github/workflows/cron-alpha-publish.yml**
- Added manual dispatch (`workflow_dispatch`) and restricted the versioning job to run only on `main`.
- New "Ensure alpha prerelease mode" step:
  - Checks `.changeset/pre.json` for `mode: pre` and `tag: alpha`.
  - If missing/invalid, runs `pnpm changeset-cli pre enter alpha`, commits the created `.changeset/pre.json`, fetches/rebases against origin, pushes the recovery commit, and sets `restored=true`.
  - If present and correct, sets `restored=false`.
- Rebased/push logic updated to tolerate main advancing during workflow execution (fetch + rebase + push HEAD to origin/${GITHUB_REF_NAME}).
- All subsequent versioning, change detection, MCP docs-server prerelease bump, and final commit/push steps are gated with `if: steps.ensure-prerelease.outputs.restored != 'true'` so recovery runs do not perform versioning/publishing.

**File: .github/workflows/npm-publish.yml**
- Prerelease flow: added early verification that hard-fails unless:
  - `.changeset/pre.json` exists and is configured for alpha prereleases (`mode: pre`, `tag: alpha`).
  - At least one publishable package version contains `-alpha.`.
  - No stable (non-`-alpha.`) package versions would be published to the alpha tag (prevents publishing stable versions under the alpha tag).
- Snapshot flow: added explicit existence check for `.changeset/pre.json` and conditionally runs the `changeset pre exit` step only when that file exists (skips pre-exit when already outside prerelease mode).
- Left publish/build/upload steps unchanged aside from the added guards; ensured npm tooling compatibility for OIDC.

## Commit messages / key notes
- Rebase the recovery commit before pushing so the workflow tolerates main advancing during execution.
- Restrict manual alpha cron dispatch to main and skip versioning/publishing during recovery runs.
- Tighten prerelease validation to require alpha package versions and block publishing stable versions to the alpha tag.
- Co-Authored-By: Mastra Code.

Lines changed: +96/-6 (approx.)
Estimated review effort: High

<!-- end of auto-generated comment: release notes by coderabbit.ai -->