### PR TITLE
docs: expand smoke test release guidance

### DIFF
--- a/.claude/skills/mastra-smoke-test/SKILL.md
+++ b/.claude/skills/mastra-smoke-test/SKILL.md
@@ -7,6 +7,55 @@ description: Smoke test Mastra projects locally or deploy to staging/production.
 
 Comprehensive smoke testing for Mastra projects.
 
+## Release smoke workflows
+
+Use progressive disclosure: stay in this file until the workflow branches, then read only the reference for the branch you are on. `references/release-smoke.md` is a short index if you need the full map.
+
+### Alpha release branch point
+
+Before alpha smoke testing, identify the alpha versioning PR state. Prefer the standard Changesets release branch:
+
+```bash
+gh pr view changeset-release/main \
+  --json number,title,state,url,headRefName,baseRefName,isDraft,mergeable,reviewDecision,updatedAt,mergedAt,mergeCommit
+```
+
+Expected shape:
+
+```text
+title: chore: version packages (alpha)
+head: changeset-release/main
+base: main
+```
+
+If that branch lookup fails, search open and recently merged PRs:
+
+```bash
+gh pr list --state open --search 'version packages alpha in:title' --limit 20
+gh pr list --state merged --search 'version packages alpha in:title' --limit 20
+```
+
+Then branch:
+
+- If the versioning PR is **open**, read `references/alpha-versioning-pr.md`.
+- If the versioning PR is **merged**, read `references/alpha-publish.md`.
+- If no versioning PR exists, report that and wait for the scheduled alpha versioning flow or user direction.
+
+Do not create the alpha smoke-test project until the automatic alpha publish workflow has completed and the intended packages are installable.
+
+### Stable release branch point
+
+If the user is running the stable/full release workflow, read `references/stable-release-smoke.md`. If that workflow fails after some packages publish, switch to `references/stable-partial-publish-recovery.md`.
+
+### Scope and targeted checks
+
+After the release package is published and before running smoke tests, read `references/release-scope-discovery.md` to identify changed features. Use the default generated project for the baseline checklist, then add targeted checks for changed features the generated project does not exercise.
+
+When scope discovery identifies a branch:
+
+- For general changed-feature coverage, read `references/targeted-feature-smoke.md`.
+- For storage/provider schema or migration changes, read `references/storage-provider-migration-smoke.md`.
+
 ## ⚠️ Mandatory Test Checklist
 
 **Use `task_write` to track progress.** Run ALL tests unless `--test` specifies otherwise.
@@ -42,6 +91,77 @@ If `--test` is provided:
 3. Skip other tests
 
 Example: `--test agents,traces` → Run steps 1, 2, and 5 only.
+
+## Local Studio Browser Smoke
+
+For local release smoke tests, do **both** API/curl checks and a Studio browser pass unless `--skip-browser` is explicitly requested or browser access is genuinely blocked. API checks prove runtime endpoints work; browser checks prove the Playground/Studio UI can load, submit forms, and display results.
+
+Before opening the browser:
+
+1. Confirm the dev server is alive on the expected port:
+
+   ```bash
+   curl -s -o /dev/null -w '%{http_code}\n' http://localhost:4111
+   lsof -i :4111 || true
+   ```
+
+2. If the process died, restart it from the generated project and wait for readiness:
+
+   ```bash
+   cd "$SMOKE_DIR/smoke-project"
+   pnpm run dev > "$SMOKE_DIR/logs/dev-server-browser.log" 2>&1 &
+
+   for i in {1..60}; do
+     code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4111 || true)
+     [ "$code" = 200 ] && break
+     sleep 1
+   done
+   ```
+
+3. Use browser tools to navigate to `http://localhost:4111`. If `networkidle` times out but `domcontentloaded` succeeds and the UI is usable, continue and note the timeout.
+
+Recommended browser task list:
+
+```text
+1. Verify Studio shell loads
+2. Smoke test agent chat UI
+3. Smoke test tools UI
+4. Smoke test workflows UI
+5. Smoke test observability, scorers, and MCP pages
+6. Report browser smoke results
+```
+
+Run these page checks:
+
+| Area         | Route                          | What to verify                                                                                                                                                           |
+| ------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Studio shell | `/` or `/agents`               | Sidebar/nav visible, Mastra version visible, no crash/error overlay                                                                                                      |
+| Agents       | `/agents` → agent chat         | Agent list shows expected agent, chat input is visible, sending `What's the weather in Tokyo?` returns a coherent response, tool call badge/result appears when expected |
+| Tools        | `/tools` → tool detail         | Tool list shows `get-weather`, input form renders, submitting a city such as `Paris` displays JSON result with weather fields                                            |
+| Workflows    | `/workflows` → workflow detail | Workflow list shows `weather-workflow`, graph/details render, running with a city such as `Berlin` completes as `success`, steps show timings/output controls            |
+| Traces       | `/observability`               | Recent agent/workflow traces appear, including runs triggered during the browser pass                                                                                    |
+| Scorers      | `/scorers`                     | Registered scorers appear with names/descriptions, e.g. Tool Call Accuracy, Completeness, Translation Quality                                                            |
+| MCP          | `/mcps`                        | Page loads. Empty state is a pass for default templates: `No MCP Servers yet`                                                                                            |
+
+If a browser interaction does not expose enough text in the accessibility snapshot, inspect `document.body.innerText` or take a screenshot, then record the visible evidence. Do not rely only on API output for browser smoke.
+
+Append browser results to `$SMOKE_DIR/smoke-report.md` with a separate section, for example:
+
+```md
+## Studio Browser Smoke Results
+
+| Area         | Result | Evidence                                                          |
+| ------------ | ------ | ----------------------------------------------------------------- |
+| Studio shell | PASS   | Browser loaded localhost:4111; sidebar/nav visible; version shown |
+| Agents UI    | PASS   | Weather Agent chat returned Tokyo weather and displayed tool call |
+| Tools UI     | PASS   | get-weather form returned Paris weather JSON                      |
+| Workflows UI | PASS   | weather-workflow Berlin run completed as success                  |
+| Traces UI    | PASS   | Recent agent/workflow traces listed                               |
+| Scorers UI   | PASS   | Expected scorers listed                                           |
+| MCP UI       | PASS   | Expected empty MCP state shown                                    |
+```
+
+Call out separately whether browser smoke was local Studio only or cloud Studio/deployed server.
 
 ---
 
