### PR TITLE
fix(convex): load workflow snapshots by composite index

### DIFF
--- a/.changeset/brown-lamps-lie.md
+++ b/.changeset/brown-lamps-lie.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Fixed Convex workflow snapshot loads to use the workflow/run index.

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -1,0 +1,42 @@
+import { TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage/constants';
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleTypedOperation } from './storage';
+
+describe('mastraStorage typed load', () => {
+  it('uses by_workflow_run for workflow snapshot composite keys', async () => {
+    const workflowRun = {
+      workflow_name: 'workflow-a',
+      run_id: 'run-1',
+      snapshot: {},
+    };
+
+    const builder = {
+      eq: vi.fn((_field: string, _value: string) => builder),
+    };
+    const unique = vi.fn(async () => workflowRun);
+    const take = vi.fn(async () => {
+      throw new Error('load should not scan workflow snapshots for composite keys');
+    });
+    const withIndex = vi.fn((_indexName: string, queryBuilder: (q: typeof builder) => typeof builder) => {
+      queryBuilder(builder);
+      return { unique, take };
+    });
+    const query = vi.fn(() => ({ withIndex, take }));
+    const ctx = { db: { query } } as any;
+
+    const result = await handleTypedOperation(ctx, 'mastra_workflow_snapshots', {
+      op: 'load',
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      keys: { workflow_name: 'workflow-a', run_id: 'run-1' },
+    });
+
+    expect(result).toEqual({ ok: true, result: workflowRun });
+    expect(query).toHaveBeenCalledWith('mastra_workflow_snapshots');
+    expect(withIndex).toHaveBeenCalledWith('by_workflow_run', expect.any(Function));
+    expect(builder.eq).toHaveBeenNthCalledWith(1, 'workflow_name', 'workflow-a');
+    expect(builder.eq).toHaveBeenNthCalledWith(2, 'run_id', 'run-1');
+    expect(unique).toHaveBeenCalledTimes(1);
+    expect(take).not.toHaveBeenCalled();
+  });
+});

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -14,6 +14,7 @@ import { findBestIndex } from './index-map';
 // Vector-specific table names (not in @mastra/core)
 const TABLE_VECTOR_INDEXES = 'mastra_vector_indexes';
 const VECTOR_TABLE_PREFIX = 'mastra_vector_';
+const CONVEX_TABLE_WORKFLOW_SNAPSHOTS = 'mastra_workflow_snapshots';
 
 /**
  * Determines which Convex table to use based on the logical table name.
@@ -28,7 +29,7 @@ function resolveTable(tableName: string): { convexTable: string; isTyped: boolea
     case TABLE_RESOURCES:
       return { convexTable: 'mastra_resources', isTyped: true };
     case TABLE_WORKFLOW_SNAPSHOT:
-      return { convexTable: 'mastra_workflow_snapshots', isTyped: true };
+      return { convexTable: CONVEX_TABLE_WORKFLOW_SNAPSHOTS, isTyped: true };
     case TABLE_SCORERS:
       return { convexTable: 'mastra_scorers', isTyped: true };
     case TABLE_VECTOR_INDEXES:
@@ -77,7 +78,7 @@ export const mastraStorage = mutationGeneric(async (ctx, request: StorageRequest
  * Records are stored with their `id` field as a regular field (not _id).
  * We query by the `id` field to find/update records.
  */
-async function handleTypedOperation(
+export async function handleTypedOperation(
   ctx: MutationCtx<any>,
   convexTable: string,
   request: StorageRequest,
@@ -134,6 +135,18 @@ async function handleTypedOperation(
         const doc = await ctx.db
           .query(convexTable)
           .withIndex('by_record_id', (q: any) => q.eq('id', keys.id))
+          .unique();
+        return { ok: true, result: doc || null };
+      }
+
+      if (
+        convexTable === CONVEX_TABLE_WORKFLOW_SNAPSHOTS &&
+        typeof keys.workflow_name === 'string' &&
+        typeof keys.run_id === 'string'
+      ) {
+        const doc = await ctx.db
+          .query(convexTable)
+          .withIndex('by_workflow_run', (q: any) => q.eq('workflow_name', keys.workflow_name).eq('run_id', keys.run_id))
           .unique();
         return { ok: true, result: doc || null };
       }


### PR DESCRIPTION
## Summary

- Fix typed Convex storage load for workflow snapshots to use the by_workflow_run composite index when workflow_name and run_id are provided.
- Add a regression test that verifies composite workflow snapshot loads do not use the scan fallback.
- Add a patch changeset for @mastra/convex.

Closes #15970.

## Testing

- pnpm --filter @mastra/convex exec vitest run src/server/storage.test.ts
- pnpm --filter @mastra/convex lint
- pnpm --filter @mastra/convex build:lib
- pnpm --filter @mastra/convex test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes workflow snapshot lookups in Convex much faster by using a shortcut (called an index) instead of searching through potentially thousands of documents. When you ask for a workflow snapshot by its name and ID, instead of checking every single document until it finds a match, it now uses a pre-built lookup table that gives you the answer instantly.

## Changes

**stores/convex/src/server/storage.ts**
- Added a constant `CONVEX_TABLE_WORKFLOW_SNAPSHOTS` for the workflow snapshots table name
- Exported `handleTypedOperation` to make it testable
- Implemented composite index lookup: when loading workflow snapshots with both `workflow_name` and `run_id` keys, the code now calls `withIndex('by_workflow_run', ...)` and uses `unique()` to fetch the document directly, instead of scanning up to 10,000 documents with `take()`

**stores/convex/src/server/storage.test.ts**
- Added new regression test for typed `load` operations on the workflow snapshots table
- Verifies that the `by_workflow_run` index is invoked with the correct filters
- Confirms that the code returns a unique document via `unique()` without falling back to `take()` scanning

**.changeset/brown-lamps-lie.md**
- Added patch changeset documenting the fix for `@mastra/convex`

## Impact

Workflow snapshot loads using both workflow_name and run_id now execute in O(1) time using the composite index instead of potentially scanning 10,000+ documents. This closes issue #15970.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->