### PR TITLE
fix(changeset): correct package name for fastify multipart fix

### DIFF
--- a/.changeset/fastify-multipart-fix.md
+++ b/.changeset/fastify-multipart-fix.md
@@ -1,5 +1,5 @@
 ---
-"@mastra/server-fastify": patch
+"@mastra/fastify": patch
 ---
 
 Fix multipart file handling in Fastify adapter by aligning return type with other adapters and preventing stream hang on file size limit.


### PR DESCRIPTION
## What

Renames the package reference inside `.changeset/fastify-multipart-fix.md` from `@mastra/server-fastify` to `@mastra/fastify`.

## Why

The changeset added in #15796 references a package that does not exist in the workspace — the real package name is `@mastra/fastify` (located at `server-adapters/fastify`).

This causes the alpha release PR (#15979) to fail with:

```
Found changeset fastify-multipart-fix for package @mastra/server-fastify which is not in the workspace
```

The failure blocks `changeset version` from running, which in turn blocks the alpha release.

## Verification

`pnpm exec changeset status` now succeeds locally and prints the expected release plan, with `@mastra/fastify` correctly listed under packages to be bumped at patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a typo in a release notes file where someone wrote the wrong package name. The release process was looking for a package that doesn't exist, which caused it to fail, so this PR corrects it to the real package name so releases can work again.

## Changes

**File Modified:** `.changeset/fastify-multipart-fix.md`

Updates the package name in the changeset metadata from `@mastra/server-fastify` to `@mastra/fastify` to correctly reference the actual workspace package located at `server-adapters/fastify`. The release description text remains unchanged.

## Context

The changeset was introduced in PR #15796 but referenced a non-existent package name. This caused the alpha release PR (#15979) to fail with the error:
```
Found changeset fastify-multipart-fix for package @mastra/server-fastify which is not in the workspace
```

This prevented `changeset version` from running and blocked the alpha release process.

## Verification

Running `pnpm exec changeset status` locally succeeds and shows the expected release plan with `@mastra/fastify` listed for a patch bump.

## Impact

- **Lines Changed:** 1
- **Effort:** Low

<!-- end of auto-generated comment: release notes by coderabbit.ai -->