### PR TITLE
fix(clickhouse): use lightweight DELETE and push deleteTasks filter into ClickHouse

### DIFF
--- a/.changeset/modern-worms-sit.md
+++ b/.changeset/modern-worms-sit.md
@@ -1,0 +1,7 @@
+---
+'@mastra/clickhouse': patch
+---
+
+Changed ClickHouse background task deletes to use lightweight `DELETE FROM` instead of `ALTER TABLE ... DELETE` mutations with `mutations_sync`. This makes deleted rows immediately invisible to subsequent reads without forcing part rewrites for each delete.
+
+Improved bulk background task deletion to push filtering into ClickHouse instead of fetching all matching task IDs into Node.js memory first. This avoids unnecessary network transfer and out-of-memory risk when deleting large result sets. As a safety guard, calling `deleteTasks` with no filters is now a no-op — use `dangerouslyClearAll` to wipe the table.

--- a/stores/_test-utils/src/domains/background-tasks/index.ts
+++ b/stores/_test-utils/src/domains/background-tasks/index.ts
@@ -243,6 +243,18 @@ export function createBackgroundTasksTests({ storage }: BackgroundTasksTestOptio
       });
     });
 
+    describe('deleteTask', () => {
+      it('deletes a single task synchronously', async () => {
+        if (!bgStorage) return;
+        const task = createSampleTask({ id: 'delete-one' });
+        await bgStorage.createTask(task);
+
+        await bgStorage.deleteTask(task.id);
+
+        expect(await bgStorage.getTask(task.id)).toBeNull();
+      });
+    });
+
     describe('deleteTasks', () => {
       it('deletes tasks matching status filter', async () => {
         if (!bgStorage) return;

--- a/stores/clickhouse/README.md
+++ b/stores/clickhouse/README.md
@@ -10,7 +10,9 @@ npm install @mastra/clickhouse
 
 ## Prerequisites
 
-- Clickhouse server (version 21.12 or higher recommended)
+- Clickhouse server (version 23.3 or higher recommended)
+  - Lightweight `DELETE FROM` requires ClickHouse 22.8+ with `allow_experimental_lightweight_delete = 1` (for 22.8–23.2), or 23.3+ where it is generally available.
+  - The `deleteTask` and `deleteTasks` methods use `DELETE FROM` on the background tasks table — ensure your server supports lightweight delete before using those operations.
 - Node.js 22.13.0 or later
 
 ## Usage
@@ -128,7 +130,6 @@ The store uses different table engines for different types of data:
 
 ### Operations Not Currently Supported
 
-- `deleteMessages(messageIds)`: Message deletion is not supported in ClickHouse
 - AI Observability (traces/spans): Not currently supported
 
 ## Data Types

--- a/stores/clickhouse/README.md
+++ b/stores/clickhouse/README.md
@@ -10,9 +10,9 @@ npm install @mastra/clickhouse
 
 ## Prerequisites
 
-- Clickhouse server (version 23.3 or higher recommended)
+- Clickhouse server (version 23.3 or higher required for delete operations; earlier versions may work for read/write operations)
   - Lightweight `DELETE FROM` requires ClickHouse 22.8+ with `allow_experimental_lightweight_delete = 1` (for 22.8–23.2), or 23.3+ where it is generally available.
-  - The `deleteTask` and `deleteTasks` methods use `DELETE FROM` on the background tasks table — ensure your server supports lightweight delete before using those operations.
+  - The `deleteTask`, `deleteTasks`, and `deleteMessages` methods use `DELETE FROM` — ensure your server supports lightweight delete before using those operations.
 - Node.js 22.13.0 or later
 
 ## Usage

--- a/stores/clickhouse/src/storage/domains/background-tasks/index.ts
+++ b/stores/clickhouse/src/storage/domains/background-tasks/index.ts
@@ -122,7 +122,7 @@ export class BackgroundTasksStorageClickhouse extends BackgroundTasksStorage {
     return rows.length > 0 ? rowToTask(rows[0]!) : null;
   }
 
-  async listTasks(filter: TaskFilter): Promise<TaskListResult> {
+  private buildFilterClause(filter: TaskFilter): { where: string; params: Record<string, any> } {
     const conditions: string[] = [];
     const params: Record<string, any> = {};
 
@@ -166,6 +166,11 @@ export class BackgroundTasksStorageClickhouse extends BackgroundTasksStorage {
     }
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    return { where, params };
+  }
+
+  async listTasks(filter: TaskFilter): Promise<TaskListResult> {
+    const { where, params } = this.buildFilterClause(filter);
 
     // Count total matching rows (before pagination)
     const countResult = await this.client.query({
@@ -202,22 +207,23 @@ export class BackgroundTasksStorageClickhouse extends BackgroundTasksStorage {
   }
 
   async deleteTask(taskId: string): Promise<void> {
-    await this.client.query({
-      query: `ALTER TABLE ${TABLE_BACKGROUND_TASKS} DELETE WHERE id = {var_id:String}`,
+    await this.client.command({
+      query: `DELETE FROM ${TABLE_BACKGROUND_TASKS} WHERE id = {var_id:String}`,
       query_params: { var_id: taskId },
-      clickhouse_settings: { mutations_sync: '1' },
     });
   }
 
   async deleteTasks(filter: TaskFilter): Promise<void> {
-    const { tasks } = await this.listTasks(filter);
-    for (const task of tasks) {
-      await this.client.query({
-        query: `ALTER TABLE ${TABLE_BACKGROUND_TASKS} DELETE WHERE id = {var_id:String}`,
-        query_params: { var_id: task.id },
-        clickhouse_settings: { mutations_sync: '1' },
-      });
-    }
+    const { where, params } = this.buildFilterClause(filter);
+
+    // Require at least one filter to avoid an unintentional table-wide delete.
+    // Use `dangerouslyClearAll` for that case.
+    if (!where) return;
+
+    await this.client.command({
+      query: `DELETE FROM ${TABLE_BACKGROUND_TASKS} ${where}`,
+      query_params: params,
+    });
   }
 
   async getRunningCount(): Promise<number> {


### PR DESCRIPTION
## Description

Two related improvements to the background-tasks delete paths in `@mastra/clickhouse`. One is a race condition and the other is a performance improvement. 

###  Switch deleteTask / deleteTasks from ALTER TABLE ... DELETE to lightweight DELETE FROM

Lightweight `DELETE FROM` (ClickHouse 23.3+) is synchronous by default, marks rows via a tombstone mask instead of rewriting parts, and is immediately visible to subsequent reads — so the mutations_sync workaround
is no longer needed and per-delete I/O drops.
- PR  #15307 introduce Clickhouse store for background tasks with a latent bug -- deletes are async.
- PR #15895 made deletes await mutation completion by setting `mutations_sync: '1'` on the `ALTER TABLE ... DELETE` mutation, and explicitly deferred the lightweight-DELETE alternative.

###  Push `deleteTasks` filtering into ClickHouse

Previously `deleteTasks(filter)` called `listTasks(filter)` and looped one mutation per matching id — every matching task id round-tripped through Node.js, followed by N separate delete statements (and N mutations
under the old ALTER TABLE path).

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
None filed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Deletes for background tasks in ClickHouse now run entirely in the database in one fast step, so removals are immediate and don't overload Node.js by shuttling lots of IDs back and forth.

## Changes

### Implementation (stores/clickhouse/src/storage/domains/background-tasks/index.ts)
- Added private buildFilterClause(filter) to produce a SQL WHERE fragment and query params reused by listTasks (count + data queries).
- listTasks now reuses the filter clause for consistent counting and paginated queries.
- deleteTask now uses lightweight synchronous DELETE FROM ... WHERE id = {var_id} via client.command instead of ALTER TABLE ... DELETE + mutations_sync.
- deleteTasks now issues a single DELETE FROM ... WHERE ... with the filter pushed into ClickHouse; it returns early (no-op) when no filters are provided to avoid accidental full-table deletes (use dangerouslyClearAll for full wipes).

### Tests (stores/_test-utils/src/domains/background-tasks/index.ts)
- Added test coverage including a test that creates a task, deletes it with deleteTask, and asserts getTask returns null.

### Docs / Changeset
- README updated to require ClickHouse 23.3+ for delete operations (22.8–23.2 can work with allow_experimental_lightweight_delete = 1).
- Changeset documents the migration from ALTER TABLE ... DELETE (mutations_sync) to lightweight DELETE and the improvement from pushing filtering into ClickHouse; deleteTasks with no filters is now a no-op.

## Notes
- Fixes async-delete race and reduces per-delete I/O and network/OOM risk by avoiding per-id round trips.
- No public API surface changes.
- Change type: Bug fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->