### PR TITLE
fix(observability): include working-memory system message in model_step trace

### DIFF
--- a/.changeset/pink-bikes-flash.md
+++ b/.changeset/pink-bikes-flash.md
@@ -1,0 +1,6 @@
+---
+'@mastra/observability': patch
+'@mastra/core': patch
+---
+
+Fixed model step traces to show the final prompt sent to the model, including memory-injected system messages.

--- a/observability/mastra/src/__snapshots__/agent-processors-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace-generate.json
@@ -217,7 +217,16 @@
                           },
                           "environment": "test"
                         },
-                        "input": {},
+                        "input": [
+                          {
+                            "role": "system",
+                            "content": "You validate input messages"
+                          },
+                          {
+                            "role": "user",
+                            "content": "Validate:   Hello! How are you?  "
+                          }
+                        ],
                         "output": {
                           "text": "Mock V2 generate response",
                           "toolCalls": []
@@ -357,7 +366,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a helpful assistant"
+                  },
+                  {
+                    "role": "user",
+                    "content": "  Hello! How are you?  "
+                  }
+                ],
                 "output": {
                   "text": "Mock V2 generate response",
                   "toolCalls": []
@@ -572,7 +590,16 @@
                           },
                           "environment": "test"
                         },
-                        "input": {},
+                        "input": [
+                          {
+                            "role": "system",
+                            "content": "You summarize text concisely"
+                          },
+                          {
+                            "role": "user",
+                            "content": "Summarize: Mock V2 generate response"
+                          }
+                        ],
                         "output": {
                           "text": "Mock V2 generate response",
                           "toolCalls": []

--- a/observability/mastra/src/__snapshots__/agent-processors-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace.json
@@ -217,7 +217,16 @@
                           },
                           "environment": "test"
                         },
-                        "input": {},
+                        "input": [
+                          {
+                            "role": "system",
+                            "content": "You validate input messages"
+                          },
+                          {
+                            "role": "user",
+                            "content": "Validate:   Hello! How are you?  "
+                          }
+                        ],
                         "output": {
                           "text": "Mock V2 generate response",
                           "toolCalls": []
@@ -356,7 +365,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a helpful assistant"
+                  },
+                  {
+                    "role": "user",
+                    "content": "  Hello! How are you?  "
+                  }
+                ],
                 "output": {
                   "text": "Mock V2 stream response",
                   "toolCalls": []
@@ -571,7 +589,16 @@
                           },
                           "environment": "test"
                         },
-                        "input": {},
+                        "input": [
+                          {
+                            "role": "system",
+                            "content": "You summarize text concisely"
+                          },
+                          {
+                            "role": "user",
+                            "content": "Summarize: Mock V2 stream response"
+                          }
+                        ],
                         "output": {
                           "text": "Mock V2 generate response",
                           "toolCalls": []

--- a/observability/mastra/src/__snapshots__/agent-structured-output-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-structured-output-trace-generate.json
@@ -144,7 +144,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "Return a simple response"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Return a list of items separated by commas"
+                  }
+                ],
                 "output": {
                   "text": "Mock V2 generate response",
                   "toolCalls": [],
@@ -369,7 +378,16 @@
                           },
                           "environment": "test"
                         },
-                        "input": {},
+                        "input": [
+                          {
+                            "role": "system",
+                            "content": "You are a data structuring specialist. Your job is to convert unstructured text into a specific JSON format.\n\nTASK: Convert the provided unstructured text into valid JSON that matches the following schema:\n\nREQUIREMENTS:\n- Return ONLY valid JSON, no additional text or explanation\n- Extract relevant information from the input text\n- If information is missing, use reasonable defaults or null values\n- Maintain data types as specified in the schema\n- Be consistent and accurate in your conversions\n\nThe input text may be in any format (sentences, bullet points, paragraphs, etc.). Extract the relevant data and structure it according to the schema."
+                          },
+                          {
+                            "role": "user",
+                            "content": "Extract and structure the key information from the following text according to the specified schema. Keep the original meaning and details. Rely on the provided text and conversation history.\n\n# Assistant Response\nMock V2 generate response"
+                          }
+                        ],
                         "output": {
                           "text": "{\"items\":\"test structured output\"}",
                           "toolCalls": [],

--- a/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
@@ -143,7 +143,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "Return a simple response"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Return a list of items separated by commas"
+                  }
+                ],
                 "output": {
                   "text": "Mock V2 stream response",
                   "toolCalls": [],
@@ -368,7 +377,16 @@
                           },
                           "environment": "test"
                         },
