### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/.changeset/exa-integration-package.md
+++ b/.changeset/exa-integration-package.md
@@ -1,0 +1,5 @@
+---
+'@mastra/exa': minor
+---
+
+Add `@mastra/exa` — first-class Exa AI search integration package. Provides four tools for Mastra agents: `exa-search` (neural/keyword/auto web search with content options), `exa-find-similar` (semantic "more like this" lookup), `exa-get-contents` (text/highlights/summary retrieval for known URLs), and `exa-answer` (synthesized answers with citations). Mirrors the structure of `@mastra/tavily`. Reads `EXA_API_KEY` from env or accepts an explicit `apiKey`.

--- a/integrations/exa/README.md
+++ b/integrations/exa/README.md
@@ -1,0 +1,131 @@
+# @mastra/exa
+
+[Exa](https://exa.ai) AI-powered web search, content retrieval, find-similar, and answer tools for [Mastra](https://mastra.ai) agents.
+
+## Installation
+
+```bash
+npm install @mastra/exa exa-js zod
+```
+
+## Quick Start
+
+Use `createExaTools()` to get all four tools with a shared configuration:
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { createExaTools } from '@mastra/exa';
+
+const tools = createExaTools();
+// Or pass an explicit API key:
+// const tools = createExaTools({ apiKey: 'your-exa-api-key' });
+
+const agent = new Agent({
+  id: 'realtime-information-agent',
+  name: 'Realtime Information Agent',
+  instructions:
+    'You are a realtime information agent. Use exa-search for fresh web results, exa-get-contents to read full pages, exa-find-similar to expand from a known good URL, and exa-answer for direct fact-finding.',
+  model: 'anthropic/claude-sonnet-4-6',
+  tools,
+});
+```
+
+By default, the tools read `EXA_API_KEY` from your environment. You can also pass `{ apiKey }` explicitly.
+
+## Individual Tools
+
+Each tool can be created independently:
+
+```typescript
+import { createExaSearchTool, createExaGetContentsTool } from '@mastra/exa';
+
+const searchTool = createExaSearchTool({ apiKey: 'your-exa-api-key' });
+const contentsTool = createExaGetContentsTool(); // uses EXA_API_KEY env var
+```
+
+### Search
+
+```typescript
+import { createExaSearchTool } from '@mastra/exa';
+
+const searchTool = createExaSearchTool();
+
+// When called by an agent, accepts:
+// - query (required)
+// - type: 'auto' | 'neural' | 'keyword' | 'hybrid' | 'fast' | 'instant'
+// - numResults: 1-100
+// - includeDomains, excludeDomains, includeText, excludeText
+// - category: 'company' | 'research paper' | 'news' | 'pdf' | 'personal site' | 'financial report' | 'people'
+// - startPublishedDate, endPublishedDate, startCrawlDate, endCrawlDate
+// - userLocation (ISO country code)
+// - text, highlights, summary (boolean or object — request multiple at once)
+// - livecrawl: 'never' | 'fallback' | 'always' | 'auto' | 'preferred'
+```
+
+### Get Contents
+
+```typescript
+import { createExaGetContentsTool } from '@mastra/exa';
+
+const contentsTool = createExaGetContentsTool();
+
+// Accepts: urls (1+), text, highlights, summary, livecrawl, livecrawlTimeout, subpages, subpageTarget
+// Returns: results[] with id, url, title, text, highlights, summary, etc.
+```
+
+### Find Similar
+
+```typescript
+import { createExaFindSimilarTool } from '@mastra/exa';
+
+const similarTool = createExaFindSimilarTool();
+
+// Accepts: url, numResults, excludeSourceDomain, includeDomains, excludeDomains,
+//          includeText, excludeText, category, date filters, text/highlights/summary
+// Returns: scored similar pages with optional content
+```
+
+### Answer
+
+```typescript
+import { createExaAnswerTool } from '@mastra/exa';
+
+const answerTool = createExaAnswerTool();
+
+// Accepts: query, text (include citation page text), systemPrompt, userLocation
+// Returns: answer string + citations[]
+```
+
+## Configuration
+
+| Option    | Type     | Default                      | Description                                                |
+| --------- | -------- | ---------------------------- | ---------------------------------------------------------- |
+| `apiKey`  | `string` | `process.env.EXA_API_KEY`    | Your Exa API key                                           |
+| `baseURL` | `string` | Exa default                  | Override the API base URL (proxies / self-hosted gateways) |
+
+If no API key is found, the tool throws a clear error at execution time.
+
+## RAG Pairing Example
+
+Combine search and content retrieval for retrieval-augmented generation:
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { createExaSearchTool, createExaGetContentsTool } from '@mastra/exa';
+
+const agent = new Agent({
+  id: 'rag-agent',
+  name: 'Research Assistant',
+  model: 'anthropic/claude-sonnet-4-6',
+  instructions:
+    'You are a research assistant. Use exa-search to find relevant pages, then use exa-get-contents to fetch full text or summaries from the best results.',
+  tools: {
+    search: createExaSearchTool(),
+    contents: createExaGetContentsTool(),
+  },
+});
+```
+
+## License
+
+Apache-2.0

--- a/integrations/exa/eslint.config.js
+++ b/integrations/exa/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/integrations/exa/package.json
+++ b/integrations/exa/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@mastra/exa",
+  "version": "1.0.0",
+  "description": "Exa AI-powered web search, contents, find-similar, and answer tools for Mastra agents",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "mastra",
+    "exa",
+    "web-search",
+    "neural-search",
+    "tools",
+    "ai-agent"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "integrations/exa"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "homepage": "https://mastra.ai",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "dependencies": {
+    "exa-js": "2.12.1"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "zod": ">=3.0.0 || >=4.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/integrations/exa/src/__tests__/answer.test.ts
+++ b/integrations/exa/src/__tests__/answer.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAnswer = vi.fn();
+
+vi.mock('exa-js', () => {
+  class FakeExa {
+    headers = { set: vi.fn() };
+    search = vi.fn();
+    findSimilar = vi.fn();
+    getContents = vi.fn();
+    answer = mockAnswer;
+  }
+  return { default: FakeExa };
+});
+
+import { createExaAnswerTool } from '../answer.js';
+
+describe('createExaAnswerTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAnswer.mockResolvedValue({
+      answer: 'The capital of France is Paris.',
+      citations: [
+        {
+          id: 'c1',
+          url: 'https://wiki.example/Paris',
+          title: 'Paris',
+          publishedDate: '2024-01-01',
+          author: 'Wiki',
+          text: 'Paris is the capital...',
+        },
+      ],
+      requestId: 'req-1',
+      costDollars: { total: 0.003 },
+    });
+  });
+
+  it('creates a tool with the correct id', () => {
+    const tool = createExaAnswerTool({ apiKey: 'test-key' });
+    expect(tool.id).toBe('exa-answer');
+  });
+
+  it('returns answer text and mapped citations', async () => {
+    const tool = createExaAnswerTool({ apiKey: 'test-key' });
+    const result = (await tool.execute!({ query: 'What is the capital of France?' }, {} as any)) as any;
+
+    expect(mockAnswer).toHaveBeenCalledWith('What is the capital of France?', {
+      text: undefined,
+      systemPrompt: undefined,
+      userLocation: undefined,
+    });
+    expect(result.answer).toBe('The capital of France is Paris.');
+    expect(result.citations).toHaveLength(1);
+    expect(result.citations[0]).toEqual({
+      id: 'c1',
+      url: 'https://wiki.example/Paris',
+      title: 'Paris',
+      publishedDate: '2024-01-01',
+      author: 'Wiki',
+      text: 'Paris is the capital...',
+    });
+  });
+
+  it('serializes object answers to JSON when outputSchema is used upstream', async () => {
+    mockAnswer.mockResolvedValue({
+      answer: { capital: 'Paris' },
+      citations: [],
+    });
+
+    const tool = createExaAnswerTool({ apiKey: 'test-key' });
+    const result = (await tool.execute!({ query: 'capital of France?' }, {} as any)) as any;
+    expect(result.answer).toBe('{"capital":"Paris"}');
+  });
+
+  it('passes through systemPrompt and userLocation', async () => {
+    const tool = createExaAnswerTool({ apiKey: 'test-key' });
+    await tool.execute!(
+      { query: 'q', text: true, systemPrompt: 'be terse', userLocation: 'US' },
+      {} as any,
+    );
+
+    expect(mockAnswer).toHaveBeenCalledWith('q', {
+      text: true,
+      systemPrompt: 'be terse',
+      userLocation: 'US',
+    });
+  });
+});

