### PR TITLE
fix(core): serialize workflow request context safely

### DIFF
--- a/.changeset/rare-kiwis-throw.md
+++ b/.changeset/rare-kiwis-throw.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workflow request context serialization to skip values that cannot be safely stored as JSON. Fixes #16043.

--- a/packages/core/src/workflows/default.test.ts
+++ b/packages/core/src/workflows/default.test.ts
@@ -608,6 +608,23 @@ describe('DefaultExecutionEngine.fmtReturnValue stepExecutionPath and payload de
 });
 
 describe('DefaultExecutionEngine.deserializeRequestContext', () => {
+  it('should produce JSON-safe serialized request context values', () => {
+    const engine = new TestableExecutionEngine({ mastra: undefined });
+    const requestContext = new RequestContext();
+    const circular: any = { name: 'service' };
+    circular.self = circular;
+
+    requestContext.set('userId', 'user-123');
+    requestContext.set('progressEmitter', () => undefined);
+    requestContext.set('service', circular);
+
+    const serialized = engine.serializeRequestContext(requestContext);
+
+    expect(() => JSON.stringify(requestContext.toJSON())).not.toThrow();
+    expect(() => JSON.stringify(serialized)).not.toThrow();
+    expect(serialized).toEqual({ userId: 'user-123' });
+  });
+
   it('should return a RequestContext instance with all entries from the plain object', () => {
     const engine = new TestableExecutionEngine({ mastra: undefined });
     const plainObj = { userId: 'user-123', tenantId: 'tenant-456', nested: { flag: true } };

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -615,11 +615,7 @@ export class DefaultExecutionEngine extends ExecutionEngine {
    * Used by durable execution engines to persist context across step replays.
    */
   serializeRequestContext(requestContext: RequestContext): Record<string, any> {
-    const obj: Record<string, any> = {};
-    requestContext.forEach((value, key) => {
-      obj[key] = value;
-    });
-    return obj;
+    return requestContext.toJSON();
   }
 
   /**


### PR DESCRIPTION
This makes workflow request context serialization use RequestContext.toJSON(), so request-scoped functions, circular objects, and other values that cannot be safely stored as JSON are filtered consistently before workflow persistence paths use the payload. Serializable values continue to round-trip through deserializeRequestContext as before.

Before, serializeRequestContext copied raw RequestContext entries and JSON.stringify could throw on circular values. After, it returns the same JSON-safe shape as RequestContext.toJSON().

Fixes https://github.com/mastra-ai/mastra/issues/16043

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When saving workflows, the system was trying to save things it shouldn't (like functions and circular objects) which caused crashes. This PR fixes it by using a method that automatically removes these unsafe things before saving, so workflows can be persisted without errors.

## Problem

The `serializeRequestContext()` function was copying raw `RequestContext` entries without filtering out non-JSON-serializable values such as functions, RPC proxies, and circular objects. This caused `JSON.stringify()` to throw errors when workflows attempted to persist request context through durable/persistence paths.

## Solution

Modified `serializeRequestContext()` to delegate to `RequestContext.toJSON()`, which already implements proper filtering of non-serializable values. This ensures consistent behavior between the two methods and prevents non-JSON-safe payloads from being persisted.

## Changes

- **packages/core/src/workflows/default.ts**: Updated `serializeRequestContext()` to call `requestContext.toJSON()` instead of manually iterating over `requestContext` entries (1 line changed, 5 lines removed)
- **packages/core/src/workflows/default.test.ts**: Added unit test validating that `serializeRequestContext()` produces JSON-safe output by verifying it strips functions and circular references while preserving valid string values
- **.changeset/rare-kiwis-throw.md**: Added Changesets entry documenting the patch-level fix for @mastra/core

## Impact

Workflow request context serialization now consistently filters values that cannot be safely stored as JSON, resolving failures in persistence workflows while maintaining backward compatibility for serializable values that continue to round-trip through deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->