### PR TITLE
fix(pg): handle escaped-backslash surrogate sequences in sanitizeJson…

### DIFF
--- a/.changeset/fix-pg-sanitize-surrogate-escape-15920.md
+++ b/.changeset/fix-pg-sanitize-surrogate-escape-15920.md
@@ -2,17 +2,6 @@
 "@mastra/pg": patch
 ---
 
-fix(pg): handle escaped-backslash surrogate sequences in sanitizeJsonForPg
-
-When a workflow step output contained strings like JavaScript regex literals
-(e.g. `[^\ud800-\udfff]`), the previous `sanitizeJsonForPg` function would
-remove the `\uXXXX` surrogate escapes but leave behind a dangling backslash,
-producing an invalid JSON escape sequence (`\-`) that caused PostgreSQL to
-throw `invalid input syntax for type json` (error code 22P02).
-
-The fix changes the surrogate-removal regex from `/\\u.../` to `/\\\\?u.../`
-so that the optional preceding escaped backslash (`\\u`) is also consumed.
-The invalid-escape-sequence fix pass now runs **after** surrogate removal
-to catch any characters newly exposed by the deletion.
+Fixed workflow snapshot sanitization in `@mastra/pg` for strings containing escaped surrogate patterns like `[^\ud800-\udfff]`. This prevents invalid JSON escape sequences that caused PostgreSQL `jsonb` writes to fail with error `22P02`.
 
 Fixes #15920

