### PR TITLE
docs: fix "Added in" version on background tasks pages

### DIFF
--- a/docs/src/content/en/docs/agents/background-tasks.mdx
+++ b/docs/src/content/en/docs/agents/background-tasks.mdx
@@ -8,7 +8,7 @@ packages:
 
 # Background tasks
 
-**Added in:** `@mastra/core@1.28.0`
+**Added in:** `@mastra/core@1.29.0`
 
 Background tasks let an agent dispatch a long-running tool call without blocking the agentic loop. The tool returns an immediate acknowledgement, the LLM continues responding, and the task runs to completion in the background. When it finishes, its result is written to memory and if you use [`streamUntilIdle()`](/reference/streaming/agents/streamUntilIdle) the agent is re-invoked automatically so the result is processed in the same call.
 

--- a/docs/src/content/en/docs/streaming/background-task-streaming.mdx
+++ b/docs/src/content/en/docs/streaming/background-task-streaming.mdx
@@ -7,7 +7,7 @@ packages:
 
 # Background task streaming
 
-**Added in:** `@mastra/core@1.28.0`
+**Added in:** `@mastra/core@1.29.0`
 
 `mastra.backgroundTaskManager.stream()` returns a `ReadableStream` of [background task](/docs/agents/background-tasks) lifecycle events. Use it to monitor running tasks across the system, for example to drive a status dashboard, surface progress in your own UI, or pipe events into an SSE response.
 

--- a/docs/src/content/en/reference/streaming/agents/streamUntilIdle.mdx
+++ b/docs/src/content/en/reference/streaming/agents/streamUntilIdle.mdx
@@ -7,7 +7,7 @@ packages:
 
 # Agent.streamUntilIdle()
 
-**Added in:** `@mastra/core@1.28.0`
+**Added in:** `@mastra/core@1.29.0`
 
 `streamUntilIdle()` streams an agent's response and keeps the stream open until every background task dispatched during the run completes. When a task finishes, its result is written to memory and the agentic loop re-enters automatically so the LLM can react to it. The stream closes once no tasks are running and no completions are queued.
 


### PR DESCRIPTION
The three pages introduced by #15843 mark the feature as `Added in: @mastra/core@1.28.0`, but 1.28.0 doesn't ship `streamUntilIdle()` — that landed in 1.29.0 via #15686. The dispatch primitive itself was added back in 1.26.0 via #15307, but on its own it isn't enough to use the feature as the docs describe, so 1.29.0 is the first release where the end-to-end flow these pages describe actually works.

Changes are mechanical: `@mastra/core@1.28.0` → `@mastra/core@1.29.0` on each of the three pages. No changeset since `mastra-docs` is private.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes the documentation's version numbers on three pages about background tasks. They incorrectly said these features were released in version 1.28.0, but they actually came out in version 1.29.0, so the documentation is being updated to show the correct version.

## Changes

Three documentation pages have their "Added in" metadata updated from `@mastra/core@1.28.0` to `@mastra/core@1.29.0`:

1. **docs/src/content/en/docs/agents/background-tasks.mdx** - Background tasks feature documentation
2. **docs/src/content/en/docs/streaming/background-task-streaming.mdx** - Background task streaming feature documentation
3. **docs/src/content/en/reference/streaming/agents/streamUntilIdle.mdx** - `Agent.streamUntilIdle()` API reference

## Context

- The documented end-to-end background tasks workflow, including the `streamUntilIdle()` method, did not ship in @mastra/core@1.28.0
- `streamUntilIdle()` was added in @mastra/core@1.29.0 (via #15686)
- A related dispatch primitive was added earlier in 1.26.0 (via #15307), but that alone doesn't provide the complete behavior described in the docs
- This is a mechanical documentation-only correction with no code changes or alterations to public API declarations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->