### PR TITLE
fix(client-js): align Vector return types with server

### DIFF
--- a/.changeset/vector-sdk-return-types.md
+++ b/.changeset/vector-sdk-return-types.md
@@ -1,0 +1,27 @@
+---
+'@mastra/client-js': major
+---
+
+Fixed Vector resource return types so they match what the server actually returns. Previously the types declared shapes that did not exist at runtime, leading to runtime failures with no TypeScript errors.
+
+**What changed**
+
+- `vector.getIndexes()` now returns `string[]` (was `{ indexes: string[] }`)
+- `vector.upsert()` now returns `{ ids: string[] }` (was `string[]`)
+- `vector.query()` now returns `QueryResult[]` (was `{ results: QueryResult[] }`)
+
+**Before**
+
+```ts
+const response = await client.getVector('docs').getIndexes();
+console.log(response.indexes); // undefined at runtime
+```
+
+**After**
+
+```ts
+const indexes = await client.getVector('docs').getIndexes();
+console.log(indexes[0]); // 'docs-index'
+```
+
+Closes #15089.

--- a/.changeset/vector-sdk-return-types.md
+++ b/.changeset/vector-sdk-return-types.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/client-js': major
+'@mastra/client-js': minor
 ---
 
 Fixed Vector resource return types so they match what the server actually returns. Previously the types declared shapes that did not exist at runtime, leading to runtime failures with no TypeScript errors.

