### PR TITLE
fix(cli): use https:// scheme for internal fetches when server.https is configured

### DIFF
--- a/packages/cli/src/commands/dev/dev.test.ts
+++ b/packages/cli/src/commands/dev/dev.test.ts
@@ -174,15 +174,21 @@ describe('dev command - https scheme in internal fetches', () => {
       debug: false,
     });
 
-    // Wait for the server-ready message handler to run (MockChildProcess fires after 10ms)
-    await new Promise(resolve => setTimeout(resolve, 50));
+    // Wait for the server-ready message handler to fire and trigger fetch calls
+    await vi.waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some((call: any[]) => {
+          const url = String(call[0]);
+          return url.includes('__restart-active-workflow-runs') || url.includes('__refresh');
+        }),
+      ).toBe(true);
+    });
 
     const fetchedUrls = fetchMock.mock.calls.map((call: any[]) => call[0] as string);
     const internalFetches = fetchedUrls.filter(
       (url: string) => url.includes('__restart-active-workflow-runs') || url.includes('__refresh'),
     );
 
-    expect(internalFetches.length).toBeGreaterThan(0);
     for (const url of internalFetches) {
       expect(url).toMatch(/^http:\/\//);
     }
@@ -213,15 +219,21 @@ describe('dev command - https scheme in internal fetches', () => {
       debug: false,
     });
 
-    // Wait for the server-ready message handler to run (MockChildProcess fires after 10ms)
-    await new Promise(resolve => setTimeout(resolve, 50));
+    // Wait for the server-ready message handler to fire and trigger fetch calls
+    await vi.waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some((call: any[]) => {
+          const url = String(call[0]);
+          return url.includes('__restart-active-workflow-runs') || url.includes('__refresh');
+        }),
+      ).toBe(true);
+    });
 
     const fetchedUrls = fetchMock.mock.calls.map((call: any[]) => call[0] as string);
     const internalFetches = fetchedUrls.filter(
       (url: string) => url.includes('__restart-active-workflow-runs') || url.includes('__refresh'),
     );
 
-    expect(internalFetches.length).toBeGreaterThan(0);
     for (const url of internalFetches) {
       expect(url).toMatch(/^https:\/\//);
     }

--- a/packages/cli/src/commands/dev/dev.test.ts
+++ b/packages/cli/src/commands/dev/dev.test.ts
@@ -129,6 +129,105 @@ class MockChildProcess extends EventEmitter {
   }
 }
 
