### PR TITLE
fix(core): preserve harness provider token usage

### DIFF
--- a/.changeset/great-papers-shake.md
+++ b/.changeset/great-papers-shake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Harness token usage so provider-reported totals, reasoning tokens, and cache token fields are preserved. Fixes https://github.com/mastra-ai/mastra/issues/16055

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -671,6 +671,40 @@ describe('usage_update', () => {
     expect(usage.totalTokens).toBe(150);
   });
 
+  it('preserves richer token usage fields from internal token counters', () => {
+    (harness as any).tokenUsage = {
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 220,
+      reasoningTokens: 70,
+      cachedInputTokens: 25,
+      cacheCreationInputTokens: 5,
+      raw: { provider: 'test-provider' },
+    };
+    emit(harness, {
+      type: 'usage_update',
+      usage: {
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 220,
+        reasoningTokens: 70,
+        cachedInputTokens: 25,
+        cacheCreationInputTokens: 5,
+        raw: { provider: 'test-provider' },
+      },
+    });
+
+    expect(harness.getDisplayState().tokenUsage).toEqual({
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 220,
+      reasoningTokens: 70,
+      cachedInputTokens: 25,
+      cacheCreationInputTokens: 5,
+      raw: { provider: 'test-provider' },
+    });
+  });
+
   it('accumulates usage across multiple updates', () => {
     (harness as any).tokenUsage = { promptTokens: 100, completionTokens: 50, totalTokens: 150 };
     emit(harness, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -40,8 +40,37 @@ import type {
   ModelAuthStatus,
   PermissionPolicy,
   PermissionRules,
+  TokenUsage,
   ToolCategory,
 } from './types';
+
+function createEmptyTokenUsage(): TokenUsage {
+  return { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+}
+
+function getUsageNumber(usage: Record<string, unknown>, key: string): number | undefined {
+  const value = usage[key];
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const numericValue = Number(value);
+    if (Number.isFinite(numericValue)) {
+      return numericValue;
+    }
+  }
+  return undefined;
+}
+
+function addOptionalUsageField(
+  usage: TokenUsage,
+  key: keyof Pick<TokenUsage, 'reasoningTokens' | 'cachedInputTokens' | 'cacheCreationInputTokens'>,
+  value: number | undefined,
+): void {
+  if (value !== undefined) {
+    usage[key] = (usage[key] ?? 0) + value;
+  }
+}
 
 /**
  * The Harness orchestrates multiple agent modes, shared state, memory, and storage.
@@ -108,11 +137,7 @@ export class Harness<TState = {}> {
     | ((ctx: { requestContext: RequestContext }) => Promise<MastraBrowser | undefined> | MastraBrowser | undefined)
     | undefined = undefined;
   private heartbeatTimers = new Map<string, { timer: NodeJS.Timeout; shutdown?: () => void | Promise<void> }>();
-  private tokenUsage: { promptTokens: number; completionTokens: number; totalTokens: number } = {
-    promptTokens: 0,
-    completionTokens: 0,
-    totalTokens: 0,
-  };
+  private tokenUsage: TokenUsage = createEmptyTokenUsage();
   private sessionGrantedCategories = new Set<string>();
   private sessionGrantedTools = new Set<string>();
   private displayState: HarnessDisplayState = defaultDisplayState();
@@ -731,7 +756,7 @@ export class Harness<TState = {}> {
       void this.setState({ currentModelId: modelId } as unknown as Partial<TState>);
     }
 
-    this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    this.tokenUsage = createEmptyTokenUsage();
     this.emit({ type: 'thread_created', thread });
 
     return thread;
@@ -770,7 +795,7 @@ export class Harness<TState = {}> {
         // Lock release failed; proceed with state cleanup regardless
       }
       this.currentThreadId = null;
-      this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      this.tokenUsage = createEmptyTokenUsage();
     }
 
     this.emit({ type: 'thread_deleted', threadId });
@@ -844,7 +869,7 @@ export class Harness<TState = {}> {
 
     this.currentThreadId = clonedThread.id;
     await this.loadThreadMetadata();
-    this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    this.tokenUsage = createEmptyTokenUsage();
     this.emit({ type: 'thread_created', thread: clonedThread });
 
     return clonedThread;
@@ -957,7 +982,7 @@ export class Harness<TState = {}> {
 
   private async loadThreadMetadata(): Promise<void> {
     if (!this.currentThreadId || !this.config.storage) {
-      this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      this.tokenUsage = createEmptyTokenUsage();
       return;
     }
 
@@ -969,12 +994,14 @@ export class Harness<TState = {}> {
       const savedUsage = thread?.metadata?.tokenUsage as typeof this.tokenUsage | undefined;
       if (savedUsage) {
         this.tokenUsage = {
+          ...createEmptyTokenUsage(),
+          ...savedUsage,
           promptTokens: savedUsage.promptTokens ?? 0,
           completionTokens: savedUsage.completionTokens ?? 0,
           totalTokens: savedUsage.totalTokens ?? 0,
         };
       } else {
-        this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+        this.tokenUsage = createEmptyTokenUsage();
       }
 
       const meta = thread?.metadata as Record<string, unknown> | undefined;
@@ -1040,7 +1067,7 @@ export class Harness<TState = {}> {
         }
       }
     } catch {
-      this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      this.tokenUsage = createEmptyTokenUsage();
     }
   }
 
@@ -1966,16 +1993,40 @@ export class Harness<TState = {}> {
         case 'step-finish': {
           const usage = chunk.payload?.output?.usage;
           if (usage) {
-            const promptTokens = usage.promptTokens ?? usage.inputTokens ?? 0;
-            const completionTokens = usage.completionTokens ?? usage.outputTokens ?? 0;
-            const totalTokens = promptTokens + completionTokens;
+            const usageRecord = usage as Record<string, unknown>;
+            const promptTokens =
+              getUsageNumber(usageRecord, 'promptTokens') ?? getUsageNumber(usageRecord, 'inputTokens') ?? 0;
+            const completionTokens =
+              getUsageNumber(usageRecord, 'completionTokens') ?? getUsageNumber(usageRecord, 'outputTokens') ?? 0;
+            const totalTokens = getUsageNumber(usageRecord, 'totalTokens') ?? promptTokens + completionTokens;
+            const stepUsage: TokenUsage = {
+              promptTokens,
+              completionTokens,
+              totalTokens,
+            };
+            addOptionalUsageField(stepUsage, 'reasoningTokens', getUsageNumber(usageRecord, 'reasoningTokens'));
+            addOptionalUsageField(stepUsage, 'cachedInputTokens', getUsageNumber(usageRecord, 'cachedInputTokens'));
+            addOptionalUsageField(
+              stepUsage,
+              'cacheCreationInputTokens',
+              getUsageNumber(usageRecord, 'cacheCreationInputTokens'),
+            );
+            if (usageRecord.raw !== undefined) {
+              stepUsage.raw = usageRecord.raw;
+            }
 
             this.tokenUsage.promptTokens += promptTokens;
             this.tokenUsage.completionTokens += completionTokens;
             this.tokenUsage.totalTokens += totalTokens;
+            addOptionalUsageField(this.tokenUsage, 'reasoningTokens', stepUsage.reasoningTokens);
+            addOptionalUsageField(this.tokenUsage, 'cachedInputTokens', stepUsage.cachedInputTokens);
+            addOptionalUsageField(this.tokenUsage, 'cacheCreationInputTokens', stepUsage.cacheCreationInputTokens);
+            if (stepUsage.raw !== undefined) {
+              this.tokenUsage.raw = stepUsage.raw;
+            }
 
             this.persistTokenUsage().catch(() => {});
-            this.emit({ type: 'usage_update', usage: { promptTokens, completionTokens, totalTokens } });
+            this.emit({ type: 'usage_update', usage: stepUsage });
           }
           break;
         }
@@ -2959,11 +3010,7 @@ export class Harness<TState = {}> {
 
       // ── Token usage ────────────────────────────────────────────────────
       case 'usage_update':
-        ds.tokenUsage = {
-          promptTokens: this.tokenUsage.promptTokens,
-          completionTokens: this.tokenUsage.completionTokens,
-          totalTokens: this.tokenUsage.totalTokens,
-        };
+        ds.tokenUsage = { ...this.tokenUsage };
         break;
 
       // ── Tasks ──────────────────────────────────────────────────────────
@@ -2980,13 +3027,13 @@ export class Harness<TState = {}> {
 
       case 'thread_created':
         this.resetThreadDisplayState();
-        ds.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+        ds.tokenUsage = createEmptyTokenUsage();
         break;
 
       case 'thread_deleted':
         if (!this.currentThreadId) {
           this.resetThreadDisplayState();
-          ds.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+          ds.tokenUsage = createEmptyTokenUsage();
         }
         break;
 
@@ -3164,7 +3211,7 @@ export class Harness<TState = {}> {
   // Token Usage
   // ===========================================================================
 
-  getTokenUsage(): { promptTokens: number; completionTokens: number; totalTokens: number } {
+  getTokenUsage(): TokenUsage {
     return { ...this.tokenUsage };
   }
 

--- a/packages/core/src/harness/token-usage.test.ts
+++ b/packages/core/src/harness/token-usage.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
+import type { HarnessEvent } from './types';
 
-function createHarness() {
+function createHarness(storage = new InMemoryStore()) {
   const agent = new Agent({
     name: 'test-agent',
     instructions: 'You are a test agent.',
@@ -12,7 +13,7 @@ function createHarness() {
 
   return new Harness({
     id: 'test-harness',
-    storage: new InMemoryStore(),
+    storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
   });
 }
@@ -73,6 +74,72 @@ describe('step-finish token usage extraction', () => {
     expect(tokenUsage.totalTokens).toBe(280);
   });
 
+  it('preserves provider totalTokens and richer usage fields', async () => {
+    const usage = {
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 220,
+      reasoningTokens: 70,
+      cachedInputTokens: 25,
+      cacheCreationInputTokens: 5,
+      raw: { provider: 'test-provider' },
+    };
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => events.push(event));
+
+    await (harness as any).processStream({ fullStream: mockStream(usage) });
+
+    const expectedUsage = {
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 220,
+      reasoningTokens: 70,
+      cachedInputTokens: 25,
+      cacheCreationInputTokens: 5,
+      raw: { provider: 'test-provider' },
+    };
+    expect(harness.getTokenUsage()).toEqual(expectedUsage);
+    expect(harness.getDisplayState().tokenUsage).toEqual(expectedUsage);
+    expect(events.find(event => event.type === 'usage_update')).toEqual({
+      type: 'usage_update',
+      usage: expectedUsage,
+    });
+  });
+
+  it('persists richer token usage in thread metadata', async () => {
+    const storage = new InMemoryStore();
+    harness = createHarness(storage);
+    await harness.init();
+    const thread = await harness.createThread();
+    const usage = {
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 220,
+      reasoningTokens: 70,
+      cachedInputTokens: 25,
+      cacheCreationInputTokens: 5,
+      raw: { provider: 'test-provider' },
+    };
+
+    await (harness as any).processStream({ fullStream: mockStream(usage) });
+
+    await expect
+      .poll(async () => {
+        const memory = await storage.getStore('memory');
+        const savedThread = await memory?.getThreadById({ threadId: thread.id });
+        return savedThread?.metadata?.tokenUsage;
+      })
+      .toEqual({
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 220,
+        reasoningTokens: 70,
+        cachedInputTokens: 25,
+        cacheCreationInputTokens: 5,
+        raw: { provider: 'test-provider' },
+      });
+  });
+
   it('accumulates token usage across multiple step-finish chunks', async () => {
     const usage1 = { inputTokens: 100, outputTokens: 50 };
     const usage2 = { inputTokens: 150, outputTokens: 70 };
@@ -116,5 +183,69 @@ describe('step-finish token usage extraction', () => {
     expect(tokenUsage.promptTokens).toBe(250);
     expect(tokenUsage.completionTokens).toBe(120);
     expect(tokenUsage.totalTokens).toBe(370);
+  });
+
+  it('accumulates richer usage fields across multiple step-finish chunks', async () => {
+    const usage1 = {
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 180,
+      reasoningTokens: 30,
+      cachedInputTokens: 10,
+      raw: { step: 1 },
+    };
+    const usage2 = {
+      inputTokens: 150,
+      outputTokens: 70,
+      totalTokens: 260,
+      reasoningTokens: 40,
+      cacheCreationInputTokens: 12,
+      raw: { step: 2 },
+    };
+
+    async function* multiStepStream() {
+      yield {
+        type: 'step-finish',
+        runId: 'run-1',
+        from: 'AGENT',
+        payload: {
+          output: { usage: usage1 },
+          stepResult: { reason: 'tool-calls' },
+          metadata: {},
+        },
+      };
+      yield {
+        type: 'step-finish',
+        runId: 'run-1',
+        from: 'AGENT',
+        payload: {
+          output: { usage: usage2 },
+          stepResult: { reason: 'stop' },
+          metadata: {},
+        },
+      };
+      yield {
+        type: 'finish',
+        runId: 'run-1',
+        from: 'AGENT',
+        payload: {
+          stepResult: { reason: 'stop' },
+          output: { usage: usage2 },
+          metadata: {},
+        },
+      };
+    }
+
+    await (harness as any).processStream({ fullStream: multiStepStream() });
+
+    expect(harness.getTokenUsage()).toEqual({
+      promptTokens: 250,
+      completionTokens: 120,
+      totalTokens: 440,
+      reasoningTokens: 70,
+      cachedInputTokens: 10,
+      cacheCreationInputTokens: 12,
+      raw: { step: 2 },
+    });
   });
 });

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -423,6 +423,10 @@ export interface TokenUsage {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
+  raw?: unknown;
 }
 
 // =============================================================================


### PR DESCRIPTION
Fixes https://github.com/mastra-ai/mastra/issues/16055.

Before, Harness reduced step usage to prompt/completion tokens and recomputed totalTokens, so provider totals that include reasoning or cache tokens were undercounted.

After, Harness keeps provider totalTokens when present and carries reasoningTokens, cachedInputTokens, cacheCreationInputTokens, and raw usage through getTokenUsage(), displayState.tokenUsage, usage_update events, and thread metadata.

Validated with `pnpm build:core`, `pnpm --filter ./packages/core test src/harness/token-usage.test.ts`, `pnpm --filter ./packages/core test src/harness/display-state.test.ts`, `pnpm --filter ./packages/core check`, and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR fixes how the Harness system tracks token usage from AI providers. Before, it was only keeping track of basic counts (prompts and completions) and throwing away other useful information that providers give, like reasoning tokens and cache tokens. Now it keeps all that extra information so you can see the complete picture of how many tokens were actually used.

## Changes Overview

The PR addresses issue #16055 by updating the Harness token usage handling to preserve richer provider-reported token data instead of discarding it during recomputation.

### Key Changes

**Type System Updates** (`packages/core/src/harness/types.ts`)
- Extended the `TokenUsage` interface with optional fields: `reasoningTokens`, `cachedInputTokens`, `cacheCreationInputTokens`, and `raw` to capture additional provider-specific token accounting.

**Token Handling Logic** (`packages/core/src/harness/harness.ts`)
- Generalized token usage handling from a fixed 3-field structure to the complete `TokenUsage` type
- Introduced `getUsageNumber()` helper for safe numeric extraction supporting both numeric and string values
- Modified `totalTokens` calculation to prefer explicit provider-reported values when available, otherwise derives from input + output
- `step-finish` event processing now preserves all optional token fields (reasoning, cache-related) in both per-step and cumulative token usage
- `usage_update` events now carry the full `stepUsage` object instead of only base counts
- `getTokenUsage()` method signature updated to return the complete `TokenUsage` type
- Display state and thread lifecycle now use `createEmptyTokenUsage()` and properly spread the full `tokenUsage` object

**Test Coverage** (`packages/core/src/harness/token-usage.test.ts` and `display-state.test.ts`)
- Added regression test confirming that richer token fields (including `reasoningTokens` and cache tokens) are preserved through `getTokenUsage()` and `getDisplayState().tokenUsage`
- Added test verifying `usage_update` events include the complete token usage payload
- Added test for token field persistence in thread metadata via `thread.metadata.tokenUsage`
- Extended coverage for multi-chunk token accumulation scenarios

**Release Notes** (`.changeset/great-papers-shake.md`)
- Recorded patch release for `@mastra/core` documenting the token usage preservation fix

### Backward Compatibility

The changes maintain backward compatibility—the existing `promptTokens`, `completionTokens`, and `totalTokens` fields remain required and functional, while optional fields are conditionally merged when present in provider responses.

### Validation

- Package build and unit tests pass for `@mastra/core`
- Token usage and display state tests confirm proper preservation of richer token fields
- TypeScript checks pass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->