--- a/client-sdks/client-js/src/resources/vector.test.ts
+++ b/client-sdks/client-js/src/resources/vector.test.ts
@@ -108,7 +108,7 @@ describe('Vector Resource', () => {
   });
 
   it('should get all indexes', async () => {
-    const mockResponse = { indexes: ['index1', 'index2'] };
+    const mockResponse = ['index1', 'index2'];
     mockFetchResponse(mockResponse);
     const result = await vector.getIndexes();
     expect(result).toEqual(mockResponse);
@@ -143,7 +143,7 @@ describe('Vector Resource', () => {
   });
 
   it('should upsert vectors with metadata and ids', async () => {
-    const mockResponse = ['id1', 'id2'];
+    const mockResponse = { ids: ['id1', 'id2'] };
     mockFetchResponse(mockResponse);
     const result = await vector.upsert({
       indexName: 'test-index',
@@ -174,16 +174,14 @@ describe('Vector Resource', () => {
   });
 
   it('should query vectors with all parameters', async () => {
-    const mockResponse = {
-      results: [
-        {
-          id: 'id1',
-          score: 0.9,
-          metadata: { label: 'a' },
-          vector: [1, 2],
-        },
-      ],
-    };
+    const mockResponse = [
+      {
+        id: 'id1',
+        score: 0.9,
+        metadata: { label: 'a' },
+        vector: [1, 2],
+      },
+    ];
     mockFetchResponse(mockResponse);
     const result = await vector.query({
       indexName: 'test-index',

--- a/client-sdks/client-js/src/resources/vector.ts
+++ b/client-sdks/client-js/src/resources/vector.ts
@@ -1,9 +1,9 @@
 import type { RequestContext } from '@mastra/core/request-context';
-import type { QueryResult } from '@mastra/core/vector';
 import type {
   CreateIndexParams,
   GetVectorIndexResponse,
   QueryVectorParams,
+  QueryVectorResponse,
   ClientOptions,
   UpsertVectorParams,
 } from '../types';
@@ -82,7 +82,7 @@ export class Vector extends BaseResource {
    * @param params - Query parameters including query vector and search options
    * @returns Promise containing query results
    */
-  query(params: QueryVectorParams): Promise<QueryResult[]> {
+  query(params: QueryVectorParams): Promise<QueryVectorResponse> {
     return this.request(`/vector/${encodeURIComponent(this.vectorName)}/query`, {
       method: 'POST',
       body: params,

--- a/client-sdks/client-js/src/resources/vector.ts
+++ b/client-sdks/client-js/src/resources/vector.ts
@@ -1,9 +1,9 @@
 import type { RequestContext } from '@mastra/core/request-context';
+import type { QueryResult } from '@mastra/core/vector';
 import type {
   CreateIndexParams,
   GetVectorIndexResponse,
   QueryVectorParams,
-  QueryVectorResponse,
   ClientOptions,
   UpsertVectorParams,
 } from '../types';
@@ -47,7 +47,7 @@ export class Vector extends BaseResource {
    * @param requestContext - Optional request context to pass as query parameter
    * @returns Promise containing array of index names
    */
-  getIndexes(requestContext?: RequestContext | Record<string, any>): Promise<{ indexes: string[] }> {
+  getIndexes(requestContext?: RequestContext | Record<string, any>): Promise<string[]> {
     return this.request(
       `/vector/${encodeURIComponent(this.vectorName)}/indexes${requestContextQueryString(requestContext)}`,
     );
@@ -68,9 +68,9 @@ export class Vector extends BaseResource {
   /**
    * Upserts vectors into an index
    * @param params - Parameters containing vectors, metadata, and optional IDs
-   * @returns Promise containing array of vector IDs
+   * @returns Promise containing the inserted vector IDs
    */
-  upsert(params: UpsertVectorParams): Promise<string[]> {
+  upsert(params: UpsertVectorParams): Promise<{ ids: string[] }> {
     return this.request(`/vector/${encodeURIComponent(this.vectorName)}/upsert`, {
       method: 'POST',
       body: params,
@@ -82,7 +82,7 @@ export class Vector extends BaseResource {
    * @param params - Query parameters including query vector and search options
    * @returns Promise containing query results
    */
-  query(params: QueryVectorParams): Promise<QueryVectorResponse> {
+  query(params: QueryVectorParams): Promise<QueryResult[]> {
     return this.request(`/vector/${encodeURIComponent(this.vectorName)}/query`, {
       method: 'POST',
       body: params,

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -542,9 +542,7 @@ export interface QueryVectorParams {
   includeVector?: boolean;
 }
 
-export interface QueryVectorResponse {
-  results: QueryResult[];
-}
+export type QueryVectorResponse = QueryResult[];
 
 export interface GetVectorIndexResponse {
   dimension: number;

--- a/e2e-tests/client-js/_test-utils/src/vector-tests.ts
+++ b/e2e-tests/client-js/_test-utils/src/vector-tests.ts
@@ -40,9 +40,7 @@ export function createVectorTests(config: VectorTestConfig = {}) {
     describe('createIndex and getIndexes', () => {
       it('should list indexes including the created one', async () => {
         const vector = client.getVector(vectorName);
-        // TODO(#15089): SDK type mismatch — client declares Promise<{ indexes: string[] }>
-        // but the server handler returns string[] directly (see vector.ts handler).
-        const result: any = await vector.getIndexes();
+        const result = await vector.getIndexes();
         expect(result).toBeDefined();
         expect(Array.isArray(result)).toBe(true);
         expect(result).toContain(indexName);
@@ -61,9 +59,7 @@ export function createVectorTests(config: VectorTestConfig = {}) {
     describe('upsert and query', () => {
       it('should upsert vectors', async () => {
         const vector = client.getVector(vectorName);
-        // TODO(#15089): SDK type mismatch — client declares Promise<string[]>
-        // but the server handler returns { ids: string[] } (see vector.ts handler).
-        const result: any = await vector.upsert({
+        const result = await vector.upsert({
           indexName,
           vectors: [
             [1.0, 0.0, 0.0],
@@ -80,9 +76,7 @@ export function createVectorTests(config: VectorTestConfig = {}) {
 
       it('should query vectors and return closest matches', async () => {
         const vector = client.getVector(vectorName);
-        // TODO(#15089): SDK type mismatch — client declares Promise<{ results: QueryResult[] }>
-        // but the server handler returns QueryResult[] directly (see vector.ts handler).
-        const results: any = await vector.query({
+        const results = await vector.query({
           indexName,
           queryVector: [1.0, 0.0, 0.0],
           topK: 2,
@@ -96,7 +90,7 @@ export function createVectorTests(config: VectorTestConfig = {}) {
 
       it('should query vectors with topK=1', async () => {
         const vector = client.getVector(vectorName);
-        const results: any = await vector.query({
+        const results = await vector.query({
           indexName,
           queryVector: [0.0, 1.0, 0.0],
           topK: 1,


### PR DESCRIPTION
## Description

Aligns three Vector resource return types in `@mastra/client-js` with what the server actually returns. The previous types described shapes that did not exist on the wire, leading to silent runtime failures with no TypeScript errors.

- Changed `vector.getIndexes()` from `Promise<{ indexes: string[] }>` to `Promise<string[]>`
- Changed `vector.upsert()` from `Promise<string[]>` to `Promise<{ ids: string[] }>`
- Changed `vector.query()` from `Promise<QueryVectorResponse>` to `Promise<QueryResult[]>`
- Updated the public `QueryVectorResponse` type from `{ results: QueryResult[] }` to a `QueryResult[]` alias so external imports still resolve
- Fixed unit-test mocks in `vector.test.ts` to match real server response shapes, closing the loophole that hid the bug at unit level
- Removed `: any` casts and `TODO(#15089)` workarounds in `e2e-tests/client-js/_test-utils/src/vector-tests.ts`
- Server is unchanged — alignment was done on the SDK side to preserve the public HTTP contract

## Related Issue(s)

Fixes #15089

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes the client library so its TypeScript types match what the server actually sends. Previously the SDK promised different shapes than the server returned, causing runtime crashes; now the SDK types and tests reflect the real responses.

## Changes

### Method Return Type Corrections
- getIndexes(): Promise<{ indexes: string[] }> → Promise<string[]>
- upsert(): Promise<string[]> → Promise<{ ids: string[] }>
- query(): Promise<QueryVectorResponse> → Promise<QueryResult[]>

### Type Definition Updates
- client-sdks/client-js/src/types.ts: `QueryVectorResponse` changed from `interface { results: QueryResult[] }` to `export type QueryVectorResponse = QueryResult[]` (keeps external imports resolvable while matching server shape).

### Tests and E2E Test Utilities
- client-sdks/client-js/src/resources/vector.test.ts: mocked fetch payloads and assertions updated to the real server response shapes for getIndexes, upsert, and query.
- e2e-tests/client-js/_test-utils/src/vector-tests.ts: removed `: any` casts and TODO(#15089) workarounds so inferred types reflect corrected SDK types.

### Release Notes / Changeset
- .changeset/vector-sdk-return-types.md added documenting the breaking changes with before/after examples and referencing issue #15089.

## Breaking Changes
- This is a breaking change for @mastra/client-js: consumers must update call sites that expected the old wrapped/ unwrapped shapes (e.g., stop using `result.indexes` and use the array directly, handle `{ ids: string[] }` for upsert, treat query responses as an array).

## Server Compatibility
- No server changes: the SDK is updated to match the existing server HTTP responses (non-breaking to the server/API).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->