### PR TITLE
chore(playground-ui): enable Storybook autodocs globally

### DIFF
--- a/packages/playground-ui/.storybook/preview.ts
+++ b/packages/playground-ui/.storybook/preview.ts
@@ -4,6 +4,7 @@ import './tailwind.css';
 import { Colors } from '@/ds/tokens/colors';
 
 const preview: Preview = {
+  tags: ['autodocs'],
   decorators: [
     (Story, context) => {
       const bg = context.globals?.backgrounds?.value;

--- a/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof AlertDialog> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Avatar/avatar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Avatar/avatar.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof Avatar> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     size: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/Badge/badge.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/badge.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Badge> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.stories.tsx
+++ b/packages/playground-ui/src/ds/components/BrandLoader/brand-loader.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof BrandLoader> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     size: {
       control: { type: 'radio' },

--- a/packages/playground-ui/src/ds/components/Breadcrumb/breadcrumb.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/breadcrumb.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Breadcrumb> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Button/button.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Button/button.stories.tsx
@@ -19,7 +19,6 @@ const meta: Meta<typeof Button> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof ButtonsGroup> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Checkbox> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: { type: 'boolean' },

--- a/packages/playground-ui/src/ds/components/Chip/chip.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Chip/chip.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Chip> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     color: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/CodeDiff/code-diff.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeDiff/code-diff.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof CodeDiff> = {
   parameters: {
     layout: 'padded',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -16,7 +16,6 @@ const meta: Meta<typeof CodeEditor> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     showCopyButton: {
       control: { type: 'boolean' },

--- a/packages/playground-ui/src/ds/components/Collapsible/collapsible.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Collapsible/collapsible.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof Collapsible> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/CombinedButtons/combined-buttons.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CombinedButtons/combined-buttons.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof CombinedButtons> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Combobox> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: { type: 'boolean' },

--- a/packages/playground-ui/src/ds/components/Command/command.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.stories.tsx
@@ -21,7 +21,6 @@ const meta: Meta<typeof Command> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.stories.tsx
@@ -12,7 +12,6 @@ const meta: Meta<typeof ContentBlocks> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/CopyButton/copy-button.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CopyButton/copy-button.stories.tsx
@@ -15,7 +15,6 @@ const meta: Meta<typeof CopyButton> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/DashboardCard/dashboard-card.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DashboardCard/dashboard-card.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof DashboardCard> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataCodeSection/data-code-section.stories.tsx
@@ -18,7 +18,6 @@ const meta: Meta<typeof DataCodeSection> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values.stories.tsx
@@ -11,7 +11,6 @@ const meta: Meta<typeof DataKeysAndValues> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     numOfCol: {
       control: { type: 'inline-radio' },

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel.stories.tsx
@@ -18,7 +18,6 @@ const meta: Meta<typeof DataPanel> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimePicker/date-time-picker.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof DateTimePicker> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DateTimeRangePicker/date-time-range-picker.stories.tsx
@@ -17,7 +17,6 @@ const meta: Meta<typeof DateTimeRangePicker> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
@@ -19,7 +19,6 @@ const meta: Meta<typeof Dialog> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.stories.tsx
@@ -24,7 +24,6 @@ const meta: Meta<typeof DropdownMenu> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/EmptyState/empty-state.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EmptyState/empty-state.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof EmptyState> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Entity/entity.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Entity/entity.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Entity> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/EntityHeader/entity-header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EntityHeader/entity-header.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof EntityHeader> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Entry/entry.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Entry/entry.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof Entry> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/EntryList/entry-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/EntryList/entry-list.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof EntryList> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/ErrorBoundary/error-boundary.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ErrorBoundary/error-boundary.stories.tsx
@@ -60,7 +60,6 @@ const meta: Meta<typeof ErrorBoundary> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.stories.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.stories.tsx
@@ -25,7 +25,6 @@ const meta: Meta<typeof SearchFieldBlock> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     size: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/select-field-block.stories.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/select-field-block.stories.tsx
@@ -14,7 +14,6 @@ const meta: Meta<typeof SelectFieldBlock> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     size: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/text-field-block.stories.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/text-field-block.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof TextFieldBlock> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     size: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/FormFields/select-field.stories.tsx
+++ b/packages/playground-ui/src/ds/components/FormFields/select-field.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof SelectField> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: { type: 'boolean' },

--- a/packages/playground-ui/src/ds/components/Header/header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Header/header.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof Header> = {
   parameters: {
     layout: 'fullscreen',
   },
-  tags: ['autodocs'],
   argTypes: {
     border: {
       control: { type: 'boolean' },

--- a/packages/playground-ui/src/ds/components/HorizontalBars/horizontal-bars.stories.tsx
+++ b/packages/playground-ui/src/ds/components/HorizontalBars/horizontal-bars.stories.tsx
@@ -33,7 +33,6 @@ const meta: Meta<typeof HorizontalBars> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   decorators: [
     Story => (
       <TooltipProvider>

--- a/packages/playground-ui/src/ds/components/Input/input.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Input/input.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof Input> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/ItemList/item-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ItemList/item-list.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof ItemList> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/JSONSchemaForm/json-schema-form.stories.tsx
+++ b/packages/playground-ui/src/ds/components/JSONSchemaForm/json-schema-form.stories.tsx
@@ -20,7 +20,6 @@ const meta: Meta<typeof JSONSchemaForm.Root> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Kbd/kbd.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Kbd/kbd.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof Kbd> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     theme: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof KeyValueList> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     labelsAreHidden: {
       control: { type: 'boolean' },

--- a/packages/playground-ui/src/ds/components/Label/label.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Label/label.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Label> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Logo/logo.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Logo/logo.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Logo> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     size: {
       control: { type: 'radio' },

--- a/packages/playground-ui/src/ds/components/MainContent/main-content.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainContent/main-content.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof MainContentLayout> = {
   parameters: {
     layout: 'fullscreen',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/MainHeader/main-header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainHeader/main-header.stories.tsx
@@ -12,7 +12,6 @@ const meta: Meta<typeof MainHeader> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar.stories.tsx
@@ -31,7 +31,6 @@ const meta: Meta<typeof MainSidebar> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.stories.tsx
@@ -17,7 +17,6 @@ const meta: Meta<typeof MarkdownRenderer> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/MetricsCard/metrics-card.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsCard/metrics-card.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof MetricsCard> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/MetricsDataTable/metrics-data-table.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsDataTable/metrics-data-table.stories.tsx
@@ -46,7 +46,6 @@ const meta: Meta<typeof MetricsDataTable<ModelRow>> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/MetricsFlexGrid/metrics-flex-grid.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsFlexGrid/metrics-flex-grid.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof MetricsFlexGrid> = {
   parameters: {
     layout: 'padded',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/MetricsKpiCard/metrics-kpi-card.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsKpiCard/metrics-kpi-card.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof MetricsKpiCard> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Notice/notice.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Notice/notice.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Notice> = {
   parameters: {
     layout: 'padded',
   },
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/Notification/notification.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Notification/notification.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Notification> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     type: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/Popover/popover.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.stories.tsx
@@ -11,7 +11,6 @@ const meta: Meta<typeof Popover> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/PropertyFilter/property-filter.stories.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/property-filter.stories.tsx
@@ -52,7 +52,6 @@ const meta: Meta = {
   parameters: {
     layout: 'padded',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof RadioGroup> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: { type: 'boolean' },

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof ScrollArea> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/ScrollableContainer/scrollable-container.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollableContainer/scrollable-container.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof ScrollableContainer> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     scrollSpeed: {
       control: { type: 'number' },

--- a/packages/playground-ui/src/ds/components/Searchbar/searchbar.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Searchbar/searchbar.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Searchbar> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Section/section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof Section> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Sections/sections.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Sections/sections.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof Sections> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Select/select.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Select/select.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof Select> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/SelectElement/select-element.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SelectElement/select-element.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof ElementSelect> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/SideDialog/side-dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SideDialog/side-dialog.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof SideDialog> = {
   parameters: {
     layout: 'fullscreen',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Skeleton/skeleton.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Skeleton/skeleton.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof Skeleton> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Slider/slider.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Slider/slider.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof Slider> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: { type: 'boolean' },

--- a/packages/playground-ui/src/ds/components/Spinner/spinner.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Spinner/spinner.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof Spinner> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     color: {
       control: { type: 'color' },

--- a/packages/playground-ui/src/ds/components/Steps/steps.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Steps/steps.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof ProcessStepList> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof Switch> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: { type: 'boolean' },

--- a/packages/playground-ui/src/ds/components/Table/table.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Table/table.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof Table> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     size: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof Tabs> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Text/text.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Text/text.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof TextAndIcon> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Textarea/textarea.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Textarea/textarea.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof Textarea> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/components/ThemeProvider/theme-provider.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ThemeProvider/theme-provider.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof ThemeProvider> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/ThemeToggle/theme-toggle.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ThemeToggle/theme-toggle.stories.tsx
@@ -11,7 +11,6 @@ const meta: Meta<typeof ThemeToggle> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Threads/threads.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Threads/threads.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof Threads> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Tooltip/tooltip.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tooltip/tooltip.stories.tsx
@@ -16,7 +16,6 @@ const meta: Meta<typeof Tooltip> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Tree/tree.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree.stories.tsx
@@ -11,7 +11,6 @@ const meta: Meta<typeof Tree> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Truncate/truncate.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Truncate/truncate.stories.tsx
@@ -15,7 +15,6 @@ const meta: Meta<typeof Truncate> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/components/Txt/txt.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Txt/txt.stories.tsx
@@ -7,7 +7,6 @@ const meta: Meta<typeof Txt> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     as: {
       control: { type: 'select' },

--- a/packages/playground-ui/src/ds/icons/icons.stories.tsx
+++ b/packages/playground-ui/src/ds/icons/icons.stories.tsx
@@ -50,7 +50,6 @@ const meta: Meta<typeof Icon> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/ds/tokens/tokens.stories.tsx
+++ b/packages/playground-ui/src/ds/tokens/tokens.stories.tsx
@@ -18,7 +18,6 @@ const meta: Meta = {
       },
     },
   },
-  tags: ['autodocs'],
 };
 
 export default meta;

--- a/packages/playground-ui/src/lib/rule-engine/components/rule-builder.stories.tsx
+++ b/packages/playground-ui/src/lib/rule-engine/components/rule-builder.stories.tsx
@@ -21,7 +21,6 @@ const meta: Meta<typeof RuleBuilder> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 };
 
 export default meta;


### PR DESCRIPTION
Move `tags: ['autodocs']` from per-story files to `.storybook/preview.ts` so every story gets a Docs page by default. Removes 84 redundant per-story tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

Instead of telling each Storybook story file individually "make documentation for this," the PR puts that instruction in one central place. Now all stories automatically get documentation pages without needing to repeat the same instruction 84 times.

## Summary

This PR consolidates Storybook's `autodocs` configuration by moving the `tags: ['autodocs']` setting from individual story files into the global Storybook preview configuration at `.storybook/preview.ts`. This enables automatic documentation generation for all stories globally without requiring per-story configuration.

### Changes

- **`.storybook/preview.ts`**: Added `tags: ['autodocs']` to the preview export, enabling autodocs behavior globally for all stories.
- **84 story files**: Removed `tags: ['autodocs']` from individual story metadata objects across all component stories in the playground-ui package, including:
  - UI components (Button, Input, Dialog, Table, etc.)
  - Layout components (Header, MainContent, Sidebar, etc.)
  - Form components and field blocks
  - Display components (Card, Badge, Toast, etc.)
  - Utility and data visualization components

### Impact

This refactoring eliminates redundant configuration without changing functionality—stories continue to receive auto-generated documentation pages, but the configuration is now centralized and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->