### PR TITLE
update publish scripts

### DIFF
--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -60,13 +60,6 @@ jobs:
             exit 0
           fi
 
-          echo "Missing .changeset/pre.json; restoring alpha prerelease mode"
-          pnpm changeset-cli pre enter alpha
-          git add .changeset/pre.json
-          git commit -m "chore: version - enter prerelease mode" --no-verify
-          git fetch origin "${GITHUB_REF_NAME}"
-          git rebase "origin/${GITHUB_REF_NAME}"
-          git push origin HEAD:"${GITHUB_REF_NAME}"
           echo "restored=true" >> "$GITHUB_OUTPUT"
 
       - name: Version packages (alpha prerelease)

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,12 +9,13 @@ on:
   workflow_dispatch:
     inputs:
       publish_type:
-        description: 'Type of publish'
+        description: 'Type of publish/action'
         required: true
         type: choice
         options:
           - prerelease
           - stable
+          - enter-prerelease
           - snapshot
         default: prerelease
       tag:
@@ -78,39 +79,6 @@ jobs:
             console.error(`Expected .changeset/pre.json to be in alpha pre mode, got mode=${pre.mode} tag=${pre.tag}`);
             process.exit(1);
           }
-
-          const packageJsons = execSync('git ls-files "**/package.json" package.json', { encoding: 'utf8' })
-            .trim()
-            .split('\n')
-            .filter(Boolean);
-          const publishablePackages = packageJsons
-            .map(file => ({ file, packageJson: JSON.parse(readFileSync(file, 'utf8')) }))
-            .filter(({ packageJson }) => packageJson.name && packageJson.version && packageJson.private !== true);
-          const alphaPackages = publishablePackages.filter(({ packageJson }) => packageJson.version.includes('-alpha.'));
-
-          if (alphaPackages.length === 0) {
-            console.error('No publishable package versions contain -alpha.; refusing to publish stable versions to the alpha tag.');
-            process.exit(1);
-          }
-
-          const unpublishedStablePackages = publishablePackages.filter(({ packageJson }) => {
-            if (packageJson.version.includes('-alpha.')) return false;
-
-            try {
-              execSync(`npm view ${packageJson.name}@${packageJson.version} version`, { stdio: 'ignore' });
-              return false;
-            } catch {
-              return true;
-            }
-          });
-
-          if (unpublishedStablePackages.length > 0) {
-            console.error('Refusing to publish unpublished stable package versions to the alpha tag:');
-            for (const { file, packageJson } of unpublishedStablePackages) {
-              console.error(`- ${packageJson.name}@${packageJson.version} (${file})`);
-            }
-            process.exit(1);
-          }
           NODE
 
       - name: Ensure npm 11.5.1+ for OIDC
@@ -172,8 +140,6 @@ jobs:
       github.event_name == 'workflow_dispatch' && 
       github.event.inputs.publish_type == 'stable'
     runs-on: ubuntu-latest
-    outputs:
-      exited_prerelease: ${{ steps.exit-prerelease-mode.outputs.executed }}
     steps:
       - name: Initial checkout
         uses: actions/checkout@v5
@@ -197,9 +163,13 @@ jobs:
 
       - name: Check for pre.json file existence
         id: check_files
-        uses: andstor/file-existence-action@v3.0.0
-        with:
-          files: '.changeset/pre.json'
+        shell: bash
+        run: |
+          if [[ -f .changeset/pre.json ]]; then
+            echo "files_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "files_exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
@@ -223,7 +193,6 @@ jobs:
         run: pnpm build
 
       - name: Exit prerelease mode
-        id: exit-prerelease-mode
         if: steps.check_files.outputs.files_exists == 'true'
         run: |
           pnpm changeset-cli pre exit
@@ -232,7 +201,6 @@ jobs:
           git add -A
           git commit -m 'chore: version - exit prerelease mode' --no-verify
           git push
-          echo "executed=true" >> "$GITHUB_OUTPUT"
           pnpm install
           pnpm build
         env:
@@ -302,8 +270,13 @@ jobs:
   enter_prerelease:
     needs: stable
     if: |
+      always() &&
       github.repository == 'mastra-ai/mastra' && 
-      needs.stable.outputs.exited_prerelease == 'true'
+      github.event_name == 'workflow_dispatch' && 
+      (
+        (github.event.inputs.publish_type == 'stable' && !inputs.dry_run && needs.stable.result == 'success') ||
+        github.event.inputs.publish_type == 'enter-prerelease'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Initial checkout
@@ -344,6 +317,10 @@ jobs:
       - name: Enter prerelease mode
         run: |
           git pull
+          if [[ -f .changeset/pre.json ]]; then
+            echo "Already in prerelease mode; no changes needed."
+            exit 0
+          fi
           pnpm changeset-cli pre enter alpha
           git add -A
           git commit -m 'chore: version - enter prerelease mode' --no-verify
@@ -449,9 +426,13 @@ jobs:
 
       - name: Check for pre.json file existence
         id: check-snapshot-pre-json
-        uses: andstor/file-existence-action@v3.0.0
-        with:
-          files: '.changeset/pre.json'
+        shell: bash
+        run: |
+          if [[ -f .changeset/pre.json ]]; then
+            echo "files_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "files_exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run Changeset Pre Exit
         if: steps.check-snapshot-pre-json.outputs.files_exists == 'true'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

These changes make it easier and more reliable to manage alpha (prerelease) versions of the code. Instead of the scripts automatically trying to create files and potentially causing errors, they now check if the prerelease setup already exists first. They also add a new manual button ("enter-prerelease") so developers can switch to alpha mode whenever they want, not just automatically through other workflows.

---

## cron-alpha-publish.yml

**Simplified Alpha Prerelease Initialization**

Removed automatic creation of `.changeset/pre.json` when entering alpha mode. The "Ensure alpha prerelease mode" step now only validates the prerelease state if the file already exists; if the file is missing, it simply sets a flag (`restored=true`) without attempting to create it. This prevents unnecessary git operations and reduces complexity when the file needs to be initialized through other means.

---

## npm-publish.yml

**Added Manual Prerelease Entry Option & Simplified File Checks**

- **New `enter-prerelease` publish type**: Extended the `workflow_dispatch` input with a new option allowing manual triggering of prerelease mode entry, in addition to automatic entry after stable releases.

- **Removed `prerelease` job logic**: Eliminated job-level logic that enumerated publishable packages and enforced alpha version constraints.

- **Simplified `stable` job**: 
  - Removed the `exited_prerelease` job output
  - Replaced `andstor/file-existence-action` with inline bash file existence checks that set output variables
  
- **Updated `enter_prerelease` job**:
  - Changed trigger condition from depending on `needs.stable.outputs.exited_prerelease` to directly evaluating `github.event.inputs.publish_type == 'enter-prerelease'` or successful stable release
  - Added `always()` to job-level conditions for more predictable execution
  - Added early-exit guard: skips Changesets execution if `.changeset/pre.json` already exists, preventing redundant operations

- **Standardized file checks**: Both `stable` and `snapshot` jobs now use consistent inline bash patterns instead of external actions for checking `.changeset/pre.json` existence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->