### PR TITLE
feat(tools): add Perplexity Search tool + provider docs

### DIFF
--- a/.changeset/three-hornets-wait.md
+++ b/.changeset/three-hornets-wait.md
@@ -1,0 +1,5 @@
+---
+'@mastra/perplexity': minor
+---
+
+Added new @mastra/perplexity integration with the Perplexity Search tool for agents.

--- a/.changeset/three-hornets-wait.md
+++ b/.changeset/three-hornets-wait.md
@@ -2,4 +2,10 @@
 '@mastra/perplexity': minor
 ---
 
-Added new @mastra/perplexity integration with the Perplexity Search tool for agents.
+Added new `@mastra/perplexity` integration with the Perplexity Search tool for agents.
+
+```ts
+import { createPerplexityTools } from '@mastra/perplexity';
+
+const { perplexitySearch } = createPerplexityTools({ apiKey: process.env.PERPLEXITY_API_KEY });
+```

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -495,6 +495,7 @@ const sidebars = {
         { type: 'doc', id: 'tools/vector-query-tool', label: 'createVectorQueryTool()' },
         { type: 'doc', id: 'tools/mcp-client', label: 'MCPClient' },
         { type: 'doc', id: 'tools/mcp-server', label: 'MCPServer' },
+        { type: 'doc', id: 'tools/perplexity', label: 'Perplexity Tools' },
         { type: 'doc', id: 'tools/tavily', label: 'Tavily Tools' },
       ],
     },

--- a/docs/src/content/en/reference/tools/perplexity.mdx
+++ b/docs/src/content/en/reference/tools/perplexity.mdx
@@ -8,29 +8,37 @@ packages:
 
 # Perplexity tools
 
-**Added in:** `@mastra/perplexity@0.1.0-alpha.0`
+Added in: `@mastra/perplexity@0.1.0-alpha.0`
 
 The `@mastra/perplexity` package wraps the [Perplexity Search API](https://docs.perplexity.ai/docs/search/quickstart) as a Mastra-compatible tool. It exposes a factory function that returns a tool created with [`createTool()`](./create-tool) and full Zod input/output schemas.
 
-For chat completions or agentic workflows powered by Perplexity, use Mastra's built-in [Perplexity model provider](/models/providers/perplexity) or [Perplexity Agent provider](/models/providers/perplexity-agent) — those are separate from this Search tool.
+For chat completions or agentic workflows powered by Perplexity, use Mastra's built-in [Perplexity model provider](/models/providers/perplexity) or [Perplexity Agent provider](/models/providers/perplexity-agent). Those are separate from this Search tool.
 
 ## Installation
+
+Install the package alongside Zod:
 
 ```sh npm2yarn
 npm install @mastra/perplexity zod
 ```
 
-## Quick start
+## Usage example
+
+The following example creates the search tool with the default configuration. By default, the tool reads `PERPLEXITY_API_KEY` (with `PPLX_API_KEY` as a fallback) from the environment. Pass `{ apiKey }` explicitly to override.
 
 ```typescript title="src/mastra/tools/index.ts"
 import { createPerplexitySearchTool } from '@mastra/perplexity'
 
 const searchTool = createPerplexitySearchTool()
-// Or pass an explicit API key:
-// const searchTool = createPerplexitySearchTool({ apiKey: 'pplx-...' })
 ```
 
-By default, the tool reads `PERPLEXITY_API_KEY` (with `PPLX_API_KEY` as a fallback) from the environment. Pass `{ apiKey }` explicitly to override.
+To pass an API key explicitly:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createPerplexitySearchTool } from '@mastra/perplexity'
+
+const searchTool = createPerplexitySearchTool({ apiKey: 'pplx-...' })
+```
 
 ## Configuration
 
@@ -61,9 +69,13 @@ All factory functions accept a `PerplexityClientOptions` object:
 ]}
 />
 
-## `createPerplexityTools()`
+## Methods
 
-Returns an object containing all Perplexity tools with a shared configuration.
+### Factory functions
+
+#### `createPerplexityTools(config?)`
+
+Returns an object containing all Perplexity tools that share the supplied configuration.
 
 ```typescript
 import { createPerplexityTools } from '@mastra/perplexity'
@@ -72,13 +84,13 @@ const tools = createPerplexityTools({ apiKey: 'pplx-...' })
 // tools.perplexitySearch
 ```
 
-**Returns:** `{ perplexitySearch }`
+Returns: `{ perplexitySearch }`
 
-## `createPerplexitySearchTool()`
+#### `createPerplexitySearchTool(config?)`
 
 Creates a tool that searches the web using the Perplexity Search API. Returns ranked results with titles, URLs, snippets, and optional publication dates.
 
-**Tool ID:** `perplexity-search`
+The tool is registered with the ID `perplexity-search`.
 
 ```typescript
 import { createPerplexitySearchTool } from '@mastra/perplexity'