--- a/integrations/exa/src/__tests__/client.test.ts
+++ b/integrations/exa/src/__tests__/client.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const ExaCtor = vi.fn();
+
+vi.mock('exa-js', () => {
+  class FakeExa {
+    headers: { set: (k: string, v: string) => void; get: (k: string) => string | undefined };
+    search = vi.fn();
+    findSimilar = vi.fn();
+    getContents = vi.fn();
+    answer = vi.fn();
+
+    constructor(apiKey: string, baseURL?: string) {
+      ExaCtor(apiKey, baseURL);
+      const store = new Map<string, string>();
+      this.headers = {
+        set: (k: string, v: string) => {
+          store.set(k, v);
+        },
+        get: (k: string) => store.get(k),
+      };
+    }
+  }
+
+  return { default: FakeExa };
+});
+
+import { getExaClient } from '../client.js';
+
+describe('getExaClient', () => {
+  const originalEnv = process.env.EXA_API_KEY;
+
+  beforeEach(() => {
+    ExaCtor.mockClear();
+    delete process.env.EXA_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.EXA_API_KEY = originalEnv;
+    } else {
+      delete process.env.EXA_API_KEY;
+    }
+  });
+
+  it('throws if no API key is provided and env var is not set', () => {
+    expect(() => getExaClient()).toThrow('Exa API key is required');
+  });
+
+  it('uses the API key from config', () => {
+    getExaClient({ apiKey: 'test-key-123' });
+    expect(ExaCtor).toHaveBeenCalledWith('test-key-123', undefined);
+  });
+
+  it('falls back to EXA_API_KEY env var', () => {
+    process.env.EXA_API_KEY = 'env-key-456';
+    getExaClient();
+    expect(ExaCtor).toHaveBeenCalledWith('env-key-456', undefined);
+  });
+
+  it('prefers config.apiKey over env var', () => {
+    process.env.EXA_API_KEY = 'env-key-456';
+    getExaClient({ apiKey: 'config-key-789' });
+    expect(ExaCtor).toHaveBeenCalledWith('config-key-789', undefined);
+  });
+
+  it('forwards baseURL to the SDK constructor', () => {
+    getExaClient({ apiKey: 'test-key', baseURL: 'https://custom.example.com' });
+    expect(ExaCtor).toHaveBeenCalledWith('test-key', 'https://custom.example.com');
+  });
+
+  it('sets the x-exa-integration tracking header to "mastra"', () => {
+    const client = getExaClient({ apiKey: 'test-key' }) as unknown as {
+      headers: { get: (k: string) => string | undefined };
+    };
+    expect(client.headers.get('x-exa-integration')).toBe('mastra');
+  });
+
+  it('returns a client with the expected method surface', () => {
+    const client = getExaClient({ apiKey: 'test-key' });
+    expect(client).toBeDefined();
+    expect(client.search).toBeDefined();
+    expect(client.findSimilar).toBeDefined();
+    expect(client.getContents).toBeDefined();
+    expect(client.answer).toBeDefined();
+  });
+});

--- a/integrations/exa/src/__tests__/disabled.test.ts
+++ b/integrations/exa/src/__tests__/disabled.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('exa-js', () => {
+  class FakeExa {
+    headers = { set: vi.fn() };
+    search = vi.fn().mockResolvedValue({ results: [] });
+    findSimilar = vi.fn().mockResolvedValue({ results: [] });
+    getContents = vi.fn().mockResolvedValue({ results: [] });
+    answer = vi.fn().mockResolvedValue({ answer: '', citations: [] });
+    constructor(apiKey: string) {
+      if (!apiKey) throw new Error('Exa SDK was constructed without an API key');
+    }
+  }
+  return { default: FakeExa };
+});
+
+import { createExaAnswerTool } from '../answer.js';
+import { createExaFindSimilarTool } from '../find-similar.js';
+import { createExaGetContentsTool } from '../get-contents.js';
+import { createExaSearchTool } from '../search.js';
+
+describe('Exa tools without an API key', () => {
+  const originalEnv = process.env.EXA_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.EXA_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.EXA_API_KEY = originalEnv;
+    } else {
+      delete process.env.EXA_API_KEY;
+    }
+  });
+
+  it('still constructs tools so they can be wired into agents at config time', () => {
+    expect(createExaSearchTool().id).toBe('exa-search');
+    expect(createExaFindSimilarTool().id).toBe('exa-find-similar');
+    expect(createExaGetContentsTool().id).toBe('exa-get-contents');
+    expect(createExaAnswerTool().id).toBe('exa-answer');
+  });
+
+  it('throws a clear error at execute time when no API key is set anywhere', async () => {
+    const tool = createExaSearchTool();
+    await expect(tool.execute!({ query: 'q' }, {} as any)).rejects.toThrow(/Exa API key is required/);
+  });
+
+  it('uses the env var when present', async () => {
+    process.env.EXA_API_KEY = 'env-key';
+    const tool = createExaSearchTool();
+    const result = (await tool.execute!({ query: 'q' }, {} as any)) as any;
+    expect(result.results).toEqual([]);
+  });
+});

