### PR TITLE
feat(agent-builder): admin-controlled Library visibility allowlist

### DIFF
--- a/.changeset/library-visible-agents.md
+++ b/.changeset/library-visible-agents.md
@@ -1,7 +1,0 @@
----
-'@mastra/core': patch
-'@mastra/server': patch
-'@mastra/client-js': patch
----
-
-Agent Builder Library now lists code-defined agents and exposes a `configuration.library.visibleAgents` allowlist for admins. Omit the field to show all code-defined agents; pass an array of agent IDs to restrict visibility.

--- a/.changeset/library-visible-agents.md
+++ b/.changeset/library-visible-agents.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+'@mastra/server': patch
+'@mastra/client-js': patch
+---
+
+Agent Builder Library now lists code-defined agents and exposes a `configuration.library.visibleAgents` allowlist for admins. Omit the field to show all code-defined agents; pass an array of agent IDs to restrict visibility.

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -9,7 +9,12 @@ import type {
   AgentInstructions,
 } from '@mastra/core/agent';
 import type { MessageListInput } from '@mastra/core/agent/message-list';
-import type { BuilderModelPolicy, DefaultModelEntry, ProviderModelEntry } from '@mastra/core/agent-builder/ee';
+import type {
+  BuilderLibraryConfig,
+  BuilderModelPolicy,
+  DefaultModelEntry,
+  ProviderModelEntry,
+} from '@mastra/core/agent-builder/ee';
 import type { MastraScorerEntry, ScoreRowData } from '@mastra/core/evals';
 import type { CoreMessage, Provider as ModelProviderId } from '@mastra/core/llm';
 import type { BaseLogMessage, LogLevel } from '@mastra/core/logger';
@@ -2818,7 +2823,7 @@ export interface BuilderAgentFeatures {
  * Re-exported from `@mastra/core/agent-builder/ee` so SDK consumers don't need
  * a second import for admin model configuration types. Owned by core.
  */
-export type { BuilderModelPolicy, DefaultModelEntry, ProviderModelEntry, ModelProviderId };
+export type { BuilderLibraryConfig, BuilderModelPolicy, DefaultModelEntry, ProviderModelEntry, ModelProviderId };
 
 /**
  * Response from GET /editor/builder/settings
@@ -2830,6 +2835,7 @@ export interface BuilderSettingsResponse {
   };
   configuration?: {
     agent?: Record<string, unknown>;
+    library?: BuilderLibraryConfig;
   };
   /**
    * Server-derived model policy. Always present; `{ active: false }` when no
@@ -2838,8 +2844,18 @@ export interface BuilderSettingsResponse {
    */
   modelPolicy?: BuilderModelPolicy;
   /**
+   * Resolved Library visibility. Present when the builder is enabled.
+   * `unrestricted: true` ⇒ admin omitted the allowlist; show all eligible agents.
+   * `unrestricted: false` ⇒ only `visibleAgents` IDs should be shown.
+   */
+  library?: {
+    visibleAgents: string[];
+    unrestricted: boolean;
+  };
+  /**
    * Non-fatal warnings produced by builder config validation (e.g. allowlist
-   * entries with unknown providers that aren't tagged `kind: 'custom'`).
+   * entries with unknown providers that aren't tagged `kind: 'custom'`, or
+   * `library.visibleAgents` IDs that don't match any registered agent).
    * Only present when there is at least one warning.
    */
   modelPolicyWarnings?: string[];

--- a/examples/agent-builder/src/mastra/index.ts
+++ b/examples/agent-builder/src/mastra/index.ts
@@ -4,16 +4,26 @@ import { LibSQLStore } from '@mastra/libsql';
 import { builderAgent } from '@mastra/editor/ee';
 import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { initWorkOS } from './auth';
+import { Agent } from '@mastra/core/agent';
 
 const storage = new LibSQLStore({
   id: 'mastra-storage',
   url: 'file:./mastra.db',
 });
 
+const testAgent = new Agent({
+  id: 'test-agent',
+  name: 'Test Agent',
+  description: 'An agent used for testing purposes',
+  instructions: 'you only say hello',
+  model: 'openai/gpt-5.1-mini',
+})
+
 export const mastra = new Mastra({
   storage,
   agents: {
     builderAgent,
+    testAgent,
   },
   bundler: {
     sourcemap: true,
@@ -67,7 +77,7 @@ export const mastra = new Mastra({
           },
         },
         library: {
-          visibleAgents: [],
+          visibleAgents: ['test-agent'],
         }
       },
     },

--- a/examples/agent-builder/src/mastra/index.ts
+++ b/examples/agent-builder/src/mastra/index.ts
@@ -66,6 +66,9 @@ export const mastra = new Mastra({
             },
           },
         },
+        library: {
+          visibleAgents: [],
+        }
       },
     },
   }),

--- a/packages/core/src/agent-builder/ee/index.ts
+++ b/packages/core/src/agent-builder/ee/index.ts
@@ -2,6 +2,7 @@ export type {
   AgentBuilderOptions,
   AgentFeatures,
   BuilderAgentDefaults,
+  BuilderLibraryConfig,
   BuilderModelPolicy,
   CustomProviderEntry,
   DefaultModelEntry,
@@ -9,6 +10,12 @@ export type {
   KnownProviderEntry,
   ProviderModelEntry,
 } from './types';
+
+export {
+  resolveLibraryVisibility,
+  type ResolveLibraryVisibilityInputs,
+  type ResolvedLibraryVisibility,
+} from './library';
 
 export {
   assertModelAllowed,

--- a/packages/core/src/agent-builder/ee/library.test.ts
+++ b/packages/core/src/agent-builder/ee/library.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLibraryVisibility } from './library';
+
+describe('resolveLibraryVisibility', () => {
+  const registeredAgentIds = ['weather', 'support', 'researcher'] as const;
+
+  it('returns unrestricted when config is undefined', () => {
+    const result = resolveLibraryVisibility({ config: undefined, registeredAgentIds });
+    expect(result).toEqual({ visibleAgents: [], unrestricted: true, warnings: [] });
+  });
+
+  it('returns unrestricted when visibleAgents is undefined', () => {
+    const result = resolveLibraryVisibility({ config: {}, registeredAgentIds });
+    expect(result).toEqual({ visibleAgents: [], unrestricted: true, warnings: [] });
+  });
+
+  it('returns empty restricted list when visibleAgents is []', () => {
+    const result = resolveLibraryVisibility({ config: { visibleAgents: [] }, registeredAgentIds });
+    expect(result).toEqual({ visibleAgents: [], unrestricted: false, warnings: [] });
+  });
+
+  it('filters to listed known IDs and preserves admin order', () => {
+    const result = resolveLibraryVisibility({
+      config: { visibleAgents: ['support', 'weather'] },
+      registeredAgentIds,
+    });
+    expect(result.visibleAgents).toEqual(['support', 'weather']);
+    expect(result.unrestricted).toBe(false);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('drops unknown IDs and emits a warning for each', () => {
+    const result = resolveLibraryVisibility({
+      config: { visibleAgents: ['weather', 'ghost', 'support', 'phantom'] },
+      registeredAgentIds,
+    });
+    expect(result.visibleAgents).toEqual(['weather', 'support']);
+    expect(result.unrestricted).toBe(false);
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings[0]).toContain('"ghost"');
+    expect(result.warnings[1]).toContain('"phantom"');
+  });
+
+  it('de-duplicates repeated IDs without double-warning', () => {
+    const result = resolveLibraryVisibility({
+      config: { visibleAgents: ['weather', 'weather', 'ghost', 'ghost'] },
+      registeredAgentIds,
+    });
+    expect(result.visibleAgents).toEqual(['weather']);
+    expect(result.warnings).toHaveLength(1);
+  });
+});

--- a/packages/core/src/agent-builder/ee/library.ts
+++ b/packages/core/src/agent-builder/ee/library.ts
@@ -1,0 +1,63 @@
+import type { BuilderLibraryConfig } from './types';
+
+/**
+ * Resolved Library visibility, returned alongside `BuilderSettingsResponse`.
+ *
+ * Mirrors the response shape so the client never has to disambiguate
+ * `undefined` vs `[]`.
+ */
+export interface ResolvedLibraryVisibility {
+  /** IDs that should appear in the Library. Filtered against the registry. */
+  visibleAgents: string[];
+  /** True when the admin omitted `visibleAgents` ⇒ show all eligible agents. */
+  unrestricted: boolean;
+  /** Non-fatal warnings (e.g. unknown agent IDs in the allowlist). */
+  warnings: string[];
+}
+
+export interface ResolveLibraryVisibilityInputs {
+  /** The `library` slice of `AgentBuilderOptions['configuration']`. */
+  config: BuilderLibraryConfig | undefined;
+  /** All agent IDs currently registered with the Mastra instance. */
+  registeredAgentIds: readonly string[];
+}
+
+/**
+ * Pure derivation of {@link ResolvedLibraryVisibility} from admin config and
+ * the registered agent set.
+ *
+ * - `config` undefined or `visibleAgents` undefined ⇒ unrestricted, no warnings.
+ * - `visibleAgents` provided ⇒ filter to known IDs; emit one warning per
+ *   unknown ID; `unrestricted` is `false`.
+ *
+ * Stable order: returned `visibleAgents` preserves the admin-provided order
+ * with unknowns dropped. Duplicates are de-duplicated.
+ */
+export function resolveLibraryVisibility({
+  config,
+  registeredAgentIds,
+}: ResolveLibraryVisibilityInputs): ResolvedLibraryVisibility {
+  const allowlist = config?.visibleAgents;
+  if (allowlist === undefined) {
+    return { visibleAgents: [], unrestricted: true, warnings: [] };
+  }
+
+  const known = new Set(registeredAgentIds);
+  const seen = new Set<string>();
+  const visibleAgents: string[] = [];
+  const warnings: string[] = [];
+
+  for (const id of allowlist) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    if (known.has(id)) {
+      visibleAgents.push(id);
+    } else {
+      warnings.push(
+        `library.visibleAgents references unknown agent "${id}" — no agent with this ID is registered. It will be hidden from the Library.`,
+      );
+    }
+  }
+
+  return { visibleAgents, unrestricted: false, warnings };
+}

--- a/packages/core/src/agent-builder/ee/types.test-d.ts
+++ b/packages/core/src/agent-builder/ee/types.test-d.ts
@@ -1,7 +1,9 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest';
 import type {
+  AgentBuilderOptions,
   AgentFeatures,
   BuilderAgentDefaults,
+  BuilderLibraryConfig,
   BuilderModelPolicy,
   CustomProviderEntry,
   DefaultModelEntry,
@@ -167,6 +169,46 @@ describe('agent-builder/ee — Phase 1 contract types', () => {
       // @ts-expect-error active is required
       const p: BuilderModelPolicy = { pickerVisible: true };
       void p;
+    });
+  });
+
+  describe('BuilderLibraryConfig', () => {
+    it('accepts an empty object (omitted allowlist)', () => {
+      const c: BuilderLibraryConfig = {};
+      void c;
+    });
+
+    it('accepts an empty array (lockdown)', () => {
+      const c: BuilderLibraryConfig = { visibleAgents: [] };
+      void c;
+    });
+
+    it('accepts a list of agent IDs', () => {
+      const c: BuilderLibraryConfig = { visibleAgents: ['weather', 'support'] };
+      void c;
+    });
+
+    it('rejects non-string entries', () => {
+      // @ts-expect-error visibleAgents must be string[]
+      const c: BuilderLibraryConfig = { visibleAgents: [1, 2, 3] };
+      void c;
+    });
+  });
+
+  describe('AgentBuilderOptions.configuration.library', () => {
+    it('accepts an optional library slot alongside agent', () => {
+      const opts: AgentBuilderOptions = {
+        configuration: {
+          agent: {},
+          library: { visibleAgents: ['a', 'b'] },
+        },
+      };
+      void opts;
+    });
+
+    it('library is optional', () => {
+      const opts: AgentBuilderOptions = { configuration: { agent: {} } };
+      void opts;
     });
   });
 });

