### PR TITLE
fix(memory/integration-tests): isolate generateTitle-with-request-context recall

### DIFF
--- a/packages/memory/integration-tests/src/shared/agent-memory.ts
+++ b/packages/memory/integration-tests/src/shared/agent-memory.ts
@@ -609,7 +609,7 @@ export async function getAgentMemoryTests({
 
     it('should use generateTitle with request context', async () => {
       const threadId = randomUUID();
-      const resourceId = 'gen-title-metadata';
+      const resourceId = 'gen-title-with-request-context';
       const metadata = { foo: 'bar', custom: 123 };
 
       const thread = await memoryWithTitle.createThread({


### PR DESCRIPTION
## Summary

The 'should use generateTitle with request context' test in `packages/memory/integration-tests/src/shared/agent-memory.ts` shared resourceId `gen-title-metadata` with the prior `should preserve metadata when generateTitle is true` test. Both tests share `dbFile` and have `semanticRecall: true`, so the second test recalled the four user/assistant messages written by the first test.

Recall ordering becomes non-deterministic when message timestamps tie (the prior test uses `vi.advanceTimersByTime(100)` between two identical user prompts, producing equal ticks). The remembered-messages block in the LLM request payload then flipped between `U/A/U/A` and `U/A/A/U` orderings depending on storage iteration order in CI vs local, which changed the request hash and broke the recorded LLM replay (`No exact match for hash 577bfeccbf72831e, ... recorded hash: f927d7c9fedd34c0`).

Use a dedicated `gen-title-with-request-context` resourceId so this test's request payload no longer depends on prior-test recall state.

## Test plan

- `pnpm vitest run src/agent-memory.test.ts --reporter=dot` from `packages/memory/integration-tests` — 79 passed, 5 skipped (was 78 passed, 5 skipped, 1 fail)
- `-t 'Agent thread metadata with generateTitle'` — 9 passed, 75 skipped, no fuzzy-match warnings
- `-t 'should use generateTitle with request context'` passes individually (V4, V5, V6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Two tests were stepping on each other's toes by sharing the same storage location, which made one test's results unpredictably depend on what the other test did first. The fix gives the second test its own storage location so each test runs independently and reliably.

## Changes

**packages/memory/integration-tests/src/shared/agent-memory.ts**

Updated the `generateTitle` with request context test to use a dedicated `resourceId` (`'gen-title-with-request-context'`) instead of reusing the shared `'gen-title-metadata'` identifier. This isolation prevents the test from being affected by message state recalled from the preceding test in the suite, which was causing non-deterministic test behavior due to tied message timestamps and variable recall ordering.

## Test Results

- **Before**: 78 passed, 5 skipped, 1 fail
- **After**: 79 passed, 5 skipped
- The previously failing test now passes consistently in both focused and full test runs across V4–V6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->