-                        "input": {},
+                        "input": [
+                          {
+                            "role": "system",
+                            "content": "You are a data structuring specialist. Your job is to convert unstructured text into a specific JSON format.\n\nTASK: Convert the provided unstructured text into valid JSON that matches the following schema:\n\nREQUIREMENTS:\n- Return ONLY valid JSON, no additional text or explanation\n- Extract relevant information from the input text\n- If information is missing, use reasonable defaults or null values\n- Maintain data types as specified in the schema\n- Be consistent and accurate in your conversions\n\nThe input text may be in any format (sentences, bullet points, paragraphs, etc.). Extract the relevant data and structure it according to the schema."
+                          },
+                          {
+                            "role": "user",
+                            "content": "Extract and structure the key information from the following text according to the specified schema. Keep the original meaning and details. Rely on the provided text and conversation history.\n\n# Assistant Response\nMock V2 stream response"
+                          }
+                        ],
                         "output": {
                           "text": "{\"items\":\"test structured output\"}",
                           "toolCalls": [],

--- a/observability/mastra/src/__snapshots__/agent-tool-call-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-tool-call-trace-generate.json
@@ -147,7 +147,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a test agent"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Calculate 5 + 3"
+                  }
+                ],
                 "output": {
                   "text": "",
                   "toolCalls": [
@@ -298,7 +307,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a test agent"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Calculate 5 + 3"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: calculator]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: calculator]"
+                  }
+                ],
                 "output": {
                   "text": {
                     "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/agent-tool-call-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-tool-call-trace.json
@@ -146,7 +146,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a test agent"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Calculate 5 + 3"
+                  }
+                ],
                 "output": {
                   "text": "",
                   "toolCalls": [
@@ -296,7 +305,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a test agent"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Calculate 5 + 3"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: calculator]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: calculator]"
+                  }
+                ],
                 "output": {
                   "text": {
                     "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/agent-workflow-direct-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-direct-trace-generate.json
@@ -142,7 +142,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You can execute workflows that exist in your config"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Execute the simpleWorkflow with test input"
+                  }
+                ],
                 "output": {
                   "text": "",
                   "toolCalls": [
@@ -346,7 +355,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You can execute workflows that exist in your config"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Execute the simpleWorkflow with test input"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: workflow-simpleWorkflow]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: workflow-simpleWorkflow]"
+                  }
+                ],
                 "output": {
                   "text": {
                     "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/agent-workflow-direct-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-direct-trace.json
@@ -141,7 +141,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You can execute workflows that exist in your config"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Execute the simpleWorkflow with test input"
+                  }
+                ],
                 "output": {
                   "text": "",
                   "toolCalls": [
@@ -344,7 +353,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You can execute workflows that exist in your config"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Execute the simpleWorkflow with test input"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: workflow-simpleWorkflow]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: workflow-simpleWorkflow]"
+                  }
+                ],
                 "output": {
                   "text": {
                     "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/agent-workflow-tool-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-tool-trace-generate.json
@@ -148,7 +148,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You can execute workflows using the workflow executor tool"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Execute the simpleWorkflow with test input"
+                  }
+                ],
                 "output": {
                   "text": "",
                   "toolCalls": [
@@ -366,7 +375,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You can execute workflows using the workflow executor tool"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Execute the simpleWorkflow with test input"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: workflowExecutor]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: workflowExecutor]"
+                  }
+                ],
                 "output": {
                   "text": {
                     "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/agent-workflow-tool-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-tool-trace.json
@@ -147,7 +147,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You can execute workflows using the workflow executor tool"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Execute the simpleWorkflow with test input"
+                  }
+                ],
                 "output": {
                   "text": "",
                   "toolCalls": [
@@ -364,7 +373,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You can execute workflows using the workflow executor tool"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Execute the simpleWorkflow with test input"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: workflowExecutor]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: workflowExecutor]"
+                  }
+                ],
                 "output": {
                   "text": {
                     "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/model-step-timing-trace.json
+++ b/observability/mastra/src/__snapshots__/model-step-timing-trace.json
@@ -129,7 +129,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a test agent"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Hello"
+                  }
+                ],
                 "output": {
                   "text": "Hello world",
                   "toolCalls": []

--- a/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace-generate.json
@@ -137,7 +137,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a helpful calculator assistant that announces what you will do before doing it."
+                  },
+                  {
+                    "role": "user",
+                    "content": "What is 5 + 3?"
+                  }
+                ],
                 "output": {
                   "text": "Let me calculate that for you. ",
                   "toolCalls": [
@@ -305,7 +314,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a helpful calculator assistant that announces what you will do before doing it."
+                  },
+                  {
+                    "role": "user",
+                    "content": "What is 5 + 3?"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "Let me calculate that for you. [tool: calculator]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: calculator]"
+                  }
+                ],
                 "output": {
                   "text": "The result of 5 + 3 is 8.",
                   "toolCalls": []

--- a/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace.json
+++ b/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace.json
@@ -136,7 +136,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a helpful calculator assistant that announces what you will do before doing it."
+                  },
+                  {
+                    "role": "user",
+                    "content": "What is 5 + 3?"
+                  }
+                ],
                 "output": {
                   "text": "Let me calculate that for you. ",
                   "toolCalls": [
@@ -303,7 +312,28 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a helpful calculator assistant that announces what you will do before doing it."
+                  },
+                  {
+                    "role": "user",
+                    "content": "What is 5 + 3?"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: calculator]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: calculator]"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "Let me calculate that for you. "
+                  }
+                ],
                 "output": {
                   "text": "The result of 5 + 3 is 8.",
                   "toolCalls": []

--- a/observability/mastra/src/__snapshots__/tags-call-overrides-defaults-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tags-call-overrides-defaults-trace-generate.json
@@ -135,7 +135,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a test agent"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Hello"
+                  }
+                ],
                 "output": {
                   "text": "Mock V2 generate response",
                   "toolCalls": []

--- a/observability/mastra/src/__snapshots__/tags-from-default-options-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tags-from-default-options-trace-generate.json
@@ -132,7 +132,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a test agent"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Hello"
+                  }
+                ],
                 "output": {
                   "text": "Mock V2 generate response",
                   "toolCalls": []

--- a/observability/mastra/src/__snapshots__/tags-from-generate-call-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tags-from-generate-call-trace-generate.json
@@ -132,7 +132,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a test agent"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Hello"
+                  }
+                ],
                 "output": {
                   "text": "Mock V2 generate response",
                   "toolCalls": []

--- a/observability/mastra/src/__snapshots__/tags-from-stream-default-options-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-from-stream-default-options-trace.json
@@ -131,7 +131,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a test agent"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Hello"
+                  }
+                ],
                 "output": {
                   "text": "Mock V2 stream response",
                   "toolCalls": []

--- a/observability/mastra/src/__snapshots__/tags-preserved-with-other-options-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tags-preserved-with-other-options-trace-generate.json
@@ -135,7 +135,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You are a test agent"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Hello"
+                  }
+                ],
                 "output": {
                   "text": "Mock V2 generate response",
                   "toolCalls": []

--- a/observability/mastra/src/__snapshots__/tool-child-spans-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tool-child-spans-trace-generate.json
@@ -141,7 +141,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You use tools that create child spans"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Use child span tool to process test-data"
+                  }
+                ],
                 "output": {
                   "text": "",
                   "toolCalls": [
@@ -303,7 +312,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You use tools that create child spans"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Use child span tool to process test-data"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: childSpanTool]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: childSpanTool]"
+                  }
+                ],
                 "output": {
                   "text": {
                     "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/tool-child-spans-trace.json
+++ b/observability/mastra/src/__snapshots__/tool-child-spans-trace.json
@@ -140,7 +140,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You use tools that create child spans"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Use child span tool to process test-data"
+                  }
+                ],
                 "output": {
                   "text": "",
                   "toolCalls": [
@@ -301,7 +310,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You use tools that create child spans"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Use child span tool to process test-data"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: childSpanTool]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: childSpanTool]"
+                  }
+                ],
                 "output": {
                   "text": {
                     "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/tool-metadata-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/tool-metadata-trace-generate.json
@@ -140,7 +140,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You use tools and add metadata"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Use metadata tool to process some data"
+                  }
+                ],
                 "output": {
                   "text": "",
                   "toolCalls": [
@@ -281,7 +290,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You use tools and add metadata"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Use metadata tool to process some data"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: metadataTool]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: metadataTool]"
+                  }
+                ],
                 "output": {
                   "text": {
                     "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/tool-metadata-trace.json
+++ b/observability/mastra/src/__snapshots__/tool-metadata-trace.json
@@ -139,7 +139,16 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You use tools and add metadata"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Use metadata tool to process some data"
+                  }
+                ],
                 "output": {
                   "text": "",
                   "toolCalls": [
@@ -279,7 +288,24 @@
                   },
                   "environment": "test"
                 },
