### PR TITLE
docs: add difficult bug debugging skill

### DIFF
--- a/.claude/skills/debugging-difficult-bugs/SKILL.md
+++ b/.claude/skills/debugging-difficult-bugs/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: debugging-difficult-bugs
+description: Use early when debugging a medium or hard bug, especially when tests alone may not reveal the real runtime failure. Trigger this before extended TDD iteration when a bug involves runtime state, ordering, persistence, streaming, UI/manual reproduction, or when a red test may not fully model the issue.
+---
+
+# Debugging Difficult Bugs
+
+Use this skill early for medium or hard bugs where normal TDD may give false confidence because the test does not fully capture the real bug.
+
+Core idea: **instrument the actual runtime path, reproduce the real issue, then inspect append-only JSONL logs before deciding on a fix.**
+
+## When to Use
+
+Use this workflow near the start of debugging when any of these are true:
+
+- The bug is medium or hard complexity, especially if it spans multiple functions, packages, processes, or UI/runtime boundaries.
+- A test is red, but the failing test might be an incomplete model of the real bug.
+- You are tempted to make a second speculative fix without new runtime evidence.
+- The bug depends on runtime ordering, state, caching, streaming, concurrency, persistence, UI interaction, or external services.
+- The user says they can reproduce the issue manually.
+- The test passes after a change, but you are not confident it proves the actual reported bug is fixed.
+
+Do **not** keep iterating only on tests if you do not understand the runtime behavior.
+
+## Required Approach
+
+1. **State the uncertainty**
+   - Acknowledge that the current test may not capture the actual bug.
+   - Identify the real code path that must be observed.
+
+2. **Add temporary unconditional instrumentation**
+   - Add logs throughout the suspected code flow.
+   - Logs must be unconditional: do **not** gate them behind an env var, debug flag, or log level.
+   - Each log point must append one JSON object per line to a `.jsonl` file in the current working directory.
+   - Include enough context to reconstruct the path: event name, timestamp, relevant ids, input shape, state transitions, branch decisions, return values, and caught errors.
+
+3. **Reproduce the real issue**
+   - Prefer to run the reproduction yourself if possible.
+   - If the issue requires the user's environment or manual interaction, ask the user to reproduce it after instrumentation is added.
+   - Tell the user exactly which `.jsonl` file to send or ask them to tell you when reproduction is complete so you can inspect it.
+
+4. **Analyze the log before fixing**
+   - Read the JSONL log chronologically.
+   - Compare expected flow vs actual flow.
+   - Identify the first point where state or behavior diverges.
+   - Only then implement the fix.
+
+5. **Clean up instrumentation**
+   - Remove all temporary unconditional logs after root cause is understood and the fix is verified.
+   - Do not leave debug files, log helpers, or noisy runtime logging in the final diff unless the user explicitly asks.
+
+6. **Keep or improve tests**
+   - Add or adjust a focused regression test once the real bug is understood.
+   - Make the test assert the actual broken behavior discovered from logs, not the earlier incorrect assumption.
+
+## JSONL Logging Pattern
+
+Use append-only JSONL in `cwd` so it works across CLIs, dev servers, tests, and manual reproduction.
+
+### Node / TypeScript
+
+```ts
+import { appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function debugBug(event: string, data: Record<string, unknown> = {}) {
+  appendFileSync(
+    join(process.cwd(), 'debug-difficult-bug.jsonl'),
+    `${JSON.stringify({
+      ts: new Date().toISOString(),
+      event,
+      ...data,
+    })}\n`,
+  );
+}
+```
+
+Call it at every meaningful branch or state transition:
+
+```ts
+debugBug('workflow.start', { runId, stepId, inputKeys: Object.keys(input ?? {}) });
+
+debugBug('workflow.beforeStep', {
+  runId,
+  stepId,
+  status: step.status,
+  hasResumeData: Boolean(resumeData),
+});
+
+try {
+  const result = await executeStep();
+  debugBug('workflow.afterStep', { runId, stepId, resultShape: Object.keys(result ?? {}) });
+  return result;
+} catch (error) {
+  debugBug('workflow.stepError', {
+    runId,
+    stepId,
+    errorName: error instanceof Error ? error.name : typeof error,
+    errorMessage: error instanceof Error ? error.message : String(error),
+  });
+  throw error;
+}
+```
+
+## What to Log
+
+Prefer compact, structured data over huge dumps.
+
+Log:
+
+- Function or phase name.
+- Stable ids: request id, run id, thread id, resource id, step id, tool call id.
+- Input/output **shape**: keys, counts, lengths, statuses.
+- Branch decisions and the data that caused them.
+- State before and after mutation.
+- Error names/messages and relevant metadata.
+- Ordering markers for async, streaming, or concurrent flows.
+
+Avoid logging:
+
+- API keys, auth headers, tokens, cookies, credentials.
+- Full user content unless necessary and safe.
+- Large payloads that make the log unreadable.
+- Binary data or full model responses unless the bug requires it.
+
+If sensitive data might appear, log redacted summaries:
+
+```ts
+debugBug('request.received', {
+  hasAuthHeader: Boolean(headers.authorization),
+  bodyKeys: Object.keys(body ?? {}),
+  messageCount: body?.messages?.length,
+});
+```
+
+## Reproduction Handoff to User
+
+When the user needs to reproduce manually, say exactly this shape:
+
+```text
+I added temporary unconditional JSONL instrumentation. Please reproduce the issue once, then send me or point me at:
+
+<cwd>/debug-difficult-bug.jsonl
+
+After I inspect that log, I’ll remove the instrumentation and make the actual fix.
+```
+
+If multiple processes have different working directories, either:
+
+- log the absolute `process.cwd()` at startup, or
+- write distinct files like `debug-server-flow.jsonl`, `debug-worker-flow.jsonl`, and `debug-client-flow.jsonl`.
+
+## Analysis Checklist
+
+Before writing the fix, answer:
+
+- Did the instrumented code path actually run?
+- What was the expected sequence of events?
+- What was the actual sequence?
+- What is the first incorrect state, missing value, duplicate event, or wrong branch?
+- Does the original red test capture that exact divergence?
+- If not, how should the regression test change?
+
+## Final Verification
+
+A difficult bug is not done until:
+
+- The real reproduction path passes.
+- The regression test fails before the fix and passes after the fix, when feasible.
+- Temporary unconditional instrumentation is removed.
+- The final diff contains only the fix and intentional tests.
+- You can explain the root cause using evidence from the JSONL log.


