### PR TITLE
feat(core): preserve compact tool output in ToolCallFilter

### DIFF
--- a/.changeset/funky-coins-sing.md
+++ b/.changeset/funky-coins-sing.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+---
+
+Added `preserveModelOutput` to `ToolCallFilter` so filtered tool history can keep compact model-facing output without raw tool args or results.
+
+```ts
+import { ToolCallFilter } from '@mastra/core/processors';
+
+const filter = new ToolCallFilter({
+  preserveModelOutput: true,
+});
+```

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -383,6 +383,14 @@ new ToolCallFilter({
 })
 ```
 
+Set `preserveModelOutput: true` to keep compact `toModelOutput` history for filtered completed tool results. The filter keeps only the model-facing output and removes raw tool args and raw results.
+
+```typescript
+new ToolCallFilter({
+  preserveModelOutput: true,
+})
+```
+
 See the [`ToolCallFilter` reference](/reference/processors/tool-call-filter) for configuration options and the [Memory Processors](/docs/memory/memory-processors#manual-control-and-deduplication) page for pre-memory filtering.
 
 ### `ToolSearchProcessor`

--- a/docs/src/content/en/reference/processors/tool-call-filter.mdx
+++ b/docs/src/content/en/reference/processors/tool-call-filter.mdx
@@ -26,6 +26,11 @@ const filterSpecific = new ToolCallFilter({
 const filterAfterRecentTools = new ToolCallFilter({
   filterAfterToolSteps: 2,
 })
+
+// Preserve compact model-facing output for filtered completed tool results
+const filterWithCompactToolHistory = new ToolCallFilter({
+  preserveModelOutput: true,
+})
 ```
 
 ## Constructor parameters
@@ -54,6 +59,14 @@ const filterAfterRecentTools = new ToolCallFilter({
             description:
               'Enables filtering during agent loops and preserves tool calls and results from this many recent tool-producing steps. If undefined, step filtering is disabled',
             isOptional: true,
+          },
+          {
+            name: 'preserveModelOutput',
+            type: 'boolean',
+            description:
+              'Preserves compact model-facing output from completed filtered tool results with providerMetadata.mastra.modelOutput. Raw tool args and raw results are removed',
+            isOptional: true,
+            defaultValue: 'false',
           },
         ],
       },
@@ -105,6 +118,27 @@ Set `filterAfterToolSteps: 0` to filter all previous tool calls and results on e
 ```typescript
 const filter = new ToolCallFilter({
   filterAfterToolSteps: 2,
+})
+```
+
+## Preserve compact model output
+
+Set `preserveModelOutput: true` to retain compact `toModelOutput` history for completed tool results that the filter removes. This keeps the model-facing output as text in the prompt while removing the raw `toolInvocation.args` and raw `toolInvocation.result` payloads.
+
+Only completed tool results with `providerMetadata.mastra.modelOutput` are preserved. Tool calls, incomplete results, and results without stored model output are still filtered.
+
+```typescript
+const filter = new ToolCallFilter({
+  preserveModelOutput: true,
+})
+```
+
+Combine `preserveModelOutput` with `exclude` to preserve compact output only for filtered tools:
+
+```typescript
+const filter = new ToolCallFilter({
+  exclude: ['searchDatabase'],
+  preserveModelOutput: true,
 })
 ```
 

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -12,7 +12,8 @@ import type { PromptInjectionOptions } from '../../processors/processors/prompt-
 import { SystemPromptScrubber } from '../../processors/processors/system-prompt-scrubber';
 import type { SystemPromptScrubberOptions } from '../../processors/processors/system-prompt-scrubber';
 import { TokenLimiterProcessor } from '../../processors/processors/token-limiter';
