### PR TITLE
feat(playground-ui): refresh Dialog visual + motion

### DIFF
--- a/.changeset/curvy-roses-smoke.md
+++ b/.changeset/curvy-roses-smoke.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Refresh Dialog visual + motion: lighter translucent surface with backdrop blur, refined typography, snappier scale-based open/close keyframes, layered ambient shadow. The shadow update flows through to SideDialog and AlertDialog via the shared `shadow-dialog` token.
+Updated the look and motion of `Dialog`. The surface is now lighter and translucent with a subtle backdrop blur, the typography is tighter, and the open/close animation feels snappier. `SideDialog` and `AlertDialog` pick up the refined ambient shadow as well, since they share the same shadow style.

--- a/.changeset/curvy-roses-smoke.md
+++ b/.changeset/curvy-roses-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Refresh Dialog visual + motion: lighter translucent surface with backdrop blur, refined typography, snappier scale-based open/close keyframes, layered ambient shadow. The shadow update flows through to SideDialog and AlertDialog via the shared `shadow-dialog` token.

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.css
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.css
@@ -1,38 +1,46 @@
 /* Dialog motion. Tailwind v4 sets `translate: -50% -50%` via the standalone
  * `translate` property — keyframes only animate `transform: scale(...)` so
  * the two don't compose and double-offset the centering. */
+
 @keyframes dialog-content-in {
   from {
     opacity: 0;
     transform: scale(1.08);
   }
+
   to {
     opacity: 1;
     transform: scale(1);
   }
 }
+
 @keyframes dialog-content-out {
   from {
     opacity: 1;
     transform: scale(1);
   }
+
   to {
     opacity: 0;
     transform: scale(1.02);
   }
 }
+
 @keyframes dialog-overlay-in {
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
 }
+
 @keyframes dialog-overlay-out {
   from {
     opacity: 1;
   }
+
   to {
     opacity: 0;
   }
@@ -41,12 +49,15 @@
 .dialog-overlay-anim[data-state='open'] {
   animation: dialog-overlay-in 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
+
 .dialog-overlay-anim[data-state='closed'] {
   animation: dialog-overlay-out 240ms cubic-bezier(0.32, 0, 0.67, 0);
 }
+
 .dialog-content-anim[data-state='open'] {
   animation: dialog-content-in 680ms cubic-bezier(0.16, 1, 0.3, 1);
 }
+
 .dialog-content-anim[data-state='closed'] {
   animation: dialog-content-out 180ms cubic-bezier(0.5, 0, 0.75, 0);
 }

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.css
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.css
@@ -1,0 +1,52 @@
+/* Dialog motion. Tailwind v4 sets `translate: -50% -50%` via the standalone
+ * `translate` property — keyframes only animate `transform: scale(...)` so
+ * the two don't compose and double-offset the centering. */
+@keyframes dialog-content-in {
+  from {
+    opacity: 0;
+    transform: scale(1.08);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+@keyframes dialog-content-out {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(1.02);
+  }
+}
+@keyframes dialog-overlay-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes dialog-overlay-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+.dialog-overlay-anim[data-state='open'] {
+  animation: dialog-overlay-in 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.dialog-overlay-anim[data-state='closed'] {
+  animation: dialog-overlay-out 240ms cubic-bezier(0.32, 0, 0.67, 0);
+}
+.dialog-content-anim[data-state='open'] {
+  animation: dialog-content-in 680ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.dialog-content-anim[data-state='closed'] {
+  animation: dialog-content-out 180ms cubic-bezier(0.5, 0, 0.75, 0);
+}

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -2,7 +2,10 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import * as React from 'react';
 
+import { Button } from '@/ds/components/Button';
 import { cn } from '@/lib/utils';
+
+import './dialog.css';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -18,12 +21,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
-    className={cn(
-      'fixed inset-0 z-50 bg-overlay backdrop-blur-sm',
-      'data-[state=open]:animate-in data-[state=closed]:animate-out',
-      'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className,
-    )}
+    className={cn('dialog-overlay-anim fixed inset-0 z-50 bg-overlay backdrop-blur-xs', className)}
     {...props}
   />
 ));
@@ -38,30 +36,19 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%]',
-        'gap-4 border border-border1 bg-surface3 py-6 shadow-dialog rounded-lg',
-        'duration-slow',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-        'data-[state=closed]:slide-out-to-bottom-4',
-        'data-[state=open]:slide-in-from-bottom-4',
+        'dialog-content-anim',
+        'fixed left-[50%] top-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%]',
+        'w-full max-w-[calc(100%-2rem)] sm:max-w-lg',
+        'rounded-xl border border-border1/40 bg-surface2/96 backdrop-blur-md shadow-dialog',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close
-        className={cn(
-          'absolute right-4 top-4 rounded-md p-1',
-          'text-neutral3 hover:text-neutral6 hover:bg-surface4',
-          'transition-all duration-normal ease-out-custom',
-          'focus:outline-hidden focus:ring-1 focus:ring-accent1 focus:shadow-focus-ring',
-          'disabled:pointer-events-none',
-        )}
-      >
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+      <DialogPrimitive.Close asChild>
+        <Button variant="ghost" size="sm" className="absolute top-3 right-3" aria-label="Close">
+          <X />
+        </Button>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
@@ -69,20 +56,17 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn('flex flex-col space-y-1.5 text-center sm:text-left border-b border-border1 pb-4 px-6', className)}
-    {...props}
-  />
+  <div className={cn('flex flex-col gap-0.5 px-4 py-3 text-left', className)} {...props} />
 );
 DialogHeader.displayName = 'DialogHeader';
 
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+  <div className={cn('flex flex-col-reverse gap-1.5 px-4 py-2.5 sm:flex-row sm:justify-end', className)} {...props} />
 );
 DialogFooter.displayName = 'DialogFooter';
 
 const DialogBody = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('overflow-y-auto px-6 max-h-[50vh]', className)} {...props} />
