### PR TITLE
fix(server): keep GET /agents resilient when an agent's dynamic getters throw

### DIFF
--- a/.changeset/agents-list-resilient-instructions.md
+++ b/.changeset/agents-list-resilient-instructions.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fix `GET /agents` returning 500 when an agent's dynamic `instructions` (or other dynamic config such as `getLLM`, `getModelList`, `getDefaultOptions`, `listTools`, sub-agent `listAgents`) throws under the active request context. Each per-agent dynamic getter is now isolated: failures are logged with the agent name and the agent is returned with safe defaults so the rest of the list still renders. The list handler also uses `Promise.allSettled` so a catastrophic failure in one agent's serialization can no longer reject the whole response, matching the existing behavior for stored agents.

--- a/.changeset/agents-list-resilient-instructions.md
+++ b/.changeset/agents-list-resilient-instructions.md
@@ -2,4 +2,5 @@
 '@mastra/server': patch
 ---
 
-Fix `GET /agents` returning 500 when an agent's dynamic `instructions` (or other dynamic config such as `getLLM`, `getModelList`, `getDefaultOptions`, `listTools`, sub-agent `listAgents`) throws under the active request context. Each per-agent dynamic getter is now isolated: failures are logged with the agent name and the agent is returned with safe defaults so the rest of the list still renders. The list handler also uses `Promise.allSettled` so a catastrophic failure in one agent's serialization can no longer reject the whole response, matching the existing behavior for stored agents.
+Fixed `GET /agents` returning 500 when one agent throws while resolving dynamic configuration under the active request context.
+The route now still returns the rest of the agent list and falls back to safe defaults for the failing agent instead of failing the whole response.

--- a/packages/server/src/server/handlers/agent.test.ts
+++ b/packages/server/src/server/handlers/agent.test.ts
@@ -423,6 +423,87 @@ describe('Agent Handlers', () => {
         modelList: undefined,
       });
     });