@@ -134,15 +254,27 @@ See `references/tests/setup.md` for setup details.
 
 ## References
 
-| File                           | Purpose                      |
-| ------------------------------ | ---------------------------- |
-| `references/tests/*.md`        | Detailed steps for each test |
-| `references/local-setup.md`    | Local dev server setup       |
-| `references/cloud-deploy.md`   | Cloud deploy details         |
-| `references/cloud-advanced.md` | BYOK, storage testing        |
-| `references/common-errors.md`  | Troubleshooting              |
-| `references/gcp-debugging.md`  | Infrastructure debugging     |
-| `scripts/test-server.sh`       | Server API test script       |
+| File                                             | Purpose                                  |
+| ------------------------------------------------ | ---------------------------------------- |
+| `references/tests/*.md`                          | Detailed steps for each mandatory test   |
+| `references/release-smoke.md`                    | Short release-smoke reference index      |
+| `references/alpha-versioning-pr.md`              | Open alpha versioning PR readiness       |
+| `references/alpha-publish.md`                    | Merged alpha PR publish verification     |
+| `references/stable-release-smoke.md`             | Stable publish and final stable smoke    |
+| `references/stable-partial-publish-recovery.md`  | Partial stable publish recovery          |
+| `references/release-scope-discovery.md`          | Release PR scope discovery and planning  |
+| `references/targeted-feature-smoke.md`           | Targeted changed-feature smoke patterns  |
+| `references/storage-provider-migration-smoke.md` | Storage/provider migration smoke pattern |
+| `references/local-setup.md`                      | Local dev server setup                   |
+| `references/cloud-deploy.md`                     | Cloud deploy details                     |
+| `references/cloud-advanced.md`                   | BYOK, storage testing                    |
+| `references/common-errors.md`                    | Troubleshooting                          |
+| `references/gcp-debugging.md`                    | Infrastructure debugging                 |
+| `references/architecture.md`                     | Smoke-test architecture notes            |
+| `references/environment-variables.md`            | Environment variable setup               |
+| `scripts/test-server.sh`                         | Server API test script                   |
+| `scripts/discover-release-scope.sh`              | Release PR scope discovery               |
+| `scripts/check-versioning-pr.sh`                 | Alpha versioning PR spot-check helper    |
 
 ## Platform Dashboards
 

--- a/.claude/skills/mastra-smoke-test/references/alpha-publish.md
+++ b/.claude/skills/mastra-smoke-test/references/alpha-publish.md
@@ -1,0 +1,51 @@
+# Alpha Publish Verification
+
+Use this after the alpha versioning PR has merged.
+
+## Confirm the automatic alpha publish workflow
+
+Merging the alpha versioning PR to `main` automatically kicks off the `Publish to npm` workflow on a `push` event. Do **not** advise manually starting the alpha publish workflow.
+
+Check for the automatic run:
+
+```bash
+gh run list --workflow "Publish to npm" --branch main --limit 5
+```
+
+Inspect the newest run. The alpha path should be the `prerelease` job, with `snapshot`, `stable`, and `enter_prerelease` skipped:
+
+```bash
+gh run view <run-id> --json name,event,status,conclusion,workflowName,headBranch,headSha,jobs,url --jq .
+```
+
+Watch it:
+
+```bash
+gh run watch <run-id>
+```
+
+Offer to open the prerelease run in the user's browser when helpful:
+
+```bash
+gh run view <run-id> --web
+```
+
+Use `gh run view --web` instead of browser automation because it opens the page in the user's normal browser/session.
+
+If no automatic publish run starts after the merge, report that as a release automation issue and ask the user before taking any recovery action.
+
+## Confirm alpha is published
+
+Before smoke testing, confirm the alpha package is installable:
+
+```bash
+npm view @mastra/core@alpha version
+npm view mastra@alpha version
+npm view create-mastra@alpha version
+```
+
+Only then create the smoke-test project with the alpha tag/version.
+
+## Next step
+
+After alpha packages are published, continue with release scope discovery in `references/release-scope-discovery.md`, then run the mandatory local checklist from `SKILL.md` plus any targeted checks.

--- a/.claude/skills/mastra-smoke-test/references/alpha-versioning-pr.md
+++ b/.claude/skills/mastra-smoke-test/references/alpha-versioning-pr.md
@@ -1,0 +1,60 @@
+# Alpha Versioning PR Readiness
+
+Use this only when the alpha versioning PR is still open.
+
+## Open the PR for the user
+
+Offer to open the open versioning PR in the user's browser when helpful:
+
+```bash
+gh pr view <pr-number> --web
+```
+
+Use `gh pr view --web` instead of browser automation because it opens the page in the user's normal browser/session.
+
+## Check readiness
+
+```bash
+gh pr view <pr-number> --json number,title,isDraft,mergeable,reviewDecision,url
+gh pr checks <pr-number> --watch=false
+```
+
+If checks are still running, wait:
+
+```bash
+gh pr checks <pr-number> --watch --interval 30
+```
+
+## Spot check the versioning diff
+
+Before telling the user it is ready to merge, spot check the versioning diff yourself and advise the user to spot check it too. Prefer the helper script:
+
+```bash
+.claude/skills/mastra-smoke-test/scripts/check-versioning-pr.sh <pr-number> --workspace "$SMOKE_DIR"
+```
+
+Or inspect manually:
+
+```bash
+gh pr diff <pr-number> --name-only
+gh pr view <pr-number> --json files --jq '.files[].path' \
+  | rg '(package\.json|CHANGELOG\.md|\.changeset/)'
+gh pr diff <pr-number>
+```
+
+Check:
+
+- package versions look intentional
+- there are no unintended major version bumps or breaking-change releases
+- changelog entries match the PRs expected in the alpha
+- CI is green and the PR is not a draft
+
+Summarize your spot-check findings for the user before they approve/merge.
+
+## Merge guidance
+
+The user must review, approve, and merge the versioning PR. The agent may check readiness and advise, but should not merge the PR without explicit user instruction.
+
+If the PR is ready, tell the user to approve and merge it in GitHub, or ask whether they want you to merge it. If branch protection rejects the merge because review is required, stop and ask for the required approval.
+
+After the PR merges, continue with `references/alpha-publish.md`.