--- a/packages/core/src/agent-builder/ee/types.ts
+++ b/packages/core/src/agent-builder/ee/types.ts
@@ -123,7 +123,37 @@ export interface AgentFeatures {
  * are dropped from the resolved list and surfaced as warnings.
  */
 export interface BuilderLibraryConfig {
-  /** Allowlist of agent IDs visible in the Library. Omit to show all. */
+  /**
+   * Allowlist of agent IDs visible in the Library. Omit to show all.
+   *
+   * IDs must match the canonical `Agent.id` (e.g. `'test-agent'`) — i.e. the
+   * value passed to `new Agent({ id })`, **not** the registration map key
+   * (e.g. `agents: { testAgent: ... }`). When the two differ, the map key is
+   * accepted as a fallback, but `Agent.id` is the documented form because it
+   * matches what users see in URLs, traces, and the `/agents` API response.
+   *
+   * Unknown IDs are dropped at resolution time and surfaced via
+   * `BuilderSettingsResponse.modelPolicyWarnings`.
+   *
+   * @example
+   * ```ts
+   * const testAgent = new Agent({ id: 'test-agent', ... });
+   *
+   * new Mastra({
+   *   agents: { testAgent }, // map key is 'testAgent'
+   *   editor: new MastraEditor({
+   *     builder: {
+   *       configuration: {
+   *         library: {
+   *           // Use the canonical Agent.id, not the map key.
+   *           visibleAgents: ['test-agent'],
+   *         },
+   *       },
+   *     },
+   *   }),
+   * });
+   * ```
+   */
   visibleAgents?: string[];
 }
 

--- a/packages/core/src/agent-builder/ee/types.ts
+++ b/packages/core/src/agent-builder/ee/types.ts
@@ -112,6 +112,22 @@ export interface AgentFeatures {
 }
 
 /**
+ * Admin-controlled visibility for the Agent Builder Library page.
+ *
+ * Semantics:
+ * - `visibleAgents` omitted (undefined) ⇒ unrestricted; show all eligible agents.
+ * - `visibleAgents: []` ⇒ hide all agents (explicit lockdown).
+ * - `visibleAgents: [...ids]` ⇒ show only the listed agent IDs.
+ *
+ * IDs are matched against `mastra.listAgents()` at request time. Unknown IDs
+ * are dropped from the resolved list and surfaced as warnings.
+ */
+export interface BuilderLibraryConfig {
+  /** Allowlist of agent IDs visible in the Library. Omit to show all. */
+  visibleAgents?: string[];
+}
+
+/**
  * Configuration for the Agent Builder EE feature.
  * Passed to `MastraEditorConfig.builder`.
  *
@@ -140,6 +156,7 @@ export interface AgentBuilderOptions {
    */
   configuration?: {
     agent?: BuilderAgentDefaults;
+    library?: BuilderLibraryConfig;
   };
 }
 
@@ -153,7 +170,8 @@ export interface IAgentBuilder {
   getConfiguration(): AgentBuilderOptions['configuration'];
   /**
    * Optional warnings produced during construction-time validation
-   * (e.g. allowlist entries with unknown providers that lack `kind: 'custom'`).
+   * (e.g. allowlist entries with unknown providers that lack `kind: 'custom'`,
+   * or `library.visibleAgents` entries that don't match a registered agent).
    * Surfaced via `GET /editor/builder/settings.modelPolicyWarnings` for admin UI display.
    */
   getModelPolicyWarnings?(): string[];

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-list/__tests__/agent-builder-list.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-list/__tests__/agent-builder-list.test.tsx
@@ -1,10 +1,9 @@
 // @vitest-environment jsdom
-import type { StoredAgentResponse } from '@mastra/client-js';
 import { TooltipProvider } from '@mastra/playground-ui';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AgentBuilderList, AgentBuilderListSkeleton } from '../agent-builder-list';
