### PR TITLE
feat(clickhouse): add ClickhouseStoreVNext helper

### DIFF
--- a/.changeset/twelve-coats-punch.md
+++ b/.changeset/twelve-coats-punch.md
@@ -1,0 +1,21 @@
+---
+'@mastra/clickhouse': minor
+---
+
+Added ClickhouseStoreVNext, a ClickHouse storage adapter that uses the vNext observability domain by default. Equivalent to constructing a ClickhouseStore and overriding the observability domain manually, but exposed as a single class for new projects.
+
+```typescript
+import { Mastra } from '@mastra/core';
+import { ClickhouseStoreVNext } from '@mastra/clickhouse';
+
+export const mastra = new Mastra({
+  storage: new ClickhouseStoreVNext({
+    id: 'clickhouse-storage',
+    url: process.env.CLICKHOUSE_URL!,
+    username: process.env.CLICKHOUSE_USERNAME!,
+    password: process.env.CLICKHOUSE_PASSWORD!,
+  }),
+});
+```
+
+ClickhouseStoreVNext accepts the same configuration as ClickhouseStore and reuses the same ClickHouse client across every domain. ClickhouseStore continues to work for projects on the legacy observability schema.

--- a/docs/src/content/en/reference/storage/clickhouse.mdx
+++ b/docs/src/content/en/reference/storage/clickhouse.mdx
@@ -89,7 +89,27 @@ New projects should use `ObservabilityStorageClickhouseVNext` instead.
 
 ### ClickHouse for every domain
 