--- a/.claude/skills/mastra-smoke-test/references/release-scope-discovery.md
+++ b/.claude/skills/mastra-smoke-test/references/release-scope-discovery.md
@@ -1,0 +1,122 @@
+# Release Scope Discovery
+
+Before running release smoke tests, determine what changed since the last release. Do not rely only on the default smoke-test checklist; use the release diff to decide whether targeted checks are needed.
+
+## 0. Create a dated smoke-test workspace
+
+Create a date-scoped workspace before collecting release artifacts. Keep the generated Mastra project, PR list, logs, and smoke reports together.
+
+```bash
+SMOKE_DATE=$(date +%F)
+SMOKE_DIR="$HOME/mastra-smoke-tests/$SMOKE_DATE"
+mkdir -p "$SMOKE_DIR/logs"
+```
+
+If `$HOME/mastra-smoke-tests` is outside the repo sandbox, request filesystem access before writing there.
+
+Expected layout:
+
+```text
+~/mastra-smoke-tests/YYYY-MM-DD/
+  merged-prs.tsv
+  smoke-scope.md
+  smoke-report.md
+  logs/
+  smoke-project/
+  stable-smoke-project/
+```
+
+Prefer the helper script when available:
+
+```bash
+.claude/skills/mastra-smoke-test/scripts/discover-release-scope.sh --release-tag '@mastra/core@1.28.0'
+```
+
+The script writes `merged-prs.tsv` and a starter `smoke-scope.md` to the workspace.
+
+## 1. Identify the last release baseline
+
+Find the previous stable release tag and timestamp. Prefer the tag/release that corresponds to the package being released, usually `@mastra/core@<version>` for monorepo releases.
+
+```bash
+gh release list --limit 20
+gh release view '@mastra/core@<version>' --json tagName,publishedAt,createdAt,targetCommitish,url
+git show -s --format='%H %cI %s' '@mastra/core@<version>'
+```
+
+Use the tag commit date or release `createdAt` as the cutoff for merged PR discovery. State which cutoff you used.
+
+## 2. List merged PRs since the cutoff
+
+Export merged PRs since the baseline into the dated workspace. Exclude Dependabot unless the release specifically needs dependency smoke coverage.
+
+```bash
+gh pr list \
+  --state merged \
+  --search 'merged:>=YYYY-MM-DDTHH:MM:SSZ -author:app/dependabot' \
+  --limit 200 \
+  --json number,title,author,mergedAt,labels,url \
+  --jq '.[] | [.number, .mergedAt, .author.login, .title, .url] | @tsv' \
+  > "$SMOKE_DIR/merged-prs.tsv"
+```
+
+If the release has more than 200 PRs, paginate or narrow by date ranges until the full set is captured. Cross-check with first-parent merge commits when needed:
+
+```bash
+git log --first-parent --oneline '@mastra/core@<previous>'..origin/main
+```
+
+## 3. Categorize the PRs
+
+Group PRs by runtime surface area and smoke implication:
+
+| Category                           | Match criteria                                                             | Smoke implication                                                      |
+| ---------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Core agent loop/streaming          | `packages/core/src/agent`, stream/resume, message conversion, loop control | Agent generate + stream/resume + memory/thread checks                  |
+| Tools/processors                   | tool execution, dynamic tools, approval, processors                        | Tool list/execute + agent tool-call path + changed processor behavior  |
+| Workflows                          | `workflows`, suspend/resume, start-async, workflow output                  | Workflow API + Studio workflow run + traces                            |
+| Memory/observability               | memory, threads, traces, scorers, logs, metrics                            | Memory persistence + trace/span/scores verification                    |
+| Server/adapters/API                | server, route registration, Express/Fastify/Hono/Koa adapters              | `/health`, `/api/*`, custom route, invalid route checks                |
+| CLI/create-mastra                  | `create-mastra`, templates, generated deps                                 | Fresh project install from target tag/version                          |
+| Studio/Playground UI               | `packages/playground-ui`, `packages/playground`                            | Browser smoke for affected pages                                       |
+| Agent Builder/auth/stored entities | stored agents/skills, auth, visibility, starring, avatar, permissions      | Authenticated staging/cloud checks when local cannot cover             |
+| MCP/A2A                            | MCP server/client/schema, A2A protocol                                     | MCP endpoints plus configured server/client if changed                 |
+| Storage/providers                  | Postgres, LibSQL, Redis, S3, Azure, vector stores                          | Provider install/import and targeted backend smoke when feasible       |
+| Mastra Code/TUI                    | `mastracode`, subagents, slash commands                                    | Separate Mastra Code smoke; default create-mastra does not cover it    |
+| Docs/examples only                 | docs, examples                                                             | Docs/example validation; no runtime smoke unless example is executable |
+
+## 4. Convert categories into a smoke plan
+
+Use full smoke as the baseline, but do **not** stop at the default generated-project happy path. The goal is to prove the **actual changed feature or bug fix** works in the published package, not just that a nearby happy path still works.
+
+For every material PR, ask:
+
+1. What user-visible behavior, API behavior, persistence behavior, or integration path changed?
+2. Does the generated smoke project execute that exact path?
+3. If not, what is the smallest targeted check that proves the changed behavior?
+4. What evidence will show the fix worked, not merely that the app did not crash?
+
+If the default project does not exercise the changed feature, add a targeted check or explicitly record why it cannot be tested in this environment.
+
+For targeted check patterns, read `references/targeted-feature-smoke.md`. For storage/provider schema or migration changes, read `references/storage-provider-migration-smoke.md`.
+
+Add a **Coverage vs Changes** table to `$SMOKE_DIR/smoke-scope.md` before testing:
+
+| Feature / PRs                        | Generated project covers it? | Targeted check to run                                                                                                                                          | Result / reason omitted     |
+| ------------------------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| Example: `resume-stream`             | No                           | Call resume-stream after starting a stream and verify resumed chunks/final response                                                                            | PASS/FAIL or blocked reason |
+| Example: tool approval change        | No                           | Configure a tool with `requireApproval`, trigger it from an agent, approve/reject, verify the changed approval behavior                                        | PASS/FAIL or blocked reason |
+| Example: Playground save persistence | No                           | Edit the affected Studio/Agent Builder form, save, reload/refetch, verify the changed field persists                                                           | PASS/FAIL or blocked reason |
+| Example: PG OM migration column      | No                           | Run Postgres in Docker, configure smoke project with `@mastra/pg`, drop old/missing column, restart, verify migration restores it and memory/OM writes succeed | PASS/FAIL or blocked reason |
+| Example: default weather tool        | Yes                          | Agent/tool smoke                                                                                                                                               | PASS                        |
+
+Write the scope analysis to `$SMOKE_DIR/smoke-scope.md` before running tests so it is not trapped in terminal output. Include:
+
+- release baseline tag and cutoff timestamp
+- command used to collect PRs
+- categorized PR table with PR number, title, author, merged time, and category
+- targeted smoke plan derived from the categories
+- coverage-vs-changes table showing what the generated project covers naturally and what needs targeted checks
+- any omitted PRs/commits and why, including Dependabot, direct non-PR commits, cloud-only features, missing credentials, or product areas outside create-mastra
+
+Report the category summary and the coverage-vs-changes summary before running tests so the user can see why each targeted check is included and where the default smoke project is insufficient.

