### PR TITLE
fix(core): preserve streamed message part order

### DIFF
--- a/.changeset/every-dragons-report.md
+++ b/.changeset/every-dragons-report.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed persisted message part ordering for streams with reasoning and tool calls.

--- a/packages/core/__recordings__/core-src-agent-__tests__-message-part-ordering.e2e.json
+++ b/packages/core/__recordings__/core-src-agent-__tests__-message-part-ordering.e2e.json
@@ -1,0 +1,312 @@
+{
+  "meta": {
+    "name": "core-src-agent-__tests__-message-part-ordering.e2e",
+    "testFile": "src/agent/__tests__/message-part-ordering.e2e.test.ts",
+    "model": "gpt-5.4",
+    "createdAt": "2026-04-30T21:08:30.900Z"
+  },
+  "recordings": [
+    {
+      "hash": "6aec207ff90ca3dd",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-5.4",
+          "input": [
+            {
+              "role": "developer",
+              "content": "You are a careful code investigator. When the user asks a single question that requires multiple lookups, gather all the information you need IN PARALLEL in one batch: call readFile AND grepFiles simultaneously in a single step. After the tool results come back, write a one-sentence summary."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "In ONE batch, in parallel, call readFile on src/a.ts AND grepFiles for `export const value` over **/*.ts. Then summarize in one sentence."
+                }
+              ]
+            }
+          ],
+          "include": ["reasoning.encrypted_content"],
+          "reasoning": {
+            "effort": "medium",
+            "summary": "detailed"
+          },
+          "tools": [
+            {
+              "type": "function",
+              "name": "readFile",
+              "description": "Read the contents of a file at the given path.",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "Absolute or repo-relative file path to read."
+                  }
+                },
+                "required": ["path"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "grepFiles",
+              "description": "Search files matching a glob for a regex pattern.",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "pattern": {
+                    "type": "string",
+                    "description": "Regex pattern to search for."
+                  },
+                  "glob": {
+                    "type": "string",
+                    "description": "Glob of files to search, e.g. **/*.ts."
+                  }
+                },
+                "required": ["pattern", "glob"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1777583305347
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9f49858b39abdd1e-ATL",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Thu, 30 Apr 2026 21:08:25 GMT",
+          "openai-organization": "work-kxidzh",
+          "openai-processing-ms": "427",
+          "openai-project": "proj_FCyHAyf1sRhVrYbrkAklMIPx",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "500",
+          "x-ratelimit-limit-tokens": "500000",
+          "x-ratelimit-remaining-requests": "499",
+          "x-ratelimit-remaining-tokens": "499348",
+          "x-ratelimit-reset-requests": "120ms",
+          "x-ratelimit-reset-tokens": "78ms",
+          "x-request-id": "req_7c69545e5ec94da4a5625a6f7d26e2fb"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0b779ee3085804690069f3c4c98b048190b67831689adfa3fa\",\"object\":\"response\",\"created_at\":1777583305,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_det",
+          "ails\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-2026-03-05\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"in_memory\",\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Read the contents of a file at the given path.\",\"name\":\"readFile\",\"parameters\":{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\",\"description\":\"Absolute or repo-relative file path to read.\"}},\"required\":[\"path\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Search files matching a glob for a regex pattern.\",\"name\":\"grepFiles\",\"parameters\":{\"type\":\"object\",\"properties\":{\"pattern\":{\"type\":\"string\",\"description\":\"Regex pattern to search for.\"},\"glob\":{\"type\":\"string\",\"description\":\"Glob of files to search, e.g. **/*.ts.\"}},\"required\":[\"pattern\",\"glob\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\nevent: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp",
+          "_0b779ee3085804690069f3c4c98b048190b67831689adfa3fa\",\"object\":\"response\",\"created_at\":1777583305,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-2026-03-05\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"in_memory\",\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Read the contents of a file at the given path.\",\"name\":\"readFile\",\"parameters\":{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\",\"description\":\"Absolute or repo-relative file path to read.\"}},\"required\":[\"path\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Search files matching a glob for a regex pattern.\",\"name\":\"grepFiles\",\"parameters\":{\"type\":\"object\",\"properties\":{\"pattern\":{\"type\":\"string\",\"description\":\"Regex pattern to search for.\"},\"glob\":{\"type\":\"string\",\"description\":\"Glob of files to search, e.g. **/*.ts.\"}},\"required\":[\"pattern\",\"glob\"],\"additionalProperties\":false},\"strict\"",
+          ":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"rs_0b779ee3085804690069f3c4ca2b148190805e3e8f6537ad1a\",\"type\":\"reasoning\",\"encrypted_content\":\"gAAAAABp88TKs4tVEl7Xag8lSd4FVRUk_64y0oq_vfTo0FwIf2T-aghbfIAv254eMWaw86H0h8d8MS-z1mgbda0oIkWTqiA8WhzjF98h4xIPSrYtTXif6up_m1QJ-x7_v1vyCGt8ZQ4D1A-VUbV1fue00N3KfCqHINeEigN0FsdlRKzAPMIZ_qzx4e5UCNL4s393HMbGGD6pvfFbHgH2VysbYA7ougRWYF8mTw3eIP_EXrgca0HeEjWRsTAq1GAlEX0O2CkjtDrvf2JQlbTlf2acchOqxf5LYYXGYAWnYwJj7vixqhvOH7-6T9aHqrFlz7cJ1mqrYvVExyPF9cs1D4_Uclv95TEs8vng5bu_IFZCbZ_cr0mG4BDMg1GOg0_gh1o_d-lQ_7-ykgxQHScs7kf1auRGfcZkLpFx9xUpi1D3wH0IYKBHT17Cn5OlNAeNozyejFUUvv2JxUpTyyyzZ9E-AK9xlUr0Zakxms08Z_yjZGGUCoif8j5BH1P0S7p0yn5Ah9xBnS9HoJxp9_jb658qkrjvPkub6cFGcHNe1dcmNe3dM8ZSJmmmC7rwztEzz_ssClTUDAYSJafAZXYonM7K-SIDnrMI2C45jt6OUunTxIBQ-3Sk8pXAjlBE0Kly8HbxyaZKisSXOOErWaaqeo0dDD7YsoMNPcFNYHtL_y7aojz_fo5lJMTfKoQTiFfooeYJoUpmOakOVE5nmTKgMUQaBwLNn4HUwZV1rFO_n60jFDj9upYeawNfZ1ClhiWFReqQnaETDO6RaSVWDU6bxvZelqx0hR-Qf5af6cLI7FYpXIEBna7-ZRDtJdNgrdo0ZIsWffR-otoc2Df8_AhT7AzNGezs2kLLOxzt4xO40GMH73eXLboUh3FGULr1ZhUsKgnf2VcfbgY3huFkIr1EOiKx4V8E-BrAfw==\",\"summary\":[]},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"rs_0b779ee3085804690069f3c4ca2b148190805e3e8f6537ad1a\",\"type\":\"reasoning\",\"encrypted_content\":\"gAAAAABp88TMnwHNaobU8fpPrzrsVmBPefdqwZx0El1dVPFbgGXuQCdpsgCyc-RZfLF5mOLH1fTX2T5TLAvWIzaN9s4gdmIAgOI5JKXn1cTRfTy8xfj3phd1vW5N74dKV38NfuoN0Yd_sg8ioIGf0RkBHh6xoeX8xwH1i7CjLndyROtTtWH0Mn_EFLKD1klILBkq1HROVEgSnv2VDN8lTq68pS9y8BSTaLkKddyTLc6Xmmgvxv0IKIwLNjkuqhSnCKLFtadAnfyB4bvq6NJReuIIQbDuUcjIVMOLfeaLUQBvhTH9fkk-yIHOOe_pTAmOJctv6LCZ1QjLrAUp35jV7soxyjyTceeX4P6xLDb77I_h80dEOjgaIUFY45ke6re1hOCu_1OKyspKS_Brlr2cxtWuqZWQt2AXr4GEUvsB9FrzpsmqPNTF4gz4KsgPWLhj2o8l9HojsDTCRckk8P9rBsAltefBV3TzJt_4wKigF87MlEnsC7a5l82Bugy4sEVGOPOzwF0ZxisEG0Bd-wAwLxJhJzJHzDsWqSv8QQfoRfomxVs1gODylJzleTuwmk51H__PshcGTKPnF5sfxd7Wg-R0Wm9ofnDnxTOzgqTrn1RQY-LMhAmQUVlIXEbuxyLoyaA-Hf9JY_rs234te6L_711XN-gWbsyQ2E-UOlDAkiGke79jT5M3VoDX9o9zDbJ7tkahshBqSHCKy1_mMPjSJ8f65PW2l-kuu_FyXFmY6guhkqHewH-E6cmXQ8gS8Hudlxx86ul9wSEOd0Xp0mfiVk8L-8WMqvDtv4aXpK3WmBfr2SM1T9Gdc5ukHUpIKMKwmtsaVSkJOG6mWUlcXrouQ_0H5CCrcNCDT-hfytJJsLTP9z_Qfk8Xs-oDSlQX9U75M6Ko0Af6vQzRrEmEMimmsTimqm2W911Aim809THnjcEDKVT9yVPDBcSv-QRH5j-YtLBSopInHqZq1NiZBdNWMokBYKZPXMmT6Mlpe_GMdX-S-Ua6MMSMWNq6cgxicfILzYLjDPbALLWKABVkrbEaM2aMi-WRW88OUz43LMyndcuqeOOFPQNgrc4PKp3b6b9RMRjXkwu2IrZo0JOM_sw4nvY6klr3CJpQfxysfx-1WeSyQhJ3rjYkphvZyTboOOcYnJKbxaHcDto9mfLFz3SI3Ez6BKPH",
+          "4WVSTA==\",\"summary\":[]},\"output_index\":0,\"sequence_number\":3}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0b779ee3085804690069f3c4ccb5188190998f16fe31d9290b\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_on8QhJXxh0Gn9qvTB5q19sBu\",\"name\":\"readFile\"},\"output_index\":1,\"sequence_number\":4}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"path\\\":\\\"src/a.ts\\\"}\",\"item_id\":\"fc_0b779ee3085804690069f3c4ccb5188190998f16fe31d9290b\",\"obfuscation\":\"0UcjyDMnOV7Em\",\"output_index\":1,\"sequence_number\":5}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"path\\\":\\\"src/a.ts\\\"}\",\"item_id\":\"fc_0b779ee3085804690069f3c4ccb5188190998f16fe31d9290b\",\"output_index\":1,\"sequence_number\":6}\n\n",
+          "event: response.output_item",
+          ".done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0b779ee3085804690069f3c4ccb5188190998f16fe31d9290b\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"path\\\":\\\"src/a.ts\\\"}\",\"call_id\":\"call_on8QhJXxh0Gn9qvTB5q19sBu\",\"name\":\"readFile\"},\"output_index\":1,\"sequence_number\":7}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0b779ee3085804690069f3c4ccb5288190a9ed6ca60d4611e7\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_lZrY62BcPXOZUofGjWpU6WQl\",\"name\":\"grepFiles\"},\"output_index\":2,\"sequence_number\":8}\n\nevent: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"pattern\\\":\\\"export const value\\\",\\\"glob\\\":\\\"**/*.ts\\\"}\",\"item_id\":\"fc_0b779ee3085804690069f3c4ccb5288190a9ed6ca60d4611e7\",\"obfuscation\":\"t7ElSYINTxggv6T\",\"output_index\":2,\"sequence_number\":9}\n\nevent: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"pattern\\\":\\\"export const value\\\",\\\"glob\\\":\\\"**/*.ts\\\"}\",\"item_id\":\"fc_0b779ee3085804690069f3c4ccb5288190a9ed6ca60d4611e7\",\"output_index\":2,\"sequence_number\":10}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0b779ee3085804690069f3c4ccb5288190a9ed6ca60d4611e7\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"pattern\\\":\\\"export const value\\\",\\\"glob\\\":\\\"**/*.ts\\\"}\",\"call_id\":\"call_lZrY62BcPXOZUofGjWpU6WQl\",\"name\":\"grepFiles\"},\"output_index\":2,\"sequence_number\":11}\n\n",
+          "event: response.completed\nd",
+          "ata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0b779ee3085804690069f3c4c98b048190b67831689adfa3fa\",\"object\":\"response\",\"created_at\":1777583305,\"status\":\"completed\",\"background\":false,\"completed_at\":1777583308,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-2026-03-05\",\"moderation\":null,\"output\":[{\"id\":\"rs_0b779ee3085804690069f3c4ca2b148190805e3e8f6537ad1a\",\"type\":\"reasoning\",\"encrypted_content\":\"gAAAAABp88TMUF6FWoo0wxkuslO6zfl_Th3_t_vZzGJys3BZPmABfEkUt4HmooyYQ6YPnwCxAsEc31byQ00_LNSdB_cLZZgNbKJPVHWLBl8U5fYNIsZ6ZcFwbROFgbOR7CPK8GlRm8k5KBijMuIwfMjxkyxSnXBjaH0Iypsw2vS989BnD46dhNVkDFukvsY-OICMQ1NOHxW4JIJ6u_D2BC8JegL2DwpaQo7PwHjEHdP-fdbuZ3Dh7Uh_REIboJ3u89ANQ_2neg4c-5TeofjepAP7iKHwBSiPIhBPimSGzX2m14o2H1wqyvr5xU1n_GvkCl9_IHVgNBo99OQzyyMASrZewkbAFa7OsKAnWt_05Ui4okTp3G0MLIviHykiRC0YZZBoceDetQpFqkQzhSwzwAp-yVo9v7oSND_ZBG_wkUt-aY_UINYC_1acsjawhdAOuGnSd2Zz7XLRNf9HVHoEk71opiO7h9M3J9FZOHDrdmM-hCCWRvzfq7mcazSpaikVbbB_nZk0GCWkzipnIe5cZaQZEBwTvCOSv6yXX1Zukos6AZXS294D_bcedib4DPuqcvPQQLSBnV3UehgzK_-KTDw9g4APCExmQKi_vUNTJmnOx2kePQ9UDdLV3sDDGESWqB02PH2mOOdPhjeTErHvjZCjDbzXmlTEtEkaOx5YcvEuEZgQUUs1OlYtK3jnH-9k2cnTsJdDOFW35lhOQDyo6zgfDfjdrwpN53tXsmWrU8LN89KVLhBvzCfU4lnFwyqTRAYIat9aPeAK69jLGNgTNsCbqxnP6YZQoCGvkDGoL88Tpjfs8oKfsJdrv-BVfOaTXoS7-UXajchO8LEcjt8Jftha",
+          "bLMxpWyy0syq8LShHaAU8ppFSu5mQti3-5JXJTgZx11MNCUBxUBmfcMieOmeaT0uAJ5hEDaIhxZu7zNawMqi-rh0CYCf5A8bXIsgCgkhvCbFYUVk3WofQ3-kJrBxj0QvsiS_NVTsv6R4JWXRWZsNp97CRG2QKc0bTbrxboM2YAruvJU6gy8cFRqZtZhCeJbe9WaTal2Rwp8DuQ9kQKWDwEgQkMDYTZtVM8774z2oJM9fvFIdRwU9dg-o7Kyd6O3blT4XIvkax4kSkJcxfdLHC107YgaS_LWPnjMpRxwZ6lEMapVozHQarH6LzNkMaK88dW-HTTnqOg==\",\"summary\":[]},{\"id\":\"fc_0b779ee3085804690069f3c4ccb5188190998f16fe31d9290b\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"path\\\":\\\"src/a.ts\\\"}\",\"call_id\":\"call_on8QhJXxh0Gn9qvTB5q19sBu\",\"name\":\"readFile\"},{\"id\":\"fc_0b779ee3085804690069f3c4ccb5288190a9ed6ca60d4611e7\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"pattern\\\":\\\"export const value\\\",\\\"glob\\\":\\\"**/*.ts\\\"}\",\"call_id\":\"call_lZrY62BcPXOZUofGjWpU6WQl\",\"name\":\"grepFiles\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"in_memory\",\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Read the contents of a file at the given path.\",\"name\":\"readFile\",\"parameters\":{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\",\"description\":\"Absolute or repo-relative file pat",
+          "h to read.\"}},\"required\":[\"path\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Search files matching a glob for a regex pattern.\",\"name\":\"grepFiles\",\"parameters\":{\"type\":\"object\",\"properties\":{\"pattern\":{\"type\":\"string\",\"description\":\"Regex pattern to search for.\"},\"glob\":{\"type\":\"string\",\"description\":\"Glob of files to search, e.g. **/*.ts.\"}},\"required\":[\"pattern\",\"glob\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":203,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":102,\"output_tokens_details\":{\"reasoning_tokens\":41},\"total_tokens\":305},\"user\":null,\"metadata\":{}},\"sequence_number\":12}\n\n"
+        ],
+        "chunkTimings": [1, 0, 0, 1, 196, 2544, 1, 1, 3, 5, 0, 55, 138, 0, 0, 0],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "16ddbf6fb820ab7e",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-5.4",
+          "input": [
+            {
+              "role": "developer",
+              "content": "You are a careful code investigator. When the user asks a single question that requires multiple lookups, gather all the information you need IN PARALLEL in one batch: call readFile AND grepFiles simultaneously in a single step. After the tool results come back, write a one-sentence summary."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "In ONE batch, in parallel, call readFile on src/a.ts AND grepFiles for `export const value` over **/*.ts. Then summarize in one sentence."
+                }
+              ]
+            },
+            {
+              "type": "item_reference",
+              "id": "rs_0b779ee3085804690069f3c4ca2b148190805e3e8f6537ad1a"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_0b779ee3085804690069f3c4ccb5188190998f16fe31d9290b"
+            },
+            {
+              "type": "item_reference",
+              "id": "fc_0b779ee3085804690069f3c4ccb5288190a9ed6ca60d4611e7"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_on8QhJXxh0Gn9qvTB5q19sBu",
+              "output": "{\"path\":\"src/a.ts\",\"contents\":\"// stub contents of src/a.ts\\nexport const value = 42;\\n\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_lZrY62BcPXOZUofGjWpU6WQl",
+              "output": "{\"pattern\":\"export const value\",\"glob\":\"**/*.ts\",\"matches\":[{\"path\":\"src/a.ts\",\"line\":12,\"text\":\"// matched export const value\"},{\"path\":\"src/b.ts\",\"line\":7,\"text\":\"// matched export const value\"}]}"
+            }
+          ],
+          "include": ["reasoning.encrypted_content"],
+          "reasoning": {
+            "effort": "medium",
+            "summary": "detailed"
+          },
+          "tools": [
+            {
+              "type": "function",
+              "name": "readFile",
+              "description": "Read the contents of a file at the given path.",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "Absolute or repo-relative file path to read."
+                  }
+                },
+                "required": ["path"],
+                "additionalProperties": false
+              }
+            },
+            {
+              "type": "function",
+              "name": "grepFiles",
+              "description": "Search files matching a glob for a regex pattern.",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "pattern": {
+                    "type": "string",
+                    "description": "Regex pattern to search for."
+                  },
+                  "glob": {
+                    "type": "string",
+                    "description": "Glob of files to search, e.g. **/*.ts."
+                  }
+                },
+                "required": ["pattern", "glob"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1777583308968
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "9f4985a17a0bdd1e-ATL",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Thu, 30 Apr 2026 21:08:29 GMT",
+          "openai-organization": "work-kxidzh",
+          "openai-processing-ms": "540",
+          "openai-project": "proj_FCyHAyf1sRhVrYbrkAklMIPx",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "500",
+          "x-ratelimit-limit-tokens": "500000",
+          "x-ratelimit-remaining-requests": "499",
+          "x-ratelimit-remaining-tokens": "499146",
+          "x-ratelimit-reset-requests": "120ms",
+          "x-ratelimit-reset-tokens": "102ms",
+          "x-request-id": "req_928d8d55cff04d67a3b9817a0fee3b85"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0b779ee3085804690069f3c4cd1c58819096a64011c83079f5\",\"object\":\"response\",\"created_at\":1777583309,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_de",
+          "tails\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-2026-03-05\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"in_memory\",\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Read the contents of a file at the given path.\",\"name\":\"readFile\",\"parameters\":{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\",\"description\":\"Absolute or repo-relative file path to read.\"}},\"required\":[\"path\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Search files matching a glob for a regex pattern.\",\"name\":\"grepFiles\",\"parameters\":{\"type\":\"object\",\"properties\":{\"pattern\":{\"type\":\"string\",\"description\":\"Regex pattern to search for.\"},\"glob\":{\"type\":\"string\",\"description\":\"Glob of files to search, e.g. **/*.ts.\"}},\"required\":[\"pattern\",\"glob\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\nevent: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"res",
+          "p_0b779ee3085804690069f3c4cd1c58819096a64011c83079f5\",\"object\":\"response\",\"created_at\":1777583309,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-2026-03-05\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"in_memory\",\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Read the contents of a file at the given path.\",\"name\":\"readFile\",\"parameters\":{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\",\"description\":\"Absolute or repo-relative file path to read.\"}},\"required\":[\"path\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Search files matching a glob for a regex pattern.\",\"name\":\"grepFiles\",\"parameters\":{\"type\":\"object\",\"properties\":{\"pattern\":{\"type\":\"string\",\"description\":\"Regex pattern to search for.\"},\"glob\":{\"type\":\"string\",\"description\":\"Glob of files to search, e.g. **/*.ts.\"}},\"required\":[\"pattern\",\"glob\"],\"additionalProperties\":false},\"strict",
+          "\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text",
+          ".delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"`\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"Ut65fInk5dYafTl\",\"output_index\":0,\"sequence_number\":4}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"src\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"Xp5sqEaMe1gST\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"/a\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"wI8UbYBT1LjmwD\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".ts\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"YLCJ2aS2Wxi5h\",\"output_index\":0,\"sequence_number\":7}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"`\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"lDS1Le4YwgRsHQi\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" contains\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"u1rtcSk\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" `\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"X6NiohKlZbdp3m\",\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"export\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"8m40JQXTTV\",\"output_index\":0,\"sequence_number\":11}\n\n",
+          "event: response.output_text",
+          ".delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" const\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"54Nat379PR\",\"output_index\":0,\"sequence_number\":12}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" value\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"BaSbUJUoDd\",\"output_index\":0,\"sequence_number\":13}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" =\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"S3s0941uPsHcd3\",\"output_index\":0,\"sequence_number\":14}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" \",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"dlIOOrg8vBvxUIS\",\"output_index\":0,\"sequence_number\":15}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"42\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"LunESNDg8giUh8\",\"output_index\":0,\"sequence_number\":16}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\";\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"iN3YX2eO5jSdAJD\",\"output_index\":0,\"sequence_number\":17}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"`,\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"HmTdo6zGIibm03\",\"output_index\":0,\"sequence_number\":18}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" and\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"0HvBpC9BgBDB\",\"output_index\":0,\"sequence_number\":19}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" searching\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"vHW0qQ\",\"output_index\":0,\"sequence_number\":20}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" `\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"lBiIoSwnwtaqq6\",\"output_index\":0,\"sequence_number\":21}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"bnaU91v8Bt5ah1\",\"output_index\":0,\"sequence_number\":22}\n\n",
+          "event: response.output_text",
+          ".delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"/*.\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"4IMCvEVtIx9wf\",\"output_index\":0,\"sequence_number\":23}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"ts\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"5Bc2sggR3RvrnW\",\"output_index\":0,\"sequence_number\":24}\n\n",
+          "event: response.output_text",
+          ".delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"`\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"c617FmS9zzaSIGZ\",\"output_index\":0,\"sequence_number\":25}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" for\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"W608jyAXMojK\",\"output_index\":0,\"sequence_number\":26}\n\n",
+          "event: response.output_text",
+          ".delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" `\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"VE1j6FffjZcPL6\",\"output_index\":0,\"sequence_number\":27}\n\n",
+          "event: response.output_text",
+          ".delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"export\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"KgAAqwluZ7\",\"output_index\":0,\"sequence_number\":28}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" const\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"Xc9kMiILTK\",\"output_index\":0,\"sequence_number\":29}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" value\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"S1T0fI4GOO\",\"output_index\":0,\"sequence_number\":30}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"`\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"1wIWGhLgGUgUs6R\",\"output_index\":0,\"sequence_number\":31}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" found\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"7e27bLLQoF\",\"output_index\":0,\"sequence_number\":32}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" matches\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"n1SWnSKT\",\"output_index\":0,\"sequence_number\":33}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" in\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"mrgzyZtTWHbZf\",\"output_index\":0,\"sequence_number\":34}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" `\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"TNpH6r0qYQztDx\",\"output_index\":0,\"sequence_number\":35}\n\n",
+          "event: response.output_text",
+          ".delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"src\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"VLpwD6tbuVi6j\",\"output_index\":0,\"sequence_number\":36}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"/a\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"7La1zOQ2F1n01A\",\"output_index\":0,\"sequence_number\":37}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".ts\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"qEV4kVvZWADjj\",\"output_index\":0,\"sequence_number\":38}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"`\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"SUuE0P08Rd2BUIZ\",\"output_index\":0,\"sequence_number\":39}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" and\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"WXm4QJdJCc3m\",\"output_index\":0,\"sequence_number\":40}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" `\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"iN4zL5yFj0FeJR\",\"output_index\":0,\"sequence_number\":41}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"src\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"swetKQEtFTUZU\",\"output_index\":0,\"sequence_number\":42}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"/b\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"Gh2Qgf4xlryaVE\",\"output_index\":0,\"sequence_number\":43}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".ts\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"l1tkPULiL60XM\",\"output_index\":0,\"sequence_number\":44}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"`.\",\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"obfuscation\":\"TqJ4NbDLZQ82r5\",\"output_index\":0,\"sequence_number\":45}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":46,\"text\":\"`src/a.ts` contains `export const value = 42;`, and searching `**/*.ts` for `export const value` found matches in `src/a.ts` and `src/b.ts`.\"}\n\n",
+          "event: response.content_par",
+          "t.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"`src/a.ts` contains `export const value = 42;`, and searching `**/*.ts` for `export const value` found matches in `src/a.ts` and `src/b.ts`.\"},\"sequence_number\":47}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"`src/a.ts` contains `export const value = 42;`, and searching `**/*.ts` for `export const value` found matches in `src/a.ts` and `src/b.ts`.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":48}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0b779ee3085804690069f3c4cd1c58819096a64011c83079f5\",\"object\":\"response\",\"created_at\":1777583309,\"status\":\"completed\",\"background\":false,\"completed_at\":1777583310,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-2026-03-05\",\"moderation\":null,\"output\":[{\"id\":\"msg_0b779ee3085804690069f3c4cde0d08190bcfae2fa231624dc\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"`src/a.ts` contains `export const value = 42;`, and searching `**/*.ts` for `export const value` found matches in `src/a.ts` and `src/b.ts`.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"in_memory\",\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"description\":\"Read the contents of a file at the given path.\",\"name\":\"readFile\",\"parameters\":{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\",\"description\":\"Absolute or repo-relative file path to read.\"}},\"required\":[\"path\"],\"additionalProperties\":false},\"strict\":true},{\"type\":\"function\",\"description\":\"Search files matching a glob for a regex pattern.\",\"name\":\"grepFiles\",\"parameters\":{\"type\":\"object\",\"properties\":{\"pattern\":{\"type\":\"string\",\"description\":\"Regex pattern to search for.\"},\"glob\":{\"type\":\"string\",\"description\":\"Glob of files to search, e.g. **/*.ts.\"}},\"required\":[\"pattern\",\"glob\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":405,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":46,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":451},\"user\":null,\"metadata\":{}},\"sequence_number\":49}\n\n"
+        ],
+        "chunkTimings": [
+          0, 0, 1, 0, 250, 0, 1, 0, 31, 6, 4, 1, 35, 2, 0, 1, 0, 41, 0, 0, 90, 0, 2, 2, 0, 41, 1, 6, 0, 1, 0, 1, 0, 2,
+          1, 71, 3, 1, 80, 5, 0, 1, 2, 1, 0, 38, 4, 2, 2, 0, 106, 13, 0, 0, 124
+        ],
+        "isStreaming": true
+      }
+    }
+  ]
+}

