### PR TITLE
fix(core,server,stores): skill files persistence, list resolution, and auto-publish

### DIFF
--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -339,6 +339,7 @@ export const SKILL_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
   references: { type: 'jsonb', nullable: true },
   scripts: { type: 'jsonb', nullable: true },
   assets: { type: 'jsonb', nullable: true },
+  files: { type: 'jsonb', nullable: true },
   metadata: { type: 'jsonb', nullable: true },
   tree: { type: 'jsonb', nullable: true },
   changedFields: { type: 'jsonb', nullable: true },

--- a/packages/core/src/storage/domains/skills/inmemory.test.ts
+++ b/packages/core/src/storage/domains/skills/inmemory.test.ts
@@ -1,0 +1,687 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InMemoryDB } from '../inmemory-db';
+import { InMemorySkillsStorage } from './inmemory';
+
+describe('InMemorySkillsStorage', () => {
+  let db: InMemoryDB;
+  let storage: InMemorySkillsStorage;
+
+  beforeEach(() => {
+    db = new InMemoryDB();
+    storage = new InMemorySkillsStorage({ db });
+  });
+
+  describe('create', () => {
+    it('should create skill with status=draft and activeVersionId=undefined', async () => {
+      const result = await storage.create({
+        skill: {
+          id: 'test-skill',
+          authorId: 'user-123',
+          name: 'Test Skill',
+          description: 'A test skill',
+          instructions: 'Do something helpful',
+        },
+      });
+
+      expect(result.id).toBe('test-skill');
+      expect(result.status).toBe('draft');
+      expect(result.activeVersionId).toBeUndefined();
+      expect(result.authorId).toBe('user-123');
+
+      const versionCount = await storage.countVersions('test-skill');
+      expect(versionCount).toBe(1);
+
+      const resolved = await storage.getByIdResolved('test-skill');
+      expect(resolved?.name).toBe('Test Skill');
+      expect(resolved?.description).toBe('A test skill');
+      expect(resolved?.instructions).toBe('Do something helpful');
+    });
+
+    it('should default visibility to private when authorId is set', async () => {
+      const result = await storage.create({
+        skill: {
+          id: 'private-skill',
+          authorId: 'user-123',
+          name: 'Private Skill',
+          description: 'desc',
+          instructions: 'instr',
+        },
+      });
+
+      expect(result.visibility).toBe('private');
+    });
+
+    it('should default visibility to undefined when no authorId', async () => {
+      const result = await storage.create({
+        skill: {
+          id: 'public-skill',
+          name: 'Public Skill',
+          description: 'desc',
+          instructions: 'instr',
+        },
+      });
+
+      expect(result.visibility).toBeUndefined();
+    });
+
+    it('should reject duplicate skill IDs', async () => {
+      await storage.create({
+        skill: {
+          id: 'dup-skill',
+          name: 'First',
+          description: 'desc',
+          instructions: 'instr',
+        },
+      });
+
+      await expect(
+        storage.create({
+          skill: {
+            id: 'dup-skill',
+            name: 'Second',
+            description: 'desc',
+            instructions: 'instr',
+          },
+        }),
+      ).rejects.toThrow('already exists');
+    });
+  });
+
+  describe('update', () => {
+    beforeEach(async () => {
+      await storage.create({
+        skill: {
+          id: 'update-skill',
+          authorId: 'user-123',
+          name: 'Original Name',
+          description: 'Original description',
+          instructions: 'Original instructions',
+        },
+      });
+    });
+
+    it('should update metadata without creating new version', async () => {
+      const versionCountBefore = await storage.countVersions('update-skill');
+      expect(versionCountBefore).toBe(1);
+
+      await storage.update({
+        id: 'update-skill',
+        visibility: 'public',
+      });
+
+      const versionCountAfter = await storage.countVersions('update-skill');
+      expect(versionCountAfter).toBe(1);
+
+      const skill = await storage.getById('update-skill');
+      expect(skill?.visibility).toBe('public');
+    });
+
+    it('should create new version when config fields change', async () => {
+      const versionCountBefore = await storage.countVersions('update-skill');
+      expect(versionCountBefore).toBe(1);
+
+      await storage.update({
+        id: 'update-skill',
+        name: 'Updated Name',
+        instructions: 'Updated instructions',
+      });
+
+      const versionCountAfter = await storage.countVersions('update-skill');
+      expect(versionCountAfter).toBe(2);
+
+      // Latest version should have updated fields
+      const latestVersion = await storage.getLatestVersion('update-skill');
+      expect(latestVersion?.name).toBe('Updated Name');
+      expect(latestVersion?.instructions).toBe('Updated instructions');
+      // Unchanged fields should carry forward
+      expect(latestVersion?.description).toBe('Original description');
+    });
+
+    it('should not create version when config values are unchanged', async () => {
+      await storage.update({
+        id: 'update-skill',
+        name: 'Original Name',
+        instructions: 'Original instructions',
+      });
+
+      const versionCount = await storage.countVersions('update-skill');
+      expect(versionCount).toBe(1);
+    });
+  });
+
+  describe('getByIdResolved', () => {
+    it('should fall back to latest version when activeVersionId is undefined', async () => {
+      await storage.create({
+        skill: {
+          id: 'fallback-skill',
+          name: 'Version 1',
+          description: 'desc',
+          instructions: 'v1',
+        },
+      });
+
+      await storage.createVersion({
+        id: 'v2',
+        skillId: 'fallback-skill',
+        versionNumber: 2,
+        name: 'Version 2',
+        description: 'desc',
+        instructions: 'v2',
+        changedFields: ['name', 'instructions'],
+        changeMessage: 'v2',
+      });
+
+      const resolved = await storage.getByIdResolved('fallback-skill');
+      expect(resolved?.name).toBe('Version 2');
+      expect(resolved?.instructions).toBe('v2');
+    });
+
+    it('should use active version when set', async () => {
+      await storage.create({
+        skill: {
+          id: 'active-skill',
+          name: 'Version 1',
+          description: 'desc',
+          instructions: 'v1',
+        },
+      });
+
+      const activeVersionId = 'active-v';
+      await storage.createVersion({
+        id: activeVersionId,
+        skillId: 'active-skill',
+        versionNumber: 2,
+        name: 'Active Version',
+        description: 'active desc',
+        instructions: 'active',
+        changedFields: ['name', 'instructions'],
+        changeMessage: 'activated',
+      });
+
+      // Create a newer version that should NOT be used
+      await storage.createVersion({
+        id: 'v3',
+        skillId: 'active-skill',
+        versionNumber: 3,
+        name: 'Latest Draft',
+        description: 'draft desc',
+        instructions: 'draft',
+        changedFields: ['name', 'instructions'],
+        changeMessage: 'draft',
+      });
+
+      await storage.update({
+        id: 'active-skill',
+        activeVersionId,
+      });
+
+      const resolved = await storage.getByIdResolved('active-skill');
+      expect(resolved?.name).toBe('Active Version');
+      expect(resolved?.instructions).toBe('active');
+    });
+
+    it('should return null for nonexistent skill', async () => {
+      const resolved = await storage.getByIdResolved('nonexistent');
+      expect(resolved).toBeNull();
+    });
+  });
+
+  describe('listResolved', () => {
+    beforeEach(async () => {
+      await storage.create({
+        skill: {
+          id: 'skill-a',
+          authorId: 'user-1',
+          name: 'Skill A',
+          description: 'desc a',
+          instructions: 'instr a',
+        },
+      });
+      await storage.create({
+        skill: {
+          id: 'skill-b',
+          authorId: 'user-2',
+          name: 'Skill B',
+          description: 'desc b',
+          instructions: 'instr b',
+        },
+      });
+    });
+
+    it('should return resolved skills with version config', async () => {
+      const result = await storage.listResolved({ status: 'draft' });
+      expect(result.skills).toHaveLength(2);
+      expect(result.skills.map(s => s.name).sort()).toEqual(['Skill A', 'Skill B']);
+    });
+
+    it('should filter by authorId', async () => {
+      const result = await storage.listResolved({ authorId: 'user-1' });
+      expect(result.skills).toHaveLength(1);
+      expect(result.skills[0]!.name).toBe('Skill A');
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete skill and all its versions', async () => {
+      await storage.create({
+        skill: {
+          id: 'delete-me',
+          name: 'Delete Me',
+          description: 'desc',
+          instructions: 'instr',
+        },
+      });
+
+      const versionCount = await storage.countVersions('delete-me');
+      expect(versionCount).toBe(1);
+
+      await storage.delete('delete-me');
+
+      const skill = await storage.getById('delete-me');
+      expect(skill).toBeNull();
+
+      const versionsAfter = await storage.countVersions('delete-me');
+      expect(versionsAfter).toBe(0);
+    });
+
+    it('should be idempotent', async () => {
+      await storage.delete('nonexistent');
+      // Should not throw
+    });
+  });
+
+  // ==========================================================================
+  // Files persistence
+  // ==========================================================================
+
+  describe('files persistence', () => {
+    it('should persist files through create and resolve', async () => {
+      const files = [
+        {
+          id: 'root',
+          name: 'my-skill',
+          type: 'folder' as const,
+          children: [
+            { id: 'skill-md', name: 'SKILL.md', type: 'file' as const, content: '# My Skill\nDo things' },
+            { id: 'license-md', name: 'LICENSE.md', type: 'file' as const, content: 'MIT' },
+            {
+              id: 'references',
+              name: 'references',
+              type: 'folder' as const,
+              children: [
+                { id: 'ref-1', name: 'api-template.md', type: 'file' as const, content: '# API Template\nGET /foo' },
+              ],
+            },
+            {
+              id: 'scripts',
+              name: 'scripts',
+              type: 'folder' as const,
+              children: [
+                { id: 'script-1', name: 'generate.sh', type: 'file' as const, content: '#!/bin/bash\necho hi' },
+              ],
+            },
+            { id: 'assets', name: 'assets', type: 'folder' as const, children: [] },
+          ],
+        },
+      ];
+
+      await storage.create({
+        skill: {
+          id: 'files-skill',
+          name: 'Files Skill',
+          description: 'A skill with files',
+          instructions: '# My Skill\nDo things',
+          files,
+        },
+      });
+
+      const resolved = await storage.getByIdResolved('files-skill');
+      expect(resolved?.files).toBeDefined();
+      expect(resolved!.files).toHaveLength(1);
+
+      const root = resolved!.files![0]!;
+      expect(root.name).toBe('my-skill');
+      expect(root.children).toHaveLength(5);
+
+      // Verify reference file content
+      const refsFolder = root.children!.find(c => c.name === 'references');
+      expect(refsFolder?.children).toHaveLength(1);
+      expect(refsFolder!.children![0]!.name).toBe('api-template.md');
+      expect(refsFolder!.children![0]!.content).toBe('# API Template\nGET /foo');
+
+      // Verify script file content
+      const scriptsFolder = root.children!.find(c => c.name === 'scripts');
+      expect(scriptsFolder?.children).toHaveLength(1);
+      expect(scriptsFolder!.children![0]!.name).toBe('generate.sh');
+      expect(scriptsFolder!.children![0]!.content).toBe('#!/bin/bash\necho hi');
+    });
+
+    it('should persist files through version creation', async () => {
+      await storage.create({
+        skill: {
+          id: 'version-files',
+          name: 'Version Files',
+          description: 'desc',
+          instructions: 'instr',
+        },
+      });
+
+      const files = [
+        {
+          id: 'root',
+          name: 'version-files',
+          type: 'folder' as const,
+          children: [
+            { id: 'skill-md', name: 'SKILL.md', type: 'file' as const, content: 'updated' },
+            {
+              id: 'references',
+              name: 'references',
+              type: 'folder' as const,
+              children: [{ id: 'ref-1', name: 'ref.md', type: 'file' as const, content: 'reference content' }],
+            },
+          ],
+        },
+      ];
+
+      await storage.createVersion({
+        id: 'v2-with-files',
+        skillId: 'version-files',
+        versionNumber: 2,
+        name: 'Version Files',
+        description: 'desc',
+        instructions: 'updated',
+        files,
+        changedFields: ['instructions', 'files'],
+        changeMessage: 'Added files',
+      });
+
+      const version = await storage.getVersion('v2-with-files');
+      expect(version?.files).toBeDefined();
+      expect(version!.files![0]!.children).toHaveLength(2);
+
+      // Resolved should also return the files from latest version
+      const resolved = await storage.getByIdResolved('version-files');
+      expect(resolved?.files).toBeDefined();
+      expect(resolved!.files![0]!.children![1]!.name).toBe('references');
+    });
+
+    it('should update files via update() and create a new version', async () => {
+      const initialFiles = [
+        {
+          id: 'root',
+          name: 'updatable',
+          type: 'folder' as const,
+          children: [
+            { id: 'skill-md', name: 'SKILL.md', type: 'file' as const, content: 'initial' },
+            { id: 'references', name: 'references', type: 'folder' as const, children: [] },
+          ],
+        },
+      ];
+
+      await storage.create({
+        skill: {
+          id: 'updatable-skill',
+          name: 'Updatable Skill',
+          description: 'desc',
+          instructions: 'initial',
+          files: initialFiles,
+        },
+      });
+
+      const updatedFiles = [
+        {
+          id: 'root',
+          name: 'updatable',
+          type: 'folder' as const,
+          children: [
+            { id: 'skill-md', name: 'SKILL.md', type: 'file' as const, content: 'updated' },
+            {
+              id: 'references',
+              name: 'references',
+              type: 'folder' as const,
+              children: [{ id: 'ref-new', name: 'new-ref.md', type: 'file' as const, content: 'new ref' }],
+            },
+          ],
+        },
+      ];
+
+      await storage.update({
+        id: 'updatable-skill',
+        files: updatedFiles,
+      });
+
+      const versionCount = await storage.countVersions('updatable-skill');
+      expect(versionCount).toBe(2);
+
+      const resolved = await storage.getByIdResolved('updatable-skill');
+      const root = resolved!.files![0]!;
+      const refsFolder = root.children!.find(c => c.name === 'references');
+      expect(refsFolder?.children).toHaveLength(1);
+      expect(refsFolder!.children![0]!.name).toBe('new-ref.md');
+    });
+
+    it('should deep-copy files to prevent mutation of stored data', async () => {
+      const files = [
+        {
+          id: 'root',
+          name: 'deep-copy',
+          type: 'folder' as const,
+          children: [{ id: 'skill-md', name: 'SKILL.md', type: 'file' as const, content: 'original' }],
+        },
+      ];
+
+      await storage.create({
+        skill: {
+          id: 'deep-copy-skill',
+          name: 'Deep Copy',
+          description: 'desc',
+          instructions: 'instr',
+          files,
+        },
+      });
+
+      // Mutate the original input
+      files[0]!.children![0]!.content = 'MUTATED';
+
+      // Stored data should be unaffected
+      const resolved = await storage.getByIdResolved('deep-copy-skill');
+      expect(resolved!.files![0]!.children![0]!.content).toBe('original');
+    });
+
+    it('should handle skills with no files', async () => {
+      await storage.create({
+        skill: {
+          id: 'no-files-skill',
+          name: 'No Files',
+          description: 'desc',
+          instructions: 'instr',
+        },
+      });
+
+      const resolved = await storage.getByIdResolved('no-files-skill');
+      expect(resolved?.files).toBeUndefined();
+    });
+
+    it('should handle empty files array', async () => {
+      await storage.create({
+        skill: {
+          id: 'empty-files-skill',
+          name: 'Empty Files',
+          description: 'desc',
+          instructions: 'instr',
+          files: [],
+        },
+      });
+
+      const resolved = await storage.getByIdResolved('empty-files-skill');
+      expect(resolved?.files).toEqual([]);
+    });
+  });
+
+  // ==========================================================================
+  // References, scripts, assets persistence
+  // ==========================================================================
+
+  describe('references/scripts/assets persistence', () => {
+    it('should persist references array through create and resolve', async () => {
+      await storage.create({
+        skill: {
+          id: 'refs-skill',
+          name: 'Refs Skill',
+          description: 'desc',
+          instructions: 'instr',
+          references: ['references/api-template.md', 'references/guide.md'],
+        },
+      });
+
+      const resolved = await storage.getByIdResolved('refs-skill');
+      expect(resolved?.references).toEqual(['references/api-template.md', 'references/guide.md']);
+    });
+
+    it('should persist scripts array through create and resolve', async () => {
+      await storage.create({
+        skill: {
+          id: 'scripts-skill',
+          name: 'Scripts Skill',
+          description: 'desc',
+          instructions: 'instr',
+          scripts: ['scripts/generate.sh'],
+        },
+      });
+
+      const resolved = await storage.getByIdResolved('scripts-skill');
+      expect(resolved?.scripts).toEqual(['scripts/generate.sh']);
+    });
+
+    it('should persist assets array through create and resolve', async () => {
+      await storage.create({
+        skill: {
+          id: 'assets-skill',
+          name: 'Assets Skill',
+          description: 'desc',
+          instructions: 'instr',
+          assets: ['assets/logo.png'],
+        },
+      });
+
+      const resolved = await storage.getByIdResolved('assets-skill');
+      expect(resolved?.assets).toEqual(['assets/logo.png']);
+    });
+
+    it('should update references via update() and create new version', async () => {
+      await storage.create({
+        skill: {
+          id: 'update-refs',
+          name: 'Update Refs',
+          description: 'desc',
+          instructions: 'instr',
+        },
+      });
+
+      await storage.update({
+        id: 'update-refs',
+        references: ['references/new-ref.md'],
+      });
+
+      const versionCount = await storage.countVersions('update-refs');
+      expect(versionCount).toBe(2);
+
+      const resolved = await storage.getByIdResolved('update-refs');
+      expect(resolved?.references).toEqual(['references/new-ref.md']);
+    });
+  });
+
+  // ==========================================================================
+  // Version management
+  // ==========================================================================
+
+  describe('version management', () => {
+    it('should list versions with pagination', async () => {
+      await storage.create({
+        skill: {
+          id: 'paginated-skill',
+          name: 'Paginated',
+          description: 'desc',
+          instructions: 'v1',
+        },
+      });
+
+      for (let i = 2; i <= 5; i++) {
+        await storage.createVersion({
+          id: `v${i}`,
+          skillId: 'paginated-skill',
+          versionNumber: i,
+          name: 'Paginated',
+          description: 'desc',
+          instructions: `v${i}`,
+          changedFields: ['instructions'],
+          changeMessage: `v${i}`,
+        });
+      }
+
+      const allVersions = await storage.listVersions({
+        skillId: 'paginated-skill',
+        perPage: false,
+      });
+      expect(allVersions.versions).toHaveLength(5);
+
+      const page0 = await storage.listVersions({
+        skillId: 'paginated-skill',
+        perPage: 2,
+        page: 0,
+      });
+      expect(page0.versions).toHaveLength(2);
+      expect(page0.hasMore).toBe(true);
+    });
+
+    it('should count versions', async () => {
+      await storage.create({
+        skill: {
+          id: 'count-skill',
+          name: 'Count',
+          description: 'desc',
+          instructions: 'v1',
+        },
+      });
+
+      expect(await storage.countVersions('count-skill')).toBe(1);
+
+      await storage.createVersion({
+        id: 'cv2',
+        skillId: 'count-skill',
+        versionNumber: 2,
+        name: 'Count',
+        description: 'desc',
+        instructions: 'v2',
+        changedFields: ['instructions'],
+        changeMessage: 'v2',
+      });
+
+      expect(await storage.countVersions('count-skill')).toBe(2);
+    });
+
+    it('should reject duplicate version numbers', async () => {
+      await storage.create({
+        skill: {
+          id: 'dup-version',
+          name: 'Dup',
+          description: 'desc',
+          instructions: 'v1',
+        },
+      });
+
+      await expect(
+        storage.createVersion({
+          id: 'dup-v1',
+          skillId: 'dup-version',
+          versionNumber: 1, // already exists from create
+          name: 'Dup',
+          description: 'desc',
+          instructions: 'v1',
+          changedFields: [],
+          changeMessage: 'dup',
+        }),
+      ).rejects.toThrow('already exists');
+    });
+  });
+});

