### PR TITLE
feat(agent-builder): Wire up Slack publish and disconnect in agent builder

### DIFF
--- a/channels/slack/src/provider.ts
+++ b/channels/slack/src/provider.ts
@@ -825,9 +825,8 @@ export class SlackProvider implements ChannelProvider {
     }
 
     const agent = this.#resolveAgent(agentId);
-    if (!agent) {
-      throw new Error(`Agent "${agentId}" not found`);
-    }
+    // Agent may not be in the runtime registry (e.g. stored/builder agents).
+    // We can still proceed as long as options provide name/description fallbacks.
 
     // If there's already a pending installation, return its authorization URL
     // instead of creating a duplicate Slack app
@@ -867,8 +866,8 @@ export class SlackProvider implements ChannelProvider {
     const webhookId = crypto.randomUUID();
 
     // Build manifest using the manifest builder (includes proper default scopes)
-    const appName = config.name ?? agent.name ?? agentId;
-    const appDescription = config.description || agent.getDescription() || 'AI assistant powered by Mastra';
+    const appName = config.name ?? agent?.name ?? agentId;
+    const appDescription = config.description || agent?.getDescription() || 'AI assistant powered by Mastra';
     const normalizedCommands = this.#normalizeCommands(config.slashCommands);
     let manifest = buildManifest({
       name: appName,

--- a/examples/agent/src/mastra/auth/workos.ts
+++ b/examples/agent/src/mastra/auth/workos.ts
@@ -32,6 +32,7 @@ export async function initWorkOS(): Promise<AuthResult> {
         'tools:read',
         'workflows:read',
         'memory:read',
+        'channels:*',
       ],
       // Can only view and run agents
       operator: ['agents:read', 'agents:execute', 'tools:read', 'workflows:read'],

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-edit/__tests__/agent-builder-mobile-menu.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-edit/__tests__/agent-builder-mobile-menu.test.tsx
@@ -1,12 +1,39 @@
 // @vitest-environment jsdom
 import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { MemoryRouter } from 'react-router';
-import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { AgentBuilderEditFormValues } from '../../../schemas';
 import { AgentBuilderMobileMenu } from '../agent-builder-mobile-menu';
+
+vi.mock('@/domains/agents/hooks/use-channels', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useChannelPlatforms: () => ({ data: [{ id: 'slack', name: 'Slack', isConfigured: true }], isLoading: false }),
+  };
+});
+
+vi.mock('@/domains/auth/hooks/use-permissions', () => ({
+  usePermissions: () => ({
+    hasPermission: () => true,
+    hasAllPermissions: () => true,
+    hasAnyPermission: () => true,
+    hasRole: () => true,
+    canEdit: () => true,
+    canDelete: () => true,
+    canExecute: () => true,
+    roles: [],
+    permissions: ['*'],
+    isLoading: false,
+    isAuthenticated: true,
+    rbacEnabled: false,
+  }),
+}));
 
 interface FormHarnessProps {
   defaultVisibility?: AgentBuilderEditFormValues['visibility'];
@@ -15,6 +42,7 @@ interface FormHarnessProps {
 }
 
 const FormHarness = ({ defaultVisibility = 'private', onDirtyChange, children }: FormHarnessProps) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const methods = useForm<AgentBuilderEditFormValues>({
     defaultValues: { name: '', instructions: '', visibility: defaultVisibility },
   });
@@ -22,15 +50,19 @@ const FormHarness = ({ defaultVisibility = 'private', onDirtyChange, children }:
   const isDirty = methods.formState.isDirty;
   onDirtyChange?.(isDirty);
   return (
-    <MemoryRouter>
-      <TooltipProvider>
-        <FormProvider {...methods}>
-          {children}
-          <span data-testid="form-visibility">{value}</span>
-          <span data-testid="form-dirty">{isDirty ? 'true' : 'false'}</span>
-        </FormProvider>
-      </TooltipProvider>
-    </MemoryRouter>
+    <QueryClientProvider client={queryClient}>
+      <MastraReactProvider baseUrl="http://localhost:4111">
+        <MemoryRouter>
+          <TooltipProvider>
+            <FormProvider {...methods}>
+              {children}
+              <span data-testid="form-visibility">{value}</span>
+              <span data-testid="form-dirty">{isDirty ? 'true' : 'false'}</span>
+            </FormProvider>
+          </TooltipProvider>
+        </MemoryRouter>
+      </MastraReactProvider>
+    </QueryClientProvider>
   );
 };
 

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-edit/agent-builder-mobile-menu.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-edit/agent-builder-mobile-menu.tsx
@@ -8,14 +8,23 @@ import {
   DialogHeader,
   DialogTitle,
   DropdownMenu,
+  toast,
 } from '@mastra/playground-ui';
 import { Globe, LockIcon, MoreVerticalIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+import { useParams } from 'react-router';
 import type { AgentBuilderEditFormValues } from '../../schemas';
 import { SlackIcon } from './slack-icon';
 import type { Visibility } from './visibility-select';
+import {
+  useConnectChannel,
+  useDisconnectChannel,
+  useChannelInstallations,
+  useChannelPlatforms,
+} from '@/domains/agents/hooks/use-channels';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 
 export interface AgentBuilderMobileMenuProps {
   /** When true, includes the "Set visibility" item + dialog. Edit page only. */
@@ -31,14 +40,66 @@ export function AgentBuilderMobileMenu({
   showPublishToSlack = true,
   disabled = false,
 }: AgentBuilderMobileMenuProps) {
+  const { id } = useParams<{ id: string }>();
   const formMethods = useFormContext<AgentBuilderEditFormValues>();
   const visibility = (useWatch({ control: formMethods.control, name: 'visibility' }) ?? 'private') as Visibility;
+  const name = useWatch({ control: formMethods.control, name: 'name' });
+  const description = useWatch({ control: formMethods.control, name: 'description' });
   const [dialogOpen, setDialogOpen] = useState(false);
+  const { mutate: connectSlack, isPending: isConnectingSlack } = useConnectChannel('slack');
+  const { mutate: disconnectSlack, isPending: isDisconnectingSlack } = useDisconnectChannel('slack');
+  const { data: platforms } = useChannelPlatforms();
+  const { data: installations } = useChannelInstallations('slack', id ?? '');
+  const isSlackConnected = installations?.some(i => i.status === 'active') ?? false;
+  const { hasPermission } = usePermissions();
+  const slackAvailable = (platforms?.some(p => p.id === 'slack') ?? false) && hasPermission('channels:write');
+  const effectiveShowSlack = showPublishToSlack && slackAvailable;
 
-  if (!showSetVisibility && !showPublishToSlack) return null;
+  if (!showSetVisibility && !effectiveShowSlack) return null;
 
   const setVisibility = (next: Visibility) => {
     formMethods.setValue('visibility', next, { shouldDirty: true });
+  };
+
+  const handlePublishToSlack = () => {
+    if (!id) {
+      toast.error('Save the agent first before publishing to Slack');
+      return;
+    }
+    connectSlack(
+      { agentId: id, options: { name, description } },
+      {
+        onSuccess: result => {
+          switch (result.type) {
+            case 'oauth':
+              window.location.href = result.authorizationUrl;
+              break;
+            case 'deep_link': {
+              const popup = window.open(result.url, '_blank', 'noopener,noreferrer');
+              if (!popup) {
+                toast.error('Popup blocked — please allow popups and try again');
+              }
+              break;
+            }
+            case 'immediate':
+              toast.success('Published to Slack');
+              break;
+          }
+        },
+        onError: (err: Error & { body?: { error?: string } }) => {
+          toast.error(err.body?.error || err.message || 'Failed to publish to Slack');
+        },
+      },
+    );
+  };
+
+  const handleRemoveFromSlack = () => {
+    if (!id) return;
+    disconnectSlack(id, {
+      onError: (err: Error & { body?: { error?: string } }) => {
+        toast.error(err.body?.error || err.message || 'Failed to remove from Slack');
+      },
+    });
   };
 
   return (
@@ -63,18 +124,26 @@ export function AgentBuilderMobileMenu({
               <span>Set visibility</span>
             </DropdownMenu.Item>
           )}
-          {showPublishToSlack && (
-            <DropdownMenu.Item
-              data-testid="agent-builder-mobile-menu-publish-slack"
-              disabled={disabled}
-              onSelect={() => {
-                /* same no-op as PublishToSlackButton today */
-              }}
-            >
-              <SlackIcon className="h-4 w-4" />
-              <span>Publish to Slack</span>
-            </DropdownMenu.Item>
-          )}
+          {effectiveShowSlack &&
+            (isSlackConnected ? (
+              <DropdownMenu.Item
+                data-testid="agent-builder-mobile-menu-publish-slack"
+                disabled={disabled || isDisconnectingSlack}
+                onSelect={handleRemoveFromSlack}
+              >
+                <SlackIcon className="h-4 w-4" />
+                <span>{isDisconnectingSlack ? 'Removing…' : 'Remove from Slack'}</span>
+              </DropdownMenu.Item>
+            ) : (
+              <DropdownMenu.Item
+                data-testid="agent-builder-mobile-menu-publish-slack"
+                disabled={disabled || isConnectingSlack}
+                onSelect={handlePublishToSlack}
+              >
+                <SlackIcon className="h-4 w-4" />
+                <span>{isConnectingSlack ? 'Publishing…' : 'Publish to Slack'}</span>
+              </DropdownMenu.Item>
+            ))}
         </DropdownMenu.Content>
       </DropdownMenu>
 

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-edit/publish-to-slack-button.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-edit/publish-to-slack-button.tsx
@@ -1,11 +1,103 @@
-import { Button } from '@mastra/playground-ui';
+import { Button, toast } from '@mastra/playground-ui';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { useParams } from 'react-router';
+import type { AgentBuilderEditFormValues } from '../../schemas';
 import { SlackIcon } from './slack-icon';
+import {
+  useConnectChannel,
+  useDisconnectChannel,
+  useChannelInstallations,
+  useChannelPlatforms,
+} from '@/domains/agents/hooks/use-channels';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 
 export function PublishToSlackButton() {
+  const { id } = useParams<{ id: string }>();
+  const { control } = useFormContext<AgentBuilderEditFormValues>();
+  const name = useWatch({ control, name: 'name' });
+  const description = useWatch({ control, name: 'description' });
+
+  const { data: platforms } = useChannelPlatforms();
+  const { hasPermission } = usePermissions();
+  const slackAvailable = platforms?.some(p => p.id === 'slack') ?? false;
+  const canWriteChannels = hasPermission('channels:write');
+
+  const { mutate: connect, isPending: isConnecting } = useConnectChannel('slack');
+  const { mutate: disconnect, isPending: isDisconnecting } = useDisconnectChannel('slack');
+  const { data: installations } = useChannelInstallations('slack', id ?? '');
+  const isConnected = installations?.some(i => i.status === 'active');
+
+  const handleConnect = () => {
+    if (!id) {
+      toast.error('Save the agent first before publishing to Slack');
+      return;
+    }
+
+    connect(
+      { agentId: id, options: { name, description } },
+      {
+        onSuccess: result => {
+          switch (result.type) {
+            case 'oauth':
+              window.location.href = result.authorizationUrl;
+              break;
+            case 'deep_link': {
+              const popup = window.open(result.url, '_blank', 'noopener,noreferrer');
+              if (!popup) {
+                toast.error('Popup blocked — please allow popups and try again');
+              }
+              break;
+            }
+            case 'immediate':
+              toast.success('Published to Slack');
+              break;
+          }
+        },
+        onError: (err: Error & { body?: { error?: string } }) => {
+          toast.error(err.body?.error || err.message || 'Failed to publish to Slack');
+        },
+      },
+    );
+  };
+
+  const handleDisconnect = () => {
+    if (!id) return;
+    disconnect(id, {
+      onError: (err: Error & { body?: { error?: string } }) => {
+        toast.error(err.body?.error || err.message || 'Failed to remove from Slack');
+      },
+    });
+  };
+
+  if (!slackAvailable || !canWriteChannels) {
+    return null;
+  }
+
+  if (isConnected) {
+    return (
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={handleDisconnect}
+        disabled={isDisconnecting}
+        data-testid="agent-builder-publish-slack"
+      >
+        <SlackIcon className="h-4 w-4" />
+        {isDisconnecting ? 'Removing…' : 'Remove from Slack'}
+      </Button>
+    );
+  }
+
   return (
-    <Button size="sm" variant="ghost" data-testid="agent-builder-publish-slack">
+    <Button
+      size="sm"
+      variant="ghost"
+      onClick={handleConnect}
+      disabled={isConnecting || !id}
+      data-testid="agent-builder-publish-slack"
+    >
       <SlackIcon className="h-4 w-4" />
-      Publish to Slack
+      {isConnecting ? 'Publishing…' : 'Publish to Slack'}
     </Button>
   );
 }

--- a/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
+++ b/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../hooks/use-channels';
 import type { ChannelPlatformInfo } from '../../hooks/use-channels';
 import { PlatformIcon } from './platform-icons';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 
 export interface AgentChannelsProps {
   agentId: string;
@@ -47,6 +48,8 @@ function PlatformSection({ platform, agentId }: PlatformSectionProps) {
   const { data: installations, isLoading } = useChannelInstallations(platform.id, agentId);
   const { mutate: connect, isPending: isConnecting } = useConnectChannel(platform.id);
   const { mutate: disconnect, isPending: isDisconnecting } = useDisconnectChannel(platform.id);
+  const { hasPermission } = usePermissions();
+  const canWriteChannels = hasPermission('channels:write');
 
   const activeInstallation = installations?.find(i => i.status === 'active');
 
@@ -106,14 +109,16 @@ function PlatformSection({ platform, agentId }: PlatformSectionProps) {
               {activeInstallation.displayName || 'Workspace'}
             </Txt>
           </div>
-          <button
-            type="button"
-            onClick={handleDisconnect}
-            disabled={isDisconnecting}
-            className="shrink-0 text-[11px] text-neutral5 hover:text-accent2 transition-colors disabled:opacity-50"
-          >
-            {isDisconnecting ? 'Removing...' : 'Remove'}
-          </button>
+          {canWriteChannels && (
+            <button
+              type="button"
+              onClick={handleDisconnect}
+              disabled={isDisconnecting}
+              className="shrink-0 text-[11px] text-neutral5 hover:text-accent2 transition-colors disabled:opacity-50"
+            >
+              {isDisconnecting ? 'Removing...' : 'Remove'}
+            </button>
+          )}
         </div>
       ) : (
         <div className="flex items-center gap-2.5">
@@ -125,11 +130,11 @@ function PlatformSection({ platform, agentId }: PlatformSectionProps) {
             <StatusBadge variant="warning" size="sm">
               Not configured
             </StatusBadge>
-          ) : (
+          ) : canWriteChannels ? (
             <Button size="sm" variant="default" onClick={handleConnect} disabled={isConnecting}>
               {isConnecting ? 'Connecting...' : 'Connect'}
             </Button>
-          )}
+          ) : null}
         </div>
       )}
     </section>

--- a/packages/playground/src/pages/agent-builder/agents/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/edit.tsx
@@ -230,12 +230,12 @@ const AgentBuilderAgentEditReady = ({
         backTooltip={mode === 'edit' ? 'Back to agent chat' : 'Agents list'}
         modeAction={
           <div className="hidden lg:flex items-center gap-2">
-            {isOwner && <PublishToSlackButton />}
+            {isOwner && mode === 'edit' && <PublishToSlackButton />}
             <VisibilitySelectConnected />
           </div>
         }
         primaryAction={<HeaderActions mode={mode} isSaving={isSaving} onSave={handleSave} />}
-        mobileExtra={<AgentBuilderMobileMenuConnected showPublishToSlack={isOwner} />}
+        mobileExtra={<AgentBuilderMobileMenuConnected showPublishToSlack={isOwner && mode === 'edit'} />}
         chat={<ConversationPanelChat />}
         configure={
           <ConfigurePanelConnected

--- a/packages/server/src/server/handlers/channels.ts
+++ b/packages/server/src/server/handlers/channels.ts
@@ -38,15 +38,6 @@ function getChannelOrThrow(mastra: any, platform: string) {
   return channel;
 }
 
-function assertAgentExists(mastra: any, agentId: string) {
-  const agent = mastra.getAgentById?.(agentId);
-  if (!agent) {
-    throw new HTTPException(404, {
-      message: `Agent "${agentId}" not found`,
-    });
-  }
-}
-
 // ============================================================================
 // Route Definitions
 // ============================================================================
@@ -160,7 +151,6 @@ export const DISCONNECT_CHANNEL_ROUTE = createRoute({
   handler: async ({ mastra, platform, agentId }) => {
     assertChannelsAvailable();
     try {
-      assertAgentExists(mastra, agentId);
       const channel = getChannelOrThrow(mastra, platform);
 
       if (!channel.disconnect) {


### PR DESCRIPTION
## Summary

Adds full Slack integration to the agent builder UI, allowing users to publish agents to Slack and disconnect them directly from the builder.

## Changes

**Agent Builder UI**
- `PublishToSlackButton` now toggles between "Publish to Slack" and "Remove from Slack" based on connection state
- Mobile menu (`AgentBuilderMobileMenu`) mirrors the same publish/disconnect behavior
- Both components are gated on:
  - `SlackProvider` being configured (platform availability check via `useChannelPlatforms`)
  - User having `channels:write` RBAC permission
  - Agent being in edit mode (not during creation)

**Agent Channels**
- Connect and disconnect actions in `AgentChannels` now enforce `channels:write` permission

**Slack Provider**
- Builder agents (not registered in the runtime) can now connect to Slack — the provider falls back to `config.name`/`config.description` when the agent isn't in the registry
- Manifest description is truncated to 139 characters to prevent Slack API rejection

**Server**
- Removed agent existence check from channel disconnect handler so builder agents can disconnect

## Test Plan

- Unit tests updated for `AgentBuilderMobileMenu` (6/6 passing)
- Manifest truncation tests added and passing (19/19)
- Manually tested Slack app creation and disconnect flow in the agent builder