### PR TITLE
feat(mastracode): support piped stdin as initial TUI message

### DIFF
--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -186,6 +186,12 @@ Examples:
   mastracode --resource-id my-project --prompt "Fix the bug"
   echo "task description" | mastracode --prompt -
 
+Piping without --prompt launches the interactive TUI with piped content
+as the first message:
+  cat file.txt | mastracode
+  git diff | mastracode
+  npm test 2>&1 | mastracode
+
 Run without --prompt for the interactive TUI.
 `);
 }

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -590,9 +590,9 @@ export async function headlessMain(predrainedInput?: string | null): Promise<nev
   }
 
   let prompt = args.prompt;
-  if (predrainedInput) {
+  if (predrainedInput !== undefined) {
     // Stdin was already drained by the caller (e.g. TTY reopen failed after pipe drain)
-    prompt = predrainedInput;
+    prompt = predrainedInput ?? '';
   } else if (prompt === '-' || (!prompt && !process.stdin.isTTY)) {
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) {

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -575,7 +575,7 @@ export async function runHeadless<TState extends Record<string, unknown>>(
  * Headless mode main entry point: parse arguments, read stdin, initialize
  * MastraCode, and run headless mode.
  */
-export async function headlessMain(): Promise<never> {
+export async function headlessMain(predrainedInput?: string | null): Promise<never> {
   if (process.argv.includes('--help') || process.argv.includes('-h')) {
     printHeadlessUsage();
     process.exit(0);
@@ -590,7 +590,10 @@ export async function headlessMain(): Promise<never> {
   }
 
   let prompt = args.prompt;
-  if (prompt === '-' || (!prompt && !process.stdin.isTTY)) {
+  if (predrainedInput) {
+    // Stdin was already drained by the caller (e.g. TTY reopen failed after pipe drain)
+    prompt = predrainedInput;
+  } else if (prompt === '-' || (!prompt && !process.stdin.isTTY)) {
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) {
       chunks.push(chunk as Buffer);

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -174,13 +174,11 @@ async function main() {
     process.stderr.write('Reading piped input...\n');
     pipedInput = await drainPipedStdin();
 
-    if (pipedInput) {
-      // Reopen a real TTY for the interactive TUI.  If this fails (e.g. no
-      // controlling terminal in CI), fall back to headless mode.
-      if (!reopenStdinFromTTY()) {
-        process.stderr.write('No TTY available — falling back to headless mode.\n');
-        return headlessMain();
-      }
+    // Always reopen a real TTY — even if the pipe was empty, the original
+    // stdin is consumed/closed and the TUI needs a live TTY for keyboard input.
+    if (!reopenStdinFromTTY()) {
+      process.stderr.write('No TTY available — falling back to headless mode.\n');
+      return headlessMain();
     }
   }
 

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -11,6 +11,7 @@ import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
 import { applyThemeMode, restoreTerminalForeground } from './tui/theme.js';
 import { setupDebugLogging } from './utils/debug-log.js';
+import { drainPipedStdin, reopenStdinFromTTY } from './utils/stdin-pipe.js';
 import { releaseAllThreadLocks } from './utils/thread-lock.js';
 import { getCurrentVersion } from './utils/update-check.js';
 import { createMastraCode } from './index.js';
@@ -32,7 +33,7 @@ process.on('unhandledRejection', reason => {
   handleFatalError(reason instanceof Error ? reason : new Error(String(reason)));
 });
 
-async function tuiMain() {
+async function tuiMain(pipedInput?: string | null) {
   // Load browser from settings (before creating harness)
   const settings = loadSettings();
   const browser = await createBrowserFromSettings(settings.browser);
@@ -93,6 +94,7 @@ async function tuiMain() {
     appName: 'Mastra Code',
     version: getCurrentVersion(),
     inlineQuestions: true,
+    ...(pipedInput ? { initialMessage: `The following was piped via stdin:\n\n${pipedInput}` } : {}),
   });
 
   tui.run().catch(error => {
@@ -159,7 +161,31 @@ function handleFatalError(error: unknown): never {
   process.exit(1);
 }
 
-const main = hasHeadlessFlag(process.argv) ? headlessMain : tuiMain;
+async function main() {
+  if (hasHeadlessFlag(process.argv)) {
+    return headlessMain();
+  }
+
+  // When stdin is piped (e.g. `cat foo | mastracode`), drain the pipe fully
+  // before starting the TUI.  The drain blocks until the sender process exits
+  // and closes its stdout, so we never see partial output.
+  let pipedInput: string | null = null;
+  if (!process.stdin.isTTY) {
+    process.stderr.write('Reading piped input...\n');
+    pipedInput = await drainPipedStdin();
+
+    if (pipedInput) {
+      // Reopen a real TTY for the interactive TUI.  If this fails (e.g. no
+      // controlling terminal in CI), fall back to headless mode.
+      if (!reopenStdinFromTTY()) {
+        process.stderr.write('No TTY available — falling back to headless mode.\n');
+        return headlessMain();
+      }
+    }
+  }
+
+  return tuiMain(pipedInput);
+}
 
 main().catch(error => {
   handleFatalError(error);

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -162,7 +162,7 @@ function handleFatalError(error: unknown): never {
 }
 
 async function main() {
-  if (hasHeadlessFlag(process.argv)) {
+  if (hasHeadlessFlag(process.argv) || process.argv.includes('--help') || process.argv.includes('-h')) {
     return headlessMain();
   }
 
@@ -178,7 +178,7 @@ async function main() {
     // stdin is consumed/closed and the TUI needs a live TTY for keyboard input.
     if (!reopenStdinFromTTY()) {
       process.stderr.write('No TTY available — falling back to headless mode.\n');
-      return headlessMain();
+      return headlessMain(pipedInput);
     }
   }
 

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -173,8 +173,15 @@ export class MastraTUI {
       hookMgr.runSessionStart().catch(() => {});
     }
 
-    // Process initial message if provided
+    // Process initial message if provided (e.g. piped stdin content)
     if (this.state.options.initialMessage) {
+      addUserMessage(this.state, {
+        id: `user-${Date.now()}`,
+        role: 'user',
+        content: [{ type: 'text', text: this.state.options.initialMessage }],
+        createdAt: new Date(),
+      });
+      this.state.ui.requestRender();
       this.fireMessage(this.state.options.initialMessage);
     }
 

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -173,16 +173,39 @@ export class MastraTUI {
       hookMgr.runSessionStart().catch(() => {});
     }
 
-    // Process initial message if provided (e.g. piped stdin content)
+    // Process initial message if provided (e.g. piped stdin content).
+    // Runs the same validation as interactive input: model check, prompt hooks.
     if (this.state.options.initialMessage) {
-      addUserMessage(this.state, {
-        id: `user-${Date.now()}`,
-        role: 'user',
-        content: [{ type: 'text', text: this.state.options.initialMessage }],
-        createdAt: new Date(),
-      });
-      this.state.ui.requestRender();
-      this.fireMessage(this.state.options.initialMessage);
+      const msg = this.state.options.initialMessage;
+
+      if (!this.state.harness.hasModelSelected()) {
+        showInfo(this.state, 'No model selected. Use /models to select a model, or /login to authenticate.');
+      } else {
+        const messageId = `user-${Date.now()}`;
+        addUserMessage(this.state, {
+          id: messageId,
+          role: 'user',
+          content: [{ type: 'text', text: msg }],
+          createdAt: new Date(),
+        });
+        this.state.ui.requestRender();
+
+        const allowed = await this.runUserPromptHook(msg);
+        if (!allowed) {
+          const comp = this.state.messageComponentsById.get(messageId);
+          if (comp) {
+            this.state.chatContainer.removeChild(comp as never);
+            this.state.messageComponentsById.delete(messageId);
+            this.state.ui.requestRender();
+          }
+        } else {
+          if (this.state.pendingNewThread) {
+            await this.state.harness.createThread();
+            this.state.pendingNewThread = false;
+          }
+          this.fireMessage(msg);
+        }
+      }
     }
 
     // Main interactive loop — never blocks on streaming,

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -199,11 +199,16 @@ export class MastraTUI {
             this.state.ui.requestRender();
           }
         } else {
-          if (this.state.pendingNewThread) {
-            await this.state.harness.createThread();
+          try {
+            if (this.state.pendingNewThread) {
+              await this.state.harness.createThread();
+              this.state.pendingNewThread = false;
+            }
+            this.fireMessage(msg);
+          } catch (error) {
             this.state.pendingNewThread = false;
+            showError(this.state, error instanceof Error ? error.message : 'Failed to start thread');
           }
-          this.fireMessage(msg);
         }
       }
     }

--- a/mastracode/src/utils/__tests__/stdin-pipe.test.ts
+++ b/mastracode/src/utils/__tests__/stdin-pipe.test.ts
@@ -30,6 +30,10 @@ describe('sanitizePipedOutput', () => {
     expect(sanitizePipedOutput('Building... |\rBuilding... /\rDone!')).toBe('Done!');
   });
 
+  it('preserves visible text when input ends with bare \\r', () => {
+    expect(sanitizePipedOutput('hello\r')).toBe('hello');
+  });
+
   it('handles \\r overwrites on multiple lines', () => {
     const input = 'line1\nspinner |\rspinner /\rspinner done\nline3';
     expect(sanitizePipedOutput(input)).toBe('line1\nspinner done\nline3');

--- a/mastracode/src/utils/__tests__/stdin-pipe.test.ts
+++ b/mastracode/src/utils/__tests__/stdin-pipe.test.ts
@@ -70,7 +70,7 @@ describe('sanitizePipedOutput', () => {
 // ---------------------------------------------------------------------------
 
 describe('drainPipedStdin', () => {
-  const originalStdin = process.stdin;
+  const originalStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin');
   const originalStderrWrite = process.stderr.write;
 
   beforeEach(() => {
@@ -79,11 +79,9 @@ describe('drainPipedStdin', () => {
   });
 
   afterEach(() => {
-    Object.defineProperty(process, 'stdin', {
-      value: originalStdin,
-      writable: true,
-      configurable: true,
-    });
+    if (originalStdinDescriptor) {
+      Object.defineProperty(process, 'stdin', originalStdinDescriptor);
+    }
     process.stderr.write = originalStderrWrite;
   });
 

--- a/mastracode/src/utils/__tests__/stdin-pipe.test.ts
+++ b/mastracode/src/utils/__tests__/stdin-pipe.test.ts
@@ -177,9 +177,7 @@ describe('drainPipedStdin', () => {
 
     expect(result).not.toBeNull();
     expect(result!.length).toBeLessThanOrEqual(oneMB);
-    expect(process.stderr.write).toHaveBeenCalledWith(
-      expect.stringContaining('truncated'),
-    );
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('truncated'));
   });
 
   it('sanitizes ANSI codes and \\r overwrites in piped content', async () => {

--- a/mastracode/src/utils/__tests__/stdin-pipe.test.ts
+++ b/mastracode/src/utils/__tests__/stdin-pipe.test.ts
@@ -1,0 +1,190 @@
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sanitizePipedOutput } from '../stdin-pipe.js';
+
+// ---------------------------------------------------------------------------
+// sanitizePipedOutput (pure function — no mocking needed)
+// ---------------------------------------------------------------------------
+
+describe('sanitizePipedOutput', () => {
+  it('returns plain text unchanged', () => {
+    expect(sanitizePipedOutput('hello world')).toBe('hello world');
+  });
+
+  it('strips SGR color codes', () => {
+    expect(sanitizePipedOutput('\x1b[31mred\x1b[0m text')).toBe('red text');
+  });
+
+  it('strips cursor movement sequences', () => {
+    // CSI A (cursor up), CSI 2K (erase line)
+    expect(sanitizePipedOutput('before\x1b[A\x1b[2Kafter')).toBe('beforeafter');
+  });
+
+  it('strips OSC title sequences', () => {
+    expect(sanitizePipedOutput('\x1b]0;window title\x07real content')).toBe('real content');
+  });
+
+  it('simulates \\r overwrites — keeps last segment', () => {
+    // Spinner: "Building... |" overwritten by "Building... /" then "Done!"
+    expect(sanitizePipedOutput('Building... |\rBuilding... /\rDone!')).toBe('Done!');
+  });
+
+  it('handles \\r overwrites on multiple lines', () => {
+    const input = 'line1\nspinner |\rspinner /\rspinner done\nline3';
+    expect(sanitizePipedOutput(input)).toBe('line1\nspinner done\nline3');
+  });
+
+  it('leaves lines without \\r unchanged', () => {
+    expect(sanitizePipedOutput('line1\nline2\nline3')).toBe('line1\nline2\nline3');
+  });
+
+  it('collapses 3+ blank lines into 2', () => {
+    expect(sanitizePipedOutput('a\n\n\n\n\nb')).toBe('a\n\nb');
+  });
+
+  it('strips binary control characters but preserves tabs', () => {
+    expect(sanitizePipedOutput('col1\tcol2\x00\x01\x7F')).toBe('col1\tcol2');
+  });
+
+  it('strips NUL bytes from binary-ish content', () => {
+    expect(sanitizePipedOutput('\x00\x00hello\x00')).toBe('hello');
+  });
+
+  it('handles combined ANSI + \\r + binary noise', () => {
+    const input = '\x1b[32mLoading\x1b[0m\rDone\x00\x01';
+    expect(sanitizePipedOutput(input)).toBe('Done');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(sanitizePipedOutput('  \n  hello  \n  ')).toBe('hello');
+  });
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(sanitizePipedOutput('   \n\n  ')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// drainPipedStdin — needs process.stdin mocking
+// ---------------------------------------------------------------------------
+
+describe('drainPipedStdin', () => {
+  const originalStdin = process.stdin;
+  const originalStderrWrite = process.stderr.write;
+
+  beforeEach(() => {
+    // Suppress stderr warnings during tests
+    process.stderr.write = vi.fn() as any;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      writable: true,
+      configurable: true,
+    });
+    process.stderr.write = originalStderrWrite;
+  });
+
+  /** Create a fake piped stdin from an array of string chunks. */
+  function mockPipedStdin(chunks: string[]) {
+    const stream = new Readable({
+      read() {
+        for (const chunk of chunks) {
+          this.push(Buffer.from(chunk));
+        }
+        this.push(null); // EOF
+      },
+    });
+    Object.defineProperty(stream, 'isTTY', { value: false });
+    Object.defineProperty(process, 'stdin', {
+      value: stream,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  /** Create a fake TTY stdin. */
+  function mockTTYStdin() {
+    const stream = new Readable({ read() {} });
+    Object.defineProperty(stream, 'isTTY', { value: true });
+    Object.defineProperty(process, 'stdin', {
+      value: stream,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  it('returns null when stdin is a TTY', async () => {
+    mockTTYStdin();
+    // Re-import to get fresh module with mocked stdin
+    const { drainPipedStdin } = await import('../stdin-pipe.js');
+    expect(await drainPipedStdin()).toBeNull();
+  });
+
+  it('reads all chunks and returns concatenated string', async () => {
+    mockPipedStdin(['hello ', 'world']);
+    const { drainPipedStdin } = await import('../stdin-pipe.js');
+    expect(await drainPipedStdin()).toBe('hello world');
+  });
+
+  it('returns null for empty pipe', async () => {
+    mockPipedStdin([]);
+    const { drainPipedStdin } = await import('../stdin-pipe.js');
+    expect(await drainPipedStdin()).toBeNull();
+  });
+
+  it('returns null for whitespace-only pipe', async () => {
+    mockPipedStdin(['   \n\n  ']);
+    const { drainPipedStdin } = await import('../stdin-pipe.js');
+    expect(await drainPipedStdin()).toBeNull();
+  });
+
+  it('concatenates multiple chunks arriving over time', async () => {
+    // Simulate chunks arriving with delays
+    const stream = new Readable({
+      read() {},
+    });
+    Object.defineProperty(stream, 'isTTY', { value: false });
+    Object.defineProperty(process, 'stdin', {
+      value: stream,
+      writable: true,
+      configurable: true,
+    });
+
+    const { drainPipedStdin } = await import('../stdin-pipe.js');
+    const promise = drainPipedStdin();
+
+    // Push chunks asynchronously
+    stream.push(Buffer.from('chunk1 '));
+    await new Promise(r => setTimeout(r, 10));
+    stream.push(Buffer.from('chunk2 '));
+    await new Promise(r => setTimeout(r, 10));
+    stream.push(Buffer.from('chunk3'));
+    stream.push(null); // EOF — sender exited
+
+    expect(await promise).toBe('chunk1 chunk2 chunk3');
+  });
+
+  it('truncates content exceeding 1MB and warns on stderr', async () => {
+    const oneMB = 1024 * 1024;
+    const bigChunk = 'x'.repeat(oneMB + 100);
+    mockPipedStdin([bigChunk]);
+    const { drainPipedStdin } = await import('../stdin-pipe.js');
+
+    const result = await drainPipedStdin();
+
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThanOrEqual(oneMB);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('truncated'),
+    );
+  });
+
+  it('sanitizes ANSI codes and \\r overwrites in piped content', async () => {
+    mockPipedStdin(['\x1b[32mLoading\x1b[0m\rDone!']);
+    const { drainPipedStdin } = await import('../stdin-pipe.js');
+    expect(await drainPipedStdin()).toBe('Done!');
+  });
+});

--- a/mastracode/src/utils/stdin-pipe.ts
+++ b/mastracode/src/utils/stdin-pipe.ts
@@ -89,6 +89,13 @@ export async function drainPipedStdin(): Promise<string | null> {
   }
 
   const raw = Buffer.concat(chunks).toString('utf-8');
+
+  // Zero out raw buffers so piped secrets don't linger in memory
+  for (const buf of chunks) {
+    buf.fill(0);
+  }
+  chunks.length = 0;
+
   const content = sanitizePipedOutput(raw);
   return content.length > 0 ? content : null;
 }

--- a/mastracode/src/utils/stdin-pipe.ts
+++ b/mastracode/src/utils/stdin-pipe.ts
@@ -24,6 +24,10 @@ export function sanitizePipedOutput(raw: string): string {
   // Strip ANSI escapes first
   let text = raw.replace(ANSI_RE, '');
 
+  // Strip binary control characters (everything below 0x20 except \t, \n, \r)
+  // eslint-disable-next-line no-control-regex
+  text = text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+
   // Simulate \r overwrites: for each line, the last \r-segment wins
   text = text
     .split('\n')

--- a/mastracode/src/utils/stdin-pipe.ts
+++ b/mastracode/src/utils/stdin-pipe.ts
@@ -33,7 +33,12 @@ export function sanitizePipedOutput(raw: string): string {
     .map(line => {
       if (!line.includes('\r')) return line;
       const segments = line.split('\r');
-      return segments[segments.length - 1];
+      // Walk backwards to find the last non-empty segment — a trailing \r
+      // produces an empty final segment that would otherwise discard visible text.
+      for (let i = segments.length - 1; i >= 0; i--) {
+        if (segments[i]!.length > 0) return segments[i]!;
+      }
+      return '';
     })
     .join('\n');
 

--- a/mastracode/src/utils/stdin-pipe.ts
+++ b/mastracode/src/utils/stdin-pipe.ts
@@ -25,7 +25,6 @@ export function sanitizePipedOutput(raw: string): string {
   let text = raw.replace(ANSI_RE, '');
 
   // Strip binary control characters (everything below 0x20 except \t, \n, \r)
-  // eslint-disable-next-line no-control-regex
   text = text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
 
   // Simulate \r overwrites: for each line, the last \r-segment wins
@@ -66,11 +65,13 @@ export async function drainPipedStdin(): Promise<string | null> {
     const buf = chunk as Buffer;
 
     if (totalBytes + buf.length > MAX_PIPE_BYTES) {
-      // Take only what fits under the cap
+      // Take only what fits under the cap — copy so we don't retain the
+      // original backing buffer, then zero the source.
       const remaining = MAX_PIPE_BYTES - totalBytes;
       if (remaining > 0) {
-        chunks.push(buf.subarray(0, remaining));
+        chunks.push(Buffer.from(buf.subarray(0, remaining)));
       }
+      buf.fill(0);
       totalBytes = MAX_PIPE_BYTES;
       truncated = true;
       // Keep draining so we don't leave unread data in the pipe, but don't
@@ -83,9 +84,7 @@ export async function drainPipedStdin(): Promise<string | null> {
   }
 
   if (truncated) {
-    process.stderr.write(
-      `Warning: Piped input exceeded ${MAX_PIPE_BYTES / 1024 / 1024}MB and was truncated.\n`,
-    );
+    process.stderr.write(`Warning: Piped input exceeded ${MAX_PIPE_BYTES / 1024 / 1024}MB and was truncated.\n`);
   }
 
   const raw = Buffer.concat(chunks).toString('utf-8');

--- a/mastracode/src/utils/stdin-pipe.ts
+++ b/mastracode/src/utils/stdin-pipe.ts
@@ -1,0 +1,119 @@
+import * as fs from 'node:fs';
+import * as tty from 'node:tty';
+
+/** Maximum piped input size (1 MB). Content beyond this is truncated. */
+const MAX_PIPE_BYTES = 1024 * 1024;
+
+/**
+ * Matches all ANSI escape sequences — SGR (colors), cursor movement, line
+ * clears, scrolling, window titles, etc.
+ */
+const ANSI_RE = /\x1b(?:\[[0-9;?]*[A-Za-z]|\][^\x07\x1b]*(?:\x07|\x1b\\)?|\([A-Z])/g;
+
+/**
+ * Clean up raw piped output so the agent sees readable text, not terminal
+ * control noise.
+ *
+ * 1. Strip all ANSI escape sequences (colors, cursor movement, line clears).
+ * 2. Simulate carriage-return overwrites: for each line, split on `\r` and
+ *    keep only the last segment — this is what the terminal would display
+ *    after a spinner/progress bar finishes.
+ * 3. Collapse runs of blank lines.
+ */
+export function sanitizePipedOutput(raw: string): string {
+  // Strip ANSI escapes first
+  let text = raw.replace(ANSI_RE, '');
+
+  // Simulate \r overwrites: for each line, the last \r-segment wins
+  text = text
+    .split('\n')
+    .map(line => {
+      if (!line.includes('\r')) return line;
+      const segments = line.split('\r');
+      return segments[segments.length - 1];
+    })
+    .join('\n');
+
+  // Collapse 3+ consecutive blank lines into 2
+  text = text.replace(/\n{3,}/g, '\n\n');
+
+  return text.trim();
+}
+
+/**
+ * If stdin is a pipe (not a TTY), read **all** data until EOF and return it as
+ * a string. The returned promise only resolves once the write end of the pipe
+ * is closed — i.e. the sending process has fully exited — so callers are
+ * guaranteed to receive the complete output, not a partial snapshot from a
+ * program that writes progressively.
+ *
+ * Returns `null` when:
+ * - stdin is a TTY (interactive terminal)
+ * - the pipe was empty or contained only whitespace
+ */
+export async function drainPipedStdin(): Promise<string | null> {
+  if (process.stdin.isTTY) return null;
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let truncated = false;
+
+  for await (const chunk of process.stdin) {
+    const buf = chunk as Buffer;
+
+    if (totalBytes + buf.length > MAX_PIPE_BYTES) {
+      // Take only what fits under the cap
+      const remaining = MAX_PIPE_BYTES - totalBytes;
+      if (remaining > 0) {
+        chunks.push(buf.subarray(0, remaining));
+      }
+      totalBytes = MAX_PIPE_BYTES;
+      truncated = true;
+      // Keep draining so we don't leave unread data in the pipe, but don't
+      // store it — we still need to wait for EOF.
+      continue;
+    }
+
+    chunks.push(buf);
+    totalBytes += buf.length;
+  }
+
+  if (truncated) {
+    process.stderr.write(
+      `Warning: Piped input exceeded ${MAX_PIPE_BYTES / 1024 / 1024}MB and was truncated.\n`,
+    );
+  }
+
+  const raw = Buffer.concat(chunks).toString('utf-8');
+  const content = sanitizePipedOutput(raw);
+  return content.length > 0 ? content : null;
+}
+
+/**
+ * Reopen `/dev/tty` (or `CON` on Windows) as `process.stdin` so that the
+ * interactive TUI can read keyboard input after the original piped stdin has
+ * been consumed.
+ *
+ * @returns `true` if the swap succeeded, `false` if a TTY could not be opened
+ * (e.g. running in a headless CI container with no controlling terminal).
+ */
+export function reopenStdinFromTTY(): boolean {
+  const ttyPath = process.platform === 'win32' ? 'CON' : '/dev/tty';
+
+  let fd: number;
+  try {
+    fd = fs.openSync(ttyPath, 'r');
+  } catch {
+    return false;
+  }
+
+  const ttyStream = new tty.ReadStream(fd);
+
+  Object.defineProperty(process, 'stdin', {
+    value: ttyStream,
+    writable: true,
+    configurable: true,
+  });
+
+  return true;
+}


### PR DESCRIPTION
## Summary

Adds support for piping command output directly into mastracode's interactive TUI:

```bash
cat file.txt | mastracode
git diff | mastracode
npm test 2>&1 | mastracode
```

When stdin is a pipe, the CLI drains it fully (waiting for the sender to exit), sanitizes the output (strips ANSI escapes, simulates `\r` overwrites, removes binary control characters), then reopens `/dev/tty` for interactive keyboard input and launches the TUI with the piped content as the first message.

## Motivation
- Existing syntax was pretty messy to get this to work (see discussion [here](https://kepler-bej6556.slack.com/archives/C0ACHFXNK7T/p1777391328249909))
- @rphansen91 wanted a nice way to get MastraCode to debug failed deployments, now once the suggestions CLI stuff lands, users can just run this to get automatic deployment debugging:
```
mastra studio deploy suggestions | mastracode
```

## Changes

- **`mastracode/src/utils/stdin-pipe.ts`** (new) — `drainPipedStdin()`, `reopenStdinFromTTY()`, `sanitizePipedOutput()`
- **`mastracode/src/main.ts`** — Detect piped stdin, drain, swap to TTY, pass content to TUI
- **`mastracode/src/tui/mastra-tui.ts`** — Display piped content as a user message before sending to agent
- **`mastracode/src/headless.ts`** — Updated help text with pipe usage examples
- **`mastracode/src/utils/__tests__/stdin-pipe.test.ts`** (new) — 20 unit tests

## Edge cases handled

- Empty/whitespace pipe → normal TUI, no initial message
- Large input (>1MB) → truncated with stderr warning
- ANSI codes, spinner `\r` overwrites → cleaned to readable text
- Binary control characters → stripped
- Slow sender → blocks with "Reading piped input..." on stderr
- No TTY available (CI/Docker) → falls back to headless mode
- Windows → tries `CON`, falls back to headless
- Raw buffers zeroed after drain to avoid leaking piped secrets in memory

## Test plan

```bash
pnpm build
echo 'hello from pipe' | node dist/cli.js        # content shows as first message
echo '' | node dist/cli.js                         # normal TUI, no message
git log --oneline -10 | node dist/cli.js           # multi-line output
(sleep 3 && echo 'delayed') | node dist/cli.js    # blocks then launches
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes mastracode accept piped command output (e.g., `cat file.txt | mastracode`) and use that text as the first message in the interactive TUI. It cleans noisy terminal output, reopens the terminal for keyboard input, and falls back to headless mode if an interactive TTY can't be opened.

