### PR TITLE
docs: address followup feedback on ClickHouse storage docs

### DIFF
--- a/docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx
+++ b/docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx
@@ -125,7 +125,7 @@ When you spot a spike in latency or token usage on the Metrics dashboard, correl
 
 - **Observability is configured**: Verify that your `Mastra` instance has an `observability` config with at least one exporter.
 - **`DefaultExporter` is present**: Other exporters (Datadog, Langfuse, etc.) don't persist metrics to Mastra storage. `DefaultExporter` is required for the Studio dashboard.
-- **Storage supports metrics**: Metrics require an OLAP-capable store (ClickHouse or DuckDB). Relational databases such as PostgreSQL, LibSQL, MSSQL, and MongoDB are not supported for metrics.
+- **Storage supports metrics**: Metrics require an OLAP-capable store (ClickHouse or DuckDB). Row-oriented databases (PostgreSQL, LibSQL, MSSQL) and document stores (MongoDB) are not supported for metrics.
 - **Sampling isn't 0%**: If sampling probability is `0` or strategy is `never`, all spans become no-ops and no metrics are extracted.
 
 ### Duration metrics are missing

--- a/docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx
+++ b/docs/src/content/en/reference/observability/metrics/automatic-metrics.mdx
@@ -22,7 +22,7 @@ Metrics are routed through an internal event bus to the `DefaultExporter`, which
 Two conditions must be true for a metric to reach storage:
 
 1. `DefaultExporter` is configured as an exporter.
-1. The storage backend supports metrics (ClickHouse, DuckDB, or in-memory).
+1. The storage backend supports metrics (ClickHouse or DuckDB).
 
 If metrics aren't appearing, see [troubleshooting](#troubleshooting).
 
@@ -125,7 +125,7 @@ When you spot a spike in latency or token usage on the Metrics dashboard, correl
 
 - **Observability is configured**: Verify that your `Mastra` instance has an `observability` config with at least one exporter.
 - **`DefaultExporter` is present**: Other exporters (Datadog, Langfuse, etc.) don't persist metrics to Mastra storage. `DefaultExporter` is required for the Studio dashboard.
-- **Storage supports metrics**: Metrics require a separate OLAP store for observability. Relational databases like PostgreSQL, LibSQL, etc. are not supported for metrics. In-memory storage resets on restart.
+- **Storage supports metrics**: Metrics require an OLAP-capable store (ClickHouse or DuckDB). Relational databases such as PostgreSQL, LibSQL, MSSQL, and MongoDB are not supported for metrics.
 - **Sampling isn't 0%**: If sampling probability is `0` or strategy is `never`, all spans become no-ops and no metrics are extracted.
 
 ### Duration metrics are missing