-                "input": {},
+                "input": [
+                  {
+                    "role": "system",
+                    "content": "You use tools and add metadata"
+                  },
+                  {
+                    "role": "user",
+                    "content": "Use metadata tool to process some data"
+                  },
+                  {
+                    "role": "assistant",
+                    "content": "[tool: metadataTool]"
+                  },
+                  {
+                    "role": "tool",
+                    "content": "[tool: metadataTool]"
+                  }
+                ],
                 "output": {
                   "text": {
                     "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/workflow-agent-step-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/workflow-agent-step-trace-generate.json
@@ -195,7 +195,16 @@
                           },
                           "environment": "test"
                         },
-                        "input": {},
+                        "input": [
+                          {
+                            "role": "system",
+                            "content": "You are a test agent"
+                          },
+                          {
+                            "role": "user",
+                            "content": "Hello from workflow"
+                          }
+                        ],
                         "output": {
                           "text": {
                             "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/workflow-agent-step-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-agent-step-trace.json
@@ -194,7 +194,16 @@
                           },
                           "environment": "test"
                         },
-                        "input": {},
+                        "input": [
+                          {
+                            "role": "system",
+                            "content": "You are a test agent"
+                          },
+                          {
+                            "role": "user",
+                            "content": "Hello from workflow"
+                          }
+                        ],
                         "output": {
                           "text": {
                             "__or__": ["Mock V2 generate response", "Mock V2 stream response"]

--- a/observability/mastra/src/__snapshots__/workflow-create-step-agent-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-create-step-agent-trace.json
@@ -214,7 +214,16 @@
                           },
                           "environment": "test"
                         },