@@ -86,7 +98,7 @@ import { createPerplexitySearchTool } from '@mastra/perplexity'
 const searchTool = createPerplexitySearchTool()
 ```
 
-### Input
+##### Input
 
 <PropertiesTable
   content={[
@@ -105,7 +117,7 @@ const searchTool = createPerplexitySearchTool()
     name: 'searchDomainFilter',
     type: 'string[]',
     description:
-      'Restrict (or exclude) results by domain. Prefix a domain with `-` to exclude it (e.g. `-pinterest.com`). Do not mix allow- and deny-list entries in the same call.',
+      'Restrict (or exclude) results by domain. Prefix a domain with `-` to exclude it (for example, `-pinterest.com`). Do not mix allow- and deny-list entries in the same call.',
     isOptional: true,
   },
   {
@@ -129,7 +141,7 @@ const searchTool = createPerplexitySearchTool()
 ]}
 />
 
-### Output
+##### Output
 
 <PropertiesTable
   content={[
@@ -158,6 +170,8 @@ const searchTool = createPerplexitySearchTool()
 />
 
 ## Agent example
+
+The following example registers the search tool on an agent so it can fetch fresh web results before answering.
 
 ```typescript title="src/mastra/agents/index.ts"
 import { Agent } from '@mastra/core/agent'

