### PR TITLE
fix(core): preserve TRequestContext in workflow loop helper type inference

### DIFF
--- a/.changeset/eleven-rings-tease.md
+++ b/.changeset/eleven-rings-tease.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed type inference on workflow loop helpers (`foreach`, `dowhile`, `dountil`) so a step's `requestContextSchema` correctly aligns with the workflow's `requestContextSchema`. Previously these methods dropped the workflow's `TRequestContext` from the step parameter, causing TypeScript to reject typed-context steps even when the workflow declared a matching schema. Steps without a `requestContextSchema` are still accepted; steps whose schema does not match the workflow's now produce a type error. Fixes [#15989](https://github.com/mastra-ai/mastra/issues/15989).

--- a/packages/core/src/workflows/workflow-schema-types.test-d.ts
+++ b/packages/core/src/workflows/workflow-schema-types.test-d.ts
@@ -327,4 +327,168 @@ describe('Workflow schema type inference', () => {
       workflow.then(step);
     });
   });
+
+  // Regression: https://github.com/mastra-ai/mastra/issues/15989
+  // foreach/dowhile/dountil dropped the TRequestContext generic on the step
+  // parameter, causing typed requestContextSchema steps to be rejected even
+  // when the workflow declared a matching requestContextSchema.
+  describe('requestContextSchema inference in loop helpers', () => {
+    const requestContextSchema = z.object({
+      propA: z.string(),
+      propB: z.number(),
+    });
+
+    it('foreach should accept a step whose requestContextSchema matches the workflow', () => {
+      const elementSchema = z.object({ value: z.number() });
+
+      const step = createStep({
+        id: 'each-with-ctx',
+        inputSchema: elementSchema,
+        outputSchema: elementSchema,
+        requestContextSchema,
+        execute: async ({ inputData }) => inputData,
+      });
+
+      const workflow = createWorkflow({
+        id: 'foreach-with-ctx',
+        inputSchema: z.array(elementSchema),
+        outputSchema: z.array(elementSchema),
+        requestContextSchema,
+      });
+
+      const chained = workflow.foreach(step);
+      expectTypeOf(chained).not.toBeNever();
+    });
+
+    it('dowhile should accept a step whose requestContextSchema matches the workflow', () => {
+      const schema = z.object({ value: z.number() });
+
+      const step = createStep({
+        id: 'dowhile-with-ctx',
+        inputSchema: schema,
+        outputSchema: schema,
+        requestContextSchema,
+        execute: async ({ inputData }) => ({ value: inputData.value + 1 }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'dowhile-ctx-workflow',
+        inputSchema: schema,
+        outputSchema: schema,
+        requestContextSchema,
+      });
+
+      const chained = workflow.dowhile(step, async ({ inputData }) => inputData.value < 10);
+      expectTypeOf(chained).not.toBeNever();
+    });
+
+    it('dountil should accept a step whose requestContextSchema matches the workflow', () => {
+      const schema = z.object({ value: z.number() });
+
+      const step = createStep({
+        id: 'dountil-with-ctx',
+        inputSchema: schema,
+        outputSchema: schema,
+        requestContextSchema,
+        execute: async ({ inputData }) => ({ value: inputData.value + 1 }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'dountil-ctx-workflow',
+        inputSchema: schema,
+        outputSchema: schema,
+        requestContextSchema,
+      });
+
+      const chained = workflow.dountil(step, async ({ inputData }) => inputData.value >= 10);
+      expectTypeOf(chained).not.toBeNever();
+    });
+
+    it('foreach should accept a step that does not declare a requestContextSchema in a workflow that does', () => {
+      const elementSchema = z.object({ value: z.number() });
+
+      const step = createStep({
+        id: 'each-no-ctx',
+        inputSchema: elementSchema,
+        outputSchema: elementSchema,
+        execute: async ({ inputData }) => inputData,
+      });
+
+      const workflow = createWorkflow({
+        id: 'foreach-with-ctx-noctx-step',
+        inputSchema: z.array(elementSchema),
+        outputSchema: z.array(elementSchema),
+        requestContextSchema,
+      });
+
+      const chained = workflow.foreach(step);
+      expectTypeOf(chained).not.toBeNever();
+    });
+
+    it('foreach should reject a step whose requestContextSchema does not match the workflow', () => {
+      const elementSchema = z.object({ value: z.number() });
+
+      const step = createStep({
+        id: 'each-bad-ctx',
+        inputSchema: elementSchema,
+        outputSchema: elementSchema,
+        requestContextSchema: z.object({ otherProp: z.boolean() }),
+        execute: async ({ inputData }) => inputData,
+      });
+
+      const workflow = createWorkflow({
+        id: 'foreach-mismatch',
+        inputSchema: z.array(elementSchema),
+        outputSchema: z.array(elementSchema),
+        requestContextSchema,
+      });
+
+      // @ts-expect-error - step's requestContextSchema does not match the workflow's
+      workflow.foreach(step);
+    });
+
+    it('dowhile should reject a step whose requestContextSchema does not match the workflow', () => {
+      const schema = z.object({ value: z.number() });
+
+      const step = createStep({
+        id: 'dowhile-bad-ctx',
+        inputSchema: schema,
+        outputSchema: schema,
+        requestContextSchema: z.object({ otherProp: z.boolean() }),
+        execute: async ({ inputData }) => ({ value: inputData.value + 1 }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'dowhile-mismatch',
+        inputSchema: schema,
+        outputSchema: schema,
+        requestContextSchema,
+      });
+
+      // @ts-expect-error - step's requestContextSchema does not match the workflow's
+      workflow.dowhile(step, async ({ inputData }) => inputData.value < 10);
+    });
+
+    it('dountil should reject a step whose requestContextSchema does not match the workflow', () => {
+      const schema = z.object({ value: z.number() });
+
+      const step = createStep({
+        id: 'dountil-bad-ctx',
+        inputSchema: schema,
+        outputSchema: schema,
+        requestContextSchema: z.object({ otherProp: z.boolean() }),
+        execute: async ({ inputData }) => ({ value: inputData.value + 1 }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'dountil-mismatch',
+        inputSchema: schema,
+        outputSchema: schema,
+        requestContextSchema,
+      });
+
+      // @ts-expect-error - step's requestContextSchema does not match the workflow's
+      workflow.dountil(step, async ({ inputData }) => inputData.value >= 10);
+    });
+  });
 });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2077,8 +2077,19 @@ export class Workflow<
     >;
   }
 
-  dowhile<TStepState, TStepInputSchema extends TPrevSchema, TStepId extends string, TSchemaOut>(
-    step: Step<TStepId, SubsetOf<TStepState, TState>, TStepInputSchema, TSchemaOut, any, any, TEngineType>,
+  dowhile<TStepState, TStepInputSchema extends TPrevSchema, TStepId extends string, TSchemaOut, TStepRC>(
+    step: Step<
+      TStepId,
+      SubsetOf<TStepState, TState>,
+      TStepInputSchema,
+      TSchemaOut,
+      any,
+      any,
+      TEngineType,
+      // Allow steps that don't declare a requestContextSchema (TStepRC=unknown) or that
+      // declare one matching the workflow's TRequestContext. Mismatched schemas error.
+      unknown extends TStepRC ? unknown : TRequestContext
+    >,
     condition: LoopConditionFunction<TState, TSchemaOut, any, any, any, TEngineType>,
   ) {
     this.stepFlow.push({
@@ -2101,7 +2112,7 @@ export class Workflow<
       serializedCondition: { id: `${step.id}-condition`, fn: condition.toString() },
       loopType: 'dowhile',
     });
-    this.steps[step.id] = step;
+    this.steps[step.id] = step as any;
     return this as unknown as Workflow<
       TEngineType,
       TSteps,
@@ -2114,8 +2125,19 @@ export class Workflow<
     >;
   }
 
-  dountil<TStepState, TStepInputSchema extends TPrevSchema, TStepId extends string, TSchemaOut>(
-    step: Step<TStepId, SubsetOf<TStepState, TState>, TStepInputSchema, TSchemaOut, any, any, TEngineType>,
+  dountil<TStepState, TStepInputSchema extends TPrevSchema, TStepId extends string, TSchemaOut, TStepRC>(
+    step: Step<
+      TStepId,
+      SubsetOf<TStepState, TState>,
+      TStepInputSchema,
+      TSchemaOut,
+      any,
+      any,
+      TEngineType,
+      // Allow steps that don't declare a requestContextSchema (TStepRC=unknown) or that
+      // declare one matching the workflow's TRequestContext. Mismatched schemas error.
+      unknown extends TStepRC ? unknown : TRequestContext
+    >,
     condition: LoopConditionFunction<TState, TSchemaOut, any, any, any, TEngineType>,
   ) {
     this.stepFlow.push({
@@ -2138,7 +2160,7 @@ export class Workflow<
       serializedCondition: { id: `${step.id}-condition`, fn: condition.toString() },
       loopType: 'dountil',
     });
-    this.steps[step.id] = step;
+    this.steps[step.id] = step as any;
     return this as unknown as Workflow<
       TEngineType,
       TSteps,
@@ -2157,9 +2179,21 @@ export class Workflow<
     TStepInputSchema extends TPrevSchema extends (infer TElement)[] ? TElement : never,
     TStepId extends string,
     TSchemaOut,
+    TStepRC,
   >(
     step: TPrevIsArray extends true
-      ? Step<TStepId, SubsetOf<TStepState, TState>, TStepInputSchema, TSchemaOut, any, any, TEngineType>
+      ? Step<
+          TStepId,
+          SubsetOf<TStepState, TState>,
+          TStepInputSchema,
+          TSchemaOut,
+          any,
+          any,
+          TEngineType,
+          // Allow steps that don't declare a requestContextSchema (TStepRC=unknown) or that
+          // declare one matching the workflow's TRequestContext. Mismatched schemas error.
+          unknown extends TStepRC ? unknown : TRequestContext
+        >
       : 'Previous step must return an array type',
     opts?: {
       concurrency: number;


### PR DESCRIPTION
Fixes #15989.

`foreach`, `dowhile`, and `dountil` were dropping the workflow's `TRequestContext` from the step parameter, so TypeScript rejected steps with a `requestContextSchema` even when the workflow declared a matching one.

Before:

```ts
const ctx = z.object({ userId: z.string() });
const step = createStep({ ..., requestContextSchema: ctx });
const wf  = createWorkflow({ ..., requestContextSchema: ctx });

wf.foreach(step); // ❌ type error, schemas didn't compose
```

After:

```ts
wf.foreach(step); // ✅ compiles when schemas match
```

Uses a conditional (`unknown extends TStepRC ? unknown : TRequestContext`) so steps without a `requestContextSchema` are still accepted, matching schemas compose, and mismatched schemas now surface as a type error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
TypeScript has special type-checking rules for workflows and their steps. This PR fixes a bug where workflow loop helpers (foreach, dowhile, dountil) were "forgetting" what type of context the workflow expected, which made them incorrectly reject steps that should have been allowed. The fix makes these loop helpers remember the context type, so they accept valid steps and correctly flag mismatches.

## Overview
Fixes a TypeScript type inference bug in Workflow loop helper methods (`foreach`, `dowhile`, `dountil`) where the workflow's `TRequestContext` generic parameter was being dropped from the Step parameter, causing valid typed-context steps to be incorrectly rejected. The fix introduces conditional type inference to preserve the workflow's context type while remaining compatible with untyped steps.

## Changes

### Type Definition Updates
Updated the public method signatures for `Workflow.foreach()`, `Workflow.dowhile()`, and `Workflow.dountil()` in `packages/core/src/workflows/workflow.ts`:
- Added a new generic parameter `TStepRC` to capture the step's request-context type
- Implemented conditional type inference: `unknown extends TStepRC ? unknown : TRequestContext`
  - Accepts steps without a declared `requestContextSchema` (when `TStepRC` is `unknown`)
  - Preserves the workflow's `TRequestContext` for properly typed steps
  - Produces type errors when `requestContextSchema` declarations mismatch
- Changed step assignments in method bodies to cast to `any` for type compatibility

### Test Coverage
Added comprehensive TypeScript type tests in `packages/core/src/workflows/workflow-schema-types.test-d.ts`:
- Validates that loop helpers accept steps when `requestContextSchema` matches the workflow's
- Confirms steps without `requestContextSchema` remain accepted in workflows with context
- Verifies type errors are correctly raised (`@ts-expect-error`) for mismatched schemas
- Confirms inferred chained result types are not `never` for valid compositions

### Changeset Documentation
Added changelog entry documenting the fix for issue #15989, clarifying the behavior change around `requestContextSchema` type propagation in loop helpers.

## Impact
- **API Compatibility**: Maintains backward compatibility; steps without `requestContextSchema` continue to work
- **Type Safety**: Mismatched request context schemas now properly surface as TypeScript errors
- **Developer Experience**: Workflow compositions with context-aware steps now type-check correctly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->