--- a/.claude/skills/mastra-smoke-test/references/release-smoke.md
+++ b/.claude/skills/mastra-smoke-test/references/release-smoke.md
@@ -1,0 +1,21 @@
+# Release Smoke Index
+
+This file is intentionally short. Use the smallest reference needed for the branch you are on.
+
+## Alpha release
+
+Start in the top-level `SKILL.md` under **Release smoke workflows**. It includes the commands to identify whether the alpha versioning PR is open, merged, or missing.
+
+- If the alpha versioning PR is **open**, read `references/alpha-versioning-pr.md`.
+- If the alpha versioning PR is **merged**, read `references/alpha-publish.md`.
+- After alpha packages publish, read `references/release-scope-discovery.md`.
+
+## Stable release
+
+- For normal stable publish monitoring and final smoke, read `references/stable-release-smoke.md`.
+- If stable publish partially fails, read `references/stable-partial-publish-recovery.md`.
+
+## Targeted checks
+
+- For changed features not covered by the generated project, read `references/targeted-feature-smoke.md`.
+- For storage/provider schema or migration changes, read `references/storage-provider-migration-smoke.md`.

--- a/.claude/skills/mastra-smoke-test/references/stable-partial-publish-recovery.md
+++ b/.claude/skills/mastra-smoke-test/references/stable-partial-publish-recovery.md
@@ -1,0 +1,38 @@
+# Stable Partial Publish Recovery
+
+Use this only when the stable publish fails after some packages have already published.
+
+Treat it as a partial release. Do not create a new versioning PR or bump versions. First identify the failed step and whether npm `latest` is split across old and new versions.
+
+## Recovery flow
+
+1. Record which packages already reached npm `latest` and which are still old.
+2. Rerun the same stable `Publish to npm` workflow from the same release commit on `main`.
+3. After the rerun succeeds, verify all intended package versions are on npm `latest`.
+4. Verify release git tags were created after the successful publish.
+5. Only then run final stable smoke against `create-mastra@latest`.
+
+## Tag behavior
+
+The `Add tags` step runs after publish:
+
+```bash
+pnpm changeset-cli tag
+git push origin --tags
+```
+
+It creates and pushes git tags only for packages Changesets considers part of the current release/version bump, not every package in the monorepo. The tags look like `@mastra/core@1.29.0`, `mastra@1.7.0`, and `create-mastra@1.7.0`. If the first publish attempt fails before `Add tags`, the rerun should create tags for the full changed-package release set after npm publish completes.
+
+Verify changed-package tags, not every workspace package:
+
+```bash
+git fetch --tags
+# Spot-check release-critical tags
+git tag -l '@mastra/core@<version>'
+git tag -l 'mastra@<version>'
+git tag -l 'create-mastra@<version>'
+git tag -l '@mastra/server@<version>'
+git tag -l '@mastra/playground-ui@<version>'
+```
+
+If a package version is on npm `latest` but its expected release tag is missing after a successful rerun, stop and report it before smoke testing.

--- a/.claude/skills/mastra-smoke-test/references/stable-release-smoke.md
+++ b/.claude/skills/mastra-smoke-test/references/stable-release-smoke.md
@@ -1,0 +1,57 @@
+# Stable Release Smoke
+
+Use this after the stable/full release workflow starts or completes.
+
+After the stable/full release publishes, run smoke again against the published stable packages. Do not rely on alpha smoke as final stable-release signoff because the stable publish path, npm dist-tags, generated project install path, and package versions are distinct release surfaces.
+
+## 1. Confirm the stable publish workflow completed
+
+Inspect the full release run. The stable path should complete successfully, with snapshot/prerelease jobs skipped when this is a normal full release.
+
+```bash
+gh run view <run-id> --json name,event,status,conclusion,workflowName,headBranch,headSha,jobs,url --jq .
+gh run watch <run-id>
+```
+
+If the run fails or is cancelled, stop and report the failed job/step before creating a fresh smoke project.
+
+If it fails after some packages published, use `references/stable-partial-publish-recovery.md` before smoke testing.
+
+## 2. Confirm stable packages are installable
+
+Check the published `latest` versions and make sure they match the intended stable release versions:
+
+```bash
+npm view @mastra/core@latest version
+npm view mastra@latest version
+npm view create-mastra@latest version
+```
+
+If npm returns the previous stable version, wait for publish/registry propagation and retry. Do not run final stable smoke against stale `latest` packages.
+
+## 3. Create a fresh stable smoke project
+
+Use the same dated workspace, but create a separate project from the alpha project so dependency resolution and generated files prove the stable release path independently.
+
+```bash
+# Reuse the existing SMOKE_DIR from the alpha/release-scope run.
+: "${SMOKE_DIR:?Set SMOKE_DIR via references/release-scope-discovery.md before stable smoke}"
+mkdir -p "$SMOKE_DIR/logs"
+
+cd "$SMOKE_DIR"
+pnpm create mastra@latest stable-smoke-project -c agents,tools,workflows,scorers -l openai -e
+cd stable-smoke-project
+pnpm run dev
+```
+
+If an existing dev server is holding port `4111` or a DuckDB lock, stop that process before starting the stable project. Do not run alpha and stable smoke projects against the same generated project directory or storage file.
+
+## 4. Rerun the required smoke coverage
+
+For stable release signoff, rerun at least:
+
+- mandatory local checklist: setup, agents, tools, workflows, traces, scorers, memory, MCP, errors
+- Local Studio browser smoke: shell/version, agent chat, tool execution, workflow run, traces, scorers, MCP
+- targeted release-scope checks identified from the PR categorization, especially any checks added because the generated project does not cover changed features
+
+Append stable results to the dated `smoke-report.md` in a separate section from alpha results and clearly record the package versions tested.