--- a/docs/src/content/en/reference/tools/perplexity.mdx
+++ b/docs/src/content/en/reference/tools/perplexity.mdx
@@ -1,0 +1,191 @@
+---
+title: "Reference: Perplexity tools | Tools & MCP"
+description: "API reference for @mastra/perplexity, which provides a Perplexity Search tool for Mastra agents."
+packages:
+  - "@mastra/perplexity"
+  - "@mastra/core"
+---
+
+# Perplexity tools
+
+**Added in:** `@mastra/perplexity@0.1.0-alpha.0`
+
+The `@mastra/perplexity` package wraps the [Perplexity Search API](https://docs.perplexity.ai/docs/search/quickstart) as a Mastra-compatible tool. It exposes a factory function that returns a tool created with [`createTool()`](./create-tool) and full Zod input/output schemas.
+
+For chat completions or agentic workflows powered by Perplexity, use Mastra's built-in [Perplexity model provider](/models/providers/perplexity) or [Perplexity Agent provider](/models/providers/perplexity-agent) — those are separate from this Search tool.
+
+## Installation
+
+```sh npm2yarn
+npm install @mastra/perplexity zod
+```
+
+## Quick start
+
+```typescript title="src/mastra/tools/index.ts"
+import { createPerplexitySearchTool } from '@mastra/perplexity'
+
+const searchTool = createPerplexitySearchTool()
+// Or pass an explicit API key:
+// const searchTool = createPerplexitySearchTool({ apiKey: 'pplx-...' })
+```
+
+By default, the tool reads `PERPLEXITY_API_KEY` (with `PPLX_API_KEY` as a fallback) from the environment. Pass `{ apiKey }` explicitly to override.
+
+## Configuration
+
+All factory functions accept a `PerplexityClientOptions` object:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'apiKey',
+    type: 'string',
+    description:
+      'Perplexity API key. Falls back to the `PERPLEXITY_API_KEY` then `PPLX_API_KEY` environment variables.',
+    isOptional: true,
+  },
+  {
+    name: 'baseUrl',
+    type: 'string',
+    description: 'Override the API base URL.',
+    isOptional: true,
+    defaultValue: "'https://api.perplexity.ai'",
+  },
+  {
+    name: 'fetch',
+    type: 'typeof fetch',
+    description: 'Custom `fetch` implementation. Useful for tests, retries, or instrumentation.',
+    isOptional: true,
+  },
+]}
+/>
+
+## `createPerplexityTools()`
+
+Returns an object containing all Perplexity tools with a shared configuration.
+
+```typescript
+import { createPerplexityTools } from '@mastra/perplexity'
+
+const tools = createPerplexityTools({ apiKey: 'pplx-...' })
+// tools.perplexitySearch
+```
+
+**Returns:** `{ perplexitySearch }`
+
+## `createPerplexitySearchTool()`
+
+Creates a tool that searches the web using the Perplexity Search API. Returns ranked results with titles, URLs, snippets, and optional publication dates.
+
+**Tool ID:** `perplexity-search`
+
+```typescript
+import { createPerplexitySearchTool } from '@mastra/perplexity'
+
+const searchTool = createPerplexitySearchTool()
+```
+
+### Input
+
+<PropertiesTable
+  content={[
+  {
+    name: 'query',
+    type: 'string',
+    description: 'The search query.',
+  },
+  {
+    name: 'maxResults',
+    type: 'number',
+    description: 'Maximum number of results to return (1-20).',
+    isOptional: true,
+  },
+  {
+    name: 'searchDomainFilter',
+    type: 'string[]',
+    description:
+      'Restrict (or exclude) results by domain. Prefix a domain with `-` to exclude it (e.g. `-pinterest.com`). Do not mix allow- and deny-list entries in the same call.',
+    isOptional: true,
+  },
+  {
+    name: 'searchRecencyFilter',
+    type: "'hour' | 'day' | 'week' | 'month' | 'year'",
+    description: 'Only return results from within the given recency window.',
+    isOptional: true,
+  },
+  {
+    name: 'searchAfterDateFilter',
+    type: 'string',
+    description: 'Only return results published on or after this date. Format: m/d/yyyy.',
+    isOptional: true,
+  },
+  {
+    name: 'searchBeforeDateFilter',
+    type: 'string',
+    description: 'Only return results published on or before this date. Format: m/d/yyyy.',
+    isOptional: true,
+  },
+]}
+/>
+
+### Output
+
+<PropertiesTable
+  content={[
+  {
+    name: 'query',
+    type: 'string',
+    description: 'The original search query.',
+  },
+  {
+    name: 'results',
+    type: 'SearchResult[]',
+    description: 'Array of search results.',
+    properties: [
+      {
+        type: 'SearchResult',
+        parameters: [
+          { name: 'title', type: 'string', description: 'Result title.' },
+          { name: 'url', type: 'string', description: 'Result URL.' },
+          { name: 'snippet', type: 'string', description: 'Content snippet.' },
+          { name: 'date', type: 'string', description: 'Publication date when available.', isOptional: true },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+## Agent example
+
+```typescript title="src/mastra/agents/index.ts"
+import { Agent } from '@mastra/core/agent'
+import { createPerplexitySearchTool } from '@mastra/perplexity'
+
+const agent = new Agent({
+  id: 'research-agent',
+  name: 'Research Agent',
+  model: 'anthropic/claude-sonnet-4-6',
+  instructions:
+    'You are a research assistant. Use the perplexity-search tool to find up-to-date information from the web before answering.',
+  tools: {
+    search: createPerplexitySearchTool(),
+  },
+})
+```
+
+## Environment variables
+
+| Variable | Description |
+| - | - |
+| `PERPLEXITY_API_KEY` | Your Perplexity API key. Used as the default when `apiKey` is not passed to a factory function. |
+| `PPLX_API_KEY` | Fallback used when `PERPLEXITY_API_KEY` is unset. |
+
+## Related
+
+- [`createTool()`](./create-tool)
+- [Perplexity Search quickstart](https://docs.perplexity.ai/docs/search/quickstart)
+- [Perplexity Agent quickstart](https://docs.perplexity.ai/docs/agent/quickstart)
+- [Perplexity model provider](/models/providers/perplexity)
+- [Perplexity Agent provider](/models/providers/perplexity-agent)

--- a/integrations/perplexity/CHANGELOG.md
+++ b/integrations/perplexity/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @mastra/perplexity
+
+## 0.1.0-alpha.0
+
+### Minor Changes
+
+- Initial release. Adds `createPerplexitySearchTool` and `createPerplexityTools` for the [Perplexity Search API](https://docs.perplexity.ai/docs/search/quickstart).

--- a/integrations/perplexity/README.md
+++ b/integrations/perplexity/README.md
@@ -1,0 +1,79 @@
+# @mastra/perplexity
+
+Web search tool for [Mastra](https://mastra.ai) agents, backed by the [Perplexity Search API](https://docs.perplexity.ai/docs/search/quickstart).
+
+## Installation
+
+```bash
+npm install @mastra/perplexity zod
+```
+
+## Quick Start
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { createPerplexitySearchTool } from '@mastra/perplexity';
+
+const agent = new Agent({
+  id: 'research-agent',
+  name: 'Research Agent',
+  model: 'anthropic/claude-sonnet-4-6',
+  instructions:
+    'You are a research assistant. Use the perplexity-search tool to find up-to-date information from the web before answering.',
+  tools: {
+    search: createPerplexitySearchTool(),
+  },
+});
+```
+
+The tool reads `PERPLEXITY_API_KEY` (or `PPLX_API_KEY` as a fallback) from the environment. Pass `{ apiKey }` explicitly to override.
+
+## Filtering
+
+The Search API supports filtering by domain and date. All filters are optional.
+
+```typescript
+const tool = createPerplexitySearchTool();
+
+await tool.execute!({
+  query: 'recent papers on agent evaluation',
+  maxResults: 10,
+  searchRecencyFilter: 'month',
+  searchDomainFilter: ['arxiv.org', 'openreview.net'],
+}, {} as any);
+```
+
+To exclude domains, prefix them with `-`. Don't mix allow- and deny-list entries in the same call.
+
+```typescript
+searchDomainFilter: ['-pinterest.com', '-quora.com'];
+```
+
+## Using Perplexity as a Model Provider
+
+Perplexity is also a first-class model provider in Mastra's model router. To chat with Perplexity models (separate from this search tool), set `PERPLEXITY_API_KEY` and reference the model directly:
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+
+const agent = new Agent({
+  id: 'agent-api',
+  name: 'Perplexity Agent',
+  model: 'perplexity-agent/openai/gpt-5',
+  instructions: 'You are a research assistant powered by the Perplexity Agent API.',
+});
+```
+
+See the [Perplexity provider docs](https://mastra.ai/models/providers/perplexity) and [Perplexity Agent provider docs](https://mastra.ai/models/providers/perplexity-agent).
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `apiKey` | `string` | `PERPLEXITY_API_KEY` → `PPLX_API_KEY` | Perplexity API key. |
+| `baseUrl` | `string` | `https://api.perplexity.ai` | Override the API base URL (useful for proxies and tests). |
+| `fetch` | `typeof fetch` | global `fetch` | Inject a custom `fetch` implementation. |
+
+## License
+
+Apache-2.0

--- a/integrations/perplexity/eslint.config.js
+++ b/integrations/perplexity/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/integrations/perplexity/package.json
+++ b/integrations/perplexity/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@mastra/perplexity",
+  "version": "0.1.0-alpha.0",
+  "description": "Perplexity Search tool for Mastra agents",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "mastra",
+    "perplexity",
+    "web-search",
+    "tools",
+    "ai-agent"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "integrations/perplexity"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "homepage": "https://mastra.ai",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "zod": ">=3.0.0 || >=4.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/integrations/perplexity/src/__tests__/client.test.ts
+++ b/integrations/perplexity/src/__tests__/client.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { perplexitySearchRequest } from '../client.js';
+
+describe('perplexitySearchRequest', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.PERPLEXITY_API_KEY;
+    delete process.env.PPLX_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it('throws when no API key is configured', async () => {
+    await expect(perplexitySearchRequest({ query: 'hello' })).rejects.toThrow(/API key is required/);
+  });
+
+  it('falls back to PPLX_API_KEY when PERPLEXITY_API_KEY is missing', async () => {
+    process.env.PPLX_API_KEY = 'env-key';
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ id: 'r-1', results: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await perplexitySearchRequest({ query: 'hello' }, { fetch: fetchMock });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: 'Bearer env-key' });
+  });
+
+  it('explicit apiKey overrides environment variables', async () => {
+    process.env.PERPLEXITY_API_KEY = 'env-key';
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ results: [] }), { status: 200 }),
+    );
+
+    await perplexitySearchRequest({ query: 'q' }, { apiKey: 'explicit-key', fetch: fetchMock });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: 'Bearer explicit-key' });
+  });
+
+  it('posts to /search at the configured base URL with the request body', async () => {
+    process.env.PERPLEXITY_API_KEY = 'k';
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ results: [] }), { status: 200 }),
+    );
+
+    await perplexitySearchRequest(
+      {
+        query: 'mastra agent framework',
+        max_results: 7,
+        search_recency_filter: 'week',
+        search_domain_filter: ['mastra.ai', '-pinterest.com'],
+      },
+      { apiKey: 'k', fetch: fetchMock, baseUrl: 'https://example.test/' },
+    );
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.test/search');
+    expect((init as RequestInit).method).toBe('POST');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      query: 'mastra agent framework',
+      max_results: 7,
+      search_recency_filter: 'week',
+      search_domain_filter: ['mastra.ai', '-pinterest.com'],
+    });
+  });
+
+  it('throws a descriptive error on non-2xx responses', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response('rate limited', { status: 429 }),
+    );
+
+    await expect(
+      perplexitySearchRequest({ query: 'q' }, { apiKey: 'k', fetch: fetchMock }),
+    ).rejects.toThrow(/429.*rate limited/);
+  });
+
+  it('normalizes a missing results field to an empty array', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ id: 'r' }), { status: 200 }),
+    );
+
+    const out = await perplexitySearchRequest(
+      { query: 'q' },
+      { apiKey: 'k', fetch: fetchMock },
+    );
+
+    expect(out).toEqual({ id: 'r', results: [] });
+  });
+});

