### PR TITLE
fix(fastify): register multipart content-type parser in upload tests

### DIFF
--- a/.changeset/fastify-multipart-test-fix.md
+++ b/.changeset/fastify-multipart-test-fix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/fastify': patch
+---
+
+Fix multipart upload tests to register the multipart content-type parser. The tests were manually adding the preHandler hook but skipping `registerContextMiddleware()`, which meant Fastify rejected `multipart/form-data` requests with 415 Unsupported Media Type.

--- a/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
+++ b/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
@@ -630,7 +630,7 @@ describe('Fastify Server Adapter', () => {
         },
       };
 
-      app.addHook('preHandler', adapter.createContextMiddleware());
+      adapter.registerContextMiddleware();
       await adapter.registerRoute(app, testRoute, { prefix: '' });
 
       const address = await app.listen({ port: 0 });
@@ -670,7 +670,7 @@ describe('Fastify Server Adapter', () => {
         handler: async (params: any) => params,
       };
 
-      app.addHook('preHandler', adapter.createContextMiddleware());
+      adapter.registerContextMiddleware();
       await adapter.registerRoute(app, testRoute, { prefix: '' });
 
       const address = await app.listen({ port: 0 });


### PR DESCRIPTION
## What

The multipart upload tests added in #15796 fail intermittently in CI with HTTP 415 instead of 200 because they bypass the standard server initialization flow.

## Why

The tests do:
```ts
app.addHook('preHandler', adapter.createContextMiddleware());
await adapter.registerRoute(app, testRoute, { prefix: '' });
```

This manually attaches the preHandler hook but skips `registerContextMiddleware()`, which is where the `multipart/form-data` content-type parser is registered (server-adapters/fastify/src/index.ts:762). Without that parser, Fastify rejects multipart requests with **415 Unsupported Media Type**, breaking the 'should expose uploaded file as buffer' test.

This is the failure currently blocking the changeset bot PR #15979.

## How

Switch both multipart tests to call `adapter.registerContextMiddleware()` directly. That method both attaches the preHandler hook and registers the JSON + multipart content-type parsers — the same code path the production `init()` uses.

## Test plan

```
pnpm --filter @mastra/fastify exec vitest run src/__tests__/fastify-adapter.test.ts
# Test Files  1 passed (1)
#       Tests  1964 passed (1964)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Tests were failing because the code that teaches Fastify how to handle file uploads wasn't being set up properly. This PR fixes it by using the correct method to initialize everything, which automatically registers the needed file upload parser.

## Problem

Multipart upload tests in the Fastify adapter were experiencing intermittent CI failures, returning HTTP 415 (Unsupported Media Type) instead of HTTP 200. The root cause was that while tests manually attached the Fastify preHandler hook via `adapter.createContextMiddleware()`, they skipped calling `adapter.registerContextMiddleware()`, which is responsible for registering the multipart/form-data content-type parser. Without this parser registration, Fastify rejects multipart requests with a 415 error.

## Solution

The fix updates both multipart stream-related tests to call `adapter.registerContextMiddleware()` directly. This method:
- Attaches the preHandler hook for context middleware
- Registers both JSON and multipart content-type parsers
- Matches the production initialization code path used in `init()`

This ensures the multipart/form-data content-type parser is properly registered before the tests execute, preventing the 415 rejection.

## Changes

- **server-adapters/fastify/src/__tests__/fastify-adapter.test.ts**: Updated two test cases to use `adapter.registerContextMiddleware()` instead of manually attaching the preHandler hook via `app.addHook()`
- **.changeset/fastify-multipart-test-fix.md**: Added changeset documenting the test fix for `@mastra/fastify` (patch version)

## Testing

The fix has been validated with the Fastify adapter test suite:
- Command: `pnpm --filter @mastra/fastify exec vitest run src/__tests__/fastify-adapter.test.ts`
- Result: 1 test file passed, 1964 tests passed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->