--- a/integrations/exa/src/__tests__/find-similar.test.ts
+++ b/integrations/exa/src/__tests__/find-similar.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFindSimilar = vi.fn();
+
+vi.mock('exa-js', () => {
+  class FakeExa {
+    headers = { set: vi.fn() };
+    search = vi.fn();
+    findSimilar = mockFindSimilar;
+    getContents = vi.fn();
+    answer = vi.fn();
+  }
+  return { default: FakeExa };
+});
+
+import { createExaFindSimilarTool } from '../find-similar.js';
+
+describe('createExaFindSimilarTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindSimilar.mockResolvedValue({
+      requestId: 'req-1',
+      results: [
+        {
+          id: 'doc-1',
+          url: 'https://similar.com',
+          title: 'Similar Page',
+          score: 0.88,
+        },
+      ],
+      costDollars: { total: 0.005 },
+    });
+  });
+
+  it('creates a tool with the correct id', () => {
+    const tool = createExaFindSimilarTool({ apiKey: 'test-key' });
+    expect(tool.id).toBe('exa-find-similar');
+    expect(tool.description!.length).toBeGreaterThan(0);
+  });
+
+  it('passes URL and parameters through to findSimilar', async () => {
+    const tool = createExaFindSimilarTool({ apiKey: 'test-key' });
+
+    await tool.execute!(
+      {
+        url: 'https://example.com',
+        numResults: 5,
+        excludeSourceDomain: true,
+        text: true,
+      },
+      {} as any,
+    );
+
+    expect(mockFindSimilar).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFindSimilar.mock.calls[0]!;
+    expect(url).toBe('https://example.com');
+    expect(options.numResults).toBe(5);
+    expect(options.excludeSourceDomain).toBe(true);
+    expect(options.contents).toEqual({ text: true });
+  });
+
+  it('omits contents when no content option is set', async () => {
+    const tool = createExaFindSimilarTool({ apiKey: 'test-key' });
+    await tool.execute!({ url: 'https://example.com' }, {} as any);
+    const [, options] = mockFindSimilar.mock.calls[0]!;
+    expect(options.contents).toBeUndefined();
+  });
+
+  it('defaults title to null when missing', async () => {
+    mockFindSimilar.mockResolvedValue({
+      results: [{ id: 'x', url: 'https://x.com', title: null }],
+    });
+
+    const tool = createExaFindSimilarTool({ apiKey: 'test-key' });
+    const result = (await tool.execute!({ url: 'https://example.com' }, {} as any)) as any;
+    expect(result.results[0].title).toBeNull();
+  });
+
+  it('lets errors propagate', async () => {
+    mockFindSimilar.mockRejectedValue(new Error('not found'));
+    const tool = createExaFindSimilarTool({ apiKey: 'test-key' });
+    await expect(tool.execute!({ url: 'https://example.com' }, {} as any)).rejects.toThrow('not found');
+  });
+});

--- a/integrations/exa/src/__tests__/get-contents.test.ts
+++ b/integrations/exa/src/__tests__/get-contents.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetContents = vi.fn();
+
+vi.mock('exa-js', () => {
+  class FakeExa {
+    headers = { set: vi.fn() };
+    search = vi.fn();
+    findSimilar = vi.fn();
+    getContents = mockGetContents;
+    answer = vi.fn();
+  }
+  return { default: FakeExa };
+});
+
+import { createExaGetContentsTool } from '../get-contents.js';
+
+describe('createExaGetContentsTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetContents.mockResolvedValue({
+      requestId: 'req-1',
+      results: [
+        {
+          id: 'a',
+          url: 'https://a.com',
+          title: 'A',
+          text: 'full text',
+          highlights: ['h1'],
+          summary: 'sum',
+        },
+      ],
+      costDollars: { total: 0.002 },
+    });
+  });
+
+  it('creates a tool with the correct id', () => {
+    const tool = createExaGetContentsTool({ apiKey: 'test-key' });
+    expect(tool.id).toBe('exa-get-contents');
+  });
+
+  it('passes urls and content options through', async () => {
+    const tool = createExaGetContentsTool({ apiKey: 'test-key' });
+
+    await tool.execute!(
+      {
+        urls: ['https://a.com', 'https://b.com'],
+        text: { maxCharacters: 500 },
+        highlights: true,
+        summary: { query: 'pricing' },
+        livecrawl: 'always',
+        livecrawlTimeout: 5000,
+        subpages: 2,
+        subpageTarget: 'docs',
+      },
+      {} as any,
+    );
+
+    expect(mockGetContents).toHaveBeenCalledTimes(1);
+    const [urls, options] = mockGetContents.mock.calls[0]!;
+    expect(urls).toEqual(['https://a.com', 'https://b.com']);
+    expect(options.text).toEqual({ maxCharacters: 500 });
+    expect(options.highlights).toBe(true);
+    expect(options.summary).toEqual({ query: 'pricing' });
+    expect(options.livecrawl).toBe('always');
+    expect(options.subpages).toBe(2);
+    expect(options.subpageTarget).toBe('docs');
+  });
+
+  it('cascades through content fields gracefully when only summary is present', async () => {
+    mockGetContents.mockResolvedValue({
+      results: [{ id: 'b', url: 'https://b.com', title: 'B', summary: 'only summary' }],
+    });
+
+    const tool = createExaGetContentsTool({ apiKey: 'test-key' });
+    const result = (await tool.execute!({ urls: ['https://b.com'], summary: true }, {} as any)) as any;
+
+    expect(result.results[0].summary).toBe('only summary');
+    expect(result.results[0].text).toBeUndefined();
+    expect(result.results[0].highlights).toBeUndefined();
+  });
+
+  it('handles missing results array', async () => {
+    mockGetContents.mockResolvedValue({ requestId: 'r' });
+    const tool = createExaGetContentsTool({ apiKey: 'test-key' });
+    const result = (await tool.execute!({ urls: ['https://x.com'] }, {} as any)) as any;
+    expect(result.results).toEqual([]);
+  });
+});