-`ClickhouseStore` implements the `memory`, `workflows`, and `observability` domains, and is suitable when you want ClickHouse to back the entire application. Its built-in observability domain uses the legacy adapter, so wrap it in a composite store that overrides the `observability` domain with `ObservabilityStorageClickhouseVNext`:
+`ClickhouseStoreVNext` backs the `memory`, `workflows`, and `observability` domains with ClickHouse and uses the vNext observability adapter automatically. Use it when you want ClickHouse to back the entire application without wiring a composite store manually.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { ClickhouseStoreVNext } from '@mastra/clickhouse'
+
+export const mastra = new Mastra({
+  storage: new ClickhouseStoreVNext({
+    id: 'clickhouse-storage',
+    url: process.env.CLICKHOUSE_URL!,
+    username: process.env.CLICKHOUSE_USERNAME!,
+    password: process.env.CLICKHOUSE_PASSWORD!,
+  }),
+})
+```
+
+`ClickhouseStoreVNext` accepts the same configuration as `ClickhouseStore` and reuses the same ClickHouse client across every domain.
+
+#### Manual composition
+
+`ClickhouseStore` is the long-standing class that backs every domain with the legacy observability adapter. New projects should prefer `ClickhouseStoreVNext`. If you need to customize the composite (for example, to override one domain with a different backend), build it manually:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -288,3 +288,48 @@ export class ClickhouseStore extends MastraCompositeStore {
     }
   }
 }
+
+/**
+ * ClickHouse storage adapter that uses the vNext observability domain by default.
+ *
+ * Equivalent to constructing a `ClickhouseStore` and overriding the `observability`
+ * domain with `ObservabilityStorageClickhouseVNext` through `MastraCompositeStore`.
+ * Use this in new projects to opt into the vNext observability schema without
+ * needing to wire the composite manually.
+ *
+ * Accepts the same configuration as `ClickhouseStore`. The underlying ClickHouse
+ * client is shared between every domain, including observability.
+ *
+ * @example
+ * ```typescript
+ * import { Mastra } from '@mastra/core';
+ * import { ClickhouseStoreVNext } from '@mastra/clickhouse';
+ *
+ * export const mastra = new Mastra({
+ *   storage: new ClickhouseStoreVNext({
+ *     id: 'clickhouse-storage',
+ *     url: process.env.CLICKHOUSE_URL!,
+ *     username: process.env.CLICKHOUSE_USERNAME!,
+ *     password: process.env.CLICKHOUSE_PASSWORD!,
+ *   }),
+ * });
+ * ```
+ */
+export class ClickhouseStoreVNext extends ClickhouseStore {
+  constructor(config: ClickhouseConfig) {
+    super(config);
+
+    // Identify as ClickhouseStoreVNext for callers that introspect `name`.
+    // The logger created by MastraBase still reflects the parent name.
+    this.name = 'ClickhouseStoreVNext';
+
+    // Replace the legacy observability domain set up by ClickhouseStore with the
+    // vNext implementation. Both share the same underlying client.
+    const observability = new ObservabilityStorageClickhouseVNext({ client: this.db });
+
+    this.stores = {
+      ...this.stores,
+      observability,
+    };
+  }
+}

--- a/stores/clickhouse/src/storage/index.vnext.test.ts
+++ b/stores/clickhouse/src/storage/index.vnext.test.ts
@@ -1,0 +1,93 @@
+import { createClient } from '@clickhouse/client';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+import { MemoryStorageClickhouse } from './domains/memory';
+import { ObservabilityStorageClickhouse } from './domains/observability';
+import { ObservabilityStorageClickhouseVNext } from './domains/observability/v-next';
+import { ScoresStorageClickhouse } from './domains/scores';
+import { WorkflowsStorageClickhouse } from './domains/workflows';
+import { ClickhouseStoreVNext } from '.';
+import type { ClickhouseConfig } from '.';
+
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+const TEST_CONFIG: ClickhouseConfig = {
+  id: 'clickhouse-vnext-test',
+  url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+  username: process.env.CLICKHOUSE_USERNAME || 'default',
+  password: process.env.CLICKHOUSE_PASSWORD || 'password',
+};
+
+describe('ClickhouseStoreVNext', () => {
+  describe('domain wiring', () => {
+    const store = new ClickhouseStoreVNext(TEST_CONFIG);
+
+    afterAll(async () => {
+      await store.close();
+    });
+
+    it('wires the vNext observability domain', () => {
+      expect(store.stores.observability).toBeInstanceOf(ObservabilityStorageClickhouseVNext);
+    });
+
+    it('does not use the legacy observability domain', () => {
+      expect(store.stores.observability).not.toBeInstanceOf(ObservabilityStorageClickhouse);
+    });
+
+    it('keeps the standard ClickHouse memory, workflows, and scores domains', () => {
+      expect(store.stores.memory).toBeInstanceOf(MemoryStorageClickhouse);
+      expect(store.stores.workflows).toBeInstanceOf(WorkflowsStorageClickhouse);
+      expect(store.stores.scores).toBeInstanceOf(ScoresStorageClickhouse);
+    });
+
+    it('exposes vNext observability through getStore()', async () => {
+      const observability = await store.getStore('observability');
+      expect(observability).toBeInstanceOf(ObservabilityStorageClickhouseVNext);
+    });
+
+    it('identifies as ClickhouseStoreVNext via the name field', () => {
+      expect(store.name).toBe('ClickhouseStoreVNext');
+    });
+  });
+
+  describe('configuration forms', () => {
+    it('accepts a pre-configured ClickHouse client', async () => {
+      const client = createClient({
+        url: TEST_CONFIG.url,
+        username: TEST_CONFIG.username,
+        password: TEST_CONFIG.password,
+      });
+      const store = new ClickhouseStoreVNext({ id: 'vnext-client-config', client });
+
+      try {
+        expect(store.stores.observability).toBeInstanceOf(ObservabilityStorageClickhouseVNext);
+      } finally {
+        await store.close();
+      }
+    });
+
+    it('rejects empty url like ClickhouseStore does', () => {
+      expect(
+        () =>
+          new ClickhouseStoreVNext({
+            id: 'invalid',
+            url: '',
+            username: 'default',
+            password: 'password',
+          }),
+      ).toThrow(/url is required/i);
+    });
+  });
+
+  describe('initialization', () => {
+    it('runs init() end-to-end without throwing', async () => {
+      const store = new ClickhouseStoreVNext({ ...TEST_CONFIG, id: 'vnext-init-test' });
+
+      try {
+        await expect(store.init()).resolves.not.toThrow();
+      } finally {
+        await store.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `ClickhouseStoreVNext`, a ClickHouse storage adapter that wires up `ObservabilityStorageClickhouseVNext` as the observability domain by default.

This is the helper class flagged during review of the ClickHouse storage docs (#15912 review thread). It's equivalent to constructing a `ClickhouseStore` and overriding the observability domain manually with `MastraCompositeStore`, but exposed as a single class so new projects don't have to repeat that wiring.

```typescript
import { Mastra } from '@mastra/core'
import { ClickhouseStoreVNext } from '@mastra/clickhouse'

