### PR TITLE
fix(core): preserve text-part whitespace in filterMessagesForPersistence (#15880)

### DIFF
--- a/.changeset/preserve-text-part-whitespace.md
+++ b/.changeset/preserve-text-part-whitespace.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `filterMessagesForPersistence` in the `MessageHistory` processor unconditionally trimming each text part. Since PR #15454, stream chunks are stored as one text part per text-start/text-end span (e.g., `"I have"`, `" access"`, `" to"`), so the per-part `.trim()` dropped token-boundary whitespace and broke word reconstruction on recall (`"I haveaccessto..."`). Trim now only runs when `removeWorkingMemoryTags` actually stripped tag content; the same guard is applied to the string-content branch for consistency. Fixes #15880.

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -653,6 +653,61 @@ describe('MessageHistory', () => {
       );
     });
 
+    it('should preserve token-boundary whitespace in text parts without stripping working_memory tags from other parts (regression #15880)', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+
+      const processor = new MessageHistory({
+        storage: mockStorage,
+      });
+
+      // Stream chunks emit text parts split at token boundaries; buildMessagesFromChunks (#15454)
+      // stores one part per text-start/text-end span. Pre-fix, every part was unconditionally
+      // trimmed, dropping the leading spaces that carry word boundaries.
+      const messages: MastraDBMessage[] = [
+        {
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              { type: 'text', text: 'I have' },
+              { type: 'text', text: ' access' },
+              { type: 'text', text: ' to <working_memory>internal</working_memory> two' },
+              { type: 'text', text: ' skills' },
+            ],
+          },
+          id: 'msg-streaming-parts',
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList().add(messages, `input`);
+      await processor.processOutputResult({
+        messageList,
+        messages,
+        abort: ((reason?: string) => {
+          throw new Error(reason || 'Aborted');
+        }) as (reason?: string) => never,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      const savedParts = ((mockStorage.saveMessages as any).mock.calls[0][0].messages[0].content as any).parts;
+      expect(savedParts.map((p: any) => p.text)).toEqual([
+        'I have',
+        ' access',
+        'to  two',
+        ' skills',
+      ]);
+    });
+
     it('should update thread metadata', async () => {
       const mockStorage = {
         saveMessages: vi.fn().mockResolvedValue(undefined),

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -182,7 +182,10 @@ export class MessageHistory implements Processor {
 
         // Strip working memory tags from string content
         if (typeof newMessage.content?.content === 'string' && newMessage.content.content.length > 0) {
-          newMessage.content.content = removeWorkingMemoryTags(newMessage.content.content).trim();
+          const original = newMessage.content.content;
+          const cleaned = removeWorkingMemoryTags(original);
+          // Only trim when working_memory tags were stripped, to preserve user whitespace.
+          newMessage.content.content = cleaned !== original ? cleaned.trim() : original;
         }
 
         if (Array.isArray(newMessage.content?.parts)) {
@@ -199,9 +202,13 @@ export class MessageHistory implements Processor {
               // Strip working memory tags from text parts
               if (p.type === `text`) {
                 const text = typeof p.text === 'string' ? p.text : '';
+                const cleaned = removeWorkingMemoryTags(text);
+                // Only trim when working_memory tags were stripped, to preserve token-boundary
+                // whitespace (e.g., " access", " to") emitted by buildMessagesFromChunks when
+                // each text-start/text-end span produces its own text part.
                 return {
                   ...p,
-                  text: removeWorkingMemoryTags(text).trim(),
+                  text: cleaned !== text ? cleaned.trim() : text,
                 };
               }
               return p;


### PR DESCRIPTION
## Summary

`MessageHistory.filterMessagesForPersistence` was unconditionally calling `.trim()` on every text part. After #15454 introduced span-based message building, stream chunks are stored as one text part per text-start/text-end span (e.g. `"I have"`, `" access"`, `" to"`, `" two"`, `" skills"`). The per-part trim dropped token-boundary leading whitespace and broke word reconstruction on recall — `"I haveaccessto..."`.

Closes #15880.

## Fix

Trim now only runs when `removeWorkingMemoryTags` actually stripped tag content (compared by value — JS string `!==` is a value comparison). The same guard is applied to the string-content branch in the same function for consistency.

```ts
const cleaned = removeWorkingMemoryTags(text);
return {
  ...p,
  text: cleaned !== text ? cleaned.trim() : text,
};
```

Inline comments document **why** the guard exists, to discourage future "simplification" back into the regression.

## Regression test

One test in `message-history.test.ts` mirroring the issue's repro: 4 text parts where 3 carry token-boundary leading whitespace and 1 contains a `<working_memory>` tag. Verifies leading whitespace is preserved on the un-tagged parts AND the strip+trim path still runs on the tagged part.

## Design choices

- **Value compare (`cleaned !== text`) vs explicit `text.includes('<working_memory>')` guard** — chose the former; it's 1 line, matches the issue body's suggested fix, and avoids hard-coding a tag string that would drift if `WORKING_MEMORY_*_TAG` constants in `working-memory-utils.ts` ever change. Happy to switch if you'd prefer the explicit guard.
- **Same-PR fix for the string-content branch** — issue body only describes the `parts[]` path, but the same `.trim()` lives 16 lines above for `content?.content === 'string'`. Fixed both for symmetry; only the `parts` path gets a regression test (the string-content path is harder to reach in normal `MessageList`-driven flow, but the inconsistency was worth removing).

## Local verification

I did not run `pnpm typecheck` / `vitest` locally — the monorepo isn't installed in my workspace. The change is a 9-line net edit + a 55-line test that mirrors the surrounding `processOutputResult` describe block. Dry-ran the four expected outputs against `removeWorkingMemoryTags`'s `indexOf`-based implementation. Relying on CI for the full suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When messages are saved by the system, each small piece of text was getting its spaces trimmed away. This caused words that should have spaces between them to run together when the message was read back later. The fix is to only remove spaces when we're actually cleaning up special tags, and leave the spaces alone otherwise.

## Overview

Fixes issue #15880 where `MessageHistory.filterMessagesForPersistence` was unconditionally trimming whitespace from individual text parts, breaking word reconstruction in span-based message persistence.

## Root Cause

After the introduction of span-based message persistence (PR #15454), each `text` span produces a separate text part. The unconditional `.trim()` call on every part was removing token-boundary leading whitespace (e.g., converting `" access"` → `"access"`), causing word fragments to concatenate incorrectly when reassembled.

## Solution

Modified `filterMessagesForPersistence` to trim text only when `removeWorkingMemoryTags` actually modifies the content. The logic now:
1. Computes `cleaned = removeWorkingMemoryTags(text)`
2. Applies `.trim()` only if `cleaned !== text` (tag removal occurred)
3. Otherwise preserves the original text with all whitespace intact
4. Applied symmetrically to both `newMessage.content.content` (string content) and `text`-typed `content.parts` entries

## Changes

- **message-history.ts**: Updated `filterMessagesForPersistence` to conditionally trim string content and text parts based on whether `removeWorkingMemoryTags` actually altered the text.
- **message-history.test.ts**: Added regression test covering chunked/token-boundary text splitting, verifying that whitespace is preserved in untagged parts while tagged content is properly stripped and trimmed.
- **.changeset/preserve-text-part-whitespace.md**: Changesets patch documenting the fix.

## Testing

Includes regression test that recreates the issue with four text parts (three with leading whitespace, one containing a `<working_memory>` tag) and verifies whitespace preservation on untagged parts while tagged parts are stripped and trimmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->