--- a/integrations/exa/src/__tests__/search.test.ts
+++ b/integrations/exa/src/__tests__/search.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSearch = vi.fn();
+
+vi.mock('exa-js', () => {
+  class FakeExa {
+    headers = { set: vi.fn() };
+    search = mockSearch;
+    findSimilar = vi.fn();
+    getContents = vi.fn();
+    answer = vi.fn();
+  }
+  return { default: FakeExa };
+});
+
+import { createExaSearchTool } from '../search.js';
+
+describe('createExaSearchTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearch.mockResolvedValue({
+      requestId: 'req-123',
+      resolvedSearchType: 'neural',
+      results: [
+        {
+          id: 'doc-1',
+          url: 'https://example.com',
+          title: 'Result 1',
+          score: 0.95,
+          publishedDate: '2025-01-01',
+          author: 'Jane Doe',
+          favicon: 'https://example.com/favicon.ico',
+          text: 'Full page text',
+          highlights: ['highlight one', 'highlight two'],
+          summary: 'A summary',
+        },
+      ],
+      costDollars: { total: 0.01 },
+    });
+  });
+
+  it('creates a tool with the correct id and description', () => {
+    const tool = createExaSearchTool({ apiKey: 'test-key' });
+    expect(tool.id).toBe('exa-search');
+    expect(tool.description).toBeDefined();
+    expect(tool.description!.length).toBeGreaterThan(0);
+  });
+
+  it('exposes input and output schemas', () => {
+    const tool = createExaSearchTool({ apiKey: 'test-key' });
+    expect(tool.inputSchema).toBeDefined();
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  it('passes mapped parameters and packs content options under contents', async () => {
+    const tool = createExaSearchTool({ apiKey: 'test-key' });
+
+    await tool.execute!(
+      {
+        query: 'quantum computing',
+        type: 'neural',
+        numResults: 5,
+        includeDomains: ['arxiv.org'],
+        category: 'research paper',
+        text: { maxCharacters: 1000 },
+        highlights: true,
+        summary: { query: 'key findings' },
+        livecrawl: 'fallback',
+      },
+      {} as any,
+    );
+
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    const [query, options] = mockSearch.mock.calls[0]!;
+    expect(query).toBe('quantum computing');
+    expect(options.type).toBe('neural');
+    expect(options.numResults).toBe(5);
+    expect(options.includeDomains).toEqual(['arxiv.org']);
+    expect(options.category).toBe('research paper');
+    expect(options.contents).toEqual({
+      text: { maxCharacters: 1000 },
+      highlights: true,
+      summary: { query: 'key findings' },
+      livecrawl: 'fallback',
+    });
+  });
+
+  it('omits contents entirely when no content options are provided', async () => {
+    const tool = createExaSearchTool({ apiKey: 'test-key' });
+    await tool.execute!({ query: 'plain search' }, {} as any);
+
+    const [, options] = mockSearch.mock.calls[0]!;
+    expect(options.contents).toBeUndefined();
+  });
+
+  it('maps response fields and falls back to undefined for missing optional fields', async () => {
+    mockSearch.mockResolvedValue({
+      requestId: 'req-1',
+      results: [{ id: 'a', url: 'https://a.com', title: null }],
+      costDollars: { total: 0 },
+    });
+
+    const tool = createExaSearchTool({ apiKey: 'test-key' });
+    const result = (await tool.execute!({ query: 'q' }, {} as any)) as any;
+
+    expect(result.results[0]).toEqual({
+      id: 'a',
+      url: 'https://a.com',
+      title: null,
+      score: undefined,
+      publishedDate: undefined,
+      author: undefined,
+      image: undefined,
+      favicon: undefined,
+      text: undefined,
+      highlights: undefined,
+      summary: undefined,
+    });
+  });
+
+  it('handles cascading content fallbacks (only highlights present)', async () => {
+    mockSearch.mockResolvedValue({
+      requestId: 'req-2',
+      results: [
+        {
+          id: 'b',
+          url: 'https://b.com',
+          title: 'B',
+          highlights: ['only highlights, no text or summary'],
+        },
+      ],
+    });
+
+    const tool = createExaSearchTool({ apiKey: 'test-key' });
+    const result = (await tool.execute!({ query: 'q', highlights: true }, {} as any)) as any;
+
+    expect(result.results[0].highlights).toEqual(['only highlights, no text or summary']);
+    expect(result.results[0].text).toBeUndefined();
+    expect(result.results[0].summary).toBeUndefined();
+  });
+
+  it('returns an empty results array when none come back', async () => {
+    mockSearch.mockResolvedValue({ requestId: 'req-3', results: undefined });
+
+    const tool = createExaSearchTool({ apiKey: 'test-key' });
+    const result = (await tool.execute!({ query: 'q' }, {} as any)) as any;
+
+    expect(result.results).toEqual([]);
+  });
+
+  it('lets errors propagate', async () => {
+    mockSearch.mockRejectedValue(new Error('API rate limit exceeded'));
+
+    const tool = createExaSearchTool({ apiKey: 'test-key' });
+    await expect(tool.execute!({ query: 'q' }, {} as any)).rejects.toThrow('API rate limit exceeded');
+  });
+});

--- a/integrations/exa/src/__tests__/tools.test.ts
+++ b/integrations/exa/src/__tests__/tools.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('exa-js', () => {
+  class FakeExa {
+    headers = { set: vi.fn() };
+    search = vi.fn();
+    findSimilar = vi.fn();
+    getContents = vi.fn();
+    answer = vi.fn();
+  }
+  return { default: FakeExa };
+});
+
+import { createExaTools } from '../tools.js';
+
+describe('createExaTools', () => {
+  it('returns all four tools', () => {
+    const tools = createExaTools({ apiKey: 'test-key' });
+
+    expect(tools.exaSearch).toBeDefined();
+    expect(tools.exaFindSimilar).toBeDefined();
+    expect(tools.exaGetContents).toBeDefined();
+    expect(tools.exaAnswer).toBeDefined();
+  });
+
+  it('creates tools with the correct ids', () => {
+    const tools = createExaTools({ apiKey: 'test-key' });
+
+    expect(tools.exaSearch.id).toBe('exa-search');
+    expect(tools.exaFindSimilar.id).toBe('exa-find-similar');
+    expect(tools.exaGetContents.id).toBe('exa-get-contents');
+    expect(tools.exaAnswer.id).toBe('exa-answer');
+  });
+
+  it('every tool has a description, input schema, and output schema', () => {
+    const tools = createExaTools({ apiKey: 'test-key' });
+
+    for (const tool of Object.values(tools)) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.outputSchema).toBeDefined();
+    }
+  });
+});