--- a/packages/core/src/agent/__tests__/message-part-ordering.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/message-part-ordering.e2e.test.ts
@@ -1,0 +1,173 @@
+/**
+ * E2E reproduction for issue #16007:
+ *   "Message persistence ordering issue"
+ *
+ * When a reasoning model (e.g. gpt-5) emits chunks that interleave reasoning
+ * and tool-calls — i.e. `reasoning-start` → `reasoning-delta` → `tool-call`
+ * → `reasoning-end` → `text` — `buildMessagesFromChunks` flushes the
+ * tool-invocation part to the saved DB message immediately while it only
+ * pushes the reasoning part on `reasoning-end`. The result is that the
+ * persisted message has its parts re-ordered relative to the live stream:
+ *
+ *   live:  reasoning, tool-call, ..., reasoning, text
+ *   saved: tool-call, ..., reasoning, reasoning, text   ← BUG
+ *
+ * This test drives a real OpenAI reasoning model with tools and asserts that
+ * the order of parts saved to memory matches the order they appeared in the
+ * live `fullStream`. The test is recorded via `createGatewayMock`, so it can
+ * run offline against the checked-in recording.
+ */
+import { createOpenAI as createOpenAIV6 } from '@ai-sdk/openai-v6';
+import { getLLMTestMode } from '@internal/llm-recorder';
+import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
+import { config } from 'dotenv';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { MockMemory } from '../../memory/mock';
+import { createTool } from '../../tools';
+import { Agent } from '../agent';
+
+config();
+
+const MODE = getLLMTestMode();
+setupDummyApiKeys(MODE, ['openai']);
+
+const mock = createGatewayMock();
+const openai_v6 = createOpenAIV6({ apiKey: process.env.OPENAI_API_KEY });
+
+beforeAll(() => mock.start());
+afterAll(() => mock.saveAndStop());
+
+type PartKind = 'reasoning' | 'tool-call' | 'text';
+
+const readFile = createTool({
+  id: 'readFile',
+  description: 'Read the contents of a file at the given path.',
+  inputSchema: z.object({
+    path: z.string().describe('Absolute or repo-relative file path to read.'),
+  }),
+  execute: async ({ path }) => {
+    return {
+      path,
+      contents: `// stub contents of ${path}\nexport const value = 42;\n`,
+    };
+  },
+});
+
+const grepFiles = createTool({
+  id: 'grepFiles',
+  description: 'Search files matching a glob for a regex pattern.',
+  inputSchema: z.object({
+    pattern: z.string().describe('Regex pattern to search for.'),
+    glob: z.string().describe('Glob of files to search, e.g. **/*.ts.'),
+  }),
+  execute: async ({ pattern, glob }) => {
+    return {
+      pattern,
+      glob,
+      matches: [
+        { path: 'src/a.ts', line: 12, text: `// matched ${pattern}` },
+        { path: 'src/b.ts', line: 7, text: `// matched ${pattern}` },
+      ],
+    };
+  },
+});
+
+describe('issue #16007: persisted part order should match live stream order (e2e)', { timeout: 120_000 }, () => {
+  it('persists reasoning/tool-call/text parts in the same order they streamed', async () => {
+    const memory = new MockMemory();
+
+    const agent = new Agent({
+      id: 'issue-16007-agent',
+      name: 'Issue 16007 Agent',
+      instructions: [
+        'You are a careful code investigator. When the user asks a single question that requires',
+        'multiple lookups, gather all the information you need IN PARALLEL in one batch:',
+        'call readFile AND grepFiles simultaneously in a single step. After the tool results come',
+        'back, write a one-sentence summary.',
+      ].join(' '),
+      model: openai_v6('gpt-5.4'),
+      memory,
+      tools: { readFile, grepFiles },
+    });
+
+    const threadId = 'issue-16007-thread';
+    const resourceId = 'issue-16007-resource';
+
+    const response = await agent.stream(
+      [
+        'In ONE batch, in parallel, call readFile on src/a.ts AND grepFiles for `export const value` over **/*.ts.',
+        'Then summarize in one sentence.',
+      ].join(' '),
+      {
+        memory: { thread: threadId, resource: resourceId },
+        providerOptions: {
+          openai: {
+            reasoningEffort: 'medium',
+            reasoningSummary: 'detailed',
+            include: ['reasoning.encrypted_content'],
+          } as any,
+        },
+      },
+    );
+
+    // Capture the live stream order. We track BOTH start and end timing for
+    // reasoning/text spans so we can prove whether a span's *close* occurs
+    // after an intervening tool-call — which is the precise condition that
+    // triggers the reordering bug in `buildMessagesFromChunks`.
+    const liveOrder: PartKind[] = [];
+    const fullChunkSeq: string[] = [];
+    for await (const chunk of response.fullStream) {
+      if (chunk.type === 'reasoning-start') {
+        liveOrder.push('reasoning');
+        fullChunkSeq.push('reasoning-start');
+      } else if (chunk.type === 'reasoning-end') {
+        fullChunkSeq.push('reasoning-end');
+      } else if (chunk.type === 'tool-call') {
+        liveOrder.push('tool-call');
+        fullChunkSeq.push('tool-call');
+      } else if (chunk.type === 'text-start') {
+        liveOrder.push('text');
+        fullChunkSeq.push('text-start');
+      } else if (chunk.type === 'text-end') {
+        fullChunkSeq.push('text-end');
+      }
+    }
+
+    // Wait for the save queue to drain.
+    await response.text;
+    // The agent's save-queue is debounced — give it a tick to flush.
+    await new Promise(r => setTimeout(r, 250));
+
+    const saved = await memory.recall({ threadId, resourceId });
+    const savedAssistant = saved.messages.filter((m: any) => m.role === 'assistant');
+    expect(savedAssistant.length).toBeGreaterThan(0);
+
+    const savedOrder: PartKind[] = [];
+    for (const msg of savedAssistant) {
+      const parts = (msg as any).content?.parts ?? [];
+      for (const p of parts) {
+        if (p.type === 'reasoning') savedOrder.push('reasoning');
+        else if (p.type === 'tool-invocation' || p.type === 'tool-call') savedOrder.push('tool-call');
+        else if (p.type === 'text') savedOrder.push('text');
+        // ignore step-start / file / source for this comparison
+      }
+    }
+
+    console.log('[#16007] live order :', liveOrder.join(' → '));
+
+    console.log('[#16007] saved order:', savedOrder.join(' → '));
+
+    console.log('[#16007] chunk seq  :', fullChunkSeq.join(' → '));
+
+    // Sanity: the model actually produced reasoning, tool-calls, and text.
+    expect(liveOrder).toContain('reasoning');
+    expect(liveOrder).toContain('tool-call');
+    expect(liveOrder).toContain('text');
+
+    // The reproducer: when reasoning interleaves with tool-calls, the saved
+    // order currently differs from the live order. We assert equality, which
+    // demonstrates the bug.
+    expect(savedOrder).toEqual(liveOrder);
+  });
+});

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -7571,6 +7571,11 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                         },
                         {
                           "providerOptions": undefined,
+                          "text": "Hello, world!",
+                          "type": "text",
+                        },
+                        {
+                          "providerOptions": undefined,
                           "text": "This is a test.",
                           "type": "text",
                         },
