### PR TITLE
fix(mongodb): correct query() docs and export MongoDBQueryVectorParams

### DIFF
--- a/.changeset/all-paws-shake.md
+++ b/.changeset/all-paws-shake.md
@@ -1,0 +1,40 @@
+---
+'@mastra/mongodb': patch
+---
+
+Fixed MongoDB vector store docs and exported `MongoDBQueryVectorParams` type.
+
+**What changed**
+
+- Removed the `minScore` parameter from the `query()` reference docs and README. It was incorrectly listed but never supported by the SDK (only `@mastra/pg` and `@mastra/libsql` implement it).
+- Exported the `MongoDBQueryVectorParams` interface so you can type query parameters that include the MongoDB-specific `documentFilter` field.
+
+**Before**
+
+```typescript
+import { MongoDBVector } from '@mastra/mongodb';
+
+// MongoDBQueryVectorParams was not exported, so TypeScript fell back to
+// QueryVectorParams<any> and rejected documentFilter
+const params = {
+  indexName: 'docs',
+  queryVector: [0.1, 0.2, 0.3],
+  documentFilter: { $contains: 'mongodb' },
+};
+await store.query(params); // TS error on documentFilter
+```
+
+**After**
+
+```typescript
+import { MongoDBVector, MongoDBQueryVectorParams } from '@mastra/mongodb';
+
+const params: MongoDBQueryVectorParams = {
+  indexName: 'docs',
+  queryVector: [0.1, 0.2, 0.3],
+  documentFilter: { $contains: 'mongodb' },
+};
+await store.query(params);
+```
+
+Fixes #15715

--- a/.changeset/all-paws-shake.md
+++ b/.changeset/all-paws-shake.md
@@ -2,39 +2,6 @@
 '@mastra/mongodb': patch
 ---
 
-Fixed MongoDB vector store docs and exported `MongoDBQueryVectorParams` type.
-
-**What changed**
-
-- Removed the `minScore` parameter from the `query()` reference docs and README. It was incorrectly listed but never supported by the SDK (only `@mastra/pg` and `@mastra/libsql` implement it).
-- Exported the `MongoDBQueryVectorParams` interface so you can type query parameters that include the MongoDB-specific `documentFilter` field.
-
-**Before**
-
-```typescript
-import { MongoDBVector } from '@mastra/mongodb';
-
-// MongoDBQueryVectorParams was not exported, so TypeScript fell back to
-// QueryVectorParams<any> and rejected documentFilter
-const params = {
-  indexName: 'docs',
-  queryVector: [0.1, 0.2, 0.3],
-  documentFilter: { $contains: 'mongodb' },
-};
-await store.query(params); // TS error on documentFilter
-```
-
-**After**
-
-```typescript
-import { MongoDBVector, MongoDBQueryVectorParams } from '@mastra/mongodb';
-
-const params: MongoDBQueryVectorParams = {
-  indexName: 'docs',
-  queryVector: [0.1, 0.2, 0.3],
-  documentFilter: { $contains: 'mongodb' },
-};
-await store.query(params);
-```
+Removed unsupported `minScore` query option from MongoDB vector store docs and README. Exported `MongoDBQueryVectorParams` so callers can type `documentFilter` for `MongoDBVector.query()`.
 
 Fixes #15715

--- a/docs/src/content/en/reference/vectors/mongodb.mdx
+++ b/docs/src/content/en/reference/vectors/mongodb.mdx
@@ -182,13 +182,6 @@ Searches for similar vectors with optional metadata filtering.
     defaultValue: 'false',
     description: 'Whether to include vector data in results',
   },
-  {
-    name: 'minScore',
-    type: 'number',
-    isOptional: true,
-    defaultValue: '0',
-    description: 'Minimum similarity score threshold',
-  },
 ]}
 />
 

