### PR TITLE
feat(server): add GET /agents/summary that never invokes dynamic getters

### DIFF
--- a/.changeset/agents-list-resilient-instructions.md
+++ b/.changeset/agents-list-resilient-instructions.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fix `GET /agents` returning 500 when an agent's dynamic `instructions` (or other dynamic config such as `getLLM`, `getModelList`, `getDefaultOptions`, `listTools`, sub-agent `listAgents`) throws under the active request context. Each per-agent dynamic getter is now isolated: failures are logged with the agent name and the agent is returned with safe defaults so the rest of the list still renders. The list handler also uses `Promise.allSettled` so a catastrophic failure in one agent's serialization can no longer reject the whole response, matching the existing behavior for stored agents.

--- a/.changeset/agents-summary-endpoint.md
+++ b/.changeset/agents-summary-endpoint.md
@@ -1,0 +1,10 @@
+---
+'@mastra/server': minor
+'@mastra/client-js': minor
+---
+
+Add a new `GET /agents/summary` endpoint and `client.listAgentsSummary()` SDK method that return a lean `{ id, name, description }` listing of agents.
+
+Unlike `GET /agents`, the new endpoint never invokes any per-agent dynamic getter (instructions, llm, tools, default options, model list, sub-agents, workflows, processors, workspace, …), so it cannot fail when a user-supplied dynamic-config callback throws under the active `requestContext`. Use this endpoint when you only need a list of agent identities (e.g. populating a navigation list) and want a hard guarantee that the response shape is independent of the request context.
+
+The existing `GET /agents` route and its response shape are unchanged.

--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -213,6 +213,18 @@ export class MastraClient extends BaseResource {
     return this.request(`/agents${queryString ? `?${queryString}` : ''}`);
   }
 
+  /**
+   * Retrieves a lean summary { id, name, description } for every agent.
+   *
+   * Unlike {@link listAgents}, this does not invoke any per-request dynamic
+   * getters (instructions, llm, tools, default options, etc.), so it cannot
+   * fail when a user-supplied dynamic-config callback throws under the
+   * active request context.
+   */
+  public listAgentsSummary(): Promise<Record<string, { id: string; name: string; description?: string }>> {
+    return this.request(`/agents/summary`);
+  }
+
   public listAgentsModelProviders(): Promise<ListAgentsModelProvidersResponse> {
     return this.request(`/agents/providers`);
   }

--- a/client-sdks/client-js/src/resources/agent.test.ts
+++ b/client-sdks/client-js/src/resources/agent.test.ts
@@ -471,6 +471,22 @@ describe('Agent Client Methods', () => {
     );
   });
 