--- a/integrations/perplexity/src/__tests__/search.test.ts
+++ b/integrations/perplexity/src/__tests__/search.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createPerplexitySearchTool } from '../search.js';
+import { createPerplexityTools } from '../tools.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  delete process.env.PERPLEXITY_API_KEY;
+  delete process.env.PPLX_API_KEY;
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('createPerplexitySearchTool', () => {
+  it('exposes the expected tool id, description, and schemas', () => {
+    const tool = createPerplexitySearchTool({ apiKey: 'k' });
+
+    expect(tool.id).toBe('perplexity-search');
+    expect(tool.description).toContain('Perplexity Search API');
+    expect(tool.description).not.toMatch(/sonar/i);
+    expect(tool.inputSchema).toBeDefined();
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  it('passes input through to the API in snake_case form', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        id: 'r-1',
+        results: [
+          { title: 'A', url: 'https://a.test', snippet: 'snip', date: '2026-01-01' },
+        ],
+      }),
+    );
+
+    const tool = createPerplexitySearchTool({ apiKey: 'k', fetch: fetchMock });
+
+    const out = await tool.execute!(
+      {
+        query: 'agent frameworks',
+        maxResults: 5,
+        searchDomainFilter: ['mastra.ai'],
+        searchRecencyFilter: 'month',
+        searchAfterDateFilter: '1/1/2025',
+      },
+      {} as any,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      query: 'agent frameworks',
+      max_results: 5,
+      search_domain_filter: ['mastra.ai'],
+      search_recency_filter: 'month',
+      search_after_date_filter: '1/1/2025',
+    });
+
+    expect(out).toEqual({
+      query: 'agent frameworks',
+      results: [{ title: 'A', url: 'https://a.test', snippet: 'snip', date: '2026-01-01' }],
+    });
+  });
+
+  it('omits unset filter fields from the request body', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ results: [] }));
+    const tool = createPerplexitySearchTool({ apiKey: 'k', fetch: fetchMock });
+
+    await tool.execute!({ query: 'q' }, {} as any);
+
+    const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body).toEqual({ query: 'q' });
+  });
+
+  it('returns an empty results array when the API returns none', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ results: [] }));
+    const tool = createPerplexitySearchTool({ apiKey: 'k', fetch: fetchMock });
+
+    const out = (await tool.execute!({ query: 'q' }, {} as any)) as { results: unknown[] };
+    expect(out.results).toEqual([]);
+  });
+
+  it('lets API errors propagate to the caller', async () => {
+    const fetchMock = vi.fn(async () => new Response('forbidden', { status: 403 }));
+    const tool = createPerplexitySearchTool({ apiKey: 'k', fetch: fetchMock });
+
+    await expect(tool.execute!({ query: 'q' }, {} as any)).rejects.toThrow(/403/);
+  });
+});
+
+describe('createPerplexityTools', () => {
+  it('returns the search tool under the perplexitySearch key', () => {
+    const tools = createPerplexityTools({ apiKey: 'k' });
+    expect(Object.keys(tools)).toEqual(['perplexitySearch']);
+    expect(tools.perplexitySearch.id).toBe('perplexity-search');
+  });
+});

