### PR TITLE
[discussion] fix(otel-exporter): use spec-compliant gen_ai.usage.cache_* attribute names

### DIFF
--- a/.changeset/new-pets-live.md
+++ b/.changeset/new-pets-live.md
@@ -1,17 +1,17 @@
 ---
 '@mastra/otel-exporter': patch
 '@mastra/arize': patch
+'@mastra/arthur': patch
+'@mastra/sentry': patch
 ---
 
-Renamed two emitted OTel GenAI usage attributes to match the OpenTelemetry GenAI semantic conventions registry (`gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cache_creation.input_tokens`, both added to the registry in semconv `v1.40.0` which `@mastra/otel-exporter` already depends on):
+Renamed emitted OTel GenAI cache usage attributes to match the OpenTelemetry semantic conventions:
 
 - `gen_ai.usage.cached_input_tokens` → `gen_ai.usage.cache_read.input_tokens`
 - `gen_ai.usage.cache_write_tokens` → `gen_ai.usage.cache_creation.input_tokens`
 
-The math is unchanged: `gen_ai.usage.input_tokens` remains the total prompt-token count, and the cache attributes are subsets of it (per spec). `@mastra/arize` is updated in lockstep so its OpenInference translation continues to receive cache values.
+`gen_ai.usage.input_tokens` is unchanged and remains the total prompt-token count. Cache attributes are emitted separately as subsets of that total.
 
