### PR TITLE
fix(react): preserve data part ids in UI messages

### DIFF
--- a/.changeset/thin-crews-cut.md
+++ b/.changeset/thin-crews-cut.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Fixed custom data stream parts so stable ids are preserved in React UI messages.

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
@@ -2850,6 +2850,38 @@ describe('toUIMessage', () => {
       });
     });
 
+    it('should preserve the id when adding a data-* part to an existing assistant message', () => {
+      const chunk: ChunkType = {
+        type: 'data-progress',
+        id: 'progress-stable-id',
+        data: {
+          taskName: 'test-task',
+          progress: 50,
+        },
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+      } as any;
+
+      const existingMessage: MastraUIMessage = {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Processing...', state: 'streaming' }],
+        metadata: baseMetadata,
+      };
+
+      const result = toUIMessage({ chunk, conversation: [existingMessage], metadata: baseMetadata });
+      const dataPart = result[0].parts.find((p: any) => p.type === 'data-progress');
+
+      expect(dataPart).toMatchObject({
+        type: 'data-progress',
+        id: 'progress-stable-id',
+        data: {
+          taskName: 'test-task',
+          progress: 50,
+        },
+      });
+    });
+
     it('should handle multiple data-* chunks accumulating in the same message', () => {
       const chunk1: ChunkType = {
         type: 'data-progress',
@@ -2883,6 +2915,42 @@ describe('toUIMessage', () => {
       expect(dataParts.length).toBe(2);
       expect((dataParts[0] as any).data.progress).toBe(25);
       expect((dataParts[1] as any).data.progress).toBe(75);
+    });
+
+    it('should preserve stable ids across multiple data-* chunks', () => {
+      const chunk1: ChunkType = {
+        type: 'data-progress',
+        id: 'progress-stable-id',
+        data: { progress: 25 },
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+      } as any;
+
+      const chunk2: ChunkType = {
+        type: 'data-progress',
+        id: 'progress-stable-id',
+        data: { progress: 75 },
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+      } as any;
+
+      const existingMessage: MastraUIMessage = {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [],
+        metadata: baseMetadata,
+      };
+
+      let conversation: MastraUIMessage[] = [existingMessage];
+      conversation = toUIMessage({ chunk: chunk1, conversation, metadata: baseMetadata });
+      conversation = toUIMessage({ chunk: chunk2, conversation, metadata: baseMetadata });
+
+      const lastMessage = conversation[conversation.length - 1];
+      const dataParts = lastMessage.parts.filter((p: any) => p.type === 'data-progress');
+
+      expect(dataParts).toHaveLength(2);
+      expect(dataParts.map((part: any) => part.id)).toEqual(['progress-stable-id', 'progress-stable-id']);
+      expect(dataParts.map((part: any) => part.data.progress)).toEqual([25, 75]);
     });
 
     it('should handle data-* chunks with different types', () => {
@@ -2938,6 +3006,24 @@ describe('toUIMessage', () => {
       const dataPart = result[0].parts.find((p: any) => p.type === 'data-progress');
       expect(dataPart).toBeDefined();
       expect((dataPart as any).data.progress).toBe(50);
+    });
+
+    it('should preserve the id when creating a new assistant message for a data-* chunk', () => {
+      const chunk: ChunkType = {
+        type: 'data-progress',
+        id: 'new-message-stable-id',
+        data: { progress: 50 },
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+      } as any;
+
+      const result = toUIMessage({ chunk, conversation: [], metadata: baseMetadata });
+
+      expect(result[0].parts[0]).toMatchObject({
+        type: 'data-progress',
+        id: 'new-message-stable-id',
+        data: { progress: 50 },
+      });
     });
 
     it('should create new assistant message for data-* chunk when last message is user message', () => {

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts
@@ -136,18 +136,18 @@ export const toUIMessage = ({ chunk, conversation, metadata }: ToUIMessageArgs):
 
   // Handle data-* chunks (custom data chunks from writer.custom())
   if (chunk.type.startsWith('data-')) {
+    const dataPart = {
+      type: chunk.type as `data-${string}`,
+      data: 'data' in chunk ? chunk.data : undefined,
+      ...('id' in chunk && typeof chunk.id === 'string' ? { id: chunk.id } : {}),
+    };
     const lastMessage = result[result.length - 1];
     if (!lastMessage || lastMessage.role !== 'assistant') {
       // Create a new assistant message with the data part
       const newMessage: MastraUIMessage = {
         id: `data-${chunk.runId}-${Date.now()}`,
         role: 'assistant',
-        parts: [
-          {
-            type: chunk.type as `data-${string}`,
-            data: 'data' in chunk ? chunk.data : undefined,
-          },
-        ],
+        parts: [dataPart],
         metadata,
       };
       return [...result, newMessage];
@@ -156,13 +156,7 @@ export const toUIMessage = ({ chunk, conversation, metadata }: ToUIMessageArgs):
     // Add data part to existing assistant message
     const updatedMessage: MastraUIMessage = {
       ...lastMessage,
-      parts: [
-        ...lastMessage.parts,
-        {
-          type: chunk.type as `data-${string}`,
-          data: 'data' in chunk ? chunk.data : undefined,
-        },
-      ],
+      parts: [...lastMessage.parts, dataPart],
     };
     return [...result.slice(0, -1), updatedMessage];
   }


### PR DESCRIPTION
Fixes #16049.

Before, React UI message projection dropped stable ids from custom data stream parts.

```ts
{ type: "data-progress", data: { progress: 50 } }
```

After, data parts preserve the incoming id so clients can reconcile custom UI state in place.

```ts
{ type: "data-progress", id: "progress-stable-id", data: { progress: 50 } }
```

Validated with `pnpm --filter ./client-sdks/react test:unit src/lib/ai-sdk/utils/toUIMessage.test.ts`, `pnpm --filter ./client-sdks/react lint`, and `pnpm --filter ./client-sdks/react build:js`.

Issue: https://github.com/mastra-ai/mastra/issues/16049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Think of it like labels on packages: when data flows through the system as a stream, each piece of data has a label (ID) attached to it. The old code was throwing away those labels when it converted the data into UI parts, making it hard to keep track of which piece of data updates which UI element. This PR makes sure the labels stay attached throughout the conversion, so the UI can properly update things in the right place.

## Changes

### 1. Changesets metadata (`.changeset/thin-crews-cut.md`)
Added a patch version bump entry for `@mastra/react` documenting the fix to preserve stable IDs in React UI messages.

### 2. Core fix (`client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts`)
Updated the `toUIMessage()` function to preserve the optional `id` field from incoming `data-*` stream chunks:
- Refactored the data-part construction to build a reusable `dataPart` object containing the computed `type`, conditional `data`, and optional `id` derived from `chunk.id`
- Applied this approach to both code paths: creating a new assistant message and appending to an existing one
- Net effect: reduced duplication and ensured IDs flow through to the projected UI message parts

### 3. Regression tests (`client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts`)
Added comprehensive test coverage for ID preservation across three scenarios:
- **Existing assistant message**: Verifies that adding a `data-progress` part to an existing assistant message retains the chunk's `id`
- **Repeated data part IDs**: Confirms that multiple `data-*` chunks with the same stable `id` both preserve that `id` while keeping their individual `data` fields (e.g., different progress values)
- **New assistant message**: Ensures that when creating a new assistant message from an empty conversation, the newly created `data-progress` part retains the provided stable `id`

## Impact

Clients using the React SDK can now reliably use stable IDs to reconcile and update custom UI parts in place, eliminating the risk of duplicates or unstable UI state changes when handling stream-based data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->