@@ -7578,11 +7583,6 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                           "providerOptions": undefined,
                           "text": "Separate thoughts",
                           "type": "reasoning",
-                        },
-                        {
-                          "providerOptions": undefined,
-                          "text": "Hello, world!",
-                          "type": "text",
                         },
                       ],
                       "role": "assistant",
@@ -7608,6 +7608,11 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                         },
                         {
                           "providerOptions": undefined,
+                          "text": "Hello, world!",
+                          "type": "text",
+                        },
+                        {
+                          "providerOptions": undefined,
                           "text": "This is a test.",
                           "type": "text",
                         },
@@ -7615,11 +7620,6 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                           "providerOptions": undefined,
                           "text": "Separate thoughts",
                           "type": "reasoning",
-                        },
-                        {
-                          "providerOptions": undefined,
-                          "text": "Hello, world!",
-                          "type": "text",
                         },
                       ],
                       "role": "assistant",
@@ -7673,6 +7673,11 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                               },
                               {
                                 "providerOptions": undefined,
+                                "text": "Hello, world!",
+                                "type": "text",
+                              },
+                              {
+                                "providerOptions": undefined,
                                 "text": "This is a test.",
                                 "type": "text",
                               },
@@ -7680,11 +7685,6 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                                 "providerOptions": undefined,
                                 "text": "Separate thoughts",
                                 "type": "reasoning",
