### PR TITLE
feat(core): add Entra ID authentication to Azure OpenAI gateway

### DIFF
--- a/.changeset/proud-bags-create.md
+++ b/.changeset/proud-bags-create.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': minor
+---
+
+Added Microsoft Entra ID authentication support for Azure OpenAI gateways, so Azure deployments can call models without API keys when using Azure SDK credentials.
+
+```ts
+import { DefaultAzureCredential } from "@azure/identity";
+import { AzureOpenAIGateway } from "@mastra/core/llm";
+
+new AzureOpenAIGateway({
+  resourceName: "my-openai-resource",
+  authentication: {
+    type: "entraId",
+    credential: new DefaultAzureCredential(),
+  },
+});
+```

--- a/.changeset/proud-bags-create.md
+++ b/.changeset/proud-bags-create.md
@@ -3,16 +3,3 @@
 ---
 
 Added Microsoft Entra ID authentication support for Azure OpenAI gateways, so Azure deployments can call models without API keys when using Azure SDK credentials.
-
-```ts
-import { DefaultAzureCredential } from "@azure/identity";
-import { AzureOpenAIGateway } from "@mastra/core/llm";
-
-new AzureOpenAIGateway({
-  resourceName: "my-openai-resource",
-  authentication: {
-    type: "entraId",
-    credential: new DefaultAzureCredential(),
-  },
-});
-```

