### PR TITLE
fix(koa): collapse route registration into a single dispatcher

### DIFF
--- a/.changeset/dirty-items-rule.md
+++ b/.changeset/dirty-items-rule.md
@@ -2,4 +2,6 @@
 '@mastra/koa': minor
 ---
 
-Improved the Koa adapter so requests go through a single route dispatcher, reducing noisy middleware tracing in APM without changing the public API.
+Improved the Koa adapter to make request routing more efficient as route counts grow.
+
+Requests now move through a leaner routing path with lower middleware overhead, which helps Koa-based Mastra servers stay faster and produce cleaner request traces without changing the public API.

--- a/.changeset/dirty-items-rule.md
+++ b/.changeset/dirty-items-rule.md
@@ -1,0 +1,5 @@
+---
+'@mastra/koa': minor
+---
+
+Improved the Koa adapter so requests go through a single route dispatcher, reducing noisy middleware tracing in APM without changing the public API.

--- a/server-adapters/koa/src/__tests__/koa-adapter.test.ts
+++ b/server-adapters/koa/src/__tests__/koa-adapter.test.ts
@@ -231,6 +231,65 @@ describe('Koa Server Adapter', () => {
       expect(paramResponse.status).toBe(200);
       await expect(paramResponse.json()).resolves.toEqual({ route: 'param', id: '42' });
     });