--- a/integrations/perplexity/src/__tests__/search.test.ts
+++ b/integrations/perplexity/src/__tests__/search.test.ts
@@ -96,6 +96,48 @@ describe('createPerplexitySearchTool', () => {
 
     await expect(tool.execute!({ query: 'q' }, {} as any)).rejects.toThrow(/403/);
   });
+
+  it('truncates long error response bodies to 1000 chars', async () => {
+    const huge = 'x'.repeat(5000);
+    const fetchMock = vi.fn(async () => new Response(huge, { status: 500 }));
+    const tool = createPerplexitySearchTool({ apiKey: 'k', fetch: fetchMock });
+
+    await expect(tool.execute!({ query: 'q' }, {} as any)).rejects.toThrow(
+      new RegExp(`status 500: x{1000}…$`),
+    );
+  });
+
+  it('rejects searchDomainFilter that mixes allow and deny entries', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ results: [] }));
+    const tool = createPerplexitySearchTool({ apiKey: 'k', fetch: fetchMock });
+
+    const parsed = tool.inputSchema!.safeParse({
+      query: 'q',
+      searchDomainFilter: ['mastra.ai', '-pinterest.com'],
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]!.message).toMatch(/cannot mix allow and deny/i);
+    }
+  });
+
+  it('accepts searchDomainFilter with only allow entries', () => {
+    const tool = createPerplexitySearchTool({ apiKey: 'k' });
+    const parsed = tool.inputSchema!.safeParse({
+      query: 'q',
+      searchDomainFilter: ['mastra.ai', 'docs.mastra.ai'],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts searchDomainFilter with only deny entries', () => {
+    const tool = createPerplexitySearchTool({ apiKey: 'k' });
+    const parsed = tool.inputSchema!.safeParse({
+      query: 'q',
+      searchDomainFilter: ['-pinterest.com', '-quora.com'],
+    });
+    expect(parsed.success).toBe(true);
+  });
 });
 
 describe('createPerplexityTools', () => {

--- a/integrations/perplexity/src/client.ts
+++ b/integrations/perplexity/src/client.ts
@@ -67,7 +67,10 @@ export async function perplexitySearchRequest(
   });
 
   if (!response.ok) {
-    const text = await response.text().catch(() => '');
+    const rawText = await response.text().catch(() => '');
+    const MAX_ERROR_BODY = 1000;
+    const text =
+      rawText.length > MAX_ERROR_BODY ? `${rawText.slice(0, MAX_ERROR_BODY)}…` : rawText;
     throw new Error(
       `Perplexity Search request failed with status ${response.status}${text ? `: ${text}` : ''}`,
     );

--- a/integrations/perplexity/src/client.ts
+++ b/integrations/perplexity/src/client.ts
@@ -1,0 +1,81 @@
+export const DEFAULT_BASE_URL = 'https://api.perplexity.ai';
+
+export type PerplexityClientOptions = {
+  /**
+   * Perplexity API key. Falls back to `PERPLEXITY_API_KEY` then `PPLX_API_KEY`
+   * environment variables when not provided.
+   */
+  apiKey?: string;
+  /**
+   * Override the API base URL. Defaults to `https://api.perplexity.ai`.
+   */
+  baseUrl?: string;
+  /**
+   * Optional `fetch` implementation. Useful for tests, retries, or instrumentation.
+   * Defaults to the global `fetch`.
+   */
+  fetch?: typeof fetch;
+};
+
+export type PerplexitySearchResultItem = {
+  title: string;
+  url: string;
+  snippet: string;
+  date?: string;
+};
+
+export type PerplexitySearchResponse = {
+  id?: string;
+  results: PerplexitySearchResultItem[];
+};
+
+export type PerplexitySearchRequest = {
+  query: string;
+  max_results?: number;
+  max_tokens_per_page?: number;
+  search_domain_filter?: string[];
+  search_recency_filter?: 'hour' | 'day' | 'week' | 'month' | 'year';
+  search_after_date_filter?: string;
+  search_before_date_filter?: string;
+};
+
+function resolveApiKey(explicit?: string): string {
+  const key = explicit ?? process.env.PERPLEXITY_API_KEY ?? process.env.PPLX_API_KEY;
+  if (!key) {
+    throw new Error(
+      'Perplexity API key is required. Pass { apiKey } or set the PERPLEXITY_API_KEY (or PPLX_API_KEY) environment variable.',
+    );
+  }
+  return key;
+}
+
+export async function perplexitySearchRequest(
+  body: PerplexitySearchRequest,
+  options?: PerplexityClientOptions,
+): Promise<PerplexitySearchResponse> {
+  const apiKey = resolveApiKey(options?.apiKey);
+  const baseUrl = options?.baseUrl ?? DEFAULT_BASE_URL;
+  const fetchImpl = options?.fetch ?? fetch;
+
+  const response = await fetchImpl(`${baseUrl.replace(/\/$/, '')}/search`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(
+      `Perplexity Search request failed with status ${response.status}${text ? `: ${text}` : ''}`,
+    );
+  }
+
+  const json = (await response.json()) as Partial<PerplexitySearchResponse>;
+  return {
+    id: json.id,
+    results: Array.isArray(json.results) ? json.results : [],
+  };
+}

--- a/integrations/perplexity/src/index.ts
+++ b/integrations/perplexity/src/index.ts
@@ -1,0 +1,10 @@
+export {
+  perplexitySearchRequest,
+  DEFAULT_BASE_URL,
+  type PerplexityClientOptions,
+  type PerplexitySearchRequest,
+  type PerplexitySearchResponse,
+  type PerplexitySearchResultItem,
+} from './client.js';
+export { createPerplexitySearchTool } from './search.js';
+export { createPerplexityTools } from './tools.js';

--- a/integrations/perplexity/src/search.ts
+++ b/integrations/perplexity/src/search.ts
@@ -16,6 +16,15 @@ const inputSchema = z.object({
   searchDomainFilter: z
     .array(z.string())
     .optional()
+    .refine(
+      domains => {
+        if (!domains || domains.length === 0) return true;
+        const hasAllow = domains.some(d => !d.startsWith('-'));
+        const hasDeny = domains.some(d => d.startsWith('-'));
+        return !(hasAllow && hasDeny);
+      },
+      { message: 'searchDomainFilter cannot mix allow and deny domain entries in the same call.' },
+    )
     .describe(
       'Restrict (or exclude) results by domain. Prefix a domain with `-` to exclude it (e.g. `-pinterest.com`). Do not mix allow and deny entries in the same call.',
     ),

--- a/integrations/perplexity/src/search.ts
+++ b/integrations/perplexity/src/search.ts
@@ -1,0 +1,88 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { perplexitySearchRequest } from './client.js';
+import type { PerplexityClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  query: z.string().describe('The search query.'),
+  maxResults: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .optional()
+    .describe('Maximum number of results to return (1-20). Defaults to the API default.'),
+  searchDomainFilter: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Restrict (or exclude) results by domain. Prefix a domain with `-` to exclude it (e.g. `-pinterest.com`). Do not mix allow and deny entries in the same call.',
+    ),
+  searchRecencyFilter: z
+    .enum(['hour', 'day', 'week', 'month', 'year'])
+    .optional()
+    .describe('Only return results from within the given recency window.'),
+  searchAfterDateFilter: z
+    .string()
+    .optional()
+    .describe('Only return results published on or after this date. Format: m/d/yyyy (e.g. 1/1/2025).'),
+  searchBeforeDateFilter: z
+    .string()
+    .optional()
+    .describe('Only return results published on or before this date. Format: m/d/yyyy (e.g. 12/31/2025).'),
+});
+
+const outputSchema = z.object({
+  query: z.string(),
+  results: z.array(
+    z.object({
+      title: z.string(),
+      url: z.string(),
+      snippet: z.string(),
+      date: z.string().optional(),
+    }),
+  ),
+});
+
+/**
+ * Creates a tool that searches the web using the Perplexity Search API.
+ *
+ * Returns ranked web results with titles, URLs, snippets, and optional
+ * publication dates. Supports filtering by domain (allow- or deny-list),
+ * recency, and explicit date ranges.
+ *
+ * @see https://docs.perplexity.ai/docs/search/quickstart
+ */
+export function createPerplexitySearchTool(config?: PerplexityClientOptions) {
+  return createTool({
+    id: 'perplexity-search',
+    description:
+      'Search the web for up-to-date information using the Perplexity Search API. Returns ranked results with titles, URLs, snippets, and optional publication dates. Supports filtering by domain, recency, and date range.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      const response = await perplexitySearchRequest(
+        {
+          query: input.query,
+          max_results: input.maxResults,
+          search_domain_filter: input.searchDomainFilter,
+          search_recency_filter: input.searchRecencyFilter,
+          search_after_date_filter: input.searchAfterDateFilter,
+          search_before_date_filter: input.searchBeforeDateFilter,
+        },
+        config,
+      );
+
+      return {
+        query: input.query,
+        results: response.results.map(r => ({
+          title: r.title,
+          url: r.url,
+          snippet: r.snippet,
+          date: r.date,
+        })),
+      };
+    },
+  });
+}