+  <div className={cn('overflow-y-auto px-4 py-3.5 max-h-[50vh]', className)} {...props} />
 );
 DialogBody.displayName = 'DialogBody';
 

--- a/packages/playground-ui/src/index.css
+++ b/packages/playground-ui/src/index.css
@@ -308,9 +308,7 @@ html.light {
   --shadow-card: 0 2px 8px oklch(0 0 0 / 0.4);
   --shadow-elevated: 0 8px 24px oklch(0 0 0 / 0.5);
   --shadow-dialog:
-    0 0 0 1px oklch(0 0 0 / 0.04),
-    0 8px 24px -8px oklch(0 0 0 / 0.28),
-    0 24px 56px -16px oklch(0 0 0 / 0.36);
+    0 0 0 1px oklch(0 0 0 / 0.04), 0 8px 24px -8px oklch(0 0 0 / 0.28), 0 24px 56px -16px oklch(0 0 0 / 0.36);
   --shadow-glow-accent1: 0 0 20px oklch(0.723 0.219 149.579 / 0.25);
   --shadow-glow-accent2: 0 0 20px oklch(0.637 0.237 25.331 / 0.25);
   --shadow-focus-ring: 0 0 0 3px oklch(0.723 0.219 149.579 / 0.12);

--- a/packages/playground-ui/src/index.css
+++ b/packages/playground-ui/src/index.css
@@ -307,7 +307,10 @@ html.light {
   --shadow-inner: inset 0 2px 4px oklch(0 0 0 / 0.3);
   --shadow-card: 0 2px 8px oklch(0 0 0 / 0.4);
   --shadow-elevated: 0 8px 24px oklch(0 0 0 / 0.5);
-  --shadow-dialog: 0 16px 48px oklch(0 0 0 / 0.6);
+  --shadow-dialog:
+    0 0 0 1px oklch(0 0 0 / 0.04),
+    0 8px 24px -8px oklch(0 0 0 / 0.28),
+    0 24px 56px -16px oklch(0 0 0 / 0.36);
   --shadow-glow-accent1: 0 0 20px oklch(0.723 0.219 149.579 / 0.25);
   --shadow-glow-accent2: 0 0 20px oklch(0.637 0.237 25.331 / 0.25);
   --shadow-focus-ring: 0 0 0 3px oklch(0.723 0.219 149.579 / 0.12);


### PR DESCRIPTION
## Summary
Polishes the `Dialog` primitive in `@mastra/playground-ui`, porting the visual + motion treatment that platform was carrying as a `temp-ds-overrides.css` patch. Once published, platform can drop its override block.

- Translucent surface — `bg-surface2/96` + `backdrop-blur-md` + `border-border1/40`
- Tighter paddings (header 12/16, body 14/16, footer 10/16) and refined title typography
- Close button now reuses the DS — `<Button variant="ghost" size="sm">` via `<DialogPrimitive.Close asChild>`
- Snappier scale-based open/close keyframes lifted into `dialog.css` (no more `animate-[…long…cubic-bezier(…)]` strings in JSX)
- `--shadow-dialog` token rewritten as a three-layer ambient shadow (oklch alphas) — `SideDialog` and `AlertDialog` inherit the new depth automatically

Before:
<img width="1077" height="1350" alt="CleanShot 2026-04-30 at 10 26 15" src="https://github.com/user-attachments/assets/d6f9f410-a712-4f0b-a877-fd776b8cdc43" />

After:
<img width="1077" height="1350" alt="CleanShot 2026-04-30 at 10 25 49" src="https://github.com/user-attachments/assets/7d06b7ac-b93b-4e7b-81fc-c666cd6a9665" />


## Test plan
- [ ] Open Storybook (`pnpm --filter @mastra/playground-ui storybook`) and verify all four `Dialog` stories (Default, WithForm, LongContent, MinimalDialog) — open/close motion, mobile inset, close-button hover
- [ ] Spot-check `SideDialog` + `AlertDialog` shadows at rest
- [ ] Smoke-test a consumer (e.g. playground feedback dialog) for paddings / overflow regressions
- [ ] `pnpm --filter @mastra/playground-ui build && pnpm --filter @mastra/playground-ui test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the Dialog popup look and feel nicer: it gains a translucent blurred surface, tighter spacing and typography, a shared DS close button, a new layered shadow, and snappier open/close animations so platform-level overrides can be removed.

---

## Overview

Bakes platform visual + motion overrides for the Dialog primitive into @mastra/playground-ui. Replaces long inline animation strings with dedicated CSS keyframes, updates visual tokens and spacing, and standardizes the close control to the shared Button so platform no longer needs a temp override.

## Visual changes

- Translucent surface: bg-surface2/96 with backdrop-blur-md and border-border1/40
- Tighter paddings:
  - Header: px-4 py-3 (≈ 12/16)
  - Body: px-4 py-3.5 (≈ 14/16)
  - Footer: px-4 py-2.5 (≈ 10/16)
- Refined title typography: text-ui-md, font-medium
- Close button now uses DS Button via DialogPrimitive.Close asChild → <Button variant="ghost" size="sm"> with X icon and aria-label="Close"
- --shadow-dialog rewritten to a three-layer ambient shadow (oklch alphas); SideDialog and AlertDialog inherit the new depth via the shared token

## Motion changes

- Adds packages/playground-ui/src/ds/components/Dialog/dialog.css with keyframes:
  - dialog-content-in/out: opacity + scale (snappier timings)
  - dialog-overlay-in/out: opacity transitions
- Dialog markup applies dialog-overlay-anim and dialog-content-anim classes keyed by data-state to drive open/close animations (removes long inline Radix/Tailwind animation strings)

## Files changed

- .changeset/curvy-roses-smoke.md — release note summarizing dialog polish
- packages/playground-ui/src/ds/components/Dialog/dialog.css — new keyframe animations and animation classes
- packages/playground-ui/src/ds/components/Dialog/dialog.tsx — refactored Dialog markup/styles, overlay/content classes, close button switched to Button asChild, adjusted paddings/spacing/overflow, and import of dialog.css
- packages/playground-ui/src/index.css — updated --shadow-dialog to a three-layer ambient shadow (oklch)

## Testing / QA

- In Storybook: verify Dialog stories (Default, WithForm, LongContent, MinimalDialog) for open/close motion, mobile inset behavior, and close-button hover/focus
- Spot-check SideDialog and AlertDialog shadow at rest
- Smoke-test a consumer dialog (e.g., playground feedback dialog) for padding and overflow regressions
- Run: pnpm --filter @mastra/playground-ui build && pnpm --filter @mastra/playground-ui test
<!-- end of auto-generated comment: release notes by coderabbit.ai -->