--- a/integrations/exa/src/answer.ts
+++ b/integrations/exa/src/answer.ts
@@ -1,0 +1,77 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getExaClient } from './client.js';
+import type { ExaClient, ExaClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  query: z.string().describe('The question to answer'),
+  text: z.boolean().optional().describe('Include full page text in citation results (default false)'),
+  systemPrompt: z.string().optional().describe('Optional system prompt to guide the answer style'),
+  userLocation: z.string().optional().describe('Two-letter ISO country code used to localize results'),
+});
+
+const citationSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  title: z.string().nullable(),
+  publishedDate: z.string().optional(),
+  author: z.string().optional(),
+  text: z.string().optional(),
+});
+
+const outputSchema = z.object({
+  answer: z.string(),
+  citations: z.array(citationSchema),
+  requestId: z.string().optional(),
+  costDollars: z
+    .object({
+      total: z.number(),
+    })
+    .passthrough()
+    .optional(),
+});
+
+export function createExaAnswerTool(config?: ExaClientOptions) {
+  let client: ExaClient | null = null;
+
+  function getClient(): ExaClient {
+    if (!client) {
+      client = getExaClient(config);
+    }
+    return client;
+  }
+
+  return createTool({
+    id: 'exa-answer',
+    description:
+      'Generate a synthesized answer to a question using Exa AI, grounded in real-time web search citations. Returns the answer text alongside the source documents that support it. Best for direct question answering and fact-finding.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      const exa = getClient();
+
+      const response = await exa.answer(input.query, {
+        text: input.text,
+        systemPrompt: input.systemPrompt,
+        userLocation: input.userLocation,
+      });
+
+      const answerText = typeof response.answer === 'string' ? response.answer : JSON.stringify(response.answer);
+
+      return {
+        answer: answerText,
+        citations: (response.citations ?? []).map((c: any) => ({
+          id: c.id,
+          url: c.url,
+          title: c.title ?? null,
+          publishedDate: c.publishedDate || undefined,
+          author: c.author || undefined,
+          text: c.text || undefined,
+        })),
+        requestId: response.requestId,
+        costDollars: response.costDollars,
+      };
+    },
+  });
+}

--- a/integrations/exa/src/client.ts
+++ b/integrations/exa/src/client.ts
@@ -1,0 +1,34 @@
+import Exa from 'exa-js';
+
+export interface ExaClientOptions {
+  /**
+   * Exa API key. If omitted, falls back to `process.env.EXA_API_KEY`.
+   */
+  apiKey?: string;
+  /**
+   * Override the Exa API base URL. Useful for proxies or self-hosted gateways.
+   */
+  baseURL?: string;
+}
+
+export type ExaClient = Exa;
+
+const INTEGRATION_HEADER = 'mastra';
+
+export function getExaClient(config?: ExaClientOptions): ExaClient {
+  const apiKey = config?.apiKey ?? process.env.EXA_API_KEY;
+  if (!apiKey) {
+    throw new Error('Exa API key is required. Pass { apiKey } or set EXA_API_KEY env var.');
+  }
+
+  const client = new Exa(apiKey, config?.baseURL);
+
+  // Attribute API usage to the Mastra integration. The `headers` field on
+  // the Exa client is a Headers-like object with a `.set()` method.
+  const headers = (client as unknown as { headers?: { set?: (k: string, v: string) => void } }).headers;
+  if (headers && typeof headers.set === 'function') {
+    headers.set('x-exa-integration', INTEGRATION_HEADER);
+  }
+
+  return client;
+}

--- a/integrations/exa/src/find-similar.ts
+++ b/integrations/exa/src/find-similar.ts
@@ -1,0 +1,145 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getExaClient } from './client.js';
+import type { ExaClient, ExaClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  url: z.string().describe('The URL to find similar pages for'),
+  numResults: z.number().min(1).max(100).optional().describe('Number of similar results (1-100, default 10)'),
+  excludeSourceDomain: z
+    .boolean()
+    .optional()
+    .describe('If true, omit pages from the same domain as the input URL'),
+  includeDomains: z.array(z.string()).optional().describe('Restrict results to these domains'),
+  excludeDomains: z.array(z.string()).optional().describe('Exclude results from these domains'),
+  includeText: z.array(z.string()).optional().describe('Strings that must appear in the page text'),
+  excludeText: z.array(z.string()).optional().describe('Strings that must not appear in the page text'),
+  category: z
+    .enum(['company', 'research paper', 'news', 'pdf', 'personal site', 'financial report', 'people'])
+    .optional()
+    .describe('Restrict results to a single content category'),
+  startPublishedDate: z.string().optional().describe('Only return pages published on or after this ISO 8601 date'),
+  endPublishedDate: z.string().optional().describe('Only return pages published on or before this ISO 8601 date'),
+  startCrawlDate: z.string().optional().describe('Only return pages crawled on or after this ISO 8601 date'),
+  endCrawlDate: z.string().optional().describe('Only return pages crawled on or before this ISO 8601 date'),
+  text: z
+    .union([
+      z.boolean(),
+      z.object({
+        maxCharacters: z.number().optional(),
+        includeHtmlTags: z.boolean().optional(),
+      }),
+    ])
+    .optional()
+    .describe('Include full page text'),
+  highlights: z
+    .union([
+      z.boolean(),
+      z.object({
+        numSentences: z.number().optional(),
+        highlightsPerUrl: z.number().optional(),
+        query: z.string().optional(),
+      }),
+    ])
+    .optional()
+    .describe('Include relevant text highlights for each result'),
+  summary: z
+    .union([
+      z.boolean(),
+      z.object({
+        query: z.string().optional(),
+      }),
+    ])
+    .optional()
+    .describe('Include an LLM-generated summary of each result'),
+});
+
+const resultSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  title: z.string().nullable(),
+  score: z.number().optional(),
+  publishedDate: z.string().optional(),
+  author: z.string().optional(),
+  image: z.string().optional(),
+  favicon: z.string().optional(),
+  text: z.string().optional(),
+  highlights: z.array(z.string()).optional(),
+  summary: z.string().optional(),
+});
+
+const outputSchema = z.object({
+  requestId: z.string().optional(),
+  results: z.array(resultSchema),
+  costDollars: z
+    .object({
+      total: z.number(),
+    })
+    .passthrough()
+    .optional(),
+});
+
+type ExaFindSimilarOptions = Parameters<ExaClient['findSimilar']>[1];
+
+export function createExaFindSimilarTool(config?: ExaClientOptions) {
+  let client: ExaClient | null = null;
+
+  function getClient(): ExaClient {
+    if (!client) {
+      client = getExaClient(config);
+    }
+    return client;
+  }
+
+  return createTool({
+    id: 'exa-find-similar',
+    description:
+      'Find pages semantically similar to a given URL using Exa AI. Useful for "more like this" discovery, competitor research, or expanding from a known good source. Supports the same content options, domain/text filters, and date ranges as exa-search.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      const exa = getClient();
+
+      const contents: Record<string, unknown> = {};
+      if (input.text !== undefined) contents.text = input.text;
+      if (input.highlights !== undefined) contents.highlights = input.highlights;
+      if (input.summary !== undefined) contents.summary = input.summary;
+
+      const options = {
+        numResults: input.numResults,
+        excludeSourceDomain: input.excludeSourceDomain,
+        includeDomains: input.includeDomains,
+        excludeDomains: input.excludeDomains,
+        includeText: input.includeText,
+        excludeText: input.excludeText,
+        category: input.category,
+        startPublishedDate: input.startPublishedDate,
+        endPublishedDate: input.endPublishedDate,
+        startCrawlDate: input.startCrawlDate,
+        endCrawlDate: input.endCrawlDate,
+        ...(Object.keys(contents).length > 0 ? { contents } : {}),
+      } as unknown as ExaFindSimilarOptions;
+
+      const response = await exa.findSimilar(input.url, options);
+
+      return {
+        requestId: response.requestId,
+        results: (response.results ?? []).map((r: any) => ({
+          id: r.id,
+          url: r.url,
+          title: r.title ?? null,
+          score: r.score,
+          publishedDate: r.publishedDate || undefined,
+          author: r.author || undefined,
+          image: r.image || undefined,
+          favicon: r.favicon || undefined,
+          text: r.text || undefined,
+          highlights: r.highlights || undefined,
+          summary: r.summary || undefined,
+        })),
+        costDollars: response.costDollars,
+      };
+    },
+  });
+}