--- a/.claude/skills/mastra-smoke-test/references/storage-provider-migration-smoke.md
+++ b/.claude/skills/mastra-smoke-test/references/storage-provider-migration-smoke.md
@@ -1,0 +1,41 @@
+# Storage/Provider Migration Smoke Pattern
+
+Use this when a release includes storage/provider schema, init, or migration changes. The goal is to prove the released provider package works against a real backend and repairs the old/broken schema state.
+
+## Pattern
+
+1. Start the affected backend locally when feasible.
+
+   ```bash
+   docker run -d --name mastra-smoke-pg \
+     -e POSTGRES_PASSWORD=postgres \
+     -e POSTGRES_DB=mastra \
+     -p 5544:5432 \
+     postgres:16
+   ```
+
+2. Add the released provider package to the generated smoke project.
+
+   ```bash
+   pnpm add @mastra/pg@alpha pg
+   # or, for stable smoke:
+   pnpm add @mastra/pg@latest pg
+   ```
+
+3. Configure the smoke project to use the provider through public Mastra config.
+4. Enable the feature that depends on the changed schema, such as observational memory.
+5. Create or mutate backend state to mimic the pre-fix schema.
+6. Restart the Mastra dev server so provider init/migration runs from the released package.
+7. Verify the missing column/table/index is restored.
+8. Run a real API/UI flow that writes and reads through the affected provider path.
+
+## Example evidence: Postgres observational-memory migration
+
+For a Postgres observational-memory migration fix, collect evidence such as:
+
+- `information_schema.columns` shows the missing column exists after restart, for example `reflectedObservationLineCount`
+- an agent call using PG-backed memory succeeds
+- a second call recalls the test phrase/thread context
+- memory messages and observational memory rows exist in Postgres
+
+Record the backend image/version, package version, schema mutation, verification query, and API result in `smoke-report.md`.

--- a/.claude/skills/mastra-smoke-test/references/targeted-feature-smoke.md
+++ b/.claude/skills/mastra-smoke-test/references/targeted-feature-smoke.md
@@ -1,0 +1,40 @@
+# Targeted Feature Smoke Pattern
+
+Use this when release scope discovery shows that the generated smoke project does not exercise a changed runtime feature.
+
+When a PR changes a specific feature, smoke the smallest real scenario that proves that feature. Avoid vague substitutes like "agent chat works" for a streaming fix, "tools list loads" for a tool approval fix, or "Studio loads" for a persistence/save bug.
+
+## Pattern
+
+1. Identify the exact changed path from the PR title, files, changelog, and tests.
+2. Configure or modify the smoke project so that path is reachable with the released package.
+3. Trigger the behavior through the public API or UI a user would use.
+4. Assert the before/after condition that would have failed before the fix.
+5. Capture concrete evidence: response fields, stream chunks, persisted rows, saved config after reload, trace/span contents, or visible UI text.
+6. If the feature requires cloud auth, external credentials, or a separate product like Mastra Code, either run that targeted environment or mark it `PARTIAL`/`NOT COVERED` with the exact reason.
+
+## Targeted additions by category
+
+- **CLI/create-mastra changed:** create a brand-new project at `$SMOKE_DIR/smoke-project` with the release tag and run `pnpm run dev`.
+- **Server/adapters/API changed:** add curl checks for `/health`, `/api/agents`, `/generate`, `/stream` if applicable, tool execute, workflow start, custom routes, and invalid routes. If route prefixing changed, add or use a custom route and verify built-in `/api/*` routes remain reserved.
+- **Agent streaming changed:** test `/stream`, `resume-stream`, `streamUntilIdle`, abort/length/error behavior, or another endpoint that actually uses the changed streaming path.
+- **Tools changed:** test the exact changed tool behavior, such as dynamic tools, approval functions, `requireApproval`, programmatic tool calls, or preserved args. A single static weather tool call is not enough for dynamic/approval/tool-merge changes.
+- **Workflows changed:** test the exact changed behavior, such as suspend/resume, background task progress, long-running runs, dataset/experiment workflows, or `start-async` output shape.
+- **Memory changed:** test thread/resource isolation plus the changed memory mode, such as current-thread recall defaults, observational memory boundaries, or agent network incompatibility. A basic two-call memory check is necessary but may not be sufficient. If the change only affects memory under a specific storage backend, configure the smoke project to use that backend.
+- **Memory storage migrations changed:** run an end-to-end migration smoke against the affected backend. Use `references/storage-provider-migration-smoke.md`.
+- **Forked subagents changed:** create or use a Mastra Code/subagent scenario that proves parent thread/resource inheritance and prompt cache prefix behavior. Do not assume a normal agent run covers forked subagents.
+- **Studio/Playground changed:** run browser smoke for the affected pages, especially observability traces/logs/metrics and theme/layout changes.
+- **Auth/permissions/Agent Builder changed:** prefer staging/production cloud smoke with an authenticated user and targeted permission flows. Local create-mastra usually does not cover stored agents/skills, starring, visibility, avatar upload, or server-side session refresh.
+- **MCP/A2A changed:** default empty MCP state is only a baseline. For SDK/client/server or schema-validator changes, run a targeted MCP/A2A integration check with a configured server/client when feasible.
+- **Storage/provider packages changed:** at minimum verify package installation/import. If the changed provider can run locally in Docker, run a provider-backed smoke against the released package rather than stopping at import.
+- **Mastra Code changed:** run a separate Mastra Code/TUI smoke path; do not assume standard create-mastra smoke covers it.
+- **Docs/examples changed:** run docs validation or example-specific checks; do not replace runtime smoke with docs-only checks.
+
+## Examples
+
+- For streaming fixes: call `/stream` or `resume-stream`, inspect event chunks and final response shape.
+- For tool approval/dynamic tool fixes: configure the affected tool mode, run an agent that triggers it, and verify approval/rejection or dynamic resolution behavior.
+- For workflow fixes: run the specific workflow mode changed, such as suspend/resume, background progress, or long-running output shape.
+- For Studio persistence fixes: change the affected form field, save, reload/refetch, and verify the value persisted.
+- For observability fixes: generate the affected run type and verify trace/span/scores/logs include the corrected data.
+- For CLI/create fixes: create a fresh project with the published CLI and verify generated files/dependencies/scripts match the intended output.