--- a/docs/src/content/en/reference/storage/clickhouse.mdx
+++ b/docs/src/content/en/reference/storage/clickhouse.mdx
@@ -10,15 +10,13 @@ packages:
 
 [ClickHouse](https://clickhouse.com/) is a columnar database designed for analytical workloads. The `@mastra/clickhouse` package provides storage adapters for several Mastra storage domains and is the recommended backend for production observability.
 
-ClickHouse is most commonly used as the dedicated observability backend in a [composite storage](/reference/storage/composite) setup, with another database serving the remaining domains. It can also back the supported domains on its own through `ClickhouseStore`.
+ClickHouse is most commonly used as the dedicated observability backend in a [composite storage](/reference/storage/composite) setup, with another database serving the remaining domains.
 
 ## When to use ClickHouse
 
-- Production observability for traces, logs, metrics, scores, and feedback.
-- Append-heavy workloads where columnar storage and compression help keep costs down.
-- Deployment platforms with ephemeral filesystems (such as [Railway](#deploying-with-railway-and-similar-platforms), Fly.io, Render, Heroku, or container schedulers) where embedded backends like DuckDB cannot persist data.
+Production observability for traces, logs, metrics, scores, and feedback.
 
-For local development, [LibSQL](/reference/storage/libsql) or `@mastra/duckdb` are usually a better fit because they need no external service.
+For local development, use a composite store that combines [LibSQL](/reference/storage/libsql) (for memory and workflows) and `@mastra/duckdb` (for observability). Neither alone covers a development setup: LibSQL does not implement the observability domain, and DuckDB does not implement the other domains. See the [observability overview](/docs/observability/overview#get-started) for an example.
 
 ## Installation
 
@@ -39,7 +37,7 @@ Compose it with another storage adapter so observability writes do not contend w
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
 import { MastraCompositeStore } from '@mastra/core/storage'
-import { LibSQLStore } from '@mastra/libsql'
+import { PostgresStore } from '@mastra/pg'
 import { ObservabilityStorageClickhouseVNext } from '@mastra/clickhouse'
 import { Observability, DefaultExporter } from '@mastra/observability'
 
@@ -52,9 +50,9 @@ const observabilityStore = new ObservabilityStorageClickhouseVNext({
 export const mastra = new Mastra({
   storage: new MastraCompositeStore({
     id: 'composite-storage',
-    default: new LibSQLStore({
-      id: 'mastra-storage',
-      url: 'file:./mastra.db',
+    default: new PostgresStore({
+      id: 'pg',
+      connectionString: process.env.DATABASE_URL!,
     }),
     domains: {
       observability: observabilityStore,
@@ -89,20 +87,28 @@ const observabilityStore = new ObservabilityStorageClickhouse({
 
 New projects should use `ObservabilityStorageClickhouseVNext` instead.
 
-### Full storage with `ClickhouseStore`
+### ClickHouse for every domain
 
-`ClickhouseStore` implements the `memory`, `workflows`, `scores`, and `observability` domains. Use it when you want a single backend for the supported domains. For most observability deployments, the composite setup above is preferable because it isolates observability writes from primary application data.
+`ClickhouseStore` implements the `memory`, `workflows`, and `observability` domains, and is suitable when you want ClickHouse to back the entire application. Its built-in observability domain uses the legacy adapter, so wrap it in a composite store that overrides the `observability` domain with `ObservabilityStorageClickhouseVNext`:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
-import { ClickhouseStore } from '@mastra/clickhouse'
+import { MastraCompositeStore } from '@mastra/core/storage'
+import { ClickhouseStore, ObservabilityStorageClickhouseVNext } from '@mastra/clickhouse'
+
+const credentials = {
+  url: process.env.CLICKHOUSE_URL!,
+  username: process.env.CLICKHOUSE_USERNAME!,
+  password: process.env.CLICKHOUSE_PASSWORD!,
+}
 
 export const mastra = new Mastra({
-  storage: new ClickhouseStore({
-    id: 'clickhouse-storage',
-    url: process.env.CLICKHOUSE_URL!,
-    username: process.env.CLICKHOUSE_USERNAME!,
-    password: process.env.CLICKHOUSE_PASSWORD!,
+  storage: new MastraCompositeStore({
+    id: 'composite-storage',
+    default: new ClickhouseStore({ id: 'clickhouse-storage', ...credentials }),
+    domains: {
+      observability: new ObservabilityStorageClickhouseVNext(credentials),
+    },
   }),
 })
 ```
@@ -157,7 +163,7 @@ The same `client` form is accepted by `ObservabilityStorageClickhouse` and `Obse
     name: 'password',
     type: 'string',
     description:
-      'ClickHouse password. Required when not passing a pre-configured `client`. Can be an empty string for the default user on a local instance.',
+      'ClickHouse password. Required when not passing a pre-configured `client`. It can be an empty string for the default user on a local instance.',
     isOptional: true,
   },
   {


### PR DESCRIPTION
Followup to #15912, which was merged before all the review comments were addressed.

## Changes

### `reference/storage/clickhouse.mdx`

- **Intro** (line 13): drop the trailing _"It can also back the supported domains on its own through `ClickhouseStore`"_ sentence — the recommended pattern is always composite + vNext.
- **"When to use ClickHouse"**: collapse the bullet list to a single line _"Production observability for traces, logs, metrics, scores, and feedback."_ Drop the append-heavy and ephemeral-filesystem bullets.
- **Local-dev guidance**: change `LibSQL **or** DuckDB` to `LibSQL **AND** DuckDB`. Neither alone covers a dev setup (LibSQL doesn't implement observability, DuckDB doesn't implement the other domains). Link to the [observability overview's example](/docs/observability/overview#get-started).
- **vNext composite example**: switch the primary store from `LibSQLStore` to `PostgresStore`. LibSQL + ClickHouse isn't a realistic pairing.
- **"Full storage with `ClickhouseStore`"** → renamed to **"ClickHouse for every domain"**: drop the deprecated `scores` domain. Even with `ClickhouseStore` as the default, show a composite that overrides the observability domain with `ObservabilityStorageClickhouseVNext` so vNext is used end-to-end.
- **Password property description**: fix sentence fragment (_"Can be..."_ → _"It can be..."_) flagged by CodeRabbit.

### `reference/observability/metrics/automatic-metrics.mdx`

- Remove all in-memory store mentions; the in-memory store is for internal Mastra development, not customer use.

https://claude.ai/code/session_01AzAdE2Ba5nsB8y2BebCFtK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzAdE2Ba5nsB8y2BebCFtK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR updates docs to stop saying "use ClickHouse for everything" and instead shows how to combine ClickHouse with other stores (Postgres/LibSQL + DuckDB) for correct production and local setups. It also removes mentions of an internal in-memory store that customers should not use.

---

## Changes

### docs/reference/storage/clickhouse.mdx
- Removed the intro sentence implying ClickhouseStore alone can back all supported domains; now recommends composite + vNext patterns.
- Collapsed "When to use ClickHouse" bullets into one line: "Production observability for traces, logs, metrics, scores, and feedback." Removed append-heavy and ephemeral-filesystem bullets.
- Local-dev guidance: changed "LibSQL **or** DuckDB" to "LibSQL **AND** DuckDB" and linked to the observability overview example.
- vNext composite example: use PostgresStore as the primary store (instead of LibSQLStore).
- Renamed "Full storage with `ClickhouseStore`" to "ClickHouse for every domain"; dropped the deprecated `scores` domain reference. Added a composite example that overrides observability with `ObservabilityStorageClickhouseVNext` so vNext is used end-to-end even when ClickhouseStore is default.
- Fixed a sentence fragment in the ClickhouseStore password property ("Can be..." → "It can be...").

### docs/reference/observability/metrics/automatic-metrics.mdx
- Removed all mentions of the in-memory store (internal to development, not for customers).
- Clarified metrics backend support to OLAP-capable stores limited to ClickHouse and DuckDB.
- Updated troubleshooting guidance to distinguish row-oriented stores (Postgres, LibSQL, MSSQL) from document stores (MongoDB) and mark them as unsupported for metrics persistence.

---

## Notes
- No code changes in this PR; a separate change will add a ClickhouseStoreVNext helper (composite + vNext override) tracked elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->