### PR TITLE
revert(core): roll back ambient-span fallback in getOrCreateSpan from #15792

### DIFF
--- a/.changeset/revert-observability-utils-getorcreatespan.md
+++ b/.changeset/revert-observability-utils-getorcreatespan.md
@@ -2,4 +2,5 @@
 '@mastra/core': patch
 ---
 
-Reverted the ambient-span fallback in `getOrCreateSpan` (and its regression tests) introduced by #15792. When no explicit `tracingContext.currentSpan` was supplied, `getOrCreateSpan` was walking to the ambient span installed by `executeWithContext()` and parenting new spans under it, which caused unintended span nesting in callers that relied on starting a new root span. The original behavior is restored: `getOrCreateSpan` creates a child span only when `tracingContext.currentSpan` is set, and otherwise starts a new root span.
+Fixed `getOrCreateSpan` to restore previous span-parenting behavior.
+Calls without `tracingContext.currentSpan` now start a new root span instead of attaching to ambient context, preventing unintended nesting.

--- a/.changeset/revert-observability-utils-getorcreatespan.md
+++ b/.changeset/revert-observability-utils-getorcreatespan.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Reverted the ambient-span fallback in `getOrCreateSpan` (and its regression tests) introduced by #15792. When no explicit `tracingContext.currentSpan` was supplied, `getOrCreateSpan` was walking to the ambient span installed by `executeWithContext()` and parenting new spans under it, which caused unintended span nesting in callers that relied on starting a new root span. The original behavior is restored: `getOrCreateSpan` creates a child span only when `tracingContext.currentSpan` is set, and otherwise starts a new root span.

--- a/packages/core/src/observability/context-storage.regression.test.ts
+++ b/packages/core/src/observability/context-storage.regression.test.ts
@@ -12,10 +12,9 @@
  * This test instantiates `Mastra` and verifies that the constructor-triggered
  * registration makes `resolveCurrentSpan()` work inside `executeWithContext`.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { Mastra } from '../mastra';
-import { EntityType, SpanType } from './types';
-import { executeWithContext, getOrCreateSpan, resolveCurrentSpan } from './utils';
+import { executeWithContext, resolveCurrentSpan } from './utils';
 
 // Instantiate Mastra — this is the production path that triggers initContextStorage().
 new Mastra();
@@ -37,75 +36,5 @@ describe('context-storage resolver registration (regression for #15072)', () => 
 
   it('resolveCurrentSpan returns undefined outside any executeWithContext scope', () => {
     expect(resolveCurrentSpan()).toBeUndefined();
-  });
-
-  it('getOrCreateSpan creates a child of the ambient span inside executeWithContext', async () => {
-    const childSpan = { id: 'child-span', traceId: 'test-trace' };
-    const parentSpan = {
-      id: 'parent-span',
-      traceId: 'test-trace',
-      createChildSpan: vi.fn().mockReturnValue(childSpan),
-    } as any;
-
-    let resolved: unknown;
-    await executeWithContext({
-      span: parentSpan,
-      fn: async () => {
-        resolved = getOrCreateSpan({
-          type: SpanType.AGENT_RUN,
-          name: "agent run: 'test-agent'",
-          entityType: EntityType.AGENT,
-          entityId: 'test-agent',
-          mastra: {
-            observability: {
-              getSelectedInstance: vi.fn(),
-            },
-          } as any,
-        });
-      },
-    });
-
-    expect(resolved).toBe(childSpan);
-    expect(parentSpan.createChildSpan).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: SpanType.AGENT_RUN,
-        name: "agent run: 'test-agent'",
-        entityType: EntityType.AGENT,
-        entityId: 'test-agent',
-      }),
-    );
-  });
-
-  it('getOrCreateSpan preserves explicit tracingOptions over the ambient span', async () => {
-    const parentSpan = {
-      id: 'parent-span',
-      traceId: 'ambient-trace',
-      createChildSpan: vi.fn(),
-    } as any;
-    const rootSpan = { id: 'root-span', traceId: 'explicit-trace' };
-    const startSpan = vi.fn().mockReturnValue(rootSpan);
-
-    let resolved: unknown;
-    await executeWithContext({
-      span: parentSpan,
-      fn: async () => {
-        resolved = getOrCreateSpan({
-          type: SpanType.AGENT_RUN,
-          name: "agent run: 'test-agent'",
-          entityType: EntityType.AGENT,
-          entityId: 'test-agent',
-          tracingOptions: { traceId: 'explicit-trace' },
-          mastra: {
-            observability: {
-              getSelectedInstance: vi.fn().mockReturnValue({ startSpan }),
-            },
-          } as any,
-        });
-      },
-    });
-
-    expect(resolved).toBe(rootSpan);
-    expect(parentSpan.createChildSpan).not.toHaveBeenCalled();
-    expect(startSpan).toHaveBeenCalledWith(expect.objectContaining({ traceId: 'explicit-trace' }));
   });
 });

