### PR TITLE
fix(playground-ui): skip lib-mode externalization when building Storybook

### DIFF
--- a/packages/playground-ui/.storybook/main.ts
+++ b/packages/playground-ui/.storybook/main.ts
@@ -9,10 +9,6 @@ const config: StorybookConfig = {
     name: getAbsolutePath('@storybook/react-vite'),
     options: {},
   },
-  viteFinal: async config => {
-    config.base = './';
-    return config;
-  },
 };
 
 export default config;

--- a/packages/playground-ui/.storybook/main.ts
+++ b/packages/playground-ui/.storybook/main.ts
@@ -9,17 +9,8 @@ const config: StorybookConfig = {
     name: getAbsolutePath('@storybook/react-vite'),
     options: {},
   },
-  // Ensure modules are properly resolved
   viteFinal: async config => {
-    // Force all modules to be treated as internal
-    config.define = {
-      ...config.define,
-      'process.env.NODE_ENV': '"production"',
-    };
-
-    // Ensure proper base URL for production builds
     config.base = './';
-
     return config;
   },
 };

--- a/packages/playground-ui/vite.config.ts
+++ b/packages/playground-ui/vite.config.ts
@@ -2,55 +2,56 @@ import { resolve } from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import nodeExternals from 'rollup-plugin-node-externals';
+import type { UserConfig } from 'vite';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
+
+const baseConfig: UserConfig = {
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+};
+
+const libConfig: UserConfig = {
+  ...baseConfig,
+  plugins: [
+    ...(baseConfig.plugins ?? []),
+    dts({
+      insertTypesEntry: true,
+    }),
+    libInjectCss(),
+    nodeExternals(),
+  ],
+  build: {
+    lib: {
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        utils: resolve(__dirname, 'src/utils.ts'),
+        tokens: resolve(__dirname, 'src/ds/tokens/index.ts'),
+      },
+      formats: ['es', 'cjs'],
+      fileName: (format, entryName) => {
+        return `${entryName}.${format}.js`;
+      },
+    },
+    sourcemap: true,
+    // Reduce bloat from legacy polyfills.
+    target: 'esnext',
+    // Leave minification up to applications.
+    minify: false,
+    rollupOptions: {
+      external: ['motion/react'],
+    },
+  },
+};
 
 // Storybook sets STORYBOOK=true and bundles this package as an app.
 // Library-mode plugins (dts, libInjectCss, nodeExternals) would externalize
 // deps and break the static build, so we skip them when Storybook is running.
 const isStorybook = process.env.STORYBOOK === 'true';
 
-export default defineConfig({
-  plugins: [
-    react(),
-    tailwindcss(),
-    ...(isStorybook
-      ? []
-      : [
-          dts({
-            insertTypesEntry: true,
-          }),
-          libInjectCss(),
-          nodeExternals(),
-        ]),
-  ],
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, './src'),
-    },
-  },
-  build: isStorybook
-    ? undefined
-    : {
-        lib: {
-          entry: {
-            index: resolve(__dirname, 'src/index.ts'),
-            utils: resolve(__dirname, 'src/utils.ts'),
-            tokens: resolve(__dirname, 'src/ds/tokens/index.ts'),
-          },
-          formats: ['es', 'cjs'],
-          fileName: (format, entryName) => {
-            return `${entryName}.${format}.js`;
-          },
-        },
-        sourcemap: true,
-        // Reduce bloat from legacy polyfills.
-        target: 'esnext',
-        // Leave minification up to applications.
-        minify: false,
-        rollupOptions: {
-          external: ['motion/react'],
-        },
-      },
-});
+export default defineConfig(isStorybook ? baseConfig : libConfig);