---

## Changes Overview

### New Stdin Handling Utilities (mastracode/src/utils/stdin-pipe.ts)
- sanitizePipedOutput(raw: string): string
  - Removes ANSI/CSI/OSC escapes, strips disallowed binary/control bytes (preserves tabs), simulates carriage-return (\r) overwrites by keeping the last segment per line (including preserving visible text when input ends with a bare `\r`), collapses long runs of blank lines, and trims; returns empty string for whitespace-only input.
- drainPipedStdin(): Promise<string | null>
  - If stdin is a pipe (not a TTY), drains until EOF, capturing up to a 1 MB cap (continues draining without storing excess), emits a stderr truncation warning when overflow occurs, copies stored slices to avoid retaining backing buffers, zeroes chunk buffers after use to avoid leaking secrets, sanitizes captured text, and returns null for TTY or whitespace-only input.
- reopenStdinFromTTY(): boolean
  - Attempts to open the controlling terminal (`/dev/tty` on Unix, `CON` on Windows) and replace process.stdin with a tty.ReadStream for interactive input; returns false when opening fails.

### Entry Point Integration (mastracode/src/main.ts)
- main() routing:
  - Routes --help/-h and headless flags to headlessMain() before pipe detection so help does not start the TUI.
  - When stdin is piped, writes "Reading piped input..." to stderr, awaits drainPipedStdin(), then attempts reopenStdinFromTTY().
  - If TTY reopen fails, writes a fallback message to stderr and calls headlessMain(pipedInput) to reuse the drained content.
  - If reopening succeeds, starts tuiMain(pipedInput). When pipedInput is passed to the TUI it is inserted as an initialMessage prefixed with: "The following was piped via stdin:\n\n${pipedInput}".