--- a/docs/src/content/en/models/gateways/azure-openai.mdx
+++ b/docs/src/content/en/models/gateways/azure-openai.mdx
@@ -99,6 +99,41 @@ export const mastra = new Mastra({
 
 The Service Principal requires "Cognitive Services User" role. See [Azure documentation](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal).
 
+### Microsoft Entra ID authentication
+
+Use Microsoft Entra ID authentication when API keys are disabled for your Azure OpenAI resource. Pass any Azure SDK-compatible credential, such as `DefaultAzureCredential` from `@azure/identity`.
+
+Install `@azure/identity` in your Mastra project if you use `DefaultAzureCredential`.
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+import { Mastra } from "@mastra/core";
+import { AzureOpenAIGateway } from "@mastra/core/llm";
+
+export const mastra = new Mastra({
+  gateways: [
+    new AzureOpenAIGateway({
+      resourceName: "my-openai-resource",
+      authentication: {
+        type: "entraId",
+        credential: new DefaultAzureCredential(),
+      },
+      deployments: ["gpt-4-prod", "gpt-35-turbo-dev"],
+    }),
+  ],
+});
+```
+
+The identity needs permission to call Azure OpenAI, such as the `Cognitive Services OpenAI User` role.
+
+For a specific managed identity, pass `ManagedIdentityCredential` instead.
+
+```typescript
+import { ManagedIdentityCredential } from "@azure/identity";
+
+const credential = new ManagedIdentityCredential("client-id");
+```
+
 ### Manual Deployment Names
 
 Provide resource name and API key only. Specify deployment names when creating agents. No IDE autocomplete.
@@ -122,7 +157,11 @@ export const mastra = new Mastra({
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `resourceName` | `string` | Yes | Azure OpenAI resource name |
-| `apiKey` | `string` | Yes | API key from "Keys and Endpoint" |
+| `apiKey` | `string` | Yes* | API key from "Keys and Endpoint" |
+| `authentication` | `object` | No | Microsoft Entra ID authentication |
+| `authentication.type` | `"entraId"` | Yes* | Authentication mode |
+| `authentication.credential` | `TokenCredential` | Yes* | Azure SDK-compatible credential for `entraId` authentication mode |
+| `authentication.scope` | `string` | No | Token scope (default: `https://cognitiveservices.azure.com/.default`) |
 | `apiVersion` | `string` | No | API version (default: `2024-04-01-preview`) |
 | `deployments` | `string[]` | No | Deployment names for static mode |
 | `management` | `object` | No | Management API credentials |
@@ -132,4 +171,4 @@ export const mastra = new Mastra({
 | `management.subscriptionId` | `string` | Yes* | Azure subscription ID |
 | `management.resourceGroup` | `string` | Yes* | Resource group name |
 
-\* Required if `management` is provided
+\* Provide either `apiKey` or `authentication.type: "entraId"`. Management fields are required if `management` is provided.

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -155,7 +155,12 @@ export {
   AzureOpenAIGateway,
   MastraGateway,
 } from './model/gateways';
-export type { AzureOpenAIGatewayConfig, MastraGatewayConfig } from './model/gateways';
+export type {
+  AzureAccessToken,
+  AzureOpenAIGatewayConfig,
+  AzureTokenCredential,
+  MastraGatewayConfig,
+} from './model/gateways';
 export { GATEWAY_AUTH_HEADER } from './model/gateways/constants';
 
 export { ModelRouterEmbeddingModel, type EmbeddingModelId, EMBEDDING_MODELS, type EmbeddingModelInfo } from './model';

--- a/packages/core/src/llm/model/gateways/azure.test.ts
+++ b/packages/core/src/llm/model/gateways/azure.test.ts
@@ -517,6 +517,26 @@ describe('AzureOpenAIGateway', () => {
       const apiKey = await gateway.getApiKey('gpt-4');
       expect(apiKey).toBe('my-test-key');
     });
+
+    it('should return empty API key when Entra ID authentication is configured', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const gateway = new AzureOpenAIGateway({
+        resourceName: 'test-resource',
+        apiKey: 'my-test-key',
+        authentication: {
+          type: 'entraId',
+          credential: {
+            getToken: vi.fn(),
+          },
+        },
+        deployments: ['gpt-4'],
+      });
+
+      const apiKey = await gateway.getApiKey('gpt-4');
+      expect(apiKey).toBe('');
+
+      warnSpy.mockRestore();
+    });
   });
 
   describe('resolveLanguageModel', () => {
@@ -584,6 +604,8 @@ describe('AzureOpenAIGateway', () => {
         apiKey: await gateway.getApiKey('gpt-4'),
       })) as any;
 
+      expect(model.options.apiKey).toBe('');
+
       mockFetch.mockResolvedValueOnce(new Response('{}'));
 
       await model.options.fetch('https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions', {
@@ -639,6 +661,57 @@ describe('AzureOpenAIGateway', () => {
       });
 
       expect(credential.getToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should dedupe concurrent Entra ID token requests', async () => {
+      let resolveToken: (value: { token: string; expiresOnTimestamp: number }) => void = () => {};
+      const tokenPromise = new Promise<{ token: string; expiresOnTimestamp: number }>(resolve => {
+        resolveToken = resolve;
+      });
+      const credential = {
+        getToken: vi.fn().mockReturnValue(tokenPromise),
+      };
+
+      const gateway = new AzureOpenAIGateway({
+        resourceName: 'test-resource',
+        authentication: {
+          type: 'entraId',
+          credential,
+        },
+        deployments: ['gpt-4'],
+      });
+
+      const model = (await gateway.resolveLanguageModel({
+        modelId: 'gpt-4',
+        providerId: 'azure-openai',
+        apiKey: await gateway.getApiKey('gpt-4'),
+      })) as any;
+
+      mockFetch.mockResolvedValue(new Response('{}'));
+
+      const requests = [
+        model.options.fetch('https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions', {
+          headers: { 'api-key': '' },
+        }),
+        model.options.fetch('https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions', {
+          headers: { 'api-key': '' },
+        }),
+      ];
+
+      await Promise.resolve();
+
+      expect(credential.getToken).toHaveBeenCalledTimes(1);
+
+      resolveToken({
+        token: 'deduped-token',
+        expiresOnTimestamp: Date.now() + 3600_000,
+      });
+
+      await Promise.all(requests);
+
+      expect(credential.getToken).toHaveBeenCalledTimes(1);
+      const headers = mockFetch.mock.calls.at(-1)?.[1].headers as Headers;
+      expect(headers.get('Authorization')).toBe('Bearer deduped-token');
     });
   });
 });

--- a/packages/core/src/llm/model/gateways/azure.test.ts
+++ b/packages/core/src/llm/model/gateways/azure.test.ts
@@ -1,6 +1,14 @@
+import { createAzure } from '@ai-sdk/azure';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { AzureOpenAIGateway } from './azure';
 import type { AzureOpenAIGatewayConfig } from './azure';
+
+vi.mock('@ai-sdk/azure', () => ({
+  createAzure: vi.fn((options: Record<string, unknown>) => {
+    const provider = vi.fn((modelId: string) => ({ modelId, options }));
+    return provider;
+  }),
+}));
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch as any;
@@ -21,13 +29,59 @@ describe('AzureOpenAIGateway', () => {
       }).toThrow('resourceName is required');
     });
 