--- a/.claude/skills/mastra-smoke-test/scripts/check-versioning-pr.sh
+++ b/.claude/skills/mastra-smoke-test/scripts/check-versioning-pr.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+#
+# Spot check a Changesets versioning PR before an alpha release.
+#
+# Usage:
+#   ./check-versioning-pr.sh <pr-number> [--workspace <dir>]
+#
+# Examples:
+#   ./check-versioning-pr.sh 15857
+#   ./check-versioning-pr.sh 15857 --workspace ~/mastra-smoke-tests/2026-04-28
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: required dependency '$1' is not installed." >&2
+    exit 1
+  fi
+}
+
+PR_NUMBER=""
+WORKSPACE="$HOME/mastra-smoke-tests/$(date +%F)"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workspace)
+      if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "Error: --workspace requires a value." >&2
+        exit 1
+      fi
+      WORKSPACE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [ -z "$PR_NUMBER" ]; then
+        PR_NUMBER="$1"
+        shift
+      else
+        echo "Unknown argument: $1" >&2
+        echo "" >&2
+        usage >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+if [ -z "$PR_NUMBER" ]; then
+  usage >&2
+  exit 1
+fi
+
+require_cmd gh
+require_cmd python3
+
+LOG_DIR="$WORKSPACE/logs"
+mkdir -p "$LOG_DIR"
+
+FILES_PATH="$LOG_DIR/pr-$PR_NUMBER-files.txt"
+DIFF_PATH="$LOG_DIR/pr-$PR_NUMBER-full.diff"
+SUMMARY_PATH="$LOG_DIR/pr-$PR_NUMBER-version-summary.tsv"
+
+printf 'Checking PR #%s\n' "$PR_NUMBER"
+printf 'Workspace: %s\n\n' "$WORKSPACE"
+
+gh pr diff "$PR_NUMBER" --name-only > "$FILES_PATH"
+gh pr diff "$PR_NUMBER" > "$DIFF_PATH"
+
+python3 - "$FILES_PATH" "$DIFF_PATH" "$SUMMARY_PATH" <<'PY'
+import pathlib
+import re
+import sys
+
+files_path = pathlib.Path(sys.argv[1])
+diff_path = pathlib.Path(sys.argv[2])
+summary_path = pathlib.Path(sys.argv[3])
+
+files = [line.strip() for line in files_path.read_text().splitlines() if line.strip()]
+diff = diff_path.read_text(errors="ignore")
+diff = re.sub(r"\x1b\[[0-9;]*m", "", diff)
+
+version_rows = []
+current = None
+old = None
+new = None
+
+for line in diff.splitlines():
+    match = re.match(r"diff --git a/(.*?package\.json) b/(.*?package\.json)", line)
+    if match:
+        if current and (old or new):
+            version_rows.append((current, old or "", new or ""))
+        current = match.group(1)
+        old = None
+        new = None
+        continue
+
+    if current:
+        old_match = re.match(r'-\s+"version": "([^"]+)"', line)
+        new_match = re.match(r'\+\s+"version": "([^"]+)"', line)
+        if old_match:
+            old = old_match.group(1)
+        if new_match:
+            new = new_match.group(1)
+
+if current and (old or new):
+    version_rows.append((current, old or "", new or ""))
+
+changelog_versions = []
+for line in diff.splitlines():
+    match = re.match(r"\+## ([^\s]+)", line)
+    if match:
+        changelog_versions.append(match.group(1))
+
+non_release_files = [
+    f
+    for f in files
+    if not (
+        f == ".changeset/pre.json"
+        or f == "package.json"
+        or f == "CHANGELOG.md"
+        or f.endswith("/package.json")
+        or f.endswith("/CHANGELOG.md")
+    )
+]
+
+major_bumps = []
+non_alpha_new_versions = []
+stable_to_alpha = []
+
+semver_re = re.compile(r"^(\d+)\.(\d+)\.(\d+)(-.+)?$")
+for package_file, old_version, new_version in version_rows:
+    old_match = semver_re.match(old_version)
+    new_match = semver_re.match(new_version)
+    if old_match and new_match:
+        old_major = int(old_match.group(1))
+        new_major = int(new_match.group(1))
+        if new_major > old_major:
+            major_bumps.append((package_file, old_version, new_version))
+    if new_version and "-alpha." not in new_version:
+        non_alpha_new_versions.append((package_file, old_version, new_version))
+    if old_version and "-" not in old_version and "-alpha." in new_version:
+        stable_to_alpha.append((package_file, old_version, new_version))
+
+with summary_path.open("w") as f:
+    f.write("package_json\told_version\tnew_version\n")
+    for row in version_rows:
+        f.write("\t".join(row) + "\n")
+
+print("Changed files:", len(files))
+print("Package version changes:", len(version_rows))
+print("Changelog version headings:", len(changelog_versions))
+print("Non release/version files:", len(non_release_files))
+print("Major version bumps:", len(major_bumps))
+print("New versions without -alpha:", len(non_alpha_new_versions))
+print("Stable -> alpha transitions:", len(stable_to_alpha))
+print()
+
+print("Version changes:")
+for package_file, old_version, new_version in version_rows:
+    print(f"  {package_file}: {old_version} -> {new_version}")
+print()
+
+if stable_to_alpha:
+    print("Stable -> alpha transitions to review:")
+    for package_file, old_version, new_version in stable_to_alpha:
+        print(f"  {package_file}: {old_version} -> {new_version}")
+    print()
+
+if major_bumps:
+    print("WARNING: major version bumps found:")
+    for package_file, old_version, new_version in major_bumps:
+        print(f"  {package_file}: {old_version} -> {new_version}")
+    print()
+
+if non_alpha_new_versions:
+    print("WARNING: new versions without -alpha found:")
+    for package_file, old_version, new_version in non_alpha_new_versions:
+        print(f"  {package_file}: {old_version} -> {new_version}")
+    print()
+
+if non_release_files:
+    print("WARNING: files outside .changeset/pre.json, package.json, and CHANGELOG.md changed:")
+    for file in non_release_files:
+        print(f"  {file}")
+    print()
+
+if not major_bumps and not non_alpha_new_versions and not non_release_files:
+    print("Summary: no major bumps, non-alpha new versions, or non-release files detected.")
+else:
+    print("Summary: review warnings above before approving/merging.")
+PY
+
+printf '\nWrote:\n'
+printf '  %s\n' "$FILES_PATH"
+printf '  %s\n' "$DIFF_PATH"
+printf '  %s\n' "$SUMMARY_PATH"

