### PR TITLE
fix(cli): use HTTPS for dev internal fetches

### DIFF
--- a/packages/cli/src/commands/dev/dev.test.ts
+++ b/packages/cli/src/commands/dev/dev.test.ts
@@ -359,4 +359,49 @@ describe('dev command - inspect flag behavior', () => {
       expect(commands.some(cmd => cmd.startsWith('--inspect-brk='))).toBe(false);
     });
   });
+
+  describe('HTTPS internal dev server requests', () => {
+    it('uses https for ready and hot-reload fetches when dev HTTPS is enabled', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ disabled: true, timestamp: 'now' }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const { dev } = await import('./dev');
+
+      await dev({
+        dir: undefined,
+        root: process.cwd(),
+        tools: undefined,
+        env: undefined,
+        inspect: false,
+        inspectBrk: false,
+        customArgs: undefined,
+        https: true,
+        debug: false,
+      });
+
+      fetchMock.mockClear();
+
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith('https://localhost:4111/__restart-active-workflow-runs', {
+          method: 'POST',
+        });
+      });
+      expect(fetchMock).toHaveBeenCalledWith('https://localhost:4111/__refresh', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      const bundleEndHandler = mockWatcher.on.mock.calls.find(([event]) => event === 'event')?.[1];
+      expect(bundleEndHandler).toBeDefined();
+
+      await bundleEndHandler({ code: 'BUNDLE_END' });
+
+      expect(fetchMock).toHaveBeenCalledWith('https://localhost:4111/__hot-reload-status');
+    });
+  });
 });

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -72,9 +72,14 @@ type ProcessOptions = {
   publicDir: string;
 };
 
-const restartAllActiveWorkflowRuns = async ({ host, port }: { host: string; port: number }) => {
+const getDevServerBaseUrl = ({ host, port, https }: { host: string; port: number; https?: HTTPSOptions }) => {
+  const protocol = https ? 'https' : 'http';
+  return `${protocol}://${host}:${port}`;
+};
+
+const restartAllActiveWorkflowRuns = async ({ baseUrl }: { baseUrl: string }) => {
   try {
-    await fetch(`http://${host}:${port}/__restart-active-workflow-runs`, {
+    await fetch(`${baseUrl}/__restart-active-workflow-runs`, {
       method: 'POST',
     });
   } catch (error) {
@@ -82,7 +87,7 @@ const restartAllActiveWorkflowRuns = async ({ host, port }: { host: string; port
     // Retry after another second
     await new Promise(resolve => setTimeout(resolve, 1500));
     try {
-      await fetch(`http://${host}:${port}/__restart-active-workflow-runs`, {
+      await fetch(`${baseUrl}/__restart-active-workflow-runs`, {
         method: 'POST',
       });
     } catch {
@@ -161,6 +166,8 @@ const startServer = async (
       );
     }
 
+    const serverBaseUrl = getDevServerBaseUrl({ host, port, https: startOptions.https });
+
     // Filter server output to remove Studio message
     if (currentServerProcess.stdout) {
       currentServerProcess.stdout.on('data', (data: Buffer) => {
@@ -206,11 +213,11 @@ const startServer = async (
         devLogger.ready(host, port, studioBasePath, apiPrefix, serverStartTime, startOptions.https);
         devLogger.watching();
 
-        await restartAllActiveWorkflowRuns({ host, port });
+        await restartAllActiveWorkflowRuns({ baseUrl: serverBaseUrl });
 
         // Send refresh signal
         try {
-          await fetch(`http://${host}:${port}${studioBasePath}/__refresh`, {
+          await fetch(`${serverBaseUrl}${studioBasePath}/__refresh`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -220,7 +227,7 @@ const startServer = async (
           // Retry after another second
           await new Promise(resolve => setTimeout(resolve, 1500));
           try {
-            await fetch(`http://${host}:${port}${studioBasePath}/__refresh`, {
+            await fetch(`${serverBaseUrl}${studioBasePath}/__refresh`, {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
@@ -292,7 +299,8 @@ async function checkAndRestart(
 
   try {
     // Check if hot reload is disabled due to template installation
-    const response = await fetch(`http://${host}:${port}${studioBasePath}/__hot-reload-status`);
+    const serverBaseUrl = getDevServerBaseUrl({ host, port, https: startOptions.https });
+    const response = await fetch(`${serverBaseUrl}${studioBasePath}/__hot-reload-status`);
     if (response.ok) {
       const status = (await response.json()) as { disabled: boolean; timestamp: string };
       if (status.disabled) {


### PR DESCRIPTION
## Description

Fixes #15953.

`mastra dev` starts the local server with HTTPS when `--https` or `server.https` is configured, but its internal workflow restart, Studio refresh, and hot-reload status fetches were still hardcoded to `http://`. This derives the internal dev server base URL from the active `StartOptions.https` value and reuses it for those fetches.

## Validation

- `corepack pnpm@10.18.0 --dir packages/cli exec vitest run src/commands/dev/dev.test.ts --project unit:packages/cli`
- `corepack pnpm@10.18.0 --filter ./packages/cli typecheck`
- `corepack pnpm@10.18.0 --filter ./packages/cli lint -- src/commands/dev/dev.ts src/commands/dev/dev.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you run `mastra dev` with a secure (HTTPS) server, the CLI tool was trying to talk to it using regular, unencrypted (HTTP) requests, which failed. This fix makes the CLI automatically detect whether the server is using HTTPS and use secure requests too, so everything works together properly.

## Changes

### Test Coverage (`dev.test.ts`)
- Added test case verifying that when `dev` is started with `https: true`, all internal dev-server interactions use HTTPS endpoints
- Test validates that workflow restart, refresh, and hot-reload status requests are sent to `https://localhost:4111/...` with appropriate request headers

### Implementation (`dev.ts`)
- Introduced helper function to derive dev server base URL from `startOptions.https` (selecting `https://` or `http://` scheme accordingly)
- Refactored internal dev HTTP calls to use the dynamically-determined base URL instead of hardcoded `http://`
- Updated endpoints:
  - `restartAllActiveWorkflowRuns`: now posts to `${baseUrl}/__restart-active-workflow-runs`
  - Studio refresh: now targets `${serverBaseUrl}${studioBasePath}/__refresh`
  - Hot-reload status check: now fetches `${serverBaseUrl}${studioBasePath}/__hot-reload-status`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->