--- a/integrations/perplexity/src/tools.ts
+++ b/integrations/perplexity/src/tools.ts
@@ -1,0 +1,8 @@
+import type { PerplexityClientOptions } from './client.js';
+import { createPerplexitySearchTool } from './search.js';
+
+export function createPerplexityTools(config?: PerplexityClientOptions) {
+  return {
+    perplexitySearch: createPerplexitySearchTool(config),
+  };
+}

--- a/integrations/perplexity/tsconfig.build.json
+++ b/integrations/perplexity/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/perplexity/tsconfig.json
+++ b/integrations/perplexity/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/perplexity/tsup.config.ts
+++ b/integrations/perplexity/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/integrations/perplexity/turbo.json
+++ b/integrations/perplexity/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/integrations/perplexity/turbo.json
+++ b/integrations/perplexity/turbo.json
@@ -8,6 +8,7 @@
         "src/**",
         "tsup.config.ts",
         "tsconfig.json",
+        "tsconfig.build.json",
         "package.json",
         "!**/*.md",
         "!**/*.test.ts",

--- a/integrations/perplexity/vitest.config.ts
+++ b/integrations/perplexity/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:integrations/perplexity',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1502,6 +1502,30 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  integrations/perplexity:
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+
   integrations/tavily:
     dependencies:
       '@tavily/core':
