### PR TITLE
Add ClickHouse storage reference documentation

### DIFF
--- a/docs/src/content/en/docs/observability/metrics/overview.mdx
+++ b/docs/src/content/en/docs/observability/metrics/overview.mdx
@@ -19,7 +19,7 @@ Three categories of metrics are emitted automatically:
 
 Metrics require an OLAP-capable store for observability. Relational databases like PostgreSQL, LibSQL, etc. are not supported for metrics. In-memory storage resets on restart.
 
-For local development, use [DuckDB](https://duckdb.org/) through `@mastra/duckdb`. For production, use [ClickHouse](/reference/storage/clickhouse), which scales to high-volume metric writes and supports per-signal retention.
+For local development, use [DuckDB](https://duckdb.org/) through `@mastra/duckdb`. For production, use [ClickHouse](https://clickhouse.com/) through `@mastra/clickhouse`.
 
 :::
 

--- a/docs/src/content/en/docs/observability/metrics/overview.mdx
+++ b/docs/src/content/en/docs/observability/metrics/overview.mdx
@@ -17,9 +17,9 @@ Three categories of metrics are emitted automatically:
 
 :::note
 
-Metrics require a separate OLAP store for observability. Relational databases like PostgreSQL, LibSQL, etc. are not supported for metrics. In-memory storage resets on restart.
+Metrics require an OLAP-capable store for observability. Relational databases like PostgreSQL, LibSQL, etc. are not supported for metrics. In-memory storage resets on restart.
 
-For local development, you can use [DuckDB](/reference/vectors/duckdb). We don't recommend using in-memory/DuckDB for production, ClickHouse support is coming soon for scalable metrics storage.
+For local development, use [DuckDB](https://duckdb.org/) through `@mastra/duckdb`. For production, use [ClickHouse](/reference/storage/clickhouse), which scales to high-volume metric writes and supports per-signal retention.
 
 :::
 

--- a/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/default.mdx
@@ -10,7 +10,7 @@ packages:
 The `DefaultExporter` persists traces to your configured storage backend, making them accessible through Studio. It's automatically enabled when using the default observability configuration and requires no external services.
 
 :::warning[Production Observability]
-Observability data can quickly overwhelm general-purpose databases in production. For high-traffic applications, we recommend using **ClickHouse** for the observability storage domain via [composite storage](/reference/storage/composite). See [Production Recommendations](#production-recommendations) for details.
+Observability data can quickly overwhelm general-purpose databases in production. For high-traffic applications, route the observability storage domain to [ClickHouse](/reference/storage/clickhouse) through [composite storage](/reference/storage/composite). See [Production Recommendations](#production-recommendations) for details.
 :::
 
 ## Configuration
@@ -123,7 +123,7 @@ If you set the strategy to `'auto'`, the `DefaultExporter` automatically selects
 
 | Storage Provider | Preferred Strategy | Supported Strategies | Recommended Use |
 | - | - | - | - |
-| **ClickHouse** (`@mastra/clickhouse`) | insert-only | insert-only | Production (high-volume) |
+| **[ClickHouse](/reference/storage/clickhouse)** | insert-only | insert-only | Production (high-volume) |
 | **[PostgreSQL](/reference/storage/postgresql)** | batch-with-updates | batch-with-updates, insert-only | Production (low volume) |
 | **[MSSQL](/reference/storage/mssql)** | batch-with-updates | batch-with-updates, insert-only | Production (low volume) |
 | **[MongoDB](/reference/storage/mongodb)** | batch-with-updates | batch-with-updates, insert-only | Production (low volume) |
@@ -152,7 +152,7 @@ Observability data grows quickly in production environments. A single agent inte
 
 ### Recommended: ClickHouse for High-Volume Production
 
-[ClickHouse](/reference/storage/composite#specialized-storage-for-observability) is a columnar database designed for high-volume analytics workloads. It's the recommended choice for production observability because:
+[ClickHouse](/reference/storage/clickhouse) is a columnar database designed for high-volume analytics workloads. It's the recommended choice for production observability because:
 
 - **Optimized for writes**: Handles millions of inserts per second
 - **Efficient compression**: Reduces storage costs for trace data

--- a/docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx
+++ b/docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx
@@ -15,14 +15,14 @@ For setup instructions, see the [Metrics overview](/docs/observability/metrics/o
 
 Metrics are extracted from spans when they end. The observability layer inspects each completed span, calculates duration, and (for model generation spans) reads token usage data. No manual instrumentation is needed.
 
-Metrics are routed through an internal event bus to the `DefaultExporter`, which batches and flushes them to storage. Only DuckDB and in-memory storage backends support metrics persistence today.
+Metrics are routed through an internal event bus to the `DefaultExporter`, which batches and flushes them to storage. Metric persistence requires an OLAP-capable backend: [DuckDB](https://duckdb.org/) for local development, [ClickHouse](/reference/storage/clickhouse) for production, or in-memory storage for tests. Row-oriented databases such as PostgreSQL, LibSQL, MSSQL, and MongoDB persist traces and logs but do not currently store metrics.
 
 ### What affects whether a metric is available
 
 Two conditions must be true for a metric to reach storage:
 
 1. `DefaultExporter` is configured as an exporter.
-1. The storage backend supports metrics (`DuckDB` or `InMemory`).
+1. The storage backend supports metrics (ClickHouse, DuckDB, or in-memory).
 
 If metrics aren't appearing, see [troubleshooting](#troubleshooting).
 

--- a/docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx
+++ b/docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx
@@ -15,7 +15,7 @@ For setup instructions, see the [Metrics overview](/docs/observability/metrics/o
 
 Metrics are extracted from spans when they end. The observability layer inspects each completed span, calculates duration, and (for model generation spans) reads token usage data. No manual instrumentation is needed.
 
-Metrics are routed through an internal event bus to the `DefaultExporter`, which batches and flushes them to storage. Metric persistence requires an OLAP-capable backend: [DuckDB](https://duckdb.org/) for local development, [ClickHouse](/reference/storage/clickhouse) for production, or in-memory storage for tests. Row-oriented databases such as PostgreSQL, LibSQL, MSSQL, and MongoDB persist traces and logs but do not currently store metrics.
+Metrics are routed through an internal event bus to the `DefaultExporter`, which batches and flushes them to storage.
 
 ### What affects whether a metric is available
 

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -431,6 +431,7 @@ const sidebars = {
       collapsed: true,
       items: [
         { type: 'doc', id: 'storage/overview', label: 'Overview' },
+        { type: 'doc', id: 'storage/clickhouse', label: 'ClickHouse Storage' },
         { type: 'doc', id: 'storage/cloudflare-d1', label: 'Cloudflare D1 Storage' },
         { type: 'doc', id: 'storage/cloudflare', label: 'Cloudflare KV Storage' },
         { type: 'doc', id: 'storage/composite', label: 'Composite Storage' },

--- a/docs/src/content/en/reference/storage/clickhouse.mdx
+++ b/docs/src/content/en/reference/storage/clickhouse.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Reference: ClickHouse storage | Storage"
-description: Documentation for the ClickHouse storage implementation in Mastra, including the vNext observability domain for high-volume traces, logs, metrics, and scores.
+description: Documentation for the ClickHouse storage implementation in Mastra, including the vNext observability domain.
 packages:
   - "@mastra/clickhouse"
   - "@mastra/core"
@@ -8,15 +8,14 @@ packages:
 
 # ClickHouse storage
 
-[ClickHouse](https://clickhouse.com/) is a columnar database designed for high-volume analytical workloads. The `@mastra/clickhouse` package provides storage adapters for every Mastra storage domain and is the recommended backend for production observability.
+[ClickHouse](https://clickhouse.com/) is a columnar database designed for analytical workloads. The `@mastra/clickhouse` package provides storage adapters for several Mastra storage domains and is the recommended backend for production observability.
 
-ClickHouse is most commonly used as the dedicated observability backend in a [composite storage](/reference/storage/composite) setup, with another database serving the remaining domains. It can also back every Mastra domain on its own through `ClickhouseStore`.
+ClickHouse is most commonly used as the dedicated observability backend in a [composite storage](/reference/storage/composite) setup, with another database serving the remaining domains. It can also back the supported domains on its own through `ClickhouseStore`.
 
 ## When to use ClickHouse
 
-- High-volume production observability where general-purpose databases struggle with the write rate.
-- Append-heavy workloads dominated by spans, logs, and metrics.
-- Long retention windows where columnar compression keeps storage costs manageable.
+- Production observability for traces, logs, metrics, scores, and feedback.
+- Append-heavy workloads where columnar storage and compression help keep costs down.
 - Deployment platforms with ephemeral filesystems (such as [Railway](#deploying-with-railway-and-similar-platforms), Fly.io, Render, Heroku, or container schedulers) where embedded backends like DuckDB cannot persist data.
 
 For local development, [LibSQL](/reference/storage/libsql) or `@mastra/duckdb` are usually a better fit because they need no external service.
@@ -33,7 +32,7 @@ You will also need a running ClickHouse server. See [Hosting options](#hosting-o
 
 ### Observability with vNext (recommended)
 
-`ObservabilityStorageClickhouseVNext` is the current observability domain implementation. It uses an insert-only schema backed by `ReplacingMergeTree`, supports per-signal retention, and is optimized for the volume produced by traces, logs, metrics, scores, and feedback.
+`ObservabilityStorageClickhouseVNext` is the current observability domain implementation. It uses an insert-only schema backed by `ReplacingMergeTree` and is optimized for the volume produced by traces, logs, metrics, scores, and feedback.
 
 Compose it with another storage adapter so observability writes do not contend with your application data:
 
@@ -48,13 +47,6 @@ const observabilityStore = new ObservabilityStorageClickhouseVNext({
   url: process.env.CLICKHOUSE_URL!,
   username: process.env.CLICKHOUSE_USERNAME!,
   password: process.env.CLICKHOUSE_PASSWORD!,
-  retention: {
-    tracing: 30, // days
-    logs: 14,
-    metrics: 90,
-    scores: 180,
-    feedback: 365,
-  },
 })
 
 export const mastra = new Mastra({
@@ -83,7 +75,7 @@ export const mastra = new Mastra({
 
 ### Observability with the legacy domain
 
-`ObservabilityStorageClickhouse` is the original observability adapter and remains supported for projects that have not migrated to the vNext schema. The configuration shape is the same as the vNext class, minus the `retention` option.
+`ObservabilityStorageClickhouse` is the original observability adapter and remains supported for projects that have not migrated to the vNext schema. The configuration shape is the same as the vNext class.
 
 ```typescript
 import { ObservabilityStorageClickhouse } from '@mastra/clickhouse'
@@ -99,7 +91,7 @@ New projects should use `ObservabilityStorageClickhouseVNext` instead.
 
 ### Full storage with `ClickhouseStore`
 
-`ClickhouseStore` implements every Mastra storage domain (memory, workflows, scores, agents, observability, background tasks). Use it when you want a single backend for the whole application. For most observability deployments, the composite setup above is preferable because it isolates observability writes from primary application data.
+`ClickhouseStore` implements the `memory`, `workflows`, `scores`, and `observability` domains. Use it when you want a single backend for the supported domains. For most observability deployments, the composite setup above is preferable because it isolates observability writes from primary application data.
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -197,58 +189,7 @@ The same `client` form is accepted by `ObservabilityStorageClickhouse` and `Obse
 
 ### Observability domain options
 
-`ObservabilityStorageClickhouse` and `ObservabilityStorageClickhouseVNext` accept the same connection options as `ClickhouseStore`. The vNext class adds a `retention` option:
-
-<PropertiesTable
-  content={[
-  {
-    name: 'retention',
-    type: 'RetentionConfig',
-    description:
-      'Per-signal retention in whole-day increments. Each value is applied as a ClickHouse `TTL` on the underlying table at init time. Omit a key to keep that signal indefinitely.',
-    isOptional: true,
-    properties: [
-      {
-        type: 'object',
-        parameters: [
-          {
-            name: 'tracing',
-            type: 'number',
-            description: 'Retention for span events and trace roots, in days.',
-            isOptional: true,
-          },
-          {
-            name: 'logs',
-            type: 'number',
-            description: 'Retention for log events, in days.',
-            isOptional: true,
-          },
-          {
-            name: 'metrics',
-            type: 'number',
-            description: 'Retention for metric events, in days.',
-            isOptional: true,
-          },
-          {
-            name: 'scores',
-            type: 'number',
-            description: 'Retention for score events, in days.',
-            isOptional: true,
-          },
-          {
-            name: 'feedback',
-            type: 'number',
-            description: 'Retention for feedback events, in days.',
-            isOptional: true,
-          },
-        ],
-      },
-    ],
-  },
-]}
-/>
-
-Retention is applied with `ALTER TABLE ... MODIFY TTL`, so changing a value and restarting the application updates the policy in place.
+`ObservabilityStorageClickhouse` and `ObservabilityStorageClickhouseVNext` accept the same connection options as `ClickhouseStore` (`url`, `username`, `password`, or a pre-configured `client`).
 
 ## Hosting options
 
@@ -300,7 +241,6 @@ export const mastra = new Mastra({
         url: process.env.CLICKHOUSE_URL!,
         username: process.env.CLICKHOUSE_USERNAME!,
         password: process.env.CLICKHOUSE_PASSWORD!,
-        retention: { tracing: 14, logs: 7, metrics: 30 },
       }),
     },
   }),
@@ -336,11 +276,9 @@ If you manage storage outside of `Mastra`, call `init()` explicitly:
 import { ObservabilityStorageClickhouseVNext } from '@mastra/clickhouse'
 
 const observability = new ObservabilityStorageClickhouseVNext({
-  client: {
-    url: process.env.CLICKHOUSE_URL!,
-    username: process.env.CLICKHOUSE_USERNAME!,
-    password: process.env.CLICKHOUSE_PASSWORD!,
-  },
+  url: process.env.CLICKHOUSE_URL!,
+  username: process.env.CLICKHOUSE_USERNAME!,
+  password: process.env.CLICKHOUSE_PASSWORD!,
 })
 
 await observability.init()
@@ -353,8 +291,7 @@ In CI/CD pipelines, set `disableInit: true` on `ClickhouseStore` and run `init()
 ClickHouse is the recommended backend for production observability:
 
 - **Insert-only strategy**: `DefaultExporter` writes completed spans in batches without per-span updates, which is the highest-throughput strategy available.
-- **Per-signal retention**: vNext applies independent TTLs for traces, logs, metrics, scores, and feedback.
-- **Columnar compression**: Span attributes and log payloads typically compress 5x to 20x compared to the same data in row-oriented databases.
+- **Columnar compression**: Span attributes and log payloads compress well compared to the same data in row-oriented databases.
 
 For the full strategy matrix and production guidance, see the [`DefaultExporter` reference](/docs/observability/tracing/exporters/default#storage-provider-support).
 

--- a/docs/src/content/en/reference/storage/clickhouse.mdx
+++ b/docs/src/content/en/reference/storage/clickhouse.mdx
@@ -1,0 +1,366 @@
+---
+title: "Reference: ClickHouse storage | Storage"
+description: Documentation for the ClickHouse storage implementation in Mastra, including the vNext observability domain for high-volume traces, logs, metrics, and scores.
+packages:
+  - "@mastra/clickhouse"
+  - "@mastra/core"
+---
+
+# ClickHouse storage
+
+[ClickHouse](https://clickhouse.com/) is a columnar database designed for high-volume analytical workloads. The `@mastra/clickhouse` package provides storage adapters for every Mastra storage domain and is the recommended backend for production observability.
+
+ClickHouse is most commonly used as the dedicated observability backend in a [composite storage](/reference/storage/composite) setup, with another database serving the remaining domains. It can also back every Mastra domain on its own through `ClickhouseStore`.
+
+## When to use ClickHouse
+
+- High-volume production observability where general-purpose databases struggle with the write rate.
+- Append-heavy workloads dominated by spans, logs, and metrics.
+- Long retention windows where columnar compression keeps storage costs manageable.
+- Deployment platforms with ephemeral filesystems (such as [Railway](#deploying-with-railway-and-similar-platforms), Fly.io, Render, Heroku, or container schedulers) where embedded backends like DuckDB cannot persist data.
+
+For local development, [LibSQL](/reference/storage/libsql) or `@mastra/duckdb` are usually a better fit because they need no external service.
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/clickhouse@latest
+```
+
+You will also need a running ClickHouse server. See [Hosting options](#hosting-options) for managed and self-hosted choices.
+
+## Usage
+
+### Observability with vNext (recommended)
+
+`ObservabilityStorageClickhouseVNext` is the current observability domain implementation. It uses an insert-only schema backed by `ReplacingMergeTree`, supports per-signal retention, and is optimized for the volume produced by traces, logs, metrics, scores, and feedback.
+
+Compose it with another storage adapter so observability writes do not contend with your application data:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraCompositeStore } from '@mastra/core/storage'
+import { LibSQLStore } from '@mastra/libsql'
+import { ObservabilityStorageClickhouseVNext } from '@mastra/clickhouse'
+import { Observability, DefaultExporter } from '@mastra/observability'
+
+const observabilityStore = new ObservabilityStorageClickhouseVNext({
+  url: process.env.CLICKHOUSE_URL!,
+  username: process.env.CLICKHOUSE_USERNAME!,
+  password: process.env.CLICKHOUSE_PASSWORD!,
+  retention: {
+    tracing: 30, // days
+    logs: 14,
+    metrics: 90,
+    scores: 180,
+    feedback: 365,
+  },
+})
+
+export const mastra = new Mastra({
+  storage: new MastraCompositeStore({
+    id: 'composite-storage',
+    default: new LibSQLStore({
+      id: 'mastra-storage',
+      url: 'file:./mastra.db',
+    }),
+    domains: {
+      observability: observabilityStore,
+    },
+  }),
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [new DefaultExporter()],
+      },
+    },
+  }),
+})
+```
+
+`DefaultExporter` automatically selects the `insert-only` strategy when ClickHouse is the observability backend, which gives the highest write throughput. See [tracing strategies](/docs/observability/tracing/exporters/default#tracing-strategies) for details.
+
+### Observability with the legacy domain
+
+`ObservabilityStorageClickhouse` is the original observability adapter and remains supported for projects that have not migrated to the vNext schema. The configuration shape is the same as the vNext class, minus the `retention` option.
+
+```typescript
+import { ObservabilityStorageClickhouse } from '@mastra/clickhouse'
+
+const observabilityStore = new ObservabilityStorageClickhouse({
+  url: process.env.CLICKHOUSE_URL!,
+  username: process.env.CLICKHOUSE_USERNAME!,
+  password: process.env.CLICKHOUSE_PASSWORD!,
+})
+```
+
+New projects should use `ObservabilityStorageClickhouseVNext` instead.
+
+### Full storage with `ClickhouseStore`
+
+`ClickhouseStore` implements every Mastra storage domain (memory, workflows, scores, agents, observability, background tasks). Use it when you want a single backend for the whole application. For most observability deployments, the composite setup above is preferable because it isolates observability writes from primary application data.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { ClickhouseStore } from '@mastra/clickhouse'
+
+export const mastra = new Mastra({
+  storage: new ClickhouseStore({
+    id: 'clickhouse-storage',
+    url: process.env.CLICKHOUSE_URL!,
+    username: process.env.CLICKHOUSE_USERNAME!,
+    password: process.env.CLICKHOUSE_PASSWORD!,
+  }),
+})
+```
+
+### Bring your own ClickHouse client
+
+Pass a pre-configured client when you need custom connection settings such as request timeouts, compression, or interceptors:
+
+```typescript
+import { createClient } from '@clickhouse/client'
+import { ClickhouseStore } from '@mastra/clickhouse'
+
+const client = createClient({
+  url: process.env.CLICKHOUSE_URL!,
+  username: process.env.CLICKHOUSE_USERNAME!,
+  password: process.env.CLICKHOUSE_PASSWORD!,
+  request_timeout: 60_000,
+  compression: { request: true, response: true },
+})
+
+const storage = new ClickhouseStore({ id: 'clickhouse-storage', client })
+```
+
+The same `client` form is accepted by `ObservabilityStorageClickhouse` and `ObservabilityStorageClickhouseVNext`.
+
+## Configuration
+
+### `ClickhouseStore` options
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Unique identifier for this storage instance.',
+    isOptional: false,
+  },
+  {
+    name: 'url',
+    type: 'string',
+    description:
+      'ClickHouse server URL (for example, `https://your-instance.clickhouse.cloud:8443` or `http://localhost:8123`). Required when not passing a pre-configured `client`.',
+    isOptional: true,
+  },
+  {
+    name: 'username',
+    type: 'string',
+    description: 'ClickHouse username. Required when not passing a pre-configured `client`.',
+    isOptional: true,
+  },
+  {
+    name: 'password',
+    type: 'string',
+    description:
+      'ClickHouse password. Required when not passing a pre-configured `client`. Can be an empty string for the default user on a local instance.',
+    isOptional: true,
+  },
+  {
+    name: 'client',
+    type: 'ClickHouseClient',
+    description:
+      'Pre-configured ClickHouse client from `@clickhouse/client`. Use this when you need custom request settings. Mutually exclusive with the credential fields above.',
+    isOptional: true,
+  },
+  {
+    name: 'ttl',
+    type: 'object',
+    description:
+      'Per-table TTL configuration applied at table creation time. Accepts row-level and column-level TTLs in interval units from `NANOSECOND` through `YEAR`.',
+    isOptional: true,
+  },
+  {
+    name: 'disableInit',
+    type: 'boolean',
+    description:
+      'When `true`, the store does not run table creation or migrations on first use. Call `storage.init()` explicitly from your deployment scripts.',
+    isOptional: true,
+    defaultValue: 'false',
+  },
+]}
+/>
+
+`ClickhouseStore` also accepts every option from `ClickHouseClientConfigOptions` (such as `database`, `request_timeout`, `compression`, `keep_alive`, and `max_open_connections`).
+
+### Observability domain options
+
+`ObservabilityStorageClickhouse` and `ObservabilityStorageClickhouseVNext` accept the same connection options as `ClickhouseStore`. The vNext class adds a `retention` option:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'retention',
+    type: 'RetentionConfig',
+    description:
+      'Per-signal retention in whole-day increments. Each value is applied as a ClickHouse `TTL` on the underlying table at init time. Omit a key to keep that signal indefinitely.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'tracing',
+            type: 'number',
+            description: 'Retention for span events and trace roots, in days.',
+            isOptional: true,
+          },
+          {
+            name: 'logs',
+            type: 'number',
+            description: 'Retention for log events, in days.',
+            isOptional: true,
+          },
+          {
+            name: 'metrics',
+            type: 'number',
+            description: 'Retention for metric events, in days.',
+            isOptional: true,
+          },
+          {
+            name: 'scores',
+            type: 'number',
+            description: 'Retention for score events, in days.',
+            isOptional: true,
+          },
+          {
+            name: 'feedback',
+            type: 'number',
+            description: 'Retention for feedback events, in days.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+Retention is applied with `ALTER TABLE ... MODIFY TTL`, so changing a value and restarting the application updates the policy in place.
+
+## Hosting options
+
+ClickHouse runs anywhere you can reach it over HTTP. Two common choices:
+
+- **[ClickHouse Cloud](https://clickhouse.com/cloud)**: Managed service with a free trial tier. Provides connection details directly compatible with `url`, `username`, and `password`.
+- **Self-hosted**: Run the official [`clickhouse/clickhouse-server`](https://hub.docker.com/r/clickhouse/clickhouse-server) container or install from the [official packages](https://clickhouse.com/docs/en/install). Suitable for VPS, dedicated hardware, or Kubernetes.
+
+For local development:
+
+```bash
+docker run -d --name mastra-clickhouse \
+  -p 8123:8123 -p 9000:9000 \
+  -e CLICKHOUSE_USER=default \
+  -e CLICKHOUSE_PASSWORD=password \
+  clickhouse/clickhouse-server
+```
+
+```typescript
+new ObservabilityStorageClickhouseVNext({
+  url: 'http://localhost:8123',
+  username: 'default',
+  password: 'password',
+})
+```
+
+## Deploying with Railway and similar platforms
+
+Platforms like [Railway](https://railway.com), [Fly.io](https://fly.io), [Render](https://render.com), and Heroku run application containers on ephemeral filesystems. Embedded observability backends such as DuckDB require a writable, persistent local file, so they either lose data on restart or fail to deploy entirely on these platforms.
+
+Use ClickHouse instead. Because ClickHouse is reached over HTTP, the same connection works from any host:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraCompositeStore } from '@mastra/core/storage'
+import { PostgresStore } from '@mastra/pg'
+import { ObservabilityStorageClickhouseVNext } from '@mastra/clickhouse'
+import { Observability, DefaultExporter } from '@mastra/observability'
+
+export const mastra = new Mastra({
+  storage: new MastraCompositeStore({
+    id: 'composite-storage',
+    default: new PostgresStore({
+      id: 'pg',
+      connectionString: process.env.DATABASE_URL!,
+    }),
+    domains: {
+      observability: new ObservabilityStorageClickhouseVNext({
+        url: process.env.CLICKHOUSE_URL!,
+        username: process.env.CLICKHOUSE_USERNAME!,
+        password: process.env.CLICKHOUSE_PASSWORD!,
+        retention: { tracing: 14, logs: 7, metrics: 30 },
+      }),
+    },
+  }),
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [new DefaultExporter()],
+      },
+    },
+  }),
+})
+```
+
+Two ways to provision the database:
+
+- **Managed**: Use ClickHouse Cloud. Set `CLICKHOUSE_URL`, `CLICKHOUSE_USERNAME`, and `CLICKHOUSE_PASSWORD` as environment variables in your hosting platform.
+- **Self-hosted on Railway**: Add a ClickHouse service to your Railway project from the official Docker image, then reference it in the application service through Railway's private networking.
+
+The same approach applies to other hosts with ephemeral filesystems. For application data that should also live off-host, pair this setup with a managed PostgreSQL or LibSQL/Turso instance for the `default` storage.
+
+:::warning
+Do not point an embedded backend like DuckDB at a path inside an ephemeral container filesystem. Data written there is lost when the container restarts, and on some platforms the path is read-only.
+:::
+
+## Initialization
+
+When passed to the `Mastra` class, `ClickhouseStore` calls `init()` automatically to create the schema and run any pending migrations. The same applies to `ObservabilityStorageClickhouseVNext` when used through `MastraCompositeStore`.
+
+If you manage storage outside of `Mastra`, call `init()` explicitly:
+
+```typescript
+import { ObservabilityStorageClickhouseVNext } from '@mastra/clickhouse'
+
+const observability = new ObservabilityStorageClickhouseVNext({
+  client: {
+    url: process.env.CLICKHOUSE_URL!,
+    username: process.env.CLICKHOUSE_USERNAME!,
+    password: process.env.CLICKHOUSE_PASSWORD!,
+  },
+})
+
+await observability.init()
+```
+
+In CI/CD pipelines, set `disableInit: true` on `ClickhouseStore` and run `init()` from a deployment step that uses elevated credentials. Runtime application credentials can then be limited to read and insert.
+
+## Observability
+
+ClickHouse is the recommended backend for production observability:
+
+- **Insert-only strategy**: `DefaultExporter` writes completed spans in batches without per-span updates, which is the highest-throughput strategy available.
+- **Per-signal retention**: vNext applies independent TTLs for traces, logs, metrics, scores, and feedback.
+- **Columnar compression**: Span attributes and log payloads typically compress 5x to 20x compared to the same data in row-oriented databases.
+
+For the full strategy matrix and production guidance, see the [`DefaultExporter` reference](/docs/observability/tracing/exporters/default#storage-provider-support).
+
+## Related
+
+- [Storage overview](/reference/storage/overview)
+- [Composite storage](/reference/storage/composite)
+- [`DefaultExporter`](/docs/observability/tracing/exporters/default)
+- [Observability overview](/docs/observability/overview)

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -267,7 +267,6 @@ const storage = new MastraCompositeStore({
       url: process.env.CLICKHOUSE_URL,
       username: process.env.CLICKHOUSE_USERNAME,
       password: process.env.CLICKHOUSE_PASSWORD,
-      retention: { tracing: 30, logs: 14, metrics: 90 },
     }),
   },
 })
@@ -275,7 +274,7 @@ const storage = new MastraCompositeStore({
 
 :::note
 
-`ObservabilityStorageClickhouseVNext` is the current observability domain implementation and supports per-signal retention. The legacy `ObservabilityStorageClickhouse` class is also exported and remains supported for projects that have not migrated. See the [ClickHouse storage reference](/reference/storage/clickhouse) for details.
+`ObservabilityStorageClickhouseVNext` is the current observability domain implementation. The legacy `ObservabilityStorageClickhouse` class is also exported and remains supported for projects that have not migrated. See the [ClickHouse storage reference](/reference/storage/clickhouse) for details.
 
 :::
 

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -250,12 +250,12 @@ const storage = new MastraCompositeStore({
 
 Observability data can quickly overwhelm general-purpose databases in production. A single agent interaction can generate hundreds of spans, and high-traffic applications can produce thousands of traces per day.
 
-**ClickHouse** is recommended for production observability because it's optimized for high-volume, write-heavy analytics workloads. Use composite storage to route observability to ClickHouse while keeping other data in your primary database:
+**[ClickHouse](/reference/storage/clickhouse)** is recommended for production observability because it's optimized for high-volume, write-heavy analytics workloads. Use composite storage to route observability to ClickHouse while keeping other data in your primary database:
 
 ```typescript
 import { MastraCompositeStore } from '@mastra/core/storage'
 import { MemoryPG, WorkflowsPG, ScoresPG } from '@mastra/pg'
-import { ObservabilityStorageClickhouse } from '@mastra/clickhouse'
+import { ObservabilityStorageClickhouseVNext } from '@mastra/clickhouse'
 
 const storage = new MastraCompositeStore({
   id: 'composite',
@@ -263,14 +263,21 @@ const storage = new MastraCompositeStore({
     memory: new MemoryPG({ connectionString: process.env.DATABASE_URL }),
     workflows: new WorkflowsPG({ connectionString: process.env.DATABASE_URL }),
     scores: new ScoresPG({ connectionString: process.env.DATABASE_URL }),
-    observability: new ObservabilityStorageClickhouse({
+    observability: new ObservabilityStorageClickhouseVNext({
       url: process.env.CLICKHOUSE_URL,
       username: process.env.CLICKHOUSE_USERNAME,
       password: process.env.CLICKHOUSE_PASSWORD,
+      retention: { tracing: 30, logs: 14, metrics: 90 },
     }),
   },
 })
 ```
+
+:::note
+
+`ObservabilityStorageClickhouseVNext` is the current observability domain implementation and supports per-signal retention. The legacy `ObservabilityStorageClickhouse` class is also exported and remains supported for projects that have not migrated. See the [ClickHouse storage reference](/reference/storage/clickhouse) for details.
+
+:::
 
 :::info
 


### PR DESCRIPTION
## Description

This PR adds comprehensive reference documentation for the ClickHouse storage implementation in Mastra. The new documentation covers:

- **New ClickHouse Storage Reference**: A complete guide to using ClickHouse as a storage backend, including:
  - Overview of ClickHouse capabilities and when to use it
  - Installation and setup instructions
  - Usage examples for observability with vNext (recommended) and legacy domain
  - Full storage configuration with `ClickhouseStore`
  - Custom client configuration options
  - Detailed configuration reference for all options
  - Hosting options (ClickHouse Cloud and self-hosted)
  - Deployment guidance for ephemeral filesystem platforms (Railway, Fly.io, Render, Heroku)
  - Initialization and schema management
  - Production observability best practices

- **Updated Related Documentation**: 
  - Updated composite storage reference to link to the new ClickHouse documentation and recommend `ObservabilityStorageClickhouseVNext`
  - Updated DefaultExporter documentation to reference the ClickHouse storage guide
  - Updated metrics overview to clarify OLAP store requirements
  - Updated automatic metrics reference documentation
  - Added ClickHouse Storage to the storage reference sidebar navigation

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have addressed all cross-references and sidebar navigation

https://claude.ai/code/session_01AzAdE2Ba5nsB8y2BebCFtK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR adds a clear how-to guide showing how to use ClickHouse (a fast analytics database) with Mastra for storing observability data. It explains setup, configuration, hosting options, and best practices so teams can run reliable production metrics and traces.

## Overview

Adds a comprehensive ClickHouse storage reference for Mastra that documents when to use ClickHouse, how to install and configure it, usage examples for both the recommended vNext observability integration and legacy adapters, hosting/deployment guidance (including ephemeral-filesystem platforms), initialization/schema management, and production observability recommendations. Also updates related docs to point to and recommend the new ClickHouse guide.

## Key Changes

### New Documentation
- **ClickHouse Storage Reference** (`docs/src/content/en/reference/storage/clickhouse.mdx`): New detailed page (~+303 lines) covering:
  - Intended analytical/observability use and recommended scenarios (recommended for production observability, especially in composite storage)
  - Installation and hosting options (ClickHouse Cloud, self-hosted Docker, local Docker example)
  - Integration modes:
    - vNext observability: `ObservabilityStorageClickhouseVNext` (recommended; per-signal retention)
    - Legacy observability: `ObservabilityStorageClickhouse`
    - Full-domain store: `ClickhouseStore` supporting domains memory, workflows, scores, and observability
  - How to inject a pre-configured `@clickhouse/client`
  - Full `ClickhouseStore` configuration reference (including `ttl`, `disableInit`, and initialization behaviors)
  - Initialization rules and CI/CD guidance (when `init()` runs automatically vs. manual/privileged init)
  - Deployment guidance for ephemeral-filesystem platforms (Railway, Fly.io, Render, Heroku) and warning against embedded backends for production
  - Observability positioning: insert-only write pattern, columnar compression, and best practices

### Documentation Updates / Cross-references
- **Metrics Overview** (`docs/src/content/en/docs/observability/metrics/overview.mdx`): Broadens phrasing to require an “OLAP-capable” store; updates local guidance to recommend DuckDB (`@mastra/duckdb`) for local development and ClickHouse (`@mastra/clickhouse`) for production.
- **Default Exporter** (`docs/src/content/en/docs/observability/tracing/exporters/default.mdx`): Routes observability storage guidance to ClickHouse via composite storage and links to the new ClickHouse reference.
- **Automatic Metrics Reference** (`docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx`): Expands supported persistence claim to include ClickHouse alongside DuckDB and in-memory; clarifies row-oriented DBs do not currently support metrics persistence.
- **Composite Storage Reference** (`docs/src/content/en/reference/storage/composite.mdx`): Switches observability example to use `ObservabilityStorageClickhouseVNext`; notes vNext is the current per-signal retention implementation while legacy adapter remains exported for backwards compatibility.
- **Sidebar Navigation** (`docs/src/content/en/reference/sidebars.js`): Adds “ClickHouse Storage” to the Storage section.

## Notable Commit/Review Adjustments
- Removed references to retention/RetentionConfig (not user-configurable).
- Corrected `ClickhouseStore` domain list to memory, workflows, scores, and observability.
- Removed “high-volume” framing and harmonized cross-links for DuckDB/ClickHouse.
- Shortened storage paragraph in automatic-metrics reference.

## Impact

Documentation-only change (no code/exported API changes). Establishes ClickHouse as the recommended production observability backend for Mastra with actionable setup, configuration, and deployment guidance, and updates related docs to point users to the new reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->