### TUI Display Updates (mastracode/src/tui/mastra-tui.ts)
- initialMessage handling now follows the same interactive validation/side-effect flow as typed input:
  - Ensures a model is selected (skips sending and shows info if not).
  - Inserts a provisional user message into UI state and runs runUserPromptHook().
  - Removes the provisional message if the hook blocks; otherwise proceeds to dispatch.
  - When creating a new thread for the initial message, createThread() is wrapped in try/catch and pendingNewThread is cleared on failure to match interactive error handling.

### Headless Help & API (mastracode/src/headless.ts)
- Usage/help text updated to document piping into mastracode without --prompt launches the interactive TUI and shows examples.
- headlessMain signature was updated so callers can pass predrained input when reopening the TTY fails (headlessMain(predrainedInput?: string | null)).

### Tests (mastracode/src/utils/__tests__/stdin-pipe.test.ts)
- Adds ~20 Vitest unit tests covering:
  - sanitizePipedOutput (ANSI/CSI/OSC removal, \r overwrite semantics including trailing \r handling, blank-line collapsing, control-byte stripping, trimming).
  - drainPipedStdin behavior (TTY returns null, chunk concatenation including async arrival, whitespace-only => null, 1 MB truncation with stderr warning, sanitization applied).
- Tests mock process.stdin/stderr and restore the original stdin descriptor in teardown.

---

## Edge Cases & Safety
- Empty/whitespace-only pipe: treated as no initial message (null).
- Large input: capped at 1 MB; excess drained but not stored; stderr warns when truncated.
- ANSI, spinner, and carriage-return overwrites: cleaned so downstream sees the final rendered text; fix added to preserve visible text when input ends with a bare `\r`.
- Binary/control bytes (including NUL) removed; tabs preserved.
- Slow/progressive senders: CLI prints "Reading piped input..." to stderr while draining.
- No controlling TTY (e.g., CI): falls back to headless mode and uses pre-drained input if provided.
- Windows: attempts `CON` when reopening TTY.
- Secrets safety: captured buffers are copied/zeroed after concatenation to avoid retaining piped secrets.

---

## Commit / Behavior Notes
- headlessMain now accepts an optional predrainedInput so drained stdin can be passed in when reopening the TTY fails.
- The TUI initial-message flow mirrors interactive input (hooks, model check, error handling).
- Truncated buffer slices are copied (Buffer.from()) and discarded source buffers are zeroed immediately to avoid leaking backing memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->