export const mastra = new Mastra({
  storage: new ClickhouseStoreVNext({
    id: 'clickhouse-storage',
    url: process.env.CLICKHOUSE_URL!,
    username: process.env.CLICKHOUSE_USERNAME!,
    password: process.env.CLICKHOUSE_PASSWORD!,
  }),
})
```

## Implementation

`ClickhouseStoreVNext` extends `ClickhouseStore`. After `super()` constructs the legacy domains, the constructor swaps `this.stores.observability` for a fresh `ObservabilityStorageClickhouseVNext` instance backed by the same ClickHouse client. No additional connections, no duplicate config surface — `ClickhouseConfig` works as-is.

The `name` field is overridden to `'ClickhouseStoreVNext'` so callers introspecting the instance see the correct identity. The console logger created by `MastraBase` still reflects the parent name (logger name is built at construction time); that's a known minor cosmetic and easy to clean up later if it matters.

## Docs

Updated `reference/storage/clickhouse.mdx` so the **ClickHouse for every domain** section leads with `ClickhouseStoreVNext` as the recommended path. The manual `MastraCompositeStore` + `ClickhouseStore` + `ObservabilityStorageClickhouseVNext` composition is preserved as a `Manual composition` subsection for users who need to customize the composite (for example, to override another domain).

## Tests

Added `stores/clickhouse/src/storage/index.vnext.test.ts` covering:

- **Domain wiring**: `observability` is `ObservabilityStorageClickhouseVNext`, not the legacy class. `memory`, `workflows`, `scores` still come from `ClickhouseStore`. `getStore('observability')` returns the vNext instance. `name` reports `'ClickhouseStoreVNext'`.
- **Configuration forms**: pre-configured `ClickHouseClient` config works. Empty `url` is rejected like `ClickhouseStore`.
- **Initialization**: `init()` runs end-to-end against ClickHouse without throwing.

The init test requires a running ClickHouse (the existing docker-compose harness handles this in CI). Local Docker wasn't available in this dev environment, but typecheck and lint pass cleanly.

## Test plan

- [x] `pnpm tsc --noEmit -p tsconfig.json` (clickhouse package) — clean
- [x] `pnpm lint` (clickhouse package) — clean
- [x] `pnpm validate` (docs) — clean
- [ ] `pnpm test` (clickhouse package) — runs in CI via docker-compose

## Followup

The `name`/logger split mentioned above could be addressed by adding a `name` override to `ClickhouseStore`'s constructor. Out of scope for this PR.

https://claude.ai/code/session_01AzAdE2Ba5nsB8y2BebCFtK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzAdE2Ba5nsB8y2BebCFtK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a new `ClickhouseStoreVNext` helper that's like an upgraded version of the existing ClickHouse storage option. Instead of using the old observability system, it uses a newer, improved one—but they both share the same database connection, so it's more efficient. Think of it like replacing an old part of your storage system with a better version without needing to set up a whole new database.

## Summary of Changes

**New Class: ClickhouseStoreVNext**
- Adds `ClickhouseStoreVNext` as a new export that extends `ClickhouseStore`
- Automatically swaps the observability domain from the legacy `ObservabilityStorageClickhouse` to the newer `ObservabilityStorageClickhouseVNext`
- Reuses the same ClickHouse client across all domains (no duplicate connections)
- Uses the same `ClickhouseConfig` configuration—no new settings required
- Sets its name to `"ClickhouseStoreVNext"`

**Documentation Updates**
- Updated `docs/src/content/en/reference/storage/clickhouse.mdx` to recommend `ClickhouseStoreVNext` as the primary option for "ClickHouse for every domain" use cases
- Provides example configuration showing direct instantiation: `new ClickhouseStoreVNext({id, url, username, password})`
- Preserves the manual composition approach (`MastraCompositeStore` + `ClickhouseStore` + `ObservabilityStorageClickhouseVNext`) as an alternative "Manual composition" subsection for users who need it

**Changeset Entry**
- Added `.changeset/twelve-coats-punch.md` marking a `minor` release for `@mastra/clickhouse` with documentation of the new adapter

**Tests**
- New test suite at `stores/clickhouse/src/storage/index.vnext.test.ts` covering:
  - Domain wiring verification (observability uses vNext; other domains unchanged)
  - Configuration validation (ClickHouseClient config acceptance, empty URL rejection)
  - `getStore()` behavior and `name` property
  - End-to-end `init()` against ClickHouse
  - Support for both configuration object and pre-created client

## Known Issues
- Minor cosmetic logger-name mismatch where the parent `MastraBase`-built logger reflects the parent class name rather than `ClickhouseStoreVNext` (documented as a follow-up item)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->