-                              },
-                              {
-                                "providerOptions": undefined,
-                                "text": "Hello, world!",
-                                "type": "text",
                               },
                             ],
                             "role": "assistant",
@@ -7752,6 +7752,11 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                         },
                         {
                           "providerOptions": undefined,
+                          "text": "Hello, world!",
+                          "type": "text",
+                        },
+                        {
+                          "providerOptions": undefined,
                           "text": "This is a test.",
                           "type": "text",
                         },
@@ -7759,11 +7764,6 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                           "providerOptions": undefined,
                           "text": "Separate thoughts",
                           "type": "reasoning",
-                        },
-                        {
-                          "providerOptions": undefined,
-                          "text": "Hello, world!",
-                          "type": "text",
                         },
                       ],
                       "role": "assistant",
@@ -7789,6 +7789,11 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                         },
                         {
                           "providerOptions": undefined,
+                          "text": "Hello, world!",
+                          "type": "text",
+                        },
+                        {
+                          "providerOptions": undefined,
                           "text": "This is a test.",
                           "type": "text",
                         },
@@ -7796,11 +7801,6 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                           "providerOptions": undefined,
                           "text": "Separate thoughts",
                           "type": "reasoning",
-                        },
-                        {
-                          "providerOptions": undefined,
-                          "text": "Hello, world!",
-                          "type": "text",
                         },
                       ],
                       "role": "assistant",
