### PR TITLE
Add @mastra/localdev zero-config storage package

### DIFF
--- a/.changeset/deep-ducks-thank.md
+++ b/.changeset/deep-ducks-thank.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Updated the `mastra init` template to use the new `@mastra/localdev` storage package. New projects now generate a single `storage: new LocalDevStore()` line instead of composing LibSQL and DuckDB by hand. The CLI now installs `@mastra/localdev` (which depends on `@mastra/libsql` and `@mastra/duckdb`) instead of installing those packages individually.

--- a/.changeset/green-beans-create.md
+++ b/.changeset/green-beans-create.md
@@ -1,0 +1,30 @@
+---
+'@mastra/localdev': minor
+---
+
+Added the new `@mastra/localdev` storage package, a zero-config wrapper around `MastraCompositeStore` that uses LibSQL for the default domains and DuckDB for the observability domain. New local projects can now configure storage with a single line:
+
+```typescript
+import { Mastra } from '@mastra/core/mastra';
+import { LocalDevStore } from '@mastra/localdev';
+
+export const mastra = new Mastra({
+  storage: new LocalDevStore(),
+});
+```
+
+The previous long-form composition still works for any project that needs to compose stores by hand:
+
+```typescript
+import { MastraCompositeStore } from '@mastra/core/storage';
+import { LibSQLStore } from '@mastra/libsql';
+import { DuckDBStore } from '@mastra/duckdb';
+
+storage: new MastraCompositeStore({
+  id: 'composite-storage',
+  default: new LibSQLStore({ id: 'mastra-storage', url: 'file:./mastra.db' }),
+  domains: { observability: new DuckDBStore().observability },
+}),
+```
+
+`LocalDevStore` is intended for local development only. Both LibSQL (file mode) and DuckDB are embedded, single-process stores. Swap to a hosted backend such as `@mastra/pg` or `@mastra/clickhouse` before deploying.

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -451,6 +451,7 @@ const sidebars = {
         { type: 'doc', id: 'storage/dynamodb', label: 'DynamoDB Storage' },
         { type: 'doc', id: 'storage/lance', label: 'LanceDB Storage' },
         { type: 'doc', id: 'storage/libsql', label: 'libSQL Storage' },
+        { type: 'doc', id: 'storage/localdev', label: 'LocalDev Storage' },
         { type: 'doc', id: 'storage/mongodb', label: 'MongoDB Storage' },
         { type: 'doc', id: 'storage/mssql', label: 'MSSQL Storage' },
         { type: 'doc', id: 'storage/postgresql', label: 'PostgreSQL Storage' },

--- a/docs/src/content/en/reference/storage/localdev.mdx
+++ b/docs/src/content/en/reference/storage/localdev.mdx
@@ -1,0 +1,110 @@
+---
+title: "Reference: LocalDevStore | Storage"
+description: API reference for LocalDevStore, the zero-config local development storage adapter for Mastra.
+packages:
+  - "@mastra/core"
+  - "@mastra/localdev"
+  - "@mastra/libsql"
+  - "@mastra/duckdb"
+---
+
+# LocalDevStore
+
+`LocalDevStore` is a zero-config wrapper around [`MastraCompositeStore`](/reference/storage/composite) for local development. It uses [LibSQL](/reference/storage/libsql) for every domain by default and routes the `observability` domain to a [DuckDB](https://duckdb.org) store for faster trace queries in Mastra Studio.
+
+`LocalDevStore` is intended for local development. Both backends are embedded and persist data to local files. For production, swap to a hosted adapter such as [PostgreSQL](/reference/storage/postgresql) or [ClickHouse](/reference/storage/clickhouse) for observability.
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/localdev@latest
+```
+
+`@mastra/localdev` depends on `@mastra/libsql` and `@mastra/duckdb`. Both are installed automatically.
+
+## Usage example
+
+The default configuration creates a LibSQL database at `file:./mastra.db` and a DuckDB database at `mastra.duckdb`:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+import { LocalDevStore } from '@mastra/localdev'
+
+export const mastra = new Mastra({
+  storage: new LocalDevStore(),
+})
+```
+
+Override the database paths:
+
+```typescript title="src/mastra/index.ts"
+import { LocalDevStore } from '@mastra/localdev'
+
+const storage = new LocalDevStore({
+  dbPath: 'file:./custom.db',
+  duckdbPath: './traces.duckdb',
+})
+```
+
+Pass per-domain overrides for advanced composition. Overrides take precedence over the built-in DuckDB observability store and the LibSQL default:
+
+```typescript title="src/mastra/index.ts"
+import { LocalDevStore } from '@mastra/localdev'
+import { MemoryLibSQL } from '@mastra/libsql'
+
+const storage = new LocalDevStore({
+  domains: {
+    memory: new MemoryLibSQL({ url: 'file:./memory.db' }),
+  },
+})
+```
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Unique identifier for this storage instance.',
+    isOptional: true,
+    defaultValue: 'localdev-storage',
+  },
+  {
+    name: 'dbPath',
+    type: 'string',
+    description:
+      'LibSQL database URL used for the default store. Accepts any value supported by `@libsql/client`, including `file:` paths and remote `libsql://` URLs.',
+    isOptional: true,
+    defaultValue: 'file:./mastra.db',
+  },
+  {
+    name: 'duckdbPath',
+    type: 'string',
+    description:
+      'DuckDB database file used for the observability domain. Use `:memory:` for an ephemeral in-memory database.',
+    isOptional: true,
+    defaultValue: 'mastra.duckdb',
+  },
+  {
+    name: 'default',
+    type: 'MastraCompositeStore',
+    description:
+      'Override the default store. When provided, replaces the built-in LibSQL default for every domain not covered by `domains`.',
+    isOptional: true,
+  },
+  {
+    name: 'domains',
+    type: 'MastraStorageDomains',
+    description:
+      'Per-domain overrides. Takes precedence over both the LibSQL default and the built-in DuckDB observability store. See [Composite storage](/reference/storage/composite) for the available domain keys.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Related
+
+- [Composite storage](/reference/storage/composite)
+- [LibSQL storage](/reference/storage/libsql)
+- [Storage overview](/reference/storage/overview)

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -76,13 +76,9 @@ export const init = async ({
 
       const depService = new DepsService();
 
-      const needsLibsql = (await depService.checkDependencies(['@mastra/libsql'])) !== `ok`;
-      if (needsLibsql) {
-        await depService.installPackages([`@mastra/libsql${packageVersionTag}`]);
-      }
-      const needsDuckDB = (await depService.checkDependencies(['@mastra/duckdb'])) !== `ok`;
-      if (needsDuckDB) {
-        await depService.installPackages([`@mastra/duckdb${packageVersionTag}`]);
+      const needsLocalDev = (await depService.checkDependencies(['@mastra/localdev'])) !== `ok`;
+      if (needsLocalDev) {
+        await depService.installPackages([`@mastra/localdev${packageVersionTag}`]);
       }
       const needsMemory =
         components.includes(`agents`) && (await depService.checkDependencies(['@mastra/memory'])) !== `ok`;

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -476,9 +476,7 @@ export const mastra = new Mastra()
       `
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
-import { LibSQLStore } from '@mastra/libsql';
-import { DuckDBStore } from "@mastra/duckdb";
-import { MastraCompositeStore } from '@mastra/core/storage';
+import { LocalDevStore } from '@mastra/localdev';
 import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 ${addWorkflow ? `import { weatherWorkflow } from './workflows/weather-workflow';` : ''}
 ${addAgent ? `import { weatherAgent } from './agents/weather-agent';` : ''}
@@ -486,16 +484,7 @@ ${addScorers ? `import { toolCallAppropriatenessScorer, completenessScorer, tran
 
 export const mastra = new Mastra({
   ${filteredExports.join('\n  ')}
-  storage: new MastraCompositeStore({
-    id: 'composite-storage',
-    default: new LibSQLStore({
-      id: "mastra-storage",
-      url: "file:./mastra.db",
-    }),
-    domains: {
-      observability: await new DuckDBStore().getStore('observability'),
-    }
-  }),
+  storage: new LocalDevStore(),
   logger: new PinoLogger({
     name: 'Mastra',
     level: 'info',
@@ -558,10 +547,10 @@ export const checkAndInstallCoreDeps = async (addExample: boolean, versionTag?: 
     }
 
     if (addExample) {
-      const needsLibsql = (await depService.checkDependencies(['@mastra/libsql'])) !== `ok`;
+      const needsLocalDev = (await depService.checkDependencies(['@mastra/localdev'])) !== `ok`;
 
-      if (needsLibsql) {
-        packages.push({ name: '@mastra/libsql', version: mastraVersionTag });
+      if (needsLocalDev) {
+        packages.push({ name: '@mastra/localdev', version: mastraVersionTag });
       }
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5738,6 +5738,46 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  stores/localdev:
+    dependencies:
+      '@mastra/duckdb':
+        specifier: workspace:^
+        version: link:../duckdb
+      '@mastra/libsql':
+        specifier: workspace:^
+        version: link:../libsql
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
+      eslint:
+        specifier: ^10.2.1
+        version: 10.2.1(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+
   stores/mongodb:
     dependencies:
       '@lukeed/uuid':

--- a/stores/localdev/CHANGELOG.md
+++ b/stores/localdev/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @mastra/localdev

--- a/stores/localdev/README.md
+++ b/stores/localdev/README.md
@@ -1,0 +1,84 @@
+# @mastra/localdev
+
+Zero-config local development storage for Mastra.
+
+`LocalDevStore` is a thin wrapper around `MastraCompositeStore` that wires
+together two embedded stores:
+
+- **LibSQL** (`@mastra/libsql`) handles every storage domain by default
+  (memory, workflows, scores, agents, datasets, …).
+- **DuckDB** (`@mastra/duckdb`) handles the observability domain (traces,
+  metrics, logs, scores, feedback) with much faster analytical queries.
+
+## Installation
+
+```bash
+npm install @mastra/localdev
+```
+
+## Usage
+
+```typescript
+import { Mastra } from '@mastra/core/mastra';
+import { LocalDevStore } from '@mastra/localdev';
+import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
+
+export const mastra = new Mastra({
+  storage: new LocalDevStore(),
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: 'mastra',
+        exporters: [new DefaultExporter(), new CloudExporter()],
+        spanOutputProcessors: [new SensitiveDataFilter()],
+      },
+    },
+  }),
+});
+```
+
+That replaces the long-form composition:
+
+```typescript
+import { MastraCompositeStore } from '@mastra/core/storage';
+import { LibSQLStore } from '@mastra/libsql';
+import { DuckDBStore } from '@mastra/duckdb';
+
+storage: new MastraCompositeStore({
+  id: 'composite-storage',
+  default: new LibSQLStore({ id: 'mastra-storage', url: 'file:./mastra.db' }),
+  domains: { observability: await new DuckDBStore().getStore('observability') },
+}),
+```
+
+## Configuration
+
+```typescript
+new LocalDevStore({
+  id: 'my-store', // default: 'localdev-storage'
+  dbPath: 'file:./custom.db', // default: 'file:./mastra.db'
+  duckdbPath: './traces.duckdb', // default: 'mastra.duckdb'
+});
+```
+
+For full control, pass a custom `default` store or per-domain `domains`
+overrides — both forward straight through to `MastraCompositeStore`.
+
+```typescript
+import { LocalDevStore } from '@mastra/localdev';
+import { LibSQLStore } from '@mastra/libsql';
+
+new LocalDevStore({
+  default: new LibSQLStore({ id: 'mastra-storage', url: 'file:./mastra.db', maxRetries: 10 }),
+  domains: {
+    // override any domain explicitly
+  },
+});
+```
+
+## When not to use it
+
+`LocalDevStore` is for local development only. Both LibSQL (file mode) and
+DuckDB are embedded, single-process stores — they are not designed for
+multi-replica production deployments. Swap to a hosted backend
+(`@mastra/pg`, `@mastra/clickhouse`, etc.) before deploying.

--- a/stores/localdev/eslint.config.js
+++ b/stores/localdev/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/stores/localdev/lint-staged.config.js
+++ b/stores/localdev/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['eslint --fix', 'prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/stores/localdev/package.json
+++ b/stores/localdev/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@mastra/localdev",
+  "version": "0.1.0",
+  "description": "Zero-config local development storage for Mastra. Wraps LibSQL (default) and DuckDB (observability) behind a single store.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "prepack": "pnpx tsx ../../scripts/generate-package-docs.ts",
+    "build:watch": "tsup --watch --silent --config tsup.config.ts",
+    "test": "vitest run",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@mastra/duckdb": "workspace:^",
+    "@mastra/libsql": "workspace:^"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.19.15",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "eslint": "^10.2.1",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "stores/localdev"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/stores/localdev/src/index.ts
+++ b/stores/localdev/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @mastra/localdev - Zero-config local development storage for Mastra.
+ *
+ * Wraps a LibSQL store (default for all domains) and a DuckDB store
+ * (observability domain) so new projects can configure storage with
+ * `new LocalDevStore()` instead of composing the two stores by hand.
+ *
+ * Intended for local development only — both backends run in-process and
+ * are not suited to production multi-replica deployments.
+ */
+
+export { LocalDevStore } from './storage/index';
+export type { LocalDevStoreConfig } from './storage/index';

--- a/stores/localdev/src/storage/index.test.ts
+++ b/stores/localdev/src/storage/index.test.ts
@@ -1,0 +1,50 @@
+import { MastraCompositeStore } from '@mastra/core/storage';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { LocalDevStore } from './index';
+
+describe('LocalDevStore', () => {
+  const created: LocalDevStore[] = [];
+
+  afterEach(() => {
+    created.length = 0;
+  });
+
+  const make = (...args: ConstructorParameters<typeof LocalDevStore>) => {
+    const store = new LocalDevStore(...args);
+    created.push(store);
+    return store;
+  };
+
+  it('extends MastraCompositeStore', () => {
+    const store = make();
+    expect(store).toBeInstanceOf(MastraCompositeStore);
+  });
+
+  it('uses an in-memory libsql default and a duckdb observability store with no config', () => {
+    const store = make({ dbPath: 'file::memory:?cache=shared', duckdbPath: ':memory:' });
+
+    expect(store.id).toBe('localdev-storage');
+    expect(store.stores?.memory).toBeDefined();
+    expect(store.stores?.workflows).toBeDefined();
+    expect(store.stores?.observability).toBeDefined();
+    expect(store.stores?.observability?.constructor.name).toBe('ObservabilityStorageDuckDB');
+    expect(store.stores?.memory?.constructor.name).not.toBe('ObservabilityStorageDuckDB');
+  });
+
+  it('accepts a custom id', () => {
+    const store = make({ id: 'my-store', dbPath: 'file::memory:?cache=shared', duckdbPath: ':memory:' });
+    expect(store.id).toBe('my-store');
+  });
+
+  it('routes domain overrides ahead of the duckdb observability default', () => {
+    const sentinel = { __sentinel: true } as any;
+    const store = make({
+      dbPath: 'file::memory:?cache=shared',
+      duckdbPath: ':memory:',
+      domains: { observability: sentinel },
+    });
+
+    expect(store.stores?.observability).toBe(sentinel);
+  });
+});

--- a/stores/localdev/src/storage/index.test.ts
+++ b/stores/localdev/src/storage/index.test.ts
@@ -1,5 +1,5 @@
 import { MastraCompositeStore } from '@mastra/core/storage';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { LocalDevStore } from './index';
 
@@ -8,6 +8,7 @@ describe('LocalDevStore', () => {
 
   afterEach(() => {
     created.length = 0;
+    vi.restoreAllMocks();
   });
 
   const make = (...args: ConstructorParameters<typeof LocalDevStore>) => {
@@ -17,11 +18,42 @@ describe('LocalDevStore', () => {
   };
 
   it('extends MastraCompositeStore', () => {
-    const store = make();
+    const store = make({ dbPath: 'file::memory:?cache=shared', duckdbPath: ':memory:' });
     expect(store).toBeInstanceOf(MastraCompositeStore);
   });
 
-  it('uses an in-memory libsql default and a duckdb observability store with no config', () => {
+  it('passes the documented defaults to its underlying stores when called with no config', async () => {
+    const libsqlConfigs: unknown[] = [];
+    const duckdbConfigs: unknown[] = [];
+
+    const libsqlMod = await import('@mastra/libsql');
+    const duckdbMod = await import('@mastra/duckdb');
+    const RealLibSQL = libsqlMod.LibSQLStore;
+    const RealDuckDB = duckdbMod.DuckDBStore;
+
+    class SpyLibSQL extends RealLibSQL {
+      constructor(config: ConstructorParameters<typeof RealLibSQL>[0]) {
+        libsqlConfigs.push(config);
+        super({ ...config, url: 'file::memory:?cache=shared' });
+      }
+    }
+    class SpyDuckDB extends RealDuckDB {
+      constructor(config?: ConstructorParameters<typeof RealDuckDB>[0]) {
+        duckdbConfigs.push(config);
+        super({ ...config, path: ':memory:' });
+      }
+    }
+
+    vi.spyOn(libsqlMod, 'LibSQLStore').mockImplementation(SpyLibSQL as never);
+    vi.spyOn(duckdbMod, 'DuckDBStore').mockImplementation(SpyDuckDB as never);
+
+    new LocalDevStore();
+
+    expect(libsqlConfigs[0]).toEqual({ id: 'mastra-storage', url: 'file:./mastra.db' });
+    expect(duckdbConfigs[0]).toEqual({ path: 'mastra.duckdb' });
+  });
+
+  it('exposes a duckdb-backed observability store and a libsql-backed memory store', () => {
     const store = make({ dbPath: 'file::memory:?cache=shared', duckdbPath: ':memory:' });
 
     expect(store.id).toBe('localdev-storage');

--- a/stores/localdev/src/storage/index.ts
+++ b/stores/localdev/src/storage/index.ts
@@ -1,0 +1,97 @@
+import type { MastraStorageDomains } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
+import { DuckDBStore } from '@mastra/duckdb';
+import { LibSQLStore } from '@mastra/libsql';
+
+/**
+ * Configuration options for {@link LocalDevStore}.
+ *
+ * All fields are optional — `new LocalDevStore()` is valid and produces a
+ * LibSQL-backed store at `file:./mastra.db` with DuckDB at `mastra.duckdb`
+ * handling the observability domain.
+ */
+export interface LocalDevStoreConfig {
+  /**
+   * Unique identifier for this storage instance.
+   * @default 'localdev-storage'
+   */
+  id?: string;
+
+  /**
+   * LibSQL database URL used for the default store.
+   * @default 'file:./mastra.db'
+   */
+  dbPath?: string;
+
+  /**
+   * DuckDB database file used for the observability store.
+   * @default 'mastra.duckdb'
+   */
+  duckdbPath?: string;
+
+  /**
+   * Override the default store. When provided, replaces the built-in LibSQL
+   * default for every domain that isn't covered by `domains`.
+   */
+  default?: MastraCompositeStore;
+
+  /**
+   * Per-domain overrides. Takes precedence over both the LibSQL default and
+   * the built-in DuckDB observability store.
+   */
+  domains?: MastraStorageDomains;
+}
+
+/**
+ * Local development storage for Mastra.
+ *
+ * Convenience wrapper around `MastraCompositeStore` that wires a LibSQL
+ * default store together with a DuckDB observability store so users can
+ * configure storage with a single line:
+ *
+ * @example
+ * ```typescript
+ * import { Mastra } from '@mastra/core/mastra';
+ * import { LocalDevStore } from '@mastra/localdev';
+ *
+ * export const mastra = new Mastra({
+ *   storage: new LocalDevStore(),
+ * });
+ * ```
+ *
+ * Override individual pieces when needed:
+ *
+ * @example
+ * ```typescript
+ * new LocalDevStore({
+ *   dbPath: 'file:./custom.db',
+ *   duckdbPath: './traces.duckdb',
+ * });
+ * ```
+ *
+ * Not recommended for production: both backends are embedded and hold their
+ * data in local files. Swap to a hosted store before deploying to anything
+ * with more than a single process.
+ */
+export class LocalDevStore extends MastraCompositeStore {
+  constructor(config: LocalDevStoreConfig = {}) {
+    const defaultStore =
+      config.default ??
+      new LibSQLStore({
+        id: 'mastra-storage',
+        url: config.dbPath ?? 'file:./mastra.db',
+      });
+
+    const duckdb = new DuckDBStore({ path: config.duckdbPath });
+
+    super({
+      id: config.id ?? 'localdev-storage',
+      name: 'LocalDevStore',
+      default: defaultStore,
+      domains: {
+        observability: duckdb.observability,
+        ...config.domains,
+      },
+    });
+  }
+}

--- a/stores/localdev/src/storage/index.ts
+++ b/stores/localdev/src/storage/index.ts
@@ -82,7 +82,7 @@ export class LocalDevStore extends MastraCompositeStore {
         url: config.dbPath ?? 'file:./mastra.db',
       });
 
-    const duckdb = new DuckDBStore({ path: config.duckdbPath });
+    const duckdb = new DuckDBStore({ path: config.duckdbPath ?? 'mastra.duckdb' });
 
     super({
       id: config.id ?? 'localdev-storage',

--- a/stores/localdev/tsconfig.build.json
+++ b/stores/localdev/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+}

--- a/stores/localdev/tsconfig.json
+++ b/stores/localdev/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/stores/localdev/tsup.config.ts
+++ b/stores/localdev/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/stores/localdev/turbo.json
+++ b/stores/localdev/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**", "!dist/docs/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/stores/localdev/vitest.config.ts
+++ b/stores/localdev/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'e2e:stores/localdev',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Description

Introduces `@mastra/localdev`, a new zero-config storage package that simplifies local development setup for Mastra projects. `LocalDevStore` is a thin wrapper around `MastraCompositeStore` that automatically wires together:

- **LibSQL** as the default store for all domains (memory, workflows, scores, agents, datasets, etc.)
- **DuckDB** for the observability domain, providing faster analytical queries for traces and metrics

This eliminates boilerplate in new projects, reducing the storage initialization from a multi-line composite store setup to a single line: `new LocalDevStore()`.

### Key Changes

- **New package**: `stores/localdev` with `LocalDevStore` class and configuration interface
- **Documentation**: Added comprehensive API reference at `docs/src/content/en/reference/storage/localdev.mdx`
- **CLI integration**: Updated `mastra init` template to use `LocalDevStore` instead of manually composing LibSQL and DuckDB
- **Tests**: Added unit tests covering inheritance, default configuration, custom IDs, and domain overrides

### Configuration

Default usage requires no configuration:
```typescript
storage: new LocalDevStore()
```

Customizable via optional parameters:
```typescript
new LocalDevStore({
  dbPath: 'file:./custom.db',
  duckdbPath: './traces.duckdb',
  domains: { /* per-domain overrides */ }
})
```

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses -->

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works
- [x] Updated CLI init template to use the new package

https://claude.ai/code/session_01NafmEob8vc576wvJjoCfUh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

This PR adds a tiny package that makes local storage setup one-line simple: instead of wiring multiple stores, you can just call new LocalDevStore() and it configures sensible local defaults for development.

## Overview

Adds @mastra/localdev — a zero-config LocalDevStore that wraps MastraCompositeStore and wires LibSQL as the default store for standard domains (memory, workflows, scores, agents, datasets, etc.) and DuckDB for the observability domain to speed analytics. It reduces multi-line composite store setup to new LocalDevStore() while allowing optional path and per-domain overrides.

## Key Changes

- New package: stores/localdev
  - Exports LocalDevStore and LocalDevStoreConfig.
  - LocalDevStore extends MastraCompositeStore and by default:
    - Uses LibSQL for standard domains.
    - Uses DuckDB for observability.
  - Config options: id, dbPath, duckdbPath, default, domains (per-domain overrides).
  - Bugfix: does not pass { path: undefined } to DuckDBStore when duckdbPath is omitted; uses the documented default instead.

- Documentation
  - Added docs/src/content/en/reference/storage/localdev.mdx (API reference, examples: zero-config, path overrides, per-domain overrides, production guidance).
  - Added stores/localdev/README.md and registered the doc in the reference sidebar.
  - Changesets updated to document the package and mastra init template change.

- CLI integration
  - packages/cli/src/commands/init/init.ts and packages/cli/src/commands/init/utils.ts updated to prefer @mastra/localdev in the init template and dependency installer (replacing individual @mastra/libsql and @mastra/duckdb installs in the example/template).

- Tests
  - stores/localdev/src/storage/index.test.ts — unit tests covering:
    - Inheritance from MastraCompositeStore.
    - Default behavior with in-memory paths.
    - Custom id handling.
    - Per-domain override precedence (domains.observability override wins over default DuckDB).

- Build & repo config for the new package
  - Added package.json, tsup.config.ts, tsconfig.json, tsconfig.build.json, vitest.config.ts, eslint.config.js, lint-staged.config.js, turbo.json, CHANGELOG.md, and related packaging files under stores/localdev.

## Type of change

New feature (non-breaking) — convenience local-development storage package, docs, tests, and CLI template updates. Intended for local development; production deployments should use hosted adapters (e.g., @mastra/pg, @mastra/clickhouse).

## High-level file summary

- Added package: stores/localdev/ (src, tests, build config, packaging, docs)
- Docs: docs/src/content/en/reference/storage/localdev.mdx and sidebar registration
- CLI: packages/cli/src/commands/init/{init.ts,utils.ts} updated
- Changesets: .changeset entries for mastra and @mastra/localdev
<!-- end of auto-generated comment: release notes by coderabbit.ai -->