### PR TITLE
docs: add Temporal deployment guide

### DIFF
--- a/docs/src/content/en/docs/deployment/workflow-runners.mdx
+++ b/docs/src/content/en/docs/deployment/workflow-runners.mdx
@@ -14,3 +14,9 @@ Mastra [workflows](../workflows/overview.mdx) can be executed using the built-in
 Inngest is a developer platform for running background workflows without managing infrastructure. Mastra workflows can be deployed to Inngest, which provides step memoization, automatic retries, real-time monitoring, and suspend/resume capabilities.
 
 Visit the [Inngest deployment guide](/guides/deployment/inngest) for setup instructions and the [Inngest workflow example](https://github.com/mastra-ai/mastra/tree/main/examples/inngest) for a complete implementation.
+
+## Temporal
+
+Temporal is a durable execution platform for orchestrating long-running workflows. Mastra workflows can run on Temporal workers, with each `createStep` mapped to a Temporal activity for automatic retries and durable state.
+
+The `@mastra/temporal` package is experimental and not ready for production use. Visit the [Temporal deployment guide](/guides/deployment/temporal) for setup instructions.

--- a/docs/src/content/en/guides/deployment/temporal.mdx
+++ b/docs/src/content/en/guides/deployment/temporal.mdx
@@ -118,7 +118,7 @@ export const mastra = new Mastra({
 The worker is a long-lived Node.js process that polls a Temporal task queue. Install `MastraPlugin` and point its `src` option at the Mastra entry file that registers your workflows.
 
 ```ts title="src/mastra/worker.ts"
-import { MastraPlugin } from '@mastra/temporal'
+import { MastraPlugin } from '@mastra/temporal/worker'
 import { NativeConnection, Worker } from '@temporalio/worker'
 
 const connection = await NativeConnection.connect({

--- a/docs/src/content/en/guides/deployment/temporal.mdx
+++ b/docs/src/content/en/guides/deployment/temporal.mdx
@@ -85,6 +85,7 @@ Compose the steps into a workflow. The workflow `id` must be a static string lit
 ```ts title="src/mastra/workflows/index.ts"
 const workflow = createWorkflow({
   id: 'increment-workflow',
+  steps: [incrementStep],
   inputSchema: z.object({
     value: z.number(),
   }),

--- a/docs/src/content/en/guides/deployment/temporal.mdx
+++ b/docs/src/content/en/guides/deployment/temporal.mdx
@@ -125,15 +125,17 @@ const connection = await NativeConnection.connect({
   address: 'localhost:7233',
 })
 
+const mastraPlugin = new MastraPlugin()
+
+await mastraPlugin.prebuild({
+  entryFile: import.meta.resolve('./index.ts'),
+})
+
 const worker = await Worker.create({
   connection,
   namespace: 'default',
   taskQueue: 'mastra',
-  plugins: [
-    new MastraPlugin({
-      src: import.meta.resolve('./index.ts'),
-    }),
-  ],
+  plugins: [mastraPlugin],
 })
 
 await worker.run()
@@ -150,10 +152,6 @@ await worker.run()
    ```bash
    docker run --rm -p 7233:7233 -p 8080:8080 temporalio/auto-setup:latest
    ```
-
-   :::note
-   The `@mastra/temporal` package also ships a `docker-compose.yaml` you can copy into your project as a reference.
-   :::
 
 1. Open the Temporal UI at [http://localhost:8080](http://localhost:8080) to inspect namespaces, workflows, and activities.
 
@@ -210,23 +208,10 @@ export const { createWorkflow, createStep } = init({
 })
 ```
 
-### `MastraPlugin` debug mode
-
-Pass `debug: true` to write the transformed modules and emitted workflow bundles to `.mastra/temporal` for inspection. Use this when troubleshooting plugin output.
-
-```ts title="src/mastra/worker.ts"
-new MastraPlugin({
-  src: import.meta.resolve('./index.ts'),
-  debug: true,
-})
-```
-
 ## Constraints and notes
 
 - Workflow ids must be static string literals. The build-time transformer reads the literal value to derive Temporal workflow export names.
-- `MastraPlugin`'s `src` must point to the Mastra entry file that registers workflows in `new Mastra({ workflows: ... })`.
 - Activities are generated automatically from `createStep()` handlers. Do not pass them in `Worker.create({ activities })`.
-- The package does not currently implement Inngest-style flow control (`concurrency`, `rateLimit`, `throttle`, `debounce`, `priority`) or `cron` scheduling on `createWorkflow()`. Use Temporal's native [retry policies](https://docs.temporal.io/encyclopedia/retry-policies) and [schedules](https://docs.temporal.io/schedules) instead.
 
 ## Related
 

--- a/docs/src/content/en/guides/deployment/temporal.mdx
+++ b/docs/src/content/en/guides/deployment/temporal.mdx
@@ -1,0 +1,235 @@
+---
+title: "Temporal | Deployment"
+description: "Deploy Mastra workflows with Temporal"
+---
+
+# Temporal workflow
+
+[Temporal](https://temporal.io/) is a durable execution platform for orchestrating long-running, fault-tolerant workflows. The `@mastra/temporal` package lets you author workflows with the standard Mastra API and run them on a Temporal cluster.
+
+:::warning
+`@mastra/temporal` is experimental and not ready for production use. The API may change between releases. See the [package README](https://github.com/mastra-ai/mastra/tree/main/workflows/temporal) for the current state.
+:::
+
+## How Temporal works with Mastra
+
+Mastra workflows authored with `createWorkflow()` and `createStep()` map onto Temporal's workflow and activity model. The `MastraPlugin` for the Temporal worker compiles your Mastra entry file at bundle time:
+
+- Each `createStep()` handler is extracted into a Temporal activity.
+- Each `createWorkflow()` is rewritten into a Temporal workflow that invokes those activities.
+- The plugin registers the generated activities and workflows with the worker automatically.
+
+When a run starts through `mastra.getWorkflow(...).createRun().start(...)`, the Mastra client hands control to Temporal. Temporal then drives durable execution, retries, and state persistence on the worker.
+
+## Setup
+
+Install the required packages:
+
+```bash npm2yarn
+npm install @mastra/temporal@latest @temporalio/client @temporalio/worker @temporalio/envconfig
+```
+
+You also need access to a Temporal cluster. For local development, you can run one with Docker (see [Running locally](#running-locally)).
+
+## Building a Temporal-backed workflow
+
+This guide walks through creating a workflow with Temporal and Mastra, demonstrating a counter application that increments a value.
+
+### Temporal initialization
+
+Initialize the Temporal integration to obtain Mastra-compatible workflow helpers. The `createWorkflow()` and `createStep()` functions are bound to a Temporal client and a task queue.
+
+```ts title="src/mastra/temporal/index.ts"
+import { init } from '@mastra/temporal'
+import { Client, Connection } from '@temporalio/client'
+import { loadClientConnectConfig } from '@temporalio/envconfig'
+
+const config = loadClientConnectConfig()
+const connection = await Connection.connect(config.connectionOptions)
+const client = new Client({ connection })
+
+export const { createWorkflow, createStep } = init({
+  client,
+  taskQueue: 'mastra',
+})
+```
+
+`loadClientConnectConfig()` reads standard Temporal environment variables such as `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE`, and mTLS settings. See the [Temporal envconfig docs](https://docs.temporal.io/develop/typescript/temporal-clients) for the full list.
+
+### Creating steps
+
+Define the individual steps that will compose your workflow. Each step becomes a Temporal activity.
+
+```ts title="src/mastra/workflows/index.ts"
+import { z } from 'zod'
+import { createWorkflow, createStep } from '../temporal'
+
+const incrementStep = createStep({
+  id: 'increment',
+  inputSchema: z.object({
+    value: z.number(),
+  }),
+  outputSchema: z.object({
+    value: z.number(),
+  }),
+  execute: async ({ inputData }) => {
+    return { value: inputData.value + 1 }
+  },
+})
+```
+
+### Creating the workflow
+
+Compose the steps into a workflow. The workflow `id` must be a static string literal so the build-time transformer can derive its Temporal export name.
+
+```ts title="src/mastra/workflows/index.ts"
+const workflow = createWorkflow({
+  id: 'increment-workflow',
+  inputSchema: z.object({
+    value: z.number(),
+  }),
+  outputSchema: z.object({
+    value: z.number(),
+  }),
+}).then(incrementStep)
+
+workflow.commit()
+
+export { workflow as incrementWorkflow }
+```
+
+### Configuring the Mastra instance
+
+Register the workflow with Mastra. The execution is driven by the Temporal worker.
+
+```ts title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { PinoLogger } from '@mastra/loggers'
+import { incrementWorkflow } from './workflows'
+
+export const mastra = new Mastra({
+  workflows: { incrementWorkflow },
+  logger: new PinoLogger({ name: 'Mastra', level: 'info' }),
+})
+```
+
+## Running the worker
+
+The worker is a long-lived Node.js process that polls a Temporal task queue. Install `MastraPlugin` and point its `src` option at the Mastra entry file that registers your workflows.
+
+```ts title="src/mastra/worker.ts"
+import { MastraPlugin } from '@mastra/temporal'
+import { NativeConnection, Worker } from '@temporalio/worker'
+
+const connection = await NativeConnection.connect({
+  address: 'localhost:7233',
+})
+
+const worker = await Worker.create({
+  connection,
+  namespace: 'default',
+  taskQueue: 'mastra',
+  plugins: [
+    new MastraPlugin({
+      src: import.meta.resolve('./index.ts'),
+    }),
+  ],
+})
+
+await worker.run()
+```
+
+`MastraPlugin` rewrites the entry file into a workflow-only bundle and wires step handlers in as Temporal activities. You do not need to pass `activities` or `workflowsPath` to `Worker.create()` manually.
+
+## Running workflows
+
+### Running locally
+
+1. Start a local Temporal server. The simplest option is the `temporalio/auto-setup` Docker image:
+
+   ```bash
+   docker run --rm -p 7233:7233 -p 8080:8080 temporalio/auto-setup:latest
+   ```
+
+   :::note
+   The `@mastra/temporal` package also ships a `docker-compose.yaml` you can copy into your project as a reference.
+   :::
+
+1. Open the Temporal UI at [http://localhost:8080](http://localhost:8080) to inspect namespaces, workflows, and activities.
+
+1. Start the worker. In a new terminal, run:
+
+   ```bash
+   npx tsx src/mastra/worker.ts
+   ```
+
+1. Trigger a workflow run from a script or any process that imports your Mastra instance:
+
+   ```ts title="scripts/run.ts"
+   import { mastra } from '../src/mastra'
+
+   const run = await mastra.getWorkflow('incrementWorkflow').createRun()
+   const result = await run.start({ inputData: { value: 5 } })
+
+   console.log(result)
+   ```
+
+1. Monitor execution in the Temporal UI under **Workflows** to see step-by-step activity progress and retry history.
+
+### Running in production
+
+For production, use [Temporal Cloud](https://temporal.io/cloud) or a self-hosted Temporal cluster. Configure the client and worker connections through environment variables read by `@temporalio/envconfig`:
+
+```bash title=".env"
+TEMPORAL_ADDRESS=your-namespace.tmprl.cloud:7233
+TEMPORAL_NAMESPACE=your-namespace
+TEMPORAL_API_KEY=your-api-key
+```
+
+See the [Temporal Cloud connection docs](https://docs.temporal.io/cloud/get-started) for mTLS and API key options.
+
+:::warning
+The Temporal worker must run as a long-lived process. Do not deploy it to serverless platforms with short execution limits, such as AWS Lambda or Vercel functions. Use a container, VM, or worker-friendly platform such as Fly.io, Railway, or Kubernetes.
+:::
+
+## Configuration options
+
+### `taskQueue`
+
+Required. Identifies the Temporal task queue your worker polls. The same value must be passed to `init()` (used by the client to start runs) and to `Worker.create()` (used by the worker to receive them).
+
+### `startToCloseTimeout`
+
+Optional. Sets the maximum time a single activity (step) is allowed to run before Temporal cancels it and applies the retry policy. Defaults to `1 minute`.
+
+```ts title="src/mastra/temporal/index.ts"
+export const { createWorkflow, createStep } = init({
+  client,
+  taskQueue: 'mastra',
+  startToCloseTimeout: '5 minutes',
+})
+```
+
+### `MastraPlugin` debug mode
+
+Pass `debug: true` to write the transformed modules and emitted workflow bundles to `.mastra/temporal` for inspection. Use this when troubleshooting plugin output.
+
+```ts title="src/mastra/worker.ts"
+new MastraPlugin({
+  src: import.meta.resolve('./index.ts'),
+  debug: true,
+})
+```
+
+## Constraints and notes
+
+- Workflow ids must be static string literals. The build-time transformer reads the literal value to derive Temporal workflow export names.
+- `MastraPlugin`'s `src` must point to the Mastra entry file that registers workflows in `new Mastra({ workflows: ... })`.
+- Activities are generated automatically from `createStep()` handlers. Do not pass them in `Worker.create({ activities })`.
+- The package does not currently implement Inngest-style flow control (`concurrency`, `rateLimit`, `throttle`, `debounce`, `priority`) or `cron` scheduling on `createWorkflow()`. Use Temporal's native [retry policies](https://docs.temporal.io/encyclopedia/retry-policies) and [schedules](https://docs.temporal.io/schedules) instead.
+
+## Related
+
+- [Workflow runners](/docs/deployment/workflow-runners)
+- [Workflows overview](/docs/workflows/overview)
+- [Temporal documentation](https://docs.temporal.io/)

--- a/docs/src/content/en/guides/sidebars.js
+++ b/docs/src/content/en/guides/sidebars.js
@@ -158,6 +158,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'deployment/temporal',
+          label: 'Temporal',
+        },
+        {
+          type: 'doc',
           id: 'deployment/vercel',
           label: 'Vercel',
         },


### PR DESCRIPTION
## Summary

Adds a deployment/integration guide for the experimental `@mastra/temporal` package and surfaces it from the workflow runners overview.

### New page: `docs/src/content/en/guides/deployment/temporal.mdx`

- Modeled on the existing Inngest guide for consistency within `guides/deployment/`.
- Clearly marked as experimental (the package is at `0.0.1`).
- Explains how Mastra workflows map to Temporal workflows and activities at worker bundle time via `MastraPlugin`.
- Walks through setup, initialization (`init({ client, taskQueue })`), creating steps and workflows, and registering them on the Mastra instance.
- Documents the worker process (`Worker.create({ plugins: [new MastraPlugin({ src })] })`) and notes that activities are generated automatically.
- Covers local development with the `temporalio/auto-setup` Docker image and the bundled `docker-compose.yaml`, plus the Temporal UI at `localhost:8080`.
- Covers production with Temporal Cloud and `@temporalio/envconfig` env vars, with a warning that the worker must run as a long-lived process (not on short-lived serverless platforms).
- Documents the available configuration options today: `taskQueue`, `startToCloseTimeout` (default `1 minute`), and `MastraPlugin` `debug: true`.
- Lists current constraints: workflow ids must be static literals, `MastraPlugin.src` must point to the Mastra entry, and Inngest-style flow control / cron are not implemented — points to native Temporal retry policies and schedules instead.

### Updated: `docs/src/content/en/docs/deployment/workflow-runners.mdx`

- Adds a `## Temporal` section after the Inngest section that summarizes the integration, flags it as experimental, and links to the new guide.

## Test plan

- [x] `pnpm --filter ./docs build` completes successfully and emits `build/guides/deployment/temporal/index.html`.
- [x] All code snippets cross-checked against `workflows/temporal/README.md`, `workflows/temporal/src/workflow.ts`, `workflows/temporal/src/plugin.ts`, and `workflows/temporal/docker-compose.yaml`. No invented APIs.
- [x] New page follows `docs/styleguides/STYLEGUIDE.md` and `docs/styleguides/GUIDE_DEPLOYMENT.md` conventions (frontmatter, `npm2yarn` install block, code titles, related links).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a simple how-to guide so developers can run Mastra workflows on Temporal (a system that keeps workflows durable and resumable) and updates the docs to mention this new experimental integration.

---

## Summary

Documentation-only PR introducing an experimental Temporal integration via a new @mastra/temporal package. Adds a full deployment guide and a brief Workflow Runners entry that points to the guide.

### Files Changed

- New: docs/src/content/en/guides/deployment/temporal.mdx (+~220 lines)
  - Experimental guide for @mastra/temporal (package at 0.0.1).
  - Explains mapping: createStep() → Temporal activities; createWorkflow() → Temporal workflows; MastraPlugin auto-generates activities and workflows at bundle time.
  - Walks through setup: installing deps, init({ client, taskQueue }), defining Zod-typed steps, composing workflows with static literal IDs, committing and exporting workflows, registering workflows on a Mastra instance, and running a long-lived Temporal Worker with MastraPlugin (e.g., Worker.create({ plugins: [new MastraPlugin({ src })] })); MastraPlugin.src must point to the Mastra entry.
  - Local dev: temporalio/auto-setup Docker image and bundled docker-compose.yaml, Temporal UI at localhost:8080.
  - Production: Temporal Cloud / self-hosted via @temporalio/envconfig env vars; warns that workers must be long-lived (not suitable for short-lived serverless platforms).
  - Documents config: taskQueue, startToCloseTimeout (default 1 minute), MastraPlugin debug flag.
  - Constraints: workflow IDs must be static string literals; Inngest-style flow control/cron not implemented (use Temporal retry/schedule features); do not manually provide activities generated by the plugin.

- Updated: docs/src/content/en/docs/deployment/workflow-runners.mdx (+6 lines)
  - Adds an experimental Temporal section after Inngest summarizing the integration and linking to the new guide.

- Updated: docs/src/content/en/guides/sidebars.js (+5 lines)
  - Adds the Temporal guide to the Deployment sidebar (inserted among existing deployment entries).

### Validation / Tests

- Docs build should emit build/guides/deployment/temporal/index.html.
- Snippets cross-checked against repository workflows/temporal files; no invented APIs.
- New page follows docs style conventions and is modeled on the existing Inngest guide.

### Impact

- Documentation-only changes; no runtime code or public API surface changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->