### PR TITLE
fix(core): preserve semantic stream order in buildMessagesFromChunks (#15914)

### DIFF
--- a/.changeset/fix-build-messages-semantic-order.md
+++ b/.changeset/fix-build-messages-semantic-order.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `buildMessagesFromChunks` to preserve semantic stream order. Previously the `parts` array followed end-event timing, so when `text-end` arrived before `reasoning-end` the reasoning part was emitted after the text even though its first delta arrived first — confusing downstream prompt assembly. Each text and reasoning span now reserves its slot at first-seen-delta (or at start for redacted reasoning) and fills the slot at end. Closes #15914.

--- a/.changeset/fix-build-messages-semantic-order.md
+++ b/.changeset/fix-build-messages-semantic-order.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix `buildMessagesFromChunks` to preserve semantic stream order. Previously the `parts` array followed end-event timing, so when `text-end` arrived before `reasoning-end` the reasoning part was emitted after the text even though its first delta arrived first — confusing downstream prompt assembly. Each text and reasoning span now reserves its slot at first-seen-delta (or at start for redacted reasoning) and fills the slot at end. Closes #15914.
+Assistant message `parts` now preserve the correct order when reasoning, text, and tool chunks interleave. Previously, parts followed the order of end events, so a span whose end arrived first appeared earlier in the message even when its content actually started streaming later — for example a tool call could be emitted before reasoning that began first. Order now tracks when content actually started arriving. Closes #15914.

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -322,6 +322,42 @@ describe('buildMessagesFromChunks', () => {
     expect(types).toEqual(['reasoning', 'text', 'tool-invocation']);
   });
 
+  it('should produce reasoning → text → tool-call when reasoning-end arrives after text-end (#15914)', () => {
+    // Regression for #15914: when spans are interleaved (text-start before reasoning-start
+    // but reasoning-delta arriving before text-delta, and reasoning-end arriving after
+    // text-end), the previous emit-on-end pattern produced [tool, tool, text, reasoning].
+    // The fix reserves each span's slot at first-seen-delta so order tracks semantic arrival.
+    const result = parts([
+      { type: 'response-metadata', payload: { id: 'rm1', modelId: 'test-model' } },
+      { type: 'text-start', payload: { id: 't1' } },
+      { type: 'reasoning-start', payload: { id: 'r1' } },
+      { type: 'reasoning-delta', payload: { id: 'r1', text: 'Thinking...' } },
+      { type: 'text-delta', payload: { id: 't1', text: 'Hello' } },
+      { type: 'tool-call-input-streaming-start', payload: { toolCallId: 'tc1', toolName: 'myTool', args: {} } },
+      { type: 'tool-call-delta', payload: { toolCallId: 'tc1', argsTextDelta: "{'q':'first'}" } },
+      { type: 'tool-call-input-streaming-end', payload: { toolCallId: 'tc1' } },
+      { type: 'tool-call', payload: { toolCallId: 'tc1', toolName: 'myTool', args: { q: 'first' } } },
+      { type: 'tool-call-input-streaming-start', payload: { toolCallId: 'tc2', toolName: 'myTool', args: {} } },
+      { type: 'tool-call-delta', payload: { toolCallId: 'tc2', argsTextDelta: "{'q':'second'}" } },
+      { type: 'tool-call-input-streaming-end', payload: { toolCallId: 'tc2' } },
+      { type: 'tool-call', payload: { toolCallId: 'tc2', toolName: 'myTool', args: { q: 'second' } } },
+      { type: 'text-end', payload: { id: 't1' } },
+      { type: 'reasoning-end', payload: { id: 'r1' } },
+      { type: 'finish', payload: { finishReason: 'stop', usage: {} } },
+    ]);
+
+    expect(result).toHaveLength(4);
+    expect(result.map((p: any) => p.type)).toEqual(['reasoning', 'text', 'tool-invocation', 'tool-invocation']);
+    expect(result[0]).toMatchObject({ type: 'reasoning', details: [{ type: 'text', text: 'Thinking...' }] });
+    expect(result[1]).toMatchObject({ type: 'text', text: 'Hello' });
+    expect(result[2]).toMatchObject({
+      toolInvocation: { state: 'call', toolCallId: 'tc1', toolName: 'myTool', args: { q: 'first' } },
+    });
+    expect(result[3]).toMatchObject({
+      toolInvocation: { state: 'call', toolCallId: 'tc2', toolName: 'myTool', args: { q: 'second' } },
+    });
+  });
+
   // ── Empty stream / no parts ─────────────────────────────────
 
   it('should return empty array for empty chunks', () => {

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -80,9 +80,10 @@ describe('buildMessagesFromChunks', () => {
       { type: 'text-end', payload: { id: 't1' } },
     ]);
     expect(result).toHaveLength(2);
-    // Parts are emitted in text-end order
-    expect(result[0]).toMatchObject({ type: 'text', text: 'Goodbye' });
-    expect(result[1]).toMatchObject({ type: 'text', text: 'Hello, world!' });
+    // Parts are emitted in first-seen-delta order (#15914): t1 receives its first delta
+    // before t2, so 'Hello, world!' precedes 'Goodbye' even though t2 ends first.
+    expect(result[0]).toMatchObject({ type: 'text', text: 'Hello, world!' });
+    expect(result[1]).toMatchObject({ type: 'text', text: 'Goodbye' });
   });
 
   // ── ProviderMetadata cascading ──────────────────────────────

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -63,13 +63,23 @@ export function buildMessagesFromChunks({
     }
   }
 
-  // State for text span accumulation (keyed by text ID to handle interleaved spans)
-  const textSpans = new Map<string, { deltas: string[]; providerMetadata: Record<string, any> | undefined }>();
+  // State for text span accumulation (keyed by text ID to handle interleaved spans).
+  // `placeholder` reserves the part's position at first-seen-delta so the resulting
+  // parts array reflects semantic stream order rather than end-event order. See #15914.
+  const textSpans = new Map<
+    string,
+    { deltas: string[]; providerMetadata: Record<string, any> | undefined; placeholder: MastraMessagePart | null }
+  >();
 
   // State for reasoning span accumulation (keyed by reasoning ID)
   const reasoningSpans = new Map<
     string,
-    { deltas: string[]; providerMetadata: Record<string, any> | undefined; redacted: boolean }
+    {
+      deltas: string[];
+      providerMetadata: Record<string, any> | undefined;
+      redacted: boolean;
+      placeholder: MastraMessagePart | null;
+    }
   >();
   for (const chunk of chunks) {
     switch (chunk.type) {
@@ -80,6 +90,7 @@ export function buildMessagesFromChunks({
           textSpans.set(p.id, {
             deltas: [],
             providerMetadata: p.providerMetadata,
+            placeholder: null,
           });
         } else {
           // Update providerMetadata if this start has it
@@ -95,8 +106,14 @@ export function buildMessagesFromChunks({
         let span = textSpans.get(p.id);
         // Auto-create span if delta arrives without a matching text-start
         if (!span) {
-          span = { deltas: [], providerMetadata: p.providerMetadata };
+          span = { deltas: [], providerMetadata: p.providerMetadata, placeholder: null };
           textSpans.set(p.id, span);
+        }
+        // First-seen-delta reserves the part's slot in `parts` so the final order tracks
+        // when content actually started arriving — not when the end event happened.
+        if (span.placeholder === null) {
+          span.placeholder = { type: 'text' as const, text: '' } as MastraMessagePart;
+          parts.push(span.placeholder);
         }
         span.deltas.push(p.text);
         // AI SDK semantics: latest non-null providerMetadata wins
@@ -114,8 +131,21 @@ export function buildMessagesFromChunks({
             span.providerMetadata = pEnd.providerMetadata;
           }
           const text = span.deltas.join('');
-          // Only emit a part if there's actual content — skip empty text spans
-          if (text.length > 0) {
+          if (span.placeholder) {
+            // Fill the slot reserved at first-seen-delta
+            if (text.length > 0) {
+              (span.placeholder as { text: string }).text = text;
+              if (span.providerMetadata) {
+                (span.placeholder as { providerMetadata?: Record<string, any> }).providerMetadata =
+                  span.providerMetadata;
+              }
+            } else {
+              // Drop the empty placeholder so we keep the prior "skip empty text spans" behavior
+              const idx = parts.indexOf(span.placeholder);
+              if (idx >= 0) parts.splice(idx, 1);
+            }
+          } else if (text.length > 0) {
+            // Defensive: text exists but no delta arrived (shouldn't happen with current chunk shapes)
             parts.push({
               type: 'text' as const,
               text,
@@ -134,10 +164,22 @@ export function buildMessagesFromChunks({
         const isRedacted = Object.values(p.providerMetadata || {}).some((v: any) => v?.redactedData);
 
         if (!reasoningSpans.has(p.id)) {
+          let placeholder: MastraMessagePart | null = null;
+          // Redacted reasoning never receives a delta, so reserve its slot at start
+          if (isRedacted) {
+            placeholder = {
+              type: 'reasoning' as const,
+              reasoning: '',
+              details: [{ type: 'redacted', data: '' }],
+              providerMetadata: p.providerMetadata,
+            } as MastraMessagePart;
+            parts.push(placeholder);
+          }
           reasoningSpans.set(p.id, {
             deltas: [],
             providerMetadata: p.providerMetadata,
             redacted: isRedacted,
+            placeholder,
           });
         } else {
           // Update providerMetadata if this start has it
@@ -156,8 +198,17 @@ export function buildMessagesFromChunks({
         let span = reasoningSpans.get(p.id);
         // Auto-create span if delta arrives without a matching reasoning-start
         if (!span) {
-          span = { deltas: [], providerMetadata: p.providerMetadata, redacted: false };
+          span = { deltas: [], providerMetadata: p.providerMetadata, redacted: false, placeholder: null };
           reasoningSpans.set(p.id, span);
+        }
+        // First-seen-delta reserves the slot for non-redacted reasoning
+        if (span.placeholder === null && !span.redacted) {
+          span.placeholder = {
+            type: 'reasoning' as const,
+            reasoning: '',
+            details: [{ type: 'text', text: '' }],
+          } as MastraMessagePart;
+          parts.push(span.placeholder);
         }
         span.deltas.push(p.text);
         // AI SDK semantics: latest non-null providerMetadata wins
@@ -175,22 +226,27 @@ export function buildMessagesFromChunks({
             span.providerMetadata = p.providerMetadata;
           }
 
-          if (span.redacted) {
-            parts.push({
-              type: 'reasoning' as const,
-              reasoning: '',
-              details: [{ type: 'redacted', data: '' }],
-              providerMetadata: span.providerMetadata,
-            } as MastraMessagePart);
+          const reasoningPart = span.redacted
+            ? {
+                type: 'reasoning' as const,
+                reasoning: '',
+                details: [{ type: 'redacted', data: '' }],
+                providerMetadata: span.providerMetadata,
+              }
+            : {
+                type: 'reasoning' as const,
+                reasoning: '',
+                details: [{ type: 'text', text: span.deltas.join('') }],
+                providerMetadata: span.providerMetadata,
+              };
+
+          if (span.placeholder) {
+            // Fill the slot reserved at first-seen-delta (or reasoning-start for redacted)
+            Object.assign(span.placeholder, reasoningPart);
           } else {
-            // Always emit reasoning parts, even if empty — OpenAI requires item_reference
-            // for tool calls that follow reasoning. See: https://github.com/mastra-ai/mastra/issues/9005
-            parts.push({
-              type: 'reasoning' as const,
-              reasoning: '',
-              details: [{ type: 'text', text: span.deltas.join('') }],
-              providerMetadata: span.providerMetadata,
-            } as MastraMessagePart);
+            // No delta arrived and not redacted — emit at end so we still satisfy
+            // the "always emit reasoning, even if empty" contract from #9005
+            parts.push(reasoningPart as MastraMessagePart);
           }
 
           reasoningSpans.delete(p.id);
@@ -288,28 +344,40 @@ export function buildMessagesFromChunks({
 
   // Flush any unclosed reasoning spans (stream ended without reasoning-end)
   for (const [_id, span] of reasoningSpans) {
-    if (span.redacted) {
-      parts.push({
-        type: 'reasoning' as const,
-        reasoning: '',
-        details: [{ type: 'redacted', data: '' }],
-        providerMetadata: span.providerMetadata,
-      } as MastraMessagePart);
+    const reasoningPart = span.redacted
+      ? {
+          type: 'reasoning' as const,
+          reasoning: '',
+          details: [{ type: 'redacted', data: '' }],
+          providerMetadata: span.providerMetadata,
+        }
+      : {
+          type: 'reasoning' as const,
+          reasoning: '',
+          details: [{ type: 'text', text: span.deltas.join('') }],
+          providerMetadata: span.providerMetadata,
+        };
+    if (span.placeholder) {
+      Object.assign(span.placeholder, reasoningPart);
     } else {
-      const text = span.deltas.join('');
-      parts.push({
-        type: 'reasoning' as const,
-        reasoning: '',
-        details: [{ type: 'text', text }],
-        providerMetadata: span.providerMetadata,
-      } as MastraMessagePart);
+      parts.push(reasoningPart as MastraMessagePart);
     }
   }
 
   // Flush any unclosed text spans (stream ended without text-end)
   for (const [, span] of textSpans) {
     const text = span.deltas.join('');
-    if (text.length > 0) {
+    if (span.placeholder) {
+      if (text.length > 0) {
+        (span.placeholder as { text: string }).text = text;
+        if (span.providerMetadata) {
+          (span.placeholder as { providerMetadata?: Record<string, any> }).providerMetadata = span.providerMetadata;
+        }
+      } else {
+        const idx = parts.indexOf(span.placeholder);
+        if (idx >= 0) parts.splice(idx, 1);
+      }
+    } else if (text.length > 0) {
       parts.push({
         type: 'text' as const,
         text,


### PR DESCRIPTION
## Summary

`buildMessagesFromChunks` previously emitted each text/reasoning span at its **end-event**, so the resulting `parts` array followed end-event timing rather than first-content arrival. When a stream interleaves spans —

- `text-start` before `reasoning-start`,
- `reasoning-delta` arrives before `text-delta`,
- `reasoning-end` arrives after `text-end`

— the parts came out as `[tool, tool, text, reasoning]` even though the semantic order is reasoning → text → tool-call → tool-call. Downstream `convertAIV5UIToModelMessages` + `addStartStepPartsForAIV5` then injected `step-start` markers in the wrong places, breaking the agent loop continuation described in the issue.

Closes #15914.

## Fix

Each text and reasoning span now reserves its slot in `parts` at **first-seen-delta**, then fills the slot at end-event. Redacted reasoning (which never receives a delta) reserves its slot at `reasoning-start` instead.

```ts
case 'text-delta': {
  // ...
  if (span.placeholder === null) {
    span.placeholder = { type: 'text', text: '' } as MastraMessagePart;
    parts.push(span.placeholder);
  }
  span.deltas.push(p.text);
}

case 'text-end': {
  // ...
  if (span.placeholder) {
    if (text.length > 0) {
      (span.placeholder as { text: string }).text = text;
      // ...
    } else {
      // Drop empty placeholder so "skip empty text spans" behavior is preserved
      const idx = parts.indexOf(span.placeholder);
      if (idx >= 0) parts.splice(idx, 1);
    }
  }
  // ...
}
```

The same pattern applies to `reasoning-delta` / `reasoning-end` and to the unclosed-span flush loops at the end of `buildMessagesFromChunks`.

## Behaviour preserved

- **"Always emit reasoning even if empty"** (#9005) — `reasoning-end`'s no-delta branch falls back to `parts.push` so empty reasoning still emits.
- **"Skip empty text spans"** — empty text drops its placeholder rather than emitting an empty text part.
- **Redacted reasoning** — placeholder reserved at `reasoning-start` (no delta arrives for redacted spans).

## Regression test

One test in `build-messages-from-chunks.test.ts` mirroring the issue's chunk sequence — pure chunk-array assertion, no model needed. Verifies `[reasoning, text, tool-invocation, tool-invocation]` on the interleaved-spans + reasoning-end-after-text-end stream from the issue body.

## Local verification

Did NOT run `pnpm typecheck` / `vitest` locally (monorepo install absent — same posture as #15904). Hand-verified:

- New test placed inside `describe('buildMessagesFromChunks', ...)` before "Empty stream" section to match local convention.
- Existing `should preserve correct order: reasoning, text, tool-call` (line 307) still expects the same output — its case has end-events arriving in semantic order, so placeholder mutation produces an identical result to the pre-fix behavior.

Happy to address CodeRabbit / typecheck / test feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the AI streamed pieces of a message out of order, the code ordered parts by when they finished arriving, which scrambled the intended sequence. This PR fixes that by reserving slots when a part first starts streaming so final parts appear in the order their content actually began.

## What's Changed

- buildMessagesFromChunks now reserves placeholders for text and reasoning spans at first-seen-delta (or at reasoning-start for redacted reasoning) and fills or removes those placeholders on end/flush, instead of only pushing parts at end events.
- Text spans: placeholder inserted on first text-delta, filled at text-end, removed if text is empty (preserves skipping empty text).
- Reasoning spans: placeholder reserved at reasoning-start for redacted reasoning or at first reasoning-delta for non-redacted; reasoning-end/flush populates the placeholder or pushes via fallback for empty-but-required reasoning.
- Unclosed-span flush logic uses the same placeholder pattern.
- Regression test added to assert semantic ordering for an interleaved sequence reproducing #15914.

## Why It Matters

Fixes semantic ordering so downstream consumers (e.g., convertAIV5UIToModelMessages + addStartStepPartsForAIV5) can rely on first-seen ordering when assembling prompts and step markers, preventing malformed prompts and broken agent loops.

## Tests

- New/updated tests in build-messages-from-chunks.test.ts:
  - Interleaved text spans now assert first-seen-delta ordering.
  - New regression test reproduces reasoning-delta arriving before text-delta but reasoning-end after text-end and asserts parts order [reasoning, text, tool-invocation, tool-invocation].

## Files Modified

- .changeset/fix-build-messages-semantic-order.md — release note
- packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts — implementation (+105/-37)
- packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts — tests (+~36)

## Notes for reviewers

- The author did not run monorepo typecheck/tests locally and requested CI/typecheck feedback. This change is focused on ordering semantics and preserves previous behaviors (empty reasoning still emits; empty text skipped).
- Closes #15914.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->