--- a/integrations/exa/src/get-contents.ts
+++ b/integrations/exa/src/get-contents.ts
@@ -1,0 +1,126 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getExaClient } from './client.js';
+import type { ExaClient, ExaClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  urls: z.array(z.string()).min(1).describe('URLs to fetch content for'),
+  text: z
+    .union([
+      z.boolean(),
+      z.object({
+        maxCharacters: z.number().optional(),
+        includeHtmlTags: z.boolean().optional(),
+      }),
+    ])
+    .optional()
+    .describe('Include full page text. Pass true for default, or an object to limit characters / include HTML tags.'),
+  highlights: z
+    .union([
+      z.boolean(),
+      z.object({
+        numSentences: z.number().optional(),
+        highlightsPerUrl: z.number().optional(),
+        query: z.string().optional(),
+      }),
+    ])
+    .optional()
+    .describe('Include relevant text highlights, optionally focused by a query'),
+  summary: z
+    .union([
+      z.boolean(),
+      z.object({
+        query: z.string().optional(),
+      }),
+    ])
+    .optional()
+    .describe('Include an LLM-generated summary of the page'),
+  livecrawl: z
+    .enum(['never', 'fallback', 'always', 'auto', 'preferred'])
+    .optional()
+    .describe('Control whether Exa fetches a fresh copy of the page at request time'),
+  livecrawlTimeout: z.number().optional().describe('Live-crawl timeout in milliseconds (default 10000)'),
+  subpages: z.number().optional().describe('Number of subpages to crawl per URL (default 0)'),
+  subpageTarget: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .describe('Topical hint for subpage crawling, e.g. "pricing" or ["docs", "api"]'),
+});
+
+const resultSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  title: z.string().nullable(),
+  publishedDate: z.string().optional(),
+  author: z.string().optional(),
+  image: z.string().optional(),
+  favicon: z.string().optional(),
+  text: z.string().optional(),
+  highlights: z.array(z.string()).optional(),
+  summary: z.string().optional(),
+});
+
+const outputSchema = z.object({
+  requestId: z.string().optional(),
+  results: z.array(resultSchema),
+  costDollars: z
+    .object({
+      total: z.number(),
+    })
+    .passthrough()
+    .optional(),
+});
+
+type ExaGetContentsOptions = Parameters<ExaClient['getContents']>[1];
+
+export function createExaGetContentsTool(config?: ExaClientOptions) {
+  let client: ExaClient | null = null;
+
+  function getClient(): ExaClient {
+    if (!client) {
+      client = getExaClient(config);
+    }
+    return client;
+  }
+
+  return createTool({
+    id: 'exa-get-contents',
+    description:
+      'Retrieve full text, highlights, and/or LLM summaries for a list of URLs using Exa AI. Useful for hydrating search results with content or scraping known pages. Combine with exa-search for retrieval-augmented generation.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      const exa = getClient();
+
+      const options = {
+        text: input.text,
+        highlights: input.highlights,
+        summary: input.summary,
+        livecrawl: input.livecrawl,
+        livecrawlTimeout: input.livecrawlTimeout,
+        subpages: input.subpages,
+        subpageTarget: input.subpageTarget,
+      } as unknown as ExaGetContentsOptions;
+
+      const response = await exa.getContents(input.urls, options);
+
+      return {
+        requestId: response.requestId,
+        results: (response.results ?? []).map((r: any) => ({
+          id: r.id,
+          url: r.url,
+          title: r.title ?? null,
+          publishedDate: r.publishedDate || undefined,
+          author: r.author || undefined,
+          image: r.image || undefined,
+          favicon: r.favicon || undefined,
+          text: r.text || undefined,
+          highlights: r.highlights || undefined,
+          summary: r.summary || undefined,
+        })),
+        costDollars: response.costDollars,
+      };
+    },
+  });
+}

--- a/integrations/exa/src/index.ts
+++ b/integrations/exa/src/index.ts
@@ -1,0 +1,6 @@
+export { getExaClient, type ExaClientOptions, type ExaClient } from './client.js';
+export { createExaSearchTool } from './search.js';
+export { createExaFindSimilarTool } from './find-similar.js';
+export { createExaGetContentsTool } from './get-contents.js';
+export { createExaAnswerTool } from './answer.js';
+export { createExaTools } from './tools.js';

