### PR TITLE
DataList style update

### DIFF
--- a/.changeset/hungry-owls-mix.md
+++ b/.changeset/hungry-owls-mix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Polished DataList visuals: removed the trailing "No more data to load" message and dropped the bottom border on the last row for a cleaner end-of-list appearance.

--- a/packages/playground-ui/src/ds/components/DataList/data-list-next-page-loading.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-next-page-loading.tsx
@@ -1,9 +1,10 @@
+import { cn } from '@/lib/utils';
+
 export type DataListNextPageLoadingProps = {
   isLoading?: boolean;
   hasMore?: boolean;
   setEndOfListElement?: (element: HTMLDivElement | null) => void;
   loadingText?: string;
-  noMoreDataText?: string;
 };
 
 export function DataListNextPageLoading({
@@ -11,7 +12,6 @@ export function DataListNextPageLoading({
   hasMore,
   setEndOfListElement,
   loadingText = 'Loading more data...',
-  noMoreDataText = 'No more data to load',
 }: DataListNextPageLoadingProps) {
   if (!setEndOfListElement) {
     return null;
@@ -20,10 +20,11 @@ export function DataListNextPageLoading({
   return (
     <div
       ref={setEndOfListElement}
-      className="col-span-full text-ui-md text-neutral3 opacity-50 flex py-4 justify-center"
+      className={cn('col-span-full text-ui-md text-neutral3 opacity-50 flex justify-center min-h-1', {
+        'py-4': isLoading,
+      })}
     >
       {isLoading && loadingText}
-      {!hasMore && !isLoading && noMoreDataText}
     </div>
   );
 }

--- a/packages/playground-ui/src/ds/components/DataList/data-list-next-page-loading.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-next-page-loading.tsx
@@ -9,8 +9,8 @@ export type DataListNextPageLoadingProps = {
 
 export function DataListNextPageLoading({
   isLoading,
-  hasMore,
   setEndOfListElement,
+  hasMore,
   loadingText = 'Loading more data...',
 }: DataListNextPageLoadingProps) {
   if (!setEndOfListElement) {
@@ -22,6 +22,7 @@ export function DataListNextPageLoading({
       ref={setEndOfListElement}
       className={cn('col-span-full text-ui-md text-neutral3 opacity-50 flex justify-center min-h-1', {
         'py-4': isLoading,
+        'py-0': !hasMore,
       })}
     >
       {isLoading && loadingText}

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -4,5 +4,6 @@ export const dataListRowStyles = [
   '[.data-list-row:hover+&]:border-t-transparent [.data-list-row:focus-visible+&]:border-t-transparent',
   '[.data-list-subheader+&]:border-t-transparent',
   '[&:has(+.data-list-subheader)]:border-b-transparent',
+  '[&:not(:has(~.data-list-row))]:border-b-transparent',
   'transition-colors duration-200 rounded-lg',
 ] as const;

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -34,11 +34,11 @@ import { useSearchParams } from 'react-router';
 import { TraceAsItemDialog } from '@/domains/observability/components/trace-as-item-dialog';
 import { useScorers } from '@/domains/scores';
 import { useTraceSpanScores } from '@/domains/scores/hooks/use-trace-span-scores';
-import { SpanFeedbackList } from '@/domains/traces/components/span-feedback-list';
-import { useTraceFeedback } from '@/domains/traces/hooks/use-trace-feedback';
 import { ScoreDataPanel } from '@/domains/traces/components/score-data-panel';
+import { SpanFeedbackList } from '@/domains/traces/components/span-feedback-list';
 import { SpanScoresList } from '@/domains/traces/components/span-scores-list';
 import { SpanScoring } from '@/domains/traces/components/span-scoring';
+import { useTraceFeedback } from '@/domains/traces/hooks/use-trace-feedback';
 import { Link } from '@/lib/link';
 
 export default function TracesPage() {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
- remove "No more data to load"
- remove the last border


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes the DataList look cleaner by removing the "No more data to load" message at the end of lists and hiding the bottom border under the last row so the list edge appears less cluttered.

## Changes

### UI/UX Updates
- Removed the end-of-list message: the DataList no longer shows "No more data to load" and the `noMoreDataText` prop was removed from the component API.
- Removed last-row border: added a CSS rule to make the bottom border transparent when a row has no following `.data-list-row` sibling.
- Loading layout tweaks: added `min-h-1` to the loading wrapper and made vertical padding conditional on `isLoading` (uses `py-4` when loading, `py-0` when no more data).

### Files Modified
- `packages/playground-ui/src/ds/components/DataList/data-list-next-page-loading.tsx` - removed "no more data" rendering and `noMoreDataText` prop; adjusted loading wrapper styles.
- `packages/playground-ui/src/ds/components/DataList/shared.ts` - added conditional border styling for the last row.
- `.changeset/hungry-owls-mix.md` - added changeset entry for `@mastra/playground-ui` patch release.
- `packages/playground/src/pages/traces/index.tsx` - import reordering (no functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->