+
+    it('preserves middleware ordering when routes are registered around app.use calls', async () => {
+      const app = new Koa();
+      app.use(bodyParser());
+
+      const adapter = new MastraServer({
+        app,
+        mastra: new Mastra({}),
+      });
+
+      adapter.registerContextMiddleware();
+
+      await adapter.registerRoute(
+        app,
+        {
+          method: 'GET',
+          path: '/before',
+          responseType: 'json',
+          handler: async () => ({ route: 'before' }),
+        },
+        { prefix: '' },
+      );
+
+      app.use(async (ctx, next) => {
+        ctx.set('x-interleaved', 'true');
+        await next();
+      });
+
+      await adapter.registerRoute(
+        app,
+        {
+          method: 'GET',
+          path: '/after',
+          responseType: 'json',
+          handler: async () => ({ route: 'after' }),
+        },
+        { prefix: '' },
+      );
+
+      const routeDispatchers = app.middleware.filter(middleware => middleware.name === 'mastraRouteDispatcher');
+      expect(routeDispatchers).toHaveLength(2);
+
+      server = await new Promise(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      const beforeResponse = await fetch(`http://localhost:${port}/before`);
+      expect(beforeResponse.status).toBe(200);
+      expect(beforeResponse.headers.get('x-interleaved')).toBeNull();
+      await expect(beforeResponse.json()).resolves.toEqual({ route: 'before' });
+
+      const afterResponse = await fetch(`http://localhost:${port}/after`);
+      expect(afterResponse.status).toBe(200);
+      expect(afterResponse.headers.get('x-interleaved')).toBe('true');
+      await expect(afterResponse.json()).resolves.toEqual({ route: 'after' });
+    });
   });
 
   describe('Stream Data Redaction', () => {

--- a/server-adapters/koa/src/__tests__/koa-adapter.test.ts
+++ b/server-adapters/koa/src/__tests__/koa-adapter.test.ts
@@ -290,6 +290,65 @@ describe('Koa Server Adapter', () => {
       expect(afterResponse.headers.get('x-interleaved')).toBe('true');
       await expect(afterResponse.json()).resolves.toEqual({ route: 'after' });
     });
+
+    it('reuses a dispatcher group when app.use wraps middleware functions', async () => {
+      const app = new Koa();
+      app.use(bodyParser());
+
+      const originalUse = app.use.bind(app);
+      app.use = ((middleware: Koa.Middleware) => {
+        const wrapped = async function wrappedMiddleware(ctx: Koa.Context, next: Koa.Next) {
+          return middleware(ctx, next);
+        };
+        return originalUse(wrapped);
+      }) as typeof app.use;
+
+      const adapter = new MastraServer({
+        app,
+        mastra: new Mastra({}),
+      });
+
+      adapter.registerContextMiddleware();
+
+      await adapter.registerRoute(
+        app,
+        {
+          method: 'GET',
+          path: '/first',
+          responseType: 'json',
+          handler: async () => ({ route: 'first' }),
+        },
+        { prefix: '' },
+      );
+
+      await adapter.registerRoute(
+        app,
+        {
+          method: 'GET',
+          path: '/second',
+          responseType: 'json',
+          handler: async () => ({ route: 'second' }),
+        },
+        { prefix: '' },
+      );
+
+      expect(app.middleware).toHaveLength(3);
+
+      server = await new Promise(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      const firstResponse = await fetch(`http://localhost:${port}/first`);
+      expect(firstResponse.status).toBe(200);
+      await expect(firstResponse.json()).resolves.toEqual({ route: 'first' });
+
+      const secondResponse = await fetch(`http://localhost:${port}/second`);
+      expect(secondResponse.status).toBe(200);
+      await expect(secondResponse.json()).resolves.toEqual({ route: 'second' });
+    });
   });
 
   describe('Stream Data Redaction', () => {

--- a/server-adapters/koa/src/__tests__/koa-adapter.test.ts
+++ b/server-adapters/koa/src/__tests__/koa-adapter.test.ts
@@ -150,6 +150,89 @@ describe('Koa Server Adapter', () => {
     },
   });
 
+  describe('Route dispatcher', () => {
+    let server: Server | null = null;
+
+    afterEach(async () => {
+      if (server) {
+        await new Promise<void>((resolve, reject) => {
+          server!.close(err => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+        server = null;
+      }
+    });
+
+    it('registers a single dispatcher middleware for built-in routes', async () => {
+      const app = new Koa();
+      app.use(bodyParser());
+
+      const adapter = new MastraServer({
+        app,
+        mastra: new Mastra({}),
+      });
+
+      await adapter.init();
+
+      const routeDispatchers = app.middleware.filter(middleware => middleware.name === 'mastraRouteDispatcher');
+      expect(routeDispatchers).toHaveLength(1);
+    });
+
+    it('preserves route registration order with static and parameterized paths', async () => {
+      const app = new Koa();
+      app.use(bodyParser());
+
+      const adapter = new MastraServer({
+        app,
+        mastra: new Mastra({}),
+      });
+
+      adapter.registerContextMiddleware();
+
+      await adapter.registerRoute(
+        app,
+        {
+          method: 'GET',
+          path: '/items/special',
+          responseType: 'json',
+          handler: async () => ({ route: 'static' }),
+        },
+        { prefix: '' },
+      );
+
+      await adapter.registerRoute(
+        app,
+        {
+          method: 'GET',
+          path: '/items/:id',
+          responseType: 'json',
+          handler: async ({ id }) => ({ route: 'param', id }),
+        },
+        { prefix: '' },
+      );
+
+      const routeDispatchers = app.middleware.filter(middleware => middleware.name === 'mastraRouteDispatcher');
+      expect(routeDispatchers).toHaveLength(1);
+
+      server = await new Promise(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      const staticResponse = await fetch(`http://localhost:${port}/items/special`);
+      expect(staticResponse.status).toBe(200);
+      await expect(staticResponse.json()).resolves.toEqual({ route: 'static' });
+
+      const paramResponse = await fetch(`http://localhost:${port}/items/42`);
+      expect(paramResponse.status).toBe(200);
+      await expect(paramResponse.json()).resolves.toEqual({ route: 'param', id: '42' });
+    });
+  });
+
   describe('Stream Data Redaction', () => {
     let context: AdapterTestContext;
     let server: Server | null = null;

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -18,6 +18,14 @@ export { createAuthMiddleware } from './auth-middleware';
 export type { KoaAuthMiddlewareOptions } from './auth-middleware';
 
 type HasPermissionFn = (userPerms: string[], required: string) => boolean;
+type RegisteredKoaRoute = {
+  route: ServerRoute;
+  prefix: string;
+  koaPath: string;
+  pathRegex: RegExp;
+  paramNames: string[];
+};
+
 let _hasPermissionPromise: Promise<HasPermissionFn | undefined> | undefined;
 function loadHasPermission(): Promise<HasPermissionFn | undefined> {
   if (!_hasPermissionPromise) {
@@ -74,6 +82,9 @@ declare module 'koa' {
 }
 
 export class MastraServer extends MastraServerBase<Koa, Context, Context> {
+  private readonly registeredRoutes: RegisteredKoaRoute[] = [];
+  private readonly routeDispatcherApps = new WeakSet<Koa>();
+
   async init() {
     this.registerErrorMiddleware();
     await super.init();
@@ -92,13 +103,15 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
    * should use `server.onError` or register their own middleware between this and the routes.
    */
   private registerErrorMiddleware(): void {
-    this.app.use(async (ctx: Context, next: Next) => {
+    const server = this;
+
+    this.app.use(async function mastraErrorBoundary(ctx: Context, next: Next) {
       try {
         await next();
       } catch (err) {
         // Try onError first (may have already been called in registerRoute,
         // but this catches errors from other middleware too)
-        if (await this.handleOnError(err, ctx)) {
+        if (await server.handleOnError(err, ctx)) {
           return;
         }
 
@@ -182,7 +195,9 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
   }
 
   createContextMiddleware(): Middleware {
-    return async (ctx: Context, next: Next) => {
+    const server = this;
+
+    return async function mastraRequestContext(ctx: Context, next: Next) {
       // Parse request context from request body and add to context
       let bodyRequestContext: Record<string, any> | undefined;
       let paramsRequestContext: Record<string, any> | undefined;
@@ -222,16 +237,16 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         }
       }
 
-      const requestContext = this.mergeRequestContext({ paramsRequestContext, bodyRequestContext });
+      const requestContext = server.mergeRequestContext({ paramsRequestContext, bodyRequestContext });
 
       // Set context in state object
       ctx.state.requestContext = requestContext;
-      ctx.state.mastra = this.mastra;
-      ctx.state.tools = this.tools || {};
-      if (this.taskStore) {
-        ctx.state.taskStore = this.taskStore;
+      ctx.state.mastra = server.mastra;
+      ctx.state.tools = server.tools || {};
+      if (server.taskStore) {
+        ctx.state.taskStore = server.taskStore;
       }
-      ctx.state.customRouteAuthConfig = this.customRouteAuthConfig;
+      ctx.state.customRouteAuthConfig = server.customRouteAuthConfig;
 
       // Create abort controller for request cancellation
       const controller = new AbortController();
@@ -245,6 +260,227 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
 
       await next();
     };
+  }
+
+  private ensureRouteDispatcher(app: Koa): void {
+    if (this.routeDispatcherApps.has(app)) {
+      return;
+    }
+
+    app.use(this.createRouteDispatcherMiddleware());
+    this.routeDispatcherApps.add(app);
+  }
+
+  private createRouteDispatcherMiddleware(): Middleware {
+    const server = this;
+
+    return async function mastraRouteDispatcher(ctx: Context, next: Next) {
+      const matchedRoute = server.findRegisteredRoute(ctx);
+
+      if (!matchedRoute) {
+        await next();
+        return;
+      }
+
+      await server.handleMatchedRoute(matchedRoute, ctx);
+    };
+  }
+
+  private findRegisteredRoute(ctx: Context): RegisteredKoaRoute | undefined {
+    const method = ctx.method.toUpperCase();
+
+    for (const registeredRoute of this.registeredRoutes) {
+      if (
+        registeredRoute.route.method.toUpperCase() !== 'ALL' &&
+        method !== registeredRoute.route.method.toUpperCase()
+      ) {
+        continue;
+      }
+
+      const match = registeredRoute.pathRegex.exec(ctx.path);
+      if (!match) {
+        continue;
+      }
+
+      ctx.params = {};
+      registeredRoute.paramNames.forEach((name, index) => {
+        ctx.params[name] = match[index + 1];
+      });
+
+      return registeredRoute;
+    }
+
+    return undefined;
+  }
+
+  private async handleMatchedRoute(registeredRoute: RegisteredKoaRoute, ctx: Context): Promise<void> {
+    const { route, prefix } = registeredRoute;
+
+    const authError = await this.checkRouteAuth(route, {
+      path: String(ctx.path || '/'),
+      method: String(ctx.method || 'GET'),
+      getHeader: name => ctx.headers[name.toLowerCase()] as string | undefined,
+      getQuery: name => (ctx.query as Record<string, string>)[name],
+      requestContext: ctx.state.requestContext,
+      request: toWebRequest(ctx),
+      buildAuthorizeContext: () => toWebRequest(ctx),
+    });
+
+    if (authError) {
+      // Apply any refresh headers (e.g. Set-Cookie from transparent session refresh)
+      if (authError.headers) {
+        for (const [key, value] of Object.entries(authError.headers)) {
+          ctx.set(key, value);
+        }
+      }
+
+      // If this is an auth error (not just a success-with-headers), return error response
+      if (authError.error) {
+        ctx.status = authError.status;
+        ctx.body = { error: authError.error };
+        return;
+      }
+    }
+
+    const params = await this.getParams(route, ctx);
+
+    // Return 400 Bad Request if body parsing failed (e.g., malformed multipart data)
+    if (params.bodyParseError) {
+      ctx.status = 400;
+      ctx.body = {
+        error: 'Invalid request body',
+        issues: [{ field: 'body', message: params.bodyParseError.message }],
+      };
+      return;
+    }
+
+    if (params.queryParams) {
+      try {
+        params.queryParams = await this.parseQueryParams(route, params.queryParams);
+      } catch (error) {
+        this.mastra.getLogger()?.error('Error parsing query params', {
+          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+        });
+        if (error instanceof ZodError) {
+          const resolved = this.resolveValidationError(route, error, 'query');
+          ctx.status = resolved.status;
+          ctx.body = resolved.body;
+          return;
+        }
+        ctx.status = 400;
+        ctx.body = {
+          error: 'Invalid query parameters',
+          issues: [{ field: 'unknown', message: error instanceof Error ? error.message : 'Unknown error' }],
+        };
+        return;
+      }
+    }
+
+    if (params.body) {
+      try {
+        params.body = await this.parseBody(route, params.body);
+      } catch (error) {
+        this.mastra.getLogger()?.error('Error parsing body', {
+          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+        });
+        if (error instanceof ZodError) {
+          const resolved = this.resolveValidationError(route, error, 'body');
+          ctx.status = resolved.status;
+          ctx.body = resolved.body;
+          return;
+        }
+        ctx.status = 400;
+        ctx.body = {
+          error: 'Invalid request body',
+          issues: [{ field: 'unknown', message: error instanceof Error ? error.message : 'Unknown error' }],
+        };
+        return;
+      }
+    }
+
+    // Parse path params through pathParamSchema for type coercion (e.g., z.coerce.number())
+    if (params.urlParams) {
+      try {
+        params.urlParams = await this.parsePathParams(route, params.urlParams);
+      } catch (error) {
+        this.mastra.getLogger()?.error('Error parsing path params', {
+          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+        });
+        if (error instanceof ZodError) {
+          const resolved = this.resolveValidationError(route, error, 'path');
+          ctx.status = resolved.status;
+          ctx.body = resolved.body;
+          return;
+        }
+        ctx.status = 400;
+        ctx.body = {
+          error: 'Invalid path parameters',
+          issues: [{ field: 'unknown', message: error instanceof Error ? error.message : 'Unknown error' }],
+        };
+        return;
+      }
+    }
+
+    const handlerParams = {
+      ...params.urlParams,
+      ...params.queryParams,
+      ...(typeof params.body === 'object' ? params.body : {}),
+      requestContext: ctx.state.requestContext,
+      mastra: this.mastra,
+      tools: ctx.state.tools,
+      taskStore: ctx.state.taskStore,
+      abortSignal: ctx.state.abortSignal,
+      routePrefix: prefix,
+    };
+
+    // Check route permission requirement (EE feature)
+    // Uses convention-based permission derivation: permissions are auto-derived
+    // from route path/method unless explicitly set or route is public
+    const authConfig = this.mastra.getServer()?.auth;
+    if (authConfig) {
+      const hasPermission = await loadHasPermission();
+      if (hasPermission) {
+        const userPermissions = ctx.state.requestContext.get('userPermissions') as string[] | undefined;
+        const permissionError = this.checkRoutePermission(route, userPermissions, hasPermission);
+
+        if (permissionError) {
+          ctx.status = permissionError.status;
+          ctx.body = {
+            error: permissionError.error,
+            message: permissionError.message,
+          };
+          return;
+        }
+      }
+    }
+
+    try {
+      const result = await route.handler(handlerParams);
+      await this.sendResponse(route, ctx, result, prefix);
+    } catch (error) {
+      this.mastra.getLogger()?.error('Error calling handler', {
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+        path: route.path,
+        method: route.method,
+      });
+      // Attach status code to the error for upstream middleware
+      if (error && typeof error === 'object') {
+        if (!('status' in error)) {
+          // Check for MastraError with status in details
+          if ('details' in error && error.details && typeof error.details === 'object' && 'status' in error.details) {
+            (error as any).status = (error.details as any).status;
+          }
+        }
+      }
+
+      // Try to call server.onError if configured
+      if (await this.handleOnError(error, ctx)) {
+        return;
+      }
+
+      // Re-throw so the error propagates up Koa's middleware chain
+      throw error;
+    }
   }
 
   async stream(route: ServerRoute, ctx: Context, result: { fullStream: ReadableStream }): Promise<void> {
@@ -535,200 +771,14 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
     // Convert Express-style :param to Koa-style :param (they're the same)
     const koaPath = fullPath;
 
-    // Define the route handler
-    const handler = async (ctx: Context, next: Next) => {
-      // Check if this route matches the request
-      const pathRegex = this.pathToRegex(koaPath);
-      const match = pathRegex.exec(ctx.path);
-
-      if (!match) {
-        await next();
-        return;
-      }
-
-      // Check HTTP method
-      if (route.method.toUpperCase() !== 'ALL' && ctx.method.toUpperCase() !== route.method.toUpperCase()) {
-        await next();
-        return;
-      }
-
-      // Extract URL params from regex match
-      const paramNames = this.extractParamNames(koaPath);
-      ctx.params = {};
-      paramNames.forEach((name, index) => {
-        ctx.params[name] = match[index + 1];
-      });
-
-      // Check route-level authentication/authorization
-      const authError = await this.checkRouteAuth(route, {
-        path: String(ctx.path || '/'),
-        method: String(ctx.method || 'GET'),
-        getHeader: name => ctx.headers[name.toLowerCase()] as string | undefined,
-        getQuery: name => (ctx.query as Record<string, string>)[name],
-        requestContext: ctx.state.requestContext,
-        request: toWebRequest(ctx),
-        buildAuthorizeContext: () => toWebRequest(ctx),
-      });
-
-      if (authError) {
-        // Apply any refresh headers (e.g. Set-Cookie from transparent session refresh)
-        if (authError.headers) {
-          for (const [key, value] of Object.entries(authError.headers)) {
-            ctx.set(key, value);
-          }
-        }
-
-        // If this is an auth error (not just a success-with-headers), return error response
-        if (authError.error) {
-          ctx.status = authError.status;
-          ctx.body = { error: authError.error };
-          return;
-        }
-      }
-
-      const params = await this.getParams(route, ctx);
-
-      // Return 400 Bad Request if body parsing failed (e.g., malformed multipart data)
-      if (params.bodyParseError) {
-        ctx.status = 400;
-        ctx.body = {
-          error: 'Invalid request body',
-          issues: [{ field: 'body', message: params.bodyParseError.message }],
-        };
-        return;
-      }
-
-      if (params.queryParams) {
-        try {
-          params.queryParams = await this.parseQueryParams(route, params.queryParams);
-        } catch (error) {
-          this.mastra.getLogger()?.error('Error parsing query params', {
-            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
-          });
-          if (error instanceof ZodError) {
-            const resolved = this.resolveValidationError(route, error, 'query');
-            ctx.status = resolved.status;
-            ctx.body = resolved.body;
-            return;
-          }
-          ctx.status = 400;
-          ctx.body = {
-            error: 'Invalid query parameters',
-            issues: [{ field: 'unknown', message: error instanceof Error ? error.message : 'Unknown error' }],
-          };
-          return;
-        }
-      }
-
-      if (params.body) {
-        try {
-          params.body = await this.parseBody(route, params.body);
-        } catch (error) {
-          this.mastra.getLogger()?.error('Error parsing body', {
-            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
-          });
-          if (error instanceof ZodError) {
-            const resolved = this.resolveValidationError(route, error, 'body');
-            ctx.status = resolved.status;
-            ctx.body = resolved.body;
-            return;
-          }
-          ctx.status = 400;
-          ctx.body = {
-            error: 'Invalid request body',
-            issues: [{ field: 'unknown', message: error instanceof Error ? error.message : 'Unknown error' }],
-          };
-          return;
-        }
-      }
-
-      // Parse path params through pathParamSchema for type coercion (e.g., z.coerce.number())
-      if (params.urlParams) {
-        try {
-          params.urlParams = await this.parsePathParams(route, params.urlParams);
-        } catch (error) {
-          this.mastra.getLogger()?.error('Error parsing path params', {
-            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
-          });
-          if (error instanceof ZodError) {
-            const resolved = this.resolveValidationError(route, error, 'path');
-            ctx.status = resolved.status;
-            ctx.body = resolved.body;
-            return;
-          }
-          ctx.status = 400;
-          ctx.body = {
-            error: 'Invalid path parameters',
-            issues: [{ field: 'unknown', message: error instanceof Error ? error.message : 'Unknown error' }],
-          };
-          return;
-        }
-      }
-
-      const handlerParams = {
-        ...params.urlParams,
-        ...params.queryParams,
-        ...(typeof params.body === 'object' ? params.body : {}),
-        requestContext: ctx.state.requestContext,
-        mastra: this.mastra,
-        tools: ctx.state.tools,
-        taskStore: ctx.state.taskStore,
-        abortSignal: ctx.state.abortSignal,
-        routePrefix: prefix,
-      };
-
-      // Check route permission requirement (EE feature)
-      // Uses convention-based permission derivation: permissions are auto-derived
-      // from route path/method unless explicitly set or route is public
-      const authConfig = this.mastra.getServer()?.auth;
-      if (authConfig) {
-        const hasPermission = await loadHasPermission();
-        if (hasPermission) {
-          const userPermissions = ctx.state.requestContext.get('userPermissions') as string[] | undefined;
-          const permissionError = this.checkRoutePermission(route, userPermissions, hasPermission);
-
-          if (permissionError) {
-            ctx.status = permissionError.status;
-            ctx.body = {
-              error: permissionError.error,
-              message: permissionError.message,
-            };
-            return;
-          }
-        }
-      }
-
-      try {
-        const result = await route.handler(handlerParams);
-        await this.sendResponse(route, ctx, result, prefix);
-      } catch (error) {
-        this.mastra.getLogger()?.error('Error calling handler', {
-          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
-          path: route.path,
-          method: route.method,
-        });
-        // Attach status code to the error for upstream middleware
-        if (error && typeof error === 'object') {
-          if (!('status' in error)) {
-            // Check for MastraError with status in details
-            if ('details' in error && error.details && typeof error.details === 'object' && 'status' in error.details) {
-              (error as any).status = (error.details as any).status;
-            }
-          }
-        }
-
-        // Try to call server.onError if configured
-        if (await this.handleOnError(error, ctx)) {
-          return;
-        }
-
-        // Re-throw so the error propagates up Koa's middleware chain
-        throw error;
-      }
-    };
-
-    // Register the middleware
-    app.use(handler);
+    this.registeredRoutes.push({
+      route,
+      prefix,
+      koaPath,
+      pathRegex: this.pathToRegex(koaPath),
+      paramNames: this.extractParamNames(koaPath),
+    });
+    this.ensureRouteDispatcher(app);
   }
 
   /**
@@ -759,12 +809,14 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
   async registerCustomApiRoutes(): Promise<void> {
     if (!(await this.buildCustomRouteHandler())) return;
 
-    this.app.use(async (ctx: Context, next: Next) => {
+    const server = this;
+
+    this.app.use(async function mastraCustomRouteDispatcher(ctx: Context, next: Next) {
       // Check if this request matches a protected custom route and run auth
       const path = String(ctx.path || '/');
       const method = String(ctx.method || 'GET');
 
-      if (isProtectedCustomRoute(path, method, this.customRouteAuthConfig)) {
+      if (isProtectedCustomRoute(path, method, server.customRouteAuthConfig)) {
         const serverRoute: ServerRoute = {
           method: method as any,
           path,
@@ -772,7 +824,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
           handler: async () => {},
         };
 
-        const authError = await this.checkRouteAuth(serverRoute, {
+        const authError = await server.checkRouteAuth(serverRoute, {
           path,
           method,
           getHeader: name => ctx.headers[name.toLowerCase()] as string | undefined,
@@ -795,7 +847,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
           }
         }
 
-        const authConfig = this.mastra.getServer()?.auth;
+        const authConfig = server.mastra.getServer()?.auth;
         if (authConfig) {
           let hasPermission: ((userPerms: string[], required: string) => boolean) | undefined;
           try {
@@ -808,7 +860,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
 
           if (hasPermission) {
             const userPermissions = ctx.state.requestContext.get('userPermissions') as string[] | undefined;
-            const permissionError = this.checkRoutePermission(serverRoute, userPermissions, hasPermission);
+            const permissionError = server.checkRoutePermission(serverRoute, userPermissions, hasPermission);
             if (permissionError) {
               ctx.status = permissionError.status;
               ctx.body = {
@@ -821,7 +873,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         }
       }
 
-      const response = await this.handleCustomRouteRequest(
+      const response = await server.handleCustomRouteRequest(
         `${ctx.protocol}://${ctx.host}${ctx.originalUrl || ctx.url}`,
         ctx.method,
         ctx.headers as Record<string, string | string[] | undefined>,
@@ -830,7 +882,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       );
       if (!response) return next();
       ctx.respond = false;
-      await this.writeCustomRouteResponse(response, ctx.res);
+      await server.writeCustomRouteResponse(response, ctx.res);
     });
   }
 
@@ -848,8 +900,10 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       return;
     }
 
-    this.app.use(async (ctx: Context, next: Next) => {
-      if (!this.shouldLogRequest(ctx.path)) {
+    const server = this;
+
+    this.app.use(async function mastraHttpLogger(ctx: Context, next: Next) {
+      if (!server.shouldLogRequest(ctx.path)) {
         return next();
       }
 
@@ -861,7 +915,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
 
       const duration = Date.now() - start;
       const status = ctx.status;
-      const level = this.httpLoggingConfig?.level || 'info';
+      const level = server.httpLoggingConfig?.level || 'info';
 
       const logData: Record<string, any> = {
         method,
@@ -870,13 +924,13 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         duration: `${duration}ms`,
       };
 
-      if (this.httpLoggingConfig?.includeQueryParams) {
+      if (server.httpLoggingConfig?.includeQueryParams) {
         logData.query = ctx.query;
       }
 
-      if (this.httpLoggingConfig?.includeHeaders) {
+      if (server.httpLoggingConfig?.includeHeaders) {
         const headers = { ...ctx.headers };
-        const redactHeaders = this.httpLoggingConfig.redactHeaders || [];
+        const redactHeaders = server.httpLoggingConfig.redactHeaders || [];
         redactHeaders.forEach((h: string) => {
           const key = h.toLowerCase();
           if (headers[key] !== undefined) {
@@ -886,7 +940,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         logData.headers = headers;
       }
 
-      this.logger[level](`${method} ${path} ${status} ${duration}ms`, logData);
+      server.logger[level](`${method} ${path} ${status} ${duration}ms`, logData);
     });
   }
 }

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -25,6 +25,10 @@ type RegisteredKoaRoute = {
   pathRegex: RegExp;
   paramNames: string[];
 };
+type RouteDispatcherGroup = {
+  routes: RegisteredKoaRoute[];
+  middleware: Middleware;
+};
 
 let _hasPermissionPromise: Promise<HasPermissionFn | undefined> | undefined;
 function loadHasPermission(): Promise<HasPermissionFn | undefined> {
@@ -82,8 +86,7 @@ declare module 'koa' {
 }
 
 export class MastraServer extends MastraServerBase<Koa, Context, Context> {
-  private readonly registeredRoutes: RegisteredKoaRoute[] = [];
-  private readonly routeDispatcherApps = new WeakSet<Koa>();
+  private readonly activeRouteDispatchers = new WeakMap<Koa, RouteDispatcherGroup>();
 
   async init() {
     this.registerErrorMiddleware();
@@ -262,20 +265,27 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
     };
   }
 
-  private ensureRouteDispatcher(app: Koa): void {
-    if (this.routeDispatcherApps.has(app)) {
-      return;
+  private getRouteDispatcherGroup(app: Koa): RouteDispatcherGroup {
+    const activeGroup = this.activeRouteDispatchers.get(app);
+    if (activeGroup && app.middleware[app.middleware.length - 1] === activeGroup.middleware) {
+      return activeGroup;
     }
 
-    app.use(this.createRouteDispatcherMiddleware());
-    this.routeDispatcherApps.add(app);
+    const group: RouteDispatcherGroup = {
+      routes: [],
+      middleware: undefined as unknown as Middleware,
+    };
+    group.middleware = this.createRouteDispatcherMiddleware(group);
+    app.use(group.middleware);
+    this.activeRouteDispatchers.set(app, group);
+    return group;
   }
 
-  private createRouteDispatcherMiddleware(): Middleware {
+  private createRouteDispatcherMiddleware(group: RouteDispatcherGroup): Middleware {
     const server = this;
 
     return async function mastraRouteDispatcher(ctx: Context, next: Next) {
-      const matchedRoute = server.findRegisteredRoute(ctx);
+      const matchedRoute = server.findRegisteredRoute(group.routes, ctx);
 
       if (!matchedRoute) {
         await next();
@@ -286,10 +296,10 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
     };
   }
 
-  private findRegisteredRoute(ctx: Context): RegisteredKoaRoute | undefined {
+  private findRegisteredRoute(routes: RegisteredKoaRoute[], ctx: Context): RegisteredKoaRoute | undefined {
     const method = ctx.method.toUpperCase();
 
-    for (const registeredRoute of this.registeredRoutes) {
+    for (const registeredRoute of routes) {
       if (
         registeredRoute.route.method.toUpperCase() !== 'ALL' &&
         method !== registeredRoute.route.method.toUpperCase()
@@ -771,14 +781,14 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
     // Convert Express-style :param to Koa-style :param (they're the same)
     const koaPath = fullPath;
 
-    this.registeredRoutes.push({
+    const group = this.getRouteDispatcherGroup(app);
+    group.routes.push({
       route,
       prefix,
       koaPath,
       pathRegex: this.pathToRegex(koaPath),
       paramNames: this.extractParamNames(koaPath),
     });
-    this.ensureRouteDispatcher(app);
   }
 
   /**

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -27,7 +27,7 @@ type RegisteredKoaRoute = {
 };
 type RouteDispatcherGroup = {
   routes: RegisteredKoaRoute[];
-  middleware: Middleware;
+  stackLengthAfterRegistration: number;
 };
 
 let _hasPermissionPromise: Promise<HasPermissionFn | undefined> | undefined;
@@ -267,16 +267,16 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
 
   private getRouteDispatcherGroup(app: Koa): RouteDispatcherGroup {
     const activeGroup = this.activeRouteDispatchers.get(app);
-    if (activeGroup && app.middleware[app.middleware.length - 1] === activeGroup.middleware) {
+    if (activeGroup && app.middleware.length === activeGroup.stackLengthAfterRegistration) {
       return activeGroup;
     }
 
     const group: RouteDispatcherGroup = {
       routes: [],
-      middleware: undefined as unknown as Middleware,
+      stackLengthAfterRegistration: 0,
     };
-    group.middleware = this.createRouteDispatcherMiddleware(group);
-    app.use(group.middleware);
+    app.use(this.createRouteDispatcherMiddleware(group));
+    group.stackLengthAfterRegistration = app.middleware.length;
     this.activeRouteDispatchers.set(app, group);
     return group;
   }


### PR DESCRIPTION
##  Summary

- Rework the Koa adapter to dispatch built-in routes through a single internal router instead of registering one Koa middleware per route.
- Precompile route matchers during registration.
- Give top-level adapter middleware stable names for clearer stack traces and diagnostics.

##  Why

- The previous adapter structure treated each route as its own app.use(...) middleware.
- That made every request walk a long middleware chain before reaching the matching route, which added avoidable routing overhead and produced noisy, hard-to-read middleware traces.
- As route counts grow, that structure scales poorly compared with a single dispatch layer.

##  What changed

- server-adapters/koa/src/index.ts
- Route registration now stores compiled route metadata instead of attaching a dedicated Koa middleware for each route.
- A single dispatcher middleware now performs built-in route matching and execution.
- Request context, auth, permissions, validation, custom API routes, MCP routes, streaming responses, and error handling remain unchanged from a public API perspective.
- Top-level middlewares now use stable names to improve observability and debugging.

##  Tests

- Added regression coverage to verify built-in routes are handled through a single dispatcher middleware.
- Added regression coverage to preserve route matching order for static and parameterized paths.


##  Impact

- Reduces per-request routing overhead in the Koa adapter.
- Produces cleaner middleware traces and stack visibility in tooling.
- Preserves the existing @mastra/koa API and route behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Old APM Look

<img width="1128" height="1039" alt="Screenshot 2026-05-01 at 1 50 18 PM" src="https://github.com/user-attachments/assets/3d4a177b-e2ee-4ad1-869f-2cfc16408084" />

## New APM look

<img width="1136" height="628" alt="Screenshot 2026-05-01 at 1 49 07 PM" src="https://github.com/user-attachments/assets/a3a74d5b-fb03-4a32-aba3-ec573411413c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Instead of adding a separate doorman for every route, this PR gives the Koa server one smart receptionist (a single dispatcher) that checks each request and forwards it to the right handler—making routing faster and request traces easier to read.

## Changes Summary

- Consolidates per-route Koa middleware into a single app-level mastraRouteDispatcher that matches requests (method + precompiled path regex) and runs the full route lifecycle.
- registerRoute now records precompiled route metadata (prefix, regex, param names) in a per-app RouteDispatcherGroup (WeakMap keyed by Koa app) instead of attaching a dedicated middleware per route.
- Dispatcher behavior:
  - Chooses first matching route by method (including ALL) and path regex; populates ctx.params.
  - Runs auth (including refresh headers), param parsing (body/query/path) with Zod validation handling, EE permission checks, handler invocation, sendResponse, and route-level error handling (including handleOnError).
- Middleware stability: top-level adapter middleware (error boundary, request context, custom API dispatcher, HTTP logger) are converted from arrow functions that rely on this to named function callbacks that capture server via closure for stable names and clearer stack traces.
- RouteDispatcherGroup logic reuses a dispatcher for an app while app.middleware.length equals the stored stackLengthAfterRegistration; creating an additional dispatcher is expected when app.use calls are interleaved between route registrations (tests cover both reuse and the interleaved case).

## Tests

- New integration tests validate:
  - init() registers a mastraRouteDispatcher middleware (one per contiguous registration block).
  - Route matching order is preserved: static paths are matched before parameterized paths when registered in that order.
  - Middleware ordering is preserved when routes are registered before/after app.use (verifies x-interleaved header behavior and dispatcher counts).
  - Dispatcher reuse when app.use wraps/overrides middleware is handled as expected.
  - Tests ensure servers are closed after each scenario.

## Files Changed (high-level)

- server-adapters/koa/src/index.ts: routing refactor; precompiled route metadata + single dispatcher; named top-level middleware (+281 / -217).
- server-adapters/koa/src/__tests__/koa-adapter.test.ts: new integration tests covering dispatcher behavior (+~200 lines).
- .changeset/dirty-items-rule.md: new changeset for @mastra/koa (minor release note).

## Impact

- Reduces per-request routing overhead and middleware noise in traces as route counts grow.
- Improves middleware traceability via stable middleware function names and fewer stacked handlers.
- No public API changes: request context, auth, permissions, validation, custom API/MCP routes, streaming responses, and error handling behaviors are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->