### PR TITLE
fix(create-mastra): pin zod to 4.3.4 in new projects

### DIFF
--- a/.changeset/full-kiwis-occur.md
+++ b/.changeset/full-kiwis-occur.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Pinned zod to 4.3.4 in newly created Mastra projects to work around a Studio UI regression where post-tool-call assistant messages were saved to the database but never rendered when zod 4.4.0+ was used. New projects created via `npm create mastra@latest` (and the `mastra init` flow) now install `zod@4.3.4` instead of `zod@^4`.

--- a/packages/cli/src/commands/create/bun-detection.test.ts
+++ b/packages/cli/src/commands/create/bun-detection.test.ts
@@ -132,7 +132,7 @@ describe('Bun Runtime Detection', () => {
     expect(mocks.mockExec).toHaveBeenCalledWith('bun init -y');
 
     // Check if bun add was used for dependencies
-    expect(mocks.mockExec).toHaveBeenCalledWith(expect.stringContaining('bun add zod@^4'));
+    expect(mocks.mockExec).toHaveBeenCalledWith(expect.stringContaining('bun add zod@4.3.4'));
   });
 
   it('should use npm init when npm is detected', async () => {
@@ -151,7 +151,7 @@ describe('Bun Runtime Detection', () => {
     // Check if npm install was used for dependencies
     expect(mocks.mockExec).toHaveBeenCalledWith(
       expect.stringContaining(
-        'npm install --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false zod@^4',
+        'npm install --audit=false --fund=false --loglevel=error --progress=false --update-notifier=false zod@4.3.4',
       ),
     );
   });

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -253,7 +253,7 @@ export const createMastraProject = async ({
 
     s.start(`Installing ${pm} dependencies`);
     try {
-      await exec(`${pm} ${installCommand} zod@^4`);
+      await exec(`${pm} ${installCommand} zod@4.3.4`);
       await exec(`${pm} ${installCommand} -D typescript @types/node`);
       await exec(`echo '{
   "compilerOptions": {

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -554,7 +554,7 @@ export const checkAndInstallCoreDeps = async (addExample: boolean, versionTag?: 
     }
 
     if (needsZod) {
-      packages.push({ name: 'zod', version: '^4' });
+      packages.push({ name: 'zod', version: '4.3.4' });
     }
 
     if (addExample) {


### PR DESCRIPTION
Zod 4.4.0+ breaks Studio UI rendering of assistant messages that follow a tool call — the message is saved to the DB but never appears in the UI. Until that's fixed upstream, new projects from `npm create mastra@latest` (and the `mastra init` flow) now install `zod@4.3.4` instead of `zod@^4`. Alternative to https://github.com/mastra-ai/mastra/pull/15969

Before:

```ts
await exec(`${pm} ${installCommand} zod@^4`);
```

After:

```ts
await exec(`${pm} ${installCommand} zod@4.3.4`);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a bug in newer versions of a library called Zod (version 4.4.0+) that prevents chat messages from showing up in the Mastra Studio UI, even though they get saved behind the scenes. The fix tells all newly created Mastra projects to use Zod version 4.3.4 instead of the latest version, as a temporary workaround until the bug is fixed upstream.

## Changes

This PR pins the Zod dependency to version `4.3.4` in new Mastra projects created via `npm create mastra@latest` and the `mastra init` workflow, replacing the previous caret-range version constraint (`^4`).

### Files Modified

- **`.changeset/full-kiwis-occur.md`** - New changesets entry documenting the Zod version pinning for upcoming release notes
- **`packages/cli/src/commands/create/utils.ts`** - Updated `createMastraProject` to install `zod@4.3.4`
- **`packages/cli/src/commands/init/utils.ts`** - Updated `checkAndInstallCoreDeps` to pin `zod@4.3.4`
- **`packages/cli/src/commands/create/bun-detection.test.ts`** - Updated test assertions to expect `zod@4.3.4` in Bun and npm install commands

### Rationale

A regression in Zod 4.4.0+ causes assistant messages following a tool call to be persisted to the database but not rendered in the Studio UI. This is a temporary workaround while awaiting an upstream fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->