-import type { AgentBuilderListProps } from '../agent-builder-list';
+import type { AgentBuilderListProps, LibraryAgentRow } from '../agent-builder-list';
 import { LinkComponentProvider } from '@/lib/framework';
 
 vi.mock('@mastra/playground-ui', async importOriginal => {
@@ -59,32 +58,29 @@ function renderList({ agents, search, ...props }: AgentBuilderListProps) {
   );
 }
 
-const now = new Date().toISOString();
-
-const fixtureAgents: StoredAgentResponse[] = [
+const fixtureAgents: LibraryAgentRow[] = [
   {
     id: 'a1',
-    status: 'active',
-    createdAt: now,
-    updatedAt: now,
     name: 'Alpha Agent',
     description: 'First agent description',
-    instructions: '',
-    model: { provider: 'openai', name: 'gpt-4' },
+    source: 'stored',
     visibility: 'private',
-    authorId: 'user-1',
   },
   {
     id: 'a2',
-    status: 'active',
-    createdAt: now,
-    updatedAt: now,
     name: 'Beta Agent',
     description: 'Second agent description',
-    instructions: '',
-    model: { provider: 'anthropic', name: 'claude' },
+    source: 'stored',
     visibility: 'public',
-    authorId: 'user-2',
+  },
+];
+
+const codeAgents: LibraryAgentRow[] = [
+  {
+    id: 'c1',
+    name: 'Code Agent',
+    description: 'Defined in code',
+    source: 'code',
   },
 ];
 
@@ -152,6 +148,20 @@ describe('AgentBuilderList', () => {
 
     expect(screen.getAllByTestId('library-agent-row')).toHaveLength(fixtureAgents.length);
     expect(screen.queryByText('Private')).toBeNull();
+  });
+
+  it('hides star button and lock icon for code-defined rows', () => {
+    renderList({ agents: codeAgents, rowTestId: 'agent-row' });
+
+    expect(screen.getByText('Code Agent')).toBeTruthy();
+    expect(screen.queryByLabelText('Star agent')).toBeNull();
+    expect(screen.queryByTestId('agent-builder-private-visibility-icon')).toBeNull();
+  });
+
+  it('shows the star button for stored rows', () => {
+    renderList({ agents: fixtureAgents, rowTestId: 'agent-row' });
+
+    expect(screen.getAllByLabelText('Star agent')).toHaveLength(fixtureAgents.length);
   });
 });
 

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-list/adapt.ts
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-list/adapt.ts
@@ -1,0 +1,39 @@
+import type { GetAgentResponse, StoredAgentResponse } from '@mastra/client-js';
+import type { LibraryAgentRow } from './agent-builder-list';
+
+function getAvatarUrl(metadata: Record<string, unknown> | null | undefined): string | undefined {
+  if (metadata && typeof metadata === 'object' && 'avatarUrl' in metadata) {
+    return metadata.avatarUrl as string | undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Adapt a `StoredAgentResponse` (from `/editor/agents`) to the normalized
+ * `LibraryAgentRow` shape consumed by `AgentBuilderList`.
+ */
+export function storedAgentToRow(agent: StoredAgentResponse): LibraryAgentRow {
+  return {
+    id: agent.id,
+    name: agent.name ?? '',
+    description: agent.description,
+    avatarUrl: getAvatarUrl(agent.metadata),
+    source: 'stored',
+    visibility: agent.visibility,
+    isStarred: agent.isStarred,
+    starCount: agent.starCount,
+  };
+}
+
+/**
+ * Adapt a `GetAgentResponse` entry (from `/agents`) to a `LibraryAgentRow`.
+ * Used by the Library page, which surfaces code-defined agents.
+ */
+export function codeAgentToRow(id: string, agent: GetAgentResponse): LibraryAgentRow {
+  return {
+    id,
+    name: agent.name ?? id,
+    description: agent.description,
+    source: 'code',
+  };
+}

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-list/agent-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-list/agent-builder-list.tsx
@@ -1,12 +1,27 @@
-import type { StoredAgentResponse } from '@mastra/client-js';
 import { Avatar, EmptyState, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
 import { LockIcon, SearchIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { StarButton } from '@/domains/agents/components/star-button';
 import { useLinkComponent } from '@/lib/framework';
 
+/**
+ * Normalized row shape consumed by `AgentBuilderList`. Decoupled from any
+ * specific server response (`StoredAgentResponse`, `GetAgentResponse`, etc.)
+ * so call sites can adapt their data via small mappers.
+ */
+export type LibraryAgentRow = {
+  id: string;
+  name: string;
+  description?: string;
+  avatarUrl?: string;
+  source: 'code' | 'stored';
+  visibility?: 'public' | 'private';
+  isStarred?: boolean;
+  starCount?: number;
+};
+
 export type AgentBuilderListProps = {
-  agents: StoredAgentResponse[];
+  agents: LibraryAgentRow[];
   search?: string;
   rowTestId?: string;
 };
@@ -15,14 +30,6 @@ export type AgentBuilderListSkeletonProps = {
   rows?: number;
   rowTestId?: string;
 };
-
-function getAvatarUrl(agent: StoredAgentResponse): string | undefined {
-  const meta = agent.metadata;
-  if (meta && typeof meta === 'object' && 'avatarUrl' in meta) {
-    return meta.avatarUrl as string | undefined;
-  }
-  return undefined;
-}
 
 function PrivateVisibilityIcon() {
   return (
@@ -71,7 +78,7 @@ export function AgentBuilderList({ agents, search, rowTestId }: AgentBuilderList
   return (
     <div className="bg-surface2 border border-border1 rounded-xl divide-y divide-border1 overflow-hidden">
       {filtered.map(agent => {
-        const avatar = getAvatarUrl(agent);
+        const isCode = agent.source === 'code';
 
         return (
           <Link
@@ -80,24 +87,26 @@ export function AgentBuilderList({ agents, search, rowTestId }: AgentBuilderList
             className="px-6 py-5 flex items-center gap-4 hover:bg-surface3 transition-colors"
             data-testid={rowTestId}
           >
-            <Avatar name={agent.name ?? ''} src={avatar} />
+            <Avatar name={agent.name ?? ''} src={agent.avatarUrl} />
 
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 min-w-0">
                 <div className="text-ui-md text-neutral6 truncate">{agent.name}</div>
-                {agent.visibility === 'private' && <PrivateVisibilityIcon />}
+                {!isCode && agent.visibility === 'private' && <PrivateVisibilityIcon />}
               </div>
               <div className="flex items-center gap-2 mt-0.5">
                 <span className="text-ui-sm text-neutral3 line-clamp-1">{agent.description || 'No description'}</span>
               </div>
             </div>
-            <StarButton
-              agentId={agent.id}
-              isStarred={agent.isStarred}
-              starCount={agent.starCount}
-              size="sm"
-              className="shrink-0"
-            />
+            {!isCode && (
+              <StarButton
+                agentId={agent.id}
+                isStarred={agent.isStarred}
+                starCount={agent.starCount}
+                size="sm"
+                className="shrink-0"
+              />
+            )}
           </Link>
         );
       })}

--- a/packages/playground/src/domains/agent-builder/mappers/code-agent-to-agent-config.ts
+++ b/packages/playground/src/domains/agent-builder/mappers/code-agent-to-agent-config.ts
@@ -1,0 +1,19 @@
+import type { GetAgentResponse } from '@mastra/client-js';
+import type { AgentConfig } from '../components/agent-builder-edit/agent-configure-panel';
+
+/**
+ * Build a read-only `AgentConfig` for a code-defined agent fetched via `/agents`.
+ *
+ * Code agents have no `visibility` or `authorId` — those are stored-agent concepts.
+ */
+export function codeAgentToAgentConfig(agent: GetAgentResponse | null | undefined, fallbackId: string): AgentConfig {
+  return {
+    id: agent?.id ?? fallbackId,
+    name: agent?.name ?? '',
+    description: agent?.description ?? '',
+    avatarUrl: undefined,
+    systemPrompt: typeof agent?.instructions === 'string' ? agent.instructions : '',
+    visibility: 'public',
+    authorId: null,
+  };
+}

--- a/packages/playground/src/domains/agent-builder/mappers/code-agent-to-form-values.ts
+++ b/packages/playground/src/domains/agent-builder/mappers/code-agent-to-form-values.ts
@@ -1,0 +1,37 @@
+import type { GetAgentResponse } from '@mastra/client-js';
+import type { AgentBuilderEditFormValues, AgentBuilderModel } from '../schemas';
+
+function toRecord(input: Record<string, unknown> | undefined): Record<string, true> {
+  if (!input) return {};
+  return Object.fromEntries(Object.keys(input).map(k => [k, true as const]));
+}
+
+function staticModel(agent: GetAgentResponse): AgentBuilderModel | undefined {
+  if (typeof agent.provider === 'string' && agent.provider && typeof agent.modelId === 'string' && agent.modelId) {
+    return { provider: agent.provider, name: agent.modelId };
+  }
+  return undefined;
+}
+
+/**
+ * Hydrate form defaults for a code-defined agent fetched via `/agents`.
+ *
+ * Code agents are read-only in the builder; this mapper exists so the same
+ * view component can render them when no stored override has been created.
+ */
+export function codeAgentToFormValues(agent: GetAgentResponse | null | undefined): AgentBuilderEditFormValues {
+  return {
+    name: agent?.name ?? '',
+    description: agent?.description ?? '',
+    instructions: typeof agent?.instructions === 'string' ? agent.instructions : '',
+    tools: toRecord(agent?.tools),
+    agents: toRecord(agent?.agents),
+    workflows: toRecord(agent?.workflows),
+    skills: Object.fromEntries((agent?.skills ?? []).map(s => [s.name, true as const])),
+    workspaceId: agent?.workspaceId,
+    browserEnabled: Boolean(agent?.browserTools && agent.browserTools.length > 0),
+    visibility: 'public',
+    avatarUrl: undefined,
+    model: agent ? staticModel(agent) : undefined,
+  };
+}

--- a/packages/playground/src/domains/builder/hooks/use-builder-settings.ts
+++ b/packages/playground/src/domains/builder/hooks/use-builder-settings.ts
@@ -51,3 +51,19 @@ export const useBuilderModelPolicy = (): BuilderModelPolicy => {
   const { data } = useBuilderSettings();
   return data?.modelPolicy ?? INACTIVE_POLICY;
 };
+
+/**
+ * Resolved Library visibility selector. Returns the admin-controlled allowlist
+ * for the Agent Builder Library page.
+ *
+ * Defaults to `unrestricted: true` while loading or when the server omitted
+ * the `library` field — so `Library` shows all eligible agents in those cases.
+ */
+export const useBuilderLibraryVisibility = (): { unrestricted: boolean; visibleAgents: Set<string> } => {
+  const { data } = useBuilderSettings();
+  const lib = data?.library;
+  if (!lib || lib.unrestricted) {
+    return { unrestricted: true, visibleAgents: new Set() };
+  }
+  return { unrestricted: false, visibleAgents: new Set(lib.visibleAgents) };
+};

--- a/packages/playground/src/domains/builder/index.ts
+++ b/packages/playground/src/domains/builder/index.ts
@@ -1,4 +1,9 @@
-export { useBuilderModelPolicy, useBuilderSettings, useIsBuilderEnabled } from './hooks/use-builder-settings';
+export {
+  useBuilderLibraryVisibility,
+  useBuilderModelPolicy,
+  useBuilderSettings,
+  useIsBuilderEnabled,
+} from './hooks/use-builder-settings';
 export { useBuilderFilteredProviders, useBuilderFilteredModels } from './hooks/use-builder-filtered-models';
 export { isModelNotAllowedError } from './utils/is-model-not-allowed';
 export type { ModelNotAllowedDetails } from './utils/is-model-not-allowed';

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/view-msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/view-msw.test.tsx
@@ -97,9 +97,45 @@ const storedAgent = {
   updatedAt: '2026-04-29T10:00:00.000Z',
 };
 
+const codeAgent = {
+  id: 'agent-123',
+  name: 'Code-Defined Agent',
+  description: 'Defined in user code',
+  instructions: 'be helpful',
+  tools: {},
+  workflows: {},
+  agents: {},
+  provider: 'openai',
+  modelId: 'gpt-4',
+  modelVersion: 'v2',
+  modelList: undefined,
+  defaultOptions: {},
+  defaultGenerateOptionsLegacy: {},
+  defaultStreamOptionsLegacy: {},
+  source: 'code',
+};
+
 describe('AgentBuilderAgentView MSW integration', () => {
   afterEach(() => {
     cleanup();
+  });
+
+  it('falls back to /agents data when the stored fetch 404s for a code-defined agent', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents/agent-123`, () =>
+        HttpResponse.json({ error: 'not found' }, { status: 404 }),
+      ),
+      http.get(`${BASE_URL}/api/agents`, () => HttpResponse.json({ 'agent-123': codeAgent })),
+      http.get(`${BASE_URL}/api/memory/threads/agent-123/messages`, () => HttpResponse.json({ messages: [] })),
+    );
+
+    renderPage();
+
+    const emptyState = await screen.findByTestId('agent-builder-agent-chat-empty-state');
+    expect(within(emptyState).getByText('Code-Defined Agent')).toBeTruthy();
+    expect(within(emptyState).getByText('Defined in user code')).toBeTruthy();
+    // Code agents are read-only — no Edit affordance.
+    expect(screen.queryByTestId('agent-builder-view-edit')).toBeNull();
   });
 
   it('renders the real empty chat state from API data and autofills a starter prompt without submitting', async () => {

--- a/packages/playground/src/pages/agent-builder/agents/index.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mastra/playground-ui';
 import { PlusIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { storedAgentToRow } from '@/domains/agent-builder/components/agent-builder-list/adapt';
 import {
   AgentBuilderList,
   AgentBuilderListSkeleton,
@@ -37,7 +38,8 @@ export default function AgentBuilderAgentsPage() {
   const [search, setSearch] = useState('');
   const { Link: FrameworkLink } = useLinkComponent();
 
-  const agents = data?.agents ?? [];
+  const storedAgents = data?.agents ?? [];
+  const agents = useMemo(() => storedAgents.map(storedAgentToRow), [storedAgents]);
 
   const body = (() => {
     if (isCurrentUserLoading || isLoading || (!data && !error)) {

--- a/packages/playground/src/pages/agent-builder/agents/index.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/index.tsx
@@ -38,8 +38,7 @@ export default function AgentBuilderAgentsPage() {
   const [search, setSearch] = useState('');
   const { Link: FrameworkLink } = useLinkComponent();
 
-  const storedAgents = data?.agents ?? [];
-  const agents = useMemo(() => storedAgents.map(storedAgentToRow), [storedAgents]);
+  const agents = useMemo(() => (data?.agents ?? []).map(storedAgentToRow), [data?.agents]);
 
   const body = (() => {
     if (isCurrentUserLoading || isLoading || (!data && !error)) {

--- a/packages/playground/src/pages/agent-builder/agents/view.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/view.tsx
@@ -1,4 +1,4 @@
-import type { StoredSkillResponse } from '@mastra/client-js';
+import type { GetAgentResponse, StoredSkillResponse } from '@mastra/client-js';
 import { Button, Spinner } from '@mastra/playground-ui';
 import { useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm, useFormContext, useWatch } from 'react-hook-form';
@@ -14,6 +14,8 @@ import { useStreamRunning } from '@/domains/agent-builder/components/agent-build
 import { VisibilitySelect } from '@/domains/agent-builder/components/agent-builder-edit/visibility-select';
 import { WorkspaceLayout } from '@/domains/agent-builder/components/agent-builder-edit/workspace-layout';
 import { useAvailableAgentTools } from '@/domains/agent-builder/hooks/use-available-agent-tools';
+import { codeAgentToAgentConfig } from '@/domains/agent-builder/mappers/code-agent-to-agent-config';
+import { codeAgentToFormValues } from '@/domains/agent-builder/mappers/code-agent-to-form-values';
 import { storedAgentToAgentConfig } from '@/domains/agent-builder/mappers/stored-agent-to-agent-config';
 import { storedAgentToFormValues } from '@/domains/agent-builder/mappers/stored-agent-to-form-values';
 import type { AgentBuilderEditFormValues } from '@/domains/agent-builder/schemas';
@@ -40,13 +42,24 @@ export default function AgentBuilderAgentView() {
   const { data: agentsData, isPending: isAgentsPending } = useAgents({ enabled: features.agents });
   const { data: workflowsData, isPending: isWorkflowsPending } = useWorkflows({ enabled: features.workflows });
   const { data: storedSkillsResponse, isPending: isSkillsPending } = useStoredSkills({ enabled: features.skills });
+
+  // Stored fetch returns null on 404. For code-defined agents (no stored override),
+  // fall back to the /agents response so the Library can route to this view.
+  const shouldLookUpCodeAgent = !isStoredAgentLoading && storedAgent == null && Boolean(id);
+  const { data: allAgentsData, isPending: isAllAgentsPending } = useAgents({ enabled: shouldLookUpCodeAgent });
+  const codeAgent =
+    shouldLookUpCodeAgent && id && allAgentsData && allAgentsData[id]?.source === 'code'
+      ? allAgentsData[id]
+      : undefined;
+
   const isReady =
     Boolean(id) &&
     !isStoredAgentLoading &&
     (!features.tools || !isToolsPending) &&
     (!features.skills || !isSkillsPending) &&
     (!features.agents || !isAgentsPending) &&
-    (!features.workflows || !isWorkflowsPending);
+    (!features.workflows || !isWorkflowsPending) &&
+    (!shouldLookUpCodeAgent || !isAllAgentsPending);
 
   if (!isReady) return <AgentBuilderAgentViewSkeleton />;
 
@@ -54,6 +67,7 @@ export default function AgentBuilderAgentView() {
     <AgentBuilderAgentViewPage
       id={id}
       storedAgent={storedAgent}
+      codeAgent={codeAgent}
       toolsData={toolsData}
       agentsData={agentsData}
       workflowsData={workflowsData}
@@ -65,6 +79,7 @@ export default function AgentBuilderAgentView() {
 interface PageProps {
   id: string | undefined;
   storedAgent: StoredAgent | null | undefined;
+  codeAgent: GetAgentResponse | undefined;
   toolsData: ToolsData | undefined;
   agentsData: AgentsData | undefined;
   workflowsData: WorkflowsData | undefined;
@@ -74,12 +89,16 @@ interface PageProps {
 const AgentBuilderAgentViewPage = ({
   id,
   storedAgent,
+  codeAgent,
   toolsData,
   agentsData,
   workflowsData,
   storedSkillsResponse,
 }: PageProps) => {
-  const defaultValues = useMemo(() => storedAgentToFormValues(storedAgent), [storedAgent]);
+  const defaultValues = useMemo(
+    () => (codeAgent ? codeAgentToFormValues(codeAgent) : storedAgentToFormValues(storedAgent)),
+    [codeAgent, storedAgent],
+  );
   const formMethods = useForm<AgentBuilderEditFormValues>({ defaultValues });
 
   useEffect(() => {
@@ -91,6 +110,7 @@ const AgentBuilderAgentViewPage = ({
       <AgentBuilderAgentViewReady
         id={id!}
         storedAgent={storedAgent}
+        codeAgent={codeAgent}
         toolsData={toolsData ?? {}}
         agentsData={agentsData ?? {}}
         workflowsData={workflowsData ?? {}}
@@ -109,6 +129,7 @@ const AgentBuilderAgentViewSkeleton = () => (
 interface AgentBuilderAgentViewReadyProps {
   id: string;
   storedAgent: StoredAgent | null | undefined;
+  codeAgent: GetAgentResponse | undefined;
   toolsData: ToolsData;
   agentsData: AgentsData;
   workflowsData: WorkflowsData;
@@ -118,6 +139,7 @@ interface AgentBuilderAgentViewReadyProps {
 const AgentBuilderAgentViewReady = ({
   id,
   storedAgent,
+  codeAgent,
   toolsData,
   agentsData,
   workflowsData,
@@ -130,7 +152,8 @@ const AgentBuilderAgentViewReady = ({
   const selectedAgents = useWatch({ control: formMethods.control, name: 'agents' });
   const selectedWorkflows = useWatch({ control: formMethods.control, name: 'workflows' });
   const { data: currentUser } = useCurrentUser();
-  const isOwner = !storedAgent?.authorId || currentUser?.id === storedAgent.authorId;
+  const isCodeAgent = codeAgent != null;
+  const isOwner = !isCodeAgent && (!storedAgent?.authorId || currentUser?.id === storedAgent?.authorId);
 
   const availableAgentTools = useAvailableAgentTools({
     toolsData,
@@ -142,7 +165,10 @@ const AgentBuilderAgentViewReady = ({
     excludeAgentId: id,
   });
 
-  const agent = useMemo(() => storedAgentToAgentConfig(storedAgent, id ?? ''), [storedAgent, id]);
+  const agent = useMemo(
+    () => (codeAgent ? codeAgentToAgentConfig(codeAgent, id) : storedAgentToAgentConfig(storedAgent, id ?? '')),
+    [codeAgent, storedAgent, id],
+  );
 
   const availableSkills = useMemo<StoredSkillResponse[]>(
     () => storedSkillsResponse?.skills ?? [],
@@ -155,16 +181,16 @@ const AgentBuilderAgentViewReady = ({
   const content = (
     <AgentChatPanelProvider
       agentId={id}
-      agentName={storedAgent?.name}
-      agentDescription={storedAgent?.description}
-      agentAvatarUrl={agent?.avatarUrl}
+      agentName={agent.name}
+      agentDescription={agent.description}
+      agentAvatarUrl={agent.avatarUrl}
     >
       <WorkspaceLayout
         isLoading={false}
         mode="test"
         defaultExpanded={false}
         detailOpen={activeDetail !== null}
-        modeAction={<VisibilitySelect disabled />}
+        modeAction={isCodeAgent ? null : <VisibilitySelect disabled />}
         primaryAction={
           isOwner ? (
             <ViewHeaderActions onEdit={() => navigate(`/agent-builder/agents/${id}/edit`, { viewTransition: true })} />

--- a/packages/playground/src/pages/agent-builder/favorite/index.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mastra/playground-ui';
 import { StarIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { storedAgentToRow } from '@/domains/agent-builder/components/agent-builder-list/adapt';
 import {
   AgentBuilderList,
   AgentBuilderListSkeleton,
@@ -30,7 +31,8 @@ export default function AgentBuilderFavoritePage() {
   );
 
   const { data, isLoading, error } = useStoredAgents(listParams);
-  const agents = data?.agents ?? [];
+  const storedAgents = data?.agents ?? [];
+  const agents = useMemo(() => storedAgents.map(storedAgentToRow), [storedAgents]);
 
   const body = (() => {
     if (isLoading) {

--- a/packages/playground/src/pages/agent-builder/favorite/index.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/index.tsx
@@ -31,8 +31,7 @@ export default function AgentBuilderFavoritePage() {
   );
 
   const { data, isLoading, error } = useStoredAgents(listParams);
-  const storedAgents = data?.agents ?? [];
-  const agents = useMemo(() => storedAgents.map(storedAgentToRow), [storedAgents]);
+  const agents = useMemo(() => (data?.agents ?? []).map(storedAgentToRow), [data?.agents]);
 
   const body = (() => {
     if (isLoading) {

--- a/packages/playground/src/pages/agent-builder/library/__tests__/library-page.test.tsx
+++ b/packages/playground/src/pages/agent-builder/library/__tests__/library-page.test.tsx
@@ -64,96 +64,119 @@ function renderPage() {
   );
 }
 
-const baseAgent = {
-  status: 'draft' as const,
-  visibility: 'public' as const,
-  instructions: '',
-  model: { provider: 'openai', name: 'gpt-4' },
-  authorId: 'user-1',
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
+type AgentFixture = {
+  id: string;
+  name: string;
+  description?: string;
+  source: 'code' | 'stored';
 };
+
+function agentsResponse(agents: AgentFixture[]) {
+  return Object.fromEntries(
+    agents.map(a => [
+      a.id,
+      {
+        id: a.id,
+        name: a.name,
+        description: a.description ?? '',
+        source: a.source,
+        instructions: '',
+        tools: {},
+        workflows: {},
+        agents: {},
+        provider: 'openai',
+        modelId: 'gpt-4',
+      },
+    ]),
+  );
+}
+
+function mockAgents(agents: AgentFixture[]) {
+  server.use(http.get(`${BASE_URL}/api/agents`, () => HttpResponse.json(agentsResponse(agents))));
+}
+
+function mockBuilderSettings(library?: { visibleAgents: string[]; unrestricted: boolean }) {
+  server.use(
+    http.get(`${BASE_URL}/api/editor/builder/settings`, () =>
+      HttpResponse.json({
+        enabled: true,
+        features: { agent: {} },
+        configuration: { agent: {} },
+        modelPolicy: { active: false },
+        modelPolicyWarnings: [],
+        ...(library ? { library } : {}),
+      }),
+    ),
+  );
+}
 
 describe('AgentBuilderLibraryPage', () => {
   afterEach(() => {
     cleanup();
   });
 
-  it('passes visibility=public to the API without a status filter', async () => {
-    let capturedSearch: URLSearchParams | null = null;
-    server.use(
-      http.get(`${BASE_URL}/api/stored/agents`, ({ request }) => {
-        capturedSearch = new URL(request.url).searchParams;
-        return HttpResponse.json({
-          agents: [
-            { ...baseAgent, id: 'lib-1', name: 'Public Alpha', description: 'Alpha desc' },
-            { ...baseAgent, id: 'lib-2', name: 'Public Beta', description: 'Beta desc' },
-          ],
-          total: 2,
-          page: 1,
-          perPage: 100,
-          hasMore: false,
-        });
-      }),
-    );
+  it('renders code-defined agents and filters out stored-source rows', async () => {
+    mockBuilderSettings();
+    mockAgents([
+      { id: 'c1', name: 'Code One', description: 'Defined in code', source: 'code' },
+      { id: 'c2', name: 'Code Two', description: 'Also code', source: 'code' },
+      { id: 's1', name: 'Stored One', description: 'Stored agent', source: 'stored' },
+    ]);
 
     renderPage();
 
     await waitFor(() => {
-      expect(capturedSearch).not.toBeNull();
+      expect(screen.getByText('Code One')).toBeTruthy();
     });
-    expect(capturedSearch!.get('visibility')).toBe('public');
-    expect(capturedSearch!.get('status')).toBeNull();
-  });
-
-  it('renders rows from the response with view links', async () => {
-    server.use(
-      http.get(`${BASE_URL}/api/stored/agents`, () =>
-        HttpResponse.json({
-          agents: [
-            { ...baseAgent, id: 'lib-1', name: 'Public Alpha', description: 'Alpha desc' },
-            { ...baseAgent, id: 'lib-2', name: 'Public Beta', description: 'Beta desc' },
-          ],
-          total: 2,
-          page: 1,
-          perPage: 100,
-          hasMore: false,
-        }),
-      ),
-    );
-
-    renderPage();
-
-    await waitFor(() => {
-      expect(screen.getByText('Public Alpha')).toBeTruthy();
-    });
-    expect(screen.getByText('Public Beta')).toBeTruthy();
+    expect(screen.getByText('Code Two')).toBeTruthy();
+    expect(screen.queryByText('Stored One')).toBeNull();
 
     const rows = screen.getAllByTestId('library-agent-row');
     expect(rows).toHaveLength(2);
-    expect(rows[0].getAttribute('href')).toBe('/agent-builder/agents/lib-1/view');
-    expect(rows[1].getAttribute('href')).toBe('/agent-builder/agents/lib-2/view');
+    expect(rows[0].getAttribute('href')).toBe('/agent-builder/agents/c1/view');
   });
 
-  it('shows the empty state when the API returns no agents', async () => {
-    server.use(
-      http.get(`${BASE_URL}/api/stored/agents`, () =>
-        HttpResponse.json({ agents: [], total: 0, page: 1, perPage: 100, hasMore: false }),
-      ),
-    );
+  it('respects library.visibleAgents allowlist', async () => {
+    mockBuilderSettings({ visibleAgents: ['c1'], unrestricted: false });
+    mockAgents([
+      { id: 'c1', name: 'Allowed', description: '', source: 'code' },
+      { id: 'c2', name: 'Hidden', description: '', source: 'code' },
+    ]);
 
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getByText('No public agents yet')).toBeTruthy();
+      expect(screen.getByText('Allowed')).toBeTruthy();
+    });
+    expect(screen.queryByText('Hidden')).toBeNull();
+  });
+
+  it('shows the restricted empty state when allowlist is empty', async () => {
+    mockBuilderSettings({ visibleAgents: [], unrestricted: false });
+    mockAgents([{ id: 'c1', name: 'Code One', description: '', source: 'code' }]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No agents in the library')).toBeTruthy();
     });
     expect(screen.queryByTestId('library-agent-row')).toBeNull();
   });
 
-  it('shows the error state when the API returns 500', async () => {
-    server.use(
-      http.get(`${BASE_URL}/api/stored/agents`, () => HttpResponse.json({ message: 'boom' }, { status: 500 })),
-    );
+  it('shows the unrestricted empty state when no code agents exist', async () => {
+    mockBuilderSettings();
+    mockAgents([{ id: 's1', name: 'Stored Only', description: '', source: 'stored' }]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No code-defined agents')).toBeTruthy();
+    });
+  });
+
+  it('shows the error state when /agents returns 500', async () => {
+    mockBuilderSettings();
+    server.use(http.get(`${BASE_URL}/api/agents`, () => HttpResponse.json({ message: 'boom' }, { status: 500 })));
 
     renderPage();
 
@@ -162,17 +185,14 @@ describe('AgentBuilderLibraryPage', () => {
     });
   });
 
-  it('shows SessionExpired when the API returns 401', async () => {
+  it('shows SessionExpired when /agents returns 401', async () => {
+    mockBuilderSettings();
     server.use(
-      http.get(`${BASE_URL}/api/stored/agents`, () => HttpResponse.json({ message: 'unauthorized' }, { status: 401 })),
+      http.get(`${BASE_URL}/api/agents`, () => HttpResponse.json({ message: 'unauthorized' }, { status: 401 })),
     );
 
     renderPage();
 
-    await waitFor(() => {
-      expect(screen.queryByText('No public agents yet')).toBeNull();
-    });
-    // SessionExpired component renders "Session expired" copy by default
     await waitFor(() => {
       expect(screen.getByText(/session expired/i)).toBeTruthy();
     });

--- a/packages/playground/src/pages/agent-builder/library/__tests__/library-page.test.tsx
+++ b/packages/playground/src/pages/agent-builder/library/__tests__/library-page.test.tsx
@@ -136,6 +136,22 @@ describe('AgentBuilderLibraryPage', () => {
     expect(rows[0].getAttribute('href')).toBe('/agent-builder/agents/c1/view');
   });
 
+  it('always hides the internal builder-agent, even in unrestricted mode', async () => {
+    mockBuilderSettings();
+    mockAgents([
+      { id: 'builder-agent', name: 'Agent Builder Agent', description: 'internal', source: 'code' },
+      { id: 'c1', name: 'Code One', description: 'visible', source: 'code' },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Code One')).toBeTruthy();
+    });
+    expect(screen.queryByText('Agent Builder Agent')).toBeNull();
+    expect(screen.getAllByTestId('library-agent-row')).toHaveLength(1);
+  });
+
   it('respects library.visibleAgents allowlist', async () => {
     mockBuilderSettings({ visibleAgents: ['c1'], unrestricted: false });
     mockAgents([

--- a/packages/playground/src/pages/agent-builder/library/index.tsx
+++ b/packages/playground/src/pages/agent-builder/library/index.tsx
@@ -19,6 +19,10 @@ import {
 import { useAgents } from '@/domains/agents/hooks/use-agents';
 import { useBuilderLibraryVisibility } from '@/domains/builder';
 
+// Mastra-internal code-defined agents that should never appear in the user-facing
+// Library, regardless of visibility config or unrestricted mode.
+const INTERNAL_HIDDEN_AGENT_IDS = new Set(['builder-agent']);
+
 export default function AgentBuilderLibraryPage() {
   const [search, setSearch] = useState('');
 
@@ -28,7 +32,8 @@ export default function AgentBuilderLibraryPage() {
   const agents = useMemo(() => {
     const all = Object.entries(data ?? {})
       .filter(([, agent]) => (agent as { source?: 'code' | 'stored' }).source === 'code')
-      .map(([id, agent]) => codeAgentToRow(id, agent));
+      .map(([id, agent]) => codeAgentToRow(id, agent))
+      .filter(row => !INTERNAL_HIDDEN_AGENT_IDS.has(row.id));
     if (visibility.unrestricted) return all;
     return all.filter(row => visibility.visibleAgents.has(row.id));
   }, [data, visibility]);

--- a/packages/playground/src/pages/agent-builder/library/index.tsx
+++ b/packages/playground/src/pages/agent-builder/library/index.tsx
@@ -1,4 +1,3 @@
-import type { ListStoredAgentsParams } from '@mastra/client-js';
 import {
   EmptyState,
   EntityListPageLayout,
@@ -12,19 +11,27 @@ import {
 } from '@mastra/playground-ui';
 import { LibraryIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { codeAgentToRow } from '@/domains/agent-builder/components/agent-builder-list/adapt';
 import {
   AgentBuilderList,
   AgentBuilderListSkeleton,
 } from '@/domains/agent-builder/components/agent-builder-list/agent-builder-list';
-import { useStoredAgents } from '@/domains/agents/hooks/use-stored-agents';
+import { useAgents } from '@/domains/agents/hooks/use-agents';
+import { useBuilderLibraryVisibility } from '@/domains/builder';
 
 export default function AgentBuilderLibraryPage() {
   const [search, setSearch] = useState('');
 
-  const listParams = useMemo<ListStoredAgentsParams>(() => ({ visibility: 'public' }), []);
+  const { data, isLoading, error } = useAgents();
+  const visibility = useBuilderLibraryVisibility();
 
-  const { data, isLoading, error } = useStoredAgents(listParams);
-  const agents = data?.agents ?? [];
+  const agents = useMemo(() => {
+    const all = Object.entries(data ?? {})
+      .filter(([, agent]) => (agent as { source?: 'code' | 'stored' }).source === 'code')
+      .map(([id, agent]) => codeAgentToRow(id, agent));
+    if (visibility.unrestricted) return all;
+    return all.filter(row => visibility.visibleAgents.has(row.id));
+  }, [data, visibility]);
 
   const body = (() => {
     if (isLoading) {
@@ -54,12 +61,17 @@ export default function AgentBuilderLibraryPage() {
     }
 
     if (agents.length === 0) {
+      const restricted = !visibility.unrestricted;
       return (
         <div className="flex items-center justify-center pt-16">
           <EmptyState
             iconSlot={<LibraryIcon className="h-8 w-8 text-neutral3" />}
-            titleSlot="No public agents yet"
-            descriptionSlot="Mark an agent as Public to share it with the team library."
+            titleSlot={restricted ? 'No agents in the library' : 'No code-defined agents'}
+            descriptionSlot={
+              restricted
+                ? 'Ask an admin to expose code-defined agents via library.visibleAgents.'
+                : 'Define agents in code (mastra.addAgent) to surface them here.'
+            }
           />
         </div>
       );
@@ -76,7 +88,7 @@ export default function AgentBuilderLibraryPage() {
             <PageHeader.Title>
               <LibraryIcon /> Library
             </PageHeader.Title>
-            <PageHeader.Description>Agents shared with the team library.</PageHeader.Description>
+            <PageHeader.Description>Code-defined agents available in this deployment.</PageHeader.Description>
           </PageHeader>
         </div>
         <div className="max-w-120">

--- a/packages/server/src/server/handlers/editor-builder.test.ts
+++ b/packages/server/src/server/handlers/editor-builder.test.ts
@@ -5,7 +5,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { GET_EDITOR_BUILDER_SETTINGS_ROUTE } from './editor-builder';
 
 // Minimal mock mastra for handler testing
-const createMockMastra = (editor?: Partial<IMastraEditor>, agents: Record<string, { source?: string }> = {}) =>
+const createMockMastra = (
+  editor?: Partial<IMastraEditor>,
+  agents: Record<string, { id?: string; source?: string }> = {},
+) =>
   ({
     getEditor: () => editor,
     listAgents: () => agents,
@@ -192,6 +195,32 @@ describe('GET /editor/builder/settings', () => {
       });
       expect((result as any).modelPolicyWarnings).toHaveLength(1);
       expect((result as any).modelPolicyWarnings[0]).toContain('"ghost"');
+    });
+
+    it('matches admin allowlist against agent.id, not the registration map key', async () => {
+      // Admins reference agents by their canonical `id` (e.g. 'test-agent'),
+      // even when registered under a different map key (e.g. `agents: { testAgent }`).
+      const mockBuilder: IAgentBuilder = {
+        enabled: true,
+        getFeatures: () => ({ agent: { tools: true } }),
+        getConfiguration: () => ({
+          agent: {},
+          library: { visibleAgents: ['test-agent'] },
+        }),
+      };
+      const mastra = createMockMastra(
+        {
+          hasEnabledBuilderConfig: () => true,
+          resolveBuilder: vi.fn().mockResolvedValue(mockBuilder),
+        },
+        { testAgent: { id: 'test-agent', source: 'code' } },
+      );
+      const result = await GET_EDITOR_BUILDER_SETTINGS_ROUTE.handler({ mastra } as any);
+
+      expect(result).toMatchObject({
+        library: { visibleAgents: ['test-agent'], unrestricted: false },
+      });
+      expect((result as any).modelPolicyWarnings).toBeUndefined();
     });
 
     it('returns empty allowlist (lockdown) when visibleAgents is []', async () => {

--- a/packages/server/src/server/handlers/editor-builder.test.ts
+++ b/packages/server/src/server/handlers/editor-builder.test.ts
@@ -5,9 +5,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { GET_EDITOR_BUILDER_SETTINGS_ROUTE } from './editor-builder';
 
 // Minimal mock mastra for handler testing
-const createMockMastra = (editor?: Partial<IMastraEditor>) =>
+const createMockMastra = (editor?: Partial<IMastraEditor>, agents: Record<string, { source?: string }> = {}) =>
   ({
     getEditor: () => editor,
+    listAgents: () => agents,
   }) as any;
 
 describe('GET /editor/builder/settings', () => {
@@ -64,6 +65,7 @@ describe('GET /editor/builder/settings', () => {
       features: { agent: { tools: true, memory: true } },
       configuration: { agent: { maxTokens: 4096 } },
       modelPolicy: { active: false },
+      library: { visibleAgents: [], unrestricted: true },
     });
   });
 
@@ -120,6 +122,124 @@ describe('GET /editor/builder/settings', () => {
     });
 
     await expect(GET_EDITOR_BUILDER_SETTINGS_ROUTE.handler({ mastra } as any)).rejects.toThrow('License check failed');
+  });
+
+  describe('library visibility', () => {
+    it('returns unrestricted: true when no library config is set', async () => {
+      const mockBuilder: IAgentBuilder = {
+        enabled: true,
+        getFeatures: () => ({ agent: { tools: true } }),
+        getConfiguration: () => ({ agent: {} }),
+      };
+      const mastra = createMockMastra(
+        {
+          hasEnabledBuilderConfig: () => true,
+          resolveBuilder: vi.fn().mockResolvedValue(mockBuilder),
+        },
+        { weather: { source: 'code' }, support: { source: 'code' } },
+      );
+      const result = await GET_EDITOR_BUILDER_SETTINGS_ROUTE.handler({ mastra } as any);
+
+      expect(result).toMatchObject({
+        library: { visibleAgents: [], unrestricted: true },
+      });
+      expect((result as any).modelPolicyWarnings).toBeUndefined();
+    });
+
+    it('returns the resolved allowlist when visibleAgents is set', async () => {
+      const mockBuilder: IAgentBuilder = {
+        enabled: true,
+        getFeatures: () => ({ agent: { tools: true } }),
+        getConfiguration: () => ({
+          agent: {},
+          library: { visibleAgents: ['weather'] },
+        }),
+      };
+      const mastra = createMockMastra(
+        {
+          hasEnabledBuilderConfig: () => true,
+          resolveBuilder: vi.fn().mockResolvedValue(mockBuilder),
+        },
+        { weather: { source: 'code' }, support: { source: 'code' } },
+      );
+      const result = await GET_EDITOR_BUILDER_SETTINGS_ROUTE.handler({ mastra } as any);
+
+      expect(result).toMatchObject({
+        library: { visibleAgents: ['weather'], unrestricted: false },
+      });
+    });
+
+    it('drops unknown IDs and surfaces them via modelPolicyWarnings', async () => {
+      const mockBuilder: IAgentBuilder = {
+        enabled: true,
+        getFeatures: () => ({ agent: { tools: true } }),
+        getConfiguration: () => ({
+          agent: {},
+          library: { visibleAgents: ['weather', 'ghost'] },
+        }),
+      };
+      const mastra = createMockMastra(
+        {
+          hasEnabledBuilderConfig: () => true,
+          resolveBuilder: vi.fn().mockResolvedValue(mockBuilder),
+        },
+        { weather: { source: 'code' } },
+      );
+      const result = await GET_EDITOR_BUILDER_SETTINGS_ROUTE.handler({ mastra } as any);
+
+      expect(result).toMatchObject({
+        library: { visibleAgents: ['weather'], unrestricted: false },
+      });
+      expect((result as any).modelPolicyWarnings).toHaveLength(1);
+      expect((result as any).modelPolicyWarnings[0]).toContain('"ghost"');
+    });
+
+    it('returns empty allowlist (lockdown) when visibleAgents is []', async () => {
+      const mockBuilder: IAgentBuilder = {
+        enabled: true,
+        getFeatures: () => ({ agent: { tools: true } }),
+        getConfiguration: () => ({
+          agent: {},
+          library: { visibleAgents: [] },
+        }),
+      };
+      const mastra = createMockMastra(
+        {
+          hasEnabledBuilderConfig: () => true,
+          resolveBuilder: vi.fn().mockResolvedValue(mockBuilder),
+        },
+        { weather: { source: 'code' } },
+      );
+      const result = await GET_EDITOR_BUILDER_SETTINGS_ROUTE.handler({ mastra } as any);
+
+      expect(result).toMatchObject({
+        library: { visibleAgents: [], unrestricted: false },
+      });
+    });
+
+    it('excludes stored-source agents from registered IDs', async () => {
+      const mockBuilder: IAgentBuilder = {
+        enabled: true,
+        getFeatures: () => ({ agent: { tools: true } }),
+        getConfiguration: () => ({
+          agent: {},
+          library: { visibleAgents: ['stored-only'] },
+        }),
+      };
+      const mastra = createMockMastra(
+        {
+          hasEnabledBuilderConfig: () => true,
+          resolveBuilder: vi.fn().mockResolvedValue(mockBuilder),
+        },
+        { 'stored-only': { source: 'stored' }, weather: { source: 'code' } },
+      );
+      const result = await GET_EDITOR_BUILDER_SETTINGS_ROUTE.handler({ mastra } as any);
+
+      expect(result).toMatchObject({
+        library: { visibleAgents: [], unrestricted: false },
+      });
+      expect((result as any).modelPolicyWarnings[0]).toContain('"stored-only"');
+    });
   });
 });
 

--- a/packages/server/src/server/handlers/editor-builder.ts
+++ b/packages/server/src/server/handlers/editor-builder.ts
@@ -1,6 +1,6 @@
 import type { Mastra } from '@mastra/core';
 
-import { builderToModelPolicy } from '@mastra/core/agent-builder/ee';
+import { builderToModelPolicy, resolveLibraryVisibility } from '@mastra/core/agent-builder/ee';
 import { HTTPException } from '../http-exception';
 import { agentFeaturesSchema, builderSettingsResponseSchema } from '../schemas/editor-builder';
 import type { AgentFeatures } from '../schemas/editor-builder';
@@ -86,13 +86,29 @@ export const GET_EDITOR_BUILDER_SETTINGS_ROUTE = createRoute({
         return { enabled: false, modelPolicy: { active: false } };
       }
 
-      const modelPolicyWarnings = builder.getModelPolicyWarnings?.() ?? [];
+      const baseWarnings = builder.getModelPolicyWarnings?.() ?? [];
+
+      const configuration = builder.getConfiguration();
+
+      // Resolve Library visibility against the registered (non-stored) agents.
+      const allRegistered = mastra.listAgents();
+      const registeredAgentIds = Object.entries(allRegistered)
+        .filter(([, agent]) => (agent as { source?: string }).source !== 'stored')
+        .map(([id]) => id);
+
+      const library = resolveLibraryVisibility({
+        config: configuration?.library,
+        registeredAgentIds,
+      });
+
+      const modelPolicyWarnings = [...baseWarnings, ...library.warnings];
 
       return {
         enabled: true,
         features: builder.getFeatures(),
-        configuration: builder.getConfiguration(),
+        configuration,
         modelPolicy: builderToModelPolicy(builder),
+        library: { visibleAgents: library.visibleAgents, unrestricted: library.unrestricted },
         ...(modelPolicyWarnings.length > 0 ? { modelPolicyWarnings } : {}),
       };
     } catch (error) {

--- a/packages/server/src/server/handlers/editor-builder.ts
+++ b/packages/server/src/server/handlers/editor-builder.ts
@@ -91,10 +91,13 @@ export const GET_EDITOR_BUILDER_SETTINGS_ROUTE = createRoute({
       const configuration = builder.getConfiguration();
 
       // Resolve Library visibility against the registered (non-stored) agents.
+      // Use `agent.id` (the canonical identifier admins reference in config),
+      // not the map key — those can differ when agents are registered via
+      // `agents: { someKey: agent }` with a different `id` on the Agent itself.
       const allRegistered = mastra.listAgents();
       const registeredAgentIds = Object.entries(allRegistered)
         .filter(([, agent]) => (agent as { source?: string }).source !== 'stored')
-        .map(([id]) => id);
+        .map(([key, agent]) => (agent as { id?: string }).id ?? key);
 
       const library = resolveLibraryVisibility({
         config: configuration?.library,

--- a/packages/server/src/server/schemas/editor-builder.ts
+++ b/packages/server/src/server/schemas/editor-builder.ts
@@ -90,6 +90,29 @@ export const agentConfigurationSchema = z
   .catchall(z.unknown());
 
 /**
+ * Admin-controlled visibility for the Agent Builder Library page.
+ *
+ * - `visibleAgents` omitted ⇒ unrestricted (all eligible agents shown).
+ * - `visibleAgents: []`     ⇒ empty Library (explicit lockdown).
+ * - `visibleAgents: [...ids]` ⇒ only the listed IDs shown.
+ */
+export const builderLibraryConfigSchema = z
+  .object({
+    visibleAgents: z.array(z.string()).optional(),
+  })
+  .strict();
+
+/**
+ * Resolved Library visibility returned in `BuilderSettingsResponse`.
+ * `unrestricted` is explicit so the client never has to disambiguate
+ * `undefined` vs `[]`.
+ */
+export const builderLibrarySchema = z.object({
+  visibleAgents: z.array(z.string()),
+  unrestricted: z.boolean(),
+});
+
+/**
  * Derived `BuilderModelPolicy`. Server-owned shape so the playground hook is a
  * thin selector and the UI never re-derives policy from `features` / `configuration`.
  *
@@ -118,9 +141,15 @@ export const builderSettingsResponseSchema = z.object({
   configuration: z
     .object({
       agent: agentConfigurationSchema.optional(),
+      library: builderLibraryConfigSchema.optional(),
     })
     .optional(),
   modelPolicy: builderModelPolicySchema.optional(),
+  /**
+   * Resolved Library visibility. Always present when the builder is enabled.
+   * Omitted when the builder is disabled (matches `modelPolicy` when inactive).
+   */
+  library: builderLibrarySchema.optional(),
   /**
    * Non-fatal warnings produced by `EditorAgentBuilder`'s constructor-time
    * validation (e.g. allowlist entries with unknown provider strings). UI
@@ -136,3 +165,5 @@ export type ProviderModelEntrySchema = z.infer<typeof providerModelEntrySchema>;
 export type DefaultModelEntrySchema = z.infer<typeof defaultModelEntrySchema>;
 export type AgentModelsSchema = z.infer<typeof agentModelsSchema>;
 export type BuilderModelPolicySchema = z.infer<typeof builderModelPolicySchema>;
+export type BuilderLibraryConfigSchema = z.infer<typeof builderLibraryConfigSchema>;
+export type BuilderLibrarySchema = z.infer<typeof builderLibrarySchema>;


### PR DESCRIPTION
## Summary

Adds an admin-controlled allowlist for which code-defined agents appear in the Agent Builder **Library** page.

Admins can now configure a `library.visibleAgents` allowlist on the Agent Builder configuration. The Library page surfaces only the listed code-defined agents, with the existing behavior (show all eligible agents) preserved when the field is omitted.

```ts
new MastraEditor({
  builder: {
    configuration: {
      library: {
        visibleAgents: ['support-agent', 'research-agent'],
      },
    },
  },
})
```

### Semantics

- `visibleAgents` omitted → unrestricted (show all eligible agents).
- `visibleAgents: []` → explicit lockdown (hide all).
- `visibleAgents: [...ids]` → show only the listed IDs.
- Unknown IDs are dropped at resolution time and surfaced via `BuilderSettingsResponse.modelPolicyWarnings`.

### What's wired

- **Core**: `BuilderLibraryConfig` type + pure `resolveLibraryVisibility` helper with unit tests.
- **Server**: `GET /editor/builder/settings` now returns a `library: { visibleAgents, unrestricted }` slice. IDs are resolved against `agent.id` (canonical), falling back to the registration map key.
- **Client SDK**: `BuilderSettingsResponse.library` typed end-to-end.
- **Playground**:
  - New `useBuilderLibraryVisibility` selector hook.
  - Library page now fetches code-defined agents from `/agents` (filtered by `source === 'code'`) and applies the visibility allowlist client-side.
  - Stored `StoredAgentResponse` and code `GetAgentResponse` are normalized into a shared `LibraryAgentRow` shape via small adapters so `AgentBuilderList` renders both.
  - Star button / lock icon hidden for code-defined rows.
- **Example**: `examples/agent-builder` demonstrates the `Agent.id` form (`'test-agent'`).

### Identifier note

`visibleAgents` matches against the canonical `Agent.id` — the same identifier surfaced in URLs, traces, and the `/agents` API response — not the registration map key. The map key is accepted as a fallback when no `id` is set on the Agent. JSDoc documents this with an example.

## Test plan

- `pnpm --filter ./packages/core check` — clean.
- `pnpm --filter ./packages/core vitest run src/agent-builder/ee/library.test.ts` — 6 tests pass.
- `pnpm --filter ./packages/server vitest run src/server/handlers/editor-builder.test.ts` — 17 tests pass (incl. new id-vs-key regression test).
- `pnpm --filter ./packages/playground vitest run` on agent-builder pages and AgentBuilderList — 42 tests pass.
- Smoke-tested in `examples/agent-builder`: `visibleAgents: ['test-agent']` correctly surfaces the `test-agent` code-defined agent in the Library.