--- a/.claude/skills/mastra-smoke-test/scripts/discover-release-scope.sh
+++ b/.claude/skills/mastra-smoke-test/scripts/discover-release-scope.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+#
+# Discover release smoke-test scope by exporting merged PRs since a release cutoff.
+#
+# Usage:
+#   ./discover-release-scope.sh [--release-tag <tag>] [--cutoff <iso-timestamp>] [--date <YYYY-MM-DD>] [--workspace <dir>]
+#
+# Examples:
+#   ./discover-release-scope.sh --release-tag '@mastra/core@1.28.0'
+#   ./discover-release-scope.sh --cutoff 2026-04-24T08:53:08Z
+#   ./discover-release-scope.sh --date 2026-04-28 --release-tag '@mastra/core@1.28.0'
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: required dependency '$1' is not installed." >&2
+    exit 1
+  fi
+}
+
+SMOKE_DATE="$(date +%F)"
+WORKSPACE=""
+RELEASE_TAG=""
+CUTOFF=""
+LIMIT="200"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --release-tag|--tag)
+      if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "Error: $1 requires a value." >&2
+        exit 1
+      fi
+      RELEASE_TAG="$2"
+      shift 2
+      ;;
+    --cutoff)
+      if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "Error: --cutoff requires a value." >&2
+        exit 1
+      fi
+      CUTOFF="$2"
+      shift 2
+      ;;
+    --date)
+      if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "Error: --date requires a value." >&2
+        exit 1
+      fi
+      SMOKE_DATE="$2"
+      shift 2
+      ;;
+    --workspace)
+      if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "Error: --workspace requires a value." >&2
+        exit 1
+      fi
+      WORKSPACE="$2"
+      shift 2
+      ;;
+    --limit)
+      if [ $# -lt 2 ] || ! [[ "${2:-}" =~ ^[1-9][0-9]*$ ]]; then
+        echo "Error: --limit requires a positive integer." >&2
+        exit 1
+      fi
+      LIMIT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd gh
+require_cmd git
+require_cmd jq
+
+if [ -z "$WORKSPACE" ]; then
+  WORKSPACE="$HOME/mastra-smoke-tests/$SMOKE_DATE"
+fi
+
+mkdir -p "$WORKSPACE/logs"
+
+if [ -f "$WORKSPACE/merged-prs.tsv" ]; then
+  cp "$WORKSPACE/merged-prs.tsv" "$WORKSPACE/merged-prs.previous.tsv"
+fi
+
+if [ -z "$RELEASE_TAG" ]; then
+  RELEASE_TAG=$(gh release list \
+    --limit 50 \
+    --json tagName,isPrerelease,isDraft \
+    --jq '.[] | select(.isDraft == false and .isPrerelease == false and (.tagName | startswith("@mastra/core@"))) | .tagName' \
+    | head -n 1)
+fi
+
+if [ -z "$RELEASE_TAG" ] && [ -z "$CUTOFF" ]; then
+  echo "Error: could not infer a release tag. Pass --release-tag or --cutoff." >&2
+  exit 1
+fi
+
+if [ -z "$CUTOFF" ]; then
+  CUTOFF=$(gh release view "$RELEASE_TAG" --json createdAt --jq '.createdAt')
+fi
+
+if [ -z "$CUTOFF" ]; then
+  echo "Error: could not determine cutoff. Pass --cutoff." >&2
+  exit 1
+fi
+
+echo "Smoke workspace: $WORKSPACE"
+echo "Release tag:     ${RELEASE_TAG:-'(none; cutoff supplied)'}"
+echo "Cutoff:          $CUTOFF"
+echo "Limit:           $LIMIT"
+echo ""
+
+if [ -n "$RELEASE_TAG" ]; then
+  gh release view "$RELEASE_TAG" \
+    --json tagName,name,createdAt,publishedAt,targetCommitish,url \
+    --jq . \
+    > "$WORKSPACE/release.json"
+
+  git show -s --format='%H%n%ci%n%D%n%s' "$RELEASE_TAG" > "$WORKSPACE/release-git.txt" || true
+fi
+
+gh pr list \
+  --state merged \
+  --limit "$LIMIT" \
+  --search "merged:>=$CUTOFF -author:app/dependabot" \
+  --json number,title,author,mergedAt,labels \
+  --jq '. | sort_by(.mergedAt) | .[] | [.mergedAt, ("#"+(.number|tostring)), .author.login, .title, (([.labels[].name] | join(",")))] | @tsv' \
+  > "$WORKSPACE/merged-prs.tsv"
+
+PR_COUNT=$(wc -l < "$WORKSPACE/merged-prs.tsv" | tr -d ' ')
+
+cat > "$WORKSPACE/smoke-scope.md" <<EOF
+# Release Smoke Scope
+
+- Workspace: \`$WORKSPACE\`
+- Release tag: \`${RELEASE_TAG:-none; cutoff supplied}\`
+- Cutoff: \`$CUTOFF\`
+- Merged PR export: \`merged-prs.tsv\`
+- Non-Dependabot PR count: $PR_COUNT
+
+## Categorization
+
+Group every PR in \`merged-prs.tsv\` using the buckets from \`.claude/skills/mastra-smoke-test/SKILL.md\`, then add the targeted checks here before running smoke tests.
+
+## Targeted checks
+
+- [ ] Always: setup, agents, tools, workflows, traces, scorers, memory, MCP, errors
+- [ ] CLI/create-mastra changes: fresh project at \`$WORKSPACE/smoke-project\`
+- [ ] Server/API changes: curl checks for health, agents, tools, workflows, custom/invalid routes
+- [ ] Studio/Playground changes: browser smoke affected pages
+- [ ] Auth/permissions/Agent Builder changes: authenticated cloud smoke
+- [ ] Storage/provider changes: package install/import or provider-specific smoke
+- [ ] Mastra Code changes: separate Mastra Code/TUI smoke path
+EOF
+
+echo "Wrote:"
+echo "  $WORKSPACE/merged-prs.tsv ($PR_COUNT PRs)"
+echo "  $WORKSPACE/smoke-scope.md"
+if [ -f "$WORKSPACE/merged-prs.previous.tsv" ]; then
+  PREVIOUS_COUNT=$(wc -l < "$WORKSPACE/merged-prs.previous.tsv" | tr -d ' ')
+  echo "  $WORKSPACE/merged-prs.previous.tsv ($PREVIOUS_COUNT PRs)"
+fi
+
+if [ "$PR_COUNT" -ge "$LIMIT" ]; then
+  echo "" >&2
+  echo "Warning: PR count reached --limit ($LIMIT). Page or narrow by date range; do not silently truncate scope." >&2
+fi


### PR DESCRIPTION
## Summary
- add alpha release readiness guidance for finding, reviewing, opening, and monitoring versioning PRs and prerelease runs
- add stable release smoke guidance for npm/tag verification, partial publish recovery, and fresh stable project validation
- add release-scope discovery and targeted feature smoke guidance so agents test the actual changed behavior, including storage/provider migration patterns

## Test plan
- reviewed the rendered markdown structure/headings
- ran `git diff --check -- .claude/skills/mastra-smoke-test/SKILL.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5

This PR adds clear step-by-step release smoke-test instructions so testers can find/version-check releases and run focused smoke tests, plus helper scripts to automate scope discovery and version-PR spot-checking. It makes it easier and safer to verify alpha and stable releases and to test just the features that changed.

---

## Summary

Converts release-testing notes into a structured, end-to-end release smoke-testing guide and adds CLI helpers to automate release-scope discovery and version-PR spot-checking. Provides repeatable procedures for alpha prereleases, stable releases (including partial-publish recovery), release-scope discovery, targeted feature and migration smoke checks, and an expanded Local Studio browser smoke procedure.

### Alpha release readiness
- Locate and review the Changesets/versioning PR (prefer branch `changeset-release/main`, fallback to open/merged PR search).
- Use the new CLI spot-check script to inspect the versioning PR diff and flag risky transitions (major bumps, non-alpha new versions, stable→alpha transitions, and changed files outside expected release paths).
- Verify the automatic alpha publish workflow ran and that alpha packages are installable before creating the alpha smoke project (see `references/alpha-publish.md`).

### Stable release smoke
- Confirm the stable/full release GitHub Actions path completed; stop/report immediately on failures and use partial-publish recovery when applicable.
- Verify `npm view ...@latest version` for `@mastra/core`, `mastra`, and `create-mastra` with propagation-aware retries and confirm expected git release tags.
- If partial publish occurred, follow the recovery flow: rerun the stable publish from the release commit, confirm all packages are on npm `latest`, and ensure tags exist before final stable smoke.
- Create an isolated fresh stable smoke project and run the full checklist (including Local Studio browser smoke); append stable results and tested package versions to the dated `smoke-report.md`.

### Release-scope discovery
- Use the release-scope script to create a dated workspace and export merged PRs since a cutoff (inferred from a stable release tag or provided timestamp), excluding Dependabot by default.
- Produce `merged-prs.tsv`, optional release metadata exports, and `smoke-scope.md` that buckets PRs by impacted runtime surface and translates buckets into targeted checks plus a Coverage vs Changes matrix.
- Record omitted PRs/commits with explicit reasons.

### Targeted feature and migration testing patterns
- Guidance for building targeted smoke tests that exercise the exact changed runtime path, assert before/after conditions, and capture concrete evidence (responses, persisted state, traces, screenshots).
- Storage/provider migration pattern: run a local backend (Postgres example), install the released provider package into a smoke project, recreate pre-fix state, restart to trigger migrations, and verify schema and end-to-end read/write behavior with recorded verification queries and evidence.

### Local Studio browser smoke
- Require both API/dev-server readiness checks (curl) and a Studio UI browser pass unless `--skip-browser` is explicitly requested.
- Dev-server readiness/restart loop and a route-by-route checklist (Studio shell, Agents, Tools, Workflows, Traces/Observability, Scorers, MCP) with evidence capture instructions and a templated browser-results section appended to `smoke-report.md`.

### Files and helper scripts added/changed
- .claude/skills/mastra-smoke-test/SKILL.md — central release smoke workflows, mandatory checklist, Local Studio browser smoke procedure, usage/parameters.
- .claude/skills/mastra-smoke-test/references/release-smoke.md — release smoke index routing (alpha, stable, targeted).
- New reference docs: alpha-versioning-pr.md, alpha-publish.md, release-scope-discovery.md, stable-release-smoke.md, stable-partial-publish-recovery.md, targeted-feature-smoke.md, storage-provider-migration-smoke.md.
- .claude/skills/mastra-smoke-test/scripts/check-versioning-pr.sh — executable Bash CLI to generate changed-files/diff/TSV summaries and flag versioning warnings for a PR.
- .claude/skills/mastra-smoke-test/scripts/discover-release-scope.sh — executable Bash CLI to export merged PRs since a cutoff/release tag, capture release metadata, and generate `smoke-scope.md`.
- .claude/skills/mastra-smoke-test/scripts/test-server.sh — executable helper to health-check and exercise a deployed Mastra server/agent endpoint.
- Additional test/reference docs under `.claude/skills/mastra-smoke-test/references/tests/` updated/organized for checklist usage.

Other notes
- Documentation-only changes plus three new executable helper scripts; no public API or exported entity changes.
- Lines added across docs and scripts; estimated review effort: docs low–medium, scripts medium.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->