+
+    it("should still list other agents when one agent's dynamic instructions throws", async () => {
+      const healthyAgent = makeMockAgent({
+        name: 'agent-b',
+        description: 'Healthy agent',
+        instructions: 'healthy instructions',
+      });
+
+      // Simulate the MRE: a dynamic instructions callback that throws when the
+      // active request context doesn't satisfy the agent's expected shape.
+      const throwingAgent = makeMockAgent({
+        name: 'agent-a',
+        description: 'Throwing agent',
+        instructions: () => {
+          throw new Error("Cannot destructure property 'name' of 'requestContext.get(...)' as it is undefined.");
+        },
+      });
+
+      const mastraWithThrowingAgent = makeMastraMock({
+        agents: {
+          'agent-a': throwingAgent,
+          'agent-b': healthyAgent,
+        },
+      });
+
+      const result = await LIST_AGENTS_ROUTE.handler({
+        ...createTestServerContext({ mastra: mastraWithThrowingAgent }),
+        requestContext,
+      });
+
+      // The handler must resolve and include both agents — the throwing agent
+      // should be returned with `instructions: undefined`.
+      expect(result['agent-a']).toBeDefined();
+      expect(result['agent-a'].name).toBe('agent-a');
+      expect(result['agent-a'].instructions).toBeUndefined();
+
+      expect(result['agent-b']).toBeDefined();
+      expect(result['agent-b'].name).toBe('agent-b');
+      expect(result['agent-b'].instructions).toBe('healthy instructions');
+    });
+
+    it('should still list other agents when an agent throws from a non-instructions dynamic getter', async () => {
+      const healthyAgent = makeMockAgent({
+        name: 'agent-b',
+        description: 'Healthy agent',
+        instructions: 'healthy instructions',
+      });
+
+      const throwingAgent = makeMockAgent({
+        name: 'agent-a',
+        description: 'Throwing agent',
+        instructions: 'agent-a instructions',
+      });
+      vi.spyOn(throwingAgent, 'getLLM').mockImplementation(async () => {
+        throw new Error('boom from getLLM');
+      });
+
+      const mastraWithThrowingAgent = makeMastraMock({
+        agents: {
+          'agent-a': throwingAgent,
+          'agent-b': healthyAgent,
+        },
+      });
+
+      const result = await LIST_AGENTS_ROUTE.handler({
+        ...createTestServerContext({ mastra: mastraWithThrowingAgent }),
+        requestContext,
+      });
+
+      // The throwing agent is still listed with safe defaults; the healthy
+      // agent is unaffected.
+      expect(result['agent-a']).toBeDefined();
+      expect(result['agent-a'].name).toBe('agent-a');
+      expect(result['agent-a'].instructions).toBe('agent-a instructions');
+      expect(result['agent-a'].provider).toBeUndefined();
+      expect(result['agent-a'].modelId).toBeUndefined();
+
+      expect(result['agent-b']).toBeDefined();
+      expect(result['agent-b'].provider).toBe('openai.chat');
+      expect(result['agent-b'].modelId).toBe('gpt-4o');
+    });
   });
 
   describe('getAgentByIdHandler', () => {

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -451,23 +451,29 @@ interface SerializedAgentDefinition {
 async function getSerializedAgentDefinition({
   agent,
   requestContext,
+  logger,
 }: {
   agent: Agent;
   requestContext: RequestContext;
+  logger?: ReturnType<Context['mastra']['getLogger']>;
 }): Promise<Record<string, SerializedAgentDefinition>> {
   let serializedAgentAgents: Record<string, SerializedAgentDefinition> = {};
 
   if ('listAgents' in agent) {
-    const agents = await agent.listAgents({ requestContext });
-    serializedAgentAgents = Object.entries(agents || {}).reduce<Record<string, SerializedAgentDefinition>>(
-      (acc, [key, agent]) => {
-        return {
-          ...acc,
-          [key]: { id: agent.id, name: agent.name },
-        };
-      },
-      {},
-    );
+    try {
+      const agents = await agent.listAgents({ requestContext });
+      serializedAgentAgents = Object.entries(agents || {}).reduce<Record<string, SerializedAgentDefinition>>(
+        (acc, [key, agent]) => {
+          return {
+            ...acc,
+            [key]: { id: agent.id, name: agent.name },
+          };
+        },
+        {},
+      );
+    } catch (error) {
+      logger?.warn('Error getting sub-agents for agent', { agentName: agent.name, error });
+    }
   }
   return serializedAgentAgents;
 }
@@ -485,21 +491,63 @@ async function formatAgentList({
   requestContext: RequestContext;
   partial?: boolean;
 }): Promise<SerializedAgentWithId> {
+  const logger = mastra.getLogger();
+
   const description = agent.getDescription();
-  const instructions = await agent.getInstructions({ requestContext });
-  const tools = await agent.listTools({ requestContext });
-  const llm = await agent.getLLM({ requestContext });
-  const defaultGenerateOptionsLegacy = await agent.getDefaultGenerateOptionsLegacy({ requestContext });
-  const defaultStreamOptionsLegacy = await agent.getDefaultStreamOptionsLegacy({ requestContext });
-  const defaultOptions = await agent.getDefaultOptions({ requestContext });
+
+  // Per-agent dynamic getters can throw (e.g. when their callbacks destructure
+  // fields from `requestContext` that aren't present under the active preset).
+  // Wrap each independent getter so a single failure doesn't abort the whole
+  // serialization — the agent will still be listed with safe defaults, and the
+  // failure is logged so the user can see what went wrong in `mastra dev`.
+  let instructions: SystemMessage | undefined;
+  try {
+    instructions = await agent.getInstructions({ requestContext });
+  } catch (error) {
+    logger.warn('Error getting instructions for agent', { agentName: agent.name, error });
+  }
+
+  let tools: Record<string, SerializedToolInput> = {};
+  try {
+    tools = await agent.listTools({ requestContext });
+  } catch (error) {
+    logger.warn('Error listing tools for agent', { agentName: agent.name, error });
+  }
+
+  let llm: Awaited<ReturnType<Agent['getLLM']>> | undefined;
+  try {
+    llm = await agent.getLLM({ requestContext });
+  } catch (error) {
+    logger.warn('Error getting LLM for agent', { agentName: agent.name, error });
+  }
+
+  let defaultGenerateOptionsLegacy: Awaited<ReturnType<Agent['getDefaultGenerateOptionsLegacy']>> | undefined;
+  try {
+    defaultGenerateOptionsLegacy = await agent.getDefaultGenerateOptionsLegacy({ requestContext });
+  } catch (error) {
+    logger.warn('Error getting default generate options for agent', { agentName: agent.name, error });
+  }
+
+  let defaultStreamOptionsLegacy: Awaited<ReturnType<Agent['getDefaultStreamOptionsLegacy']>> | undefined;
+  try {
+    defaultStreamOptionsLegacy = await agent.getDefaultStreamOptionsLegacy({ requestContext });
+  } catch (error) {
+    logger.warn('Error getting default stream options for agent', { agentName: agent.name, error });
+  }
+
+  let defaultOptions: Awaited<ReturnType<Agent['getDefaultOptions']>> | undefined;
+  try {
+    defaultOptions = await agent.getDefaultOptions({ requestContext });
+  } catch (error) {
+    logger.warn('Error getting default options for agent', { agentName: agent.name, error });
+  }
+
   const serializedAgentTools = await getSerializedAgentTools(tools, partial);
 
   let serializedAgentWorkflows: Record<
     string,
     { name: string; steps?: Record<string, { id: string; description?: string }> }
   > = {};
-
-  const logger = mastra.getLogger();
 
   if ('listWorkflows' in agent) {
     try {
@@ -519,7 +567,7 @@ async function formatAgentList({
     }
   }
 
-  const serializedAgentAgents = await getSerializedAgentDefinition({ agent, requestContext });
+  const serializedAgentAgents = await getSerializedAgentDefinition({ agent, requestContext, logger });
 
   // Get and serialize only user-configured processors (excludes memory-derived processors)
   // This ensures the UI only shows processors explicitly configured by the user
@@ -550,7 +598,13 @@ async function formatAgentList({
   }
 
   const model = llm?.getModel();
-  const models = await agent.getModelList(requestContext);
+
+  let models: Awaited<ReturnType<Agent['getModelList']>> | undefined;
+  try {
+    models = await agent.getModelList(requestContext);
+  } catch (error) {
+    logger.warn('Error getting model list for agent', { agentName: agent.name, error });
+  }
   const modelList = models?.map(md => ({
     ...md,
     model: {
@@ -872,7 +926,12 @@ export const LIST_AGENTS_ROUTE = createRoute({
 
       // Apply stored config overrides to code-defined agents before serializing
       const editor = mastra.getEditor?.();
-      const serializedCodeAgentsMap = await Promise.all(
+      const logger = mastra.getLogger();
+      // Use `Promise.allSettled` so that one agent's catastrophic serialization
+      // failure (e.g. an unhandled throw from a user-supplied dynamic config
+      // callback) cannot reject the entire response. Failing agents are logged
+      // and skipped, matching the existing stored-agent loop below.
+      const serializedCodeAgentsMap = await Promise.allSettled(
         Object.entries(codeAgents).map(async ([id, agent]) => {
           let mergedAgent = agent;
           if (editor) {
@@ -886,13 +945,17 @@ export const LIST_AGENTS_ROUTE = createRoute({
         }),
       );
 
-      const serializedAgents = serializedCodeAgentsMap.reduce<Record<string, (typeof serializedCodeAgentsMap)[number]>>(
-        (acc, { id, ...rest }) => {
-          acc[id] = { id, ...rest };
-          return acc;
-        },
-        {},
-      );
+      const serializedAgents: Record<string, SerializedAgentWithId> = {};
+      for (let i = 0; i < serializedCodeAgentsMap.length; i++) {
+        const settled = serializedCodeAgentsMap[i]!;
+        if (settled.status === 'fulfilled') {
+          const { id, ...rest } = settled.value;
+          serializedAgents[id] = { id, ...rest };
+        } else {
+          const agentId = Object.keys(codeAgents)[i];
+          logger.warn('Failed to serialize agent', { agentId, error: settled.reason });
+        }
+      }
 
       // Also fetch and include stored agents
       try {


### PR DESCRIPTION
## Summary

`GET /agents` previously returned 500 if any registered agent's dynamic `instructions` (or any other dynamic getter — `getLLM`, `listTools`, `getDefaultOptions`, `getModelList`, sub-agent `listAgents`, etc.) threw under the active `requestContext`. Because all per-agent serialization runs inside a single `Promise.all`, one rejected promise tore down the entire response and Studio's agent list / Request Context pages stopped rendering.

This PR isolates per-agent failures so a misbehaving agent degrades gracefully:

- Each dynamic getter inside `formatAgentList` is wrapped in `try/catch`. On failure the field falls back to a safe default (`undefined` / `{}`) and a `logger.warn` is emitted with the agent name and the underlying error so the user can still see *why* their callback failed in `mastra dev` logs.
- `LIST_AGENTS_ROUTE` now uses `Promise.allSettled` per code-defined agent. A hard throw inside `formatAgentList` for one agent no longer rejects the whole response — that agent is logged and skipped, the rest still render. (The stored-agents branch already iterates per-agent in a try/catch.)

The response shape is unchanged: every field touched by the new `try/catch` blocks is already optional in `serializedAgentSchema`.

## Test plan

- Added two regression tests in `packages/server/src/server/handlers/agent.test.ts`:
  - One agent's `instructions` callback throws → both agents are listed; the throwing agent's `instructions` is `undefined`, the healthy agent is unaffected.
  - One agent's `getLLM` throws → both agents are listed; the throwing agent has `provider`/`modelId` undefined, the healthy agent renders normally.
- `pnpm test:server` — 1065 tests pass.
- `pnpm build:server` — clean.
- Manual verification against the MRE in the issue (`vanbujm/mastra-mre-agents-preset`): `curl http://localhost:4111/api/agents` now returns 200 with both agents and Studio renders under each preset.

Fixes #15906


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If one agent "breaks" while the server tries to read its details, the whole list used to fail — now the server skips the broken part for that agent, logs the error, and still shows all the other agents.

---

## Overview

Makes GET /agents resilient: any agent throwing from dynamic getters (instructions, getLLM, listTools, getDefaultOptions, getModelList, sub-agent listAgents, etc.) no longer causes a 500 or prevents the full agent list from returning. Failures are isolated per-agent, logged, and the response uses safe defaults for the failing fields.

---

## Changes

- Changeset
  - Adds a patch note for @mastra/server documenting that GET /agents no longer fails when a single agent's dynamic getters throw.

- Handler logic (packages/server/src/server/handlers/agents.ts)
  - Wraps each dynamic getter used during agent serialization in try/catch; on error the field falls back to a safe default (undefined or {}) and a warning with agent name/error is logged.
  - Uses Promise.allSettled for serializing code-defined agents in LIST_AGENTS_ROUTE so a hard throw for one agent is logged and skipped while others still render. Stored-agent behavior remains unchanged.
  - Injects logger into sub-agent serialization and guards sub-agent listAgents enumeration with try/catch.
  - Adds an optional logger parameter to getSerializedAgentDefinition’s destructured args.

- Tests (packages/server/src/server/handlers/agent.test.ts)
  - Adds two regression tests:
    - Agent's instructions throws → both agents listed; failing agent has instructions: undefined.
    - Agent's getLLM throws → both agents listed; failing agent has provider and modelId: undefined.

---

## Validation

- pnpm test:server passes (1065 tests)
- pnpm build:server clean
- Manual MRE verification: GET /api/agents returns 200 and Studio renders under presets.

---

## Related Issue

Fixes #15906
<!-- end of auto-generated comment: release notes by coderabbit.ai -->