-**Why this matters**: spec-compliant downstream backends — including current Langfuse Cloud (`v3.172.0`+, server-side fix from [langfuse#13110](https://github.com/langfuse/langfuse/pull/13110)) — recognize the new names and not the old ones. Mastra users on Langfuse with prompt caching active have been seeing inflated input-token totals because Langfuse's normalizer didn't recognize Mastra's emitted names; this rename resolves that.
+Updated Arize, Arthur, and Sentry mappings so cache values continue to flow through those exporters.
 
-**Action required for direct consumers of these attributes**: any custom dashboard, alert, or query keyed off the old names needs to be updated to the new names.
-
-**Bump-level note**: this changeset uses `patch`, but the change is technically observable to anyone reading the old names. The bump level is part of the upstream discussion on the linked issue (see [mastra-ai/mastra#15962](https://github.com/mastra-ai/mastra/issues/15962)) — `patch`, `minor`, `major`, or dual-emit transition are all options. Adjust before release if needed.
+Direct consumers should update any dashboards, alerts, or queries that reference the old attribute names.

--- a/.changeset/new-pets-live.md
+++ b/.changeset/new-pets-live.md
@@ -1,0 +1,17 @@
+---
+'@mastra/otel-exporter': patch
+'@mastra/arize': patch
+---
+
+Renamed two emitted OTel GenAI usage attributes to match the OpenTelemetry GenAI semantic conventions registry (`gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cache_creation.input_tokens`, both added to the registry in semconv `v1.40.0` which `@mastra/otel-exporter` already depends on):
+
+- `gen_ai.usage.cached_input_tokens` → `gen_ai.usage.cache_read.input_tokens`
+- `gen_ai.usage.cache_write_tokens` → `gen_ai.usage.cache_creation.input_tokens`
+
+The math is unchanged: `gen_ai.usage.input_tokens` remains the total prompt-token count, and the cache attributes are subsets of it (per spec). `@mastra/arize` is updated in lockstep so its OpenInference translation continues to receive cache values.
+
+**Why this matters**: spec-compliant downstream backends — including current Langfuse Cloud (`v3.172.0`+, server-side fix from [langfuse#13110](https://github.com/langfuse/langfuse/pull/13110)) — recognize the new names and not the old ones. Mastra users on Langfuse with prompt caching active have been seeing inflated input-token totals because Langfuse's normalizer didn't recognize Mastra's emitted names; this rename resolves that.
+
+**Action required for direct consumers of these attributes**: any custom dashboard, alert, or query keyed off the old names needs to be updated to the new names.
+
+**Bump-level note**: this changeset uses `patch`, but the change is technically observable to anyone reading the old names. The bump level is part of the upstream discussion on the linked issue (see [mastra-ai/mastra#15962](https://github.com/mastra-ai/mastra/issues/15962)) — `patch`, `minor`, `major`, or dual-emit transition are all options. Adjust before release if needed.

--- a/observability/arize/src/openInferenceOTLPExporter.ts
+++ b/observability/arize/src/openInferenceOTLPExporter.ts
@@ -33,9 +33,10 @@ import {
 } from '@opentelemetry/semantic-conventions/incubating';
 
 // GenAI usage attribute keys (not all are in @opentelemetry/semantic-conventions yet)
+// @see https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/
 const GEN_AI_USAGE_REASONING_TOKENS = 'gen_ai.usage.reasoning_tokens';
-const GEN_AI_USAGE_CACHED_INPUT_TOKENS = 'gen_ai.usage.cached_input_tokens';
-const GEN_AI_USAGE_CACHE_WRITE_TOKENS = 'gen_ai.usage.cache_write_tokens';
+const GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = 'gen_ai.usage.cache_read.input_tokens';
+const GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = 'gen_ai.usage.cache_creation.input_tokens';
 const GEN_AI_USAGE_AUDIO_INPUT_TOKENS = 'gen_ai.usage.audio_input_tokens';
 const GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS = 'gen_ai.usage.audio_output_tokens';
 
@@ -90,14 +91,14 @@ function convertUsageMetricsToOpenInference(attributes: Record<string, any>): Re
   }
 
   // Cache tokens (prompt details)
-  const cachedInputTokens = attributes[GEN_AI_USAGE_CACHED_INPUT_TOKENS];
-  if (cachedInputTokens !== undefined) {
-    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] = cachedInputTokens;
+  const cacheReadInputTokens = attributes[GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS];
+  if (cacheReadInputTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] = cacheReadInputTokens;
   }
 
-  const cacheWriteTokens = attributes[GEN_AI_USAGE_CACHE_WRITE_TOKENS];
-  if (cacheWriteTokens !== undefined) {
-    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE] = cacheWriteTokens;
+  const cacheCreationInputTokens = attributes[GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS];
+  if (cacheCreationInputTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE] = cacheCreationInputTokens;
   }
 
   // Reasoning tokens (completion details)

--- a/observability/arthur/src/openInferenceOTLPExporter.ts
+++ b/observability/arthur/src/openInferenceOTLPExporter.ts
@@ -34,8 +34,8 @@ import {
 
 // GenAI usage attribute keys (not all are in @opentelemetry/semantic-conventions yet)
 const GEN_AI_USAGE_REASONING_TOKENS = 'gen_ai.usage.reasoning_tokens';
-const GEN_AI_USAGE_CACHED_INPUT_TOKENS = 'gen_ai.usage.cached_input_tokens';
-const GEN_AI_USAGE_CACHE_WRITE_TOKENS = 'gen_ai.usage.cache_write_tokens';
+const GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = 'gen_ai.usage.cache_read.input_tokens';
+const GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = 'gen_ai.usage.cache_creation.input_tokens';
 const GEN_AI_USAGE_AUDIO_INPUT_TOKENS = 'gen_ai.usage.audio_input_tokens';
 const GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS = 'gen_ai.usage.audio_output_tokens';
 
@@ -90,14 +90,14 @@ function convertUsageMetricsToOpenInference(attributes: Record<string, any>): Re
   }
 
   // Cache tokens (prompt details)
-  const cachedInputTokens = attributes[GEN_AI_USAGE_CACHED_INPUT_TOKENS];
-  if (cachedInputTokens !== undefined) {
-    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] = cachedInputTokens;
+  const cacheReadInputTokens = attributes[GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS];
+  if (cacheReadInputTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] = cacheReadInputTokens;
   }
 
-  const cacheWriteTokens = attributes[GEN_AI_USAGE_CACHE_WRITE_TOKENS];
-  if (cacheWriteTokens !== undefined) {
-    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE] = cacheWriteTokens;
+  const cacheCreationInputTokens = attributes[GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS];
+  if (cacheCreationInputTokens !== undefined) {
+    result[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE] = cacheCreationInputTokens;
   }
 
   // Reasoning tokens (completion details)

--- a/observability/otel-exporter/src/gen-ai-semantics.test.ts
+++ b/observability/otel-exporter/src/gen-ai-semantics.test.ts
@@ -28,24 +28,24 @@ describe('getAttributes - token usage', () => {
     expect(attrs['gen_ai.usage.output_tokens']).toBe(50);
   });
 
-  it('should extract cacheRead from inputDetails', () => {
+  it('should extract cacheRead from inputDetails using OTel-spec attribute name', () => {
     const span = createModelGenerationSpan({
       model: 'claude-3-opus',
       provider: 'anthropic',
       usage: { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheRead: 800 } },
     });
     const attrs = getAttributes(span);
-    expect(attrs['gen_ai.usage.cached_input_tokens']).toBe(800);
+    expect(attrs['gen_ai.usage.cache_read.input_tokens']).toBe(800);
   });
 
-  it('should extract cacheWrite from inputDetails', () => {
+  it('should extract cacheWrite from inputDetails using OTel-spec attribute name', () => {
     const span = createModelGenerationSpan({
       model: 'claude-3-opus',
       provider: 'anthropic',
       usage: { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheWrite: 500 } },
     });
     const attrs = getAttributes(span);
-    expect(attrs['gen_ai.usage.cache_write_tokens']).toBe(500);
+    expect(attrs['gen_ai.usage.cache_creation.input_tokens']).toBe(500);
   });
 
   it('should extract reasoning from outputDetails', () => {
@@ -67,22 +67,33 @@ describe('formatUsageMetrics', () => {
     expect(result['gen_ai.usage.output_tokens']).toBe(50);
   });
 
-  it('should extract cacheRead from inputDetails', () => {
+  it('should extract cacheRead from inputDetails using OTel-spec attribute name', () => {
     const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheRead: 800 } };
     const result = formatUsageMetrics(usage);
-    expect(result['gen_ai.usage.cached_input_tokens']).toBe(800);
+    expect(result['gen_ai.usage.cache_read.input_tokens']).toBe(800);
   });
 
-  it('should extract cacheWrite from inputDetails', () => {
+  it('should extract cacheWrite from inputDetails using OTel-spec attribute name', () => {
     const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheWrite: 500 } };
     const result = formatUsageMetrics(usage);
-    expect(result['gen_ai.usage.cache_write_tokens']).toBe(500);
+    expect(result['gen_ai.usage.cache_creation.input_tokens']).toBe(500);
   });
 
   it('should extract reasoning from outputDetails', () => {
     const usage: UsageStats = { inputTokens: 100, outputTokens: 500, outputDetails: { reasoning: 400 } };
     const result = formatUsageMetrics(usage);
     expect(result['gen_ai.usage.reasoning_tokens']).toBe(400);
+  });
+
+  it('should not emit non-spec cache attribute names that older versions used', () => {
+    const usage: UsageStats = {
+      inputTokens: 1000,
+      outputTokens: 500,
+      inputDetails: { cacheRead: 600, cacheWrite: 200 },
+    };
+    const result = formatUsageMetrics(usage) as Record<string, unknown>;
+    expect(result['gen_ai.usage.cached_input_tokens']).toBeUndefined();
+    expect(result['gen_ai.usage.cache_write_tokens']).toBeUndefined();
   });
 
   it('should return empty metrics for undefined usage', () => {

--- a/observability/otel-exporter/src/gen-ai-semantics.ts
+++ b/observability/otel-exporter/src/gen-ai-semantics.ts
@@ -37,6 +37,8 @@ import {
   ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_USAGE_INPUT_TOKENS,
   ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
   ATTR_GEN_AI_AGENT_ID,
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_TOOL_DESCRIPTION,
@@ -58,9 +60,9 @@ import { convertMastraMessagesToGenAIMessages } from './gen-ai-messages';
 export interface OtelUsageMetrics {
   [ATTR_GEN_AI_USAGE_INPUT_TOKENS]?: number;
   [ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]?: number;
+  [ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]?: number;
+  [ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]?: number;
   'gen_ai.usage.reasoning_tokens'?: number;
-  'gen_ai.usage.cached_input_tokens'?: number;
-  'gen_ai.usage.cache_write_tokens'?: number;
   'gen_ai.usage.audio_input_tokens'?: number;
   'gen_ai.usage.audio_output_tokens'?: number;
 }
@@ -86,14 +88,14 @@ export function formatUsageMetrics(usage?: UsageStats): OtelUsageMetrics {
     metrics['gen_ai.usage.reasoning_tokens'] = usage.outputDetails.reasoning;
   }
 
-  // Cache read tokens from inputDetails
+  // Cache read input tokens (subset of input_tokens)
   if (usage.inputDetails?.cacheRead !== undefined) {
-    metrics['gen_ai.usage.cached_input_tokens'] = usage.inputDetails.cacheRead;
+    metrics[ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] = usage.inputDetails.cacheRead;
   }
 
-  // Cache write tokens from inputDetails
+  // Cache creation input tokens (subset of input_tokens)
   if (usage.inputDetails?.cacheWrite !== undefined) {
-    metrics['gen_ai.usage.cache_write_tokens'] = usage.inputDetails.cacheWrite;
+    metrics[ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS] = usage.inputDetails.cacheWrite;
   }
 
   // Audio tokens from inputDetails/outputDetails

--- a/observability/otel-exporter/src/span-converter.test.ts
+++ b/observability/otel-exporter/src/span-converter.test.ts
@@ -265,11 +265,12 @@ describe('SpanConverter', () => {
       expect(attrs['gen_ai.usage.input_tokens']).toBe(100);
       expect(attrs['gen_ai.usage.output_tokens']).toBe(50);
       expect(attrs['gen_ai.usage.reasoning_tokens']).toBe(20);
-      expect(attrs['gen_ai.usage.cached_input_tokens']).toBe(30);
+      expect(attrs['gen_ai.usage.cache_read.input_tokens']).toBe(30);
 
       // Should NOT have old naming
       expect(attrs['llm.usage.prompt_tokens']).toBeUndefined();
       expect(attrs['gen_ai.usage.prompt_tokens']).toBeUndefined();
+      expect(attrs['gen_ai.usage.cached_input_tokens']).toBeUndefined();
     });
   });
 

--- a/observability/sentry/README.md
+++ b/observability/sentry/README.md
@@ -125,8 +125,8 @@ const mastra = new Mastra({
 - `gen_ai.response.text`: Output text response
 - `gen_ai.usage.input_tokens`: Input token count
 - `gen_ai.usage.output_tokens`: Output token count
-- `gen_ai.usage.cache_read_input_tokens`: Cached input tokens
-- `gen_ai.usage.cache_write_input_tokens`: Cache write tokens
+- `gen_ai.usage.cache_read.input_tokens`: Cached input tokens
+- `gen_ai.usage.cache_creation.input_tokens`: Cache write tokens
 - `gen_ai.usage.reasoning_tokens`: Reasoning tokens (for models like o1)
 - `gen_ai.request.temperature`: Temperature parameter
 - `gen_ai.request.max_tokens`: Max tokens parameter
@@ -161,8 +161,8 @@ const mastra = new Mastra({
 - `gen_ai.usage.input_tokens`: Input tokens from the child MODEL_GENERATION span
 - `gen_ai.usage.output_tokens`: Output tokens from the child MODEL_GENERATION span
 - `gen_ai.usage.total_tokens`: Total tokens from the child MODEL_GENERATION span
-- `gen_ai.usage.cache_read_input_tokens`: Cached input tokens from the child MODEL_GENERATION span
-- `gen_ai.usage.cache_write_input_tokens`: Cache write tokens from the child MODEL_GENERATION span
+- `gen_ai.usage.cache_read.input_tokens`: Cached input tokens from the child MODEL_GENERATION span
+- `gen_ai.usage.cache_creation.input_tokens`: Cache write tokens from the child MODEL_GENERATION span
 - `gen_ai.usage.reasoning_tokens`: Reasoning tokens from the child MODEL_GENERATION span
 - `agent.max_steps`: Maximum steps allowed
 - `agent.available_tools`: Available tools (comma-separated)

--- a/observability/sentry/src/tracing.test.ts
+++ b/observability/sentry/src/tracing.test.ts
@@ -404,8 +404,8 @@ describe('SentryExporter', () => {
         expect.objectContaining({
           'gen_ai.usage.input_tokens': 150,
           'gen_ai.usage.output_tokens': 75,
-          'gen_ai.usage.cached_input_tokens': 100,
-          'gen_ai.usage.cache_write_tokens': 50,
+          'gen_ai.usage.cache_read.input_tokens': 100,
+          'gen_ai.usage.cache_creation.input_tokens': 50,
         }),
       );
     });
@@ -892,8 +892,8 @@ describe('SentryExporter', () => {
       // Verify tokens were copied to the parent span
       expect(mockSpan.setAttribute).toHaveBeenCalledWith('gen_ai.usage.input_tokens', 100);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith('gen_ai.usage.output_tokens', 50);
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith('gen_ai.usage.cache_read_input_tokens', 20);
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith('gen_ai.usage.cache_write_input_tokens', 10);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith('gen_ai.usage.cache_read.input_tokens', 20);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith('gen_ai.usage.cache_creation.input_tokens', 10);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith('gen_ai.usage.reasoning_tokens', 30);
     });
 

--- a/observability/sentry/src/tracing.ts
+++ b/observability/sentry/src/tracing.ts
@@ -69,8 +69,8 @@ const ATTRIBUTE_KEYS = {
   GEN_AI_USAGE_INPUT_TOKENS: 'gen_ai.usage.input_tokens',
   GEN_AI_USAGE_OUTPUT_TOKENS: 'gen_ai.usage.output_tokens',
   GEN_AI_USAGE_TOTAL_TOKENS: 'gen_ai.usage.total_tokens',
-  GEN_AI_USAGE_CACHE_READ_TOKENS: 'gen_ai.usage.cache_read_input_tokens',
-  GEN_AI_USAGE_CACHE_WRITE_TOKENS: 'gen_ai.usage.cache_write_input_tokens',
+  GEN_AI_USAGE_CACHE_READ_TOKENS: 'gen_ai.usage.cache_read.input_tokens',
+  GEN_AI_USAGE_CACHE_WRITE_TOKENS: 'gen_ai.usage.cache_creation.input_tokens',
   GEN_AI_USAGE_REASONING_TOKENS: 'gen_ai.usage.reasoning_tokens',
 } as const;
 


### PR DESCRIPTION
Hi Mastra team 👋

Following up on the issue https://github.com/mastra-ai/mastra/issues/15962, here is a draft proposal for "Option-A"

Full description generated by Claude Code 🤖 :

**This PR implements one of four options laid out in [issue #15962](https://github.com/mastra-ai/mastra/issues/15962). It is intentionally a draft — please weigh in on the issue thread on the bump strategy before merging.**

## Summary

Renames two emitted OTel GenAI usage attributes in `@mastra/otel-exporter` to match the [OpenTelemetry GenAI semantic conventions registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/) (added in semconv `v1.40.0`, the version `@mastra/otel-exporter` already depends on):

| Before | After | Constant |
|---|---|---|
| `gen_ai.usage.cached_input_tokens` | `gen_ai.usage.cache_read.input_tokens` | `ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS` |
| `gen_ai.usage.cache_write_tokens` | `gen_ai.usage.cache_creation.input_tokens` | `ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS` |

The math is unchanged: `gen_ai.usage.input_tokens` remains the total prompt-token count, and the cache attributes are subsets per spec. Only the attribute keys are renamed.

`@mastra/arize` is updated in lockstep — `openInferenceOTLPExporter.ts` consumes these exact names to translate them into OpenInference attributes, so the producer and consumer must move together.

`gen_ai.usage.reasoning_tokens` is **deliberately not renamed** in this PR. The spec defines `gen_ai.usage.reasoning.output_tokens`, but ecosystem adoption is currently against the spec name on this attribute (OpenLLMetry, VS Code Copilot, AgentOps, Pipecat, Trigger.dev all still emit the older form per GitHub code search at filing time — see issue #15962 for the data). We can revisit once upstream adoption converges.

## Why this is the right fix

See issue [#15962](https://github.com/mastra-ai/mastra/issues/15962) for the full picture. Short version:

1. **Spec backing**: both new names are first-class registry entries with named-constant exports in `@opentelemetry/semantic-conventions@1.40.0` (already a Mastra dependency).
2. **Ecosystem alignment**: `vercel/ai` (the AI SDK Mastra is built on), `pydantic-ai`, MLflow, Google ADK, OpenAI Codex, VSCode Copilot, OpenLLMetry, MLflow's OTel translation layer all emit the spec names. Adoption ratios for cache attributes: 8:1 (cache-read) and 4:1 (cache-creation) in favor of the spec names.
3. **Real user-visible bug**: current Langfuse Cloud (`v3.172.0`, server fix from [langfuse/langfuse#13110](https://github.com/langfuse/langfuse/pull/13110)) recognizes the spec names and correctly subtracts cache from `input_tokens`, but does **not** recognize Mastra's current names — causing the ~2× input-token inflation reported by users with prompt caching active. This rename directly resolves that.

## What this PR is NOT

- **Not a decision on semver-bump strategy.** The changeset uses `patch` so CI passes, but the bump level is the open question on issue #15962. Maintainers can change `patch` → `minor` / `major` before release, or rework into a dual-emit transition (Option D, with working precedent in OpenLLMetry's `LLM_USAGE_*` legacy aliases). Happy to revise.
- **Not a fix for the older `gen_ai.usage.reasoning_tokens`** — see "Summary" above for the adoption-data reasoning.
- **Not a fix for `gen_ai.usage.audio_input_tokens` / `audio_output_tokens`** — these have no spec equivalent in the registry and are out of scope.
- **Not a fix for the Mastra-internal `extractUsageMetrics` layer** (`observability/mastra/src/usage.ts`) — that's where #15316, #13381, #15828 etc. operate. This PR is purely at the OTel emit layer.

## What's tested

- `pnpm --filter @mastra/otel-exporter test` — 66/66 (one new test asserts non-spec keys are not emitted)
- `pnpm --filter @mastra/arize test` — 24/24 (existing E2E test through the full chain confirms cache values still flow into OpenInference attrs after the rename)
- `pnpm --filter @mastra/langfuse test` — 43/43 (sanity)
- `pnpm --filter @mastra/otel-bridge test` — 14/14 (sanity — uses `SpanConverter` directly)
- `pnpm --filter @mastra/otel-exporter build` — clean (tsup catches type errors)
- `pnpm --filter @mastra/otel-exporter lint` — clean
- `pnpm --filter @mastra/arize lint` — clean

CI on this PR will surface anything else (snapshot tests, doc generation, sample apps) that may have captured the old names — none expected, but worth verifying via the run.

## Files changed

| Path | Change |
|---|---|
| `observability/otel-exporter/src/gen-ai-semantics.ts` | Switched 2 emit lines to use the new spec constants; updated `OtelUsageMetrics` interface |
| `observability/otel-exporter/src/gen-ai-semantics.test.ts` | Updated 4 test assertions; added 1 guard test that the renamed-from non-spec keys are not emitted |
| `observability/otel-exporter/src/span-converter.test.ts` | Updated 1 assertion + 1 negative assertion (around line 265) |
| `observability/arize/src/openInferenceOTLPExporter.ts` | Renamed two consumed-attribute string constants to match the new emit |
| `.changeset/new-pets-live.md` | Coordinated patch changeset for `@mastra/otel-exporter` and `@mastra/arize`, with explicit note that the bump level is part of the upstream discussion |

5 files changed, 81 insertions(+), 24 deletions(-).

## Verification

The fix can be verified end-to-end without Langfuse:

1. `pnpm --filter @mastra/otel-exporter build`
2. Wire up any OTel receiver and run a Mastra agent that produces `usage.inputDetails.cacheRead > 0`
3. Confirm the receiver sees `gen_ai.usage.cache_read.input_tokens` instead of `gen_ai.usage.cached_input_tokens`. Same value; new name.

For the Langfuse-symptom verification specifically: with Langfuse Cloud `v3.172.0` (current), the input-token total displayed for a prompt-cached generation should now match LiteLLM / provider billing rather than being inflated by the cached portion.

## Closes / Refs

Refs [#15962](https://github.com/mastra-ai/mastra/issues/15962).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR renames two labels used to report cached token counts so they match the official OpenTelemetry names. The numbers reported don't change — only the label names do — so dashboards or code that look for the old names must be updated.

## Overview

Implements Option A from issue #15962: updates @mastra/otel-exporter to emit OpenTelemetry GenAI semantic-convention attribute names per @opentelemetry/semantic-conventions@1.40.0.

## Attribute Name Changes

- gen_ai.usage.cached_input_tokens → gen_ai.usage.cache_read.input_tokens (constant: ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS)  
- gen_ai.usage.cache_write_tokens → gen_ai.usage.cache_creation.input_tokens (constant: ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS)

Numeric calculations are unchanged: gen_ai.usage.input_tokens remains the total prompt-token count; the renamed cache attributes are subsets per the spec. gen_ai.usage.reasoning_tokens is intentionally not renamed.

## Files Modified

- observability/otel-exporter/src/gen-ai-semantics.ts
  - Maps usage.inputDetails.cacheRead/cacheWrite to the new constant-backed OTel keys.
  - Updates exported OtelUsageMetrics interface to use the new constant-keyed fields and remove deprecated string-keyed cache fields.

- observability/otel-exporter/src/gen-ai-semantics.test.ts
  - Tests updated to assert cache tokens at the new attribute keys and verify legacy keys are not emitted.

- observability/otel-exporter/src/span-converter.test.ts
  - Token usage tests updated to expect gen_ai.usage.cache_read.input_tokens and confirm legacy cache attribute is absent.

- observability/arize/src/openInferenceOTLPExporter.ts
  - Converter updated to read the new GenAI cache attribute names and map them to the same OpenInference prompt-details cache attributes to preserve downstream behavior.

- .changeset/new-pets-live.md
  - Documentation-only changeset noting the attribute renames and advising downstream updates; semver bump level remains under discussion in issue #15962.

(Other related docs/tests for Arthur and Sentry were updated to use the new attribute names; no public API changes beyond attribute key names.)

## Testing

- Unit/integration tests updated. Local test runs reported passing:
  - @mastra/otel-exporter: 66/66
  - @mastra/arize: 24/24
  - @mastra/langfuse: 43/43
  - @mastra/otel-bridge: 14/14
- Builds and lints clean for otel-exporter and arize.

## Migration Note

This is a breaking change for consumers that reference the old attribute names directly. Update any dashboards, alerts, queries, or code that depend on:
- gen_ai.usage.cached_input_tokens → gen_ai.usage.cache_read.input_tokens
- gen_ai.usage.cache_write_tokens → gen_ai.usage.cache_creation.input_tokens

## Related

- Issue #15962
<!-- end of auto-generated comment: release notes by coderabbit.ai -->