--- a/integrations/exa/src/search.ts
+++ b/integrations/exa/src/search.ts
@@ -1,0 +1,165 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { getExaClient } from './client.js';
+import type { ExaClient, ExaClientOptions } from './client.js';
+
+const inputSchema = z.object({
+  query: z.string().describe('The search query'),
+  type: z
+    .enum(['auto', 'neural', 'keyword', 'hybrid', 'fast', 'instant'])
+    .optional()
+    .describe(
+      "Search type — 'auto' (default) intelligently picks, 'neural' uses embeddings, 'keyword' is traditional, 'fast'/'instant' optimize for latency",
+    ),
+  numResults: z.number().min(1).max(100).optional().describe('Number of results to return (1-100, default 10)'),
+  includeDomains: z.array(z.string()).optional().describe('Restrict results to these domains'),
+  excludeDomains: z.array(z.string()).optional().describe('Exclude results from these domains'),
+  includeText: z
+    .array(z.string())
+    .optional()
+    .describe('Strings that must appear in the page text. Currently supports a single string of up to 5 words.'),
+  excludeText: z
+    .array(z.string())
+    .optional()
+    .describe('Strings that must not appear in the page text. Currently supports a single string of up to 5 words.'),
+  category: z
+    .enum(['company', 'research paper', 'news', 'pdf', 'personal site', 'financial report', 'people'])
+    .optional()
+    .describe('Restrict results to a single content category'),
+  startPublishedDate: z
+    .string()
+    .optional()
+    .describe('Only return results published on or after this ISO 8601 date (e.g. 2024-01-01)'),
+  endPublishedDate: z.string().optional().describe('Only return results published on or before this ISO 8601 date'),
+  startCrawlDate: z.string().optional().describe('Only return results crawled on or after this ISO 8601 date'),
+  endCrawlDate: z.string().optional().describe('Only return results crawled on or before this ISO 8601 date'),
+  userLocation: z.string().optional().describe('Two-letter ISO country code used to localize results (e.g. "US")'),
+  text: z
+    .union([
+      z.boolean(),
+      z.object({
+        maxCharacters: z.number().optional(),
+        includeHtmlTags: z.boolean().optional(),
+      }),
+    ])
+    .optional()
+    .describe('Include full page text. Pass true for default, or an object to limit characters / include HTML tags.'),
+  highlights: z
+    .union([
+      z.boolean(),
+      z.object({
+        numSentences: z.number().optional(),
+        highlightsPerUrl: z.number().optional(),
+        query: z.string().optional(),
+      }),
+    ])
+    .optional()
+    .describe('Include relevant text highlights for each result'),
+  summary: z
+    .union([
+      z.boolean(),
+      z.object({
+        query: z.string().optional(),
+      }),
+    ])
+    .optional()
+    .describe('Include an LLM-generated summary of each result, optionally guided by a focus query'),
+  livecrawl: z
+    .enum(['never', 'fallback', 'always', 'auto', 'preferred'])
+    .optional()
+    .describe('Control whether Exa fetches a fresh copy of each page at request time'),
+});
+
+const resultSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  title: z.string().nullable(),
+  score: z.number().optional(),
+  publishedDate: z.string().optional(),
+  author: z.string().optional(),
+  image: z.string().optional(),
+  favicon: z.string().optional(),
+  text: z.string().optional(),
+  highlights: z.array(z.string()).optional(),
+  summary: z.string().optional(),
+});
+
+const outputSchema = z.object({
+  requestId: z.string().optional(),
+  resolvedSearchType: z.string().optional(),
+  results: z.array(resultSchema),
+  costDollars: z
+    .object({
+      total: z.number(),
+    })
+    .passthrough()
+    .optional(),
+});
+
+type ExaSearchOptions = Parameters<ExaClient['search']>[1];
+
+export function createExaSearchTool(config?: ExaClientOptions) {
+  let client: ExaClient | null = null;
+
+  function getClient(): ExaClient {
+    if (!client) {
+      client = getExaClient(config);
+    }
+    return client;
+  }
+
+  return createTool({
+    id: 'exa-search',
+    description:
+      'Search the web using Exa AI. Supports neural and keyword search types with rich content options (text, highlights, LLM-generated summaries), category filters, domain include/exclude lists, text-match filters, date ranges, and live crawling. Returns scored results with optional inline page content.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      const exa = getClient();
+
+      const contents: Record<string, unknown> = {};
+      if (input.text !== undefined) contents.text = input.text;
+      if (input.highlights !== undefined) contents.highlights = input.highlights;
+      if (input.summary !== undefined) contents.summary = input.summary;
+      if (input.livecrawl !== undefined) contents.livecrawl = input.livecrawl;
+
+      const options = {
+        type: input.type,
+        numResults: input.numResults,
+        includeDomains: input.includeDomains,
+        excludeDomains: input.excludeDomains,
+        includeText: input.includeText,
+        excludeText: input.excludeText,
+        category: input.category,
+        startPublishedDate: input.startPublishedDate,
+        endPublishedDate: input.endPublishedDate,
+        startCrawlDate: input.startCrawlDate,
+        endCrawlDate: input.endCrawlDate,
+        userLocation: input.userLocation,
+        ...(Object.keys(contents).length > 0 ? { contents } : {}),
+      } as unknown as ExaSearchOptions;
+
+      const response = await exa.search(input.query, options);
+
+      return {
+        requestId: response.requestId,
+        resolvedSearchType: response.resolvedSearchType,
+        results: (response.results ?? []).map((r: any) => ({
+          id: r.id,
+          url: r.url,
+          title: r.title ?? null,
+          score: r.score,
+          publishedDate: r.publishedDate || undefined,
+          author: r.author || undefined,
+          image: r.image || undefined,
+          favicon: r.favicon || undefined,
+          text: r.text || undefined,
+          highlights: r.highlights || undefined,
+          summary: r.summary || undefined,
+        })),
+        costDollars: response.costDollars,
+      };
+    },
+  });
+}

--- a/integrations/exa/src/tools.ts
+++ b/integrations/exa/src/tools.ts
@@ -1,0 +1,14 @@
+import { createExaAnswerTool } from './answer.js';
+import type { ExaClientOptions } from './client.js';
+import { createExaFindSimilarTool } from './find-similar.js';
+import { createExaGetContentsTool } from './get-contents.js';
+import { createExaSearchTool } from './search.js';
+
+export function createExaTools(config?: ExaClientOptions) {
+  return {
+    exaSearch: createExaSearchTool(config),
+    exaFindSimilar: createExaFindSimilarTool(config),
+    exaGetContents: createExaGetContentsTool(config),
+    exaAnswer: createExaAnswerTool(config),
+  };
+}

--- a/integrations/exa/tsconfig.build.json
+++ b/integrations/exa/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/exa/tsconfig.json
+++ b/integrations/exa/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/exa/tsup.config.ts
+++ b/integrations/exa/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/integrations/exa/turbo.json
+++ b/integrations/exa/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/integrations/exa/vitest.config.ts
+++ b/integrations/exa/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:integrations/exa',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1469,6 +1469,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  integrations/exa:
+    dependencies:
+      exa-js:
+        specifier: 2.12.1
+        version: 2.12.1(encoding@0.1.13)(ws@8.20.0(bufferutil@4.1.0))
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+
   integrations/opencode:
     dependencies:
       '@mastra/core':
@@ -18536,6 +18564,10 @@ packages:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
     engines: {node: '>=18'}
 
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -18997,6 +19029,9 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  exa-js@2.12.1:
+    resolution: {integrity: sha512-ydGF1dw2V/pyksFbxaMG6pkP3/QED2WOsbjJvopEz2d0VaS5uBUXsx88uXLBkdYCX2/FuEmLQA7h4ZT46gnF7A==}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -40281,6 +40316,8 @@ snapshots:
     dependencies:
       type-fest: 4.41.0
 
