### PR TITLE
fix(dynamodb): preserve empty thread titles so title generation runs

### DIFF
--- a/.changeset/empty-ads-clean.md
+++ b/.changeset/empty-ads-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dynamodb': patch
+---
+
+Fixed an issue where automatic thread title generation was skipped when using the DynamoDB storage adapter. The adapter was overwriting empty thread titles with a `Thread <id>` placeholder on save, which prevented the title-generation step (gated on an empty title) from running. Empty titles now round-trip correctly so generated titles work the same as with other storage adapters. Resolves #15998.

--- a/stores/_test-utils/src/domains/memory/threads.ts
+++ b/stores/_test-utils/src/domains/memory/threads.ts
@@ -29,6 +29,20 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       expect(retrievedThread?.title).toEqual(thread.title);
     });
 
+    // Regression test for https://github.com/mastra-ai/mastra/issues/15998
+    // Core gates auto-generated thread titles on `!thread.title`, so adapters
+    // must preserve an empty title round-trip rather than substituting a
+    // placeholder like `Thread <id>`.
+    it('should preserve an empty thread title (issue #15998)', async () => {
+      const thread = { ...createSampleThread(), title: '' };
+
+      const savedThread = await memoryStorage.saveThread({ thread });
+      expect(savedThread.title).toBe('');
+
+      const retrievedThread = await memoryStorage.getThreadById({ threadId: thread.id });
+      expect(retrievedThread?.title).toBe('');
+    });
+
     it('should create and retrieve a thread with the same given threadId and resourceId', async () => {
       const exampleThreadId = '1346362547862769664';
       const exampleResourceId = '532374164040974346';

--- a/stores/dynamodb/src/storage/domains/memory/index.ts
+++ b/stores/dynamodb/src/storage/domains/memory/index.ts
@@ -170,7 +170,7 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
       entity: 'thread',
       id: thread.id,
       resourceId: thread.resourceId,
-      title: thread.title || `Thread ${thread.id}`,
+      title: thread.title ?? `Thread ${thread.id}`,
       createdAt: thread.createdAt?.toISOString() || now.toISOString(),
       updatedAt: thread.updatedAt?.toISOString() || now.toISOString(),
       metadata: thread.metadata ? JSON.stringify(thread.metadata) : undefined,

--- a/stores/dynamodb/src/storage/index.test.ts
+++ b/stores/dynamodb/src/storage/index.test.ts
@@ -393,4 +393,45 @@ describe('DynamoDBStore', () => {
       await memoryDomain.deleteThread({ threadId: thread.id });
     });
   });
+
+  // Regression test for https://github.com/mastra-ai/mastra/issues/15998
+  // PR #13151 changed core to pass an empty title for pre-created threads
+  // so that title generation runs on the first message (gated by !thread.title).
+  // The DynamoDB adapter previously overwrote `''` with `Thread <id>`, which
+  // permanently disabled title generation. The adapter must preserve an empty
+  // title round-trip.
+  describe('Issue #15998: thread title preservation for title generation', () => {
+    it('should preserve an empty thread title through saveThread/getThreadById', async () => {
+      const memoryDomain = new MemoryStorageDynamoDB({
+        tableName: TEST_TABLE_NAME,
+        endpoint: LOCAL_ENDPOINT,
+        region: LOCAL_REGION,
+        credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+      });
+      await memoryDomain.init();
+
+      const threadId = `thread-empty-title-${Date.now()}`;
+      const thread = {
+        id: threadId,
+        resourceId: 'test-resource',
+        title: '',
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const savedThread = await memoryDomain.saveThread({ thread });
+      expect(savedThread.title).toBe('');
+
+      const fetched = await memoryDomain.getThreadById({ threadId });
+      expect(fetched).not.toBeNull();
+      // Title generation in core checks `!thread.title` to decide whether to
+      // generate. If the adapter substitutes a placeholder here, generation
+      // will never fire for pre-created threads.
+      expect(fetched?.title).toBe('');
+
+      // Clean up
+      await memoryDomain.deleteThread({ threadId });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #15998.

The DynamoDB storage adapter was overwriting empty thread titles with a `Thread <id>` placeholder on save. Core's automatic title generation only runs when `thread.title` is empty, so this silently prevented it from ever running on DynamoDB.

Before:
\`\`\`ts
title: thread.title || \`Thread \${thread.id}\`,
\`\`\`

After:
\`\`\`ts
title: thread.title ?? \`Thread \${thread.id}\`,
\`\`\`

Empty titles now round-trip and generated titles work the same as with the other adapters. I audited every other adapter's saveThread and DynamoDB was the only one with this coercion. Added a dynamodb-specific regression test plus a shared test in storage-test-utils so any future adapter regressing this fails CI immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
The DynamoDB storage adapter was accidentally throwing away empty thread titles and replacing them with a placeholder, which broke the system's ability to auto-generate titles later. This fix ensures empty titles are preserved so automatic title generation can work as intended.

## Problem
The DynamoDB storage adapter's `saveThread` method was using the logical-OR operator (`||`) to fall back to `Thread ${thread.id}` when `thread.title` was missing. Since `||` treats empty strings as falsy, this caused empty-string titles to be replaced with the placeholder. This prevented the core's automatic title generation logic (which only runs when `!thread.title` evaluates to true) from functioning correctly.

## Solution
Replaced the logical-OR operator with nullish coalescing (`??`) in the DynamoDB adapter's `saveThread` method. This preserves empty-string titles through the save/round-trip while still providing a fallback only when `thread.title` is genuinely `null` or `undefined`, allowing the core's title generation to work as expected.

## Changes
- **stores/dynamodb/src/storage/domains/memory/index.ts**: Changed `title: thread.title || ...` to `title: thread.title ?? ...`
- **stores/dynamodb/src/storage/index.test.ts**: Added a DynamoDB-specific regression test verifying that empty titles round-trip correctly through `saveThread` → `getThreadById`
- **stores/_test-utils/src/domains/memory/threads.ts**: Added a shared test case for all storage adapters to catch regressions around empty thread title handling
- **.changeset/empty-ads-clean.md**: Added changeset documenting the patch for `@mastra/dynamodb`

## Testing & Validation
The fix includes two test cases:
- A DynamoDB-specific test ensuring the adapter preserves empty thread titles
- A shared test in the storage test utilities to ensure all adapters handle empty titles consistently

The author audited other storage adapter implementations and confirmed DynamoDB was the only adapter using the problematic `||` coercion pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->