### PR TITLE
DataPanel Loading style - less attention-grabbing

### DIFF
--- a/.changeset/twelve-signs-arrive.md
+++ b/.changeset/twelve-signs-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Refined the DataPanel loading state with a smaller spinner and tightened layout for a less prominent appearance.

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-loading-data.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-loading-data.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { Spinner } from '@/ds/components/Spinner';
+import { Colors } from '@/ds/tokens';
 
 export interface DataPanelLoadingDataProps {
   children?: ReactNode;
@@ -7,8 +8,8 @@ export interface DataPanelLoadingDataProps {
 
 export function DataPanelLoadingData({ children }: DataPanelLoadingDataProps) {
   return (
-    <div className="flex items-center justify-center gap-2 px-4 py-6 text-ui-sm text-neutral3">
-      <Spinner /> {children ?? 'Loading...'}
+    <div className="flex items-center justify-center gap-2 px-4 py-6 text-ui-sm text-neutral2 min-h-32">
+      <Spinner size="sm" color={Colors.neutral1} /> {children ?? 'Loading...'}
     </div>
   );
 }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the loading indicator in the DataPanel less noticeable by making the spinner smaller, adjusting colors to be more subtle, and ensuring consistent spacing around it. Think of it like turning down the volume on an announcement when you want things to feel calmer.

## Changes

### Changeset
- Added a new changeset file (`.changeset/twelve-signs-arrive.md`) for `@mastra/playground-ui` marking a patch release

### DataPanel Loading Component
Updated `packages/playground-ui/src/ds/components/DataPanel/data-panel-loading-data.tsx`:
- **Spinner size**: Changed from default to `size="sm"` for a smaller visual footprint
- **Spinner color**: Updated to use `Colors.neutral1` for better integration with the UI
- **Text color**: Changed from `text-neutral3` to `text-neutral2` for improved contrast
- **Height constraint**: Added `min-h-32` to the container for consistent spacing

These changes work together to make the loading state less attention-grabbing while maintaining clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->