--- a/packages/playground-ui/vite.config.ts
+++ b/packages/playground-ui/vite.config.ts
@@ -2,43 +2,55 @@ import { resolve } from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import nodeExternals from 'rollup-plugin-node-externals';
-import type { UserConfig } from 'vite';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 
-const sharedConfig: UserConfig = {
-  plugins: [react(), tailwindcss()],
+// Storybook sets STORYBOOK=true and bundles this package as an app.
+// Library-mode plugins (dts, libInjectCss, nodeExternals) would externalize
+// deps and break the static build, so we skip them when Storybook is running.
+const isStorybook = process.env.STORYBOOK === 'true';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    tailwindcss(),
+    ...(isStorybook
+      ? []
+      : [
+          dts({
+            insertTypesEntry: true,
+          }),
+          libInjectCss(),
+          nodeExternals(),
+        ]),
+  ],
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
     },
   },
-};
-
-const libConfig: UserConfig = {
-  ...sharedConfig,
-  plugins: [...(sharedConfig.plugins ?? []), dts({ insertTypesEntry: true }), libInjectCss(), nodeExternals()],
-  build: {
-    lib: {
-      entry: {
-        index: resolve(__dirname, 'src/index.ts'),
-        utils: resolve(__dirname, 'src/utils.ts'),
-        tokens: resolve(__dirname, 'src/ds/tokens/index.ts'),
+  build: isStorybook
+    ? undefined
+    : {
+        lib: {
+          entry: {
+            index: resolve(__dirname, 'src/index.ts'),
+            utils: resolve(__dirname, 'src/utils.ts'),
+            tokens: resolve(__dirname, 'src/ds/tokens/index.ts'),
+          },
+          formats: ['es', 'cjs'],
+          fileName: (format, entryName) => {
+            return `${entryName}.${format}.js`;
+          },
+        },
+        sourcemap: true,
+        // Reduce bloat from legacy polyfills.
+        target: 'esnext',
+        // Leave minification up to applications.
+        minify: false,
+        rollupOptions: {
+          external: ['motion/react'],
+        },
       },
-      formats: ['es', 'cjs'],
-      fileName: (format, entryName) => `${entryName}.${format}.js`,
-    },
-    sourcemap: true,
-    target: 'esnext',
-    minify: false,
-    rollupOptions: {
-      external: ['motion/react'],
-    },
-  },
-};
-
-// Storybook sets STORYBOOK=true and bundles this package as an app.
-// Library-mode plugins (dts, libInjectCss, nodeExternals) would externalize
-// deps and break the static build, so we serve a minimal config instead.
-export default defineConfig(process.env.STORYBOOK === 'true' ? sharedConfig : libConfig);
+});