+describe('dev command - https scheme in internal fetches', () => {
+  let execaMock: any;
+  let mockChildProcess: MockChildProcess;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockChildProcess = new MockChildProcess();
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({ disabled: false }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { execa } = await import('execa');
+    execaMock = vi.mocked(execa);
+    execaMock.mockReturnValue(mockChildProcess as unknown as ChildProcess);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should use http:// scheme for internal fetches when https is not configured', async () => {
+    const { getServerOptions } = await import('@mastra/deployer/build');
+    vi.mocked(getServerOptions).mockResolvedValue({
+      port: 4111,
+      host: 'localhost',
+    } as any);
+
+    const { dev } = await import('./dev');
+
+    await dev({
+      dir: undefined,
+      root: process.cwd(),
+      tools: undefined,
+      env: undefined,
+      inspect: false,
+      inspectBrk: false,
+      customArgs: undefined,
+      https: false,
+      debug: false,
+    });
+
+    // Wait for the server-ready message handler to run (MockChildProcess fires after 10ms)
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const fetchedUrls = fetchMock.mock.calls.map((call: any[]) => call[0] as string);
+    const internalFetches = fetchedUrls.filter(
+      (url: string) => url.includes('__restart-active-workflow-runs') || url.includes('__refresh'),
+    );
+
+    expect(internalFetches.length).toBeGreaterThan(0);
+    for (const url of internalFetches) {
+      expect(url).toMatch(/^http:\/\//);
+    }
+  });
+
+  it('should use https:// scheme for internal fetches when server.https is configured', async () => {
+    const { getServerOptions } = await import('@mastra/deployer/build');
+    vi.mocked(getServerOptions).mockResolvedValue({
+      port: 4111,
+      host: 'localhost',
+      https: {
+        key: Buffer.from('mock-key'),
+        cert: Buffer.from('mock-cert'),
+      },
+    } as any);
+
+    const { dev } = await import('./dev');
+
+    await dev({
+      dir: undefined,
+      root: process.cwd(),
+      tools: undefined,
+      env: undefined,
+      inspect: false,
+      inspectBrk: false,
+      customArgs: undefined,
+      https: false,
+      debug: false,
+    });
+
+    // Wait for the server-ready message handler to run (MockChildProcess fires after 10ms)
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const fetchedUrls = fetchMock.mock.calls.map((call: any[]) => call[0] as string);
+    const internalFetches = fetchedUrls.filter(
+      (url: string) => url.includes('__restart-active-workflow-runs') || url.includes('__refresh'),
+    );
+
+    expect(internalFetches.length).toBeGreaterThan(0);
+    for (const url of internalFetches) {
+      expect(url).toMatch(/^https:\/\//);
+    }
+  });
+});
+
 describe('dev command - inspect flag behavior', () => {
   let execaMock: any;
   let mockChildProcess: MockChildProcess;

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -72,9 +72,10 @@ type ProcessOptions = {
   publicDir: string;
 };
 
-const restartAllActiveWorkflowRuns = async ({ host, port }: { host: string; port: number }) => {
+const restartAllActiveWorkflowRuns = async ({ host, port, https }: { host: string; port: number; https?: boolean }) => {
+  const scheme = https ? 'https' : 'http';
   try {
-    await fetch(`http://${host}:${port}/__restart-active-workflow-runs`, {
+    await fetch(`${scheme}://${host}:${port}/__restart-active-workflow-runs`, {
       method: 'POST',
     });
   } catch (error) {
@@ -82,7 +83,7 @@ const restartAllActiveWorkflowRuns = async ({ host, port }: { host: string; port
     // Retry after another second
     await new Promise(resolve => setTimeout(resolve, 1500));
     try {
-      await fetch(`http://${host}:${port}/__restart-active-workflow-runs`, {
+      await fetch(`${scheme}://${host}:${port}/__restart-active-workflow-runs`, {
         method: 'POST',
       });
     } catch {
@@ -206,11 +207,12 @@ const startServer = async (
         devLogger.ready(host, port, studioBasePath, apiPrefix, serverStartTime, startOptions.https);
         devLogger.watching();
 
-        await restartAllActiveWorkflowRuns({ host, port });
+        await restartAllActiveWorkflowRuns({ host, port, https: !!startOptions.https });
 
         // Send refresh signal
+        const scheme = startOptions.https ? 'https' : 'http';
         try {
-          await fetch(`http://${host}:${port}${studioBasePath}/__refresh`, {
+          await fetch(`${scheme}://${host}:${port}${studioBasePath}/__refresh`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -220,7 +222,7 @@ const startServer = async (
           // Retry after another second
           await new Promise(resolve => setTimeout(resolve, 1500));
           try {
-            await fetch(`http://${host}:${port}${studioBasePath}/__refresh`, {
+            await fetch(`${scheme}://${host}:${port}${studioBasePath}/__refresh`, {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
@@ -292,7 +294,8 @@ async function checkAndRestart(
 
   try {
     // Check if hot reload is disabled due to template installation
-    const response = await fetch(`http://${host}:${port}${studioBasePath}/__hot-reload-status`);
+    const scheme = startOptions.https ? 'https' : 'http';
+    const response = await fetch(`${scheme}://${host}:${port}${studioBasePath}/__hot-reload-status`);
     if (response.ok) {
       const status = (await response.json()) as { disabled: boolean; timestamp: string };
       if (status.disabled) {


### PR DESCRIPTION
## Summary

- All internal `fetch` calls in `mastra dev` (workflow restart, studio refresh, hot-reload status) were hardcoded to `http://`, causing `TypeError: fetch failed` when `server.https` was configured
- Added `https?: boolean` param to `restartAllActiveWorkflowRuns`, computed `scheme` from `startOptions.https` at each of the 5 affected call sites
- Adds unit tests covering both `http://` (no https) and `https://` (with https config) cases

Fixes #15953

## Test plan

- [ ] New test `should use https:// scheme for internal fetches when server.https is configured` was failing before this fix, now passes
- [ ] Existing test `should use http:// scheme when https is not configured` continues to pass (no regression)
- [ ] Full CLI test suite: 314/314 passing
- [ ] TypeScript typecheck: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you run mastra dev with HTTPS enabled, some internal requests were still using HTTP and failing. This PR makes those internal self-requests use HTTPS when the server is configured for it, so they succeed.

## Changes

### packages/cli/src/commands/dev/dev.ts
- Compute request scheme from startOptions.https (scheme = startOptions.https ? 'https' : 'http') for internal calls.
- Thread a new optional parameter https?: boolean through restartAllActiveWorkflowRuns and pass !!startOptions.https at call sites.
- Use the computed scheme for POSTs to /__restart-active-workflow-runs, {studioBasePath}/__refresh, and /__hot-reload-status (including their retry attempts).
- Preserve existing retry behavior and logging.

### packages/cli/src/commands/dev/dev.test.ts
- Add tests that stub global.fetch and assert internal fetch URLs use:
  - http:// when getServerOptions returns only host/port, and
  - https:// when getServerOptions includes https cert/key.
- Tests wait deterministically for the server-ready flow (vi.waitFor) and verify all matching internal fetches use the correct scheme.

## Impact
- Fixes issue #15953: avoids TypeError: fetch failed when server.https is configured.
- CLI test suite: 314/314 passing; TypeScript typecheck clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->