-import { ToolCallFilter, type ToolCallFilterOptions } from '../../processors/processors/tool-call-filter';
+import { ToolCallFilter } from '../../processors/processors/tool-call-filter';
+import type { ToolCallFilterOptions } from '../../processors/processors/tool-call-filter';
 import { UnicodeNormalizer } from '../../processors/processors/unicode-normalizer';
 import type { ProcessorProvider, ProcessorPhase } from '../types';
 

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -74,6 +74,7 @@ export const toolCallFilterProvider: ProcessorProvider = {
   },
   configSchema: z.object({
     exclude: z.array(z.string()).optional(),
+    filterAfterToolSteps: z.number().optional(),
     preserveModelOutput: z.boolean().optional(),
   }),
   availablePhases: ['processInput'] as ProcessorPhase[],

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -12,7 +12,7 @@ import type { PromptInjectionOptions } from '../../processors/processors/prompt-
 import { SystemPromptScrubber } from '../../processors/processors/system-prompt-scrubber';
 import type { SystemPromptScrubberOptions } from '../../processors/processors/system-prompt-scrubber';
 import { TokenLimiterProcessor } from '../../processors/processors/token-limiter';
-import { ToolCallFilter } from '../../processors/processors/tool-call-filter';
+import { ToolCallFilter, type ToolCallFilterOptions } from '../../processors/processors/tool-call-filter';
 import { UnicodeNormalizer } from '../../processors/processors/unicode-normalizer';
 import type { ProcessorProvider, ProcessorPhase } from '../types';
 
@@ -74,10 +74,11 @@ export const toolCallFilterProvider: ProcessorProvider = {
   },
   configSchema: z.object({
     exclude: z.array(z.string()).optional(),
+    preserveModelOutput: z.boolean().optional(),
   }),
   availablePhases: ['processInput'] as ProcessorPhase[],
   createProcessor(config) {
-    return new ToolCallFilter(config as { exclude?: string[] });
+    return new ToolCallFilter(config as ToolCallFilterOptions);
   },
 };
 

--- a/packages/core/src/processors/processors/tool-call-filter.test.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import { MessageList } from '../../agent/message-list';
 import type { MastraDBMessage } from '../../memory/types';
+import { toolCallFilterProvider } from '../../processor-provider/providers';
 import type { ProcessInputStepArgs } from '../index';
 
 import { ToolCallFilter } from './tool-call-filter';