-    it('should throw error if apiKey missing', () => {
+    it('should throw error if apiKey and Entra ID authentication are missing', () => {
       expect(() => {
         new AzureOpenAIGateway({
           resourceName: 'test-resource',
           deployments: ['gpt-4'],
         } as AzureOpenAIGatewayConfig);
-      }).toThrow('apiKey is required');
+      }).toThrow('apiKey or Entra ID authentication is required');
+    });
+
+    it('should allow Entra ID authentication without apiKey', () => {
+      expect(() => {
+        new AzureOpenAIGateway({
+          resourceName: 'test-resource',
+          deployments: ['gpt-4'],
+          authentication: {
+            type: 'entraId',
+            credential: {
+              getToken: vi.fn(),
+            },
+          },
+        });
+      }).not.toThrow();
+    });
+
+    it('should throw error if Entra ID credential missing', () => {
+      expect(() => {
+        new AzureOpenAIGateway({
+          resourceName: 'test-resource',
+          deployments: ['gpt-4'],
+          authentication: {
+            type: 'entraId',
+          } as any,
+        });
+      }).toThrow('credential is required');
+    });
+
+    it('should warn if both apiKey and Entra ID authentication provided', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      new AzureOpenAIGateway({
+        resourceName: 'test-resource',
+        apiKey: 'test-key',
+        deployments: ['gpt-4'],
+        authentication: {
+          type: 'entraId',
+          credential: {
+            getToken: vi.fn(),
+          },
+        },
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Both apiKey and Entra ID authentication provided'));
+      warnSpy.mockRestore();
     });
 
     it('should allow neither deployments nor management (manual deployment names)', () => {
@@ -481,6 +535,14 @@ describe('AzureOpenAIGateway', () => {
       });
 
       expect(model).toBeDefined();
+      expect(createAzure).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          resourceName: 'test-resource',
+          apiKey: 'test-key',
+          apiVersion: '2024-04-01-preview',
+          useDeploymentBasedUrls: true,
+        }),
+      );
     });
 
     it('should use default API version if not provided', async () => {
@@ -497,6 +559,86 @@ describe('AzureOpenAIGateway', () => {
       });
 
       expect(model).toBeDefined();
+    });
+
+    it('should use Entra ID bearer auth through custom fetch', async () => {
+      const credential = {
+        getToken: vi.fn().mockResolvedValue({
+          token: 'entra-token',
+          expiresOnTimestamp: Date.now() + 3600_000,
+        }),
+      };
+
+      const gateway = new AzureOpenAIGateway({
+        resourceName: 'test-resource',
+        authentication: {
+          type: 'entraId',
+          credential,
+        },
+        deployments: ['gpt-4'],
+      });
+
+      const model = (await gateway.resolveLanguageModel({
+        modelId: 'gpt-4',
+        providerId: 'azure-openai',
+        apiKey: await gateway.getApiKey('gpt-4'),
+      })) as any;
+
+      mockFetch.mockResolvedValueOnce(new Response('{}'));
+
+      await model.options.fetch('https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions', {
+        headers: {
+          'api-key': '',
+          'Content-Type': 'application/json',
+        },
+      });
+
+      expect(credential.getToken).toHaveBeenCalledWith('https://cognitiveservices.azure.com/.default');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions',
+        expect.objectContaining({
+          headers: expect.any(Headers),
+        }),
+      );
+
+      const headers = mockFetch.mock.calls.at(-1)?.[1].headers as Headers;
+      expect(headers.get('Authorization')).toBe('Bearer entra-token');
+      expect(headers.has('api-key')).toBe(false);
+    });
+
+    it('should cache Entra ID tokens', async () => {
+      const credential = {
+        getToken: vi.fn().mockResolvedValue({
+          token: 'cached-token',
+          expiresOnTimestamp: Date.now() + 3600_000,
+        }),
+      };
+
+      const gateway = new AzureOpenAIGateway({
+        resourceName: 'test-resource',
+        authentication: {
+          type: 'entraId',
+          credential,
+        },
+        deployments: ['gpt-4'],
+      });
+
+      const model = (await gateway.resolveLanguageModel({
+        modelId: 'gpt-4',
+        providerId: 'azure-openai',
+        apiKey: await gateway.getApiKey('gpt-4'),
+      })) as any;
+
+      mockFetch.mockResolvedValue(new Response('{}'));
+
+      await model.options.fetch('https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions', {
+        headers: { 'api-key': '' },
+      });
+      await model.options.fetch('https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions', {
+        headers: { 'api-key': '' },
+      });
+
+      expect(credential.getToken).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/core/src/llm/model/gateways/azure.ts
+++ b/packages/core/src/llm/model/gateways/azure.ts
@@ -34,11 +34,25 @@ interface CachedToken {
   expiresAt: number;
 }
 
+export interface AzureAccessToken {
+  token: string;
+  expiresOnTimestamp?: number;
+}
+
+export interface AzureTokenCredential {
+  getToken(scopes: string | string[], options?: unknown): Promise<AzureAccessToken | null>;
+}
+
 export interface AzureOpenAIGatewayConfig {
   resourceName: string;
-  apiKey: string;
+  apiKey?: string;
   apiVersion?: string;
   deployments?: string[];
+  authentication?: {
+    type: 'entraId';
+    credential: AzureTokenCredential;
+    scope?: string;
+  };
   management?: {
     tenantId: string;
     clientId: string;
@@ -68,13 +82,28 @@ export class AzureOpenAIGateway extends MastraModelGateway {
       });
     }
 
-    if (!this.config.apiKey) {
+    if (!this.config.apiKey && this.config.authentication?.type !== 'entraId') {
       throw new MastraError({
         id: 'AZURE_GATEWAY_INVALID_CONFIG',
         domain: 'LLM',
         category: 'UNKNOWN',
-        text: 'apiKey is required for Azure OpenAI gateway',
+        text: 'apiKey or Entra ID authentication is required for Azure OpenAI gateway',
       });
+    }
+
+    if (this.config.authentication?.type === 'entraId' && !this.config.authentication.credential) {
+      throw new MastraError({
+        id: 'AZURE_GATEWAY_INVALID_CONFIG',
+        domain: 'LLM',
+        category: 'UNKNOWN',
+        text: 'credential is required for Azure OpenAI Entra ID authentication',
+      });
+    }
+
+    if (this.config.apiKey && this.config.authentication?.type === 'entraId') {
+      console.warn(
+        '[AzureOpenAIGateway] Both apiKey and Entra ID authentication provided. Using Entra ID authentication and ignoring apiKey.',
+      );
     }
 
     const hasDeployments = this.config.deployments && this.config.deployments.length > 0;
@@ -294,7 +323,58 @@ export class AzureOpenAIGateway extends MastraModelGateway {
   }
 
   async getApiKey(_modelId: string): Promise<string> {
-    return this.config.apiKey;
+    return this.config.apiKey ?? '';
+  }
+
+  private async getEntraIdToken(): Promise<string> {
+    if (this.config.authentication?.type !== 'entraId') {
+      throw new MastraError({
+        id: 'AZURE_ENTRA_ID_AUTH_NOT_CONFIGURED',
+        domain: 'LLM',
+        category: 'UNKNOWN',
+        text: 'Entra ID authentication is not configured for Azure OpenAI gateway',
+      });
+    }
+
+    const scope = this.config.authentication.scope ?? 'https://cognitiveservices.azure.com/.default';
+    const cacheKey = `azure-openai-token:${scope}`;
+    const cached = (await this.tokenCache.get(cacheKey)) as CachedToken | undefined;
+    if (cached && cached.expiresAt > Date.now() / 1000 + 60) {
+      return cached.token;
+    }
+
+    const accessToken = await this.config.authentication.credential.getToken(scope);
+    if (!accessToken?.token) {
+      throw new MastraError({
+        id: 'AZURE_ENTRA_ID_TOKEN_ERROR',
+        domain: 'LLM',
+        category: 'UNKNOWN',
+        text: 'Failed to get Entra ID token for Azure OpenAI gateway',
+      });
+    }
+
+    await this.tokenCache.set(cacheKey, {
+      token: accessToken.token,
+      expiresAt: accessToken.expiresOnTimestamp
+        ? Math.floor(accessToken.expiresOnTimestamp / 1000)
+        : Math.floor(Date.now() / 1000) + 300,
+    });
+
+    return accessToken.token;
+  }
+
+  private createEntraIdFetch(): typeof globalThis.fetch {
+    return async (input, init) => {
+      const token = await this.getEntraIdToken();
+      const headers = new Headers(init?.headers);
+      headers.delete('api-key');
+      headers.set('Authorization', `Bearer ${token}`);
+
+      return fetch(input, {
+        ...init,
+        headers,
+      });
+    };
   }
 
   async resolveLanguageModel({
@@ -308,13 +388,22 @@ export class AzureOpenAIGateway extends MastraModelGateway {
     headers?: Record<string, string>;
   }): Promise<LanguageModelV2> {
     const apiVersion = this.config.apiVersion || '2024-04-01-preview';
-
-    return createAzure({
+    const useEntraId = this.config.authentication?.type === 'entraId';
+    const azureConfig = {
       resourceName: this.config.resourceName,
       apiKey,
       apiVersion,
       useDeploymentBasedUrls: true,
       headers: { 'User-Agent': MASTRA_USER_AGENT, ...headers },
-    })(modelId);
+    };
+
+    if (useEntraId) {
+      return createAzure({
+        ...azureConfig,
+        fetch: this.createEntraIdFetch(),
+      })(modelId);
+    }
+
+    return createAzure(azureConfig)(modelId);
   }
 }

--- a/packages/core/src/llm/model/gateways/azure.ts
+++ b/packages/core/src/llm/model/gateways/azure.ts
@@ -66,6 +66,7 @@ export class AzureOpenAIGateway extends MastraModelGateway {
   readonly id = 'azure-openai';
   readonly name = 'azure-openai';
   private tokenCache = new InMemoryServerCache();
+  private entraIdTokenRequests = new Map<string, Promise<CachedToken>>();
 
   constructor(private config: AzureOpenAIGatewayConfig) {
     super();
@@ -323,7 +324,7 @@ export class AzureOpenAIGateway extends MastraModelGateway {
   }
 
   async getApiKey(_modelId: string): Promise<string> {
-    return this.config.apiKey ?? '';
+    return this.config.authentication?.type === 'entraId' ? '' : (this.config.apiKey ?? '');
   }
 
   private async getEntraIdToken(): Promise<string> {
@@ -343,6 +344,31 @@ export class AzureOpenAIGateway extends MastraModelGateway {
       return cached.token;
     }
 
+    let tokenRequest = this.entraIdTokenRequests.get(cacheKey);
+
+    if (!tokenRequest) {
+      tokenRequest = this.fetchEntraIdToken(scope, cacheKey);
+      this.entraIdTokenRequests.set(cacheKey, tokenRequest);
+    }
+
+    try {
+      const token = await tokenRequest;
+      return token.token;
+    } finally {
+      this.entraIdTokenRequests.delete(cacheKey);
+    }
+  }
+
+  private async fetchEntraIdToken(scope: string, cacheKey: string): Promise<CachedToken> {
+    if (this.config.authentication?.type !== 'entraId') {
+      throw new MastraError({
+        id: 'AZURE_ENTRA_ID_AUTH_NOT_CONFIGURED',
+        domain: 'LLM',
+        category: 'UNKNOWN',
+        text: 'Entra ID authentication is not configured for Azure OpenAI gateway',
+      });
+    }
+
     const accessToken = await this.config.authentication.credential.getToken(scope);
     if (!accessToken?.token) {
       throw new MastraError({
@@ -353,14 +379,16 @@ export class AzureOpenAIGateway extends MastraModelGateway {
       });
     }
 
-    await this.tokenCache.set(cacheKey, {
+    const token = {
       token: accessToken.token,
       expiresAt: accessToken.expiresOnTimestamp
         ? Math.floor(accessToken.expiresOnTimestamp / 1000)
         : Math.floor(Date.now() / 1000) + 300,
-    });
+    };
 
-    return accessToken.token;
+    await this.tokenCache.set(cacheKey, token);
+
+    return token;
   }
 
   private createEntraIdFetch(): typeof globalThis.fetch {
@@ -391,7 +419,7 @@ export class AzureOpenAIGateway extends MastraModelGateway {
     const useEntraId = this.config.authentication?.type === 'entraId';
     const azureConfig = {
       resourceName: this.config.resourceName,
-      apiKey,
+      apiKey: useEntraId ? '' : apiKey,
       apiVersion,
       useDeploymentBasedUrls: true,
       headers: { 'User-Agent': MASTRA_USER_AGENT, ...headers },

--- a/packages/core/src/llm/model/gateways/index.ts
+++ b/packages/core/src/llm/model/gateways/index.ts
@@ -1,7 +1,12 @@
 import { MastraError } from '../../../error/index.js';
 import type { MastraModelGateway } from './base.js';
 export { MastraModelGateway, type ProviderConfig, type GatewayLanguageModel } from './base.js';
-export { AzureOpenAIGateway, type AzureOpenAIGatewayConfig } from './azure.js';
+export {
+  AzureOpenAIGateway,
+  type AzureAccessToken,
+  type AzureOpenAIGatewayConfig,
+  type AzureTokenCredential,
+} from './azure.js';
 export { ModelsDevGateway } from './models-dev.js';
 export { MastraGateway, type MastraGatewayConfig } from './mastra.js';
 export { NetlifyGateway } from './netlify.js';


### PR DESCRIPTION
## Description

Adds Microsoft Entra ID (managed identity / service principal) authentication to the Azure OpenAI gateway so users can call Azure OpenAI deployments without an API key. This is required in production environments where API keys are disabled for security reasons.

- Added optional `authentication: { type: 'entraId', credential, scope? }` field on `AzureOpenAIGatewayConfig`
- Defined `AzureTokenCredential` interface that is structurally compatible with `@azure/identity`'s `TokenCredential`, so callers can pass `DefaultAzureCredential`, `ManagedIdentityCredential`, etc. without forcing `@azure/identity` as a dependency
- Implemented token acquisition via `credential.getToken(scope)` with caching through the existing `InMemoryServerCache` (60s expiry buffer, default 5-minute TTL when `expiresOnTimestamp` is missing)
- Wrapped `createAzure` with a custom `fetch` that strips the `api-key` header and injects `Authorization: Bearer <token>`
- Made `apiKey` optional in `AzureOpenAIGatewayConfig` and updated validation to require either `apiKey` or `authentication.type: 'entraId'`
- Re-exported `AzureAccessToken` and `AzureTokenCredential` types from `@mastra/core/llm`
- Added documentation section and config table updates in `docs/src/content/en/models/gateways/azure-openai.mdx`
- Added unit tests covering Entra ID validation, custom fetch bearer injection, and token caching
- Added changeset entry (minor bump for `@mastra/core`)

## Related Issue(s)

Fixes #15814

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR lets the system talk to Azure OpenAI without storing a secret key by using Azure's built-in identity system (like a secure badge your app can use). That makes production setups safer because you don't have to manage API keys.

## Overview

Adds Microsoft Entra ID (managed identity / service principal) authentication to the Azure OpenAI gateway so callers can authenticate using Azure credentials instead of an API key, meeting production security needs where API keys are disabled.

## Key Changes

- Core gateway logic (packages/core/src/llm/model/gateways/azure.ts)
  - Added exported types AzureAccessToken and AzureTokenCredential (structurally compatible with @azure/identity TokenCredential).
  - Extended AzureOpenAIGatewayConfig with optional authentication: { type: 'entraId'; credential: AzureTokenCredential; scope?: string }.
  - Made apiKey optional and updated validation to require either apiKey or authentication.type === 'entraId'.
  - Enforced presence of credential for Entra ID; warn if both apiKey and Entra ID provided (Entra ID wins).
  - Implemented token acquisition via credential.getToken(scope) with caching (InMemoryServerCache) including 60s expiry buffer and default 5-minute TTL when expiresOnTimestamp is absent.
  - Added in-flight deduplication for concurrent getToken requests.
  - Wrapped createAzure with a custom fetch that strips api-key header and injects Authorization: Bearer <token>.
  - getApiKey returns empty string in Entra ID mode and explicit error paths for missing credential or failed token retrieval.

- Public exports
  - Re-exported AzureAccessToken and AzureTokenCredential from packages/core/src/llm and updated barrel exports.

- Tests (packages/core/src/llm/model/gateways/azure.test.ts)
  - Added tests for validation (missing credential throws, warning when both methods present), custom-fetch bearer injection (no api-key header, Authorization set), correct scope passed to getToken, token caching, and concurrent request deduplication.

- Documentation & release
  - docs updated (docs/src/content/en/models/gateways/azure-openai.mdx) with Entra ID examples (DefaultAzureCredential, ManagedIdentityCredential), required roles/permissions, and configuration table reflecting conditional apiKey requirement.
  - Added changeset entry for a minor bump of @mastra/core.

## Public API Changes

- AzureOpenAIGatewayConfig:
  - apiKey: string → apiKey?: string
  - + authentication?: { type: 'entraId'; credential: AzureTokenCredential; scope?: string }

- New exported types: AzureAccessToken, AzureTokenCredential

## Notes / Behavior

- No new runtime dependencies added; credential interface is compatible with Azure SDK types so callers may pass DefaultAzureCredential, ManagedIdentityCredential, etc.
- Entra ID authentication takes precedence over apiKey when both are provided (warning logged).
- Token caching and dedupe reduce calls to credential.getToken and improve performance.
- Fixes issue #15814.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->