+  dotenv@16.4.7: {}
+
   dotenv@16.6.1: {}
 
   dotenv@17.3.1: {}
@@ -41021,6 +41058,17 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
+
+  exa-js@2.12.1(encoding@0.1.13)(ws@8.20.0(bufferutil@4.1.0)):
+    dependencies:
+      cross-fetch: 4.1.0(encoding@0.1.13)
+      dotenv: 16.4.7
+      openai: 5.23.2(ws@8.20.0(bufferutil@4.1.0))(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+      - ws
 
   execa@5.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,3 +43,6 @@ trustPolicyExclude:
   - '@clerk/shared@3.47.4'
   # 0.7.4 is published with provenance attestation rather than trusted publisher.
   - 'prettier-plugin-tailwindcss@0.7.4'
+  # exa-js 2.12.1 is signed but lacks provenance/trusted-publisher metadata that earlier versions carried.
+  # Used by `@mastra/exa` integration. Verified via npm registry signature.
+  - 'exa-js@2.12.1'


### PR DESCRIPTION
## Summary

Adds a first-class Exa AI search integration package (`@mastra/exa`) that mirrors the structure of `@mastra/tavily`.

Provides four tools agents can use out of the box:

- **`exa-search`** – neural / keyword / auto web search with rich content options (text, highlights, LLM-generated summaries), category filters, domain include/exclude lists, text-match filters, date ranges, user location, and live-crawl modes
- **`exa-find-similar`** – semantic "more like this" lookup from a known URL with the same content options and filters
- **`exa-get-contents`** – text / highlights / summary retrieval for an arbitrary list of URLs (with subpage support)
- **`exa-answer`** – synthesized answer with citations for direct fact-finding

Reads `EXA_API_KEY` from env or accepts an explicit `{ apiKey, baseURL }`.

## Usage

```ts
import { Agent } from '@mastra/core/agent';
import { createExaTools } from '@mastra/exa';

const agent = new Agent({
  id: 'realtime-information-agent',
  name: 'Realtime Information Agent',
  instructions: 'Use exa-search for fresh web results, exa-get-contents to read full pages, exa-find-similar to expand from a known URL, and exa-answer for direct fact-finding.',
  model: 'anthropic/claude-sonnet-4-6',
  tools: createExaTools(),
});
```

Individual tools (`createExaSearchTool`, `createExaGetContentsTool`, `createExaFindSimilarTool`, `createExaAnswerTool`) are also exported for selective wiring.

## Files changed

- `integrations/exa/` – new package: `src/{client,search,find-similar,get-contents,answer,tools,index}.ts`, full unit tests under `src/__tests__/`, README, and standard package config (`package.json`, `tsconfig*`, `tsup.config.ts`, `vitest.config.ts`, `turbo.json`, `eslint.config.js`)
- `.changeset/exa-integration-package.md` – minor changeset for `@mastra/exa`
- `pnpm-workspace.yaml` – adds `exa-js@2.12.1` to `trustPolicyExclude`. The current SDK release is signed but lacks the trusted-publisher / provenance metadata that earlier versions carried, so `pnpm install` rejects it under the workspace's `no-downgrade` policy. The signature on the registry artifact still verifies normally; the comment in the file explains the same.
- `pnpm-lock.yaml` – regenerated for the new package + dep

## Test plan

- [x] `pnpm --filter @mastra/exa test` – 7 suites / 34 tests passing (client, search, find-similar, get-contents, answer, tools, disabled-state)
- [x] `pnpm --filter @mastra/exa lint` – clean
- [x] `pnpm turbo run build:lib --filter @mastra/exa` – builds ESM + CJS, generates `.d.ts` via `@internal/types-builder`
- [x] Verified built `dist/index.js` exports: `getExaClient`, `createExaSearchTool`, `createExaFindSimilarTool`, `createExaGetContentsTool`, `createExaAnswerTool`, `createExaTools`
- [x] Verified `x-exa-integration: mastra` header is set on the underlying SDK client (covered by `client.test.ts`)
- [ ] Maintainer review of the `trustPolicyExclude` entry (matches the pattern used for `prettier-plugin-tailwindcss@0.7.4` and `@clerk/shared@3.47.4`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This pull request adds a new search tool to Mastra that uses Exa AI to help agents find and understand information from the web. It's like giving your AI assistant a super-smart search engine that can find relevant content, get the actual text from web pages, and even synthesize answers with citations—all powered by Exa's AI technology.

## Overview

Introduces a new first-class integration package `@mastra/exa` that provides AI-powered web search capabilities to Mastra agents. The integration mirrors the structure and patterns of the existing `@mastra/tavily` package and exposes the Exa API through four purpose-built tools.

## Key Components

**Four Agent Tools:**
- **exa-search** — Neural/keyword/auto web search with support for text snippets, highlights, LLM-generated summaries, category filtering, domain inclusion/exclusion, text-match filters, date ranges, user location, and live-crawl modes
- **exa-find-similar** — Semantic "more like this" lookup from a known URL, with the same content and filtering options as search
- **exa-get-contents** — Text/highlights/summary retrieval for arbitrary lists of URLs with subpage support
- **exa-answer** — Synthesized answer generation with citations for direct fact-finding queries

**Exports:**
- `getExaClient` — client factory supporting `EXA_API_KEY` environment variable or explicit `{ apiKey, baseURL }` configuration
- Tool factories: `createExaSearchTool`, `createExaFindSimilarTool`, `createExaGetContentsTool`, `createExaAnswerTool`
- `createExaTools` — convenience function for wiring all four tools at once

## Implementation Details

- New package structure: `integrations/exa/` with source files for client, search, find-similar, get-contents, answer, tools, and index
- Comprehensive test coverage with 34 tests across 7 test suites (client, search, find-similar, get-contents, answer, tools, disabled-state)
- Full TypeScript support with declaration files and source maps
- Zod validation for all tool inputs and outputs with normalized field handling for optional API response fields
- Lazy client instantiation to support graceful degradation when API key is unavailable
- Custom `x-exa-integration: mastra` header injected into the underlying Exa SDK client

## Configuration & Workspace Updates

- **pnpm-workspace.yaml** — Added `exa-js@2.12.1` to `trustPolicyExclude` due to missing provenance metadata on the SDK release
- **Package configuration** — Build tooling via tsup with ESM and CommonJS outputs, Vitest test runner, TypeScript compilation with source maps
- **.changeset entry** — Minor version bump for `@mastra/exa`

## Test & Build Status

✅ Tests: 7 suites, 34 tests passing  
✅ Lint: Clean  
✅ Build: ESM + CJS outputs with declaration files generated  
✅ Verified exports and `x-exa-integration` header injection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->