### PR DESCRIPTION
Adds a new `debugging-difficult-bugs` skill for cases where tests may not capture the actual runtime failure.

The skill tells agents to use append-only JSONL instrumentation early for medium/hard bugs, reproduce the real issue, inspect the log before fixing, then remove the temporary instrumentation and keep/update focused regression tests.

**Multiple times I've described this workflow manually to agents when they're spinning on fixing a difficult bug, and every time they identify the real cause of the bug within a few minutes**, so this is a very powerful debugging method for agents, even though it's quite obvious. In a way this is similar to an agent pausing a debugger and selectively inspecting variables, even though it looks like logging.
This is because the jsonl part allows for the agent to write scripts to parse through the output, and it doesn't have to ignore irrelevant console logs, comparing this to just having it log out to stdout.

Example temporary helper the skill recommends:

```ts
function debugBug(event: string, data: Record<string, unknown> = {}) {
  appendFileSync(
    join(process.cwd(), 'debug-difficult-bug.jsonl'),
    `${JSON.stringify({ ts: new Date().toISOString(), event, ...data })}\n`,
  );
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a how-to guide that teaches agents a debugging technique: when you have a tricky bug that doesn't show up in tests, temporarily add logging (like breadcrumbs) to track exactly what the code is doing, reproduce the problem yourself to collect those logs, read through them to find where things went wrong, fix the bug, clean up the logging, and then write a better test to catch it next time.

## Overview

Adds a new "Debugging Difficult Bugs" skill documentation to guide developers through a structured workflow for tackling medium and hard bugs, particularly those where standard test-driven debugging may provide false confidence.

## Key Content

**When to Use:** The skill is recommended early in debugging when:
- A bug spans multiple functions, packages, or processes
- Existing tests may not fully capture the real runtime failure
- Issues involve runtime ordering, state, caching, streaming, concurrency, or external services
- Manual user reproduction is available

**Core Approach:**
1. State the uncertainty and identify the actual code path to observe
2. Add unconditional, append-only JSONL logging throughout the suspected flow (not gated behind debug flags)
3. Reproduce the real issue (either locally or with user assistance)
4. Analyze the JSONL log chronologically to identify where behavior first diverges from expected
5. Remove temporary instrumentation after understanding root cause
6. Create or refine a regression test based on the discovered broken behavior

**Practical Guidance Included:**
- Reference implementation of a `debugBug()` helper function for Node/TypeScript
- Code examples showing instrumentation patterns (workflow start, step execution, error handling)
- Guidance on what to log (ids, input/output shapes, branch decisions, state transitions) vs. what to avoid (credentials, sensitive data, large payloads)
- Template language for requesting log files from users
- Analysis checklist before implementing fixes
- Final verification criteria

## Changes

- **File added:** `.claude/skills/debugging-difficult-bugs/SKILL.md` (+172 lines)
- **Type:** Documentation only
- **Impact:** No code or exported API changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->