### PR TITLE
fix(core): honor cancellation in dountil/dowhile/foreach loops

### DIFF
--- a/.changeset/chilly-turtles-rescue.md
+++ b/.changeset/chilly-turtles-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workflow runs not being cancellable when steps or conditions ignored the abort signal. Cancelling a run now correctly stops `dountil`, `dowhile`, and `foreach` loops at every cancellation boundary — between iterations, after a step returns, after the loop condition is evaluated, and (for `foreach`) between concurrency chunks and after the final chunk. Previously, long-running loops (e.g. a `dountil` with a `setTimeout` inside the step) would keep running and eventually emit `success` even after the run was cancelled. Closes #15990.

--- a/packages/core/src/workflows/default.test.ts
+++ b/packages/core/src/workflows/default.test.ts
@@ -184,6 +184,272 @@ describe('DefaultExecutionEngine.executeConditional error handling', () => {
   });
 });
 
+describe('DefaultExecutionEngine.executeLoop cancellation', () => {
+  let engine: DefaultExecutionEngine;
+  let pubsub: PubSub;
+  let requestContext: RequestContext;
+  let abortController: AbortController;
+
+  beforeEach(() => {
+    engine = new DefaultExecutionEngine({ mastra: undefined });
+    pubsub = new EventEmitterPubSub();
+    requestContext = new RequestContext();
+    abortController = new AbortController();
+  });
+
+  // Reproduces https://github.com/mastra-ai/mastra/issues/15990
+  // A long-running dountil loop should stop iterating once the run is
+  // cancelled, even when the user's step does not observe abortSignal.
+  it('should stop iterating a dountil loop when abortController is aborted between iterations', async () => {
+    const workflowId = 'test-workflow';
+    const runId = randomUUID();
+
+    let iterations = 0;
+    const step = {
+      id: 'fetch-user',
+      inputSchema: z.any(),
+      outputSchema: z.any(),
+      execute: async ({ inputData }: { inputData: { iteration: number } }) => {
+        iterations++;
+        // Simulate a step that does NOT observe the abort signal,
+        // matching the user's repro (raw setTimeout/fetch).
+        // Trigger cancel while the second iteration is in-flight.
+        if (iterations === 2) {
+          abortController.abort();
+        }
+        return { iteration: (inputData?.iteration ?? 0) + 1 };
+      },
+    };
+
+    const entry = {
+      type: 'loop' as const,
+      step,
+      // dountil: stop when iteration >= 1000
+      condition: async ({ inputData }: { inputData: { iteration: number } }) => inputData.iteration >= 1000,
+      loopType: 'dountil' as const,
+    };
+
+    const result = await engine.executeLoop({
+      workflowId,
+      runId,
+      entry,
+      prevStep: { type: 'step', step } as any,
+      prevOutput: { iteration: 0 },
+      stepResults: {} as Record<string, StepResult<any, any, any, any>>,
+      serializedStepGraph: [],
+      executionContext: {
+        workflowId,
+        runId,
+        executionPath: [0],
+        stepExecutionPath: [],
+        suspendedPaths: {},
+        retryConfig: { attempts: 0, delay: 0 },
+        activeStepsPath: {},
+        resumeLabels: {},
+        state: {},
+      },
+      pubsub,
+      abortController,
+      requestContext,
+      tracingContext: {},
+    });
+
+    // The loop must terminate quickly with 'canceled' rather than running 1000 times.
+    expect(result.status).toBe('canceled');
+    // Should have stopped at the iteration that triggered cancel,
+    // not run the full 1000 iterations.
+    expect(iterations).toBeLessThan(10);
+  }, 30_000);
+
+  // The condition context exposes `abort()` and the run can also be cancelled
+  // externally while the condition is awaiting. If the condition returns a
+  // terminal value (e.g. dountil reaching its target) after that, the loop
+  // must still surface 'canceled' rather than 'success'.
+  it('should surface canceled when abortController is aborted during condition evaluation', async () => {
+    const workflowId = 'test-workflow';
+    const runId = randomUUID();
+
+    let stepCalls = 0;
+    const step = {
+      id: 'fetch-user',
+      inputSchema: z.any(),
+      outputSchema: z.any(),
+      execute: async ({ inputData }: { inputData: { iteration: number } }) => {
+        stepCalls++;
+        return { iteration: (inputData?.iteration ?? 0) + 1 };
+      },
+    };
+
+    const entry = {
+      type: 'loop' as const,
+      step,
+      // Condition aborts the run mid-evaluation, then returns true (dountil
+      // terminal value). Pre-fix, the loop exits as 'success'.
+      condition: async ({ abort }: { abort: () => void }) => {
+        abort();
+        return true;
+      },
+      loopType: 'dountil' as const,
+    };
+
+    const result = await engine.executeLoop({
+      workflowId,
+      runId,
+      entry,
+      prevStep: { type: 'step', step } as any,
+      prevOutput: { iteration: 0 },
+      stepResults: {} as Record<string, StepResult<any, any, any, any>>,
+      serializedStepGraph: [],
+      executionContext: {
+        workflowId,
+        runId,
+        executionPath: [0],
+        stepExecutionPath: [],
+        suspendedPaths: {},
+        retryConfig: { attempts: 0, delay: 0 },
+        activeStepsPath: {},
+        resumeLabels: {},
+        state: {},
+      },
+      pubsub,
+      abortController,
+      requestContext,
+      tracingContext: {},
+    });
+
+    expect(result.status).toBe('canceled');
+    expect(stepCalls).toBe(1);
+  }, 30_000);
+});
+
+describe('DefaultExecutionEngine.executeForeach cancellation', () => {
+  let engine: DefaultExecutionEngine;
+  let pubsub: PubSub;
+  let requestContext: RequestContext;
+  let abortController: AbortController;
+
+  beforeEach(() => {
+    engine = new DefaultExecutionEngine({ mastra: undefined });
+    pubsub = new EventEmitterPubSub();
+    requestContext = new RequestContext();
+    abortController = new AbortController();
+  });
+
+  // Cancellation that lands before the next concurrency chunk starts must
+  // stop the foreach from dispatching more work. Steps that ignore abortSignal
+  // would otherwise let the loop keep iterating.
+  it('should return canceled before dispatching the next concurrency chunk', async () => {
+    const workflowId = 'test-workflow';
+    const runId = randomUUID();
+
+    let callCount = 0;
+    const step = {
+      id: 'process-item',
+      inputSchema: z.any(),
+      outputSchema: z.any(),
+      execute: async ({ inputData }: { inputData: number }) => {
+        callCount++;
+        // Trigger cancel from inside a step but ignore the abort signal,
+        // matching user steps that don't observe abortSignal (e.g. raw fetch).
+        if (inputData === 1) {
+          abortController.abort();
+        }
+        return inputData * 2;
+      },
+    };
+
+    const entry = {
+      type: 'foreach' as const,
+      step,
+      opts: { concurrency: 2 },
+    };
+
+    const result = await engine.executeForeach({
+      workflowId,
+      runId,
+      entry,
+      prevStep: { type: 'step', step } as any,
+      prevOutput: [0, 1, 2, 3],
+      stepResults: {} as Record<string, StepResult<any, any, any, any>>,
+      serializedStepGraph: [],
+      executionContext: {
+        workflowId,
+        runId,
+        executionPath: [0],
+        stepExecutionPath: [],
+        suspendedPaths: {},
+        retryConfig: { attempts: 0, delay: 0 },
+        activeStepsPath: {},
+        resumeLabels: {},
+        state: {},
+      },
+      pubsub,
+      abortController,
+      requestContext,
+      tracingContext: {},
+    });
+
+    expect(result.status).toBe('canceled');
+    // Items 2 and 3 (the next chunk) must not have been dispatched.
+    expect(callCount).toBe(2);
+  }, 30_000);
+
+  // Cancellation can land during the final concurrency chunk. Without the
+  // post-loop abort check, the foreach would emit a successful workflow-step
+  // result and persist 'success' even though the run was cancelled.
+  it('should return canceled when abortController is aborted during the final chunk', async () => {
+    const workflowId = 'test-workflow';
+    const runId = randomUUID();
+
+    const step = {
+      id: 'process-item',
+      inputSchema: z.any(),
+      outputSchema: z.any(),
+      execute: async ({ inputData }: { inputData: number }) => {
+        // Single-chunk run (concurrency >= length), so this is the final chunk.
+        // Step ignores abortSignal — only the post-loop check can catch it.
+        if (inputData === 1) {
+          abortController.abort();
+        }
+        return inputData * 2;
+      },
+    };
+
+    const entry = {
+      type: 'foreach' as const,
+      step,
+      opts: { concurrency: 4 },
+    };
+
+    const result = await engine.executeForeach({
+      workflowId,
+      runId,
+      entry,
+      prevStep: { type: 'step', step } as any,
+      prevOutput: [0, 1],
+      stepResults: {} as Record<string, StepResult<any, any, any, any>>,
+      serializedStepGraph: [],
+      executionContext: {
+        workflowId,
+        runId,
+        executionPath: [0],
+        stepExecutionPath: [],
+        suspendedPaths: {},
+        retryConfig: { attempts: 0, delay: 0 },
+        activeStepsPath: {},
+        resumeLabels: {},
+        state: {},
+      },
+      pubsub,
+      abortController,
+      requestContext,
+      tracingContext: {},
+    });
+
+    expect(result.status).toBe('canceled');
+  }, 30_000);
+});
+
 describe('DefaultExecutionEngine.fmtReturnValue stepExecutionPath and payload deduplication', () => {
   let engine: TestableExecutionEngine;
   let pubsub: PubSub;

--- a/packages/core/src/workflows/handlers/control-flow.ts
+++ b/packages/core/src/workflows/handlers/control-flow.ts
@@ -608,6 +608,21 @@ export async function executeLoop(
   let currentTimeTravel = timeTravel;
 
   do {
+    // Honor cancellation between iterations so long-running loops (e.g. dountil
+    // with delays inside the step) terminate when the run is cancelled.
+    if (abortController?.signal?.aborted) {
+      await engine.endChildSpan({
+        span: loopSpan,
+        operationId: `workflow.${workflowId}.run.${runId}.loop.${executionContext.executionPath.join('-')}.span.end.early`,
+        endOptions: {
+          attributes: {
+            totalIterations: iteration,
+          },
+        },
+      });
+      return { status: 'canceled' } as unknown as StepResult<any, any, any, any>;
+    }
+
     const stepExecResult = await engine.executeStep({
       workflowId,
       runId,
@@ -655,6 +670,22 @@ export async function executeLoop(
         },
       });
       return result;
+    }
+
+    // If the step finished but the run was cancelled while it was running
+    // (e.g. user step ignored abortSignal), surface cancellation now instead
+    // of evaluating the loop condition and starting another iteration.
+    if (abortController?.signal?.aborted) {
+      await engine.endChildSpan({
+        span: loopSpan,
+        operationId: `workflow.${workflowId}.run.${runId}.loop.${executionContext.executionPath.join('-')}.span.end.early`,
+        endOptions: {
+          attributes: {
+            totalIterations: iteration + 1,
+          },
+        },
+      });
+      return { status: 'canceled' } as unknown as StepResult<any, any, any, any>;
     }
 
     const evalSpan = await engine.createChildSpan({
@@ -720,6 +751,23 @@ export async function executeLoop(
     });
 
     iteration++;
+
+    // Honor cancellation triggered during condition evaluation (the condition
+    // context exposes `abort()`, and the run can be cancelled externally while
+    // the condition is awaiting). Without this check a condition that returns
+    // a terminal value after aborting would let the loop exit as 'success'.
+    if (abortController?.signal?.aborted) {
+      await engine.endChildSpan({
+        span: loopSpan,
+        operationId: `workflow.${workflowId}.run.${runId}.loop.${executionContext.executionPath.join('-')}.span.end.early`,
+        endOptions: {
+          attributes: {
+            totalIterations: iteration,
+          },
+        },
+      });
+      return { status: 'canceled' } as unknown as StepResult<any, any, any, any>;
+    }
   } while (entry.loopType === 'dowhile' ? isTrue : !isTrue);
 
   await engine.endChildSpan({
@@ -856,6 +904,24 @@ export async function executeForeach(
   let completedCount = 0;
 
   for (let i = 0; i < prevOutput.length; i += concurrency) {
+    // Honor cancellation between concurrency chunks so cancelling a long
+    // foreach (large list / slow steps) terminates without dispatching more work.
+    if (abortController?.signal?.aborted) {
+      await engine.endChildSpan({
+        span: loopSpan,
+        operationId: `workflow.${workflowId}.run.${runId}.foreach.${executionContext.executionPath.join('-')}.span.end.early`,
+        endOptions: {
+          output: results,
+        },
+      });
+      return { ...stepInfo, status: 'canceled', output: results, endedAt: Date.now() } as unknown as StepResult<
+        any,
+        any,
+        any,
+        any
+      >;
+    }
+
     const items = prevOutput.slice(i, i + concurrency);
     const itemsResults = await Promise.all(
       items.map(async (item: any, j: number) => {
@@ -1050,6 +1116,26 @@ export async function executeForeach(
         },
       } as StepSuspended<any, any, any>;
     }
+  }
+
+  // Honor cancellation that landed during the final concurrency chunk. Without
+  // this check, a foreach whose steps ignore abortSignal would still emit a
+  // 'success' workflow-step-result and persist a successful step result, even
+  // though the run was cancelled.
+  if (abortController?.signal?.aborted) {
+    await engine.endChildSpan({
+      span: loopSpan,
+      operationId: `workflow.${workflowId}.run.${runId}.foreach.${executionContext.executionPath.join('-')}.span.end.early`,
+      endOptions: {
+        output: results,
+      },
+    });
+    return { ...stepInfo, status: 'canceled', output: results, endedAt: Date.now() } as unknown as StepResult<
+      any,
+      any,
+      any,
+      any
+    >;
   }
 
   await pubsub.publish(`workflow.events.v2.${runId}`, {


### PR DESCRIPTION
Fixes #15990. Cancelling a workflow run did not stop `dountil`/`dowhile`/`foreach` loops if the step (or condition) didn't observe `abortSignal` — the loop kept iterating and eventually returned `success`. The repro in the issue is a `dountil` with a raw `setTimeout` inside the step.

The loop handlers now check `abortController.signal.aborted` at every cancellation boundary: before each iteration, after the step returns, after the condition is evaluated, and (for `foreach`) before each concurrency chunk and after the final chunk. When set, the loop ends its span and returns `{ status: 'canceled' }`.

Before:

```ts
const wf = createWorkflow(...)
  .dountil(slowStep, async ({ inputData }) => inputData.iteration >= 1000);

const run = await wf.createRunAsync();
const promise = run.start({ inputData: {} });
await run.cancel(); // run reports cancelled, but slowStep keeps looping
```

After: the loop terminates on the next boundary and the run result is `canceled`.

Tests cover each path independently; each new test was verified to fail without its corresponding fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you ask someone to do something repeatedly until a condition is met, but you change your mind and tell them to stop. This PR fixes a bug where if the person wasn't listening for your "stop" signal, they'd keep going and eventually report they succeeded even though you cancelled them. Now the system checks for the cancellation signal at multiple points during the loop so it stops properly no matter what.

## Overview

This PR fixes issue #15990 where cancelling a workflow run did not properly stop `dountil`, `dowhile`, or `foreach` loops when the steps or conditions within those loops did not actively listen to the provided `abortSignal`. Previously, long-running loops with steps that ignored cancellation signals would continue executing and ultimately report success despite the run being cancelled.

## Changes

**Changeset**  
Added a patch-level changeset documenting the behavior fix for `@mastra/core`.

**Test Coverage**  
Added 266 lines of new test cases in `packages/core/src/workflows/default.test.ts` that verify:
- `executeLoop` for `dountil` returns `status: 'canceled'` when aborted between iterations or during async condition evaluation
- `executeForeach` returns `status: 'canceled'` and prevents dispatching subsequent concurrency chunks when cancellation is detected
- Cancellation is properly honored even when steps ignore abort signals

Each test case was confirmed to fail before the corresponding implementation fix.

**Core Fix**  
Modified `packages/core/src/workflows/handlers/control-flow.ts` to add cancellation checks at critical boundaries:
- Before each loop iteration starts
- After a loop step returns but before evaluating the condition
- After condition evaluation and increment logic
- For `foreach`: between concurrency chunks and after the final chunk

When cancellation is detected (`abortController?.signal?.aborted`), the loop ends its tracing span with an `end.early` operationId and returns `{ status: 'canceled' }` instead of continuing execution or reporting success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->