### PR TITLE
fix(core): fail fast when token limiter removes all input

### DIFF
--- a/.changeset/two-nights-decide.md
+++ b/.changeset/two-nights-decide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed TokenLimiterProcessor failing silently when no input messages fit the token budget.

--- a/packages/core/src/processors/processors/token-limiter.test.ts
+++ b/packages/core/src/processors/processors/token-limiter.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { MastraDBMessage } from '../../agent/message-list';
 import { MessageList } from '../../agent/message-list';
+import { TripWire } from '../../agent/trip-wire';
 import type { IMastraLogger } from '../../logger';
 import { ProcessorRunner } from '../../processors/runner';
 import type { ChunkType } from '../../stream';
@@ -868,6 +869,54 @@ describe('TokenLimiterProcessor', () => {
           steps: [],
         }),
       ).rejects.toThrow('System messages alone exceed token limit');
+    });
+
+    it('should throw TripWire when no messages fit within the remaining token budget', async () => {
+      const processor = new TokenLimiterProcessor({ limit: 25 });
+      const messageList = new MessageList();
+
+      messageList.add(
+        {
+          id: 'user-1',
+          role: 'user',
+          content: { format: 2, content: 'Hello', parts: [{ type: 'text', text: 'Hello' }] },
+          createdAt: new Date('2023-01-01T00:00:00Z'),
+        },
+        'input',
+      );
+
+      try {
+        await processor.processInputStep({
+          messageList,
+          stepNumber: 1,
+          model: createMockModel(),
+          steps: [],
+          systemMessages: [],
+          state: {},
+          retryCount: 0,
+          abort: (() => {
+            throw new Error('aborted');
+          }) as any,
+        });
+        expect.fail('Expected TokenLimiterProcessor to throw a TripWire');
+      } catch (error) {
+        expect(error).toBeInstanceOf(TripWire);
+        expect(error).toHaveProperty(
+          'message',
+          'TokenLimiterProcessor: No messages fit within the remaining token budget. Cannot send LLM a request with no messages.',
+        );
+        expect((error as TripWire).options).toEqual({
+          retry: false,
+          metadata: {
+            systemTokens: 0,
+            limit: 25,
+            remainingBudget: 1,
+            messageCount: 1,
+          },
+        });
+      }
+
+      expect(messageList.get.all.db()).toHaveLength(1);
     });
 
     it('should handle tool call messages in token counting', async () => {

--- a/packages/core/src/processors/processors/token-limiter.ts
+++ b/packages/core/src/processors/processors/token-limiter.ts
@@ -36,7 +36,14 @@ export interface TokenLimiterOptions {
  * - Input processor: Filters historical messages to fit within context window, prioritizing recent messages
  * - Output processor: Limits generated response tokens via streaming (processOutputStream) or non-streaming (processOutputResult)
  */
-export class TokenLimiterProcessor implements Processor<'token-limiter', { systemTokens: number; limit: number }> {
+type TokenLimiterTripWireMetadata = {
+  systemTokens: number;
+  limit: number;
+  remainingBudget?: number;
+  messageCount?: number;
+};
+
+export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLimiterTripWireMetadata> {
   public readonly id = 'token-limiter';
   public readonly name = 'Token Limiter';
   private encoderPromise: Promise<Tiktoken> | undefined;
@@ -150,6 +157,16 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', { syste
         }
         // best-fit → continue (existing behavior)
       }
+    }
+
+    if (messagesToKeep.length === 0) {
+      throw new TripWire(
+        'TokenLimiterProcessor: No messages fit within the remaining token budget. Cannot send LLM a request with no messages.',
+        {
+          retry: false,
+          metadata: { systemTokens, limit, remainingBudget, messageCount: messages.length },
+        },
+      );
     }
 
     // Remove messages that don't fit within the token budget


### PR DESCRIPTION
TokenLimiterProcessor can currently trim every non-system input message when none fit the remaining budget. This changes that path to throw a non-retryable TripWire instead of silently sending an empty message list.

Fixes #16047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR fixes a bug where the token limiter processor could silently remove all conversation messages to fit within a token budget, leaving nothing for the AI model to respond to. Now, instead of letting this happen quietly, the processor throws an error to let you know immediately that the token budget is too small for any messages.

## Summary
Implements fail-fast behavior in `TokenLimiterProcessor` to prevent silent failures when the remaining token budget is insufficient to include any non-system input messages.

### Changes Made

**Core Implementation** (`packages/core/src/processors/processors/token-limiter.ts`):
- Added new exported type `TokenLimiterTripWireMetadata` with optional `remainingBudget` and `messageCount` fields to provide richer error context
- Updated `TokenLimiterProcessor` to throw a non-retryable `TripWire` when no messages can fit within the remaining token budget, preventing empty message lists from being sent to downstream LLM requests
- Enhanced error reporting to include budget-related metadata details

**Test Coverage** (`packages/core/src/processors/processors/token-limiter.test.ts`):
- Added comprehensive regression test for the edge case where the token budget excludes all input messages
- Test validates that `TripWire` is thrown with correct error message and structured metadata (`retry: false`, `remainingBudget`, `messageCount`)
- Confirms original message list is preserved after the throw

**Release Documentation** (`.changeset/two-nights-decide.md`):
- Created Changesets entry for `@mastra/core` patch release documenting the fix

### Impact
This change prevents a silent failure mode where TokenLimiterProcessor could produce an empty message list, ensuring explicit error handling instead of potentially confusing downstream failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->