--- a/packages/core/src/observability/utils.ts
+++ b/packages/core/src/observability/utils.ts
@@ -78,26 +78,22 @@ export function executeWithContextSync<T>(params: { span?: AnySpan; fn: () => T 
  * Creates or gets a child span from existing tracing context or starts a new trace.
  * This helper consolidates the common pattern of creating spans that can either be:
  * 1. Children of an existing span (when tracingContext.currentSpan exists)
- * 2. Children of the ambient span installed by executeWithContext()
- * 3. New root spans (when no current span exists)
+ * 2. New root spans (when no current span exists)
  *
  * @param options - Configuration object for span creation
  * @returns The created Span or undefined if tracing is disabled
  */
 export function getOrCreateSpan<T extends SpanType>(options: GetOrCreateSpanOptions<T>): Span<T> | undefined {
   const { type, attributes, tracingContext, requestContext, tracingOptions, ...rest } = options;
-  const currentSpan =
-    tracingContext?.currentSpan ??
-    (tracingOptions?.traceId || tracingOptions?.parentSpanId ? undefined : resolveCurrentSpan());
 
   const metadata = {
     ...(rest.metadata ?? {}),
     ...(tracingOptions?.metadata ?? {}),
   };
 
-  // If we have a current span, create a child span.
-  if (currentSpan) {
-    return currentSpan.createChildSpan({
+  // If we have a current span, create a child span
+  if (tracingContext?.currentSpan) {
+    return tracingContext.currentSpan.createChildSpan({
       type,
       attributes,
       ...rest,


### PR DESCRIPTION
## Summary

Reverts only the observability `getOrCreateSpan` changes from #15792 — specifically:

- `packages/core/src/observability/utils.ts`
- `packages/core/src/observability/context-storage.regression.test.ts`

The other files in #15792 (dataset experiment executor/scorer/index changes and their tests, plus the original changeset) are intentionally left in place.


## Why

I'm reverting this change because it is a significant change to how tracing operates, and I'd like to examine the consequences of this in a separate PR.  

This change will touch too many places to be included in a PR that is patching a missing trace for start experiment.

A `@mastra/core` patch changeset is included.

## Test plan

- [ ] `pnpm test:core` (focused: `packages/core/src/observability/context-storage.regression.test.ts`) passes against the reverted file pair
- [ ] `pnpm --filter ./packages/core check` is clean (no unused imports left over from the test file revert)
- [ ] Existing dataset experiment tests still pass — those files from #15792 are untouched

https://claude.ai/code/session_01CzuChUD6d41F31ZAzfPE4j

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzuChUD6d41F31ZAzfPE4j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR undoes a change that tried to automatically attach new tracing spans to a nearby "ambient" span. Now, new spans only get a parent if one is explicitly provided; otherwise they start fresh as root spans.

## Changes

Reverts the ambient-span fallback behavior introduced by #15792 so that getOrCreateSpan only creates a child span when tracingContext.currentSpan is explicitly set. If tracingContext.currentSpan is absent, getOrCreateSpan now starts a new root span instead of resolving an ambient span via resolveCurrentSpan().

Files changed:
- .changeset/revert-observability-utils-getorcreatespan.md — new changeset noting the patch for @mastra/core restoring prior span-parenting semantics.
- packages/core/src/observability/utils.ts — removed fallback to resolveCurrentSpan(); child spans are created only when tracingContext.currentSpan exists; otherwise a new root span is started via the selected observability instance.
- packages/core/src/observability/context-storage.regression.test.ts — removed the regression assertions that relied on ambient-span fallback; the file now only tests resolveCurrentSpan() behavior within and outside executeWithContext().

## Tests / Verification

- Run pnpm test:core (focus on the reverted regression test).
- Run pnpm --filter ./packages/core check to catch any unused imports after the revert.
- Existing dataset experiment tests (left in place from #15792) should continue to run unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->