### PR TITLE
feat(server): add ZodOpenAPIRouteConfig — Zod-first OpenAPI for custom routes

### DIFF
--- a/.changeset/fix-zod-openapi-detection-and-proto-pollution.md
+++ b/.changeset/fix-zod-openapi-detection-and-proto-pollution.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': patch
+'@mastra/server': patch
+---
+
+fix(server): broaden ZodOpenAPIRouteConfig detection and prevent prototype pollution
+
+`isZodOpenAPIRouteConfig` now recognises configs without a `request` field
+(e.g. `{ operationId, responses }`) by checking for the absence of
+`DescribeRouteOptions`-specific fields (`parameters[]` / `requestBody`).
+Previously those configs silently fell through to the legacy converter and
+lost `operationId` and any other Zod-specific processing.
+
+`generateOpenAPIDocument` and `convertCustomRoutesToOpenAPIPaths` now use
+`Object.create(null)` for both the top-level `paths` map and per-path
+objects, eliminating prototype-pollution risk when a route path is
+`__proto__`, `constructor`, or `toString`.

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -3,7 +3,7 @@ import type { DescribeRouteOptions } from 'hono-openapi';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
 import type { Mastra } from '../mastra';
 import type { RequestContext } from '../request-context';
-import type { ApiRoute, MastraAuthConfig, Methods } from './types';
+import type { ApiRoute, MastraAuthConfig, Methods, ZodOpenAPIRouteConfig } from './types';
 
 export type {
   MastraAuthConfig,
@@ -13,6 +13,7 @@ export type {
   ValidationErrorContext,
   ValidationErrorResponse,
   ValidationErrorHook,
+  ZodOpenAPIRouteConfig,
 } from './types';
 export { MastraAuthProvider } from './auth';
 export type { MastraAuthProviderOptions } from './auth';
@@ -40,7 +41,7 @@ type CustomRouteVariables = {
 
 type RegisterApiRouteOptions<P extends string> = {
   method: Methods;
-  openapi?: DescribeRouteOptions;
+  openapi?: DescribeRouteOptions | ZodOpenAPIRouteConfig;
   handler?: Handler<
     {
       Variables: CustomRouteVariables;

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -9,13 +9,120 @@ import type { MastraAuthProvider } from './auth';
 
 export type Methods = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'ALL';
 
+/**
+ * Zod-based OpenAPI route configuration.
+ * An alternative to `DescribeRouteOptions` that lets you define request/response schemas
+ * using Zod schemas directly (inspired by @hono/zod-openapi's `createRoute` API).
+ *
+ * @example
+ * ```typescript
+ * import { z } from 'zod';
+ * import { registerApiRoute } from '@mastra/core/server';
+ *
+ * export const getUserRoute = registerApiRoute('/users/:id', {
+ *   method: 'GET',
+ *   openapi: {
+ *     summary: 'Get user by ID',
+ *     tags: ['users'],
+ *     request: {
+ *       params: z.object({ id: z.string() }),
+ *     },
+ *     responses: {
+ *       200: {
+ *         description: 'User found',
+ *         content: {
+ *           'application/json': {
+ *             schema: z.object({ id: z.string(), name: z.string() }),
+ *           },
+ *         },
+ *       },
+ *       404: { description: 'User not found' },
+ *     },
+ *   },
+ *   handler: async (c) => {
+ *     const { id } = c.req.param();
+ *     return c.json({ id, name: 'Alice' });
+ *   },
+ * });
+ * ```
+ */
+export type ZodOpenAPIRouteConfig = {
+  /** Route summary shown in OpenAPI docs */
+  summary?: string;
+  /** Route description shown in OpenAPI docs */
+  description?: string;
+  /** Tags for grouping routes in OpenAPI docs */
+  tags?: string[];
+  /** Whether this route is deprecated */
+  deprecated?: boolean;
+  /** Unique operation identifier for client generation */
+  operationId?: string;
+  /** Whether to hide this route from OpenAPI docs */
+  hide?: boolean;
+  /** External documentation reference */
+  externalDocs?: { url: string; description?: string };
+  /** Security requirements for this route */
+  security?: Record<string, string[]>[];
+  /**
+   * Request schemas using Zod.
+   * Each schema is converted to JSON Schema when building the OpenAPI spec.
+   * The presence of this property is used to distinguish `ZodOpenAPIRouteConfig`
+   * from `DescribeRouteOptions` at runtime.
+   */
+  request?: {
+    /**
+     * Zod object schema for path parameters.
+     * Field names must match the path param names in the route path (e.g. `:id`).
+     *
+     * @example
+     * params: z.object({ id: z.string().describe('User ID') })
+     */
+    params?: object;
+    /**
+     * Zod object schema for query parameters.
+     *
+     * @example
+     * query: z.object({ limit: z.coerce.number().optional(), cursor: z.string().optional() })
+     */
+    query?: object;
+    /**
+     * Request body schema.
+     * Supports multiple media types.
+     *
+     * @example
+     * body: {
+     *   content: { 'application/json': { schema: z.object({ name: z.string() }) } },
+     * }
+     */
+    body?: {
+      content: { [mediaType: string]: { schema: object } };
+      /** Whether the request body is required (default: true) */
+      required?: boolean;
+      /** Description of the request body */
+      description?: string;
+    };
+  };
+  /**
+   * Response schemas by HTTP status code.
+   * Zod schemas in `content[mediaType].schema` are converted to JSON Schema automatically.
+   */
+  responses: {
+    [statusCode: string]: {
+      description: string;
+      content?: {
+        [mediaType: string]: { schema: object };
+      };
+    };
+  };
+};
+
 export type ApiRoute =
   | {
       path: string;
       method: Methods;
       handler: Handler;
       middleware?: MiddlewareHandler | MiddlewareHandler[];
-      openapi?: DescribeRouteOptions;
+      openapi?: DescribeRouteOptions | ZodOpenAPIRouteConfig;
       requiresAuth?: boolean;
     }
   | {
@@ -23,7 +130,7 @@ export type ApiRoute =
       method: Methods;
       createHandler: ({ mastra }: { mastra: Mastra }) => Promise<Handler>;
       middleware?: MiddlewareHandler | MiddlewareHandler[];
-      openapi?: DescribeRouteOptions;
+      openapi?: DescribeRouteOptions | ZodOpenAPIRouteConfig;
       requiresAuth?: boolean;
     };
 

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -66,8 +66,12 @@ export type ZodOpenAPIRouteConfig = {
   /**
    * Request schemas using Zod.
    * Each schema is converted to JSON Schema when building the OpenAPI spec.
-   * The presence of this property is used to distinguish `ZodOpenAPIRouteConfig`
-   * from `DescribeRouteOptions` at runtime.
+   *
+   * At runtime, configs with `request` present are unambiguously identified as
+   * `ZodOpenAPIRouteConfig`. Configs without `request` but also without the
+   * `parameters[]` / `requestBody` fields of `DescribeRouteOptions` are also
+   * treated as `ZodOpenAPIRouteConfig` — so fields like `operationId` are
+   * preserved even when no request schemas are needed.
    */
   request?: {
     /**

--- a/packages/server/src/server/server-adapter/openapi-utils.test.ts
+++ b/packages/server/src/server/server-adapter/openapi-utils.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod/v4';
+import { generateOpenAPIDocument, convertCustomRoutesToOpenAPIPaths } from './openapi-utils';
+import type { ServerRoute } from './routes';
+import type { ApiRoute } from '@mastra/core/server';
+
+const mockHandler = () => new Response('ok');
+
+describe('generateOpenAPIDocument', () => {
+  it('does not pollute Object.prototype when a route path is "__proto__"', () => {
+    const pollutingRoute = {
+      method: 'GET',
+      path: '__proto__',
+      openapi: {
+        summary: 's',
+        description: 'd',
+        tags: ['t'],
+        requestParams: {},
+        responses: {
+          200: {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: z.object({ polluted: z.boolean() }),
+              },
+            },
+          },
+        },
+      },
+      handler: () => new Response('ok'),
+    } as unknown as ServerRoute;
+
+    generateOpenAPIDocument([pollutingRoute], { title: 't', version: '1' });
+
+    expect(({} as any).polluted).toBeUndefined();
+    expect(({} as any).get).toBeUndefined();
+  });
+});
+
+describe('convertCustomRoutesToOpenAPIPaths — ZodOpenAPIRouteConfig', () => {
+  it('converts request.params Zod schema to path parameters', () => {
+    const routes: ApiRoute[] = [
+      {
+        path: '/users/:id',
+        method: 'GET',
+        handler: mockHandler,
+        openapi: {
+          summary: 'Get user',
+          tags: ['users'],
+          request: {
+            params: z.object({ id: z.string().describe('User ID') }),
+          },
+          responses: {
+            200: { description: 'User found' },
+          },
+        },
+      },
+    ];
+
+    const paths = convertCustomRoutesToOpenAPIPaths(routes);
+
+    expect(paths['/users/{id}']).toBeDefined();
+    const op = paths['/users/{id}']['get'];
+    expect(op.summary).toBe('Get user');
+    expect(op.tags).toEqual(['users']);
+    expect(op.parameters).toHaveLength(1);
+    expect(op.parameters[0]).toMatchObject({
+      name: 'id',
+      in: 'path',
+      required: true,
+    });
+    expect(op.parameters[0].schema.type).toBe('string');
+    expect(op.parameters[0].description).toBe('User ID');
+  });
+
+  it('converts request.query Zod schema to query parameters', () => {
+    const routes: ApiRoute[] = [
+      {
+        path: '/users',
+        method: 'GET',
+        handler: mockHandler,
+        openapi: {
+          request: {
+            query: z.object({
+              limit: z.coerce.number().optional(),
+              cursor: z.string().optional(),
+            }),
+          },
+          responses: {
+            200: { description: 'User list' },
+          },
+        },
+      },
+    ];
+
+    const paths = convertCustomRoutesToOpenAPIPaths(routes);
+    const op = paths['/users']['get'];
+
+    expect(op.parameters).toHaveLength(2);
+    const paramNames = op.parameters.map((p: any) => p.name);
+    expect(paramNames).toContain('limit');
+    expect(paramNames).toContain('cursor');
+    op.parameters.forEach((p: any) => {
+      expect(p.in).toBe('query');
+    });
+  });
+
+  it('converts request.body Zod schema to requestBody', () => {
+    const CreateUserSchema = z.object({
+      name: z.string(),
+      email: z.string().email(),
+    });
+
+    const routes: ApiRoute[] = [
+      {
+        path: '/users',
+        method: 'POST',
+        handler: mockHandler,
+        openapi: {
+          summary: 'Create user',
+          request: {
+            body: {
+              content: {
+                'application/json': { schema: CreateUserSchema },
+              },
+            },
+          },
+          responses: {
+            201: { description: 'User created' },
+          },
+        },
+      },
+    ];
+
+    const paths = convertCustomRoutesToOpenAPIPaths(routes);
+    const op = paths['/users']['post'];
+
+    expect(op.requestBody).toBeDefined();
+    expect(op.requestBody.required).toBe(true);
+    expect(op.requestBody.content['application/json']).toBeDefined();
+    const schema = op.requestBody.content['application/json'].schema;
+    expect(schema.type).toBe('object');
+    expect(schema.properties).toHaveProperty('name');
+    expect(schema.properties).toHaveProperty('email');
+  });
+
+  it('converts response Zod schemas to JSON Schema', () => {
+    const UserSchema = z.object({ id: z.string(), name: z.string() });
+
+    const routes: ApiRoute[] = [
+      {
+        path: '/users/:id',
+        method: 'GET',
+        handler: mockHandler,
+        openapi: {
+          request: {
+            params: z.object({ id: z.string() }),
+          },
+          responses: {
+            200: {
+              description: 'User found',
+              content: {
+                'application/json': { schema: UserSchema },
+              },
+            },
+            404: { description: 'User not found' },
+          },
+        },
+      },
+    ];
+
+    const paths = convertCustomRoutesToOpenAPIPaths(routes);
+    const op = paths['/users/{id}']['get'];
+
+    expect(op.responses['200']).toBeDefined();
+    expect(op.responses['200'].description).toBe('User found');
+    const responseSchema = op.responses['200'].content['application/json'].schema;
+    expect(responseSchema.type).toBe('object');
+    expect(responseSchema.properties).toHaveProperty('id');
+    expect(responseSchema.properties).toHaveProperty('name');
+
+    expect(op.responses['404']).toBeDefined();
+    expect(op.responses['404'].description).toBe('User not found');
+    expect(op.responses['404'].content).toBeUndefined();
+  });
+
+  it('skips routes with hide: true', () => {
+    const routes: ApiRoute[] = [
+      {
+        path: '/internal',
+        method: 'GET',
+        handler: mockHandler,
+        openapi: {
+          hide: true,
+          request: {},
+          responses: { 200: { description: 'ok' } },
+        },
+      },
+    ];
+
+    const paths = convertCustomRoutesToOpenAPIPaths(routes);
+    expect(Object.keys(paths)).toHaveLength(0);
+  });
+
+  it('handles routes with only metadata and no request schemas', () => {
+    const routes: ApiRoute[] = [
+      {
+        path: '/health',
+        method: 'GET',
+        handler: mockHandler,
+        openapi: {
+          summary: 'Health check',
+          tags: ['system'],
+          request: {},
+          responses: {
+            200: { description: 'OK' },
+          },
+        },
+      },
+    ];
+
+    const paths = convertCustomRoutesToOpenAPIPaths(routes);
+    const op = paths['/health']['get'];
+
+    expect(op.summary).toBe('Health check');
+    expect(op.tags).toEqual(['system']);
+    expect(op.parameters).toBeUndefined();
+    expect(op.requestBody).toBeUndefined();
+    expect(op.responses['200'].description).toBe('OK');
+  });
+
+  it('converts both params and body in same route', () => {
+    const UpdateUserSchema = z.object({ name: z.string() });
+
+    const routes: ApiRoute[] = [
+      {
+        path: '/users/:id',
+        method: 'PUT',
+        handler: mockHandler,
+        openapi: {
+          summary: 'Update user',
+          request: {
+            params: z.object({ id: z.string() }),
+            body: {
+              content: {
+                'application/json': { schema: UpdateUserSchema },
+              },
+            },
+          },
+          responses: {
+            200: { description: 'Updated' },
+          },
+        },
+      },
+    ];
+
+    const paths = convertCustomRoutesToOpenAPIPaths(routes);
+    const op = paths['/users/{id}']['put'];
+
+    expect(op.parameters).toHaveLength(1);
+    expect(op.parameters[0].name).toBe('id');
+    expect(op.requestBody.content['application/json'].schema.type).toBe('object');
+  });
+});
+
+describe('convertCustomRoutesToOpenAPIPaths — DescribeRouteOptions (existing format)', () => {
+  it('still supports the legacy DescribeRouteOptions format with Zod schemas', () => {
+    const routes: ApiRoute[] = [
+      {
+        path: '/items',
+        method: 'GET',
+        handler: mockHandler,
+        openapi: {
+          summary: 'List items',
+          responses: {
+            200: {
+              description: 'Item list',
+              content: {
+                'application/json': {
+                  schema: z.object({ items: z.array(z.string()) }),
+                },
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const paths = convertCustomRoutesToOpenAPIPaths(routes);
+    const op = paths['/items']['get'];
+
+    expect(op.summary).toBe('List items');
+    const schema = op.responses['200'].content['application/json'].schema;
+    expect(schema.type).toBe('object');
+    expect(schema.properties).toHaveProperty('items');
+  });
+});

--- a/packages/server/src/server/server-adapter/openapi-utils.test.ts
+++ b/packages/server/src/server/server-adapter/openapi-utils.test.ts
@@ -294,4 +294,83 @@ describe('convertCustomRoutesToOpenAPIPaths — DescribeRouteOptions (existing f
     expect(schema.type).toBe('object');
     expect(schema.properties).toHaveProperty('items');
   });
+
+  it('preserves raw JSON Schema responses in DescribeRouteOptions (no Zod)', () => {
+    const routes: ApiRoute[] = [
+      {
+        path: '/status',
+        method: 'GET',
+        handler: mockHandler,
+        openapi: {
+          summary: 'Status check',
+          parameters: [],
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: { type: 'object', properties: { status: { type: 'string' } } },
+                },
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const paths = convertCustomRoutesToOpenAPIPaths(routes);
+    const op = paths['/status']['get'];
+
+    expect(op.summary).toBe('Status check');
+    const schema = op.responses['200'].content['application/json'].schema;
+    expect(schema.type).toBe('object');
+    expect(schema.properties).toHaveProperty('status');
+  });
+});
+
+describe('convertCustomRoutesToOpenAPIPaths — operationId preservation', () => {
+  it('preserves operationId on ZodOpenAPIRouteConfig without request field', () => {
+    // Regression: configs like { operationId, responses } type-check as
+    // ZodOpenAPIRouteConfig but were previously misrouted to the legacy converter,
+    // which silently dropped operationId.
+    const routes: ApiRoute[] = [
+      {
+        path: '/ping',
+        method: 'GET',
+        handler: mockHandler,
+        openapi: {
+          operationId: 'getPing',
+          summary: 'Ping',
+          responses: {
+            200: { description: 'pong' },
+          },
+        },
+      },
+    ];
+
+    const paths = convertCustomRoutesToOpenAPIPaths(routes);
+    const op = paths['/ping']['get'];
+
+    expect(op.operationId).toBe('getPing');
+    expect(op.summary).toBe('Ping');
+    expect(op.responses['200'].description).toBe('pong');
+  });
+
+  it('does not pollute Object.prototype when a route path is "__proto__"', () => {
+    const routes: ApiRoute[] = [
+      {
+        path: '__proto__',
+        method: 'GET',
+        handler: mockHandler,
+        openapi: {
+          request: {},
+          responses: { 200: { description: 'ok' } },
+        },
+      },
+    ];
+
+    convertCustomRoutesToOpenAPIPaths(routes);
+
+    expect(({} as any).get).toBeUndefined();
+  });
 });

--- a/packages/server/src/server/server-adapter/openapi-utils.ts
+++ b/packages/server/src/server/server-adapter/openapi-utils.ts
@@ -213,7 +213,9 @@ export function generateOpenAPIDocument(
   routes: readonly ServerRoute[],
   info: { title: string; version: string; description?: string },
 ): any {
-  const paths: Record<string, any> = {};
+  // Use Object.create(null) to prevent prototype pollution if a route path is
+  // ever '__proto__', 'constructor', or 'toString'.
+  const paths: Record<string, any> = Object.create(null);
 
   // Build paths object from routes
   // Convert Express-style :param to OpenAPI-style {param}
@@ -222,7 +224,7 @@ export function generateOpenAPIDocument(
 
     const openapiPath = route.path.replace(/:(\w+)/g, '{$1}');
     if (!paths[openapiPath]) {
-      paths[openapiPath] = {};
+      paths[openapiPath] = Object.create(null);
     }
 
     // Convert Zod schemas to JSON Schema
@@ -242,15 +244,31 @@ export function generateOpenAPIDocument(
 
 /**
  * Type guard: returns true when `openapi` was created using the Zod-based
- * `ZodOpenAPIRouteConfig` format (i.e. it has a `request` key) rather than
- * the raw `DescribeRouteOptions` / `OpenAPIV3_1.OperationObject` format.
+ * `ZodOpenAPIRouteConfig` format rather than the raw `DescribeRouteOptions` /
+ * `OpenAPIV3_1.OperationObject` format.
  *
  * `DescribeRouteOptions` extends `OpenAPIV3_1.OperationObject` which uses
  * `parameters[]` / `requestBody`; `ZodOpenAPIRouteConfig` uses `request.params`,
  * `request.query`, and `request.body` instead.
+ *
+ * Detection strategy:
+ *  1. If `request` is present → ZodOpenAPIRouteConfig (unambiguous).
+ *  2. If `parameters` (array) or `requestBody` is present → DescribeRouteOptions.
+ *  3. Otherwise, if `responses` is present, assume ZodOpenAPIRouteConfig so that
+ *     configs like `{ operationId, responses }` (no request schemas) are routed
+ *     through the Zod converter and don't silently lose `operationId`.
  */
 function isZodOpenAPIRouteConfig(openapi: unknown): openapi is ZodOpenAPIRouteConfig {
-  return typeof openapi === 'object' && openapi !== null && 'request' in openapi;
+  if (typeof openapi !== 'object' || openapi === null) return false;
+  if ('request' in openapi) return true;
+  // DescribeRouteOptions distinguishing fields
+  const hasDescribeRouteFields =
+    ('parameters' in openapi && Array.isArray((openapi as any).parameters)) ||
+    'requestBody' in openapi;
+  if (hasDescribeRouteFields) return false;
+  // No request schemas provided and no DescribeRouteOptions fields — treat as
+  // ZodOpenAPIRouteConfig when `responses` is present (required field on the type).
+  return 'responses' in openapi;
 }
 
 /**
@@ -378,7 +396,9 @@ function convertZodRouteConfigToOperation(route: ApiRoute, openapi: ZodOpenAPIRo
  * @returns OpenAPI paths object to be merged into the main spec
  */
 export function convertCustomRoutesToOpenAPIPaths(routes: ApiRoute[]): Record<string, any> {
-  const paths: Record<string, any> = {};
+  // Use Object.create(null) to prevent prototype pollution if a route path is
+  // ever '__proto__', 'constructor', or 'toString'.
+  const paths: Record<string, any> = Object.create(null);
 
   for (const route of routes) {
     // Skip routes without openapi metadata or routes marked as hidden
@@ -395,7 +415,7 @@ export function convertCustomRoutesToOpenAPIPaths(routes: ApiRoute[]): Record<st
     const openapiPath = route.path.replace(/:(\w+)/g, '{$1}');
 
     if (!paths[openapiPath]) {
-      paths[openapiPath] = {};
+      paths[openapiPath] = Object.create(null);
     }
 
     const method = route.method.toLowerCase();

--- a/packages/server/src/server/server-adapter/openapi-utils.ts
+++ b/packages/server/src/server/server-adapter/openapi-utils.ts
@@ -1,6 +1,6 @@
 import type { PublicSchema } from '@mastra/core/schema';
 import { toStandardSchema } from '@mastra/core/schema';
-import type { ApiRoute } from '@mastra/core/server';
+import type { ApiRoute, ZodOpenAPIRouteConfig } from '@mastra/core/server';
 import { zodToJsonSchema } from '@mastra/core/utils/zod-to-json';
 import { standardSchemaToJSONSchema } from '@mastra/schema-compat';
 import type { JSONSchema7 } from '@mastra/schema-compat';
@@ -241,9 +241,138 @@ export function generateOpenAPIDocument(
 }
 
 /**
+ * Type guard: returns true when `openapi` was created using the Zod-based
+ * `ZodOpenAPIRouteConfig` format (i.e. it has a `request` key) rather than
+ * the raw `DescribeRouteOptions` / `OpenAPIV3_1.OperationObject` format.
+ *
+ * `DescribeRouteOptions` extends `OpenAPIV3_1.OperationObject` which uses
+ * `parameters[]` / `requestBody`; `ZodOpenAPIRouteConfig` uses `request.params`,
+ * `request.query`, and `request.body` instead.
+ */
+function isZodOpenAPIRouteConfig(openapi: unknown): openapi is ZodOpenAPIRouteConfig {
+  return typeof openapi === 'object' && openapi !== null && 'request' in openapi;
+}
+
+/**
+ * Returns true when `schema` looks like a Zod schema (v3 uses `_def`, v4 uses `_zod`).
+ */
+function isZodSchema(schema: unknown): boolean {
+  return (
+    typeof schema === 'object' &&
+    schema !== null &&
+    ('_def' in schema || '_zod' in (schema as Record<string, unknown>))
+  );
+}
+
+/**
+ * Converts a `ZodOpenAPIRouteConfig` to a plain OpenAPI operation object,
+ * translating Zod schemas in `request.params`, `request.query`, `request.body`,
+ * and `responses` to JSON Schema.
+ */
+function convertZodRouteConfigToOperation(route: ApiRoute, openapi: ZodOpenAPIRouteConfig): Record<string, any> {
+  const operation: Record<string, any> = {
+    summary: openapi.summary || `${route.method} ${route.path}`,
+    description: openapi.description,
+    tags: openapi.tags || ['custom'],
+    deprecated: openapi.deprecated,
+    operationId: openapi.operationId,
+    externalDocs: openapi.externalDocs,
+    security: openapi.security,
+  };
+
+  const parameters: any[] = [];
+
+  // Convert request.params (Zod object → path parameters)
+  if (openapi.request?.params && isZodSchema(openapi.request.params)) {
+    const jsonSchema = zodToJsonSchema(openapi.request.params as any, 'openApi3', 'none') as any;
+    const properties = jsonSchema.properties || {};
+    Object.entries(properties).forEach(([name, schema]) => {
+      parameters.push({
+        name,
+        in: 'path',
+        required: true,
+        description: (schema as any).description || `The ${name} parameter`,
+        schema,
+      });
+    });
+  }
+
+  // Convert request.query (Zod object → query parameters)
+  if (openapi.request?.query && isZodSchema(openapi.request.query)) {
+    const jsonSchema = zodToJsonSchema(openapi.request.query as any, 'openApi3', 'none') as any;
+    const properties = jsonSchema.properties || {};
+    const required: string[] = jsonSchema.required || [];
+    Object.entries(properties).forEach(([name, schema]) => {
+      parameters.push({
+        name,
+        in: 'query',
+        required: required.includes(name),
+        description: (schema as any).description || `Query parameter: ${name}`,
+        schema,
+      });
+    });
+  }
+
+  if (parameters.length > 0) {
+    operation.parameters = parameters;
+  }
+
+  // Convert request.body (multi-media-type support)
+  if (openapi.request?.body?.content) {
+    operation.requestBody = {
+      required: openapi.request.body.required ?? true,
+      description: openapi.request.body.description,
+      content: {},
+    };
+    for (const [mediaType, mediaContent] of Object.entries(openapi.request.body.content)) {
+      if (mediaContent?.schema && isZodSchema(mediaContent.schema)) {
+        operation.requestBody.content[mediaType] = {
+          schema: zodToJsonSchema(mediaContent.schema as any, 'openApi3', 'none'),
+        };
+      } else if (mediaContent?.schema) {
+        operation.requestBody.content[mediaType] = mediaContent;
+      }
+    }
+  }
+
+  // Convert responses
+  operation.responses = {};
+  for (const [statusCode, response] of Object.entries(openapi.responses)) {
+    if (!response) continue;
+    operation.responses[statusCode] = { description: response.description };
+
+    if (response.content) {
+      operation.responses[statusCode].content = {};
+      for (const [mediaType, mediaContent] of Object.entries(response.content)) {
+        if (mediaContent?.schema && isZodSchema(mediaContent.schema)) {
+          operation.responses[statusCode].content[mediaType] = {
+            schema: zodToJsonSchema(mediaContent.schema as any, 'openApi3', 'none'),
+          };
+        } else if (mediaContent?.schema) {
+          operation.responses[statusCode].content[mediaType] = mediaContent;
+        }
+      }
+    }
+  }
+
+  // Remove undefined values
+  Object.keys(operation).forEach(key => {
+    if (operation[key] === undefined) {
+      delete operation[key];
+    }
+  });
+
+  return operation;
+}
+
+/**
  * Converts custom API routes with DescribeRouteOptions to OpenAPI path entries.
  * The DescribeRouteOptions from hono-openapi extends OpenAPIV3_1.OperationObject,
  * so it already has the standard OpenAPI structure (parameters, requestBody, responses, etc.).
+ *
+ * Also supports ZodOpenAPIRouteConfig where Zod schemas are specified via
+ * `request.params`, `request.query`, and `request.body` and are automatically
+ * converted to JSON Schema.
  *
  * @param routes - Array of ApiRoute objects with optional openapi specifications
  * @returns OpenAPI paths object to be merged into the main spec
@@ -253,7 +382,7 @@ export function convertCustomRoutesToOpenAPIPaths(routes: ApiRoute[]): Record<st
 
   for (const route of routes) {
     // Skip routes without openapi metadata or routes marked as hidden
-    if (!route.openapi || route.openapi.hide) {
+    if (!route.openapi || (route.openapi as any).hide) {
       continue;
     }
 
@@ -271,6 +400,13 @@ export function convertCustomRoutesToOpenAPIPaths(routes: ApiRoute[]): Record<st
 
     const method = route.method.toLowerCase();
     const openapi = route.openapi;
+
+    // ZodOpenAPIRouteConfig: detected by the presence of a `request` property.
+    // Convert Zod schemas in request.params/query/body and responses to JSON Schema.
+    if (isZodOpenAPIRouteConfig(openapi)) {
+      paths[openapiPath][method] = convertZodRouteConfigToOperation(route, openapi);
+      continue;
+    }
 
     // Build the OpenAPI operation object from DescribeRouteOptions
     // DescribeRouteOptions extends OpenAPIV3_1.OperationObject, so it already has:
@@ -292,8 +428,8 @@ export function convertCustomRoutesToOpenAPIPaths(routes: ApiRoute[]): Record<st
     // Copy parameters directly if provided (already in OpenAPI format)
     if (openapi.parameters && Array.isArray(openapi.parameters)) {
       operation.parameters = openapi.parameters.map((param: any) => {
-        // Convert Zod schemas in parameter schemas if needed
-        if (param.schema && typeof param.schema === 'object' && '_def' in param.schema) {
+        // Convert Zod schemas (v3: _def, v4: _zod) in parameter schemas if needed
+        if (param.schema && isZodSchema(param.schema)) {
           return {
             ...param,
             schema: zodToJsonSchema(param.schema, 'openApi3', 'none'),
@@ -312,7 +448,7 @@ export function convertCustomRoutesToOpenAPIPaths(routes: ApiRoute[]): Record<st
       if (requestBody.content) {
         operation.requestBody.content = {};
         for (const [mediaType, mediaContent] of Object.entries(requestBody.content as Record<string, any>)) {
-          if (mediaContent?.schema && typeof mediaContent.schema === 'object' && '_def' in mediaContent.schema) {
+          if (mediaContent?.schema && isZodSchema(mediaContent.schema)) {
             operation.requestBody.content[mediaType] = {
               ...mediaContent,
               schema: zodToJsonSchema(mediaContent.schema, 'openApi3', 'none'),
@@ -342,7 +478,7 @@ export function convertCustomRoutesToOpenAPIPaths(routes: ApiRoute[]): Record<st
         if (response.content) {
           operation.responses[statusCode].content = {};
           for (const [mediaType, mediaContent] of Object.entries(response.content as Record<string, any>)) {
-            if (mediaContent?.schema && typeof mediaContent.schema === 'object' && '_def' in mediaContent.schema) {
+            if (mediaContent?.schema && isZodSchema(mediaContent.schema)) {
               operation.responses[statusCode].content[mediaType] = {
                 ...mediaContent,
                 schema: zodToJsonSchema(mediaContent.schema, 'openApi3', 'none'),


### PR DESCRIPTION
## Summary

Closes #5454.

`registerApiRoute()` now accepts a Zod-first OpenAPI config (inspired by `@hono/zod-openapi`'s `createRoute` API) as an alternative to the raw `DescribeRouteOptions` format. Schemas are converted to JSON Schema automatically when building the OpenAPI spec.

**Before** (raw `DescribeRouteOptions` — still works):
```typescript
registerApiRoute('/users/:id', {
  method: 'GET',
  openapi: {
    summary: 'Get user',
    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
    responses: { 200: { description: 'User' } },
  },
  handler: async (c) => c.json({ id: c.req.param('id') }),
});
```

**After** (new `ZodOpenAPIRouteConfig` — Zod schemas inline):
```typescript
import { z } from 'zod';

registerApiRoute('/users/:id', {
  method: 'GET',
  openapi: {
    summary: 'Get user',
    tags: ['users'],
    request: {
      params: z.object({ id: z.string().describe('User ID') }),
      query: z.object({ include: z.string().optional() }),
    },
    responses: {
      200: {
        description: 'User found',
        content: {
          'application/json': {
            schema: z.object({ id: z.string(), name: z.string() }),
          },
        },
      },
      404: { description: 'User not found' },
    },
  },
  handler: async (c) => {
    const { id } = c.req.param();
    return c.json({ id, name: 'Alice' });
  },
});
```

## Changes

- **`packages/core/src/server/types.ts`**: adds `ZodOpenAPIRouteConfig` type; `ApiRoute.openapi` is now `DescribeRouteOptions | ZodOpenAPIRouteConfig` (fully backwards-compatible)
- **`packages/core/src/server/index.ts`**: exports `ZodOpenAPIRouteConfig`; `registerApiRoute` accepts either openapi format
- **`packages/server/src/server/server-adapter/openapi-utils.ts`**:
  - `isZodOpenAPIRouteConfig()` type guard (detects `request` key — absent from `DescribeRouteOptions`)
  - `isZodSchema()` helper covering both Zod v3 (`_def`) and v4 (`_zod`)
  - `convertZodRouteConfigToOperation()` converts `request.params/query/body` + `responses` to JSON Schema
  - `convertCustomRoutesToOpenAPIPaths` dispatches on format
  - Fix: the existing `DescribeRouteOptions` path now uses `isZodSchema()` instead of checking `_def` only, so Zod v4 schemas work there too
- **`packages/server/src/server/server-adapter/openapi-utils.test.ts`**: new tests for the new format (path params, query params, request body, response schemas, `hide` flag, mixed routes, legacy format unchanged)

## Notes

- No new dependencies — uses the already-present `zodToJsonSchema` from `@mastra/core/utils/zod-to-json`
- The discriminator between formats is the `request` key: `DescribeRouteOptions` (which extends `OpenAPIV3_1.OperationObject`) never has a `request` property; `ZodOpenAPIRouteConfig` always does (even if `request: {}`)
- Both Zod v3 and v4 schemas are handled via the existing `zodToJsonSchema` adapter

## Test plan

- [ ] `pnpm test --filter @mastra/server` — new `openapi-utils.test.ts` tests pass
- [ ] Existing custom route OpenAPI tests unaffected (backwards compat)
- [ ] Manual: define a route with `ZodOpenAPIRouteConfig`, hit `/openapi.json`, confirm path params / query params / body / responses appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

You can now describe custom API routes using Zod schemas (for params, query, body, and responses) and the server will auto-convert them into OpenAPI docs—while the old format still works. The PR also fixes edge-cases so operation IDs aren’t lost and prevents prototype-pollution in the generated OpenAPI paths.

## Overview

Adds Zod-first OpenAPI support for custom routes via a new ZodOpenAPIRouteConfig type and conversion logic that turns Zod schemas into JSON Schema (using the existing zodToJsonSchema) when building the OpenAPI spec. The change is backwards-compatible: the existing DescribeRouteOptions format remains supported.

## Changes

### Types & Exports
- packages/core/src/server/types.ts
  - New exported type: ZodOpenAPIRouteConfig (OpenAPI metadata + optional request { params, query, body } and responses keyed by status).
  - ApiRoute.openapi now accepts DescribeRouteOptions | ZodOpenAPIRouteConfig.
- packages/core/src/server/index.ts
  - Exports ZodOpenAPIRouteConfig and updates RegisterApiRouteOptions to allow the new format.

### OpenAPI Conversion & Helpers
- packages/server/src/server/server-adapter/openapi-utils.ts
  - Added isZodOpenAPIRouteConfig type-guard and convertZodRouteConfigToOperation to convert Zod request/response schemas to OpenAPI operations (via zodToJsonSchema).
  - Added isZodSchema helper that recognizes Zod v3 (_def) and v4 (_zod).
  - convertCustomRoutesToOpenAPIPaths now dispatches between Zod and legacy DescribeRouteOptions conversion.
  - Broadened Zod-config detection to handle configs missing request (3-step detection so entries like { operationId, responses } are treated as Zod configs).
  - Replaced plain object maps with Object.create(null) for the top-level paths container and per-path objects to prevent prototype pollution.
  - Legacy path generation updated to use isZodSchema so Zod v4 schemas work in DescribeRouteOptions flows.

### Tests
- packages/server/src/server/server-adapter/openapi-utils.test.ts
  - New tests covering Zod format conversions (path params, query, body, responses), hide flag, mixed routes, routes with metadata-only, and backwards compatibility.
  - Regression tests for operationId-preservation and prototype-pollution prevention.

### Release notes / changeset
- .changeset/fix-zod-openapi-detection-and-proto-pollution.md updates for @mastra/core and @mastra/server describing the detection broadening and prototype-pollution fix.

## Impact

- Backwards-compatible: existing DescribeRouteOptions users unaffected.
- No new dependencies.
- Developer experience improved: Zod-first route schemas produce deterministic OpenAPI output and can be used alongside existing formats.
- Fixes: ensures operationId and other metadata aren’t lost for Zod-shaped configs without request, and defends against prototype-pollution in OpenAPI path keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->