--- a/stores/mongodb/README.md
+++ b/stores/mongodb/README.md
@@ -135,7 +135,6 @@ const vectorDB = new MongoDBVector({
 
 - Vector similarity search with cosine, euclidean, and dotproduct metrics (Atlas Search)
 - Metadata filtering with MongoDB-style query syntax
-- Minimum score threshold for queries
 - Automatic UUID generation for vectors
 - Collection (index) management: create, list, describe, delete
 - Atlas Search readiness checks for reliable testing

--- a/stores/mongodb/README.md
+++ b/stores/mongodb/README.md
@@ -50,7 +50,6 @@ const results = await vectorDB.query({
   topK: 10,
   filter: { text: 'doc1' },
   includeVector: false,
-  minScore: 0.5,
 });
 
 // Clean up
@@ -175,7 +174,7 @@ The following distance metrics are supported:
 
 - `createIndex({indexName, dimension, metric})`: Create a new collection with vector search support
 - `upsert({indexName, vectors, metadata?, ids?})`: Add or update vectors
-- `query({indexName, queryVector, topK?, filter?, includeVector?, minScore?, documentFilter?})`: Search for similar vectors (optionally filter by document content)
+- `query({indexName, queryVector, topK?, filter?, includeVector?, documentFilter?})`: Search for similar vectors (optionally filter by document content)
 
 > **Note:** `documentFilter` allows filtering results based on the content of the `document` field. Example: `{ $contains: 'specific text' }` will return only vectors whose associated document contains the specified text.
 

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -26,7 +26,7 @@ export interface MongoDBUpsertVectorParams extends UpsertVectorParams {
   documents?: string[];
 }
 
-interface MongoDBQueryVectorParams extends QueryVectorParams<MongoDBVectorFilter> {
+export interface MongoDBQueryVectorParams extends QueryVectorParams<MongoDBVectorFilter> {
   documentFilter?: MongoDBVectorFilter;
 }
 


### PR DESCRIPTION
## Description

Fixes documentation and SDK type-export mismatches in `@mastra/mongodb` reported in #15715. The MongoDB vector store docs incorrectly listed a `minScore` parameter on `query()` that was never implemented in the SDK (only `@mastra/pg` and `@mastra/libsql` support it). Additionally, `MongoDBQueryVectorParams` was defined but not exported, so customers typing query params separately could not access the MongoDB-specific `documentFilter` field and TS fell back to the base `QueryVectorParams<any>`.

- Removed the `minScore` entry from `docs/src/content/en/reference/vectors/mongodb.mdx` `query()` properties table
- Removed `minScore: 0.5` from the query example and `minScore?` from the method signature in `stores/mongodb/README.md`
- Added `export` to the `MongoDBQueryVectorParams` interface in `stores/mongodb/src/vector/index.ts` so customers can correctly type query params that include `documentFilter`

## Related Issue(s)

Fixes #15715

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR removes a wrongly-documented MongoDB query option that was never implemented, and makes it easier for developers to type MongoDB-specific query parameters by exporting a TypeScript interface.

## Changes

### Documentation
- Removed the unsupported `minScore` parameter from the MongoDB vector store reference docs (docs/src/content/en/reference/vectors/mongodb.mdx) and the MongoDB README (stores/mongodb/README.md).
- Updated `MongoDBVector.query()` examples and documented method signature to no longer include `minScore`; remaining query options include `indexName`, `queryVector`, `topK`, `filter`, `includeVector`, and `documentFilter`.

### TypeScript API
- Exported the `MongoDBQueryVectorParams` interface in stores/mongodb/src/vector/index.ts so consumers can type query parameters that include the MongoDB-specific `documentFilter` field (previously unexported).

### Changeset
- Added a changeset (.changeset/all-paws-shake.md) documenting a patch release that removes `minScore` and notes the new export for `MongoDBQueryVectorParams`.

## Type
Bug fix and documentation update — addresses incorrect docs and improves typing for consumers. Fixes #15715
<!-- end of auto-generated comment: release notes by coderabbit.ai -->