### PR TITLE
feat(core): add coalesced harness display-state subscriptions

### DIFF
--- a/.changeset/five-hands-punch.md
+++ b/.changeset/five-hands-punch.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': patch
+---
+
+Added a coalesced display state subscription API for Harness.
+
+This helps UI clients render fewer updates while still receiving the latest state. The example below renders the initial state, then subscribes to coalesced updates with the default `windowMs` and `maxWaitMs` timing options.
+
+```ts
+render(harness.getDisplayState());
+
+const unsubscribe = harness.subscribeDisplayState(render, {
+  windowMs: 250,
+  maxWaitMs: 500,
+});
+```

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -347,6 +347,14 @@ Return a read-only snapshot of the current harness state.
 const state = harness.getState()
 ```
 
+#### `getDisplayState()`
+
+Return the current `HarnessDisplayState` snapshot for UI rendering.
+
+```typescript
+const displayState = harness.getDisplayState()
+```
+
 #### `setState(updates)`
 
 Update the harness state. Validates against `stateSchema` if provided, and emits a `state_changed` event with the new state and changed keys.
@@ -917,9 +925,34 @@ Forked mode trades isolation for context inheritance. If the subagent should run
 
 ### Events
 
+#### `subscribeDisplayState(listener, options?)`
+
+Register a listener for coalesced display state snapshots. Use this method for UI, Server-Sent Events (SSE), terminal UI (TUI), and bridge rendering paths that only need the latest `HarnessDisplayState`. Use [`subscribe`](#subscribelistener) when you need the raw event log.
+
+```typescript
+const unsubscribe = harness.subscribeDisplayState(displayState => {
+  render(displayState)
+})
+
+// Optional tuning:
+harness.subscribeDisplayState(render, {
+  windowMs: 250,
+  maxWaitMs: 500,
+})
+
+// Later:
+unsubscribe()
+```
+
+Returns: `() => void`
+
+`subscribeDisplayState()` does not call the listener immediately. Call [`getDisplayState`](#getdisplaystate) first if the UI needs an initial render before the next harness event.
+
 #### `subscribe(listener)`
 
 Register an event listener. Returns an unsubscribe function.
+
+Use this method for audit logs, debugging, analytics, deterministic replay, or consumers that need every raw event. For display rendering, prefer [`subscribeDisplayState`](#subscribedisplaystatelistener-options) so high-frequency events such as `message_update`, `tool_update`, and `tool_input_delta` are coalesced into the latest display state snapshot.
 
 ```typescript
 const unsubscribe = harness.subscribe(event => {

--- a/packages/core/src/harness/display-state-scheduler.ts
+++ b/packages/core/src/harness/display-state-scheduler.ts
@@ -1,0 +1,220 @@
+import type { HarnessDisplayState, HarnessDisplayStateListener, HarnessEvent } from './types';
+
+export const DEFAULT_DISPLAY_STATE_SUBSCRIPTION_OPTIONS = {
+  windowMs: 250,
+  maxWaitMs: 500,
+} as const;
+
+export const CRITICAL_DISPLAY_STATE_EVENT_TYPES: ReadonlySet<HarnessEvent['type']> = new Set([
+  'agent_start',
+  'agent_end',
+  'error',
+  'tool_approval_required',
+  'tool_suspended',
+  'ask_question',
+  'plan_approval_required',
+  'plan_approved',
+  'thread_changed',
+  'thread_created',
+  'thread_deleted',
+  'mode_changed',
+  'model_changed',
+  'subagent_model_changed',
+  'state_changed',
+  'tool_input_end',
+  'tool_end',
+  'subagent_end',
+]);
+
+function cloneValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+
+  if (seen.has(value)) {
+    return seen.get(value);
+  }
+
+  if (Array.isArray(value)) {
+    const cloned: unknown[] = [];
+    seen.set(value, cloned);
+    for (const item of value) {
+      cloned.push(cloneValue(item, seen));
+    }
+    return cloned;
+  }
+
+  if (value instanceof Map) {
+    const cloned = new Map<unknown, unknown>();
+    seen.set(value, cloned);
+    for (const [key, mapValue] of value) {
+      cloned.set(cloneValue(key, seen), cloneValue(mapValue, seen));
+    }
+    return cloned;
+  }
+
+  if (value instanceof Set) {
+    const cloned = new Set<unknown>();
+    seen.set(value, cloned);
+    for (const item of value) {
+      cloned.add(cloneValue(item, seen));
+    }
+    return cloned;
+  }
+
+  const cloned: Record<PropertyKey, unknown> = {};
+  seen.set(value, cloned);
+  for (const key of Reflect.ownKeys(value)) {
+    cloned[key] = cloneValue((value as Record<PropertyKey, unknown>)[key], seen);
+  }
+  return cloned;
+}
+
+function cloneUnknown<T>(value: T): T {
+  return cloneValue(value) as T;
+}
+
+function cloneDisplayState(state: HarnessDisplayState): HarnessDisplayState {
+  return {
+    ...state,
+    currentMessage: state.currentMessage
+      ? {
+          ...state.currentMessage,
+          createdAt: new Date(state.currentMessage.createdAt.getTime()),
+          content: state.currentMessage.content.map(part => cloneUnknown(part)),
+        }
+      : null,
+    tokenUsage: { ...state.tokenUsage },
+    activeTools: new Map(
+      Array.from(state.activeTools, ([id, tool]) => [
+        id,
+        {
+          ...tool,
+          args: cloneUnknown(tool.args),
+          result: cloneUnknown(tool.result),
+        },
+      ]),
+    ),
+    toolInputBuffers: new Map(Array.from(state.toolInputBuffers, ([id, buffer]) => [id, { ...buffer }])),
+    pendingApproval: state.pendingApproval
+      ? { ...state.pendingApproval, args: cloneUnknown(state.pendingApproval.args) }
+      : null,
+    pendingSuspension: state.pendingSuspension
+      ? {
+          ...state.pendingSuspension,
+          args: cloneUnknown(state.pendingSuspension.args),
+          suspendPayload: cloneUnknown(state.pendingSuspension.suspendPayload),
+        }
+      : null,
+    pendingQuestion: state.pendingQuestion
+      ? {
+          ...state.pendingQuestion,
+          options: state.pendingQuestion.options?.map(option => cloneUnknown(option)),
+        }
+      : null,
+    pendingPlanApproval: state.pendingPlanApproval ? { ...state.pendingPlanApproval } : null,
+    activeSubagents: new Map(
+      Array.from(state.activeSubagents, ([id, subagent]) => [
+        id,
+        {
+          ...subagent,
+          toolCalls: subagent.toolCalls.map(toolCall => cloneUnknown(toolCall)),
+        },
+      ]),
+    ),
+    omProgress: {
+      ...state.omProgress,
+      buffered: {
+        observations: { ...state.omProgress.buffered.observations },
+        reflection: { ...state.omProgress.buffered.reflection },
+      },
+    },
+    modifiedFiles: new Map(
+      Array.from(state.modifiedFiles, ([path, modifiedFile]) => [
+        path,
+        {
+          ...modifiedFile,
+          firstModified: new Date(modifiedFile.firstModified.getTime()),
+          operations: [...modifiedFile.operations],
+        },
+      ]),
+    ),
+    tasks: state.tasks.map(task => cloneUnknown(task)),
+    previousTasks: state.previousTasks.map(task => cloneUnknown(task)),
+  };
+}
+
+export class DisplayStateScheduler {
+  private disposed = false;
+  private pendingState: HarnessDisplayState | null = null;
+  private windowTimer: ReturnType<typeof setTimeout> | null = null;
+  private maxWaitTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly listener: HarnessDisplayStateListener,
+    private readonly windowMs: number,
+    private readonly maxWaitMs: number,
+  ) {}
+
+  notify(state: HarnessDisplayState, isCritical: boolean): void {
+    if (this.disposed) return;
+
+    if (isCritical) {
+      this.flush(state);
+      return;
+    }
+
+    this.pendingState = state;
+
+    if (this.windowTimer) {
+      clearTimeout(this.windowTimer);
+    }
+    this.windowTimer = setTimeout(() => this.flushPending(), this.windowMs);
+
+    if (!this.maxWaitTimer) {
+      this.maxWaitTimer = setTimeout(() => this.flushPending(), this.maxWaitMs);
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.pendingState = null;
+    this.clearTimers();
+  }
+
+  private flushPending(): void {
+    if (!this.pendingState) return;
+    this.flush(this.pendingState);
+  }
+
+  private flush(state: HarnessDisplayState): void {
+    if (this.disposed) return;
+
+    this.pendingState = null;
+    this.clearTimers();
+
+    try {
+      const result = this.listener(cloneDisplayState(state));
+      if (result && typeof result === 'object' && 'catch' in result && typeof result.catch === 'function') {
+        (result as Promise<void>).catch(err => console.error('Error in harness display state listener:', err));
+      }
+    } catch (err) {
+      console.error('Error in harness display state listener:', err);
+    }
+  }
+
+  private clearTimers(): void {
+    if (this.windowTimer) {
+      clearTimeout(this.windowTimer);
+    }
+    if (this.maxWaitTimer) {
+      clearTimeout(this.maxWaitTimer);
+    }
+    this.windowTimer = null;
+    this.maxWaitTimer = null;
+  }
+}

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
@@ -1203,6 +1203,273 @@ describe('display_state_changed emission', () => {
     // Just check the second subscriber's snapshots
     expect(snapshots[0]).toBe(true); // after agent_start
     expect(snapshots[1]).toBe(false); // after agent_end
+  });
+});
+
+describe('Harness.subscribeDisplayState()', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    harness = createHarness();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('coalesces rapid high-frequency display mutations', () => {
+    const listener = vi.fn();
+    harness.subscribeDisplayState(listener, { windowMs: 250, maxWaitMs: 500 });
+
+    emit(harness, { type: 'agent_start' });
+    expect(listener).toHaveBeenCalledTimes(1);
+    listener.mockClear();
+
+    emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+    for (let i = 0; i < 100; i++) {
+      emit(harness, {
+        type: 'tool_input_delta',
+        toolCallId: 't1',
+        argsTextDelta: String(i),
+        toolName: 'write_file',
+      });
+    }
+
+    expect(listener).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(249);
+    expect(listener).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0]).not.toBe(harness.getDisplayState());
+    expect(listener.mock.calls[0]?.[0].toolInputBuffers.get('t1')?.text).toContain('99');
+  });
+
+  it('uses maxWaitMs to prevent starvation during constant streams', () => {
+    const listener = vi.fn();
+    harness.subscribeDisplayState(listener, { windowMs: 250, maxWaitMs: 500 });
+
+    emit(harness, { type: 'agent_start' });
+    listener.mockClear();
+
+    emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(100);
+      emit(harness, {
+        type: 'tool_input_delta',
+        toolCallId: 't1',
+        argsTextDelta: 'x',
+        toolName: 'write_file',
+      });
+    }
+
+    expect(listener).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes immediately for critical lifecycle events', () => {
+    const listener = vi.fn();
+    harness.subscribeDisplayState(listener, { windowMs: 250, maxWaitMs: 500 });
+
+    emit(harness, { type: 'agent_start' });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0].isRunning).toBe(true);
+
+    emit(harness, { type: 'agent_end', reason: 'complete' });
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls[1]?.[0].isRunning).toBe(false);
+  });
+
+  it('flushes immediately for approvals, suspensions, questions, plans, errors, and state changes', () => {
+    const listener = vi.fn();
+    harness.subscribeDisplayState(listener, { windowMs: 250, maxWaitMs: 500 });
+
+    emit(harness, {
+      type: 'tool_approval_required',
+      toolCallId: 't1',
+      toolName: 'write_file',
+      args: {},
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0].pendingApproval?.toolCallId).toBe('t1');
+
+    emit(harness, {
+      type: 'tool_suspended',
+      toolCallId: 't2',
+      toolName: 'confirmAction',
+      args: {},
+      suspendPayload: {},
+    });
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls[1]?.[0].pendingSuspension?.toolCallId).toBe('t2');
+
+    emit(harness, {
+      type: 'ask_question',
+      questionId: 'q1',
+      question: 'Proceed?',
+    });
+    expect(listener).toHaveBeenCalledTimes(3);
+    expect(listener.mock.calls[2]?.[0].pendingQuestion?.questionId).toBe('q1');
+
+    emit(harness, {
+      type: 'plan_approval_required',
+      planId: 'p1',
+      title: 'Plan',
+      plan: '# Plan',
+    });
+    expect(listener).toHaveBeenCalledTimes(4);
+    expect(listener.mock.calls[3]?.[0].pendingPlanApproval?.planId).toBe('p1');
+
+    emit(harness, {
+      type: 'error',
+      error: new Error('boom'),
+    });
+    expect(listener).toHaveBeenCalledTimes(5);
+
+    emit(harness, {
+      type: 'state_changed',
+      state: { observationThreshold: 12_000 },
+      changedKeys: ['observationThreshold'],
+    });
+    expect(listener).toHaveBeenCalledTimes(6);
+    expect(listener.mock.calls[5]?.[0].omProgress.threshold).toBe(12_000);
+  });
+
+  it('critical events emit one latest post-critical snapshot when state is pending', () => {
+    const listener = vi.fn();
+    harness.subscribeDisplayState(listener, { windowMs: 250, maxWaitMs: 500 });
+
+    const message = { id: 'm1', role: 'assistant' as const, content: [], createdAt: new Date() };
+    emit(harness, { type: 'message_update', message: message as any });
+    expect(listener).not.toHaveBeenCalled();
+
+    emit(harness, { type: 'agent_end', reason: 'complete' });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0].isRunning).toBe(false);
+    expect(listener.mock.calls[0]?.[0].currentMessage?.id).toBe('m1');
+
+    vi.advanceTimersByTime(500);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes fresh snapshots to display state listeners', () => {
+    const listener = vi.fn();
+    harness.subscribeDisplayState(listener, { windowMs: 250, maxWaitMs: 500 });
+
+    emit(harness, { type: 'agent_start' });
+    emit(harness, { type: 'agent_end', reason: 'complete' });
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls[0]?.[0]).not.toBe(listener.mock.calls[1]?.[0]);
+    expect(listener.mock.calls[1]?.[0]).not.toBe(harness.getDisplayState());
+  });
+
+  it('isolates listener snapshot mutations from live display state', () => {
+    const listener = vi.fn();
+    harness.subscribeDisplayState(listener, { windowMs: 250, maxWaitMs: 500 });
+
+    const args = { path: 'original.ts', nested: { marker: 'original' } };
+    const firstModified = new Date('2026-01-01T00:00:00.000Z');
+    vi.setSystemTime(firstModified);
+
+    emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'write_file', args });
+    emit(harness, { type: 'tool_end', toolCallId: 't1', result: { ok: true }, isError: false });
+
+    const snapshot = listener.mock.calls.at(-1)?.[0];
+    expect(snapshot).toBeDefined();
+
+    (snapshot!.activeTools.get('t1')!.args as typeof args).nested.marker = 'mutated';
+    snapshot!.modifiedFiles.get('original.ts')!.firstModified.setUTCFullYear(2030);
+    snapshot!.modifiedFiles.get('original.ts')!.operations.push('extra');
+
+    const liveToolArgs = harness.getDisplayState().activeTools.get('t1')!.args as typeof args;
+    const liveModifiedFile = harness.getDisplayState().modifiedFiles.get('original.ts')!;
+    expect(liveToolArgs.nested.marker).toBe('original');
+    expect(liveModifiedFile.firstModified).toEqual(firstModified);
+    expect(liveModifiedFile.operations).toEqual(['write_file']);
+  });
+
+  it('unsubscribe cancels pending timers and prevents later callbacks', () => {
+    const listener = vi.fn();
+    const unsubscribe = harness.subscribeDisplayState(listener, { windowMs: 250, maxWaitMs: 500 });
+
+    emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+    emit(harness, {
+      type: 'tool_input_delta',
+      toolCallId: 't1',
+      argsTextDelta: 'x',
+      toolName: 'write_file',
+    });
+
+    unsubscribe();
+    vi.advanceTimersByTime(1000);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('destroy cancels pending display state callbacks', async () => {
+    const listener = vi.fn();
+    harness.subscribeDisplayState(listener, { windowMs: 250, maxWaitMs: 500 });
+
+    emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+    await harness.destroy();
+    vi.advanceTimersByTime(1000);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('honors custom coalescing options', () => {
+    const listener = vi.fn();
+    harness.subscribeDisplayState(listener, { windowMs: 50, maxWaitMs: 100 });
+
+    emit(harness, { type: 'tool_input_start', toolCallId: 't1', toolName: 'write_file' });
+    vi.advanceTimersByTime(49);
+    expect(listener).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('raw subscribe still receives every event and every display_state_changed', () => {
+    const raw = vi.fn();
+    const display = vi.fn();
+    harness.subscribe(raw);
+    harness.subscribeDisplayState(display, { windowMs: 250, maxWaitMs: 500 });
+
+    for (let i = 0; i < 5; i++) {
+      emit(harness, {
+        type: 'tool_input_delta',
+        toolCallId: 'missing',
+        argsTextDelta: String(i),
+      });
+    }
+
+    const rawEvents = raw.mock.calls.map(([event]) => event.type);
+    expect(rawEvents.filter(type => type === 'tool_input_delta')).toHaveLength(5);
+    expect(rawEvents.filter(type => type === 'display_state_changed')).toHaveLength(5);
+    expect(display).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(250);
+    expect(display).toHaveBeenCalledTimes(1);
+  });
+
+  it('listener errors do not break the harness or other display listeners', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const healthyListener = vi.fn();
+
+    harness.subscribeDisplayState(() => {
+      throw new Error('listener failed');
+    });
+    harness.subscribeDisplayState(healthyListener);
+
+    expect(() => emit(harness, { type: 'agent_start' })).not.toThrow();
+    expect(consoleError).toHaveBeenCalledWith('Error in harness display state listener:', expect.any(Error));
+    expect(healthyListener).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -14,6 +14,11 @@ import { safeStringify } from '../utils';
 import { Workspace } from '../workspace/workspace';
 import type { WorkspaceConfig } from '../workspace/workspace';
 
+import {
+  CRITICAL_DISPLAY_STATE_EVENT_TYPES,
+  DEFAULT_DISPLAY_STATE_SUBSCRIPTION_OPTIONS,
+  DisplayStateScheduler,
+} from './display-state-scheduler';
 import { askUserTool, createSubagentTool, submitPlanTool, taskCheckTool, taskWriteTool } from './tools';
 import { defaultDisplayState, defaultOMProgressState } from './types';
 import type {
@@ -21,6 +26,8 @@ import type {
   HeartbeatHandler,
   HarnessConfig,
   HarnessDisplayState,
+  HarnessDisplayStateListener,
+  HarnessDisplayStateSubscriptionOptions,
   HarnessEvent,
   HarnessEventListener,
   HarnessMessage,
@@ -73,6 +80,7 @@ export class Harness<TState = {}> {
   private resourceId: string;
   private defaultResourceId: string;
   private listeners: HarnessEventListener[] = [];
+  private displayStateSchedulers = new Set<DisplayStateScheduler>();
   private abortController: AbortController | null = null;
   private abortRequested: boolean = false;
   private currentRunId: string | null = null;
@@ -2553,6 +2561,29 @@ export class Harness<TState = {}> {
     };
   }
 
+  /**
+   * Subscribe to coalesced display state snapshots.
+   *
+   * Use this for UI rendering paths that only need the latest display state.
+   * Raw event consumers should continue to use `subscribe()`.
+   */
+  subscribeDisplayState(
+    listener: HarnessDisplayStateListener,
+    options: HarnessDisplayStateSubscriptionOptions = {},
+  ): () => void {
+    const scheduler = new DisplayStateScheduler(
+      listener,
+      options.windowMs ?? DEFAULT_DISPLAY_STATE_SUBSCRIPTION_OPTIONS.windowMs,
+      options.maxWaitMs ?? DEFAULT_DISPLAY_STATE_SUBSCRIPTION_OPTIONS.maxWaitMs,
+    );
+    this.displayStateSchedulers.add(scheduler);
+
+    return () => {
+      this.displayStateSchedulers.delete(scheduler);
+      scheduler.dispose();
+    };
+  }
+
   private emit(event: HarnessEvent): void {
     // Update display state based on the event (before dispatching to listeners)
     this.applyDisplayStateUpdate(event);
@@ -2567,6 +2598,13 @@ export class Harness<TState = {}> {
         type: 'display_state_changed',
         displayState: this.displayState,
       });
+    }
+
+    if (event.type !== 'display_state_changed' && this.displayStateSchedulers.size > 0) {
+      const isCritical = CRITICAL_DISPLAY_STATE_EVENT_TYPES.has(event.type);
+      for (const scheduler of Array.from(this.displayStateSchedulers)) {
+        scheduler.notify(this.displayState, isCritical);
+      }
     }
   }
 
@@ -3282,6 +3320,10 @@ export class Harness<TState = {}> {
   // ===========================================================================
 
   async destroy(): Promise<void> {
+    for (const scheduler of this.displayStateSchedulers) {
+      scheduler.dispose();
+    }
+    this.displayStateSchedulers.clear();
     await this.stopHeartbeats();
     await this.destroyWorkspace();
   }

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -10,6 +10,8 @@ export type {
   CustomModelCatalogProvider,
   HarnessConfig,
   HarnessDisplayState,
+  HarnessDisplayStateListener,
+  HarnessDisplayStateSubscriptionOptions,
   HarnessEvent,
   HarnessEventListener,
   HarnessMessage,

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -879,6 +879,27 @@ export type HarnessEvent =
  */
 export type HarnessEventListener = (event: HarnessEvent) => void | Promise<void>;
 
+/**
+ * Listener function for coalesced harness display state snapshots.
+ */
+export type HarnessDisplayStateListener = (displayState: HarnessDisplayState) => void | Promise<void>;
+
+export interface HarnessDisplayStateSubscriptionOptions {
+  /**
+   * Minimum quiet window before non-critical display state callbacks.
+   *
+   * @default 250
+   */
+  windowMs?: number;
+
+  /**
+   * Maximum time a pending display state snapshot may wait while updates continue.
+   *
+   * @default 500
+   */
+  maxWaitMs?: number;
+}
+
 // =============================================================================
 // Messages
 // =============================================================================


### PR DESCRIPTION
Adds Harness.subscribeDisplayState() for UI, SSE, TUI, and bridge consumers that render from HarnessDisplayState. Raw subscribe() still delivers every event for logs, debugging, analytics, and replay.

Example usage:

```ts
render(harness.getDisplayState());

const unsubscribe = harness.subscribeDisplayState(render, {
  windowMs: 250,
  maxWaitMs: 500,
});
```

The scheduler coalesces high-frequency message and tool updates, emits fresh display-state snapshots, and flushes critical lifecycle updates immediately.

Fixes #15973.

Validated with `pnpm --filter ./packages/core test -- display-state`, `pnpm --filter ./packages/core check`, and `pnpm build:core`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a smarter way for UI components to listen to harness updates. Instead of getting bombarded with every single internal event, they can now use `subscribeDisplayState()` to receive batched updates that combine rapid changes into fewer snapshots, while keeping the old raw `subscribe()` method unchanged for debugging and logging.

## Overview

This PR introduces `Harness.subscribeDisplayState()`, a new UI-facing subscription API that delivers coalesced `HarnessDisplayState` snapshots. It implements intelligent batching of high-frequency internal events (messages, tool updates) into consolidated display-state snapshots, while preserving the raw event semantics of the existing `subscribe()` API. Critical lifecycle events (agent start/end, errors, approvals, suspensions, questions, plans) bypass coalescing and flush immediately.

## Key Changes

### New Display State Scheduler Module
- **`display-state-scheduler.ts`**: Introduces `DisplayStateScheduler` class that buffers non-critical display state updates and dispatches them using two configurable timers:
  - `windowMs` (default 250ms): throttle window that resets on each non-critical update
  - `maxWaitMs` (default 500ms): maximum wait time to prevent starvation
  - Critical updates bypass buffering and flush immediately
  - Deep-clones entire `HarnessDisplayState` before invoking listeners to ensure isolation
  - Catches and logs listener errors via `console.error` without disrupting other listeners
  - Exports constants: `DEFAULT_DISPLAY_STATE_SUBSCRIPTION_OPTIONS` and `CRITICAL_DISPLAY_STATE_EVENT_TYPES`

### API Additions to Harness
- **`getDisplayState()`**: Returns a snapshot of current `HarnessDisplayState` for initial rendering
- **`subscribeDisplayState(listener, options?)`**: Registers a coalesced display-state listener that returns an unsubscribe function
  - Accepts optional `windowMs` and `maxWaitMs` tuning parameters
  - Listener is not invoked immediately (caller must use `getDisplayState()` for initial render)
  - All subscriptions are cleaned up during `harness.destroy()`

### Integration Updates
- Modified `Harness.emit()` to notify schedulers after dispatching events, passing `isCritical` flag based on event type
- Event type `display_state_changed` is skipped to avoid double-notification
- Harness destroy method extended to dispose and clear all registered schedulers

### Type System Enhancements
- **New types in `types.ts`**:
  - `HarnessDisplayStateListener`: callback type receiving `HarnessDisplayState`, may be sync or async
  - `HarnessDisplayStateSubscriptionOptions`: configuration interface for `windowMs` and `maxWaitMs`
- **Index re-exports**: Both new types exported from harness module

### Documentation
- Updated harness-class.mdx with comprehensive documentation of both new APIs
- Clarified that `subscribe()` is intended for raw event logs while `subscribeDisplayState()` is preferred for UI rendering
- Added changeset documenting the new API with usage examples

## Testing

Comprehensive test suite in `display-state.test.ts` covering:
- Coalescing behavior driven by `windowMs` with fake timers
- Forced flushes at `maxWaitMs` to prevent starvation
- Critical event types trigger immediate (non-coalesced) emission
- Emitted snapshots are fresh deep-clones isolated from harness internal state
- Unsubscribe and `harness.destroy()` properly cancel pending timer flushes
- Custom coalescing options change flush timing as configured
- Raw subscriptions continue to receive every event while display subscribers remain coalesced
- Listener errors are caught and logged without preventing other listeners
- Validation of key snapshot fields like `isRunning`, `pendingApproval`, `pendingSuspension`, etc.

## Validation

Changes have been validated with:
- `pnpm --filter ./packages/core test -- display-state`
- `pnpm --filter ./packages/core check`
- `pnpm build:core`

Fixes issue #15973.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->