-                        "input": {},
+                        "input": [
+                          {
+                            "role": "system",
+                            "content": "You are an agent in a workflow"
+                          },
+                          {
+                            "role": "user",
+                            "content": "test query"
+                          }
+                        ],
                         "output": {
                           "text": "Test response from agent",
                           "toolCalls": []

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -853,6 +853,66 @@ describe('ModelSpanTracker', () => {
       ]);
     });
 
+    it('should preserve final Mastra input when a later step-start chunk has only request metadata', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+      const inputMessages = [
+        {
+          role: 'system',
+          content: 'WORKING_MEMORY_SYSTEM_INSTRUCTION:\n<working_memory_data>saved</working_memory_data>',
+        },
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      ];
+
+      tracker.startStep();
+      tracker.updateStep({
+        messageId: 'msg-1',
+        inputMessages,
+        request: {
+          body: JSON.stringify({
+            model: 'gpt-4o',
+            messages: [{ role: 'user', content: 'Hello' }],
+          }),
+        },
+      });
+
+      const chunks = [
+        {
+          type: 'step-start',
+          payload: {
+            messageId: 'msg-1',
+            request: {
+              body: JSON.stringify({
+                model: 'gpt-4o',
+                messages: [{ role: 'user', content: 'Hello' }],
+              }),
+            },
+          },
+        },
+        { type: 'text-delta', payload: { text: 'Hi!' } },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+      modelSpan.end();
+
+      const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      expect(stepSpans).toHaveLength(1);
+      expect(stepSpans[0]!.input).toEqual([
+        {
+          role: 'system',
+          content: 'WORKING_MEMORY_SYSTEM_INSTRUCTION:\n<working_memory_data>saved</working_memory_data>',
+        },
+        { role: 'user', content: 'Hello' },
+      ]);
+    });
+
     it('should extract a shallow message preview from Google/Gemini-format request body', async () => {
       const modelSpan = tracing.startSpan({
         type: SpanType.MODEL_GENERATION,

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -803,6 +803,56 @@ describe('ModelSpanTracker', () => {
       expect(stepSpans[0]!.input).toEqual(messages);
     });
 
+    it('should prefer final Mastra input messages over provider request body', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+      });
+
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      const inputMessages = [
+        {
+          role: 'system',
+          content: 'WORKING_MEMORY_SYSTEM_INSTRUCTION:\n<working_memory_data>saved</working_memory_data>',
+        },
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      ];
+
+      const chunks = [
+        {
+          type: 'step-start',
+          payload: {
+            messageId: 'msg-1',
+            inputMessages,
+            request: {
+              body: JSON.stringify({
+                model: 'gpt-4o',
+                messages: [{ role: 'user', content: 'Hello' }],
+              }),
+            },
+          },
+        },
+        { type: 'text-delta', payload: { text: 'Hi!' } },
+        { type: 'step-finish', payload: { output: {}, stepResult: { reason: 'stop' }, metadata: {} } },
+      ];
+
+      const stream = createMockStream(chunks);
+      const wrappedStream = tracker.wrapStream(stream);
+      await consumeStream(wrappedStream);
+      modelSpan.end();
+
+      const stepSpans = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      expect(stepSpans).toHaveLength(1);
+      expect(stepSpans[0]!.input).toEqual([
+        {
+          role: 'system',
+          content: 'WORKING_MEMORY_SYSTEM_INSTRUCTION:\n<working_memory_data>saved</working_memory_data>',
+        },
+        { role: 'user', content: 'Hello' },
+      ]);
+    });
+
     it('should extract a shallow message preview from Google/Gemini-format request body', async () => {
       const modelSpan = tracing.startSpan({
         type: SpanType.MODEL_GENERATION,

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -244,6 +244,7 @@ export class ModelSpanTracker {
   #stepIndex: number = 0;
   #chunkSequence: number = 0;
   #completionStartTime?: Date;
+  #currentStepInputIsFinal: boolean = false;
   /** When true, step-finish chunks don't auto-close the step span (for durable execution) */
   #deferStepClose: boolean = false;
   /** Stored step-finish payload when defer mode is enabled */
@@ -353,6 +354,7 @@ export class ModelSpanTracker {
       return;
     }
 
+    const input = extractStepInput(payload);
     this.#currentStepSpan = this.#modelSpan?.createChildSpan({
       name: `step: ${this.#stepIndex}`,
       type: SpanType.MODEL_STEP,
@@ -361,8 +363,9 @@ export class ModelSpanTracker {
         ...(payload?.messageId ? { messageId: payload.messageId } : {}),
         ...(payload?.warnings?.length ? { warnings: payload.warnings } : {}),
       },
-      input: extractStepInput(payload),
+      input,
     });
+    this.#currentStepInputIsFinal = Array.isArray(payload?.inputMessages);
     // Reset chunk sequence for new step
     this.#chunkSequence = 0;
   }
@@ -376,14 +379,20 @@ export class ModelSpanTracker {
       return;
     }
 
+    const hasFinalInput = Array.isArray(payload.inputMessages);
+    const input = hasFinalInput || !this.#currentStepInputIsFinal ? extractStepInput(payload) : undefined;
+
     // Update span with request/warnings from the step-start chunk
     this.#currentStepSpan.update({
-      input: extractStepInput(payload),
+      ...(input !== undefined ? { input } : {}),
       attributes: {
         ...(payload.messageId ? { messageId: payload.messageId } : {}),
         ...(payload.warnings?.length ? { warnings: payload.warnings } : {}),
       },
     });
+    if (hasFinalInput) {
+      this.#currentStepInputIsFinal = true;
+    }
   }
 
   /**
@@ -429,6 +438,7 @@ export class ModelSpanTracker {
       },
     });
     this.#currentStepSpan = undefined;
+    this.#currentStepInputIsFinal = false;
     this.#stepIndex++;
   }
 

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -207,12 +207,14 @@ function summarizeRequestBody(body: unknown): StepInputPreview {
 }
 
 /**
- * Extract messages from the raw AI SDK request metadata for use as span input.
- * Parses request.body and returns a shallow conversation preview instead of the
- * full request payload, which keeps span serialization bounded for large
- * multi-turn conversations.
+ * Extract a shallow conversation preview for model_step span input.
  */
