### PR TITLE
fix(server,core): skip framework-internal routes in custom-route validator

### DIFF
--- a/.changeset/all-shirts-know.md
+++ b/.changeset/all-shirts-know.md
@@ -1,0 +1,7 @@
+---
+'@mastra/hono': patch
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Fixed a regression in 1.29.0 where configuring an agent with channel adapters (e.g. `channels.adapters.slack`) caused server startup to crash with a "Custom API route ... must not start with /api" error. The custom-route prefix validation now skips framework-generated webhook routes.

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -694,7 +694,7 @@ export class AgentChannels {
         path: `/api/agents/${agentId}/channels/${platform}/webhook`,
         method: 'POST',
         requiresAuth: false,
-        _internal: true,
+        _mastraInternal: true,
         createHandler: async () => {
           return async c => {
             // Await initialization to handle serverless cold starts where

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -694,6 +694,7 @@ export class AgentChannels {
         path: `/api/agents/${agentId}/channels/${platform}/webhook`,
         method: 'POST',
         requiresAuth: false,
+        _internal: true,
         createHandler: async () => {
           return async c => {
             // Await initialization to handle serverless cold starts where

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -17,8 +17,8 @@ export type ApiRoute =
       middleware?: MiddlewareHandler | MiddlewareHandler[];
       openapi?: DescribeRouteOptions;
       requiresAuth?: boolean;
-      /** Framework-generated route. Bypasses the apiPrefix collision check. */
-      _internal?: boolean;
+      /** Framework-generated route. Bypasses the apiPrefix collision check. Mastra-internal — do not use. */
+      _mastraInternal?: true;
     }
   | {
       path: string;
@@ -27,8 +27,8 @@ export type ApiRoute =
       middleware?: MiddlewareHandler | MiddlewareHandler[];
       openapi?: DescribeRouteOptions;
       requiresAuth?: boolean;
-      /** Framework-generated route. Bypasses the apiPrefix collision check. */
-      _internal?: boolean;
+      /** Framework-generated route. Bypasses the apiPrefix collision check. Mastra-internal — do not use. */
+      _mastraInternal?: true;
     };
 
 export type Middleware = MiddlewareHandler | { path: string; handler: MiddlewareHandler };

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -17,6 +17,8 @@ export type ApiRoute =
       middleware?: MiddlewareHandler | MiddlewareHandler[];
       openapi?: DescribeRouteOptions;
       requiresAuth?: boolean;
+      /** Framework-generated route. Bypasses the apiPrefix collision check. */
+      _internal?: boolean;
     }
   | {
       path: string;
@@ -25,6 +27,8 @@ export type ApiRoute =
       middleware?: MiddlewareHandler | MiddlewareHandler[];
       openapi?: DescribeRouteOptions;
       requiresAuth?: boolean;
+      /** Framework-generated route. Bypasses the apiPrefix collision check. */
+      _internal?: boolean;
     };
 
 export type Middleware = MiddlewareHandler | { path: string; handler: MiddlewareHandler };

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -529,7 +529,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     const prefix = this.prefix ?? '';
     if (!prefix) return;
     for (const route of routes) {
-      if (route._internal) continue;
+      if (route._mastraInternal) continue;
       if (route.path.startsWith(`${prefix}/`) || route.path === prefix) {
         throw new Error(
           `Custom API route "${route.path}" must not start with "${prefix}" — ` +

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -529,6 +529,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     const prefix = this.prefix ?? '';
     if (!prefix) return;
     for (const route of routes) {
+      if (route._internal) continue;
       if (route.path.startsWith(`${prefix}/`) || route.path === prefix) {
         throw new Error(
           `Custom API route "${route.path}" must not start with "${prefix}" — ` +

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -749,6 +749,30 @@ describe('Hono Server Adapter', () => {
       await expect(adapter.init()).rejects.toThrow(/must not start with "\/mastra"/);
     });
 
+    it('should allow framework-internal routes under the server prefix', async () => {
+      const customRoutes = [
+        {
+          path: '/mastra/agents/bot/channels/slack/webhook',
+          method: 'POST' as const,
+          requiresAuth: false,
+          _internal: true,
+          handler: async (c: any) => c.json({ ok: true }),
+        },
+      ];
+
+      const mastra = new Mastra({});
+      const app = new Hono();
+
+      const adapter = new MastraServer({
+        app,
+        mastra,
+        customApiRoutes: customRoutes,
+        prefix: '/mastra',
+      });
+
+      await expect(adapter.init()).resolves.not.toThrow();
+    });
+
     it('should allow custom routes at paths not starting with the server prefix', async () => {
       const customRoutes = [
         registerApiRoute('/custom/hello', {

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -755,7 +755,7 @@ describe('Hono Server Adapter', () => {
           path: '/mastra/agents/bot/channels/slack/webhook',
           method: 'POST' as const,
           requiresAuth: false,
-          _internal: true,
+          _mastraInternal: true,
           handler: async (c: any) => c.json({ ok: true }),
         },
       ];


### PR DESCRIPTION
## Description

Fixes a regression in 1.29.0 where configuring an agent with channel adapters (e.g. `channels.adapters.slack`) crashed server startup with `Custom API route "/api/agents/<id>/channels/<platform>/webhook" must not start with "/api"`. The custom-route prefix validator added in #15743 did not distinguish framework-generated webhook routes from user-supplied custom routes, even though both share the same `apiRoutes` array.

- Add an optional `_internal?: boolean` field to `ApiRoute` to mark framework-generated routes
- Tag routes returned by `AgentChannels.getWebhookRoutes()` with `_internal: true`
- Update `validateCustomRoutePaths` in `@mastra/server` to skip routes carrying the marker
- Add a regression test in the hono adapter alongside existing validator tests
- `registerApiRoute()` does not propagate `_internal`, so users cannot bypass the guard via the public helper

## Related Issue(s)

Fixes #15948

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Server startup was crashing because the framework's own webhook routes were being rejected as "custom" routes; this change marks those routes as internal so the validator ignores them and the server starts normally.

---

## Overview

Fixes a regression introduced in v1.29.0 where server startup crashed when agents used channel adapters (e.g., channels.adapters.slack) because the custom-route validator rejected framework-generated webhook routes that collide with the server's reserved API prefix.

## Changes Made

- Type system
  - Added an internal-only marker to ApiRoute: _mastraInternal?: true (literal true) to unambiguously mark framework-generated routes.
- Framework route tagging
  - AgentChannels.getWebhookRoutes() now tags generated webhook ApiRoute objects with _mastraInternal: true.
- Validation behavior
  - validateCustomRoutePaths (server adapter) skips routes bearing _mastraInternal when enforcing that custom routes must not start with the server's apiPrefix.
- Safety
  - registerApiRoute() does not propagate the _mastraInternal flag, preventing users from marking routes as internal to bypass validations.
- Tests & release note
  - Added a regression/integration test in the Hono adapter to confirm MastraServer.init() accepts framework-internal routes under the configured prefix.
  - Added a changeset documenting the patch releases for @mastra/hono, @mastra/server, and @mastra/core.

## Impact

- Bug fix (non-breaking). Addresses and closes issue #15948. Tests added; no breaking API changes for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->