--- a/.changeset/fix-pg-sanitize-surrogate-escape-15920.md
+++ b/.changeset/fix-pg-sanitize-surrogate-escape-15920.md
@@ -1,0 +1,18 @@
+---
+"@mastra/pg": patch
+---
+
+fix(pg): handle escaped-backslash surrogate sequences in sanitizeJsonForPg
+
+When a workflow step output contained strings like JavaScript regex literals
+(e.g. `[^\ud800-\udfff]`), the previous `sanitizeJsonForPg` function would
+remove the `\uXXXX` surrogate escapes but leave behind a dangling backslash,
+producing an invalid JSON escape sequence (`\-`) that caused PostgreSQL to
+throw `invalid input syntax for type json` (error code 22P02).
+
+The fix changes the surrogate-removal regex from `/\\u.../` to `/\\\\?u.../`
+so that the optional preceding escaped backslash (`\\u`) is also consumed.
+The invalid-escape-sequence fix pass now runs **after** surrogate removal
+to catch any characters newly exposed by the deletion.
+
+Fixes #15920

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -28,18 +28,25 @@ function getTableName({ indexName, schemaName }: { indexName: string; schemaName
 
 /**
  * Sanitizes JSON string for PostgreSQL jsonb:
- * - Escapes invalid JSON escape sequences (e.g. \v, \k → \\v, \\k)
  * - Removes problematic Unicode sequences:
  *   - \u0000 (null character) - causes error 22P05 "unsupported Unicode escape sequence"
  *   - \uD800-\uDFFF (unpaired surrogates) - causes "Unicode low surrogate must follow a high surrogate"
+ *   - \\uD800 (escaped-backslash + surrogate, e.g. from JS regex literals like [^\ud800-\udfff]):
+ *     removing just \uXXXX would leave a dangling backslash that creates a new invalid escape (e.g. \-)
+ * - Escapes any remaining invalid JSON escape sequences (e.g. \v, \k, \-)
  */
 function sanitizeJsonForPg(jsonString: string): string {
   return (
     jsonString
-      // Fix invalid JSON escape sequences safely without rewriting already-escaped backslashes.
+      // Remove null char and surrogate escape sequences. The optional extra backslash (\\\\?)
+      // also handles the escaped-backslash variant (\\uXXXX), which would otherwise leave a
+      // dangling backslash and produce a new invalid escape sequence after removal.
+      .replace(/\\\\?u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g, '')
+      // Fix any remaining invalid JSON escape sequences safely without rewriting
+      // already-escaped backslashes. Running this AFTER surrogate removal ensures that
+      // characters newly exposed by the removal (e.g. a hyphen left after \\ud800-\\udfff)
+      // are also caught and escaped.
       .replace(/(^|[^\\])(\\(?!["\\/bfnrtu]))/g, '$1\\\\')
-      // Remove problematic Unicode sequences.
-      .replace(/\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g, '')
   );
 }
 

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -35,7 +35,7 @@ function getTableName({ indexName, schemaName }: { indexName: string; schemaName
  *     removing just \uXXXX would leave a dangling backslash that creates a new invalid escape (e.g. \-)
  * - Escapes any remaining invalid JSON escape sequences (e.g. \v, \k, \-)
  */
-function sanitizeJsonForPg(jsonString: string): string {
+export function sanitizeJsonForPg(jsonString: string): string {
   return (
     jsonString
       // Remove null char and surrogate escape sequences. The optional extra backslash (\\\\?)

--- a/stores/pg/src/storage/domains/workflows/sanitize-json.test.ts
+++ b/stores/pg/src/storage/domains/workflows/sanitize-json.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeJsonForPg } from './index';
+
+describe('sanitizeJsonForPg', () => {
+  it('removes bare null character escapes', () => {
+    expect(sanitizeJsonForPg('"prefix\\u0000suffix"')).toBe('"prefixsuffix"');
+  });
+
+  it('removes bare unpaired surrogate escapes (high and low, mixed case)', () => {
+    expect(sanitizeJsonForPg('"a\\uD800b"')).toBe('"ab"');
+    expect(sanitizeJsonForPg('"a\\udfffb"')).toBe('"ab"');
+    expect(sanitizeJsonForPg('"a\\uDABCb"')).toBe('"ab"');
+  });
+
+  it('escapes invalid JSON escape sequences (\\v, \\k)', () => {
+    expect(sanitizeJsonForPg('"Omschr\\vijving"')).toBe('"Omschr\\\\vijving"');
+    expect(sanitizeJsonForPg('"Toepassel\\k"')).toBe('"Toepassel\\\\k"');
+  });
+
+  it('preserves valid JSON escapes (\\n, \\t, \\", \\\\)', () => {
+    expect(sanitizeJsonForPg('"line1\\nline2"')).toBe('"line1\\nline2"');
+    expect(sanitizeJsonForPg('"a\\tb"')).toBe('"a\\tb"');
+    expect(sanitizeJsonForPg('"quote\\""')).toBe('"quote\\""');
+    expect(sanitizeJsonForPg('"back\\\\slash"')).toBe('"back\\\\slash"');
+  });
+
+  // Regression for #15920: escaped-backslash + surrogate (e.g. JSON-encoded JS regex
+  // literals like [^\ud800-\udfff]). The old surrogate regex stripped only the \uXXXX
+  // and left the preceding \\ orphaned, which then merged with the next char to form a
+  // new invalid escape (\-), causing PostgreSQL error 22P02.
+  describe('escaped-backslash surrogate sequences (regression #15920)', () => {
+    it('removes \\\\uD800 fully, including the preceding escaped backslash', () => {
+      expect(sanitizeJsonForPg('"prefix\\\\uD800suffix"')).toBe('"prefixsuffix"');
+    });
+
+    it('handles a JS-style surrogate range without producing invalid \\- escapes', () => {
+      // Input is the JSON-encoded form of: a = "[^\ud800-\udfff]"
+      const input = '"a = \\"[^\\\\ud800-\\\\udfff]\\""';
+      const sanitized = sanitizeJsonForPg(input);
+
+      // No dangling backslashes should remain before the hyphen.
+      expect(sanitized).not.toContain('\\\\-');
+      expect(sanitized).not.toContain('\\-');
+
+      // Result must be parseable as JSON (the original failure mode was
+      // PostgreSQL rejecting the value with "invalid input syntax for type json").
+      expect(() => JSON.parse(sanitized)).not.toThrow();
+      expect(JSON.parse(sanitized)).toBe('a = "[^-]"');
+    });
+
+    it('removes escaped-backslash null chars (\\\\u0000) cleanly', () => {
+      expect(sanitizeJsonForPg('"prefix\\\\u0000suffix"')).toBe('"prefixsuffix"');
+    });
+
+    it('output of mixed surrogate + invalid-escape inputs is always valid JSON', () => {
+      // Mix: invalid \v escape, JS-style surrogate range, null char, unpaired surrogate.
+      const input = JSON.stringify({
+        invalidEscape: 'Omschr\\vijving',
+        regex: '[^\\ud800-\\udfff]',
+        nullChar: 'a\u0000b',
+        surrogate: 'x\uD800y',
+      });
+      const sanitized = sanitizeJsonForPg(input);
+      expect(() => JSON.parse(sanitized)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
…ForPg

When workflow step output contains strings like JS regex literals (e.g. '[^\ud800-\udfff]'), the previous regex removed surrogate escapes but left a dangling backslash, producing an invalid JSON escape (\-) that caused PostgreSQL error 22P02 'invalid input syntax for type json'.

Change the surrogate-removal pattern from /\\u.../ to /\\\\?u.../ so the preceding escaped backslash is also consumed. Run the invalid-escape-sequence fix pass AFTER surrogate removal to catch characters newly exposed by the deletion.

Fixes #15920

## Description

Closes #15920

### Problem

When a workflow step output contained strings with JavaScript regex literals like
`[^\ud800-\udfff]` (where `\ud800` and `\udfff` are literal backslash-escaped text, not
actual Unicode surrogate characters), the `sanitizeJsonForPg` function would:

1. Correctly match and remove `\ud800` and `\udfff` surrogate patterns from the JSON string
2. But leave behind a dangling **double-backslash** `\\` from the escaped-backslash variant `\\ud800`
3. That dangling backslash combined with the hyphen `-` between the two surrogates to produce `\-`
4. `\-` is an invalid JSON escape sequence → PostgreSQL throws `invalid input syntax for type json` (error code `22P02`)

**Reproducer:**
```ts
sanitizeJsonForPg(JSON.stringify('a = "[^\\ud800-\\udfff"'));
// Before fix: produces  "a = \"[^\-\""  ← invalid JSON
// After fix:  produces  "a = \"[^-\""   ← valid JSON
```

This scenario occurs in real workflows when a step scrapes HTML containing JavaScript
code with Unicode range regex patterns (e.g. from `xregexp` or similar libraries).

### Root Cause

The surrogate-removal regex `/\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g` only matches
the **bare** surrogate escape `\uXXXX`. When the JSON string contains `\\uXXXX` (an
escaped backslash followed by `uXXXX`), the regex removes the `\uXXXX` part but leaves
the preceding `\\` as an orphan, which can then merge with an adjacent character to form
a new invalid escape.

### Fix

Two changes to `stores/pg/src/storage/domains/workflows/index.ts`:

1. **Change surrogate regex** from `/\\u.../` to `/\\\\?u.../`  
   The optional extra backslash (`\\\\?`) consumes the preceding escaped-backslash as well,
   so `\\ud800` is removed in its entirety instead of leaving a dangling `\\`.

2. **Swap execution order** — run the surrogate-removal pass **before** the
   invalid-escape-sequence fix pass.  
   This ensures that any characters newly exposed after surrogate removal (e.g. a hyphen
   that was sitting between `\\ud800` and `\\udfff`) are caught and properly escaped by
   the second pass.

```ts
// Before
.replace(/(^|[^\\])(\\(?!["\\/bfnrtu]))/g, '$1\\\\')   // step 1: fix invalid escapes
.replace(/\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g, '') // step 2: remove surrogates

// After
.replace(/\\\\?u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g, '') // step 1: remove surrogates (+ escaped-backslash variant)
.replace(/(^|[^\\])(\\(?!["\\/bfnrtu]))/g, '$1\\\\')        // step 2: fix any remaining invalid escapes
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added a changeset (`@mastra/pg` patch)
- [x] No new warnings introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Summary

A text-cleaning function that prepares workflow snapshots for PostgreSQL was leaving stray backslashes and creating invalid escape sequences. This PR fixes the sanitizer so those tricky patterns are fully removed and the JSON written to Postgres is always valid.

---

## What Changed

### stores/pg/src/storage/domains/workflows/index.ts

- Exported and updated sanitizeJsonForPg(jsonString: string): string.
- Changed surrogate/null removal regex from /\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g to /\\\\?u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})/g to also consume an optional escaped backslash (handles inputs like \\uD800).
- Reordered sanitizer passes: remove nulls/surrogates (including escaped-backslash variants) first, then run the invalid-JSON-escape escaping pass. This prevents dangling backslashes (e.g., producing "\-") after removal.
- Updated comments to document behavior and rationale.
- Calls to sanitizeJsonForPg are used where snapshots are persisted/upserted.

### stores/pg/src/storage/domains/workflows/sanitize-json.test.ts

- Added Vitest suite covering:
  - Removal of \u0000 and unpaired surrogate escapes (mixed case).
  - Escaping of invalid JSON escapes (e.g., \v, \k) while preserving valid escapes.
  - Regression tests for escaped-backslash surrogate sequences (e.g., JSON-encoded JS regex literals like [^\ud800-\udfff]) ensuring no dangling backslashes, sanitized output is valid JSON, and specific expected transformations.
  - A mixed-case test combining several problematic sequences to assert parseability.

### .changeset/fix-pg-sanitize-surrogate-escape-15920.md

- New changeset added to release a patch for @mastra/pg documenting the fix and referencing Fixes #15920.

---

Why this fixes the bug: by consuming optional escaped backslashes when removing surrogate/null escapes and running the invalid-escape escaping afterwards, the sanitizer no longer leaves orphaned backslashes that can combine with adjacent characters to form invalid JSON escape sequences (which previously caused PostgreSQL error 22P02).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->