-function extractStepInput(request: StepStartPayload['request'] | undefined): StepInputPreview {
+function extractStepInput(payload?: StepStartPayload): StepInputPreview {
+  if (Array.isArray(payload?.inputMessages)) {
+    return normalizeMessages(payload.inputMessages);
+  }
+
+  const request = payload?.request;
   if (!request) return undefined;
 
   const { body } = request;
@@ -222,7 +224,7 @@ function extractStepInput(request: StepStartPayload['request'] | undefined): Ste
     const parsed = typeof body === 'string' ? JSON.parse(body) : body;
     return summarizeRequestBody(parsed);
   } catch {
-    // body was not valid JSON — return as-is
+    // body was not valid JSON; return as-is
     return request;
   }
 }
@@ -359,7 +361,7 @@ export class ModelSpanTracker {
         ...(payload?.messageId ? { messageId: payload.messageId } : {}),
         ...(payload?.warnings?.length ? { warnings: payload.warnings } : {}),
       },
-      input: extractStepInput(payload?.request),
+      input: extractStepInput(payload),
     });
     // Reset chunk sequence for new step
     this.#chunkSequence = 0;
@@ -376,7 +378,7 @@ export class ModelSpanTracker {
 
     // Update span with request/warnings from the step-start chunk
     this.#currentStepSpan.update({
-      input: extractStepInput(payload.request),
+      input: extractStepInput(payload),
       attributes: {
         ...(payload.messageId ? { messageId: payload.messageId } : {}),
         ...(payload.warnings?.length ? { warnings: payload.warnings } : {}),

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -3,7 +3,7 @@ import type { PubSub } from '../../events/pubsub';
 import type { Event } from '../../events/types';
 import type { IMastraLogger } from '../../logger';
 import { MastraModelOutput } from '../../stream/base/output';
-import type { ChunkType, StepStartPayload } from '../../stream/types';
+import type { ChunkType } from '../../stream/types';
 import { MessageList } from '../message-list';
 import { AGENT_STREAM_TOPIC, AgentStreamEventTypes } from './constants';
 import type {
@@ -303,12 +303,7 @@ export async function emitChunkEvent<OUTPUT = undefined>(
 export async function emitStepStartEvent(
   pubsub: PubSub,
   runId: string,
-  data: {
-    stepId?: string;
-    request?: unknown;
-    inputMessages?: StepStartPayload['inputMessages'];
-    warnings?: unknown[];
-  },
+  data: { stepId?: string; request?: unknown; warnings?: unknown[] },
 ): Promise<void> {
   await pubsub.publish(AGENT_STREAM_TOPIC(runId), {
     type: AgentStreamEventTypes.STEP_START,

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -3,7 +3,7 @@ import type { PubSub } from '../../events/pubsub';
 import type { Event } from '../../events/types';
 import type { IMastraLogger } from '../../logger';
 import { MastraModelOutput } from '../../stream/base/output';
-import type { ChunkType } from '../../stream/types';
+import type { ChunkType, StepStartPayload } from '../../stream/types';
 import { MessageList } from '../message-list';
 import { AGENT_STREAM_TOPIC, AgentStreamEventTypes } from './constants';
 import type {
@@ -303,7 +303,12 @@ export async function emitChunkEvent<OUTPUT = undefined>(
 export async function emitStepStartEvent(
   pubsub: PubSub,
   runId: string,
-  data: { stepId?: string; request?: unknown; warnings?: unknown[] },
+  data: {
+    stepId?: string;
+    request?: unknown;
+    inputMessages?: StepStartPayload['inputMessages'];
+    warnings?: unknown[];
+  },
 ): Promise<void> {
   await pubsub.publish(AGENT_STREAM_TOPIC(runId), {
     type: AgentStreamEventTypes.STEP_START,

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -310,7 +310,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 warnings = w || [];
                 request = r || {};
                 rawResponse = rr || {};
-                modelSpanTracker?.updateStep?.({ request, inputMessages, warnings });
+                modelSpanTracker?.updateStep?.({ request, inputMessages, warnings, messageId: currentMessageId });
 
                 if (pubsub) {
                   void emitStepStartEvent(pubsub, runId, {

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -310,7 +310,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 warnings = w || [];
                 request = r || {};
                 rawResponse = rr || {};
-                modelSpanTracker?.updateStep({ request, inputMessages, warnings });
+                modelSpanTracker?.updateStep?.({ request, inputMessages, warnings });
 
                 if (pubsub) {
                   void emitStepStartEvent(pubsub, runId, {

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -310,11 +310,13 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 warnings = w || [];
                 request = r || {};
                 rawResponse = rr || {};
+                modelSpanTracker?.updateStep({ request, inputMessages, warnings });
 
                 if (pubsub) {
                   void emitStepStartEvent(pubsub, runId, {
                     stepId: DurableStepIds.LLM_EXECUTION,
                     request,
+                    inputMessages,
                     warnings,
                   });
                 }

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -316,7 +316,6 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   void emitStepStartEvent(pubsub, runId, {
                     stepId: DurableStepIds.LLM_EXECUTION,
                     request,
-                    inputMessages,
                     warnings,
                   });
                 }

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -575,11 +575,16 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     });
   });
 
-  it('includes final input messages on step-start chunks for tracing', async () => {
+  it('updates model step tracing with final input messages', async () => {
     messageList.addSystem(
       'WORKING_MEMORY_SYSTEM_INSTRUCTION:\n<working_memory_data>saved</working_memory_data>',
       'memory',
     );
+    const modelSpanTracker = {
+      getTracingContext: vi.fn(() => ({})),
+      startStep: vi.fn(),
+      updateStep: vi.fn(),
+    };
 
     const doStream = vi.fn(async () => ({
       stream: convertArrayToReadableStream([]),
@@ -621,6 +626,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
         serialize: vi.fn(),
         deserialize: vi.fn(),
       },
+      modelSpanTracker,
       logger: {
         error: vi.fn(),
         warn: vi.fn(),
@@ -633,19 +639,24 @@ describe('createLLMExecutionStep gateway provider tools', () => {
 
     await llmExecutionStep.execute(createExecuteParams(input));
 
+    expect(modelSpanTracker.updateStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputMessages: expect.arrayContaining([
+          expect.objectContaining({
+            role: 'system',
+            content: expect.stringContaining('WORKING_MEMORY_SYSTEM_INSTRUCTION'),
+          }),
+          expect.objectContaining({
+            role: 'user',
+          }),
+        ]),
+      }),
+    );
     expect(controller.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'step-start',
-        payload: expect.objectContaining({
-          inputMessages: expect.arrayContaining([
-            expect.objectContaining({
-              role: 'system',
-              content: expect.stringContaining('WORKING_MEMORY_SYSTEM_INSTRUCTION'),
-            }),
-            expect.objectContaining({
-              role: 'user',
-            }),
-          ]),
+        payload: expect.not.objectContaining({
+          inputMessages: expect.any(Array),
         }),
       }),
     );

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -575,6 +575,82 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     });
   });
 
+  it('includes final input messages on step-start chunks for tracing', async () => {
+    messageList.addSystem(
+      'WORKING_MEMORY_SYSTEM_INSTRUCTION:\n<working_memory_data>saved</working_memory_data>',
+      'memory',
+    );
+
+    const doStream = vi.fn(async () => ({
+      stream: convertArrayToReadableStream([]),
+      request: {
+        body: JSON.stringify({
+          model: 'mock-model-id',
+          messages: [{ role: 'user', content: 'Find the latest AI agent news' }],
+        }),
+      },
+      response: { headers: undefined },
+      warnings: [],
+    }));
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream,
+          } as any,
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<{}>);
+
+    const input = createIterationInput();
+    input.stepResult.isContinued = false;
+
+    await llmExecutionStep.execute(createExecuteParams(input));
+
+    expect(controller.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'step-start',
+        payload: expect.objectContaining({
+          inputMessages: expect.arrayContaining([
+            expect.objectContaining({
+              role: 'system',
+              content: expect.stringContaining('WORKING_MEMORY_SYSTEM_INSTRUCTION'),
+            }),
+            expect.objectContaining({
+              role: 'user',
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
   it('stamps step-start.model from the processor-updated model', async () => {
     const initialDoStream = vi.fn(async () => ({
       stream: convertArrayToReadableStream([]),

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -801,13 +801,19 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                     request = requestFromStream || {};
                     rawResponse = rawResponseFromStream;
 
+                    modelSpanTracker?.updateStep({
+                      request: request || {},
+                      inputMessages,
+                      warnings: warnings || [],
+                      messageId: currentStep.messageId,
+                    });
+
                     safeEnqueue(controller, {
                       runId,
                       from: ChunkFrom.AGENT,
                       type: 'step-start',
                       payload: {
                         request: request || {},
-                        inputMessages,
                         warnings: warnings || [],
                         messageId: currentStep.messageId,
                       },

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -801,7 +801,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                     request = requestFromStream || {};
                     rawResponse = rawResponseFromStream;
 
-                    modelSpanTracker?.updateStep({
+                    modelSpanTracker?.updateStep?.({
                       request: request || {},
                       inputMessages,
                       warnings: warnings || [],

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -807,6 +807,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                       type: 'step-start',
                       payload: {
                         request: request || {},
+                        inputMessages,
                         warnings: warnings || [],
                         messageId: currentStep.messageId,
                       },

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -842,7 +842,7 @@ export interface IModelSpanTracker {
   updateGeneration(options: UpdateSpanOptions<SpanType.MODEL_GENERATION>): void;
   wrapStream<T extends { pipeThrough: Function }>(stream: T): T;
   startStep(payload?: StepStartPayload): void;
-  updateStep(payload?: StepStartPayload): void;
+  updateStep?(payload?: StepStartPayload): void;
 
   /**
    * Enable or disable deferred step closing for durable execution.

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -842,6 +842,7 @@ export interface IModelSpanTracker {
   updateGeneration(options: UpdateSpanOptions<SpanType.MODEL_GENERATION>): void;
   wrapStream<T extends { pipeThrough: Function }>(stream: T): T;
   startStep(payload?: StepStartPayload): void;
+  updateStep(payload?: StepStartPayload): void;
 
   /**
    * Enable or disable deferred step closing for durable execution.

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -2,6 +2,7 @@ import type {
   LanguageModelV2FinishReason,
   LanguageModelV2Usage,
   LanguageModelV2CallWarning,
+  LanguageModelV2Prompt,
   LanguageModelV2ResponseMetadata,
   LanguageModelV2StreamPart,
 } from '@ai-sdk/provider-v5';
@@ -249,6 +250,7 @@ export interface StepStartPayload {
     body?: string;
     [key: string]: unknown;
   };
+  inputMessages?: LanguageModelV2Prompt;
   warnings?: LanguageModelV2CallWarning[];
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Description

Model_step span input no longer drops the working-memory system message for providers that send `system` outside the `messages` array (Anthropic, Gemini). The fix surfaces the final, memory-injected prompt that the agent built in Mastra rather than parsing the provider-shaped request body.

- Added optional `inputMessages` to `StepStartPayload` and emit it on the `step-start` chunk in `llm-execution-step.ts` after working-memory / suspended-tool / background-task prompts have been merged in
- Wired `inputMessages` through the durable agent path in `stream-adapter.ts` and `durable/workflows/steps/llm-execution.ts`, including a `modelSpanTracker.updateStep` call so durable runs get the same trace input as non-durable
- Exposed `updateStep` on the `IModelSpanTracker` interface
- `extractStepInput` in `observability/mastra` now prefers `payload.inputMessages` and falls back to the previous `request.body` parsing path, keeping backward compatibility with v4 chunks that don't carry `inputMessages`
- Added vitest coverage for both the chunk emission and the trace-input precedence

## Before
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/b7b29011-f356-47d8-baa6-737b5927f105" />

## After
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/d10db7ac-a26a-460e-9850-f22136c21d0e" />

## Related Issue(s)

Fixes #13129

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)
When the system adds memory for an AI chat, it inserts a hidden instruction so the AI remembers context — but that instruction wasn't showing up in traces. This PR makes sure that memory-injected system instruction is included in the model-step trace so developers can see and replay exactly what the model was given.

---

## Overview
This PR fixes observability so the working-memory-injected system message is captured in model_step spans (including for providers that send `system` outside `messages`, e.g., Anthropic/Gemini). It surfaces the final, memory-merged prompt in traces while preserving backward compatibility with existing chunk formats.

## Key changes

- Types / stream payload
  - Added optional `inputMessages?: LanguageModelV2Prompt` to `StepStartPayload` (packages/core/src/stream/types.ts) to carry the resolved prompt through streaming.

- Tracing API
  - Exposed optional `updateStep?(payload?: StepStartPayload): void` on `IModelSpanTracker` (packages/core/src/observability/types/tracing.ts).

- Observability logic
  - `extractStepInput` (observability/mastra/src/model-tracing.ts) now accepts the full `StepStartPayload`, prefers `payload.inputMessages` to produce the MODEL_STEP span `input`, and falls back to parsing `payload.request.body` for v4/back-compat.
  - ModelSpanTracker tracks a `#currentStepInputIsFinal` flag so an input derived from `inputMessages` isn't later overwritten.

- Durable and non-durable execution paths
  - Durable LLM execution wired to pass `inputMessages` and call `modelSpanTracker.updateStep` when results are available (packages/core/src/agent/durable/workflows/steps/llm-execution.ts).
  - Non-durable LLM execution calls `modelSpanTracker.updateStep(...)` in `onResult` with resolved `request`, `inputMessages`, `warnings`, and `messageId` before emitting the `step-start` chunk (packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts).
  - `step-start` streaming output continues to omit `inputMessages` in the emitted chunk payload, while tracing receives the input via `updateStep`.

- Tests & snapshots
  - Added vitest coverage verifying: (1) precedence of `payload.inputMessages` over provider `request.body` parsing for trace input, and (2) that once `inputMessages` is set via `startStep()/updateStep()`, later `step-start` events don't overwrite the finalized input (observability/mastra/src/model-tracing.test.ts).
  - Added a test ensuring `modelSpanTracker.updateStep` receives the memory-injected system instruction + user message while the emitted `step-start` chunk omits `inputMessages` (packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts).
  - Updated many observability snapshots so `model_step` span `input` is populated with the final message arrays instead of `{}`.
  - .changeset/pink-bikes-flash.md: release note describing the fix.

## Impact
- Model-step traces now include the full, memory-injected prompt (including the working-memory system message), improving debugging, Phoenix UI trace display, and replayability in the Playground.
- Durable and non-durable agent runs are consistent in trace input capture.
- Backward compatibility retained via fallback to existing request-body parsing for older chunk formats.

## Related issues
- Fixes #13129
<!-- end of auto-generated comment: release notes by coderabbit.ai -->