### PR TITLE
fix(google-drive): google drive tweaks

### DIFF
--- a/.changeset/sixty-results-sniff.md
+++ b/.changeset/sixty-results-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/google-drive': patch
+---
+
+GoogleDriveFilesystem tweaks: mkdir defaults to recursive, appendFile uses optimistic concurrency, rmdir skips redundant child listing, JSON body requests include Content-Type header, readFile uses consistent searchParams, and concurrent token refreshes are deduplicated.

--- a/workspaces/google-drive/src/filesystem/index.test.ts
+++ b/workspaces/google-drive/src/filesystem/index.test.ts
@@ -306,6 +306,16 @@ describe('GoogleDriveFilesystem', () => {
       expect(await fs.readFile('/log.txt', { encoding: 'utf-8' })).toBe('ab');
     });
 
+    it('appendFile creates a new file when path does not exist', async () => {
+      await fs.appendFile('/new/log.txt', 'first');
+      expect(await fs.readFile('/new/log.txt', { encoding: 'utf-8' })).toBe('first');
+    });
+
+    it('appendFile throws IsDirectoryError when target is a folder', async () => {
+      await fs.mkdir('/folder');
+      await expect(fs.appendFile('/folder', 'data')).rejects.toBeInstanceOf(IsDirectoryError);
+    });
+
     it('throws FileExistsError when overwrite is false', async () => {
       await fs.writeFile('/doc.txt', 'x');
       await expect(fs.writeFile('/doc.txt', 'y', { overwrite: false })).rejects.toBeInstanceOf(FileExistsError);
@@ -367,6 +377,20 @@ describe('GoogleDriveFilesystem', () => {
       expect(await fs.exists('/a.txt')).toBe(true);
       expect(await fs.exists('/existing-dir')).toBe(true);
     });
+
+    it('sends Content-Type application/json for copy and folder-creation requests', async () => {
+      await fs.writeFile('/src.txt', 'data');
+      await fs.copyFile('/src.txt', '/copy.txt');
+
+      const fetchMock = vi.mocked(globalThis.fetch);
+      const copyCall = fetchMock.mock.calls.find(([input]) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        return url.includes('/copy');
+      });
+      expect(copyCall).toBeDefined();
+      const copyHeaders = copyCall![1]?.headers as Record<string, string>;
+      expect(copyHeaders['Content-Type']).toBe('application/json');
+    });
   });
 
   describe('directory operations', () => {
@@ -375,8 +399,14 @@ describe('GoogleDriveFilesystem', () => {
       expect(await fs.exists('/deep/nested/path/file.txt')).toBe(true);
     });
 
-    it('mkdir throws without recursive when parent is missing', async () => {
-      await expect(fs.mkdir('/missing/child')).rejects.toBeInstanceOf(DirectoryNotFoundError);
+    it('mkdir creates parent directories by default', async () => {
+      await fs.mkdir('/missing/child');
+      expect(await fs.exists('/missing/child')).toBe(true);
+      expect(await fs.exists('/missing')).toBe(true);
+    });
+
+    it('mkdir throws with recursive: false when parent is missing', async () => {
+      await expect(fs.mkdir('/missing/child', { recursive: false })).rejects.toBeInstanceOf(DirectoryNotFoundError);
     });
 
     it('mkdir is idempotent for existing directories', async () => {

--- a/workspaces/google-drive/src/filesystem/index.ts
+++ b/workspaces/google-drive/src/filesystem/index.ts
@@ -94,6 +94,7 @@ export class GoogleDriveFilesystem extends MastraFilesystem {
 
   private accessToken?: string;
   private tokenExpiresAt = 0;
+  private tokenRefreshPromise?: Promise<string>;
   private readonly folderId: string;
   private readonly getAccessToken?: () => string | Promise<string>;
   private readonly serviceAccount?: GoogleDriveServiceAccount;
@@ -161,7 +162,10 @@ export class GoogleDriveFilesystem extends MastraFilesystem {
     await this.ensureReady();
     const file = await this.getFile(path);
     if (file.mimeType === FOLDER_MIME_TYPE) throw new IsDirectoryError(path);
-    const response = await this.fetch(`${DRIVE_API}/files/${encodeURIComponent(file.id)}?alt=media`, { method: 'GET' });
+    const response = await this.fetch(`${DRIVE_API}/files/${encodeURIComponent(file.id)}`, {
+      method: 'GET',
+      searchParams: { alt: 'media' },
+    });
     const buffer = Buffer.from(await response.arrayBuffer());
     return options?.encoding ? buffer.toString(options.encoding) : buffer;
   }
@@ -189,8 +193,19 @@ export class GoogleDriveFilesystem extends MastraFilesystem {
   }
 
   async appendFile(path: string, content: FileContent): Promise<void> {
-    const current = (await this.exists(path)) ? await this.readFile(path) : Buffer.alloc(0);
-    await this.writeFile(path, Buffer.concat([this.toBuffer(current), this.toBuffer(content)]), { recursive: true });
+    await this.ensureReady();
+    this.assertWritable('appendFile');
+    const existing = await this.findFile(path);
+    if (existing) {
+      if (existing.mimeType === FOLDER_MIME_TYPE) throw new IsDirectoryError(path);
+      const current = await this.readFile(path);
+      const expectedMtime = existing.modifiedTime ? new Date(existing.modifiedTime) : undefined;
+      await this.writeFile(path, Buffer.concat([this.toBuffer(current), this.toBuffer(content)]), {
+        expectedMtime,
+      });
+    } else {
+      await this.writeFile(path, content, { recursive: true });
+    }
   }
 
   async deleteFile(path: string, options?: RemoveOptions): Promise<void> {
@@ -253,7 +268,7 @@ export class GoogleDriveFilesystem extends MastraFilesystem {
       if (existing.mimeType !== FOLDER_MIME_TYPE) throw new FileExistsError(path);
       return;
     }
-    const { parentId, name } = await this.resolveParent(path, options?.recursive ?? false);
+    const { parentId, name } = await this.resolveParent(path, options?.recursive ?? true);
     await this.createFolder(parentId, name);
   }
 
@@ -266,8 +281,10 @@ export class GoogleDriveFilesystem extends MastraFilesystem {
       throw new DirectoryNotFoundError(path);
     }
     if (dir.mimeType !== FOLDER_MIME_TYPE) throw new NotDirectoryError(path);
-    const children = await this.listChildren(dir.id);
-    if (children.length && !options?.recursive) throw new DirectoryNotEmptyError(path);
+    if (!options?.recursive) {
+      const children = await this.listChildren(dir.id);
+      if (children.length) throw new DirectoryNotEmptyError(path);
+    }
     await this.request<void>(`${DRIVE_API}/files/${encodeURIComponent(dir.id)}`, { method: 'DELETE' });
   }
 
@@ -497,9 +514,14 @@ export class GoogleDriveFilesystem extends MastraFilesystem {
     const token = await this.getToken();
     const target = new URL(url);
     for (const [key, value] of Object.entries(init.searchParams ?? {})) target.searchParams.set(key, value);
+    const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+    // Auto-apply Content-Type for JSON bodies when not explicitly set (e.g. multipart uploads).
+    if (init.body && typeof init.body === 'string' && !init.headers) {
+      headers['Content-Type'] = 'application/json';
+    }
     const response = await globalThis.fetch(target, {
       ...init,
-      headers: { Authorization: `Bearer ${token}`, ...init.headers },
+      headers: { ...headers, ...(init.headers as Record<string, string>) },
     });
     if (!response.ok) {
       const message = await response.text().catch(() => response.statusText);
@@ -511,7 +533,15 @@ export class GoogleDriveFilesystem extends MastraFilesystem {
   private async getToken(): Promise<string> {
     if (this.accessToken && Date.now() < this.tokenExpiresAt - 60_000) return this.accessToken;
     if (this.getAccessToken) return this.getAccessToken();
-    if (this.serviceAccount) return this.getServiceAccountToken();
+    if (this.serviceAccount) {
+      // Dedup concurrent refresh attempts — all callers share the same in-flight promise.
+      if (!this.tokenRefreshPromise) {
+        this.tokenRefreshPromise = this.getServiceAccountToken().finally(() => {
+          this.tokenRefreshPromise = undefined;
+        });
+      }
+      return this.tokenRefreshPromise;
+    }
     if (this.accessToken) return this.accessToken;
     throw new Error('GoogleDriveFilesystem requires accessToken, getAccessToken, or serviceAccount authentication.');
   }


### PR DESCRIPTION
Followup tweaks for GoogleDriveFilesystem (#15756):

- mkdir defaults to recursive, matching LocalFilesystem
- appendFile passes expectedMtime to prevent lost-update races
- rmdir skips listing children when deleting recursively
- JSON body requests get Content-Type header automatically
- readFile uses searchParams for alt=media consistently
- Concurrent service-account token refreshes are deduplicated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR fixes the Google Drive file system to work more intuitively and safely. When you create folders, it now creates parent folders automatically by default (like most file systems do). It also prevents data loss when multiple people try to save the same file at the same time, makes downloading files more consistent, and prevents the system from refreshing permissions multiple times when it doesn't need to.

## Changes Overview

This PR includes runtime behavior adjustments to `GoogleDriveFilesystem` along with corresponding test updates and a changelog entry. The changes aim to improve the consistency, safety, and efficiency of Google Drive operations.

## Detailed Changes

### Changeset Entry
A new changeset file (`sixty-results-sniff.md`) documents the `patch` version bump for `@mastra/google-drive` with release notes summarizing all the runtime behavior adjustments.

### Core Implementation Changes (`workspaces/google-drive/src/filesystem/index.ts`)

**Directory Operations:**
- `mkdir` now defaults to recursive behavior to match `LocalFilesystem`, making parent creation automatic by default
- `rmdir` now skips unnecessary child enumeration when deleting recursively, since the Drive API handles folder content deletion in a single operation

**File Operations:**
- `readFile` now uses URL `searchParams` for `alt=media` requests for consistency
- `appendFile` adds several improvements:
  - Explicitly resolves readiness and writability guards
  - Throws `IsDirectoryError` when targeting a folder
  - Passes `expectedMtime` to `writeFile` to enable optimistic concurrency control and prevent lost-update races
  - Creates files with `recursive: true` when they don't exist

**Network & Token Management:**
- The `fetch` wrapper now more deliberately constructs headers, always setting `Authorization` and auto-adding `Content-Type: application/json` for string request bodies when no explicit Content-Type header is provided
- Service account token acquisition now deduplicates concurrent refresh attempts by sharing a single in-flight promise across callers, preventing parallel refresh operations

### Test Updates (`workspaces/google-drive/src/filesystem/index.test.ts`)

- Adds assertions for `appendFile` behavior: file creation when path doesn't exist and rejection of directory targets with `IsDirectoryError`
- Introduces fetch-mocking assertions verifying that `copyFile` and related folder-creation calls include the `Content-Type: application/json` header
- Updates `mkdir` expectations: non-recursive missing-parent behavior now creates parents by default, with explicit test coverage for `recursive: false` preserving the original error behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->