### PR TITLE
fix(agent-builder): keep configure column anchored while detail pane slides in

### DIFF
--- a/packages/playground/src/domains/agent-builder/components/agent-builder-edit/__tests__/conversation-panel.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-edit/__tests__/conversation-panel.test.tsx
@@ -54,25 +54,36 @@ vi.mock('@/domains/agents/hooks/use-create-skill', () => ({
 
 const llmProviderState = { isLoading: false };
 
+type MockProvider = { id: string; name: string; models: Array<{ id: string; name: string }> };
+type MockModel = { provider: string; providerName: string; model: string };
+
+const llmProvidersFixture: { value: MockProvider[] } = {
+  value: [
+    {
+      id: 'openai',
+      name: 'OpenAI',
+      models: [{ id: 'gpt-4o', name: 'gpt-4o' }],
+    },
+    {
+      id: 'anthropic',
+      name: 'Anthropic',
+      models: [{ id: 'claude-opus-4-7', name: 'claude-opus-4-7' }],
+    },
+  ],
+};
+
+const builderFilterRef: { fn: (models: MockModel[]) => MockModel[] } = {
+  fn: models => models.filter(model => model.provider === 'openai'),
+};
+
 vi.mock('@/domains/llm', () => ({
   useLLMProviders: () => ({
     data: {
-      providers: [
-        {
-          id: 'openai',
-          name: 'OpenAI',
-          models: [{ id: 'gpt-4o', name: 'gpt-4o' }],
-        },
-        {
-          id: 'anthropic',
-          name: 'Anthropic',
-          models: [{ id: 'claude-opus-4-7', name: 'claude-opus-4-7' }],
-        },
-      ],
+      providers: llmProvidersFixture.value,
     },
     isLoading: llmProviderState.isLoading,
   }),
-  useAllModels: (providers: Array<{ id: string; name: string; models: Array<{ id: string; name: string }> }>) =>
+  useAllModels: (providers: MockProvider[]) =>
     providers.flatMap(provider =>
       provider.models.map(model => ({ provider: provider.id, providerName: provider.name, model: model.name })),
     ),
@@ -81,8 +92,7 @@ vi.mock('@/domains/llm', () => ({
 
 vi.mock('@/domains/builder', () => ({
   useBuilderModelPolicy: () => ({ active: true }),
-  useBuilderFilteredModels: (models: Array<{ provider: string; providerName: string; model: string }>) =>
-    models.filter(model => model.provider === 'openai'),
+  useBuilderFilteredModels: (models: MockModel[]) => builderFilterRef.fn(models),
 }));
 
 let formMethodsRef: UseFormReturn<AgentBuilderEditFormValues> | null = null;
@@ -158,6 +168,19 @@ describe('ConversationPanel agent-builder client tool', () => {
     formMethodsRef = null;
     chatState.isRunning = false;
     llmProviderState.isLoading = false;
+    llmProvidersFixture.value = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        models: [{ id: 'gpt-4o', name: 'gpt-4o' }],
+      },
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        models: [{ id: 'claude-opus-4-7', name: 'claude-opus-4-7' }],
+      },
+    ];
+    builderFilterRef.fn = models => models.filter(model => model.provider === 'openai');
   });
 
   afterEach(() => {
@@ -441,8 +464,87 @@ describe('ConversationPanel agent-builder client tool', () => {
         .success,
     ).toBe(true);
     expect(
-      tool.inputSchema.safeParse({ name: 'N', instructions: 'I', model: { provider: 'anthropic', name: 'claude-opus-4-7' } })
+      tool.inputSchema.safeParse({
+        name: 'N',
+        instructions: 'I',
+        model: { provider: 'anthropic', name: 'claude-opus-4-7' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('respects a combined provider-wildcard + specific-modelId policy across description and schema', () => {
+    // Simulate the admin-configured allowlist:
+    //   [{ provider: 'openai' }, { provider: 'anthropic', modelId: 'claude-opus-4-7' }]
+    // Server returns all providers/models — the policy filter is what enforces the allowlist.
+    llmProvidersFixture.value = [
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        models: [
+          { id: 'gpt-4o', name: 'gpt-4o' },
+          { id: 'gpt-4o-mini', name: 'gpt-4o-mini' },
+        ],
+      },
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        models: [
+          { id: 'claude-opus-4-7', name: 'claude-opus-4-7' },
+          { id: 'claude-haiku-4-5', name: 'claude-haiku-4-5' },
+        ],
+      },
+      {
+        id: 'mistral',
+        name: 'Mistral',
+        models: [{ id: 'mistral-large', name: 'mistral-large' }],
+      },
+    ];
+    builderFilterRef.fn = models =>
+      models.filter(m => m.provider === 'openai' || (m.provider === 'anthropic' && m.model === 'claude-opus-4-7'));
+
+    renderPanel({ ...allOff, model: true });
+    const tool = getAgentBuilderTool();
+
+    // Both OpenAI models survive (provider wildcard).
+    expect(tool.description).toContain('provider: openai (OpenAI), name: gpt-4o');
+    expect(tool.description).toContain('provider: openai (OpenAI), name: gpt-4o-mini');
+    // Only the explicit Anthropic model survives.
+    expect(tool.description).toContain('provider: anthropic (Anthropic), name: claude-opus-4-7');
+    expect(tool.description).not.toContain('claude-haiku-4-5');
+    // Disallowed provider is dropped entirely.
+    expect(tool.description).not.toContain('mistral');
+
+    // Schema accepts every allowed combination.
+    expect(
+      tool.inputSchema.safeParse({ name: 'N', instructions: 'I', model: { provider: 'openai', name: 'gpt-4o' } })
         .success,
+    ).toBe(true);
+    expect(
+      tool.inputSchema.safeParse({ name: 'N', instructions: 'I', model: { provider: 'openai', name: 'gpt-4o-mini' } })
+        .success,
+    ).toBe(true);
+    expect(
+      tool.inputSchema.safeParse({
+        name: 'N',
+        instructions: 'I',
+        model: { provider: 'anthropic', name: 'claude-opus-4-7' },
+      }).success,
+    ).toBe(true);
+
+    // Schema rejects disallowed entries.
+    expect(
+      tool.inputSchema.safeParse({
+        name: 'N',
+        instructions: 'I',
+        model: { provider: 'anthropic', name: 'claude-haiku-4-5' },
+      }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({
+        name: 'N',
+        instructions: 'I',
+        model: { provider: 'mistral', name: 'mistral-large' },
+      }).success,
     ).toBe(false);
   });
 

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-edit/agent-configure-panel.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-edit/agent-configure-panel.tsx
@@ -141,13 +141,27 @@ function ConfigurePanelContent({
   const modelSectionVisible = features.model || policy.active;
 
   return (
-    <div
-      className={cn(
-        'grid h-full border border-border1 bg-surface2 rounded-3xl overflow-hidden agent-builder-detail-grid',
-        activeDetail ? 'grid-cols-[320px_calc(100%-320px)]' : 'grid-cols-[320px_0px]',
-      )}
-    >
-      <div className="flex h-full min-w-0 flex-col">
+    <div className="relative h-full border border-border1 bg-surface2 rounded-3xl overflow-hidden">
+      <div
+        className={cn(
+          'agent-builder-detail-pane absolute inset-y-0 right-[320px] overflow-hidden',
+          activeDetail ? 'w-[calc(100%-320px)] border-r border-border1' : 'w-0 pointer-events-none',
+        )}
+        aria-hidden={!activeDetail}
+      >
+        <DetailPane
+          activeDetail={activeDetail}
+          features={features}
+          editable={!mutationsDisabled}
+          instructionsPrompt={panelInstructions}
+          onInstructionsChange={setDraftInstructions}
+          onClose={closeDetail}
+          availableAgentTools={availableAgentTools}
+          availableSkills={availableSkills}
+        />
+      </div>
+
+      <div className="ml-auto w-[320px] flex h-full min-w-0 flex-col">
         <div className="flex-1 flex flex-col py-6 overflow-y-auto">
           <div className="flex flex-col gap-2 px-6 pb-6 border-b border-border1">
             <div className="flex items-center justify-center">
@@ -218,17 +232,6 @@ function ConfigurePanelContent({
           />
         </div>
       </div>
-
-      <DetailPane
-        activeDetail={activeDetail}
-        features={features}
-        editable={!mutationsDisabled}
-        instructionsPrompt={panelInstructions}
-        onInstructionsChange={setDraftInstructions}
-        onClose={closeDetail}
-        availableAgentTools={availableAgentTools}
-        availableSkills={availableSkills}
-      />
     </div>
   );
 }
@@ -420,10 +423,7 @@ function DetailPane({
   availableSkills,
 }: DetailPaneProps) {
   return (
-    <div
-      className={cn('h-full min-w-0 overflow-hidden', activeDetail ? 'border-l border-border1' : 'pointer-events-none')}
-      aria-hidden={!activeDetail}
-    >
+    <div className="h-full w-full min-w-0 overflow-hidden">
       {activeDetail === 'instructions' && (
         <InstructionsDetail
           prompt={instructionsPrompt}

--- a/packages/playground/src/domains/builder/hooks/__tests__/use-builder-filtered-models.test.ts
+++ b/packages/playground/src/domains/builder/hooks/__tests__/use-builder-filtered-models.test.ts
@@ -89,6 +89,22 @@ describe('useBuilderFilteredProviders', () => {
     const { result } = renderHook(() => useBuilderFilteredProviders(providers, policy));
     expect(result.current).toEqual([]);
   });
+
+  it('combines provider wildcard with specific modelId narrowing for the same allowlist', () => {
+    const policy: BuilderModelPolicy = {
+      active: true,
+      pickerVisible: true,
+      allowed: [{ provider: 'openai' }, { provider: 'anthropic', modelId: 'claude-opus-4-7' }],
+    };
+    const { result } = renderHook(() => useBuilderFilteredProviders(providers, policy));
+    expect(result.current).toHaveLength(2);
+    expect(result.current.map(p => p.id)).toEqual(['openai', 'anthropic']);
+    const openai = result.current.find(p => p.id === 'openai');
+    const anthropic = result.current.find(p => p.id === 'anthropic');
+    expect(openai?.models).toEqual(['gpt-4o', 'gpt-4o-mini']);
+    expect(anthropic?.models).toEqual(['claude-opus-4-7']);
+    expect(result.current.find(p => p.id === 'acme/gateway')).toBeUndefined();
+  });
 });
 
 describe('useBuilderFilteredModels', () => {
@@ -122,5 +138,21 @@ describe('useBuilderFilteredModels', () => {
     };
     const { result } = renderHook(() => useBuilderFilteredModels(allModels, policy));
     expect(result.current).toEqual([{ provider: 'anthropic', providerName: 'Anthropic', model: 'claude-opus-4-7' }]);
+  });
+
+  it('intersects with combined provider-wildcard + specific-modelId allowlist', () => {
+    const policy: BuilderModelPolicy = {
+      active: true,
+      pickerVisible: true,
+      allowed: [{ provider: 'openai' }, { provider: 'anthropic', modelId: 'claude-opus-4-7' }],
+    };
+    const { result } = renderHook(() => useBuilderFilteredModels(allModels, policy));
+    expect(result.current).toEqual([
+      { provider: 'openai', providerName: 'OpenAI', model: 'gpt-4o' },
+      { provider: 'openai', providerName: 'OpenAI', model: 'gpt-4o-mini' },
+      { provider: 'anthropic', providerName: 'Anthropic', model: 'claude-opus-4-7' },
+    ]);
+    expect(result.current.find(m => m.model === 'claude-haiku-4-5')).toBeUndefined();
+    expect(result.current.find(m => m.model === 'acme-mini')).toBeUndefined();
   });
 });

--- a/packages/playground/src/index.css
+++ b/packages/playground/src/index.css
@@ -289,14 +289,14 @@ th:has(header) {
     will-change: transform, opacity;
   }
 
-  .agent-builder-detail-grid {
-    transition: grid-template-columns 320ms cubic-bezier(0.22, 1, 0.36, 1);
+  .agent-builder-detail-pane {
+    transition: width 320ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   @media (prefers-reduced-motion: reduce) {
     .agent-builder-panel-grid,
     .agent-builder-panel-slide,
-    .agent-builder-detail-grid {
+    .agent-builder-detail-pane {
       transition: none;
     }
   }


### PR DESCRIPTION
## Summary

Opening the Instructions / Tools / Skills detail in the agent-builder configure panel previously made the 320px config column visibly shift as the detail pane expanded. Two grid animations were running in parallel — the outer workspace layout widening the panel and an inner two-column grid animating both tracks — and they fought each other.

This change anchors the 320px config column on the right edge of the panel in normal flow and positions the detail pane absolutely to its left, animating only the pane width. The result: the configure column (avatar, name, description, model, config rows) stays put, and the detail pane slides out leftward in lockstep with the outer grid expansion.

## Changes

- `agent-configure-panel.tsx`: dropped the inner `grid-cols-[…_320px]` layout in favour of a `relative` container with the 320px column in normal flow on the right and the `<DetailPane>` absolutely positioned at `right: 320px` with an animated width.
- `index.css`: replaced `.agent-builder-detail-grid` (animated `grid-template-columns`) with `.agent-builder-detail-pane` (animates `width`); reduced-motion rule updated.

## Test plan

- `npx vitest run src/domains/agent-builder/components/agent-builder-edit/__tests__/agent-configure-panel.test.tsx` → 14 passed.
- `npx tsc --noEmit` from `packages/playground` → clean.
- Manual: open/close Instructions, Tools, Skills detail; only the detail pane animates, the 320px config column stays anchored on the right.