@@ -7854,6 +7854,11 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                               },
                               {
                                 "providerOptions": undefined,
+                                "text": "Hello, world!",
+                                "type": "text",
+                              },
+                              {
+                                "providerOptions": undefined,
                                 "text": "This is a test.",
                                 "type": "text",
                               },
@@ -7861,11 +7866,6 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                                 "providerOptions": undefined,
                                 "text": "Separate thoughts",
                                 "type": "reasoning",
-                              },
-                              {
-                                "providerOptions": undefined,
-                                "text": "Hello, world!",
-                                "type": "text",
                               },
                             ],
                             "role": "assistant",

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -80,9 +80,11 @@ describe('buildMessagesFromChunks', () => {
       { type: 'text-end', payload: { id: 't1' } },
     ]);
     expect(result).toHaveLength(2);
-    // Parts are emitted in text-end order
-    expect(result[0]).toMatchObject({ type: 'text', text: 'Goodbye' });
-    expect(result[1]).toMatchObject({ type: 'text', text: 'Hello, world!' });
+    // Parts are emitted in text-start order (the order spans began in the stream).
+    // See #16007 — emitting at *-end caused tool-calls and other interleaved parts
+    // to be reordered relative to the spans that started before them.
+    expect(result[0]).toMatchObject({ type: 'text', text: 'Hello, world!' });
+    expect(result[1]).toMatchObject({ type: 'text', text: 'Goodbye' });
   });
 
   // ── ProviderMetadata cascading ──────────────────────────────