--- a/packages/playground-ui/vite.config.ts
+++ b/packages/playground-ui/vite.config.ts
@@ -2,25 +2,22 @@ import { resolve } from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import nodeExternals from 'rollup-plugin-node-externals';
-import { defineConfig } from 'vite';
+import { defineConfig, type UserConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 
-export default defineConfig({
-  plugins: [
-    react(),
-    tailwindcss(),
-    dts({
-      insertTypesEntry: true,
-    }),
-    libInjectCss(),
-    nodeExternals(),
-  ],
+const sharedConfig: UserConfig = {
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
     },
   },
+};
+
+const libConfig: UserConfig = {
+  ...sharedConfig,
+  plugins: [...(sharedConfig.plugins ?? []), dts({ insertTypesEntry: true }), libInjectCss(), nodeExternals()],
   build: {
     lib: {
       entry: {
@@ -29,17 +26,18 @@ export default defineConfig({
         tokens: resolve(__dirname, 'src/ds/tokens/index.ts'),
       },
       formats: ['es', 'cjs'],
-      fileName: (format, entryName) => {
-        return `${entryName}.${format}.js`;
-      },
+      fileName: (format, entryName) => `${entryName}.${format}.js`,
     },
     sourcemap: true,
-    // Reduce bloat from legacy polyfills.
     target: 'esnext',
-    // Leave minification up to applications.
     minify: false,
     rollupOptions: {
       external: ['motion/react'],
     },
   },
-});
+};
+
+// Storybook sets STORYBOOK=true and bundles this package as an app.
+// Library-mode plugins (dts, libInjectCss, nodeExternals) would externalize
+// deps and break the static build, so we serve a minimal config instead.
+export default defineConfig(process.env.STORYBOOK === 'true' ? sharedConfig : libConfig);

--- a/packages/playground-ui/vite.config.ts
+++ b/packages/playground-ui/vite.config.ts
@@ -2,7 +2,8 @@ import { resolve } from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import nodeExternals from 'rollup-plugin-node-externals';
-import { defineConfig, type UserConfig } from 'vite';
+import type { UserConfig } from 'vite';
+import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 


### PR DESCRIPTION
## Summary

- Storybook's Vite builder inherited `packages/playground-ui/vite.config.ts`, which uses `rollup-plugin-node-externals` and `build.lib` to externalize all dependencies for the published package.
- As a result, `storybook build` left bare imports (e.g. `import { Check } from "lucide-react"`) in the static output, and the browser threw `Failed to resolve module specifier "lucide-react"` when opening any Docs page.
- Gate the lib-only plugins (`dts`, `libInjectCss`, `nodeExternals`) and the lib `build` block behind `process.env.STORYBOOK`. Storybook now bundles deps as an app; `pnpm build` still produces the same library output.
- Enables hosting the static Storybook on Vercel (e.g. `storybook.mastra.ai`) without runtime errors.

The goal is to not have this issue:

<img width="3060" height="2146" alt="CleanShot 2026-04-30 at 10 36 05@2x" src="https://github.com/user-attachments/assets/ac6b4469-7159-4be2-8c5c-e056e1bfebff" />

## Test plan

- [x] `pnpm --filter @mastra/playground-ui build-storybook` — succeeds, zero bare `lucide-react`/`react` imports in `storybook-static/assets/*.js`
- [x] `pnpm --filter @mastra/playground-ui build` — lib output unchanged (`dist/index.es.js` still externalizes `lucide-react`)
- [ ] Locally serve `storybook-static/` and confirm Docs page renders (`?path=/docs/elements-alert--docs`)
- [ ] Vercel preview deploy renders Docs page without browser errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Storybook was getting confused because the package's library build left some imports unbundled. This change makes Storybook build bundle those dependencies so the static Storybook site runs correctly, while keeping the package's library build behavior for publishing unchanged.

## Summary

This PR refactors packages/playground-ui's Vite config to distinguish between library-mode builds and Storybook builds so Storybook does not externalize dependencies or run the library build.

### Problem
Storybook inherited the package's library-mode Vite config (vite-plugin-dts, vite-plugin-lib-inject-css, rollup-plugin-node-externals, and build.lib). That produced bare imports (e.g., "lucide-react") in Storybook's static output and caused runtime errors like "Failed to resolve module specifier 'lucide-react'" on Docs pages.

### Solution
- Split Vite config into baseConfig and libConfig in packages/playground-ui/vite.config.ts:
  - baseConfig: common plugins (React, Tailwind-related plugin), alias '@' -> ./src, and no library-only plugins or build.lib.
  - libConfig: spreads baseConfig and adds vite-plugin-dts, vite-plugin-lib-inject-css, rollup-plugin-node-externals, and the multi-entry library build (build.lib) producing ES/CJS outputs.
- Add isStorybook = process.env.STORYBOOK === 'true' and export defineConfig(isStorybook ? baseConfig : libConfig) so:
  - When STORYBOOK=true, Storybook uses baseConfig (no lib-only plugins, no build.lib) and dependencies are bundled into the Storybook static output.
  - When not STORYBOOK, the existing library-mode behavior (dts, libInjectCss, nodeExternals, build.lib) is preserved for package publishing.
- Simplified packages/playground-ui/.storybook/main.ts:
  - Removed the redundant viteFinal override entirely.

### Files changed
- packages/playground-ui/vite.config.ts
  - Added baseConfig and libConfig, introduced isStorybook gating, and conditional default export.
- packages/playground-ui/.storybook/main.ts
  - Removed the viteFinal override.

### Impact / Test status
- pnpm --filter @mastra/playground-ui build-storybook — checked: succeeds; storybook-static/assets/*.js contain no bare lucide-react/react imports.
- pnpm --filter @mastra/playground-ui build — checked: library output unchanged; dist/index.es.js still externalizes lucide-react.
- Locally serving storybook-static/ — pending.
- Vercel preview deploy — pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->