### PR TITLE
Add config option to disable Mastra Platform observability

### DIFF
--- a/.changeset/funky-glasses-flow.md
+++ b/.changeset/funky-glasses-flow.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Added a project config option to disable Mastra Platform observability during deploys.

--- a/packages/cli/src/commands/platform-api.d.ts
+++ b/packages/cli/src/commands/platform-api.d.ts
@@ -2783,6 +2783,7 @@ export interface operations {
           envVars?: {
             [key: string]: string;
           };
+          disablePlatformObservability?: boolean;
         };
       };
     };
@@ -3736,6 +3737,7 @@ export interface operations {
           envVars?: {
             [key: string]: string;
           };
+          disablePlatformObservability?: boolean;
         };
       };
     };

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -87,6 +87,15 @@ vi.mock('../../utils/run-build.js', () => ({
 }));
 
 vi.mock('../studio/project-config.js', () => ({
+  getProjectConfigToSave: vi.fn((projectId, projectName, projectSlug, organizationId, projectConfig) => ({
+    projectId,
+    projectName,
+    projectSlug,
+    organizationId,
+    ...(projectConfig?.disablePlatformObservability !== undefined
+      ? { disablePlatformObservability: projectConfig.disablePlatformObservability }
+      : {}),
+  })),
   loadProjectConfig: vi.fn().mockResolvedValue(null),
   saveProjectConfig: vi.fn().mockResolvedValue(undefined),
 }));
