### PR TITLE
draft: agents.ts ownership/authorship changes (parked)

### DIFF
--- a/packages/server/src/server/handlers/agent.test.ts
+++ b/packages/server/src/server/handlers/agent.test.ts
@@ -16,6 +16,7 @@ import {
   GENERATE_AGENT_ROUTE,
   getSerializedAgentTools,
   UPDATE_AGENT_MODEL_ROUTE,
+  RESET_AGENT_MODEL_ROUTE,
   REORDER_AGENT_MODEL_LIST_ROUTE,
   UPDATE_AGENT_MODEL_IN_MODEL_LIST_ROUTE,
   STREAM_GENERATE_LEGACY_ROUTE,
@@ -876,6 +877,154 @@ describe('Agent Handlers', () => {
     });
   });
 
+  describe('Phase 8a: model-route allowlist enforcement', () => {
+    function makeBuilderEditor(opts: {
+      allowed?: Array<{ provider: string; modelId?: string; kind?: 'known' | 'custom' }>;
+    }) {
+      const allowed = opts.allowed?.map(a => ({
+        kind: a.kind ?? ('known' as const),
+        provider: a.provider,
+        ...(a.modelId !== undefined ? { modelId: a.modelId } : {}),
+      }));
+      return {
+        hasEnabledBuilderConfig: () => true,
+        resolveBuilder: async () => ({
+          enabled: true,
+          getFeatures: () => ({ agent: { model: true } }),
+          getConfiguration: () => ({ agent: { models: { allowed } } }),
+        }),
+      };
+    }
+
+    function attachEditorToMastra(mastra: Mastra, editor: ReturnType<typeof makeBuilderEditor> | undefined) {
+      (mastra as unknown as { getEditor: () => unknown }).getEditor = () => editor;
+    }
+
+    describe('UPDATE_AGENT_MODEL_ROUTE', () => {
+      it('rejects with 422 + MODEL_NOT_ALLOWED when target model is outside the allowlist', async () => {
+        attachEditorToMastra(mockMastra, makeBuilderEditor({ allowed: [{ provider: 'openai' }] }));
+
+        let caught: HTTPException | undefined;
+        try {
+          await UPDATE_AGENT_MODEL_ROUTE.handler({
+            ...createTestServerContext({ mastra: mockMastra }),
+            agentId: 'test-agent',
+            modelId: 'claude-opus-4-7',
+            provider: 'anthropic',
+          });
+        } catch (e) {
+          caught = e as HTTPException;
+        }
+
+        expect(caught).toBeInstanceOf(HTTPException);
+        expect(caught?.status).toBe(422);
+        const body = await caught!.getResponse().json();
+        expect(body.error.code).toBe('MODEL_NOT_ALLOWED');
+        expect(body.error.attempted).toMatchObject({ provider: 'anthropic', modelId: 'claude-opus-4-7' });
+      });
+
+      it('accepts an allowed wildcard provider entry', async () => {
+        attachEditorToMastra(mockMastra, makeBuilderEditor({ allowed: [{ provider: 'openai' }] }));
+
+        const result = await UPDATE_AGENT_MODEL_ROUTE.handler({
+          ...createTestServerContext({ mastra: mockMastra }),
+          agentId: 'test-agent',
+          modelId: 'gpt-4o-mini',
+          provider: 'openai',
+        });
+        expect(result).toEqual({ message: 'Agent model updated' });
+      });
+
+      it('passes through when no editor is configured', async () => {
+        attachEditorToMastra(mockMastra, undefined);
+
+        const result = await UPDATE_AGENT_MODEL_ROUTE.handler({
+          ...createTestServerContext({ mastra: mockMastra }),
+          agentId: 'test-agent',
+          modelId: 'claude-opus-4-7',
+          provider: 'anthropic',
+        });
+        expect(result).toEqual({ message: 'Agent model updated' });
+      });
+    });
+
+    describe('RESET_AGENT_MODEL_ROUTE', () => {
+      it('rejects when the original model is no longer in the allowlist', async () => {
+        attachEditorToMastra(mockMastra, makeBuilderEditor({ allowed: [{ provider: 'anthropic' }] }));
+
+        let caught: HTTPException | undefined;
+        try {
+          await RESET_AGENT_MODEL_ROUTE.handler({
+            ...createTestServerContext({ mastra: mockMastra }),
+            agentId: 'test-agent',
+          });
+        } catch (e) {
+          caught = e as HTTPException;
+        }
+
+        expect(caught).toBeInstanceOf(HTTPException);
+        expect(caught?.status).toBe(422);
+        const body = await caught!.getResponse().json();
+        expect(body.error.code).toBe('MODEL_NOT_ALLOWED');
+      });
+
+      it('accepts reset when original model is in the allowlist', async () => {
+        // The mock agent's resolved provider is "openai.chat" (AI SDK provider id), not the
+        // registered "openai" entry, so we have to declare it as a custom provider.
+        attachEditorToMastra(mockMastra, makeBuilderEditor({ allowed: [{ kind: 'custom', provider: 'openai.chat' }] }));
+
+        const result = await RESET_AGENT_MODEL_ROUTE.handler({
+          ...createTestServerContext({ mastra: mockMastra }),
+          agentId: 'test-agent',
+        });
+        expect(result).toEqual({ message: 'Agent model reset to original' });
+      });
+    });
+
+    describe('UPDATE_AGENT_MODEL_IN_MODEL_LIST_ROUTE', () => {
+      it('rejects 422 when the new entry is outside the allowlist', async () => {
+        attachEditorToMastra(mockMastra, makeBuilderEditor({ allowed: [{ provider: 'openai' }] }));
+
+        const agent = mockMastra.getAgentById('test-multi-model-agent');
+        const modelList = await agent.getModelList();
+        const targetId = modelList![0].id;
+
+        let caught: HTTPException | undefined;
+        try {
+          await UPDATE_AGENT_MODEL_IN_MODEL_LIST_ROUTE.handler({
+            ...createTestServerContext({ mastra: mockMastra }),
+            agentId: 'test-multi-model-agent',
+            modelConfigId: targetId,
+            model: { provider: 'anthropic', modelId: 'claude-opus-4-7' },
+          });
+        } catch (e) {
+          caught = e as HTTPException;
+        }
+
+        expect(caught).toBeInstanceOf(HTTPException);
+        expect(caught?.status).toBe(422);
+        const body = await caught!.getResponse().json();
+        expect(body.error.code).toBe('MODEL_NOT_ALLOWED');
+      });
+
+      it('skips enforcement when body does not change provider/modelId', async () => {
+        attachEditorToMastra(mockMastra, makeBuilderEditor({ allowed: [{ provider: 'anthropic' }] }));
+
+        const agent = mockMastra.getAgentById('test-multi-model-agent');
+        const modelList = await agent.getModelList();
+        const targetId = modelList![0].id;
+
+        const result = await UPDATE_AGENT_MODEL_IN_MODEL_LIST_ROUTE.handler({
+          ...createTestServerContext({ mastra: mockMastra }),
+          agentId: 'test-multi-model-agent',
+          modelConfigId: targetId,
+          maxRetries: 5,
+        });
+        expect(result).toMatchObject({ message: 'Model updated in model list' });
+      });
+    });
+  });
+
   describe('enhanceInstructionsHandler', () => {
     it('should enhance instructions and return structured output', async () => {
       // Set OPENAI_API_KEY so isProviderConnected returns true
@@ -911,6 +1060,52 @@ describe('Agent Handlers', () => {
       } finally {
         generateSpy.mockRestore();
         // Restore original env var
+        if (originalEnv === undefined) {
+          delete process.env.OPENAI_API_KEY;
+        } else {
+          process.env.OPENAI_API_KEY = originalEnv;
+        }
+      }
+    });
+
+    it('rejects with 400 when the only connected model is outside the admin allowlist', async () => {
+      const originalEnv = process.env.OPENAI_API_KEY;
+      process.env.OPENAI_API_KEY = 'test-key';
+
+      // Allow only anthropic — agent's openai model must be filtered out by the
+      // policy-aware findConnectedModel, even though OPENAI_API_KEY is set.
+      const editor = {
+        hasEnabledBuilderConfig: () => true,
+        resolveBuilder: async () => ({
+          enabled: true,
+          getFeatures: () => ({ agent: { model: true } }),
+          getConfiguration: () => ({
+            agent: { models: { allowed: [{ kind: 'known' as const, provider: 'anthropic' }] } },
+          }),
+        }),
+      };
+      (mockMastra as unknown as { getEditor: () => unknown }).getEditor = () => editor;
+
+      const generateSpy = vi.spyOn(Agent.prototype, 'generate');
+
+      try {
+        let caught: HTTPException | undefined;
+        try {
+          await ENHANCE_INSTRUCTIONS_ROUTE.handler({
+            ...createTestServerContext({ mastra: mockMastra }),
+            agentId: 'test-agent',
+            instructions: 'You are a helpful assistant.',
+            comment: 'Make it more specific',
+          });
+        } catch (e) {
+          caught = e as HTTPException;
+        }
+
+        expect(caught).toBeInstanceOf(HTTPException);
+        expect(caught?.status).toBe(400);
+        expect(generateSpy).not.toHaveBeenCalled();
+      } finally {
+        generateSpy.mockRestore();
         if (originalEnv === undefined) {
           delete process.env.OPENAI_API_KEY;
         } else {

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -1024,6 +1024,96 @@ describe('Agent Routes Authorization', () => {
   });
 });
 
+// ============================================================================
+// Stored Agent Visibility / Ownership on execute routes
+// ============================================================================
+
+describe('GENERATE_AGENT_ROUTE stored-agent visibility', () => {
+  let storage: InMemoryStore;
+  let mockAgent: Agent;
+  let mastra: Mastra;
+
+  beforeEach(async () => {
+    storage = new InMemoryStore();
+
+    mockAgent = new Agent({
+      id: 'private-agent',
+      name: 'private-agent',
+      instructions: 'test',
+      model: {} as any,
+    });
+
+    mastra = new Mastra({
+      agents: { 'private-agent': mockAgent },
+      storage,
+      logger: false,
+    });
+
+    // Seed a stored record marking the agent as private and owned by user-a
+    const agentsStore = (await storage.getStore('agents')) as any;
+    await agentsStore.create({
+      agent: {
+        id: 'private-agent',
+        authorId: 'user-a',
+        visibility: 'private',
+      },
+    });
+
+    vi.spyOn(mockAgent, 'generate').mockResolvedValue({ text: 'ok' } as any);
+  });
+
+  it('should 404 when non-owner executes a private stored agent', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'user-b');
+
+    await expect(
+      GENERATE_AGENT_ROUTE.handler({
+        mastra,
+        agentId: 'private-agent',
+        requestContext,
+        abortSignal: new AbortController().signal,
+        messages: [{ role: 'user', content: 'hi' }],
+      } as any),
+    ).rejects.toThrow(HTTPException);
+  });
+
+  it('should allow owner to execute a private stored agent', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'user-a');
+
+    await expect(
+      GENERATE_AGENT_ROUTE.handler({
+        mastra,
+        agentId: 'private-agent',
+        requestContext,
+        abortSignal: new AbortController().signal,
+        messages: [{ role: 'user', content: 'hi' }],
+      } as any),
+    ).resolves.toBeDefined();
+  });
+
+  it('should allow non-owner to execute a public stored agent', async () => {
+    const agentsStore = (await storage.getStore('agents')) as any;
+    await agentsStore.update({
+      id: 'private-agent',
+      visibility: 'public',
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'user-b');
+
+    await expect(
+      GENERATE_AGENT_ROUTE.handler({
+        mastra,
+        agentId: 'private-agent',
+        requestContext,
+        abortSignal: new AbortController().signal,
+        messages: [{ role: 'user', content: 'hi' }],
+      } as any),
+    ).resolves.toBeDefined();
+  });
+});
+
 describe('extractVersionOptions', () => {
   it('should return undefined when no requestContext or bodyRequestContext', () => {
     expect(extractVersionOptions()).toBeUndefined();

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -1,6 +1,7 @@
 import { Agent, isDurableAgentLike } from '@mastra/core/agent';
 import type { AgentModelManagerConfig, DurableAgentLike } from '@mastra/core/agent';
 import { AGENT_STREAM_TOPIC } from '@mastra/core/agent/durable';
+import { assertModelAllowed, isModelAllowed } from '@mastra/core/agent-builder/ee';
 import type { VersionOverrides } from '@mastra/core/di';
 import { mergeVersionOverrides } from '@mastra/core/di';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
@@ -59,6 +60,16 @@ import type { Context } from '../types';
 
 import { toSlug } from '../utils';
 
+import { resolveBuilderModelPolicy } from '../utils/resolve-builder-model-policy';
+import {
+  assertExecuteAccess,
+  assertReadAccess,
+  assertWriteAccess,
+  getCallerAuthorId,
+  matchesAuthorFilter,
+  resolveAuthorFilter,
+} from './authorship';
+import type { OwnedRecord } from './authorship';
 import { handleError } from './error';
 import {
   sanitizeBody,
@@ -84,6 +95,86 @@ function stashVersionOverrides(ctx: RequestContext, versions: VersionOverrides |
   if (merged) {
     ctx.set(MASTRA_VERSIONS_KEY, merged);
   }
+}
+
+/**
+ * Loads the thin stored-agent record for `agentId` (or null when storage isn't
+ * configured / there is no stored record).
+ */
+async function loadStoredAgentRecord(args: {
+  mastra: Context['mastra'];
+  agentId: string;
+}): Promise<OwnedRecord | null> {
+  const { mastra, agentId } = args;
+  const storage = mastra.getStorage?.();
+  if (!storage) return null;
+  let agentsStore;
+  try {
+    agentsStore = await storage.getStore('agents');
+  } catch {
+    return null;
+  }
+  if (!agentsStore) return null;
+
+  try {
+    return ((await agentsStore.getById(agentId)) as OwnedRecord | null) ?? null;
+  } catch (error) {
+    mastra.getLogger()?.debug('Failed to load stored agent record for ownership check', { agentId, error });
+    return null;
+  }
+}
+
+/**
+ * Enforces read access on a stored agent. No-op when there is no stored record
+ * for the id (i.e. the id resolves only to a code-defined agent).
+ *
+ * Read access is granted to owners, admins, holders of `agents:read[:<id>]`,
+ * and anyone when the record is `visibility: 'public'` or legacy unowned.
+ */
+async function assertStoredAgentReadAccess(args: {
+  mastra: Context['mastra'];
+  agentId: string;
+  requestContext: RequestContext;
+}): Promise<void> {
+  const { mastra, agentId, requestContext } = args;
+  const record = await loadStoredAgentRecord({ mastra, agentId });
+  if (!record) return;
+  assertReadAccess({ requestContext, resource: 'agents', resourceId: agentId, record });
+}
+
+/**
+ * Enforces execute access on a stored agent. No-op when there is no stored
+ * record for the id.
+ *
+ * Execute access is granted to owners, admins, holders of
+ * `agents:execute[:<id>]` or `agents:read[:<id>]`, and anyone when the record
+ * is `visibility: 'public'` or legacy unowned.
+ */
+async function assertStoredAgentExecuteAccess(args: {
+  mastra: Context['mastra'];
+  agentId: string;
+  requestContext: RequestContext;
+}): Promise<void> {
+  const { mastra, agentId, requestContext } = args;
+  const record = await loadStoredAgentRecord({ mastra, agentId });
+  if (!record) return;
+  assertExecuteAccess({ requestContext, resource: 'agents', resourceId: agentId, record });
+}
+
+/**
+ * Enforces write access (edit/delete) on a stored agent. No-op when there is
+ * no stored record for the id.
+ */
+async function assertStoredAgentWriteAccess(args: {
+  mastra: Context['mastra'];
+  agentId: string;
+  requestContext: RequestContext;
+  action: 'edit' | 'delete';
+}): Promise<void> {
+  const { mastra, agentId, requestContext, action } = args;
+  const record = await loadStoredAgentRecord({ mastra, agentId });
+  if (!record) return;
+  assertWriteAccess({ requestContext, resource: 'agents', resourceId: agentId, record, action });
 }
 
 /**
@@ -930,16 +1021,34 @@ export const LIST_AGENTS_ROUTE = createRoute({
   responseType: 'json',
   queryParamSchema: z.object({
     partial: z.string().optional(),
+    authorId: z.string().optional(),
+    visibility: z.literal('public').optional(),
   }),
   responseSchema: listAgentsResponseSchema,
   summary: 'List all agents',
-  description: 'Returns a list of all available agents in the system (both code-defined and stored)',
+  description:
+    'Returns the agents visible to the caller: all code-defined agents, all stored agents they own, plus legacy unowned stored agents. Use `?authorId=X` to scope to a single owner (returns only their public stored agents if you are not X). Use `?visibility=public` to aggregate every public stored agent across owners.',
   tags: ['Agents'],
   requiresAuth: true,
   requiresPermission: 'agents:read',
-  handler: async ({ mastra, requestContext, partial }) => {
+  handler: async ({ mastra, requestContext, partial, authorId, visibility }) => {
     try {
-      const codeAgents = mastra.listAgents();
+      // Resolves ownership scoping for stored agents. Code-defined agents are
+      // always included regardless of the filter because they have no owner.
+      const authorFilter = resolveAuthorFilter({
+        requestContext,
+        resource: 'agents',
+        queryAuthorId: authorId,
+        queryVisibility: visibility,
+      });
+
+      const allRegisteredAgents = mastra.listAgents();
+      // Exclude stored-source agents from the code-defined list — they are
+      // registered on the Mastra instance via addAgent(..., { source: 'stored' }),
+      // but we fetch them separately below so the authorship filter can apply.
+      const codeAgents = Object.fromEntries(
+        Object.entries(allRegisteredAgents).filter(([, agent]) => (agent as { source?: string }).source !== 'stored'),
+      );
 
       const isPartial = partial === 'true';
 
@@ -976,13 +1085,18 @@ export const LIST_AGENTS_ROUTE = createRoute({
         }
       }
 
-      // Also fetch and include stored agents
+      // Also fetch and include stored agents, scoped by author ownership.
+      // We push the filter down to storage when we can (exact match) and
+      // post-filter for the `ownedOrPublic` case since the storage layer only
+      // supports equality on `authorId`.
       try {
         const editor = mastra.getEditor();
 
+        const listArgs = authorFilter.kind === 'exact' ? { authorId: authorFilter.authorId } : undefined;
+
         let storedAgentsResult;
         try {
-          storedAgentsResult = await editor?.agent.list();
+          storedAgentsResult = await editor?.agent.list(listArgs);
         } catch (error) {
           console.error('Error listing stored agents:', error);
           storedAgentsResult = null;
@@ -991,6 +1105,7 @@ export const LIST_AGENTS_ROUTE = createRoute({
         if (storedAgentsResult?.agents) {
           // Process each agent individually to avoid one bad agent breaking the whole list
           for (const storedAgentConfig of storedAgentsResult.agents) {
+            if (!matchesAuthorFilter(storedAgentConfig, authorFilter)) continue;
             try {
               const agent = await editor?.agent.getById(storedAgentConfig.id, { status: 'draft' });
               if (!agent) continue;
@@ -1042,6 +1157,11 @@ export const GET_AGENT_BY_ID_ROUTE = createRoute({
   requiresPermission: 'agents:read',
   handler: async ({ agentId, mastra, requestContext, status, versionId }) => {
     try {
+      // If there is a stored record for this agent, enforce read access.
+      // Code-only agents (no stored record) have no owner and are always
+      // visible to callers that passed the route's `agents:read` check.
+      await assertStoredAgentReadAccess({ mastra, agentId, requestContext });
+
       const versionOptions = versionId ? { versionId } : status ? { status } : undefined;
       const agent = await getAgentFromSystem({ mastra, agentId, versionOptions, requestContext });
       const isStudio = false; // TODO: Get from context if needed
@@ -1070,19 +1190,21 @@ export const CLONE_AGENT_ROUTE = createRoute({
     newId: z.string().optional().describe('ID for the cloned agent. If not provided, derived from agent ID.'),
     newName: z.string().optional().describe('Name for the cloned agent. Defaults to "{name} (Clone)".'),
     metadata: z.record(z.string(), z.unknown()).optional(),
-    authorId: z.string().optional(),
   }),
   responseSchema: createStoredAgentResponseSchema,
   summary: 'Clone agent',
   description: 'Clones a code-defined or stored agent to a new stored agent in the database',
   tags: ['Agents'],
   requiresAuth: true,
-  handler: async ({ agentId, mastra, newId, newName, metadata, authorId, requestContext }) => {
+  handler: async ({ agentId, mastra, newId, newName, metadata, requestContext }) => {
     try {
       const editor = mastra.getEditor();
       if (!editor) {
         return handleError(new Error('Editor is not configured on the Mastra instance'), 'Error cloning agent');
       }
+
+      // Prevent cloning from a stored source the caller can't read.
+      await assertStoredAgentReadAccess({ mastra, agentId, requestContext });
 
       const agent = await getAgentFromSystem({
         mastra,
@@ -1092,11 +1214,17 @@ export const CLONE_AGENT_ROUTE = createRoute({
 
       const cloneId = toSlug(newId || `${agentId}-clone`);
 
+      // Force authorship to the authenticated caller; ignore any client-supplied
+      // authorId so clones cannot be created under another user's namespace.
+      // Clones always start private.
+      const callerAuthorId = getCallerAuthorId(requestContext) ?? undefined;
+
       const result = await editor.agent.clone(agent, {
         newId: cloneId,
         newName,
         metadata,
-        authorId,
+        authorId: callerAuthorId,
+        visibility: 'private',
         requestContext,
       });
 
@@ -1121,6 +1249,8 @@ export const GENERATE_AGENT_ROUTE = createRoute({
   requiresPermission: 'agents:execute',
   handler: async ({ agentId, mastra, abortSignal, requestContext: serverRequestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext: serverRequestContext });
+
       // UI Frameworks may send "client tools" in the body,
       // but it interferes with llm providers tool handling, so we remove them
       sanitizeBody(params, ['tools']);
@@ -1212,6 +1342,8 @@ export const GENERATE_LEGACY_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext });
+
       const agent = await getAgentFromSystem({
         mastra,
         agentId,
@@ -1273,6 +1405,8 @@ export const STREAM_GENERATE_LEGACY_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext });
+
       const agent = await getAgentFromSystem({
         mastra,
         agentId,
@@ -1423,6 +1557,8 @@ export const STREAM_GENERATE_ROUTE = createRoute({
   requiresPermission: 'agents:execute',
   handler: async ({ mastra, agentId, abortSignal, requestContext: serverRequestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext: serverRequestContext });
+
       // UI Frameworks may send "client tools" in the body,
       // but it interferes with llm providers tool handling, so we remove them
       sanitizeBody(params, ['tools']);
@@ -1731,6 +1867,8 @@ export const APPROVE_TOOL_CALL_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext });
+
       const agent = await getAgentFromSystem({
         mastra,
         agentId,
@@ -1776,6 +1914,8 @@ export const DECLINE_TOOL_CALL_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext });
+
       const agent = await getAgentFromSystem({
         mastra,
         agentId,
@@ -1917,6 +2057,8 @@ export const APPROVE_TOOL_CALL_GENERATE_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext });
+
       const agent = await getAgentFromSystem({
         mastra,
         agentId,
@@ -1961,6 +2103,8 @@ export const DECLINE_TOOL_CALL_GENERATE_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, abortSignal, requestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext });
+
       const agent = await getAgentFromSystem({
         mastra,
         agentId,
@@ -2006,6 +2150,8 @@ export const STREAM_NETWORK_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, messages, agentId, requestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext });
+
       const agent = await getAgentFromSystem({
         mastra,
         agentId,
@@ -2043,6 +2189,8 @@ export const APPROVE_NETWORK_TOOL_CALL_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, requestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext });
+
       const agent = await getAgentFromSystem({
         mastra,
         agentId,
@@ -2082,6 +2230,8 @@ export const DECLINE_NETWORK_TOOL_CALL_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, requestContext, ...params }) => {
     try {
+      await assertStoredAgentExecuteAccess({ mastra, agentId, requestContext });
+
       const agent = await getAgentFromSystem({
         mastra,
         agentId,
@@ -2118,12 +2268,20 @@ export const UPDATE_AGENT_MODEL_ROUTE = createRoute({
   description: 'Updates the AI model used by the agent',
   tags: ['Agents', 'Models'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, modelId, provider }) => {
+  handler: async ({ mastra, agentId, modelId, provider, requestContext }) => {
     try {
+      await assertStoredAgentWriteAccess({ mastra, agentId, requestContext, action: 'edit' });
+
       const agent = await getAgentFromSystem({ mastra, agentId });
 
       // Use the universal Mastra router format: provider/model
       const newModel = `${provider}/${modelId}`;
+
+      // Enforce admin model allowlist (Phase 6) before swapping in-memory.
+      const policy = await resolveBuilderModelPolicy(mastra.getEditor?.());
+      if (policy.active) {
+        assertModelAllowed(policy.allowed, newModel);
+      }
 
       // Update the model in-memory only (for temporary testing)
       // This allows users to test different models without persisting
@@ -2147,9 +2305,24 @@ export const RESET_AGENT_MODEL_ROUTE = createRoute({
   description: 'Resets the agent model to its original configuration',
   tags: ['Agents', 'Models'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId }) => {
+  handler: async ({ mastra, agentId, requestContext }) => {
     try {
+      await assertStoredAgentWriteAccess({ mastra, agentId, requestContext, action: 'edit' });
+
       const agent = await getAgentFromSystem({ mastra, agentId });
+
+      // Enforce admin model allowlist (Phase 6) BEFORE reset: if the original
+      // model is no longer permitted by the current allowlist, reject loudly
+      // rather than silently restoring a disallowed model.
+      const policy = await resolveBuilderModelPolicy(mastra.getEditor?.());
+      if (policy.active) {
+        const original = agent.__getOriginalModel();
+        // Dynamic functions can't be statically validated; runtime defense
+        // (Phase 7) is the safety net for those.
+        if (typeof original !== 'function') {
+          assertModelAllowed(policy.allowed, original as Parameters<typeof assertModelAllowed>[1]);
+        }
+      }
 
       agent.__resetToOriginalModel();
 
@@ -2171,8 +2344,10 @@ export const REORDER_AGENT_MODEL_LIST_ROUTE = createRoute({
   description: 'Reorders the model list for agents with multiple model configurations',
   tags: ['Agents', 'Models'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, reorderedModelIds }) => {
+  handler: async ({ mastra, agentId, reorderedModelIds, requestContext }) => {
     try {
+      await assertStoredAgentWriteAccess({ mastra, agentId, requestContext, action: 'edit' });
+
       const agent = await getAgentFromSystem({ mastra, agentId });
 
       const modelList = await agent.getModelList();
@@ -2180,6 +2355,9 @@ export const REORDER_AGENT_MODEL_LIST_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'Agent model list is not found or empty' });
       }
 
+      // Reorder does not introduce new models, so no static allowlist check
+      // is needed here. Phase 7 runtime defense still validates the active
+      // model at execution time.
       agent.reorderModels(reorderedModelIds);
 
       return { message: 'Model list reordered' };
@@ -2200,8 +2378,10 @@ export const UPDATE_AGENT_MODEL_IN_MODEL_LIST_ROUTE = createRoute({
   description: 'Updates a specific model configuration in the agent model list',
   tags: ['Agents', 'Models'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, modelConfigId, model: bodyModel, maxRetries, enabled }) => {
+  handler: async ({ mastra, agentId, modelConfigId, model: bodyModel, maxRetries, enabled, requestContext }) => {
     try {
+      await assertStoredAgentWriteAccess({ mastra, agentId, requestContext, action: 'edit' });
+
       const agent = await getAgentFromSystem({ mastra, agentId });
 
       const modelList = await agent.getModelList();
@@ -2216,6 +2396,17 @@ export const UPDATE_AGENT_MODEL_IN_MODEL_LIST_ROUTE = createRoute({
 
       const newModel =
         bodyModel?.modelId && bodyModel?.provider ? `${bodyModel.provider}/${bodyModel.modelId}` : modelConfig.model;
+
+      // Enforce admin model allowlist (Phase 6) when the caller supplies a new
+      // provider/model pair. If the body keeps the existing model, we skip —
+      // existing models predate any allowlist toggle and Phase 7 catches
+      // stale-disallowed runs at execution time.
+      if (bodyModel?.modelId && bodyModel?.provider) {
+        const policy = await resolveBuilderModelPolicy(mastra.getEditor?.());
+        if (policy.active) {
+          assertModelAllowed(policy.allowed, newModel);
+        }
+      }
 
       const updated = {
         ...modelConfig,
@@ -2283,15 +2474,22 @@ Return your response as JSON with exactly these two fields:
 Remember: A good system prompt should be specific enough to guide behavior but flexible enough to handle edge cases. Focus on creating prompts that are clear, actionable, and aligned with the intended use case.`;
 
 // Helper to find the first model with a connected provider
-async function findConnectedModel(agent: Agent): Promise<Awaited<ReturnType<Agent['getModel']>> | null> {
+async function findConnectedModel(
+  agent: Agent,
+  policy?: Awaited<ReturnType<typeof resolveBuilderModelPolicy>>,
+): Promise<Awaited<ReturnType<Agent['getModel']>> | null> {
+  const allowed = policy?.active ? policy.allowed : undefined;
+  const isPermitted = (model: { provider: string; modelId: string }) =>
+    isModelAllowed(allowed, { provider: model.provider, modelId: model.modelId });
+
   const modelList = await agent.getModelList();
 
   if (modelList && modelList.length > 0) {
-    // Find the first enabled model with a connected provider
+    // Find the first enabled model with a connected provider that is allowed by policy
     for (const modelConfig of modelList) {
       if (modelConfig.enabled !== false) {
         const model = modelConfig.model;
-        if (isProviderConnected(model.provider)) {
+        if (isProviderConnected(model.provider) && isPermitted(model)) {
           return model;
         }
       }
@@ -2301,7 +2499,7 @@ async function findConnectedModel(agent: Agent): Promise<Awaited<ReturnType<Agen
 
   // No model list, check the default model
   const defaultModel = await agent.getModel();
-  if (isProviderConnected(defaultModel.provider)) {
+  if (isProviderConnected(defaultModel.provider) && isPermitted(defaultModel)) {
     return defaultModel;
   }
   return null;
@@ -2320,16 +2518,21 @@ export const ENHANCE_INSTRUCTIONS_ROUTE = createRoute({
   description: 'Uses AI to enhance or modify agent instructions based on user feedback',
   tags: ['Agents'],
   requiresAuth: true,
-  handler: async ({ mastra, agentId, instructions, comment }) => {
+  handler: async ({ mastra, agentId, requestContext, instructions, comment }) => {
     try {
+      await assertStoredAgentReadAccess({ mastra, agentId, requestContext });
+
       const agent = await getAgentFromSystem({ mastra, agentId });
 
-      // Find the first model with a connected provider (similar to how chat works)
-      const model = await findConnectedModel(agent);
+      // Find the first model with a connected provider AND permitted by the
+      // Agent Builder allowlist (so enhance never picks a model the runtime
+      // would reject with MODEL_NOT_ALLOWED).
+      const policy = await resolveBuilderModelPolicy(mastra.getEditor?.());
+      const model = await findConnectedModel(agent, policy);
       if (!model) {
         throw new HTTPException(400, {
           message:
-            'No model with a configured API key found. Please set the required environment variable for your model provider.',
+            'No model with a configured API key found that is permitted by the current model policy. Please set an environment variable for an allowed provider, or update the Agent Builder model policy.',
         });
       }
 
@@ -2425,6 +2628,7 @@ export const STREAM_UI_MESSAGE_DEPRECATED_ROUTE = createRoute({
 export const GET_AGENT_SKILL_ROUTE = createRoute({
   method: 'GET',
   path: '/agents/:agentId/skills/:skillName',
+  requiresAuth: true,
   responseType: 'json',
   pathParamSchema: agentSkillPathParams,
   queryParamSchema: skillDisambiguationQuerySchema,
@@ -2434,6 +2638,8 @@ export const GET_AGENT_SKILL_ROUTE = createRoute({
   tags: ['Agents', 'Skills'],
   handler: async ({ mastra, agentId, skillName, path, requestContext }) => {
     try {
+      await assertStoredAgentReadAccess({ mastra, agentId, requestContext });
+
       const agent = agentId ? mastra.getAgentById(agentId) : null;
       if (!agent) {
         throw new HTTPException(404, { message: 'Agent not found' });

--- a/packages/server/src/server/schemas/__tests__/route-contracts.typetest.ts
+++ b/packages/server/src/server/schemas/__tests__/route-contracts.typetest.ts
@@ -119,7 +119,9 @@ type _AssertListAgentsBodyNever = Expect<IsNever<ListAgentsBody>>;
 
 // GET /agents has an inline query schema — pin to exact shape
 type ListAgentsQuery = InferQueryParams<RouteMap['GET /agents']>;
-type _AssertListAgentsQuery = Expect<Equal<ListAgentsQuery, { partial?: string }>>;
+type _AssertListAgentsQuery = Expect<
+  Equal<ListAgentsQuery, { partial?: string; authorId?: string; visibility?: 'public' }>
+>;
 
 // POST routes without query params should return never
 type GenerateQuery = InferQueryParams<RouteMap['POST /agents/:agentId/generate']>;


### PR DESCRIPTION
**Draft — do not merge yet.**

Holds the agents.ts ownership/authorship/model-policy changes that were removed from the feature branch to keep scope focused.

### Files changed
- `packages/server/src/server/handlers/agents.ts` — ownership checks (`assertStoredAgentExecuteAccess`, `assertStoredAgentReadAccess`, `loadStoredAgentRecord`), `authorId`/`visibility` query params on list, model allowlist enforcement
- `packages/server/src/server/handlers/agents.test.ts` — stored-agent visibility/ownership tests
- `packages/server/src/server/handlers/agent.test.ts` — handler unit tests (model allowlist, enhance instructions)
- `packages/server/src/server/schemas/__tests__/route-contracts.typetest.ts` — query param type assertion

When ready, merge this back into `yj/magnificent-marquess` to re-add these changes.