@@ -25340,6 +25364,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -25348,10 +25373,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuidv7@0.6.3:


### PR DESCRIPTION
## Summary

Adds **`@mastra/perplexity`**, a new integration package providing a Mastra tool for the [Perplexity Search API](https://docs.perplexity.ai/docs/search/quickstart). 

Mastra already supports Perplexity as a model provider via the auto-generated `perplexity` and `perplexity-agent` entries in the model router (see [Perplexity Agent quickstart](https://docs.perplexity.ai/docs/agent/quickstart)) — this PR adds the missing **search tool** so agents can ground their answers in fresh web results.

## What's added

- **`integrations/perplexity/`** — new workspace package `@mastra/perplexity`
  - `createPerplexitySearchTool(config?)` — `createTool({ id: 'perplexity-search', ... })` calling `POST https://api.perplexity.ai/search`
  - `createPerplexityTools(config?)` — convenience aggregator (`{ perplexitySearch }`)
  - Inputs (Zod): `query`, `maxResults`, `searchDomainFilter`, `searchRecencyFilter`, `searchAfterDateFilter`, `searchBeforeDateFilter`
  - Output: `{ query, results: [{ title, url, snippet, date? }] }`
  - API key resolution: `apiKey` arg → `PERPLEXITY_API_KEY` → `PPLX_API_KEY` → throw
  - Injectable `fetch` for tests / instrumentation
- **`docs/src/content/en/reference/tools/perplexity.mdx`** — reference docs mirroring `tavily.mdx`
- **`docs/src/content/en/reference/sidebars.js`** — registers the page in the Tools section
- **Changeset** for `@mastra/perplexity` (minor)

## Tests

12 unit tests (vitest, mocked fetch) across 2 files:

- `src/__tests__/client.test.ts` (6) — env-var resolution, override precedence, request shape, error propagation, response normalization
- `src/__tests__/search.test.ts` (6) — tool surface, snake_case mapping, optional filters, empty results, error propagation, `createPerplexityTools` shape

```
$ pnpm --filter @mastra/perplexity test
 Test Files  2 passed (2)
      Tests  12 passed (12)
```

`pnpm --filter @mastra/perplexity lint` and `pnpm --filter @mastra/perplexity build:lib` also pass cleanly.

## Notes

- Tool description deliberately avoids referencing model names — the Search API is the product surface here.
- Domain filtering follows the API rules: prefix with `-` to exclude; do not mix allow + deny in the same call.
- See [Perplexity Search quickstart](https://docs.perplexity.ai/docs/search/quickstart) and [Perplexity Agent quickstart](https://docs.perplexity.ai/docs/agent/quickstart) for the underlying APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR gives AI agents a built-in "search the web" button by adding a Perplexity Search tool so agents can fetch fresh web results to support answers.

## Overview

Adds a new workspace package, @mastra/perplexity, that wraps the Perplexity Search API (POST https://api.perplexity.ai/search) as a Mastra tool. The package mirrors @mastra/tavily patterns and enables agents to ground responses in web search results.

## Core Implementation

- New package: integrations/perplexity/
  - src/client.ts
    - Exports DEFAULT_BASE_URL, request/response types, and perplexitySearchRequest(body, options)
    - API key resolution: explicit apiKey → PERPLEXITY_API_KEY → PPLX_API_KEY → throw if missing
    - Configurable baseUrl and injectable fetch
    - Sends POST /search with JSON snake_case body and Authorization header
    - On non-2xx responses reads response text (best-effort), truncates it (max 1000 chars) and throws an error including status + truncated text; normalizes results to an array
  - src/search.ts
    - createPerplexitySearchTool(config?)
      - Tool id: 'perplexity-search'
      - inputSchema (Zod): required query; optional maxResults (1–20), searchDomainFilter (array; validated to disallow mixing allow and deny entries with deny prefixed by '-'), searchRecencyFilter (hour/day/week/month/year), searchAfterDateFilter, searchBeforeDateFilter
      - outputSchema: { query, results: [{ title, url, snippet, date? }] }
      - execute maps camelCase → snake_case and returns normalized { query, results }
  - src/tools.ts
    - createPerplexityTools(config?) → { perplexitySearch }
  - src/index.ts
    - Barrel exports: client function/consts/types and tool factories

## Documentation

- docs/src/content/en/reference/tools/perplexity.mdx — reference docs modeled after tavily.mdx: installation, API key precedence (PERPLEXITY_API_KEY → PPLX_API_KEY → explicit apiKey), factory signatures, input/output schemas, examples and usage notes.
- docs/src/content/en/reference/sidebars.js — registers the Perplexity Tools page in the Tools sidebar.
- integrations/perplexity/README.md and integrations/perplexity/CHANGELOG.md added.
- Changeset (.changeset/three-hornets-wait.md) marks a minor release and includes a small usage snippet.

## Tests

- Two Vitest suites (mocked fetch):
  - src/__tests__/client.test.ts: API key precedence, request shape, error handling, response normalization.
  - src/__tests__/search.test.ts: tool metadata, schemas, camelCase→snake_case mapping, filter inclusion/omission, output mapping, validation of domain filter (reject mixed allow/deny), truncation of long error response bodies.
- Tests pass locally; pnpm --filter @mastra/perplexity lint and build:lib pass.

## Build & Config

- New integrations/perplexity/package.json with ESM/CJS exports, scripts (tsup, vitest, eslint), peerDependencies on @mastra/core and zod.
- tsup.config.ts, tsconfig.json, tsconfig.build.json, vitest.config.ts, eslint.config.js, turbo.json added/updated to support building and testing the package.

## Notes / Review Points

- Domain filtering follows Perplexity API rules (use '-' prefix to deny; do not mix allow + deny).
- Error messages include HTTP status and a best-effort truncated response body (max 1000 chars).
- The client allows injecting fetch for tests/instrumentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->