@@ -317,11 +326,70 @@ describe('readEnvVars (server deploy)', () => {
 describe('serverDeployAction', () => {
   beforeEach(async () => {
     const { access } = await import('node:fs/promises');
+    const { loadProjectConfig } = await import('../studio/project-config.js');
+
     vi.mocked(access).mockResolvedValue(undefined);
+    vi.mocked(loadProjectConfig).mockResolvedValue(null);
   });
 
   afterEach(() => {
     vi.resetModules();
+  });
+
+  it('passes disablePlatformObservability to uploadServerDeploy and preserves it when saving config', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const { fetchOrgs } = await import('../auth/api.js');
+    const { getCurrentOrgId, getToken } = await import('../auth/credentials.js');
+    const { fetchServerProjects, uploadServerDeploy, pollServerDeploy } = await import('./platform-api.js');
+    const { loadProjectConfig, saveProjectConfig } = await import('../studio/project-config.js');
+
+    vi.mocked(getToken).mockResolvedValue('test-token');
+    vi.mocked(getCurrentOrgId).mockResolvedValue('org-1');
+    vi.mocked(fetchOrgs).mockResolvedValue([{ id: 'org-1', name: 'Test Org', role: 'admin', isCurrent: true }]);
+    vi.mocked(fetchServerProjects).mockResolvedValue([]);
+    vi.mocked(pollServerDeploy).mockResolvedValue({
+      id: 'deploy-1',
+      status: 'running',
+      instanceUrl: 'https://example.com',
+      error: null,
+    });
+    vi.mocked(loadProjectConfig).mockResolvedValue({
+      organizationId: 'org-2',
+      projectId: 'old-proj',
+      projectName: 'old-app',
+      projectSlug: 'old-app',
+      disablePlatformObservability: true,
+    });
+    vi.mocked(readdir).mockResolvedValue([{ name: '.env', isFile: () => true }] as unknown as Awaited<
+      ReturnType<typeof readdir>
+    >);
+    vi.mocked(readFile).mockImplementation(async path => {
+      if (String(path).endsWith('.env')) return 'API_KEY=test';
+      return Buffer.from('zip-data');
+    });
+
+    const { serverDeployAction } = await import('./deploy.js');
+
+    await expect(
+      serverDeployAction(undefined, { yes: true, skipBuild: true, org: 'org-1', project: 'my-app' }),
+    ).resolves.toBeUndefined();
+
+    expect(saveProjectConfig).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        projectId: 'my-app',
+        projectName: 'my-app',
+        projectSlug: 'my-app',
+        organizationId: 'org-1',
+        disablePlatformObservability: true,
+      },
+      undefined,
+    );
+    expect(uploadServerDeploy).toHaveBeenCalledWith('test-token', 'org-1', 'my-app', expect.any(Buffer), {
+      projectName: 'my-app',
+      envVars: { API_KEY: 'test' },
+      disablePlatformObservability: true,
+    });
   });
 
   it('throws when headless mode is missing required env vars and flags', async () => {

--- a/packages/cli/src/commands/server/deploy.test.ts
+++ b/packages/cli/src/commands/server/deploy.test.ts
@@ -421,6 +421,7 @@ describe('serverDeployAction', () => {
 
     const { readdir, readFile } = await import('node:fs/promises');
     const { loadProjectConfig } = await import('../studio/project-config.js');
+    const { uploadServerDeploy } = await import('./platform-api.js');
     vi.mocked(readdir).mockResolvedValue([{ name: '.env', isFile: () => true }] as unknown as Awaited<
       ReturnType<typeof readdir>
     >);
@@ -438,6 +439,11 @@ describe('serverDeployAction', () => {
     const { serverDeployAction } = await import('./deploy.js');
 
     await expect(serverDeployAction(undefined, {})).resolves.toBeUndefined();
+    expect(uploadServerDeploy).toHaveBeenCalledWith('test-token', 'org-1', 'proj-1', expect.any(Buffer), {
+      projectName: 'my-app',
+      envVars: { API_KEY: 'test' },
+      disablePlatformObservability: false,
+    });
   });
 
   it('uses project config in headless mode without fetching orgs', async () => {

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -9,7 +9,7 @@ import { runBuild } from '../../utils/run-build.js';
 import { fetchOrgs } from '../auth/api.js';
 import { MASTRA_STUDIO_URL } from '../auth/client.js';
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
-import { loadProjectConfig, saveProjectConfig } from '../studio/project-config.js';
+import { getProjectConfigToSave, loadProjectConfig, saveProjectConfig } from '../studio/project-config.js';
 import { fetchServerProjects, createServerProject, uploadServerDeploy, pollServerDeploy } from './platform-api.js';
 
 /* ------------------------------------------------------------------ */
@@ -326,12 +326,7 @@ export async function serverDeployAction(
 
     await saveProjectConfig(
       targetDir,
-      {
-        projectId,
-        projectName,
-        projectSlug,
-        organizationId: orgId,
-      },
+      getProjectConfigToSave(projectId, projectName, projectSlug, orgId, projectConfig),
       opts.config,
     );
     p.log.success(`Saved ${opts.config || '.mastra-project.json'}`);
@@ -377,6 +372,9 @@ export async function serverDeployAction(
   const deployResult = await uploadServerDeploy(token, orgId, projectId, zipBuffer, {
     projectName,
     envVars: envCount > 0 ? envVars : undefined,
+    ...(projectConfig?.disablePlatformObservability !== undefined
+      ? { disablePlatformObservability: projectConfig.disablePlatformObservability }
+      : {}),
   });
   s.stop(`Deploy accepted: ${deployResult.id}`);
 

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -372,9 +372,7 @@ export async function serverDeployAction(
   const deployResult = await uploadServerDeploy(token, orgId, projectId, zipBuffer, {
     projectName,
     envVars: envCount > 0 ? envVars : undefined,
-    ...(projectConfig?.disablePlatformObservability !== undefined
-      ? { disablePlatformObservability: projectConfig.disablePlatformObservability }
-      : {}),
+    disablePlatformObservability: projectConfig?.disablePlatformObservability === true,
   });
   s.stop(`Deploy accepted: ${deployResult.id}`);
 

--- a/packages/cli/src/commands/server/platform-api.test.ts
+++ b/packages/cli/src/commands/server/platform-api.test.ts
@@ -588,9 +588,44 @@ describe('uploadServerDeploy', () => {
       .mockResolvedValueOnce({ error: undefined, response: { status: 200 } });
 
     const { uploadServerDeploy } = await import('./platform-api.js');
-    const result = await uploadServerDeploy('tok', 'org-1', 'proj-1', Buffer.from('zip'));
+    const result = await uploadServerDeploy('tok', 'org-1', 'proj-1', Buffer.from('zip'), {
+      projectName: 'my-app',
+      envVars: { FOO: 'bar' },
+      disablePlatformObservability: true,
+    });
 
     expect(result).toEqual({ id: 'dep-1', status: 'queued' });
+    expect(mockPOST).toHaveBeenCalledWith('/v1/server/deploys', {
+      body: {
+        projectId: 'proj-1',
+        projectName: 'my-app',
+        envVars: { FOO: 'bar' },
+        disablePlatformObservability: true,
+      },
+    });
     expect(mockFetch).toHaveBeenCalledWith('https://signed.example/put', expect.objectContaining({ method: 'PUT' }));
+  });
+
+  it('omits disablePlatformObservability from deploy body when not provided', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    mockPOST
+      .mockResolvedValueOnce({
+        data: { id: 'dep-1', uploadUrl: 'https://signed.example/put', status: 'queued' },
+        error: undefined,
+        response: { status: 202 },
+      })
+      .mockResolvedValueOnce({ error: undefined, response: { status: 200 } });
+
+    const { uploadServerDeploy } = await import('./platform-api.js');
+    await uploadServerDeploy('tok', 'org-1', 'proj-1', Buffer.from('zip'));
+
+    expect(mockPOST).toHaveBeenCalledWith('/v1/server/deploys', {
+      body: {
+        projectId: 'proj-1',
+        projectName: undefined,
+        envVars: undefined,
+      },
+    });
+    expect(mockPOST.mock.calls[0]![1].body).not.toHaveProperty('disablePlatformObservability');
   });
 });

--- a/packages/cli/src/commands/server/platform-api.ts
+++ b/packages/cli/src/commands/server/platform-api.ts
@@ -64,13 +64,20 @@ export async function uploadServerDeploy(
   orgId: string,
   projectId: string,
   zipBuffer: Buffer,
-  meta?: { projectName?: string; envVars?: Record<string, string> },
+  meta?: { projectName?: string; envVars?: Record<string, string>; disablePlatformObservability?: boolean },
 ): Promise<{ id: string; status: string }> {
   const client = createApiClient(token, orgId);
 
   // Step 1: Create the deploy — returns upload URL
   const { data, error, response } = await client.POST('/v1/server/deploys', {
-    body: { projectId, projectName: meta?.projectName, envVars: meta?.envVars },
+    body: {
+      projectId,
+      projectName: meta?.projectName,
+      envVars: meta?.envVars,
+      ...(meta?.disablePlatformObservability !== undefined
+        ? { disablePlatformObservability: meta.disablePlatformObservability }
+        : {}),
+    },
   });
 
   if (error) {

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -3,6 +3,22 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
+let closeHandler: (() => void) | undefined;
+
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    createWriteStream: vi.fn(() => ({
+      on: vi.fn((event: string, callback: () => void) => {
+        if (event === 'close') {
+          closeHandler = callback;
+        }
+      }),
+    })),
+  };
+});
+
 describe('getMastraVersion', () => {
   let tmpDir: string;
 
@@ -73,10 +89,18 @@ vi.mock('@clack/prompts', () => ({
   isCancel: vi.fn(() => false),
   cancel: vi.fn(),
   spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  outro: vi.fn(),
 }));
 
 vi.mock('archiver', () => ({
-  default: vi.fn(),
+  default: vi.fn(() => ({
+    on: vi.fn(),
+    pipe: vi.fn(),
+    glob: vi.fn(),
+    finalize: vi.fn(async () => {
+      closeHandler?.();
+    }),
+  })),
 }));
 
 vi.mock('node:fs/promises', async importOriginal => {
@@ -94,7 +118,7 @@ vi.mock('node:fs/promises', async importOriginal => {
         const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
         throw err;
       }
-      return (actual.readFile as (path: string) => Promise<string>)(path);
+      return Buffer.from('zip-data');
     }),
   };
 });
@@ -116,12 +140,22 @@ vi.mock('./platform-api.js', () => ({
 }));
 
 vi.mock('./project-config.js', () => ({
+  getProjectConfigToSave: vi.fn((projectId, projectName, projectSlug, organizationId, projectConfig) => ({
+    projectId,
+    projectName,
+    projectSlug,
+    organizationId,
+    ...(projectConfig?.disablePlatformObservability !== undefined
+      ? { disablePlatformObservability: projectConfig.disablePlatformObservability }
+      : {}),
+  })),
   loadProjectConfig: vi.fn().mockResolvedValue(null),
   saveProjectConfig: vi.fn().mockResolvedValue(undefined),
 }));
 
 beforeEach(() => {
   vi.resetAllMocks();
+  closeHandler = undefined;
 });
 
 afterEach(() => {
@@ -390,6 +424,82 @@ describe('readEnvVars', () => {
 });
 
 describe('deployAction', () => {
+  it('passes disablePlatformObservability to uploadDeploy and preserves it when saving config', async () => {
+    const { access, readdir, readFile, stat } = await import('node:fs/promises');
+    const { fetchOrgs } = await import('../auth/api.js');
+    const { getCurrentOrgId, getToken } = await import('../auth/credentials.js');
+    const { fetchProjects, createProject, uploadDeploy, pollDeploy } = await import('./platform-api.js');
+    const { loadProjectConfig, saveProjectConfig } = await import('./project-config.js');
+
+    vi.mocked(getToken).mockResolvedValue('test-token');
+    vi.mocked(getCurrentOrgId).mockResolvedValue('org-1');
+    vi.mocked(access).mockResolvedValue(undefined);
+    vi.mocked(stat).mockResolvedValue({ size: 1024 } as Awaited<ReturnType<typeof stat>>);
+    vi.mocked(fetchOrgs).mockResolvedValue([{ id: 'org-1', name: 'Test Org', role: 'admin', isCurrent: true }]);
+    vi.mocked(fetchProjects).mockResolvedValue([]);
+    vi.mocked(createProject).mockResolvedValue({
+      id: 'proj-1',
+      name: 'my-app',
+      slug: 'my-app',
+      organizationId: 'org-1',
+      latestDeployId: null,
+      latestDeployStatus: null,
+      instanceUrl: null,
+      createdAt: null,
+      updatedAt: null,
+    });
+    vi.mocked(uploadDeploy).mockResolvedValue({ id: 'deploy-1', status: 'starting' });
+    vi.mocked(pollDeploy).mockResolvedValue({
+      id: 'deploy-1',
+      status: 'running',
+      instanceUrl: 'https://example.com',
+      error: null,
+    });
+    vi.mocked(loadProjectConfig).mockResolvedValue({
+      organizationId: 'org-2',
+      projectId: 'old-proj',
+      projectName: 'old-app',
+      projectSlug: 'old-app',
+      disablePlatformObservability: true,
+    });
+    vi.mocked(readdir).mockResolvedValue([{ name: '.env', isFile: () => true }] as unknown as Awaited<
+      ReturnType<typeof readdir>
+    >);
+    vi.mocked(readFile).mockImplementation(async path => {
+      if (String(path).endsWith('.env')) return 'API_KEY=test';
+      return Buffer.from('zip-data');
+    });
+
+    const { deployAction } = await import('./deploy.js');
+
+    await expect(
+      deployAction(undefined, { yes: true, skipBuild: true, org: 'org-1', project: 'my-app' }),
+    ).resolves.toBeUndefined();
+
+    expect(saveProjectConfig).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        projectId: 'proj-1',
+        projectName: 'my-app',
+        projectSlug: 'my-app',
+        organizationId: 'org-1',
+        disablePlatformObservability: true,
+      },
+      undefined,
+    );
+    expect(uploadDeploy).toHaveBeenCalledWith(
+      'test-token',
+      'org-1',
+      'proj-1',
+      expect.any(Buffer),
+      expect.objectContaining({
+        projectName: 'my-app',
+        envVars: { API_KEY: 'test' },
+        disablePlatformObservability: true,
+      }),
+    );
+  });
+
   it('throws when headless mode missing required env vars', async () => {
     process.env.MASTRA_API_TOKEN = 'headless-token';
     // Missing MASTRA_ORG_ID and MASTRA_PROJECT_ID

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -500,6 +500,69 @@ describe('deployAction', () => {
     );
   });
 
+  it('sends disablePlatformObservability false when config omits it', async () => {
+    const { access, readdir, readFile, stat } = await import('node:fs/promises');
+    const { fetchOrgs } = await import('../auth/api.js');
+    const { getCurrentOrgId, getToken } = await import('../auth/credentials.js');
+    const { fetchProjects, uploadDeploy, pollDeploy } = await import('./platform-api.js');
+    const { loadProjectConfig } = await import('./project-config.js');
+
+    vi.mocked(getToken).mockResolvedValue('test-token');
+    vi.mocked(getCurrentOrgId).mockResolvedValue('org-1');
+    vi.mocked(access).mockResolvedValue(undefined);
+    vi.mocked(stat).mockResolvedValue({ size: 1024 } as Awaited<ReturnType<typeof stat>>);
+    vi.mocked(fetchOrgs).mockResolvedValue([{ id: 'org-1', name: 'Test Org', role: 'admin', isCurrent: true }]);
+    vi.mocked(fetchProjects).mockResolvedValue([
+      {
+        id: 'proj-1',
+        name: 'my-app',
+        slug: 'my-app',
+        organizationId: 'org-1',
+        latestDeployId: null,
+        latestDeployStatus: null,
+        instanceUrl: null,
+        createdAt: null,
+        updatedAt: null,
+      },
+    ]);
+    vi.mocked(uploadDeploy).mockResolvedValue({ id: 'deploy-1', status: 'starting' });
+    vi.mocked(pollDeploy).mockResolvedValue({
+      id: 'deploy-1',
+      status: 'running',
+      instanceUrl: 'https://example.com',
+      error: null,
+    });
+    vi.mocked(loadProjectConfig).mockResolvedValue({
+      organizationId: 'org-1',
+      projectId: 'proj-1',
+      projectName: 'my-app',
+      projectSlug: 'my-app',
+    });
+    vi.mocked(readdir).mockResolvedValue([{ name: '.env', isFile: () => true }] as unknown as Awaited<
+      ReturnType<typeof readdir>
+    >);
+    vi.mocked(readFile).mockImplementation(async path => {
+      if (String(path).endsWith('.env')) return 'API_KEY=test';
+      return Buffer.from('zip-data');
+    });
+
+    const { deployAction } = await import('./deploy.js');
+
+    await expect(deployAction(undefined, { yes: true, skipBuild: true })).resolves.toBeUndefined();
+
+    expect(uploadDeploy).toHaveBeenCalledWith(
+      'test-token',
+      'org-1',
+      'proj-1',
+      expect.any(Buffer),
+      expect.objectContaining({
+        projectName: 'my-app',
+        envVars: { API_KEY: 'test' },
+        disablePlatformObservability: false,
+      }),
+    );
+  });
+
   it('throws when headless mode missing required env vars', async () => {
     process.env.MASTRA_API_TOKEN = 'headless-token';
     // Missing MASTRA_ORG_ID and MASTRA_PROJECT_ID

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -455,9 +455,7 @@ export async function deployAction(
     projectName,
     envVars: envCount > 0 ? envVars : undefined,
     mastraVersion: mastraVersion ?? undefined,
-    ...(projectConfig?.disablePlatformObservability !== undefined
-      ? { disablePlatformObservability: projectConfig.disablePlatformObservability }
-      : {}),
+    disablePlatformObservability: projectConfig?.disablePlatformObservability === true,
   });
   s.stop(`Uploaded (${elapsed(performance.now() - t)})`);
 

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -11,7 +11,7 @@ import { fetchOrgs } from '../auth/api.js';
 import { MASTRA_STUDIO_URL } from '../auth/client.js';
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
 import { fetchProjects, createProject, uploadDeploy, pollDeploy } from './platform-api.js';
-import { loadProjectConfig, saveProjectConfig } from './project-config.js';
+import { getProjectConfigToSave, loadProjectConfig, saveProjectConfig } from './project-config.js';
 
 function elapsed(ms: number): string {
   return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
@@ -361,7 +361,11 @@ export async function deployAction(
     }
 
     if (!isAlreadyLinked) {
-      await saveProjectConfig(targetDir, { projectId, projectName, projectSlug, organizationId: orgId }, opts.config);
+      await saveProjectConfig(
+        targetDir,
+        getProjectConfigToSave(projectId, projectName, projectSlug, orgId, projectConfig),
+        opts.config,
+      );
       p.log.success(`Saved ${opts.config || '.mastra-project.json'}`);
     }
   } else {
@@ -397,7 +401,11 @@ export async function deployAction(
     p.log.success(`Created project "${projectName}"`);
 
     // Save the project link
-    await saveProjectConfig(targetDir, { projectId, projectName, projectSlug, organizationId: orgId }, opts.config);
+    await saveProjectConfig(
+      targetDir,
+      getProjectConfigToSave(projectId, projectName, projectSlug, orgId, projectConfig),
+      opts.config,
+    );
     p.log.success(`Saved ${opts.config || '.mastra-project.json'}`);
   }
 
@@ -447,6 +455,9 @@ export async function deployAction(
     projectName,
     envVars: envCount > 0 ? envVars : undefined,
     mastraVersion: mastraVersion ?? undefined,
+    ...(projectConfig?.disablePlatformObservability !== undefined
+      ? { disablePlatformObservability: projectConfig.disablePlatformObservability }
+      : {}),
   });
   s.stop(`Uploaded (${elapsed(performance.now() - t)})`);
 

--- a/packages/cli/src/commands/studio/platform-api.test.ts
+++ b/packages/cli/src/commands/studio/platform-api.test.ts
@@ -142,6 +142,7 @@ describe('uploadDeploy', () => {
       gitBranch: 'main',
       projectName: 'my-app',
       envVars: { FOO: 'bar' },
+      disablePlatformObservability: true,
     });
 
     expect(result).toMatchObject({ id: 'dep-1', status: 'starting' });
@@ -151,7 +152,7 @@ describe('uploadDeploy', () => {
     expect(mockPOST).toHaveBeenCalledWith(
       '/v1/studio/deploys',
       expect.objectContaining({
-        body: { envVars: { FOO: 'bar' } },
+        body: { envVars: { FOO: 'bar' }, disablePlatformObservability: true },
       }),
     );
     expect(mockPOST).toHaveBeenCalledWith('/v1/studio/deploys/{id}/upload-complete', {
@@ -162,6 +163,30 @@ describe('uploadDeploy', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch.mock.calls[0]![0]).toBe('https://storage.example.com/signed-url');
     expect(mockFetch.mock.calls[0]![1].method).toBe('PUT');
+  });
+
+  it('omits disablePlatformObservability from deploy body when not provided', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: true }));
+    mockPOST
+      .mockResolvedValueOnce({
+        data: { deploy: { id: 'dep-1', status: 'starting', uploadUrl: 'https://storage.example.com/signed-url' } },
+        response: { status: 202 },
+      })
+      .mockResolvedValueOnce({
+        data: { status: 'ok' },
+        response: { status: 200 },
+      });
+
+    const { uploadDeploy } = await import('./platform-api.js');
+    await uploadDeploy('tok', 'org-1', 'proj-1', Buffer.from('zip-data'));
+
+    expect(mockPOST).toHaveBeenCalledWith(
+      '/v1/studio/deploys',
+      expect.objectContaining({
+        body: { envVars: undefined },
+      }),
+    );
+    expect(mockPOST.mock.calls[0]![1].body).not.toHaveProperty('disablePlatformObservability');
   });
 
   it('throws when deploy creation fails', async () => {

--- a/packages/cli/src/commands/studio/platform-api.ts
+++ b/packages/cli/src/commands/studio/platform-api.ts
@@ -73,7 +73,13 @@ export async function uploadDeploy(
   orgId: string,
   projectId: string,
   zipBuffer: Buffer,
-  meta?: { gitBranch?: string; projectName?: string; envVars?: Record<string, string>; mastraVersion?: string },
+  meta?: {
+    gitBranch?: string;
+    projectName?: string;
+    envVars?: Record<string, string>;
+    mastraVersion?: string;
+    disablePlatformObservability?: boolean;
+  },
 ): Promise<{ id: string; status: string }> {
   const client = createApiClient(token, orgId);
 
@@ -87,7 +93,12 @@ export async function uploadDeploy(
         'x-mastra-version': meta?.mastraVersion,
       },
     },
-    body: { envVars: meta?.envVars },
+    body: {
+      envVars: meta?.envVars,
+      ...(meta?.disablePlatformObservability !== undefined
+        ? { disablePlatformObservability: meta.disablePlatformObservability }
+        : {}),
+    },
   });
 
   if (error) {

--- a/packages/cli/src/commands/studio/project-config.test.ts
+++ b/packages/cli/src/commands/studio/project-config.test.ts
@@ -34,6 +34,20 @@ describe('loadProjectConfig', () => {
     expect(result).toEqual(config);
   });
 
+  it('loads disablePlatformObservability from config', async () => {
+    const config = {
+      projectId: 'proj-1',
+      projectName: 'My App',
+      organizationId: 'org-1',
+      disablePlatformObservability: true,
+    };
+
+    writeFileSync(join(tempDir, PROJECT_CONFIG_FILE), JSON.stringify(config, null, 2));
+
+    const result = await loadProjectConfig(tempDir);
+    expect(result).toEqual(config);
+  });
+
   it('loads config from custom file path', async () => {
     const config = {
       projectId: 'proj-1',
@@ -76,6 +90,37 @@ describe('saveProjectConfig', () => {
     const parsed = JSON.parse(content);
 
     expect(parsed).toEqual(config);
+  });
+
+  it('writes disablePlatformObservability when present', async () => {
+    const config = {
+      projectId: 'proj-1',
+      projectName: 'My App',
+      organizationId: 'org-1',
+      disablePlatformObservability: true,
+    };
+
+    await saveProjectConfig(tempDir, config);
+
+    const content = readFileSync(join(tempDir, PROJECT_CONFIG_FILE), 'utf-8');
+    const parsed = JSON.parse(content);
+
+    expect(parsed).toEqual(config);
+  });
+
+  it('omits disablePlatformObservability when not provided', async () => {
+    const config = {
+      projectId: 'proj-1',
+      projectName: 'My App',
+      organizationId: 'org-1',
+    };
+
+    await saveProjectConfig(tempDir, config);
+
+    const content = readFileSync(join(tempDir, PROJECT_CONFIG_FILE), 'utf-8');
+    const parsed = JSON.parse(content);
+
+    expect(parsed).not.toHaveProperty('disablePlatformObservability');
   });
 
   it('writes config to custom file path', async () => {

--- a/packages/cli/src/commands/studio/project-config.ts
+++ b/packages/cli/src/commands/studio/project-config.ts
@@ -8,6 +8,25 @@ export interface ProjectConfig {
   projectName: string;
   projectSlug?: string;
   organizationId: string;
+  disablePlatformObservability?: boolean;
+}
+
+export function getProjectConfigToSave(
+  projectId: string,
+  projectName: string,
+  projectSlug: string,
+  organizationId: string,
+  projectConfig: ProjectConfig | null,
+): ProjectConfig {
+  return {
+    projectId,
+    projectName,
+    projectSlug,
+    organizationId,
+    ...(projectConfig?.disablePlatformObservability !== undefined
+      ? { disablePlatformObservability: projectConfig.disablePlatformObservability }
+      : {}),
+  };
 }
 
 function resolveConfigPath(dir: string, configFile?: string): string {


### PR DESCRIPTION
## Description

- Adds disablePlatformObservability?: boolean to the project config shape.
- Preserves disablePlatformObservability when the CLI rewrites .mastra-project.json during deploy linking.
- Sends disablePlatformObservability in Studio and Server deploy create requests when present in project config.
- Updates generated platform API typings for the new deploy request body field.
- Adds CLI coverage for config load/save behavior and Studio/Server deploy upload payloads.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

This PR adds a simple on/off switch so projects can tell Mastra "do not collect platform monitoring data" when you deploy. Set disablePlatformObservability: true in your project config to opt out of Mastra's observability during deploys.

## Overview

Adds an optional project config field disablePlatformObservability?: boolean, preserves it when writing .mastra-project.json, and propagates it into Studio and Server deploy creation requests (with the CLI explicitly sending false when the field is absent). Generated platform API typings were updated and tests/docs were added.

## Changes

### Configuration & Types
- Added disablePlatformObservability?: boolean to ProjectConfig (packages/cli/src/commands/studio/project-config.ts).
- Added helper getProjectConfigToSave(...) to construct the persisted config and conditionally include disablePlatformObservability.
- Updated generated OpenAPI typings (packages/cli/src/commands/platform-api.d.ts) to include disablePlatformObservability?: boolean in request bodies for postV1StudioDeploys and postV1ServerDeploys.

### CLI — Studio & Server Deploy Flows
- Studio deploys: deployAction now uses getProjectConfigToSave and uploadDeploy accepts meta.disablePlatformObservability and includes it in POST /v1/studio/deploys when defined (packages/cli/src/commands/studio/deploy.ts, packages/cli/src/commands/studio/platform-api.ts).
- Server deploys: deployAction now uses getProjectConfigToSave and uploadServerDeploy accepts meta.disablePlatformObservability and includes it in POST /v1/server/deploys when defined (packages/cli/src/commands/server/deploy.ts, packages/cli/src/commands/server/platform-api.ts).
- CLI behavior: when the project config omits the field, the CLI sends an explicit false value in deploy requests (per commit "Send false when field is absent").

### Tests
- Added/updated tests to cover load/save behavior and deploy payload propagation:
  - packages/cli/src/commands/studio/project-config.test.ts
  - packages/cli/src/commands/studio/deploy.test.ts
  - packages/cli/src/commands/studio/platform-api.test.ts
  - packages/cli/src/commands/server/deploy.test.ts
  - packages/cli/src/commands/server/platform-api.test.ts

### Documentation & Release
- Added changeset for a patch release (.changeset/funky-glasses-flow.md).
- Documentation changes and tests included in the PR.

## Notes / Remaining Items
- Checklist indicates one remaining item about addressing CodeRabbit comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->