@@ -320,6 +322,182 @@ describe('buildMessagesFromChunks', () => {
 
     const types = result.map((p: any) => p.type);
     expect(types).toEqual(['reasoning', 'text', 'tool-invocation']);
+  });
+
+  /**
+   * Regression test for GitHub issue #16007
+   * https://github.com/mastra-ai/mastra/issues/16007
+   *
+   * OpenAI reasoning models (gpt-5/o3) with AI SDK v6 emit chunk sequences
+   * where tool-call chunks arrive INSIDE a reasoning span (between
+   * reasoning-start and reasoning-end). The live trace order is:
+   *   reasoning → tool:read → tool:grep → reasoning → text
+   *
+   * But the part-emission strategy in buildMessagesFromChunks pushes
+   * tool-invocation parts immediately while reasoning parts are only pushed
+   * at reasoning-end. With interleaved chunks this reorders the persisted
+   * message: tools end up BEFORE the reasoning that produced them.
+   */
+  it('should preserve order when tool-call arrives inside a reasoning span (#16007)', () => {
+    const result = parts([
+      // First reasoning span wraps the first batch of tool calls
+      { type: 'reasoning-start', payload: { id: 'r1' } },
+      { type: 'reasoning-delta', payload: { id: 'r1', text: 'Need to read and grep.' } },
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'tc-read', toolName: 'read', args: { path: 'a.txt' } },
+      },
+      {
+        type: 'tool-result',
+        payload: { toolCallId: 'tc-read', toolName: 'read', args: { path: 'a.txt' }, result: 'ok' },
+      },
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'tc-grep', toolName: 'grep', args: { pattern: 'foo' } },
+      },
+      {
+        type: 'tool-result',
+        payload: { toolCallId: 'tc-grep', toolName: 'grep', args: { pattern: 'foo' }, result: 'match' },
+      },
+      { type: 'reasoning-end', payload: { id: 'r1' } },
+      // Second reasoning span, then final text answer
+      { type: 'reasoning-start', payload: { id: 'r2' } },
+      { type: 'reasoning-delta', payload: { id: 'r2', text: 'Now answer.' } },
+      { type: 'reasoning-end', payload: { id: 'r2' } },
+      { type: 'text-start', payload: { id: 't1' } },
+      { type: 'text-delta', payload: { id: 't1', text: 'Final answer' } },
+      { type: 'text-end', payload: { id: 't1' } },
+    ]);
+
+    const types = result.map((p: any) => p.type);
+
+    // Expected order matches the live stream order reported in the issue:
+    //   reasoning → tool:read → tool:grep → reasoning → text
+    // The first reasoning part is preserved before the tool-invocations
+    // because its slot was reserved at reasoning-start time.
+    expect(types).toEqual(['reasoning', 'tool-invocation', 'tool-invocation', 'reasoning', 'text']);
+
+    // And the first reasoning part must contain the deltas that actually
+    // arrived before the tool-calls in the stream.
+    const firstReasoning = result[0] as any;
+    expect(firstReasoning.type).toBe('reasoning');
+    expect(firstReasoning.details[0]).toEqual({
+      type: 'text',
+      text: 'Need to read and grep.',
+    });
+  });
+
+  /**
+   * #16007 — broader coverage: an unclosed reasoning span that wraps
+   * tool-calls must still land BEFORE the tool-invocations once flushed.
+   */
+  it('should preserve order when an unclosed reasoning span wraps tool-calls (#16007)', () => {
+    const result = parts([
+      { type: 'reasoning-start', payload: { id: 'r1' } },
+      { type: 'reasoning-delta', payload: { id: 'r1', text: 'thinking…' } },
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'tc-1', toolName: 'read', args: {} },
+      },
+      {
+        type: 'tool-result',
+        payload: { toolCallId: 'tc-1', toolName: 'read', args: {}, result: 'ok' },
+      },
+      // No reasoning-end — span flushed at end of stream
+    ]);
+
+    const types = result.map((p: any) => p.type);
+    expect(types).toEqual(['reasoning', 'tool-invocation']);
+    expect((result[0] as any).details[0]).toEqual({ type: 'text', text: 'thinking…' });
+  });
+
+  /**
+   * #16007 — slot reservation must work for `source` and `file` parts that
+   * arrive between reasoning-start and reasoning-end. Source/file parts are
+   * pushed immediately, so they should land between the reserved reasoning
+   * slot and any later parts.
+   */
+  it('should preserve order when source/file parts arrive inside a reasoning span (#16007)', () => {
+    const result = parts([
+      { type: 'reasoning-start', payload: { id: 'r1' } },
+      { type: 'reasoning-delta', payload: { id: 'r1', text: 'consulting sources' } },
+      {
+        type: 'source',
+        payload: {
+          id: 's1',
+          sourceType: 'url',
+          url: 'https://example.com',
+          title: 'Example',
+        },
+      },
+      {
+        type: 'file',
+        payload: { mediaType: 'text/plain', data: 'hello' },
+      },
+      { type: 'reasoning-end', payload: { id: 'r1' } },
+      { type: 'text-start', payload: { id: 't1' } },
+      { type: 'text-delta', payload: { id: 't1', text: 'done' } },
+      { type: 'text-end', payload: { id: 't1' } },
+    ]);
+
+    const types = result.map((p: any) => p.type);
+    expect(types).toEqual(['reasoning', 'source', 'file', 'text']);
+  });
+
+  /**
+   * #16007 — empty text spans inside a reasoning span must not shift
+   * neighbouring slots out of order. The empty text leaves a `null` placeholder
+   * which is filtered out at the end without disturbing other parts.
+   */
+  it('should keep order intact when an empty text span sits between reasoning and tool-call (#16007)', () => {
+    const result = parts([
+      { type: 'reasoning-start', payload: { id: 'r1' } },
+      { type: 'reasoning-delta', payload: { id: 'r1', text: 'plan' } },
+      // Empty text span — reserves a slot but produces no part
+      { type: 'text-start', payload: { id: 't-empty' } },
+      { type: 'text-end', payload: { id: 't-empty' } },
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'tc-1', toolName: 'read', args: {} },
+      },
+      {
+        type: 'tool-result',
+        payload: { toolCallId: 'tc-1', toolName: 'read', args: {}, result: 'ok' },
+      },
+      { type: 'reasoning-end', payload: { id: 'r1' } },
+      { type: 'text-start', payload: { id: 't1' } },
+      { type: 'text-delta', payload: { id: 't1', text: 'answer' } },
+      { type: 'text-end', payload: { id: 't1' } },
+    ]);
+
+    const types = result.map((p: any) => p.type);
+    expect(types).toEqual(['reasoning', 'tool-invocation', 'step-start', 'text']);
+  });
+
+  /**
+   * #16007 — auto-created spans (delta arrives without *-start) must also
+   * reserve their slot at the position the delta first appeared.
+   */
+  it('should preserve order for auto-created reasoning span wrapping a tool-call (#16007)', () => {
+    const result = parts([
+      // No reasoning-start — span auto-created on first delta
+      { type: 'reasoning-delta', payload: { id: 'r1', text: 'auto' } },
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'tc-1', toolName: 'read', args: {} },
+      },
+      {
+        type: 'tool-result',
+        payload: { toolCallId: 'tc-1', toolName: 'read', args: {}, result: 'ok' },
+      },
+      { type: 'reasoning-end', payload: { id: 'r1' } },
+      { type: 'text-start', payload: { id: 't1' } },
+      { type: 'text-delta', payload: { id: 't1', text: 'final' } },
+      { type: 'text-end', payload: { id: 't1' } },
+    ]);
+
+    const types = result.map((p: any) => p.type);
+    expect(types).toEqual(['reasoning', 'tool-invocation', 'step-start', 'text']);
   });
 
   // ── Empty stream / no parts ─────────────────────────────────

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -43,7 +43,11 @@ export function buildMessagesFromChunks({
   responseModelMetadata?: { metadata: Record<string, unknown> };
   tools?: ToolSet;
 }): MastraDBMessage[] {
-  const parts: MastraMessagePart[] = [];
+  // We allow `null` placeholders so text/reasoning spans can reserve their
+  // position in stream order at *-start time, then fill content at *-end.
+  // This prevents tool-call parts (which push immediately) from being placed
+  // before earlier-but-still-open reasoning/text spans. See #16007.
+  const parts: (MastraMessagePart | null)[] = [];
 
   // Collect tool results so we can match them to tool calls
   const toolResults = new Map<
@@ -63,13 +67,28 @@ export function buildMessagesFromChunks({
     }
   }
 
+  // Reserve a placeholder slot in `parts` for a span and return its index.
+  // The slot is filled with the actual part when the span ends.
+  const reserveSlot = (): number => {
+    parts.push(null);
+    return parts.length - 1;
+  };
+
   // State for text span accumulation (keyed by text ID to handle interleaved spans)
-  const textSpans = new Map<string, { deltas: string[]; providerMetadata: Record<string, any> | undefined }>();
+  const textSpans = new Map<
+    string,
+    { deltas: string[]; providerMetadata: Record<string, any> | undefined; slotIndex: number }
+  >();
 
   // State for reasoning span accumulation (keyed by reasoning ID)
   const reasoningSpans = new Map<
     string,
-    { deltas: string[]; providerMetadata: Record<string, any> | undefined; redacted: boolean }
+    {
+      deltas: string[];
+      providerMetadata: Record<string, any> | undefined;
+      redacted: boolean;
+      slotIndex: number;
+    }
   >();
   for (const chunk of chunks) {
     switch (chunk.type) {
@@ -77,9 +96,11 @@ export function buildMessagesFromChunks({
       case 'text-start': {
         const p = chunk.payload as TextStartPayload;
         if (!textSpans.has(p.id)) {
+          // Reserve the part slot in stream order; we'll fill it on text-end.
           textSpans.set(p.id, {
             deltas: [],
             providerMetadata: p.providerMetadata,
+            slotIndex: reserveSlot(),
           });
         } else {
           // Update providerMetadata if this start has it
@@ -93,9 +114,10 @@ export function buildMessagesFromChunks({
       case 'text-delta': {
         const p = chunk.payload as TextDeltaPayload;
         let span = textSpans.get(p.id);
-        // Auto-create span if delta arrives without a matching text-start
+        // Auto-create span if delta arrives without a matching text-start.
+        // Reserve a slot at the position the delta first appeared.
         if (!span) {
-          span = { deltas: [], providerMetadata: p.providerMetadata };
+          span = { deltas: [], providerMetadata: p.providerMetadata, slotIndex: reserveSlot() };
           textSpans.set(p.id, span);
         }
         span.deltas.push(p.text);
@@ -114,13 +136,14 @@ export function buildMessagesFromChunks({
             span.providerMetadata = pEnd.providerMetadata;
           }
           const text = span.deltas.join('');
-          // Only emit a part if there's actual content — skip empty text spans
+          // Only emit a part if there's actual content — skip empty text spans.
+          // Empty spans leave their reserved slot as null, which is filtered out below.
           if (text.length > 0) {
-            parts.push({
+            parts[span.slotIndex] = {
               type: 'text' as const,
               text,
               ...(span.providerMetadata ? { providerMetadata: span.providerMetadata } : {}),
-            } as MastraMessagePart);
+            } as MastraMessagePart;
           }
           textSpans.delete(pEnd.id);
         }
@@ -134,10 +157,14 @@ export function buildMessagesFromChunks({
         const isRedacted = Object.values(p.providerMetadata || {}).some((v: any) => v?.redactedData);
 
         if (!reasoningSpans.has(p.id)) {
+          // Reserve the part slot in stream order; we'll fill it on reasoning-end.
+          // This preserves order when tool-call chunks arrive between reasoning-start
+          // and reasoning-end (e.g. Qwen thinking models, see #16007).
           reasoningSpans.set(p.id, {
             deltas: [],
             providerMetadata: p.providerMetadata,
             redacted: isRedacted,
+            slotIndex: reserveSlot(),
           });
         } else {
           // Update providerMetadata if this start has it
@@ -154,9 +181,14 @@ export function buildMessagesFromChunks({
       case 'reasoning-delta': {
         const p = chunk.payload as ReasoningDeltaPayload;
         let span = reasoningSpans.get(p.id);
-        // Auto-create span if delta arrives without a matching reasoning-start
+        // Auto-create span if delta arrives without a matching reasoning-start.
         if (!span) {
-          span = { deltas: [], providerMetadata: p.providerMetadata, redacted: false };
+          span = {
+            deltas: [],
+            providerMetadata: p.providerMetadata,
+            redacted: false,
+            slotIndex: reserveSlot(),
+          };
           reasoningSpans.set(p.id, span);
         }
         span.deltas.push(p.text);
@@ -176,21 +208,21 @@ export function buildMessagesFromChunks({
           }
 
           if (span.redacted) {
-            parts.push({
+            parts[span.slotIndex] = {
               type: 'reasoning' as const,
               reasoning: '',
               details: [{ type: 'redacted', data: '' }],
               providerMetadata: span.providerMetadata,
-            } as MastraMessagePart);
+            } as MastraMessagePart;
           } else {
             // Always emit reasoning parts, even if empty — OpenAI requires item_reference
             // for tool calls that follow reasoning. See: https://github.com/mastra-ai/mastra/issues/9005
-            parts.push({
+            parts[span.slotIndex] = {
               type: 'reasoning' as const,
               reasoning: '',
               details: [{ type: 'text', text: span.deltas.join('') }],
               providerMetadata: span.providerMetadata,
-            } as MastraMessagePart);
+            } as MastraMessagePart;
           }
 
           reasoningSpans.delete(p.id);
@@ -287,43 +319,47 @@ export function buildMessagesFromChunks({
   }
 
   // Flush any unclosed reasoning spans (stream ended without reasoning-end)
+  // by filling their reserved slots so order is preserved.
   for (const [_id, span] of reasoningSpans) {
     if (span.redacted) {
-      parts.push({
+      parts[span.slotIndex] = {
         type: 'reasoning' as const,
         reasoning: '',
         details: [{ type: 'redacted', data: '' }],
         providerMetadata: span.providerMetadata,
-      } as MastraMessagePart);
+      } as MastraMessagePart;
     } else {
       const text = span.deltas.join('');
-      parts.push({
+      parts[span.slotIndex] = {
         type: 'reasoning' as const,
         reasoning: '',
         details: [{ type: 'text', text }],
         providerMetadata: span.providerMetadata,
-      } as MastraMessagePart);
+      } as MastraMessagePart;
     }
   }
 
   // Flush any unclosed text spans (stream ended without text-end)
+  // by filling their reserved slots so order is preserved.
   for (const [, span] of textSpans) {
     const text = span.deltas.join('');
     if (text.length > 0) {
-      parts.push({
+      parts[span.slotIndex] = {
         type: 'text' as const,
         text,
         ...(span.providerMetadata ? { providerMetadata: span.providerMetadata } : {}),
-      } as MastraMessagePart);
+      } as MastraMessagePart;
     }
   }
 
   // Insert step-start markers between tool-invocation and subsequent text parts.
   // This matches the convention used by MessageMerger.pushNewPart when merging messages,
   // and is required so that AI SDK convertToModelMessages splits them into separate steps.
+  // Null entries are unfilled placeholders (e.g. empty text spans) — skip them.
   const finalParts: MastraMessagePart[] = [];
   for (let i = 0; i < parts.length; i++) {
-    const part = parts[i]!;
+    const part = parts[i];
+    if (part == null) continue;
     if (
       part.type === 'text' &&
       finalParts.length > 0 &&


### PR DESCRIPTION
Fixes #16007.

This fixes persisted message ordering when a reasoning or text span overlaps with tool calls or other immediate stream parts. The saved message parts now keep the same order as the live stream, so recalled messages and UI messages do not move reasoning after tool calls.

Before, a stream like reasoning → tool call → text could be saved with the tool call before the reasoning part if the reasoning span closed later. After this change, the span keeps its original stream position and is filled in when it closes.

I added focused unit coverage for overlapping, unclosed, empty, and auto-created spans, plus a recorded e2e replay test for persisted message part ordering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Saved messages were sometimes getting scrambled: actions (tool calls) could show up before the thinking that triggered them. This PR reserves each thinking/text block's spot when it starts and fills it when it ends, so saved messages keep the same order as the live stream.

## Summary

Fixes persisted message part ordering so parts are stored in the same order they appeared in the live stream even when reasoning/text spans overlap with immediate parts like tool calls. Implements a slot-reservation approach in buildMessagesFromChunks to preserve stream-relative ordering, handles empty/unclosed/auto-created spans correctly, and adds focused unit and E2E tests. Fixes issue #16007.

### Problem

Reasoning/text spans were only appended when they closed, while interleaved immediate parts (e.g., tool-call) were pushed immediately, allowing tool-call parts to jump ahead of still-open spans in persisted messages.

### Solution

- Reserve a null placeholder slot in the parts array at span start (text-start / reasoning-start or when deltas auto-create spans).
- Accumulate deltas into span state and fill the reserved slot on span end (text-end / reasoning-end).
- Leave reserved slots null for empty text spans and filter them out when assembling final parts.
- Merge tool-call + tool-result into a single tool-invocation part as before; tool parts still push at their stream position but cannot bypass reserved span slots.

### Key changes

- packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
  - Implemented slot reservation + delayed filling for text and reasoning spans.
  - Skip empty text spans; flush unclosed spans at stream end.
- packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
  - Updated expectations and added regression tests covering overlapping spans, unclosed spans, empty spans, auto-created spans, and correct delta accumulation.
- packages/core/src/agent/__tests__/message-part-ordering.e2e.test.ts
  - New E2E reproduction (with recorded gateway) asserting persisted message part order matches live stream order for interleaved reasoning/tool/text sequences.
- packages/core/__recordings__/core-src-agent-__tests__-message-part-ordering.e2e.json
  - Recorded API interactions for the E2E test.
- .changeset/every-dragons-report.md
  - Changeset noting the patch release and fix.

### Tests & coverage

- Added unit tests exercising interleaved reasoning/text/tool scenarios, including edge cases (empty spans, auto-created spans, unclosed spans).
- Added an offline-capable E2E replay that verifies persisted ordering matches live stream ordering.

### Fixes

Closes/fixes issue #16007 — persisted mastra_messages.content.parts now preserve the live stream order for reasoning, tool calls, and text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->