### PR TITLE
feat(core): preserve harness subagent history

### DIFF
--- a/.changeset/metal-icons-worry.md
+++ b/.changeset/metal-icons-worry.md
@@ -5,3 +5,11 @@
 Added `subagentHistory` to `HarnessDisplayState` so UIs can keep rendering completed, errored, and aborted subagent runs after `agent_end`.
 
 Use `harness.getDisplayState().subagentHistory` to read the retained subagent activity, including `toolCallId`, `endedAt`, `order`, and `parentEndReason`. Closes #16056.
+
+```ts
+const history = harness.getDisplayState().subagentHistory;
+
+for (const entry of history) {
+  console.log(entry.toolCallId, entry.status, entry.parentEndReason);
+}
+```

--- a/.changeset/metal-icons-worry.md
+++ b/.changeset/metal-icons-worry.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': minor
+---
+
+Added `subagentHistory` to `HarnessDisplayState` so UIs can keep rendering completed, errored, and aborted subagent runs after `agent_end`.
+
+Use `harness.getDisplayState().subagentHistory` to read the retained subagent activity, including `toolCallId`, `endedAt`, `order`, and `parentEndReason`. Closes #16056.

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -355,6 +355,10 @@ Return the current `HarnessDisplayState` snapshot for UI rendering.
 const displayState = harness.getDisplayState()
 ```
 
+`HarnessDisplayState.subagentHistory` contains completed, errored, and aborted subagent runs. Each entry includes the `ActiveSubagentState` fields plus `toolCallId`, `endedAt`, `order`, optional `parentEndReason`, and an extra `aborted` status for subagents still running when the parent run ends.
+
+Harness appends entries on `subagent_end` and keeps them after `agent_end`, while `activeSubagents` is cleared on `agent_end`. During a run, a completed or errored subagent can appear in both `activeSubagents` and `subagentHistory`, so display adapters that read both should dedupe by `toolCallId`. The history resets on `agent_start` and thread display-state resets.
+
 #### `setState(updates)`
 
 Update the harness state. Validates against `stateSchema` if provided, and emits a `state_changed` event with the new state and changed keys.

--- a/packages/core/src/harness/display-state-scheduler.ts
+++ b/packages/core/src/harness/display-state-scheduler.ts
@@ -126,6 +126,11 @@ function cloneDisplayState(state: HarnessDisplayState): HarnessDisplayState {
         },
       ]),
     ),
+    subagentHistory: state.subagentHistory.map(entry => ({
+      ...entry,
+      toolCalls: entry.toolCalls.map(toolCall => cloneUnknown(toolCall)),
+      endedAt: new Date(entry.endedAt.getTime()),
+    })),
     omProgress: {
       ...state.omProgress,
       buffered: {

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -1298,12 +1298,61 @@ describe('resetThreadDisplayState', () => {
   });
 
   it('resets omProgress on thread_changed', () => {
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'explore',
+      result: 'done',
+      isError: false,
+      durationMs: 100,
+    });
     emit(harness, { type: 'om_observation_start', cycleId: 'c1', operationType: 'observation', tokensToObserve: 5000 });
+    expect(harness.getDisplayState().subagentHistory).toHaveLength(1);
     expect(harness.getDisplayState().omProgress.status).toBe('observing');
 
     emit(harness, { type: 'thread_changed', threadId: 'other', previousThreadId: 'old' });
     expect(harness.getDisplayState().omProgress.status).toBe('idle');
     expect(harness.getDisplayState().omProgress.pendingTokens).toBe(0);
+    expect(harness.getDisplayState().subagentHistory).toEqual([]);
+  });
+
+  it('resets subagentHistory on thread_deleted when no current thread is set', () => {
+    (harness as any).tokenUsage = { promptTokens: 100, completionTokens: 50, totalTokens: 150 };
+    emit(harness, { type: 'usage_update', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } });
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'explore',
+      result: 'done',
+      isError: false,
+      durationMs: 100,
+    });
+    expect(harness.getDisplayState().subagentHistory).toHaveLength(1);
+    expect(harness.getDisplayState().tokenUsage.totalTokens).toBe(150);
+
+    emit(harness, { type: 'thread_deleted', threadId: 'deleted' });
+
+    expect(harness.getDisplayState().subagentHistory).toEqual([]);
+    expect(harness.getDisplayState().tokenUsage).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+  });
+
+  it('preserves subagentHistory on thread_deleted when another thread remains current', () => {
+    (harness as any).currentThreadId = 'current';
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'explore',
+      result: 'done',
+      isError: false,
+      durationMs: 100,
+    });
+
+    emit(harness, { type: 'thread_deleted', threadId: 'deleted' });
+
+    expect(harness.getDisplayState().subagentHistory).toHaveLength(1);
   });
 
   it('syncs tokenUsage from internal counters on thread_changed', () => {

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -39,6 +39,7 @@ describe('defaultDisplayState', () => {
     expect(ds.pendingPlanApproval).toBeNull();
     expect(ds.activeSubagents).toBeInstanceOf(Map);
     expect(ds.activeSubagents.size).toBe(0);
+    expect(ds.subagentHistory).toEqual([]);
     expect(ds.omProgress.status).toBe('idle');
     expect(ds.omProgress.pendingTokens).toBe(0);
     expect(ds.omProgress.threshold).toBe(30000);
@@ -75,6 +76,7 @@ describe('Harness.getDisplayState()', () => {
     expect(ds.pendingQuestion).toBeNull();
     expect(ds.pendingPlanApproval).toBeNull();
     expect(ds.activeSubagents.size).toBe(0);
+    expect(ds.subagentHistory).toEqual([]);
     expect(ds.modifiedFiles.size).toBe(0);
     expect(ds.tasks).toEqual([]);
     expect(ds.previousTasks).toEqual([]);
@@ -182,6 +184,13 @@ describe('agent lifecycle', () => {
 
     emit(harness, { type: 'agent_end', reason: 'complete' });
     expect(harness.getDisplayState().activeSubagents.size).toBe(0);
+    expect(harness.getDisplayState().subagentHistory).toEqual([
+      expect.objectContaining({
+        toolCallId: 's1',
+        status: 'aborted',
+        parentEndReason: 'complete',
+      }),
+    ]);
   });
 });
 
@@ -635,6 +644,43 @@ describe('subagent lifecycle', () => {
     expect(sub.result).toBe('done');
   });
 
+  it('records completed subagent history on subagent_end', () => {
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_tool_start',
+      toolCallId: 's1',
+      agentType: 'execute',
+      subToolName: 'read_file',
+      subToolArgs: {},
+    });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'execute',
+      result: 'done',
+      isError: false,
+      durationMs: 1234,
+    });
+
+    const ds = harness.getDisplayState();
+    expect(ds.activeSubagents.get('s1')?.status).toBe('completed');
+    expect(ds.subagentHistory).toHaveLength(1);
+    expect(ds.subagentHistory[0]).toEqual(
+      expect.objectContaining({
+        toolCallId: 's1',
+        agentType: 'execute',
+        task: 't',
+        modelId: 'm',
+        status: 'completed',
+        durationMs: 1234,
+        result: 'done',
+        order: 0,
+      }),
+    );
+    expect(ds.subagentHistory[0]!.endedAt).toBeInstanceOf(Date);
+    expect(ds.subagentHistory[0]!.toolCalls).toEqual([{ name: 'read_file', isError: false }]);
+  });
+
   it('marks subagent as error on failed subagent_end', () => {
     emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
     emit(harness, {
@@ -646,6 +692,98 @@ describe('subagent lifecycle', () => {
       durationMs: 500,
     });
     expect(harness.getDisplayState().activeSubagents.get('s1')!.status).toBe('error');
+  });
+
+  it('records errored subagent history on failed subagent_end', () => {
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'execute',
+      result: 'failed',
+      isError: true,
+      durationMs: 500,
+    });
+
+    const history = harness.getDisplayState().subagentHistory;
+    expect(history).toHaveLength(1);
+    expect(history[0]).toEqual(
+      expect.objectContaining({
+        toolCallId: 's1',
+        status: 'error',
+        result: 'failed',
+        durationMs: 500,
+      }),
+    );
+    expect(history[0]!.parentEndReason).toBeUndefined();
+  });
+
+  it('preserves subagentHistory after agent_end', () => {
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'execute',
+      result: 'done',
+      isError: false,
+      durationMs: 1234,
+    });
+
+    emit(harness, { type: 'agent_end', reason: 'complete' });
+
+    const ds = harness.getDisplayState();
+    expect(ds.activeSubagents.size).toBe(0);
+    expect(ds.subagentHistory).toHaveLength(1);
+    expect(ds.subagentHistory[0]).toEqual(expect.objectContaining({ toolCallId: 's1', status: 'completed' }));
+  });
+
+  it('records running subagents as aborted when agent_end fires', () => {
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 'find', modelId: 'm' });
+
+    emit(harness, { type: 'agent_end', reason: 'error' });
+
+    const ds = harness.getDisplayState();
+    expect(ds.activeSubagents.size).toBe(0);
+    expect(ds.subagentHistory).toHaveLength(1);
+    expect(ds.subagentHistory[0]).toEqual(
+      expect.objectContaining({
+        toolCallId: 's1',
+        status: 'aborted',
+        parentEndReason: 'error',
+        order: 0,
+      }),
+    );
+    expect(ds.subagentHistory[0]!.endedAt).toBeInstanceOf(Date);
+  });
+
+  it('defaults parentEndReason to aborted when agent_end has no reason', () => {
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 'find', modelId: 'm' });
+
+    emit(harness, { type: 'agent_end' });
+
+    expect(harness.getDisplayState().subagentHistory[0]).toEqual(
+      expect.objectContaining({
+        status: 'aborted',
+        parentEndReason: 'aborted',
+      }),
+    );
+  });
+
+  it('clears subagentHistory on agent_start', () => {
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'execute',
+      result: 'done',
+      isError: false,
+      durationMs: 1234,
+    });
+    expect(harness.getDisplayState().subagentHistory).toHaveLength(1);
+
+    emit(harness, { type: 'agent_start' });
+
+    expect(harness.getDisplayState().subagentHistory).toEqual([]);
   });
 });
 
@@ -1108,6 +1246,14 @@ describe('resetThreadDisplayState', () => {
     emit(harness, { type: 'ask_question', questionId: 'q1', question: 'Q?', options: [] });
     emit(harness, { type: 'plan_approval_required', planId: 'p1', title: 'P', plan: '#' });
     emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'explore', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'explore',
+      result: 'done',
+      isError: false,
+      durationMs: 100,
+    });
     emit(harness, { type: 'task_updated', tasks: [{ content: 'T', status: 'pending', activeForm: 'T' }] });
     emit(harness, { type: 'om_observation_start', cycleId: 'c1', operationType: 'observation', tokensToObserve: 5000 });
     emit(harness, { type: 'om_buffering_start', cycleId: 'c2', operationType: 'observation', tokensToBuffer: 1000 });
@@ -1122,6 +1268,7 @@ describe('resetThreadDisplayState', () => {
     expect(ds.pendingQuestion).toBeNull();
     expect(ds.pendingPlanApproval).toBeNull();
     expect(ds.activeSubagents.size).toBe(0);
+    expect(ds.subagentHistory).toEqual([]);
     expect(ds.currentMessage).toBeNull();
     expect(ds.modifiedFiles.size).toBe(0);
     expect(ds.tasks).toEqual([]);
@@ -1426,6 +1573,44 @@ describe('Harness.subscribeDisplayState()', () => {
     expect(liveToolArgs.nested.marker).toBe('original');
     expect(liveModifiedFile.firstModified).toEqual(firstModified);
     expect(liveModifiedFile.operations).toEqual(['write_file']);
+  });
+
+  it('isolates listener subagentHistory snapshots from live display state', () => {
+    const listener = vi.fn();
+    harness.subscribeDisplayState(listener, { windowMs: 250, maxWaitMs: 500 });
+
+    const endedAt = new Date('2026-01-01T00:00:00.000Z');
+    vi.setSystemTime(endedAt);
+
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_tool_start',
+      toolCallId: 's1',
+      agentType: 'execute',
+      subToolName: 'read_file',
+      subToolArgs: {},
+    });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'execute',
+      result: 'done',
+      isError: false,
+      durationMs: 1234,
+    });
+
+    const snapshot = listener.mock.calls.at(-1)?.[0];
+    const liveEntry = harness.getDisplayState().subagentHistory[0]!;
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.subagentHistory).toHaveLength(1);
+    expect(snapshot!.subagentHistory[0]).not.toBe(liveEntry);
+    expect(snapshot!.subagentHistory[0]!.endedAt).not.toBe(liveEntry.endedAt);
+
+    snapshot!.subagentHistory[0]!.toolCalls[0]!.name = 'mutated';
+    harness.getDisplayState().subagentHistory.push({ ...liveEntry, toolCallId: 's2', order: 1 });
+
+    expect(liveEntry.toolCalls[0]!.name).toBe('read_file');
+    expect(snapshot!.subagentHistory).toHaveLength(1);
   });
 
   it('unsubscribe cancels pending timers and prevents later callbacks', () => {

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -718,6 +718,45 @@ describe('subagent lifecycle', () => {
     expect(history[0]!.parentEndReason).toBeUndefined();
   });
 
+  it('ignores duplicate subagent_end events for an already-ended subagent', () => {
+    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'execute',
+      result: 'done',
+      isError: false,
+      durationMs: 1234,
+    });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 's1',
+      agentType: 'execute',
+      result: 'late duplicate',
+      isError: true,
+      durationMs: 2000,
+    });
+
+    const ds = harness.getDisplayState();
+    expect(ds.activeSubagents.get('s1')).toEqual(
+      expect.objectContaining({
+        status: 'completed',
+        result: 'done',
+        durationMs: 1234,
+      }),
+    );
+    expect(ds.subagentHistory).toHaveLength(1);
+    expect(ds.subagentHistory[0]).toEqual(
+      expect.objectContaining({
+        toolCallId: 's1',
+        status: 'completed',
+        result: 'done',
+        durationMs: 1234,
+        order: 0,
+      }),
+    );
+  });
+
   it('preserves subagentHistory after agent_end', () => {
     emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
     emit(harness, {
@@ -754,6 +793,41 @@ describe('subagent lifecycle', () => {
       }),
     );
     expect(ds.subagentHistory[0]!.endedAt).toBeInstanceOf(Date);
+  });
+
+  it('keeps completed history and aborts only running subagents on agent_end', () => {
+    emit(harness, { type: 'subagent_start', toolCallId: 'done', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(harness, { type: 'subagent_start', toolCallId: 'running', agentType: 'explore', task: 'find', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_end',
+      toolCallId: 'done',
+      agentType: 'execute',
+      result: 'done',
+      isError: false,
+      durationMs: 1234,
+    });
+
+    emit(harness, { type: 'agent_end', reason: 'suspended' });
+
+    const ds = harness.getDisplayState();
+    expect(ds.activeSubagents.size).toBe(0);
+    expect(ds.subagentHistory).toHaveLength(2);
+    expect(ds.subagentHistory[0]).toEqual(
+      expect.objectContaining({
+        toolCallId: 'done',
+        status: 'completed',
+        order: 0,
+      }),
+    );
+    expect(ds.subagentHistory[0]!.parentEndReason).toBeUndefined();
+    expect(ds.subagentHistory[1]).toEqual(
+      expect.objectContaining({
+        toolCallId: 'running',
+        status: 'aborted',
+        parentEndReason: 'suspended',
+        order: 1,
+      }),
+    );
   });
 
   it('defaults parentEndReason to aborted when agent_end has no reason', () => {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -38,6 +38,7 @@ import type {
   HarnessRequestContext,
   HarnessSession,
   HarnessSubagentHistoryEntry,
+  HarnessSubagentHistoryStatus,
   HarnessThread,
   ModelAuthStatus,
   PermissionPolicy,
@@ -55,7 +56,7 @@ function createSubagentHistoryEntry({
 }: {
   toolCallId: string;
   subagent: ActiveSubagentState;
-  status: ActiveSubagentState['status'] | 'aborted';
+  status: HarnessSubagentHistoryStatus;
   parentEndReason?: 'complete' | 'aborted' | 'error' | 'suspended';
   order: number;
 }): HarnessSubagentHistoryEntry {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -2940,7 +2940,7 @@ export class Harness<TState = {}> {
 
       case 'subagent_end': {
         const endedSub = ds.activeSubagents.get(event.toolCallId);
-        if (endedSub) {
+        if (endedSub?.status === 'running') {
           endedSub.status = event.isError ? 'error' : 'completed';
           endedSub.durationMs = event.durationMs;
           endedSub.result = event.result;

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -24,6 +24,7 @@ import { defaultDisplayState, defaultOMProgressState } from './types';
 import type {
   AvailableModel,
   HeartbeatHandler,
+  ActiveSubagentState,
   HarnessConfig,
   HarnessDisplayState,
   HarnessDisplayStateListener,
@@ -36,6 +37,7 @@ import type {
   HarnessQuestionAnswer,
   HarnessRequestContext,
   HarnessSession,
+  HarnessSubagentHistoryEntry,
   HarnessThread,
   ModelAuthStatus,
   PermissionPolicy,
@@ -43,6 +45,33 @@ import type {
   TokenUsage,
   ToolCategory,
 } from './types';
+
+function createSubagentHistoryEntry({
+  toolCallId,
+  subagent,
+  status,
+  parentEndReason,
+  order,
+}: {
+  toolCallId: string;
+  subagent: ActiveSubagentState;
+  status: ActiveSubagentState['status'] | 'aborted';
+  parentEndReason?: 'complete' | 'aborted' | 'error' | 'suspended';
+  order: number;
+}): HarnessSubagentHistoryEntry {
+  const entry: HarnessSubagentHistoryEntry = {
+    ...subagent,
+    toolCallId,
+    status,
+    toolCalls: subagent.toolCalls.map(toolCall => ({ ...toolCall })),
+    endedAt: new Date(),
+    order,
+  };
+  if (parentEndReason) {
+    entry.parentEndReason = parentEndReason;
+  }
+  return entry;
+}
 
 function createEmptyTokenUsage(): TokenUsage {
   return { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
@@ -2360,6 +2389,7 @@ export class Harness<TState = {}> {
     this.displayState.pendingQuestion = null;
     this.displayState.pendingPlanApproval = null;
     this.displayState.activeSubagents = new Map();
+    this.displayState.subagentHistory = [];
     this.displayState.currentMessage = null;
     this.displayState.modifiedFiles = new Map();
     this.displayState.tasks = [];
@@ -2686,6 +2716,7 @@ export class Harness<TState = {}> {
         ds.isRunning = true;
         ds.activeTools = new Map();
         ds.toolInputBuffers = new Map();
+        ds.subagentHistory = [];
         ds.currentMessage = null;
         ds.pendingApproval = null;
         ds.pendingSuspension = null;
@@ -2703,6 +2734,20 @@ export class Harness<TState = {}> {
         for (const [, tool] of ds.activeTools) {
           if (tool.status === 'running' || tool.status === 'streaming_input') {
             tool.status = 'error';
+          }
+        }
+        for (const [toolCallId, subagent] of ds.activeSubagents) {
+          if (subagent.status === 'running') {
+            ds.subagentHistory.push(
+              createSubagentHistoryEntry({
+                toolCallId,
+                subagent,
+                status: 'aborted',
+                // External event emitters may omit reason, but internal agent_end events always set it.
+                parentEndReason: event.reason ?? 'aborted',
+                order: ds.subagentHistory.length,
+              }),
+            );
           }
         }
         ds.activeSubagents = new Map();
@@ -2898,6 +2943,14 @@ export class Harness<TState = {}> {
           endedSub.status = event.isError ? 'error' : 'completed';
           endedSub.durationMs = event.durationMs;
           endedSub.result = event.result;
+          ds.subagentHistory.push(
+            createSubagentHistoryEntry({
+              toolCallId: event.toolCallId,
+              subagent: endedSub,
+              status: endedSub.status,
+              order: ds.subagentHistory.length,
+            }),
+          );
         }
         break;
       }

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -25,6 +25,7 @@ export type {
   HarnessSession,
   HarnessStateSchema,
   HarnessSubagent,
+  HarnessSubagentHistoryEntry,
   HarnessThread,
   HeartbeatHandler,
   ModelAuthChecker,

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -26,6 +26,7 @@ export type {
   HarnessStateSchema,
   HarnessSubagent,
   HarnessSubagentHistoryEntry,
+  HarnessSubagentHistoryStatus,
   HarnessThread,
   HeartbeatHandler,
   ModelAuthChecker,

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -511,12 +511,14 @@ export interface ActiveSubagentState {
   result?: string;
 }
 
+export type HarnessSubagentHistoryStatus = 'completed' | 'error' | 'aborted';
+
 /**
  * Terminal subagent activity retained for display snapshots after the parent run ends.
  */
 export interface HarnessSubagentHistoryEntry extends Omit<ActiveSubagentState, 'status'> {
   toolCallId: string;
-  status: ActiveSubagentState['status'] | 'aborted';
+  status: HarnessSubagentHistoryStatus;
   endedAt: Date;
   order: number;
   parentEndReason?: 'complete' | 'aborted' | 'error' | 'suspended';

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -512,6 +512,17 @@ export interface ActiveSubagentState {
 }
 
 /**
+ * Terminal subagent activity retained for display snapshots after the parent run ends.
+ */
+export interface HarnessSubagentHistoryEntry extends Omit<ActiveSubagentState, 'status'> {
+  toolCallId: string;
+  status: ActiveSubagentState['status'] | 'aborted';
+  endedAt: Date;
+  order: number;
+  parentEndReason?: 'complete' | 'aborted' | 'error' | 'suspended';
+}
+
+/**
  * Controls whether an `ask_user` prompt accepts one choice or multiple choices.
  *
  * `single_select` is the default for prompts that provide options, preserving the
@@ -608,6 +619,9 @@ export interface HarnessDisplayState {
   /** Active subagent executions keyed by parent toolCallId */
   activeSubagents: Map<string, ActiveSubagentState>;
 
+  /** Terminal subagent executions retained after they leave activeSubagents */
+  subagentHistory: HarnessSubagentHistoryEntry[];
+
   // ── Observational Memory ─────────────────────────────────────────────
   /** Full OM progress state (status, tokens, thresholds, buffered) */
   omProgress: OMProgressState;
@@ -653,6 +667,7 @@ export function defaultDisplayState(): HarnessDisplayState {
     pendingQuestion: null,
     pendingPlanApproval: null,
     activeSubagents: new Map(),
+    subagentHistory: [],
     omProgress: defaultOMProgressState(),
     bufferingMessages: false,
     bufferingObservations: false,


### PR DESCRIPTION
Adds `subagentHistory` to `HarnessDisplayState` so UIs can keep rendering completed, errored, and aborted subagent runs after `agent_end`. Entries include `toolCallId`, `endedAt`, `order`, `parentEndReason`, and the final status.

Example:
```ts
const { subagentHistory } = harness.getDisplayState()
```

Closes https://github.com/mastra-ai/mastra/issues/16056

Validated with `pnpm build:core`, `pnpm --filter ./packages/core test src/harness/display-state.test.ts`, `pnpm --filter ./packages/core check`, `pnpm --filter ./packages/core lint`, and `git diff --check`. The broader `pnpm --filter ./packages/core test` run hit unrelated environment failures from missing provider API keys, DNS/network access, read-only home cache writes, git sandboxing, and bwrap timeouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an AI agent finishes, the app used to forget the sub-tasks it ran; this PR makes the app remember finished sub-tasks so the UI can still show them after the agent ends.

## Overview

Adds a durable subagentHistory array to HarnessDisplayState that records terminal subagent runs (completed, error, aborted) with metadata — toolCallId, endedAt, order, optional parentEndReason, and final status — so UIs can render completed/errored/aborted subagents even after agent_end.

## Key Changes

- Types
  - Introduces HarnessSubagentHistoryStatus = 'completed' | 'error' | 'aborted'.
  - Adds HarnessSubagentHistoryEntry (based on ActiveSubagentState minus live status, plus toolCallId, terminal status, endedAt: Date, order: number, optional parentEndReason).
  - Extends HarnessDisplayState with subagentHistory: HarnessSubagentHistoryEntry[].
  - Re-exports HarnessSubagentHistoryEntry and HarnessSubagentHistoryStatus.

- Runtime behavior (harness)
  - Initializes/clears subagentHistory on display-state boundaries (agent_start and thread resets: thread_changed, thread_created, thread_deleted).
  - On subagent_end, appends a terminal history entry (deep-cloning toolCalls, stamping endedAt, setting order and status) but guards against duplicate subagent_end events.
  - On agent_end, preserves subagentHistory, clears activeSubagents, and converts any still-running subagents into terminal entries (aborted or error) with parentEndReason drawn from agent_end.reason (defaulting to 'aborted').
  - Ensures history entries use only terminal statuses and updates history before clearing activeSubagents.

- Display-state cloning
  - display-state-scheduler clones subagentHistory: shallow-copies entries, deep-clones nested toolCalls, and recreates endedAt as Date so subscribers receive isolated snapshots.

- Tests & docs
  - Adds focused tests: initialization, subagent_end recording (duration/result/order/endedAt/toolCalls), duplicate-end guarding, conversion of running subagents to aborted history on agent_end with parentEndReason, clearing on agent_start and thread resets, and snapshot isolation for subscribers.
  - Documentation and a changeset updated to describe feature and usage (harness.getDisplayState().subagentHistory).

## Release & Validation

- Changeset added for a minor @mastra/core bump documenting subagentHistory.
- Validation performed: pnpm build:core, targeted unit tests, typecheck, lint, and git diff checks; a full core test run was skipped/failed due to unrelated environment issues (missing provider keys, network/DNS, cache/write/sandboxing constraints).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->