@@ -908,6 +909,362 @@ describe('ToolCallFilter', () => {
       const resultMessages = Array.isArray(result) ? result : result.get.all.db();
       expect(resultMessages).toHaveLength(1);
       expect(resultMessages[0]!.id).toBe('msg-1');
+    });
+  });
+
+  describe('preserveModelOutput', () => {
+    const createMessageList = (messages: MastraDBMessage[]) => {
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+      return messageList;
+    };
+
+    const toolMessages: MastraDBMessage[] = [
+      {
+        id: 'msg-user',
+        role: 'user',
+        content: {
+          format: 2,
+          content: 'Search and summarize',
+          parts: [{ type: 'text' as const, text: 'Search and summarize' }],
+        },
+        createdAt: new Date(),
+      },
+      {
+        id: 'msg-tools',
+        role: 'assistant',
+        content: {
+          format: 2,
+          content: '',
+          parts: [
+            {
+              type: 'tool-invocation' as const,
+              toolInvocation: {
+                state: 'call' as const,
+                toolCallId: 'call-search',
+                toolName: 'search',
+                args: { query: 'SECRET_QUERY' },
+              },
+              providerMetadata: {
+                mastra: {
+                  modelOutput: { type: 'text', value: 'Call metadata must not be preserved' },
+                },
+              },
+            },
+            {
+              type: 'tool-invocation' as const,
+              toolInvocation: {
+                state: 'result' as const,
+                toolCallId: 'call-search',
+                toolName: 'search',
+                args: { query: 'SECRET_QUERY' },
+                result: { raw: 'SECRET_RAW_RESULT' },
+              },
+              providerMetadata: {
+                mastra: {
+                  modelOutput: { type: 'text', value: 'Compact search summary' },
+                },
+              },
+            },
+            {
+              type: 'tool-invocation' as const,
+              toolInvocation: {
+                state: 'result' as const,
+                toolCallId: 'call-without-model-output',
+                toolName: 'raw-search',
+                args: { query: 'UNSAFE_ARGS' },
+                result: { raw: 'UNSAFE_RESULT' },
+              },
+            },
+          ],
+        },
+        createdAt: new Date(),
+      },
+    ];
+
+    it('keeps default filtering unchanged when model output is present', async () => {
+      const filter = new ToolCallFilter();
+      const messageList = createMessageList(toolMessages);
+
+      const result = await filter.processInput({
+        messages: toolMessages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      expect(JSON.stringify(resultMessages)).not.toContain('Compact search summary');
+      expect(JSON.stringify(resultMessages)).not.toContain('SECRET_RAW_RESULT');
+    });
+
+    it('preserves only compact model output for excluded completed tool results', async () => {
+      const filter = new ToolCallFilter({ preserveModelOutput: true });
+      const messageList = createMessageList(toolMessages);
+
+      const result = await filter.processInput({
+        messages: toolMessages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      const serialized = JSON.stringify(resultMessages);
+      expect(serialized).toContain('Compact search summary');
+      expect(serialized).not.toContain('Call metadata must not be preserved');
+      expect(serialized).not.toContain('SECRET_RAW_RESULT');
+      expect(serialized).not.toContain('SECRET_QUERY');
+      expect(serialized).not.toContain('UNSAFE_RESULT');
+      expect(serialized).not.toContain('UNSAFE_ARGS');
+
+      const assistantParts = resultMessages.flatMap(message =>
+        typeof message.content === 'string' ? [] : message.content.parts,
+      );
+      expect(assistantParts.some((part: any) => part.type === 'tool-invocation')).toBe(false);
+      expect(assistantParts.filter((part: any) => part.type === 'text').map((part: any) => part.text)).toContain(
+        'search result:\nCompact search summary',
+      );
+    });
+
+    it('preserves model output while filtering only matching specific tools', async () => {
+      const filter = new ToolCallFilter({ exclude: ['search'], preserveModelOutput: true });
+      const messages: MastraDBMessage[] = [
+        ...toolMessages,
+        {
+          id: 'msg-calculator',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-calculator',
+                  toolName: 'calculator',
+                  args: { expression: '2+2' },
+                  result: 4,
+                },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+      const messageList = createMessageList(messages);
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      const parts = resultMessages.flatMap(message =>
+        typeof message.content === 'string' ? [] : message.content.parts,
+      );
+      expect(
+        parts.some((part: any) => part.type === 'text' && part.text === 'search result:\nCompact search summary'),
+      ).toBe(true);
+      expect(
+        parts.some((part: any) => part.type === 'tool-invocation' && part.toolInvocation.toolName === 'search'),
+      ).toBe(false);
+      expect(
+        parts.some((part: any) => part.type === 'tool-invocation' && part.toolInvocation.toolName === 'calculator'),
+      ).toBe(true);
+    });
+
+    it('uses the compact representation for filtered step history without dangling tool results', async () => {
+      const filter = new ToolCallFilter({ filterAfterToolSteps: 0, preserveModelOutput: true });
+      const messageList = createMessageList(toolMessages);
+
+      const result = await filter.processInputStep(mockStepArgs(messageList));
+
+      expect(result.messages).toBeDefined();
+      const filteredMessages = result.messages!;
+      expect(JSON.stringify(filteredMessages)).toContain('Compact search summary');
+
+      const promptList = new MessageList();
+      promptList.add(filteredMessages, 'input');
+      const prompt = await promptList.get.all.aiV5.llmPrompt();
+      expect(prompt.some(message => message.role === 'tool')).toBe(false);
+      expect(JSON.stringify(prompt)).toContain('Compact search summary');
+    });
+
+    it('leaves recent step tool results intact when filterAfterToolSteps preserves them', async () => {
+      const filter = new ToolCallFilter({ filterAfterToolSteps: 1, preserveModelOutput: true });
+      const messageList = new MessageList();
+      messageList.add(toolMessages[0]!, 'input');
+      messageList.add(toolMessages[1]!, 'response');
+
+      const result = await filter.processInputStep(mockStepArgs(messageList));
+
+      expect(result.messages).toBeDefined();
+      const serialized = JSON.stringify(result.messages);
+      expect(serialized).toContain('SECRET_QUERY');
+      expect(serialized).toContain('SECRET_RAW_RESULT');
+      expect(serialized).not.toContain('search result:\\nCompact search summary');
+
+      const parts = result.messages!.flatMap(message =>
+        typeof message.content === 'string' ? [] : message.content.parts,
+      );
+      expect(parts.some((part: any) => part.type === 'tool-invocation')).toBe(true);
+    });
+
+    it('supports text, primitive, array, and json-like model output shapes', async () => {
+      const filter = new ToolCallFilter({ preserveModelOutput: true });
+      const messages: MastraDBMessage[] = [
+        toolMessages[0]!,
+        {
+          id: 'msg-output-shapes',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-text',
+                  toolName: 'textTool',
+                  args: { secret: 'TEXT_ARGS' },
+                  result: 'TEXT_RAW',
+                },
+                providerMetadata: { mastra: { modelOutput: { type: 'text', text: 'Text from text field' } } },
+              },
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-number',
+                  toolName: 'numberTool',
+                  args: { secret: 'NUMBER_ARGS' },
+                  result: 'NUMBER_RAW',
+                },
+                providerMetadata: { mastra: { modelOutput: 42 } },
+              },
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-array',
+                  toolName: 'arrayTool',
+                  args: { secret: 'ARRAY_ARGS' },
+                  result: 'ARRAY_RAW',
+                },
+                providerMetadata: {
+                  mastra: {
+                    modelOutput: [
+                      { type: 'text', value: 'First line' },
+                      { type: 'json', value: { safe: true } },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+      const messageList = createMessageList(messages);
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      const preservedTexts = resultMessages.flatMap(message =>
+        typeof message.content === 'string'
+          ? []
+          : message.content.parts.filter((part: any) => part.type === 'text').map((part: any) => part.text),
+      );
+      const serialized = JSON.stringify(resultMessages);
+      expect(preservedTexts).toContain('textTool result:\nText from text field');
+      expect(preservedTexts).toContain('numberTool result:\n42');
+      expect(preservedTexts).toContain('arrayTool result:\nFirst line\n{"safe":true}');
+      expect(serialized).not.toContain('TEXT_ARGS');
+      expect(serialized).not.toContain('NUMBER_RAW');
+      expect(serialized).not.toContain('ARRAY_RAW');
+    });
+
+    it('drops model output that cannot be represented as text', async () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      const filter = new ToolCallFilter({ preserveModelOutput: true });
+      const messages: MastraDBMessage[] = [
+        toolMessages[0]!,
+        {
+          id: 'msg-circular-output',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-circular',
+                  toolName: 'circularTool',
+                  args: { secret: 'CIRCULAR_ARGS' },
+                  result: 'CIRCULAR_RAW',
+                },
+                providerMetadata: { mastra: { modelOutput: circular } },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+      const messageList = createMessageList(messages);
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      const serialized = JSON.stringify(resultMessages);
+      expect(serialized).not.toContain('circularTool result');
+      expect(serialized).not.toContain('CIRCULAR_ARGS');
+      expect(serialized).not.toContain('CIRCULAR_RAW');
+    });
+
+    it('does not transform messages when exclude is empty', async () => {
+      const filter = new ToolCallFilter({ exclude: [], preserveModelOutput: true });
+      const messageList = createMessageList(toolMessages);
+
+      const result = await filter.processInput({
+        messages: toolMessages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      const serialized = JSON.stringify(resultMessages);
+      expect(serialized).toContain('SECRET_QUERY');
+      expect(serialized).toContain('SECRET_RAW_RESULT');
+      expect(serialized).toContain('Compact search summary');
+      expect(serialized).not.toContain('search result:\\nCompact search summary');
+    });
+
+    it('exposes preserveModelOutput through the processor provider config', async () => {
+      const parsedConfig = toolCallFilterProvider.configSchema.parse({ preserveModelOutput: true });
+      const processor = toolCallFilterProvider.createProcessor(parsedConfig);
+      const messageList = createMessageList(toolMessages);
+
+      const result = await processor.processInput?.({
+        messages: toolMessages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result?.get.all.db();
+      expect(JSON.stringify(resultMessages)).toContain('Compact search summary');
     });
   });
 

--- a/packages/core/src/processors/processors/tool-call-filter.test.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.test.ts
@@ -1252,6 +1252,23 @@ describe('ToolCallFilter', () => {
       expect(serialized).not.toContain('search result:\\nCompact search summary');
     });
 
+    it('exposes filterAfterToolSteps and preserveModelOutput through the processor provider config', async () => {
+      const parsedConfig = toolCallFilterProvider.configSchema.parse({
+        filterAfterToolSteps: 0,
+        preserveModelOutput: true,
+      });
+      const processor = toolCallFilterProvider.createProcessor(parsedConfig);
+      const messageList = createMessageList(toolMessages);
+
+      const result = await processor.processInputStep?.(mockStepArgs(messageList));
+
+      expect(result?.messages).toBeDefined();
+      const resultMessages = result?.messages;
+      expect(JSON.stringify(resultMessages)).toContain('Compact search summary');
+      expect(JSON.stringify(resultMessages)).not.toContain('SECRET_QUERY');
+      expect(JSON.stringify(resultMessages)).not.toContain('SECRET_RAW_RESULT');
+    });
+
     it('exposes preserveModelOutput through the processor provider config', async () => {
       const parsedConfig = toolCallFilterProvider.configSchema.parse({ preserveModelOutput: true });
       const processor = toolCallFilterProvider.createProcessor(parsedConfig);

--- a/packages/core/src/processors/processors/tool-call-filter.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.ts
@@ -15,6 +15,15 @@ type V2ToolInvocationPart = {
     result?: unknown;
     state: 'call' | 'result';
   };
+  providerMetadata?: {
+    mastra?: Record<string, unknown>;
+  };
+};
+
+export type ToolCallFilterOptions = {
+  exclude?: string[];
+  filterAfterToolSteps?: number;
+  preserveModelOutput?: boolean;
 };
 
 /**
@@ -29,14 +38,16 @@ export class ToolCallFilter implements Processor {
   name = 'ToolCallFilter';
   private exclude: string[] | 'all';
   private filterAfterToolSteps: number | undefined;
+  private preserveModelOutput: boolean;
 
   /**
    * Create a filter for tool calls and results.
    * @param options Configuration options
    * @param options.exclude List of specific tool names to exclude. If not provided, all tool calls are excluded.
    * @param options.filterAfterToolSteps Enable agentic loop step filtering and preserve tool calls/results from this many recent tool-producing steps.
+   * @param options.preserveModelOutput Preserve sanitized model-facing output from completed filtered tool results with providerMetadata.mastra.modelOutput.
    */
-  constructor(options: { exclude?: string[]; filterAfterToolSteps?: number } = {}) {
+  constructor(options: ToolCallFilterOptions = {}) {
     // If no options or exclude is provided, exclude all tools
     if (!options || !options.exclude) {
       this.exclude = 'all'; // Exclude all tools
@@ -46,6 +57,7 @@ export class ToolCallFilter implements Processor {
     }
 
     this.filterAfterToolSteps = options.filterAfterToolSteps;
+    this.preserveModelOutput = options.preserveModelOutput ?? false;
   }
 
   async processInput(args: {
@@ -129,6 +141,86 @@ export class ToolCallFilter implements Processor {
     return message.content.parts.filter((part: any) => part.type === 'tool-invocation');
   }
 
+  private getToolCallId(invocation: V2ToolInvocationPart['toolInvocation']): string | undefined {
+    return invocation.toolCallId ?? (invocation as any).toolCall?.id;
+  }
+
+  private getPreservedModelOutputPart(part: V2ToolInvocationPart): { type: 'text'; text: string } | null {
+    if (!this.preserveModelOutput || part.toolInvocation.state !== 'result') {
+      return null;
+    }
+
+    const mastraMetadata = part.providerMetadata?.mastra;
+    if (!mastraMetadata || !Object.hasOwn(mastraMetadata, 'modelOutput')) {
+      return null;
+    }
+
+    const modelOutput = mastraMetadata.modelOutput;
+    if (modelOutput == null) {
+      return null;
+    }
+
+    const text = this.modelOutputToText(modelOutput);
+    if (!text) {
+      return null;
+    }
+
+    return {
+      type: 'text',
+      text: `${part.toolInvocation.toolName} result:\n${text}`,
+    };
+  }
+
+  private modelOutputToText(modelOutput: unknown): string | null {
+    if (typeof modelOutput === 'string') {
+      return modelOutput;
+    }
+
+    if (typeof modelOutput === 'number' || typeof modelOutput === 'boolean' || typeof modelOutput === 'bigint') {
+      return String(modelOutput);
+    }
+
+    if (Array.isArray(modelOutput)) {
+      const text = modelOutput
+        .map(part => this.modelOutputToText(part))
+        .filter((part): part is string => Boolean(part))
+        .join('\n');
+      return text || this.safeStringify(modelOutput);
+    }
+
+    if (modelOutput && typeof modelOutput === 'object') {
+      const output = modelOutput as Record<string, unknown>;
+      if (output.type === 'text') {
+        if (typeof output.value === 'string') {
+          return output.value;
+        }
+        if (typeof output.text === 'string') {
+          return output.text;
+        }
+      }
+
+      if ('value' in output) {
+        return this.modelOutputToText(output.value);
+      }
+
+      if ('text' in output && typeof output.text === 'string') {
+        return output.text;
+      }
+
+      return this.safeStringify(modelOutput);
+    }
+
+    return null;
+  }
+
+  private safeStringify(value: unknown): string | null {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return null;
+    }
+  }
+
   private filterAllToolCalls(messages: MastraDBMessage[], preserveToolCallIds = new Set<string>()): MastraDBMessage[] {
     return messages
       .map(message => {
@@ -144,12 +236,18 @@ export class ToolCallFilter implements Processor {
           return message;
         }
 
-        const nonToolParts = message.content.parts.filter((part: any) => {
+        const nonToolParts = message.content.parts.flatMap((part: any) => {
           if (part.type !== 'tool-invocation') {
-            return true;
+            return [part];
           }
 
-          return preserveToolCallIds.has(part.toolInvocation?.toolCallId ?? part.toolInvocation?.toolCall?.id);
+          const toolCallId = this.getToolCallId(part.toolInvocation);
+          if (toolCallId && preserveToolCallIds.has(toolCallId)) {
+            return [part];
+          }
+
+          const modelOutputPart = this.getPreservedModelOutputPart(part);
+          return modelOutputPart ? [modelOutputPart] : [];
         });
 
         if (nonToolParts.length === 0) {
@@ -192,7 +290,10 @@ export class ToolCallFilter implements Processor {
         const invocation = invocationPart.toolInvocation;
 
         if (this.exclude.includes(invocation.toolName)) {
-          excludedToolCallIds.add(invocation.toolCallId);
+          const toolCallId = this.getToolCallId(invocation);
+          if (toolCallId) {
+            excludedToolCallIds.add(toolCallId);
+          }
         }
       }
     }
@@ -211,31 +312,30 @@ export class ToolCallFilter implements Processor {
           return message;
         }
 
-        const filteredParts = message.content.parts.filter((part: any) => {
+        const filteredParts = message.content.parts.flatMap((part: any) => {
           if (part.type !== 'tool-invocation') {
-            return true;
+            return [part];
           }
 
           const invocationPart = part as unknown as V2ToolInvocationPart;
           const invocation = invocationPart.toolInvocation;
+          const toolCallId = this.getToolCallId(invocation);
 
-          if (preserveToolCallIds.has(invocation.toolCallId ?? (invocation as any).toolCall?.id)) {
-            return true;
+          if (toolCallId && preserveToolCallIds.has(toolCallId)) {
+            return [part];
           }
 
-          if (invocation.state === 'call' && this.exclude.includes(invocation.toolName)) {
-            return false;
+          const shouldExclude =
+            (invocation.state === 'call' && this.exclude.includes(invocation.toolName)) ||
+            (invocation.state === 'result' && toolCallId !== undefined && excludedToolCallIds.has(toolCallId)) ||
+            (invocation.state === 'result' && this.exclude.includes(invocation.toolName));
+
+          if (!shouldExclude) {
+            return [part];
           }
 
-          if (invocation.state === 'result' && excludedToolCallIds.has(invocation.toolCallId)) {
-            return false;
-          }
-
-          if (invocation.state === 'result' && this.exclude.includes(invocation.toolName)) {
-            return false;
-          }
-
-          return true;
+          const modelOutputPart = this.getPreservedModelOutputPart(invocationPart);
+          return modelOutputPart ? [modelOutputPart] : [];
         });
 
         if (filteredParts.length === 0) {
@@ -251,7 +351,8 @@ export class ToolCallFilter implements Processor {
         if (Array.isArray(originalToolInvocations)) {
           const filteredToolInvocations = originalToolInvocations.filter(
             (inv: any) =>
-              preserveToolCallIds.has(inv.toolCallId ?? inv.toolCall?.id) || !this.exclude.includes(inv.toolName),
+              preserveToolCallIds.has(inv.toolCallId ?? inv.toolCall?.id) ||
+              (!this.exclude.includes(inv.toolName) && !excludedToolCallIds.has(inv.toolCallId ?? inv.toolCall?.id)),
           );
           if (filteredToolInvocations.length > 0) {
             updatedContent.toolInvocations = filteredToolInvocations;


### PR DESCRIPTION
## Summary

Closes #16039.

Adds an opt-in `preserveModelOutput` mode to `ToolCallFilter` so filtered tool history can keep compact model-facing context from `providerMetadata.mastra.modelOutput` without retaining raw tool arguments or raw tool results.

Default behavior is unchanged. When enabled, only completed filtered tool results with stored `modelOutput` are converted into sanitized text parts for later model context.

## Changes

- Adds `preserveModelOutput` to `ToolCallFilterOptions`.
- Replaces eligible filtered tool-result parts with compact text derived from `providerMetadata.mastra.modelOutput`.
- Keeps raw tool calls, raw args, raw results, incomplete results, and results without `modelOutput` filtered out.
- Exposes the option through the `tool-call-filter` processor-provider config schema.
- Documents the option in the processors guide and ToolCallFilter reference.
- Adds tests for default behavior, global and per-tool filtering, `filterAfterToolSteps`, provider config, supported `modelOutput` shapes, and unstringifiable values.
- Adds a minor changeset for `@mastra/core`.

## Validation

- `pnpm --filter ./packages/core test src/processors/processors/tool-call-filter.test.ts`
- `pnpm --filter ./packages/core check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds an optional setting to ToolCallFilter so, instead of completely discarding certain tool results, it can keep a short, safe summary (the tool's "model-facing" output). It's like saving a tidy note of what a tool produced rather than the full messy data.

## Overview
Implements an opt-in preserveModelOutput feature for the ToolCallFilter processor that retains compact, model-facing projections (from providerMetadata.mastra.modelOutput) for completed tool results while still stripping raw tool payloads. Default behavior is unchanged.

## Key Changes

### Core Feature
- Adds preserveModelOutput?: boolean to ToolCallFilterOptions (defaults to false).
- When enabled, completed tool-result parts containing providerMetadata.mastra.modelOutput are converted to a sanitized text part ("<toolName> result:\n<text>") and preserved instead of being removed.
- Converts strings, primitives, arrays, and common object shapes to text with safe JSON fallback; drops modelOutput that cannot be stringified (e.g., circular structures).

### Behavior
- Only preserves completed results that include providerMetadata.mastra.modelOutput.
- Continues to filter out raw tool invocations, raw args, raw results, incomplete results, and results without modelOutput.
- Integrates with filterAfterToolSteps so older filtered history can retain compact projections while recent tool calls remain intact.
- Refactors internal logic to use a centralized tool-call ID extractor and flatMap to enable replacement or omission of parts.

### Config & API
- Exposes preserveModelOutput (and filterAfterToolSteps) through the tool-call-filter processor-provider Zod config schema.
- Exports new ToolCallFilterOptions type and updates constructor typing: constructor(options: ToolCallFilterOptions = {}).

### Docs & Tests
- Documentation updated in processors guide and ToolCallFilter reference with examples (new ToolCallFilter({ preserveModelOutput: true })).
- Adds tests covering default behavior, global and per-tool preservation, filterAfterToolSteps interactions, provider config wiring, supported modelOutput shapes, handling of unstringifiable values, and ensuring raw payloads remain excluded.

### Release
- Adds a changeset for a minor release bump of @mastra/core documenting the new option and usage example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->