### PR TITLE
fix(editor): reconcile stale builder workspaces on startup

### DIFF
--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -2102,6 +2102,8 @@ export interface StoredWorkspaceResponse {
   };
   autoSync?: boolean;
   operationTimeout?: number;
+  /** Whether this workspace is registered at runtime (only present in list responses) */
+  runtimeRegistered?: boolean;
 }
 
 /**

--- a/packages/editor/src/editor-workspace-reconciliation.test.ts
+++ b/packages/editor/src/editor-workspace-reconciliation.test.ts
@@ -1,0 +1,438 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Mastra } from '@mastra/core';
+import { LibSQLStore } from '@mastra/libsql';
+import { Workspace } from '@mastra/core/workspace';
+import { LocalFilesystem } from '@mastra/core/workspace';
+import { MastraEditor, snapshotsMatch } from './index';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const mockLogger = () => ({
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+  trackException: vi.fn(),
+});
+
+let testStorageCount = 0;
+
+/** Wait for an async condition to become true (polls every 50ms, max 3s) */
+const waitFor = async (condition: () => Promise<boolean>, timeoutMs = 3000) => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await condition()) return;
+    await new Promise(r => setTimeout(r, 50));
+  }
+  throw new Error('waitFor timed out');
+};
+
+// =============================================================================
+// snapshotsMatch — unit tests
+// =============================================================================
+
+describe('snapshotsMatch', () => {
+  it('returns true for identical snapshots', () => {
+    const snapshot = { name: 'ws', filesystem: { provider: 'local', config: { basePath: '/tmp' } } };
+    expect(snapshotsMatch(snapshot, snapshot)).toBe(true);
+  });
+
+  it('returns true when both have only name', () => {
+    expect(snapshotsMatch({ name: 'ws' }, { name: 'ws' })).toBe(true);
+  });
+
+  it('returns false when names differ', () => {
+    expect(snapshotsMatch({ name: 'a' }, { name: 'b' })).toBe(false);
+  });
+
+  it('returns false when one has filesystem and other does not', () => {
+    const a = { name: 'ws' };
+    const b = { name: 'ws', filesystem: { provider: 'local', config: {} } };
+    expect(snapshotsMatch(a, b)).toBe(false);
+  });
+
+  it('returns false when filesystem config differs', () => {
+    const a = { name: 'ws', filesystem: { provider: 'local', config: { basePath: '/a' } } };
+    const b = { name: 'ws', filesystem: { provider: 'local', config: { basePath: '/b' } } };
+    expect(snapshotsMatch(a, b)).toBe(false);
+  });
+
+  it('returns false when filesystem provider differs', () => {
+    const a = { name: 'ws', filesystem: { provider: 'local', config: {} } };
+    const b = { name: 'ws', filesystem: { provider: 's3', config: {} } };
+    expect(snapshotsMatch(a, b)).toBe(false);
+  });
+
+  it('returns true when both have undefined optional fields', () => {
+    const a = { name: 'ws', description: undefined, sandbox: undefined };
+    const b = { name: 'ws' };
+    expect(snapshotsMatch(a, b)).toBe(true);
+  });
+
+  it('detects sandbox changes', () => {
+    const a = { name: 'ws', sandbox: { provider: 'local', config: {} } };
+    const b = { name: 'ws', sandbox: { provider: 'e2b', config: {} } };
+    expect(snapshotsMatch(a, b)).toBe(false);
+  });
+
+  it('detects tools config changes', () => {
+    const a = { name: 'ws', tools: { enabled: true } };
+    const b = { name: 'ws', tools: { enabled: false } };
+    expect(snapshotsMatch(a, b)).toBe(false);
+  });
+
+  it('ignores metadata fields not in snapshot keys', () => {
+    // snapshotsMatch only compares config fields, not id/metadata/status
+    const stored = { name: 'ws', id: 'x', status: 'draft' as const } as any;
+    const runtime = { name: 'ws' };
+    expect(snapshotsMatch(stored, runtime)).toBe(true);
+  });
+});
+
+// =============================================================================
+// ensureBuilderWorkspaces — metadata tagging & config drift upsert
+// =============================================================================
+
+describe('ensureBuilderWorkspaces', () => {
+  it('creates workspace with builder metadata on first startup', async () => {
+    const storage = new LibSQLStore({ id: `ws-builder-meta-${testStorageCount++}`, url: ':memory:' });
+    await storage.init();
+
+    // Register a runtime workspace that the builder will reference
+    const workspace = new Workspace({
+      id: 'builder-ws',
+      name: 'Builder Workspace',
+      filesystem: new LocalFilesystem({ basePath: '/tmp/builder-test' }),
+    });
+
+    const editor = new MastraEditor({
+      logger: mockLogger() as any,
+      builder: {
+        enabled: true,
+        configuration: {
+          agent: {
+            workspace: { type: 'id', workspaceId: 'builder-ws' },
+          },
+        },
+      } as any,
+    });
+
+    new Mastra({ storage, editor, workspace });
+
+    // Wait for ensureBuilderWorkspaces to complete (fire-and-forget)
+    const workspaceStore = (await storage.getStore('workspaces'))!;
+    await waitFor(async () => {
+      const ws = await workspaceStore.getByIdResolved('builder-ws');
+      return ws !== null && ws !== undefined;
+    });
+
+    const ws = await workspaceStore.getByIdResolved('builder-ws');
+    expect(ws).toBeDefined();
+    expect(ws!.name).toBe('Builder Workspace');
+    expect(ws!.metadata).toEqual(
+      expect.objectContaining({
+        source: 'builder',
+        builderWorkspaceId: 'builder-ws',
+      }),
+    );
+  });
+
+  it('updates workspace config when runtime snapshot differs from DB', async () => {
+    const storage = new LibSQLStore({ id: `ws-drift-${testStorageCount++}`, url: ':memory:' });
+    await storage.init();
+
+    // Pre-create workspace with old config (simulating previous startup)
+    const workspaceStore = (await storage.getStore('workspaces'))!;
+    await workspaceStore.create({
+      workspace: {
+        id: 'builder-ws',
+        name: 'Builder Workspace',
+        metadata: { source: 'builder', builderWorkspaceId: 'builder-ws' },
+        filesystem: { provider: 'local', config: { basePath: '/tmp/old' } },
+      },
+    });
+
+    // Now start with a different config
+    const workspace = new Workspace({
+      id: 'builder-ws',
+      name: 'Builder Workspace',
+      filesystem: new LocalFilesystem({ basePath: '/tmp/new' }),
+    });
+
+    const editor = new MastraEditor({
+      logger: mockLogger() as any,
+      builder: {
+        enabled: true,
+        configuration: {
+          agent: {
+            workspace: { type: 'id', workspaceId: 'builder-ws' },
+          },
+        },
+      } as any,
+    });
+
+    new Mastra({ storage, editor, workspace });
+
+    // Wait for the config drift update
+    await waitFor(async () => {
+      // Need to bypass editor cache — go directly to store
+      const ws = await workspaceStore.getByIdResolved('builder-ws');
+      return ws?.filesystem?.config?.basePath === '/tmp/new';
+    });
+
+    const ws = await workspaceStore.getByIdResolved('builder-ws');
+    expect(ws!.filesystem!.config).toEqual(expect.objectContaining({ basePath: '/tmp/new' }));
+  });
+
+  it('does nothing when snapshot matches', async () => {
+    const storage = new LibSQLStore({ id: `ws-match-${testStorageCount++}`, url: ':memory:' });
+    await storage.init();
+
+    // Pre-create workspace with matching config
+    const workspaceStore = (await storage.getStore('workspaces'))!;
+    await workspaceStore.create({
+      workspace: {
+        id: 'builder-ws',
+        name: 'Builder Workspace',
+        metadata: { source: 'builder', builderWorkspaceId: 'builder-ws' },
+        filesystem: { provider: 'local', config: { basePath: '/tmp/same', contained: true } },
+      },
+    });
+
+    const workspace = new Workspace({
+      id: 'builder-ws',
+      name: 'Builder Workspace',
+      filesystem: new LocalFilesystem({ basePath: '/tmp/same' }),
+    });
+
+    const logger = mockLogger();
+    const editor = new MastraEditor({
+      logger: logger as any,
+      builder: {
+        enabled: true,
+        configuration: {
+          agent: {
+            workspace: { type: 'id', workspaceId: 'builder-ws' },
+          },
+        },
+      } as any,
+    });
+
+    new Mastra({ storage, editor, workspace });
+
+    // Give it time to complete
+    await new Promise(r => setTimeout(r, 500));
+
+    // No config drift log message
+    const infoCalls = logger.info.mock.calls.map((c: any[]) => c[0]);
+    expect(infoCalls).not.toContainEqual(expect.stringContaining('config drifted'));
+  });
+
+  it('backfills metadata on existing workspace without source tag', async () => {
+    const storage = new LibSQLStore({ id: `ws-backfill-${testStorageCount++}`, url: ':memory:' });
+    await storage.init();
+
+    // Pre-create workspace WITHOUT builder metadata (simulating pre-change deployment)
+    const workspaceStore = (await storage.getStore('workspaces'))!;
+    await workspaceStore.create({
+      workspace: {
+        id: 'builder-ws',
+        name: 'Builder Workspace',
+        filesystem: { provider: 'local', config: { basePath: '/tmp/same', contained: true } },
+      },
+    });
+
+    const workspace = new Workspace({
+      id: 'builder-ws',
+      name: 'Builder Workspace',
+      filesystem: new LocalFilesystem({ basePath: '/tmp/same' }),
+    });
+
+    const editor = new MastraEditor({
+      logger: mockLogger() as any,
+      builder: {
+        enabled: true,
+        configuration: {
+          agent: {
+            workspace: { type: 'id', workspaceId: 'builder-ws' },
+          },
+        },
+      } as any,
+    });
+
+    new Mastra({ storage, editor, workspace });
+
+    // Wait for metadata backfill
+    await waitFor(async () => {
+      const ws = await workspaceStore.getByIdResolved('builder-ws');
+      return ws?.metadata?.source === 'builder';
+    });
+
+    const ws = await workspaceStore.getByIdResolved('builder-ws');
+    expect(ws!.metadata).toEqual(
+      expect.objectContaining({
+        source: 'builder',
+        builderWorkspaceId: 'builder-ws',
+      }),
+    );
+  });
+});
+
+// =============================================================================
+// reconcileBuilderWorkspaces — orphan detection
+// =============================================================================
+
+describe('reconcileBuilderWorkspaces', () => {
+  it('archives orphaned builder workspaces', async () => {
+    const storage = new LibSQLStore({ id: `ws-orphan-${testStorageCount++}`, url: ':memory:' });
+    await storage.init();
+
+    const workspaceStore = (await storage.getStore('workspaces'))!;
+
+    // Create an old builder workspace (orphan — builder config now points elsewhere)
+    await workspaceStore.create({
+      workspace: {
+        id: 'old-builder-ws',
+        name: 'Old Builder Workspace',
+        metadata: { source: 'builder', builderWorkspaceId: 'old-builder-ws' },
+        filesystem: { provider: 'local', config: { basePath: '/tmp/old' } },
+      },
+    });
+
+    // Current workspace is different
+    const workspace = new Workspace({
+      id: 'new-builder-ws',
+      name: 'New Builder Workspace',
+      filesystem: new LocalFilesystem({ basePath: '/tmp/new' }),
+    });
+
+    const editor = new MastraEditor({
+      logger: mockLogger() as any,
+      builder: {
+        enabled: true,
+        configuration: {
+          agent: {
+            workspace: { type: 'id', workspaceId: 'new-builder-ws' },
+          },
+        },
+      } as any,
+    });
+
+    new Mastra({ storage, editor, workspace });
+
+    // Wait for reconciliation to archive the old workspace
+    await waitFor(async () => {
+      const ws = await workspaceStore.getById('old-builder-ws');
+      return ws?.status === 'archived';
+    });
+
+    const oldWs = await workspaceStore.getById('old-builder-ws');
+    expect(oldWs!.status).toBe('archived');
+
+    // New workspace should be created and active
+    await waitFor(async () => {
+      const ws = await workspaceStore.getByIdResolved('new-builder-ws');
+      return ws !== null && ws !== undefined;
+    });
+
+    const newWs = await workspaceStore.getByIdResolved('new-builder-ws');
+    expect(newWs).toBeDefined();
+    expect(newWs!.status).toBe('draft');
+  });
+
+  it('does not archive non-builder workspaces', async () => {
+    const storage = new LibSQLStore({ id: `ws-noarch-${testStorageCount++}`, url: ':memory:' });
+    await storage.init();
+
+    const workspaceStore = (await storage.getStore('workspaces'))!;
+
+    // Create a user-created workspace (no builder metadata)
+    await workspaceStore.create({
+      workspace: {
+        id: 'user-ws',
+        name: 'User Workspace',
+        filesystem: { provider: 'local', config: { basePath: '/tmp/user' } },
+      },
+    });
+
+    const workspace = new Workspace({
+      id: 'builder-ws',
+      name: 'Builder Workspace',
+      filesystem: new LocalFilesystem({ basePath: '/tmp/builder' }),
+    });
+
+    const editor = new MastraEditor({
+      logger: mockLogger() as any,
+      builder: {
+        enabled: true,
+        configuration: {
+          agent: {
+            workspace: { type: 'id', workspaceId: 'builder-ws' },
+          },
+        },
+      } as any,
+    });
+
+    new Mastra({ storage, editor, workspace });
+
+    // Wait for reconciliation to complete (new workspace created)
+    await waitFor(async () => {
+      const ws = await workspaceStore.getByIdResolved('builder-ws');
+      return ws !== null && ws !== undefined;
+    });
+
+    // Give extra time for reconciliation to finish
+    await new Promise(r => setTimeout(r, 300));
+
+    // User workspace should NOT be touched
+    const userWs = await workspaceStore.getById('user-ws');
+    expect(userWs!.status).toBe('draft');
+  });
+
+  it('does not archive the current builder workspace', async () => {
+    const storage = new LibSQLStore({ id: `ws-current-${testStorageCount++}`, url: ':memory:' });
+    await storage.init();
+
+    const workspaceStore = (await storage.getStore('workspaces'))!;
+
+    // Pre-create current workspace with builder metadata
+    await workspaceStore.create({
+      workspace: {
+        id: 'builder-ws',
+        name: 'Builder Workspace',
+        metadata: { source: 'builder', builderWorkspaceId: 'builder-ws' },
+        filesystem: { provider: 'local', config: { basePath: '/tmp/same', contained: true } },
+      },
+    });
+
+    const workspace = new Workspace({
+      id: 'builder-ws',
+      name: 'Builder Workspace',
+      filesystem: new LocalFilesystem({ basePath: '/tmp/same' }),
+    });
+
+    const editor = new MastraEditor({
+      logger: mockLogger() as any,
+      builder: {
+        enabled: true,
+        configuration: {
+          agent: {
+            workspace: { type: 'id', workspaceId: 'builder-ws' },
+          },
+        },
+      } as any,
+    });
+
+    new Mastra({ storage, editor, workspace });
+
+    // Give time for reconciliation to run
+    await new Promise(r => setTimeout(r, 500));
+
+    // Current workspace should still be active (not archived)
+    const ws = await workspaceStore.getById('builder-ws');
+    expect(ws!.status).not.toBe('archived');
+  });
+});

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -11,7 +11,7 @@ import type {
 import type { IMastraLogger as Logger } from '@mastra/core/logger';
 import { BUILT_IN_PROCESSOR_PROVIDERS } from '@mastra/core/processor-provider';
 import type { ProcessorProvider } from '@mastra/core/processor-provider';
-import type { BlobStore } from '@mastra/core/storage';
+import type { BlobStore, StorageWorkspaceSnapshotType } from '@mastra/core/storage';
 import type { ToolProvider } from '@mastra/core/tool-provider';
 
 import {
@@ -151,10 +151,15 @@ export class MastraEditor implements IMastraEditor {
       this.__logger = mastra.getLogger();
     }
 
-    // Fire-and-forget: persist builder default workspace to DB if configured
-    this.ensureBuilderWorkspaces().catch(err => {
-      this.__logger?.warn('[MastraEditor] Failed to persist builder default workspace on startup', { error: err });
-    });
+    // Fire-and-forget: persist builder default workspace to DB if configured,
+    // then reconcile orphaned builder workspaces
+    this.ensureBuilderWorkspaces()
+      .then(() => this.reconcileBuilderWorkspaces())
+      .catch(err => {
+        this.__logger?.warn('[MastraEditor] Failed to persist/reconcile builder workspaces on startup', {
+          error: err,
+        });
+      });
   }
 
   /**
@@ -162,6 +167,11 @@ export class MastraEditor implements IMastraEditor {
    * Called automatically on startup when the editor registers with Mastra.
    * Goes through the normal create() path so hydration validates that
    * all providers (filesystem, sandbox) are properly registered.
+   *
+   * If the workspace already exists but its config has drifted from the
+   * runtime workspace, the DB record is updated (creating a new version).
+   * Builder-created workspaces are tagged with `metadata.source = 'builder'`
+   * so they can be identified during reconciliation.
    */
   private async ensureBuilderWorkspaces(): Promise<void> {
     if (!this.hasEnabledBuilderConfig()) return;
@@ -171,19 +181,86 @@ export class MastraEditor implements IMastraEditor {
     const workspaceRef = agentConfig?.workspace as { type: string; workspaceId?: string } | undefined;
     if (!workspaceRef || workspaceRef.type !== 'id' || !workspaceRef.workspaceId) return;
 
-    // Already persisted?
-    const existing = await this.workspace.getById(workspaceRef.workspaceId);
-    if (existing) return;
-
     const runtimeWorkspace = this.__mastra?.getWorkspaceById(workspaceRef.workspaceId);
     if (!runtimeWorkspace) return;
 
     const snapshot = this.workspace.snapshotFromWorkspace(runtimeWorkspace);
-    await this.workspace.create({
-      id: workspaceRef.workspaceId,
-      ...snapshot,
+    const builderMetadata = { source: 'builder' as const, builderWorkspaceId: workspaceRef.workspaceId };
+
+    const existing = await this.workspace.getById(workspaceRef.workspaceId);
+    if (!existing) {
+      // First time — create with builder metadata
+      await this.workspace.create({
+        id: workspaceRef.workspaceId,
+        metadata: builderMetadata,
+        ...snapshot,
+      });
+      this.__logger?.info(`[MastraEditor] Persisted builder workspace '${workspaceRef.workspaceId}' to DB`);
+      return;
+    }
+
+    // Workspace exists — check for config drift and backfill metadata
+    const needsMetadataBackfill = !existing.metadata?.source;
+    const configDrifted = !snapshotsMatch(existing, snapshot);
+
+    if (needsMetadataBackfill || configDrifted) {
+      const updateInput: Record<string, unknown> = { id: workspaceRef.workspaceId };
+      if (needsMetadataBackfill) {
+        updateInput.metadata = { ...existing.metadata, ...builderMetadata };
+      }
+      if (configDrifted) {
+        Object.assign(updateInput, snapshot);
+        this.__logger?.info(
+          `[MastraEditor] Workspace '${workspaceRef.workspaceId}' config drifted — updating DB record`,
+        );
+      }
+      await this.workspace.update(updateInput as any);
+    }
+  }
+
+  /**
+   * Archive builder-created workspaces that no longer match the current
+   * builder configuration. Called after `ensureBuilderWorkspaces()` on startup.
+   *
+   * Only touches workspaces tagged with `metadata.source === 'builder'`.
+   * The current builder workspace (if any) is never archived.
+   */
+  private async reconcileBuilderWorkspaces(): Promise<void> {
+    if (!this.hasEnabledBuilderConfig()) return;
+
+    const builder = await this.resolveBuilder();
+    const agentConfig = builder?.getConfiguration()?.agent;
+    const workspaceRef = agentConfig?.workspace as { type: string; workspaceId?: string } | undefined;
+
+    // Determine the "current" builder workspace ID
+    let currentWorkspaceId: string | undefined;
+    if (workspaceRef?.type === 'id' && workspaceRef.workspaceId) {
+      currentWorkspaceId = workspaceRef.workspaceId;
+    }
+    // For inline workspaces, the ID is deterministic based on config hash
+    // (computed in agent.ensureStoredWorkspace), but since ensureBuilderWorkspaces
+    // only handles type='id', we just need the current ID here.
+
+    // List all builder-tagged workspaces
+    const { workspaces: allWorkspaces } = await this.workspace.listResolved({
+      perPage: false, // fetch all
+      metadata: { source: 'builder' },
     });
-    this.__logger?.info(`[MastraEditor] Persisted builder workspace '${workspaceRef.workspaceId}' to DB`);
+
+    for (const ws of allWorkspaces) {
+      // Skip the current builder workspace
+      if (ws.id === currentWorkspaceId) continue;
+      // Skip already archived
+      if (ws.status === 'archived') continue;
+
+      // Archive this orphaned builder workspace
+      try {
+        await this.workspace.update({ id: ws.id, status: 'archived' } as any);
+        this.__logger?.info(`[MastraEditor] Archived orphaned builder workspace '${ws.id}'`);
+      } catch (err) {
+        this.__logger?.warn(`[MastraEditor] Failed to archive workspace '${ws.id}'`, { error: err });
+      }
+    }
   }
 
   /**
@@ -302,4 +379,42 @@ export class MastraEditor implements IMastraEditor {
     if (!blobStore) throw new Error('Blob storage domain is not available');
     return blobStore;
   }
+}
+
+/**
+ * Compare a resolved workspace's config fields against a runtime snapshot.
+ * Returns true if all snapshot config fields match.
+ */
+export function snapshotsMatch(
+  stored: { name: string } & Partial<StorageWorkspaceSnapshotType>,
+  runtime: StorageWorkspaceSnapshotType,
+): boolean {
+  const keys: (keyof StorageWorkspaceSnapshotType)[] = [
+    'name',
+    'description',
+    'filesystem',
+    'sandbox',
+    'mounts',
+    'search',
+    'skills',
+    'tools',
+    'autoSync',
+    'operationTimeout',
+  ];
+
+  // JSON replacer that strips falsy leaf values (false, null, 0) so DB-hydrated
+  // defaults don't cause spurious mismatches against runtime snapshots.
+  const replacer = (_k: string, v: unknown) => (v === false || v === null || v === 0 ? undefined : v);
+
+  for (const key of keys) {
+    const storedVal = stored[key];
+    const runtimeVal = runtime[key];
+
+    const storedJSON = storedVal == null || storedVal === false ? undefined : JSON.stringify(storedVal, replacer);
+    const runtimeJSON = runtimeVal == null || runtimeVal === false ? undefined : JSON.stringify(runtimeVal, replacer);
+
+    if (storedJSON !== runtimeJSON) return false;
+  }
+
+  return true;
 }

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -248,6 +248,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
         const snapshot = workspaceNs.snapshotFromWorkspace(runtimeWorkspace);
         await workspaceNs.create({
           id: workspaceRef.workspaceId,
+          metadata: { source: 'builder', builderWorkspaceId: workspaceRef.workspaceId },
           ...snapshot,
         });
         this.logger?.debug(`[ensureStoredWorkspace] Persisted runtime workspace '${workspaceRef.workspaceId}' to DB`);
@@ -262,6 +263,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
 
         await workspaceNs.create({
           id: workspaceId,
+          metadata: { source: 'builder', builderConfigHash: configHash },
           ...workspaceRef.config,
         });
         this.logger?.debug(`[ensureStoredWorkspace] Persisted inline workspace '${workspaceId}' to DB`);

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
@@ -70,7 +70,11 @@ export function SkillEditDialog({
   const { data: workspacesData } = useStoredWorkspaces();
   const { data: builderSettings } = useBuilderSettings();
   const workspaceOptions = useMemo(
-    () => (workspacesData?.workspaces ?? []).map(ws => ({ value: ws.id, label: ws.name })),
+    () =>
+      (workspacesData?.workspaces ?? [])
+        .filter(ws => ws.status !== 'archived')
+        .sort((a, b) => (b.runtimeRegistered ? 1 : 0) - (a.runtimeRegistered ? 1 : 0))
+        .map(ws => ({ value: ws.id, label: ws.name })),
     [workspacesData],
   );
   const { data: workspaceInfo } = useWorkspaceInfo(workspaceId || undefined);

--- a/packages/playground/src/pages/agent-builder/agents/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/edit.tsx
@@ -64,7 +64,11 @@ export default function AgentBuilderAgentEdit() {
     (!features.workflows || !isWorkflowsPending);
 
   const availableWorkspaces = useMemo<AvailableWorkspace[]>(
-    () => (workspacesData?.workspaces ?? []).map(ws => ({ id: ws.id, name: ws.name })),
+    () =>
+      (workspacesData?.workspaces ?? [])
+        .filter(ws => ws.status !== 'archived')
+        .sort((a, b) => (b.runtimeRegistered ? 1 : 0) - (a.runtimeRegistered ? 1 : 0))
+        .map(ws => ({ id: ws.id, name: ws.name })),
     [workspacesData],
   );
 

--- a/packages/server/src/server/handlers/stored-workspaces.ts
+++ b/packages/server/src/server/handlers/stored-workspaces.ts
@@ -53,7 +53,14 @@ export const LIST_STORED_WORKSPACES_ROUTE = createRoute({
         metadata,
       });
 
-      return result;
+      // Annotate each workspace with whether it's registered at runtime
+      const runtimeWorkspaces = mastra.listWorkspaces();
+      const workspaces = result.workspaces.map(ws => ({
+        ...ws,
+        runtimeRegistered: ws.id in runtimeWorkspaces,
+      }));
+
+      return { ...result, workspaces };
     } catch (error) {
       return handleError(error, 'Error listing stored workspaces');
     }

--- a/packages/server/src/server/schemas/stored-workspaces.ts
+++ b/packages/server/src/server/schemas/stored-workspaces.ts
@@ -124,8 +124,12 @@ export const storedWorkspaceSchema = z.object({
   operationTimeout: z.number().optional().describe('Operation timeout in milliseconds'),
 });
 
+const listedWorkspaceSchema = storedWorkspaceSchema.extend({
+  runtimeRegistered: z.boolean().optional().describe('Whether this workspace is registered at runtime'),
+});
+
 export const listStoredWorkspacesResponseSchema = paginationInfoSchema.extend({
-  workspaces: z.array(storedWorkspaceSchema),
+  workspaces: z.array(listedWorkspaceSchema),
 });
 
 export const getStoredWorkspaceResponseSchema = storedWorkspaceSchema;


### PR DESCRIPTION
When an admin changes the workspace config (e.g. swapping from LocalFilesystem to DaytonaSandbox, or changing workspace ID) and restarts the server, the old DB records would persist with stale config. This fixes that.

**What changed:**

`ensureBuilderWorkspaces()` now compares the runtime snapshot against the DB record and updates it if they've drifted (auto-creates a new version, old config preserved in history). Builder workspaces are tagged with `metadata.source = 'builder'` so `reconcileBuilderWorkspaces()` can find and archive orphans on every server start.

The stored workspaces LIST endpoint now includes a `runtimeRegistered` flag per workspace. Agent edit and skill edit dropdowns filter out archived workspaces and sort runtime-registered ones first.

**Test coverage:** 17 new reconciliation tests covering config drift, orphan archival, metadata backfill, and non-builder workspace safety.