### PR TITLE
fix(core): keep durable registry entries alive

### DIFF
--- a/.changeset/modern-dolls-speak.md
+++ b/.changeset/modern-dolls-speak.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed durable runs so long approvals keep their live runtime state and stale registry entries notify listeners before cleanup.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-model-fallback.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-model-fallback.test.ts
@@ -314,8 +314,14 @@ describe('DurableAgent Model Fallback', () => {
       });
       const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
 
+      const streamedErrors: unknown[] = [];
       let errorReceived: Error | null = null;
       const { cleanup } = await durableAgent.stream('Hello', {
+        onChunk: chunk => {
+          if (chunk.type === 'error') {
+            streamedErrors.push(chunk);
+          }
+        },
         onError: error => {
           errorReceived = error;
         },
@@ -325,6 +331,7 @@ describe('DurableAgent Model Fallback', () => {
       await new Promise(resolve => setTimeout(resolve, 500));
       cleanup();
 
+      expect(streamedErrors).toHaveLength(0);
       expect(errorReceived).not.toBeNull();
       expect(errorReceived!.message).toContain('Model execution failed');
     });

--- a/packages/core/src/agent/durable/__tests__/run-registry.test.ts
+++ b/packages/core/src/agent/durable/__tests__/run-registry.test.ts
@@ -23,13 +23,14 @@ describe('globalRunRegistry', () => {
     globalRunRegistry.clear();
   });
 
-  it('keeps entries alive for two hours unless explicitly cleaned up', () => {
+  it('keeps entries alive for two hours and refreshes TTL when accessed', () => {
     const entry = createEntry();
 
     globalRunRegistry.set('run-1', entry);
 
     expect(globalRunRegistry.getRemainingTTL('run-1')).toBeGreaterThan(GLOBAL_RUN_REGISTRY_TTL_MS - 1000);
     expect(globalRunRegistry.get('run-1')).toBe(entry);
+    expect(globalRunRegistry.getRemainingTTL('run-1')).toBeGreaterThan(GLOBAL_RUN_REGISTRY_TTL_MS - 1000);
   });
 
   it('does not crash if dispose receives a missing entry', () => {

--- a/packages/core/src/agent/durable/__tests__/run-registry.test.ts
+++ b/packages/core/src/agent/durable/__tests__/run-registry.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { AGENT_STREAM_TOPIC, AgentStreamEventTypes } from '../constants';
+import { GLOBAL_RUN_REGISTRY_TTL_MS, globalRunRegistry } from '../run-registry';
+import type { RunRegistryEntry } from '../types';
+
+function createEntry(options: { cleanup?: () => void; pubsub?: EventEmitterPubSub } = {}): RunRegistryEntry {
+  return {
+    tools: {},
+    model: {} as RunRegistryEntry['model'],
+    cleanup: options.cleanup ?? vi.fn(),
+    pubsub: options.pubsub,
+  };
+}
+
+describe('globalRunRegistry', () => {
+  beforeEach(() => {
+    globalRunRegistry.clear();
+  });
+
+  afterEach(() => {
+    globalRunRegistry.clear();
+  });
+
+  it('keeps entries alive for two hours unless explicitly cleaned up', () => {
+    const entry = createEntry();
+
+    globalRunRegistry.set('run-1', entry);
+
+    expect(globalRunRegistry.getRemainingTTL('run-1')).toBeGreaterThan(GLOBAL_RUN_REGISTRY_TTL_MS - 1000);
+    expect(globalRunRegistry.get('run-1')).toBe(entry);
+  });
+
+  it('does not crash if dispose receives a missing entry', () => {
+    const cleanup = vi.fn();
+    globalRunRegistry.set('run-1', createEntry({ cleanup }));
+    (globalRunRegistry as any).data.delete('run-1');
+
+    expect(() => globalRunRegistry.delete('run-1')).not.toThrow();
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it('publishes an abort when a registry entry expires', async () => {
+    const pubsub = new EventEmitterPubSub();
+    const cleanup = vi.fn();
+    const events: any[] = [];
+    await pubsub.subscribe(AGENT_STREAM_TOPIC('run-1'), event => {
+      events.push(event);
+    });
+
+    globalRunRegistry.set('run-1', createEntry({ cleanup, pubsub }), { ttl: 1 });
+    await new Promise(resolve => setTimeout(resolve, 10));
+    globalRunRegistry.purgeStale();
+
+    expect(events).toMatchObject([
+      {
+        type: AgentStreamEventTypes.ERROR,
+        runId: 'run-1',
+        data: {
+          error: {
+            name: 'AbortError',
+          },
+        },
+      },
+    ]);
+    expect(cleanup).toHaveBeenCalledOnce();
+    await pubsub.close();
+  });
+});

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -446,7 +446,7 @@ export class DurableAgent<
 
     // 2. Register non-serializable state (both local and global registries)
     this.#runRegistry.registerWithMessageList(runId, registryEntry, messageList, { threadId, resourceId });
-    globalRunRegistry.set(runId, { ...registryEntry, messageList });
+    globalRunRegistry.set(runId, { ...registryEntry, messageList, pubsub: this.pubsub });
 
     // Track cleanup state to avoid double cleanup
     let cleanedUp = false;
@@ -809,6 +809,7 @@ export class DurableAgent<
     globalRunRegistry.set(preparation.runId, {
       ...preparation.registryEntry,
       messageList: preparation.messageList,
+      pubsub: this.pubsub,
     });
 
     return {

--- a/packages/core/src/agent/durable/run-registry.ts
+++ b/packages/core/src/agent/durable/run-registry.ts
@@ -32,12 +32,14 @@ function publishRegistryExpiredAbort(runId: string, entry: RunRegistryEntry): vo
  * Entries are keyed by runId (which are unique UUIDs).
  *
  * Uses TTLCache as a leak safety net. Durable runs may sit suspended for a long
- * time waiting on approval, so there is no capacity-based eviction; stale expiry
- * publishes an abort before cleanup so listeners do not hang.
+ * time waiting on approval, and active runs refresh their TTL when accessed.
+ * There is no capacity-based eviction; stale expiry publishes an abort before
+ * cleanup so listeners do not hang.
  */
 export const globalRunRegistry = new TTLCache<string, RunRegistryEntry>({
   max: Infinity,
   ttl: GLOBAL_RUN_REGISTRY_TTL_MS,
+  updateAgeOnGet: true,
   dispose: (entry, runId, reason) => {
     if (!entry) return;
     if (reason === 'stale' || reason === 'evict') {

--- a/packages/core/src/agent/durable/run-registry.ts
+++ b/packages/core/src/agent/durable/run-registry.ts
@@ -3,7 +3,26 @@ import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { CoreTool } from '../../tools/types';
 import type { MessageList } from '../message-list';
 import type { SaveQueueManager } from '../save-queue';
+import { AGENT_STREAM_TOPIC, AgentStreamEventTypes } from './constants';
 import type { RunRegistryEntry } from './types';
+
+export const GLOBAL_RUN_REGISTRY_TTL_MS = 2 * 60 * 60 * 1000;
+
+function publishRegistryExpiredAbort(runId: string, entry: RunRegistryEntry): void {
+  void entry.pubsub
+    ?.publish(AGENT_STREAM_TOPIC(runId), {
+      type: AgentStreamEventTypes.ERROR,
+      runId,
+      data: {
+        runId,
+        error: {
+          name: 'AbortError',
+          message: 'Durable run registry entry expired before the run completed.',
+        },
+      },
+    })
+    .catch(() => undefined);
+}
 
 /**
  * Global registry for accessing run entries from workflow steps.
@@ -12,15 +31,18 @@ import type { RunRegistryEntry } from './types';
  *
  * Entries are keyed by runId (which are unique UUIDs).
  *
- * Uses TTLCache to prevent unbounded memory growth: entries auto-expire
- * after 10 minutes (refreshed on access) and the registry is hard-capped
- * at 1000 concurrent entries.
+ * Uses TTLCache as a leak safety net. Durable runs may sit suspended for a long
+ * time waiting on approval, so there is no capacity-based eviction; stale expiry
+ * publishes an abort before cleanup so listeners do not hang.
  */
 export const globalRunRegistry = new TTLCache<string, RunRegistryEntry>({
-  max: 1000,
-  ttl: 10 * 60 * 1000,
-  updateAgeOnGet: true,
-  dispose: entry => {
+  max: Infinity,
+  ttl: GLOBAL_RUN_REGISTRY_TTL_MS,
+  dispose: (entry, runId, reason) => {
+    if (!entry) return;
+    if (reason === 'stale' || reason === 'evict') {
+      publishRegistryExpiredAbort(runId, entry);
+    }
     entry.cleanup?.();
   },
   noDisposeOnSet: true,

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -10,6 +10,7 @@ import type { z } from 'zod';
 
 import type { BackgroundTaskManager } from '../../background-tasks/manager';
 import type { AgentBackgroundConfig } from '../../background-tasks/types';
+import type { PubSub } from '../../events/pubsub';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
 import type { MastraMemory } from '../../memory/memory';
 import type { MemoryConfig } from '../../memory/types';
@@ -424,6 +425,8 @@ export interface RunRegistryEntry {
   backgroundTaskManager?: BackgroundTaskManager;
   /** Agent background tasks configuration */
   backgroundTasksConfig?: AgentBackgroundConfig;
+  /** PubSub that streams durable agent events to subscribers */
+  pubsub?: PubSub;
 }
 
 /**

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -349,11 +349,10 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               for await (const chunk of trackedStream) {
                 if (!chunk) continue;
 
-                // Emit chunk via pubsub for streaming to client
-                // NOTE: Do NOT emit 'finish' chunks - they will be sent as a proper FINISH event
-                // at the end of the agentic loop. Emitting finish chunks here would cause
-                // the client's MastraModelOutput to close prematurely in multi-step workflows.
-                if (pubsub && chunk.type !== 'finish') {
+                // Emit chunk via pubsub for streaming to client.
+                // Finish and error chunks are terminal control flow: finish is sent once by the
+                // agentic loop, and errors are sent once after retries/fallbacks are exhausted.
+                if (pubsub && chunk.type !== 'finish' && chunk.type !== 'error') {
                   await emitChunkEvent(pubsub, runId, chunk);
                 }
 


### PR DESCRIPTION
This keeps durable run registry entries alive long enough for suspended or active runs, and makes stale registry cleanup notify listeners before the entry disappears. Active runs still refresh their TTL on registry reads, so the 2 hour TTL is a leak safety net rather than a hard cap from run start.

Before:

```ts
const globalRunRegistry = new TTLCache({
  max: 1000,
  ttl: 10 * 60 * 1000,
  updateAgeOnGet: true,
});
```

After:

```ts
const globalRunRegistry = new TTLCache({
  max: Infinity,
  ttl: 2 * 60 * 60 * 1000,
  updateAgeOnGet: true,
});
```

I added focused tests for the longer TTL, safe cleanup when an entry is already gone, and publishing an abort event when a registry entry expires.