--- a/packages/server/src/server/auth/helpers.test.ts
+++ b/packages/server/src/server/auth/helpers.test.ts
@@ -786,7 +786,7 @@ describe('auth helpers', () => {
       expect(result.action).toBe('next');
       expect(result).toHaveProperty('headers');
       expect((result as any).headers['Set-Cookie']).toContain('wos-session=refreshed-token');
-      expect(requestContext.get('user')).toBe(user);
+      expect(requestContext.get(MASTRA_USER_KEY)).toBe(user);
       expect(callCount).toBe(2); // authenticateToken called twice
     });
 

--- a/packages/server/src/server/handlers/stored-agents.test.ts
+++ b/packages/server/src/server/handlers/stored-agents.test.ts
@@ -777,6 +777,36 @@ describe('Stored Agents Handlers', () => {
         expect((error as HTTPException).status).toBe(400);
       }
     });
+
+    it('should auto-publish by updating activeVersionId when a new version is created', async () => {
+      const newVersionId = 'v-autopub-2';
+      mockAgentsData.set('autopub-test', {
+        id: 'autopub-test',
+        name: 'Original Name',
+        instructions: 'Original instructions',
+        model: { name: 'gpt-4', provider: 'openai' },
+        activeVersionId: 'v-autopub-1',
+      });
+
+      // listVersions is called multiple times: once by enforceRetentionLimit
+      // inside handleAutoVersioning, then again by the auto-publish code.
+      // Return the new version each time so auto-publish can activate it.
+      mockAgentsStore.listVersions.mockResolvedValue({
+        versions: [{ id: newVersionId, versionNumber: 2 }],
+        total: 2,
+      });
+
+      await UPDATE_STORED_AGENT_ROUTE.handler({
+        ...createTestContext(mockMastra),
+        storedAgentId: 'autopub-test',
+        name: 'Updated Name',
+        instructions: 'Updated instructions',
+      });
+
+      // Verify activeVersionId was updated to the latest version
+      const stored = mockAgentsData.get('autopub-test');
+      expect(stored?.activeVersionId).toBe(newVersionId);
+    });
   });
 
   describe('DELETE_STORED_AGENT_ROUTE', () => {

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -554,7 +554,6 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
 
       // Handle auto-versioning with retry logic for race conditions
       // This creates a new version if there are meaningful config changes.
-      // It does NOT update activeVersionId — the version stays as a draft until explicitly published.
       const autoVersionResult = await handleAutoVersioning(
         agentsStore as unknown as VersionedStoreInterface,
         storedAgentId,
@@ -570,13 +569,29 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
         throw new Error('handleAutoVersioning returned undefined');
       }
 
+      // Auto-publish: activate the latest version so the update is immediately
+      // visible in list views. The Agent Builder UI has no separate "Publish"
+      // button, so without this every edit after creation would create orphaned
+      // draft versions that never surface in the list.
+      // When a proper publish flow ships, this block can be removed.
+      if (autoVersionResult.versionCreated) {
+        const { versions } = await agentsStore.listVersions({ agentId: storedAgentId, perPage: 1 });
+        const latestVersion = versions[0];
+        if (latestVersion) {
+          await agentsStore.update({
+            id: storedAgentId,
+            activeVersionId: latestVersion.id,
+          });
+        }
+      }
+
       // Clear the cached agent instance so the next request gets the updated config
       const editor = mastra.getEditor();
       if (editor) {
         editor.agent.clearCache(storedAgentId);
       }
 
-      // Return the resolved agent with the latest (draft) version so the UI sees its edits
+      // Return the resolved agent with the latest version
       const resolved = await agentsStore.getByIdResolved(storedAgentId, { status: 'draft' });
       if (!resolved) {
         throw new HTTPException(500, { message: 'Failed to resolve updated agent' });

--- a/packages/server/src/server/handlers/stored-skills.ts
+++ b/packages/server/src/server/handlers/stored-skills.ts
@@ -1,3 +1,4 @@
+import type { StorageSkillFileNode } from '@mastra/core/storage';
 import { LocalSkillSource } from '@mastra/core/workspace';
 
 import { HTTPException } from '../http-exception';
@@ -27,6 +28,78 @@ import {
 import { isBuilderFeatureEnabled } from './editor-builder';
 import { handleError } from './error';
 import { prepareStarsEnrichment, stripStarFields } from './stars-enrichment';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Well-known folder names in the skill file tree whose children represent
+ * indexable path arrays (references, scripts, assets).
+ */
+const INDEXED_FOLDERS = ['references', 'scripts', 'assets'] as const;
+
+/**
+ * Walks the `files` tree and collects relative file paths for each well-known
+ * folder (references, scripts, assets).  Returned arrays only include entries
+ * that are not already present in any explicitly-provided arrays so callers
+ * can pass both `files` and `references` without creating duplicates.
+ */
+function extractIndexedPathsFromFiles(
+  files: StorageSkillFileNode[] | undefined,
+  existing: {
+    references?: string[];
+    scripts?: string[];
+    assets?: string[];
+  },
+): {
+  references?: string[];
+  scripts?: string[];
+  assets?: string[];
+} {
+  if (!files || files.length === 0) return {};
+
+  // Find the root folder (first folder node, usually id="root")
+  const root = files.find(n => n.type === 'folder');
+  if (!root?.children) return {};
+
+  const result: Record<string, string[]> = {};
+
+  for (const folderName of INDEXED_FOLDERS) {
+    const folder = root.children.find(n => n.type === 'folder' && n.name === folderName);
+    if (!folder?.children || folder.children.length === 0) continue;
+
+    const existingPaths = new Set(existing[folderName] ?? []);
+    const paths: string[] = [...existingPaths];
+
+    collectFilePaths(folder.children, folderName, existingPaths, paths);
+
+    if (paths.length > 0) {
+      result[folderName] = paths;
+    }
+  }
+
+  return result;
+}
+
+/** Recursively collects file paths from a subtree, building relative paths. */
+function collectFilePaths(
+  nodes: StorageSkillFileNode[],
+  prefix: string,
+  existingPaths: Set<string>,
+  out: string[],
+): void {
+  for (const node of nodes) {
+    if (node.type === 'file') {
+      const relativePath = `${prefix}/${node.name}`;
+      if (!existingPaths.has(relativePath)) {
+        out.push(relativePath);
+      }
+    } else if (node.type === 'folder' && node.children) {
+      collectFilePaths(node.children, `${prefix}/${node.name}`, existingPaths, out);
+    }
+  }
+}
 
 // ============================================================================
 // Route Definitions
@@ -260,6 +333,10 @@ export const CREATE_STORED_SKILL_ROUTE = createRoute({
       const authorId = getCallerAuthorId(requestContext) ?? undefined;
       const visibility: 'private' | 'public' = bodyVisibility ?? (authorId ? 'private' : 'public');
 
+      // Derive references/scripts/assets path arrays from the files tree
+      // so agents can discover them via skill_read even when only `files` is provided.
+      const indexedPaths = extractIndexedPathsFromFiles(files, { references, scripts, assets });
+
       await skillStore.create({
         skill: {
           id,
@@ -271,9 +348,9 @@ export const CREATE_STORED_SKILL_ROUTE = createRoute({
           license,
           compatibility,
           source,
-          references,
-          scripts,
-          assets,
+          references: indexedPaths.references ?? references,
+          scripts: indexedPaths.scripts ?? scripts,
+          assets: indexedPaths.assets ?? assets,
           files,
           metadata,
         },
@@ -353,6 +430,9 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
         record: existing,
       });
 
+      // Derive references/scripts/assets path arrays from the files tree
+      const indexedPaths = files ? extractIndexedPathsFromFiles(files, { references, scripts, assets }) : {};
+
       // Update the skill with both entity-level and config-level fields
       // The storage layer handles separating these into record updates vs new-version creation
       await skillStore.update({
@@ -365,9 +445,9 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
         license,
         compatibility,
         source,
-        references,
-        scripts,
-        assets,
+        references: indexedPaths.references ?? references,
+        scripts: indexedPaths.scripts ?? scripts,
+        assets: indexedPaths.assets ?? assets,
         files,
         metadata,
       });

--- a/stores/libsql/src/storage/domains/skills/index.ts
+++ b/stores/libsql/src/storage/domains/skills/index.ts
@@ -41,6 +41,7 @@ const SNAPSHOT_FIELDS = [
   'references',
   'scripts',
   'assets',
+  'files',
   'metadata',
   'tree',
 ] as const;
@@ -68,6 +69,12 @@ export class SkillsLibSQL extends SkillsStorage {
       tableName: TABLE_SKILLS,
       schema: SKILLS_SCHEMA,
       ifNotExists: ['visibility', 'starCount'],
+    });
+
+    await this.#db.alterTable({
+      tableName: TABLE_SKILL_VERSIONS,
+      schema: SKILL_VERSIONS_SCHEMA,
+      ifNotExists: ['files'],
     });
 
     // Unique constraint on (skillId, versionNumber) to prevent duplicate versions from concurrent updates
@@ -438,9 +445,9 @@ export class SkillsLibSQL extends SkillsStorage {
         sql: `INSERT INTO "${TABLE_SKILL_VERSIONS}" (
           id, "skillId", "versionNumber",
           name, description, instructions, license, compatibility,
-          source, "references", scripts, assets, metadata, tree,
+          source, "references", scripts, assets, files, metadata, tree,
           "changedFields", "changeMessage", "createdAt"
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         args: [
           input.id,
           input.skillId,
@@ -454,6 +461,7 @@ export class SkillsLibSQL extends SkillsStorage {
           input.references ? JSON.stringify(input.references) : null,
           input.scripts ? JSON.stringify(input.scripts) : null,
           input.assets ? JSON.stringify(input.assets) : null,
+          input.files ? JSON.stringify(input.files) : null,
           input.metadata ? JSON.stringify(input.metadata) : null,
           input.tree ? JSON.stringify(input.tree) : null,
           input.changedFields ? JSON.stringify(input.changedFields) : null,
@@ -697,6 +705,7 @@ export class SkillsLibSQL extends SkillsStorage {
       references: safeParseJSON(row.references) as SkillVersion['references'],
       scripts: safeParseJSON(row.scripts) as SkillVersion['scripts'],
       assets: safeParseJSON(row.assets) as SkillVersion['assets'],
+      files: safeParseJSON(row.files) as SkillVersion['files'],
       metadata: safeParseJSON(row.metadata) as Record<string, unknown> | undefined,
       tree: safeParseJSON(row.tree) as SkillVersion['tree'],
       changedFields: safeParseJSON(row.changedFields) as string[] | undefined,

--- a/stores/mongodb/src/storage/domains/skills/index.ts
+++ b/stores/mongodb/src/storage/domains/skills/index.ts
@@ -39,6 +39,7 @@ const SNAPSHOT_FIELDS = [
   'references',
   'scripts',
   'assets',
+  'files',
   'metadata',
   'tree',
 ] as const;

--- a/stores/pg/src/storage/domains/skills/index.ts
+++ b/stores/pg/src/storage/domains/skills/index.ts
@@ -37,6 +37,7 @@ const SNAPSHOT_FIELDS = [
   'references',
   'scripts',
   'assets',
+  'files',
   'metadata',
   'tree',
 ] as const;
@@ -96,6 +97,11 @@ export class SkillsPG extends SkillsStorage {
       tableName: TABLE_SKILLS,
       schema: TABLE_SCHEMAS[TABLE_SKILLS],
       ifNotExists: ['visibility', 'starCount'],
+    });
+    await this.#db.alterTable({
+      tableName: TABLE_SKILL_VERSIONS,
+      schema: TABLE_SCHEMAS[TABLE_SKILL_VERSIONS],
+      ifNotExists: ['files'],
     });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
@@ -537,10 +543,10 @@ export class SkillsPG extends SkillsStorage {
         `INSERT INTO ${tableName} (
           id, "skillId", "versionNumber",
           name, description, instructions, license, compatibility,
-          source, "references", scripts, assets, metadata, tree,
+          source, "references", scripts, assets, files, metadata, tree,
           "changedFields", "changeMessage",
           "createdAt", "createdAtZ"
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
         [
           input.id,
           input.skillId,
@@ -554,6 +560,7 @@ export class SkillsPG extends SkillsStorage {
           input.references ? JSON.stringify(input.references) : null,
           input.scripts ? JSON.stringify(input.scripts) : null,
           input.assets ? JSON.stringify(input.assets) : null,
+          input.files ? JSON.stringify(input.files) : null,
           input.metadata ? JSON.stringify(input.metadata) : null,
           input.tree ? JSON.stringify(input.tree) : null,
           input.changedFields ? JSON.stringify(input.changedFields) : null,
@@ -862,6 +869,7 @@ export class SkillsPG extends SkillsStorage {
       references: this.parseJson(row.references, 'references'),
       scripts: this.parseJson(row.scripts, 'scripts'),
       assets: this.parseJson(row.assets, 'assets'),
+      files: this.parseJson(row.files, 'files'),
       metadata: this.parseJson(row.metadata, 'metadata'),
       tree: this.parseJson(row.tree, 'tree'),
       changedFields: this.parseJson(row.changedFields, 'changedFields'),


### PR DESCRIPTION
## Summary

Fixes three issues in the Agent Builder's stored entity system:

1. **Skill files not persisted to DB** — The `files` field (full file tree with references, scripts, assets) was defined in types and schemas but missing from the database column definition and all storage adapters. Skills created in advanced mode with reference/script files had their file tree silently dropped.

2. **Agent name changes not reflected in list views** — After editing an agent's name, the list view continued showing the old name. The root cause: `handleAutoVersioning` creates a new draft version on update, but `activeVersionId` still pointed to the original version. Fixed by auto-publishing (updating `activeVersionId`) on every update, matching the create behavior. No publish UI exists yet, so every save should be immediately visible.

3. **References/scripts/assets arrays never populated** — The server CREATE and UPDATE handlers accepted `references`, `scripts`, and `assets` path arrays in the schema but never extracted them from the file tree. Added `extractIndexedPathsFromFiles()` to automatically walk the `files` tree and populate these arrays from well-known folders.

## Changes

### Files column (all storage adapters)
- `packages/core/src/storage/constants.ts` — Add `files` column to `SKILL_VERSIONS_SCHEMA`
- `stores/libsql`, `stores/pg`, `stores/mongodb` — Add `files` to field lists, SQL, parsing, and ALTER TABLE migration

### List resolution default
- `packages/server/src/server/handlers/stored-agents.ts` — Auto-publish version on update
- All 5 list handlers (agents, skills, mcp-clients, mcp-servers, prompt-blocks) — Default `status` to `'draft'` so lists resolve with the latest version

### File tree extraction
- `packages/server/src/server/handlers/stored-skills.ts` — Add `extractIndexedPathsFromFiles()`, apply on CREATE and UPDATE. Explicit caller arrays take precedence.

### Tests
- `packages/core/src/storage/domains/skills/inmemory.test.ts` — 27 new tests covering create, update, versioning, files round-trip, and resolved queries
- `packages/server/src/server/handlers/stored-skills.test.ts` — 4 new tests for references/scripts/assets extraction
- `packages/server/src/server/handlers/stored-agents.test.ts` — Unskipped update test, added auto-publish test, fixed auth test key

## Test Plan

- 27 InMemorySkillsStorage tests pass
- 4 server handler extraction tests pass
- 68 auth tests pass (including previously-broken session refresh test)
- All storage adapters build clean
- Manually verified in example app: agent name sync, skill file tree round-trip, references/scripts extraction