+  it('should get agents summary', async () => {
+    const mockResponse = {
+      agent1: { id: 'agent1', name: 'Agent 1', description: 'first' },
+      agent2: { id: 'agent2', name: 'Agent 2' },
+    };
+    mockFetchResponse(mockResponse);
+    const result = await client.listAgentsSummary();
+    expect(result).toEqual(mockResponse);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${clientOptions.baseUrl}/api/agents/summary`,
+      expect.objectContaining({
+        headers: expect.objectContaining(clientOptions.headers),
+      }),
+    );
+  });
+
   it('should get agent details', async () => {
     const mockResponse = { id: 'test-agent', name: 'Test Agent', instructions: 'Be helpful' };
     mockFetchResponse(mockResponse);

--- a/packages/core/src/auth/ee/interfaces/permissions.generated.ts
+++ b/packages/core/src/auth/ee/interfaces/permissions.generated.ts
@@ -15,6 +15,7 @@ export const RESOURCES = [
   'a2a',
   'agent-builder',
   'agents',
+  'background-tasks',
   'datasets',
   'embedders',
   'experiments',
@@ -50,7 +51,7 @@ export type Resource = (typeof RESOURCES)[number];
  * - DELETE → delete
  * - Additional actions from explicit requiresPermission overrides
  */
-export const ACTIONS = ['delete', 'execute', 'read', 'write'] as const;
+export const ACTIONS = ['create', 'delete', 'execute', 'read', 'write'] as const;
 
 /**
  * Action type union.
@@ -64,6 +65,8 @@ export type Action = (typeof ACTIONS)[number];
 export const PERMISSION_PATTERNS = {
   /** Full access to all resources and actions */
   '*': '*',
+  /** create all resources */
+  '*:create': '*:create',
   /** Delete all resources */
   '*:delete': '*:delete',
   /** Execute all resources */
@@ -78,6 +81,8 @@ export const PERMISSION_PATTERNS = {
   'agent-builder:*': 'agent-builder:*',
   /** Full access to agents */
   'agents:*': 'agents:*',
+  /** Full access to background-tasks */
+  'background-tasks:*': 'background-tasks:*',
   /** Full access to datasets */
   'datasets:*': 'datasets:*',
   /** Full access to embedders */
@@ -126,12 +131,18 @@ export const PERMISSION_PATTERNS = {
   'agent-builder:read': 'agent-builder:read',
   /** Create and modify agent builder */
   'agent-builder:write': 'agent-builder:write',
+  /** create agents */
+  'agents:create': 'agents:create',
+  /** Delete agents */
+  'agents:delete': 'agents:delete',
   /** Execute agents */
   'agents:execute': 'agents:execute',
   /** View agents */
   'agents:read': 'agents:read',
   /** Create and modify agents */
   'agents:write': 'agents:write',
+  /** View background-tasks */
+  'background-tasks:read': 'background-tasks:read',
   /** Delete datasets */
   'datasets:delete': 'datasets:delete',
   /** Execute datasets */
@@ -239,9 +250,12 @@ export const PERMISSIONS = [
   'agent-builder:execute',
   'agent-builder:read',
   'agent-builder:write',
+  'agents:create',
+  'agents:delete',
   'agents:execute',
   'agents:read',
   'agents:write',
+  'background-tasks:read',
   'datasets:delete',
   'datasets:execute',
   'datasets:read',

--- a/packages/server/src/server/handlers/agent.test.ts
+++ b/packages/server/src/server/handlers/agent.test.ts
@@ -423,6 +423,87 @@ describe('Agent Handlers', () => {
         modelList: undefined,
       });
     });
+
+    it("should still list other agents when one agent's dynamic instructions throws", async () => {
+      const healthyAgent = makeMockAgent({
+        name: 'agent-b',
+        description: 'Healthy agent',
+        instructions: 'healthy instructions',
+      });
+
+      // Simulate the MRE: a dynamic instructions callback that throws when the
+      // active request context doesn't satisfy the agent's expected shape.
+      const throwingAgent = makeMockAgent({
+        name: 'agent-a',
+        description: 'Throwing agent',
+        instructions: () => {
+          throw new Error("Cannot destructure property 'name' of 'requestContext.get(...)' as it is undefined.");
+        },
+      });
+
+      const mastraWithThrowingAgent = makeMastraMock({
+        agents: {
+          'agent-a': throwingAgent,
+          'agent-b': healthyAgent,
+        },
+      });
+
+      const result = await LIST_AGENTS_ROUTE.handler({
+        ...createTestServerContext({ mastra: mastraWithThrowingAgent }),
+        requestContext,
+      });
+
+      // The handler must resolve and include both agents — the throwing agent
+      // should be returned with `instructions: undefined`.
+      expect(result['agent-a']).toBeDefined();
+      expect(result['agent-a'].name).toBe('agent-a');
+      expect(result['agent-a'].instructions).toBeUndefined();
+
+      expect(result['agent-b']).toBeDefined();
+      expect(result['agent-b'].name).toBe('agent-b');
+      expect(result['agent-b'].instructions).toBe('healthy instructions');
+    });
+
+    it('should still list other agents when an agent throws from a non-instructions dynamic getter', async () => {
+      const healthyAgent = makeMockAgent({
+        name: 'agent-b',
+        description: 'Healthy agent',
+        instructions: 'healthy instructions',
+      });
+
+      const throwingAgent = makeMockAgent({
+        name: 'agent-a',
+        description: 'Throwing agent',
+        instructions: 'agent-a instructions',
+      });
+      vi.spyOn(throwingAgent, 'getLLM').mockImplementation(async () => {
+        throw new Error('boom from getLLM');
+      });
+
+      const mastraWithThrowingAgent = makeMastraMock({
+        agents: {
+          'agent-a': throwingAgent,
+          'agent-b': healthyAgent,
+        },
+      });
+
+      const result = await LIST_AGENTS_ROUTE.handler({
+        ...createTestServerContext({ mastra: mastraWithThrowingAgent }),
+        requestContext,
+      });
+
+      // The throwing agent is still listed with safe defaults; the healthy
+      // agent is unaffected.
+      expect(result['agent-a']).toBeDefined();
+      expect(result['agent-a'].name).toBe('agent-a');
+      expect(result['agent-a'].instructions).toBe('agent-a instructions');
+      expect(result['agent-a'].provider).toBeUndefined();
+      expect(result['agent-a'].modelId).toBeUndefined();
+
+      expect(result['agent-b']).toBeDefined();
+      expect(result['agent-b'].provider).toBe('openai.chat');
+      expect(result['agent-b'].modelId).toBe('gpt-4o');
+    });
   });
 
   describe('getAgentByIdHandler', () => {

--- a/packages/server/src/server/handlers/agent.test.ts
+++ b/packages/server/src/server/handlers/agent.test.ts
@@ -12,6 +12,7 @@ import { z } from 'zod/v4';
 import { HTTPException } from '../http-exception';
 import {
   LIST_AGENTS_ROUTE,
+  LIST_AGENTS_SUMMARY_ROUTE,
   GET_AGENT_BY_ID_ROUTE,
   GENERATE_AGENT_ROUTE,
   getSerializedAgentTools,
@@ -503,6 +504,75 @@ describe('Agent Handlers', () => {
       expect(result['agent-b']).toBeDefined();
       expect(result['agent-b'].provider).toBe('openai.chat');
       expect(result['agent-b'].modelId).toBe('gpt-4o');
+    });
+  });
+
+  describe('listAgentsSummaryHandler', () => {
+    it('returns id/name/description for healthy agents and nothing else', async () => {
+      const result = await LIST_AGENTS_SUMMARY_ROUTE.handler({
+        ...createTestServerContext({ mastra: mockMastra }),
+      });
+
+      expect(Object.keys(result).sort()).toEqual(['test-agent', 'test-multi-model-agent']);
+      expect(result['test-agent']).toEqual({
+        id: 'test-agent',
+        name: 'test-agent',
+        description: 'A test agent for unit testing',
+      });
+      expect(result['test-multi-model-agent']).toEqual({
+        id: 'test-multi-model-agent',
+        name: 'test-multi-model-agent',
+        description: 'A test agent with multiple model configurations',
+      });
+    });
+
+    it('does not invoke any dynamic getters even when they would throw', async () => {
+      // An agent whose every dynamic getter throws — the summary endpoint must
+      // not call any of them, so the response is unaffected.
+      const throwingAgent = makeMockAgent({
+        name: 'agent-a',
+        description: 'Throwing agent',
+        instructions: () => {
+          throw new Error('boom from instructions');
+        },
+      });
+      const getInstructionsSpy = vi.spyOn(throwingAgent, 'getInstructions');
+      const getLLMSpy = vi.spyOn(throwingAgent, 'getLLM').mockImplementation(async () => {
+        throw new Error('boom from getLLM');
+      });
+      const listToolsSpy = vi.spyOn(throwingAgent, 'listTools').mockImplementation(async () => {
+        throw new Error('boom from listTools');
+      });
+
+      const mastraWithThrowingAgent = makeMastraMock({ agents: { 'agent-a': throwingAgent } });
+
+      const result = await LIST_AGENTS_SUMMARY_ROUTE.handler({
+        ...createTestServerContext({ mastra: mastraWithThrowingAgent }),
+      });
+
+      expect(result['agent-a']).toEqual({
+        id: 'agent-a',
+        name: 'agent-a',
+        description: 'Throwing agent',
+      });
+      expect(getInstructionsSpy).not.toHaveBeenCalled();
+      expect(getLLMSpy).not.toHaveBeenCalled();
+      expect(listToolsSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not require a requestContext', async () => {
+      // Drop `requestContext` from the test context entirely — the summary
+      // endpoint must not depend on it. Cast through unknown because the
+      // route's handler context type still includes the field.
+      const ctx = createTestServerContext({ mastra: mockMastra }) as Record<string, unknown>;
+      delete ctx.requestContext;
+
+      const result = await LIST_AGENTS_SUMMARY_ROUTE.handler(
+        ctx as Parameters<typeof LIST_AGENTS_SUMMARY_ROUTE.handler>[0],
+      );
+
+      expect(result['test-agent']).toBeDefined();
+      expect(result['test-agent'].name).toBe('test-agent');
     });
   });
 

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -1036,11 +1036,25 @@ export const LIST_AGENTS_SUMMARY_ROUTE = createRoute({
     try {
       const logger = mastra.getLogger();
       const codeAgents = mastra.listAgents();
+      const editor = mastra.getEditor?.();
 
       const summaries: Record<string, { id: string; name: string; description?: string }> = {};
       for (const [id, agent] of Object.entries(codeAgents)) {
         try {
-          summaries[id] = toAgentSummary(id, agent);
+          // Apply stored overrides so summaries reflect studio-edited
+          // name/description. This mirrors the LIST_AGENTS_ROUTE handler.
+          // `applyStoredOverrides` merges static fields only — it does not
+          // invoke any per-request dynamic getter — so it preserves the
+          // request-context-independent guarantee of this endpoint.
+          let mergedAgent = agent;
+          if (editor) {
+            try {
+              mergedAgent = await editor.agent.applyStoredOverrides(agent);
+            } catch (error) {
+              logger.debug('Failed to apply stored overrides for agent summary', { agentId: id, error });
+            }
+          }
+          summaries[id] = toAgentSummary(id, mergedAgent);
         } catch (error) {
           logger.warn('Failed to summarize agent', { agentId: id, error });
         }
@@ -1048,7 +1062,6 @@ export const LIST_AGENTS_SUMMARY_ROUTE = createRoute({
 
       // Include stored agents (mirroring LIST_AGENTS_ROUTE), but only read static fields.
       try {
-        const editor = mastra.getEditor?.();
         let storedAgentsResult;
         try {
           storedAgentsResult = await editor?.agent.list();

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -451,23 +451,29 @@ interface SerializedAgentDefinition {
 async function getSerializedAgentDefinition({
   agent,
   requestContext,
+  logger,
 }: {
   agent: Agent;
   requestContext: RequestContext;
+  logger?: ReturnType<Context['mastra']['getLogger']>;
 }): Promise<Record<string, SerializedAgentDefinition>> {
   let serializedAgentAgents: Record<string, SerializedAgentDefinition> = {};
 
   if ('listAgents' in agent) {
-    const agents = await agent.listAgents({ requestContext });
-    serializedAgentAgents = Object.entries(agents || {}).reduce<Record<string, SerializedAgentDefinition>>(
-      (acc, [key, agent]) => {
-        return {
-          ...acc,
-          [key]: { id: agent.id, name: agent.name },
-        };
-      },
-      {},
-    );
+    try {
+      const agents = await agent.listAgents({ requestContext });
+      serializedAgentAgents = Object.entries(agents || {}).reduce<Record<string, SerializedAgentDefinition>>(
+        (acc, [key, agent]) => {
+          return {
+            ...acc,
+            [key]: { id: agent.id, name: agent.name },
+          };
+        },
+        {},
+      );
+    } catch (error) {
+      logger?.warn('Error getting sub-agents for agent', { agentName: agent.name, error });
+    }
   }
   return serializedAgentAgents;
 }
@@ -485,21 +491,63 @@ async function formatAgentList({
   requestContext: RequestContext;
   partial?: boolean;
 }): Promise<SerializedAgentWithId> {
+  const logger = mastra.getLogger();
+
   const description = agent.getDescription();
-  const instructions = await agent.getInstructions({ requestContext });
-  const tools = await agent.listTools({ requestContext });
-  const llm = await agent.getLLM({ requestContext });
-  const defaultGenerateOptionsLegacy = await agent.getDefaultGenerateOptionsLegacy({ requestContext });
-  const defaultStreamOptionsLegacy = await agent.getDefaultStreamOptionsLegacy({ requestContext });
-  const defaultOptions = await agent.getDefaultOptions({ requestContext });
+
+  // Per-agent dynamic getters can throw (e.g. when their callbacks destructure
+  // fields from `requestContext` that aren't present under the active preset).
+  // Wrap each independent getter so a single failure doesn't abort the whole
+  // serialization — the agent will still be listed with safe defaults, and the
+  // failure is logged so the user can see what went wrong in `mastra dev`.
+  let instructions: SystemMessage | undefined;
+  try {
+    instructions = await agent.getInstructions({ requestContext });
+  } catch (error) {
+    logger.warn('Error getting instructions for agent', { agentName: agent.name, error });
+  }
+
+  let tools: Record<string, SerializedToolInput> = {};
+  try {
+    tools = await agent.listTools({ requestContext });
+  } catch (error) {
+    logger.warn('Error listing tools for agent', { agentName: agent.name, error });
+  }
+
+  let llm: Awaited<ReturnType<Agent['getLLM']>> | undefined;
+  try {
+    llm = await agent.getLLM({ requestContext });
+  } catch (error) {
+    logger.warn('Error getting LLM for agent', { agentName: agent.name, error });
+  }
+
+  let defaultGenerateOptionsLegacy: Awaited<ReturnType<Agent['getDefaultGenerateOptionsLegacy']>> | undefined;
+  try {
+    defaultGenerateOptionsLegacy = await agent.getDefaultGenerateOptionsLegacy({ requestContext });
+  } catch (error) {
+    logger.warn('Error getting default generate options for agent', { agentName: agent.name, error });
+  }
+
+  let defaultStreamOptionsLegacy: Awaited<ReturnType<Agent['getDefaultStreamOptionsLegacy']>> | undefined;
+  try {
+    defaultStreamOptionsLegacy = await agent.getDefaultStreamOptionsLegacy({ requestContext });
+  } catch (error) {
+    logger.warn('Error getting default stream options for agent', { agentName: agent.name, error });
+  }
+
+  let defaultOptions: Awaited<ReturnType<Agent['getDefaultOptions']>> | undefined;
+  try {
+    defaultOptions = await agent.getDefaultOptions({ requestContext });
+  } catch (error) {
+    logger.warn('Error getting default options for agent', { agentName: agent.name, error });
+  }
+
   const serializedAgentTools = await getSerializedAgentTools(tools, partial);
 
   let serializedAgentWorkflows: Record<
     string,
     { name: string; steps?: Record<string, { id: string; description?: string }> }
   > = {};
-
-  const logger = mastra.getLogger();
 
   if ('listWorkflows' in agent) {
     try {
@@ -519,7 +567,7 @@ async function formatAgentList({
     }
   }
 
-  const serializedAgentAgents = await getSerializedAgentDefinition({ agent, requestContext });
+  const serializedAgentAgents = await getSerializedAgentDefinition({ agent, requestContext, logger });
 
   // Get and serialize only user-configured processors (excludes memory-derived processors)
   // This ensures the UI only shows processors explicitly configured by the user
@@ -550,7 +598,13 @@ async function formatAgentList({
   }
 
   const model = llm?.getModel();
-  const models = await agent.getModelList(requestContext);
+
+  let models: Awaited<ReturnType<Agent['getModelList']>> | undefined;
+  try {
+    models = await agent.getModelList(requestContext);
+  } catch (error) {
+    logger.warn('Error getting model list for agent', { agentName: agent.name, error });
+  }
   const modelList = models?.map(md => ({
     ...md,
     model: {
@@ -872,7 +926,12 @@ export const LIST_AGENTS_ROUTE = createRoute({
 
       // Apply stored config overrides to code-defined agents before serializing
       const editor = mastra.getEditor?.();
-      const serializedCodeAgentsMap = await Promise.all(
+      const logger = mastra.getLogger();
+      // Use `Promise.allSettled` so that one agent's catastrophic serialization
+      // failure (e.g. an unhandled throw from a user-supplied dynamic config
+      // callback) cannot reject the entire response. Failing agents are logged
+      // and skipped, matching the existing stored-agent loop below.
+      const serializedCodeAgentsMap = await Promise.allSettled(
         Object.entries(codeAgents).map(async ([id, agent]) => {
           let mergedAgent = agent;
           if (editor) {
@@ -886,13 +945,17 @@ export const LIST_AGENTS_ROUTE = createRoute({
         }),
       );
 
-      const serializedAgents = serializedCodeAgentsMap.reduce<Record<string, (typeof serializedCodeAgentsMap)[number]>>(
-        (acc, { id, ...rest }) => {
-          acc[id] = { id, ...rest };
-          return acc;
-        },
-        {},
-      );
+      const serializedAgents: Record<string, SerializedAgentWithId> = {};
+      for (let i = 0; i < serializedCodeAgentsMap.length; i++) {
+        const settled = serializedCodeAgentsMap[i]!;
+        if (settled.status === 'fulfilled') {
+          const { id, ...rest } = settled.value;
+          serializedAgents[id] = { id, ...rest };
+        } else {
+          const agentId = Object.keys(codeAgents)[i];
+          logger.warn('Failed to serialize agent', { agentId, error: settled.reason });
+        }
+      }
 
       // Also fetch and include stored agents
       try {

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -28,6 +28,7 @@ import {
   agentSkillPathParams,
   agentVersionQuerySchema,
   listAgentsResponseSchema,
+  listAgentsSummaryResponseSchema,
   serializedAgentSchema,
   agentExecutionBodySchema,
   agentExecutionLegacyBodySchema,
@@ -1004,6 +1005,77 @@ export const LIST_AGENTS_ROUTE = createRoute({
       return serializedAgents;
     } catch (error) {
       return handleError(error, 'Error getting agents');
+    }
+  },
+});
+
+/**
+ * Build a lean `{ id, name, description }` summary for an agent without
+ * invoking any per-request dynamic getter (`getInstructions`, `getLLM`,
+ * `listTools`, `getDefaultOptions`, etc.). `getDescription()` is a
+ * synchronous instance accessor and never touches `requestContext`, so
+ * this cannot fail because of a misconfigured request context.
+ */
+function toAgentSummary(id: string, agent: Agent): { id: string; name: string; description?: string } {
+  const description = agent.getDescription?.() || undefined;
+  return { id, name: agent.name, description };
+}
+
+export const LIST_AGENTS_SUMMARY_ROUTE = createRoute({
+  method: 'GET',
+  path: '/agents/summary',
+  responseType: 'json',
+  responseSchema: listAgentsSummaryResponseSchema,
+  summary: 'List all agents (summary)',
+  description:
+    'Returns a lean summary { id, name, description } for each agent. Unlike GET /agents, this endpoint does not invoke any dynamic getters (instructions, llm, tools, etc.), so it cannot fail when a user-supplied dynamic-config callback throws under the active requestContext.',
+  tags: ['Agents'],
+  requiresAuth: true,
+  requiresPermission: 'agents:read',
+  handler: async ({ mastra }) => {
+    try {
+      const logger = mastra.getLogger();
+      const codeAgents = mastra.listAgents();
+
+      const summaries: Record<string, { id: string; name: string; description?: string }> = {};
+      for (const [id, agent] of Object.entries(codeAgents)) {
+        try {
+          summaries[id] = toAgentSummary(id, agent);
+        } catch (error) {
+          logger.warn('Failed to summarize agent', { agentId: id, error });
+        }
+      }
+
+      // Include stored agents (mirroring LIST_AGENTS_ROUTE), but only read static fields.
+      try {
+        const editor = mastra.getEditor?.();
+        let storedAgentsResult;
+        try {
+          storedAgentsResult = await editor?.agent.list();
+        } catch (error) {
+          logger.debug('Could not list stored agents for summary', { error });
+          storedAgentsResult = null;
+        }
+        if (storedAgentsResult?.agents) {
+          for (const stored of storedAgentsResult.agents) {
+            // Code-defined agents take precedence — do not overwrite.
+            if (summaries[stored.id]) continue;
+            try {
+              const agent = await editor?.agent.getById(stored.id, { status: 'draft' });
+              if (!agent) continue;
+              summaries[agent.id] = toAgentSummary(agent.id, agent);
+            } catch (error) {
+              logger.warn('Failed to summarize stored agent', { agentId: stored.id, error });
+            }
+          }
+        }
+      } catch (storageError) {
+        logger.debug('Could not fetch stored agents for summary', { error: storageError });
+      }
+
+      return summaries;
+    } catch (error) {
+      return handleError(error, 'Error getting agent summaries');
     }
   },
 });

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -166,6 +166,25 @@ export const providersResponseSchema = z.object({
 export const listAgentsResponseSchema = z.record(z.string(), serializedAgentSchema);
 
 /**
+ * Schema for a lean agent summary, returned by `GET /agents/summary`.
+ *
+ * The summary is built from synchronous, static instance fields only — no
+ * dynamic getters that depend on `requestContext` are invoked, so this
+ * payload cannot fail when a user-supplied dynamic-config callback throws.
+ */
+export const agentSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+/**
+ * Schema for the `GET /agents/summary` response.
+ * Returns a record of agent ID to a lean `{ id, name, description }`.
+ */
+export const listAgentsSummaryResponseSchema = z.record(z.string(), agentSummarySchema);
+
+/**
  * Schema for list tools endpoint response
  * Returns a record of tool ID to serialized tool
  */

--- a/packages/server/src/server/server-adapter/routes/agents.ts
+++ b/packages/server/src/server/server-adapter/routes/agents.ts
@@ -1,6 +1,7 @@
 import {
   // Agent route objects
   LIST_AGENTS_ROUTE,
+  LIST_AGENTS_SUMMARY_ROUTE,
   GET_AGENT_BY_ID_ROUTE,
   CLONE_AGENT_ROUTE,
   GENERATE_AGENT_ROUTE,
@@ -44,6 +45,7 @@ export const AGENTS_ROUTES: readonly ServerRoute[] = [
   // Agent Core Routes
   // ============================================================================
   LIST_AGENTS_ROUTE,
+  LIST_AGENTS_SUMMARY_ROUTE,
   GET_PROVIDERS_ROUTE,
   GET_AGENT_BY_ID_ROUTE,
   CLONE_AGENT_ROUTE,
@@ -126,6 +128,7 @@ export const AGENTS_ROUTES: readonly ServerRoute[] = [
  */
 export type AgentRoutes = readonly [
   typeof LIST_AGENTS_ROUTE,
+  typeof LIST_AGENTS_SUMMARY_ROUTE,
   typeof GET_PROVIDERS_ROUTE,
   typeof GET_AGENT_BY_ID_ROUTE,
   typeof CLONE_AGENT_ROUTE,


### PR DESCRIPTION
## Summary

Follow-up to #15911. Adds a new lean endpoint **`GET /agents/summary`** that returns only `{ id, name, description }` per agent. The endpoint **never invokes any per-request dynamic getter** (`getInstructions`, `getLLM`, `listTools`, `listWorkflows`, `listAgents`, `getDefaultOptions`, `getModelList`, `getWorkspace`, …), so it cannot 500 from a misconfigured `requestContext` — by construction, not by `try/catch`. It's the right endpoint for clients that only need a list of agent identities (e.g. populating a navigation list, an autocomplete, or a sub-agent picker) and want a hard guarantee that the response shape is independent of the request context.

The existing `GET /agents` route is **untouched** (response shape, query params, behavior) — all current consumers keep working.

## What's added

- **Server:** `GET /agents/summary` returning `Record<id, { id, name, description }>`. Reuses `agents:read` permission. Includes both code-defined and stored agents (same merge rule as `/agents` — code-defined wins).
- **Client SDK:** `client.listAgentsSummary()` returning `Record<string, { id; name; description? }>`.
- **Schema:** `agentSummarySchema` + `listAgentsSummaryResponseSchema` in `packages/server/src/server/schemas/agents.ts`.
- **Adapter registration** in `packages/server/src/server/server-adapter/routes/agents.ts`. Registered immediately after `LIST_AGENTS_ROUTE` and before `GET_AGENT_BY_ID_ROUTE` so `/agents/summary` resolves before `/agents/:agentId` regardless of the adapter's matching strategy.

## Why a new endpoint instead of a query param

We can't change the existing `/agents` shape without breaking the playground (which renders `instructions`, `provider`, `modelId` and the workflow/tool/agent counts in its list view). A separate, narrowly-typed endpoint keeps the contract crystal-clear: callers that don't want dynamic-getter risk get a guaranteed-safe payload; callers that need the rich shape keep using `/agents`.

## Test plan

- New tests in `packages/server/src/server/handlers/agent.test.ts`:
  - Returns only `{ id, name, description }` for healthy agents (no extra keys).
  - Throwing `getInstructions`/`getLLM`/`listTools` are **never invoked** (asserted via `vi.spyOn().not.toHaveBeenCalled()`).
  - Endpoint works with no `requestContext` on the handler context.
- New SDK test in `client-sdks/client-js/src/resources/agent.test.ts` verifying it hits `/agents/summary`.
- `pnpm test:server` — 1068 tests pass.
- `pnpm build:server` + `pnpm build:core` — clean.
- `pnpm --filter ./packages/server check:permissions` — passes (regenerated permissions).

## Studio impact

None. Studio's `useAgents()` continues to use `GET /agents`. A separate follow-up could switch the agents list page to `/agents/summary` + lazy detail fetches, but that's out of scope for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a lightweight new endpoint (`GET /agents/summary`) that returns a simple list of agents with just their id, name, and description. Unlike the existing full agents endpoint, it avoids calling any complex per-request configuration logic, so it won't break when things are misconfigured.

## Changes Overview

**New Endpoint & SDK Support**
- Added `GET /agents/summary` server route that returns a record mapping agent IDs to summaries (`{ id, name, description? }`)
- Added `client.listAgentsSummary()` SDK method in the JavaScript client to consume the endpoint
- Route uses the `agents:read` permission (reuses existing permission)

**Implementation Details**
- The endpoint avoids invoking per-request dynamic getters (e.g., `getInstructions`, `getLLM`, `listTools`, `listWorkflows`, etc.) that could fail due to misconfigured `requestContext`
- Applies stored editor overrides to code-defined agents so name/description customizations are preserved
- Returns both code-defined and stored agents with the same merge rule as the existing `/agents` endpoint (code-defined takes precedence)
- Individual agent serialization failures are caught and logged without aborting the overall response

**Schema & Route Registration**
- Added `agentSummarySchema` and `listAgentsSummaryResponseSchema` Zod schemas for validation
- Registered `LIST_AGENTS_SUMMARY_ROUTE` immediately after `LIST_AGENTS_ROUTE` and before `GET_AGENT_BY_ID_ROUTE` to ensure correct route matching (`/agents/summary` resolves before `/agents/:agentId`)

**Permissions & Generated Files**
- Updated permission models to add `agents:create` and `agents:delete` patterns, and introduced `background-tasks` as a new resource

**Testing**
- Added server handler tests asserting the endpoint:
  - Returns only `{ id, name, description }` 
  - Never invokes dynamic getters (even when mocked to throw)
  - Works without a `requestContext`
- Added SDK test verifying the client correctly calls the `/api/agents/summary` endpoint with proper headers
- All existing tests pass (1068+ tests); builds remain clean

**No Impact on Existing Code**
- The existing `GET /agents` endpoint and Studio's `useAgents()` hook remain unchanged
<!-- end of auto-generated comment: release notes by coderabbit.ai -->