### PR TITLE
feat(core): subscribe to durable thread streams

### DIFF
--- a/.changeset/quiet-threads-observe.md
+++ b/.changeset/quiet-threads-observe.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Add a durable agent API for subscribing to thread streams across active run ids.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
@@ -463,6 +463,141 @@ describe('DurableAgent memory integration', () => {
     cleanup();
   });
 
+  it('should subscribe to an active stream by thread id', async () => {
+    const mockModel = createTextStreamModel('Hello from thread');
+
+    const baseAgent = new Agent({
+      id: 'thread-subscription-agent',
+      name: 'Thread Subscription Agent',
+      instructions: 'Test',
+      model: mockModel as LanguageModelV2,
+    });
+
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    const stream = await durableAgent.stream('Test', {
+      memory: {
+        thread: 'thread-to-subscribe',
+        resource: 'user-to-subscribe',
+      },
+    });
+
+    const subscription = await durableAgent.subscribeToThread({
+      threadId: 'thread-to-subscribe',
+      resourceId: 'user-to-subscribe',
+    });
+    const iterator = subscription.runs[Symbol.asyncIterator]();
+    const subscribedRun = await iterator.next();
+
+    expect(subscribedRun.value.runId).toBe(stream.runId);
+    await expect(subscribedRun.value.output.text).resolves.toBe('Hello from thread');
+
+    subscription.cleanup();
+    stream.cleanup();
+  });
+
+  it('should replay an active thread stream after events have already emitted', async () => {
+    const mockModel = createTextStreamModel('Hello from replay');
+
+    const baseAgent = new Agent({
+      id: 'thread-replay-subscription-agent',
+      name: 'Thread Replay Subscription Agent',
+      instructions: 'Test',
+      model: mockModel as LanguageModelV2,
+    });
+
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    const stream = await durableAgent.stream('Test', {
+      memory: {
+        thread: 'thread-to-replay',
+        resource: 'user-to-replay',
+      },
+    });
+
+    await expect(stream.output.text).resolves.toBe('Hello from replay');
+
+    const subscription = await durableAgent.subscribeToThread({
+      threadId: 'thread-to-replay',
+      resourceId: 'user-to-replay',
+    });
+    const subscribedRun = await subscription.runs[Symbol.asyncIterator]().next();
+
+    expect(subscribedRun.value.runId).toBe(stream.runId);
+    await expect(subscribedRun.value.output.text).resolves.toBe('Hello from replay');
+
+    subscription.cleanup();
+    stream.cleanup();
+  });
+
+  it('should notify a thread subscriber when a future run starts', async () => {
+    const mockModel = createTextStreamModel('Hello from future run');
+
+    const baseAgent = new Agent({
+      id: 'future-thread-subscription-agent',
+      name: 'Future Thread Subscription Agent',
+      instructions: 'Test',
+      model: mockModel as LanguageModelV2,
+    });
+
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+    const subscription = await durableAgent.subscribeToThread({
+      threadId: 'future-thread',
+      resourceId: 'future-user',
+    });
+    const nextRun = subscription.runs[Symbol.asyncIterator]().next();
+
+    const stream = await durableAgent.stream('Test', {
+      memory: {
+        thread: 'future-thread',
+        resource: 'future-user',
+      },
+    });
+
+    const subscribedRun = await nextRun;
+    expect(subscribedRun.value.runId).toBe(stream.runId);
+    await expect(subscribedRun.value.output.text).resolves.toBe('Hello from future run');
+
+    subscription.cleanup();
+    stream.cleanup();
+  });
+
+  it('should notify a thread subscriber across multiple run ids', async () => {
+    const mockModel = createTextStreamModel('Hello from another run');
+
+    const baseAgent = new Agent({
+      id: 'multi-run-thread-subscription-agent',
+      name: 'Multi Run Thread Subscription Agent',
+      instructions: 'Test',
+      model: mockModel as LanguageModelV2,
+    });
+
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+    const subscription = await durableAgent.subscribeToThread({
+      threadId: 'multi-run-thread',
+      resourceId: 'multi-run-user',
+    });
+    const iterator = subscription.runs[Symbol.asyncIterator]();
+
+    const firstStream = await durableAgent.stream('First', {
+      memory: { thread: 'multi-run-thread', resource: 'multi-run-user' },
+    });
+    const firstRun = await iterator.next();
+    expect(firstRun.value.runId).toBe(firstStream.runId);
+
+    firstStream.cleanup();
+
+    const secondStream = await durableAgent.stream('Second', {
+      memory: { thread: 'multi-run-thread', resource: 'multi-run-user' },
+    });
+    const secondRun = await iterator.next();
+    expect(secondRun.value.runId).toBe(secondStream.runId);
+    expect(secondRun.value.runId).not.toBe(firstRun.value.runId);
+
+    subscription.cleanup();
+    secondStream.cleanup();
+  });
+
   it('should handle streaming without memory options', async () => {
     const mockModel = createTextStreamModel('Hello');
 

--- a/packages/core/src/agent/durable/constants.ts
+++ b/packages/core/src/agent/durable/constants.ts
@@ -16,6 +16,15 @@ export const RUN_REGISTRY_SYMBOL = Symbol('run_registry');
 export const AGENT_STREAM_TOPIC = (runId: string): string => `agent.stream.${runId}`;
 
 /**
+ * Generate the pubsub topic name for thread-level durable stream updates.
+ * @param resourceId - The resource identifier for memory scoping
+ * @param threadId - The thread identifier
+ * @returns The topic name for active run updates on a thread
+ */
+export const AGENT_THREAD_STREAM_TOPIC = (resourceId: string | undefined, threadId: string): string =>
+  `agent.thread-stream.${resourceId ?? ''}.${threadId}`;
+
+/**
  * Event type constants for agent stream events
  */
 export const AgentStreamEventTypes = {

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -11,7 +11,7 @@ import type { AgentExecutionOptions } from '../agent.types';
 import type { MessageListInput } from '../message-list';
 import type { ToolsInput } from '../types';
 
-import { AGENT_STREAM_TOPIC } from './constants';
+import { AGENT_STREAM_TOPIC, AGENT_THREAD_STREAM_TOPIC } from './constants';
 import { runDurableStreamUntilIdle } from './durable-stream-until-idle';
 import { prepareForDurableExecution } from './preparation';
 import { ExtendedRunRegistry, globalRunRegistry } from './run-registry';
@@ -93,6 +93,45 @@ export interface DurableAgentStreamResult<OUTPUT = undefined> {
   /** Cleanup function to call when done (unsubscribes from pubsub) */
   cleanup: () => void;
 }
+
+/**
+ * Options for subscribing to durable streams for a memory thread.
+ */
+export interface DurableAgentSubscribeToThreadOptions<OUTPUT = undefined> {
+  /** Resource ID for the memory thread */
+  resourceId?: string;
+  /** Thread ID for the memory thread */
+  threadId: string;
+  /** Start replay from this event offset for each run stream */
+  offset?: number;
+  /** Callback when chunk is received */
+  onChunk?: (chunk: ChunkType<OUTPUT>) => void | Promise<void>;
+  /** Callback when step finishes */
+  onStepFinish?: (result: AgentStepFinishEventData) => void | Promise<void>;
+  /** Callback when execution finishes */
+  onFinish?: (result: AgentFinishEventData) => void | Promise<void>;
+  /** Callback on error */
+  onError?: (error: Error) => void | Promise<void>;
+  /** Callback when workflow suspends (e.g., for tool approval) */
+  onSuspended?: (data: AgentSuspendedEventData) => void | Promise<void>;
+}
+
+export interface DurableAgentThreadSubscription<OUTPUT = undefined> {
+  /** Streams for active runs on this thread, including future run IDs. */
+  runs: AsyncIterable<DurableAgentStreamResult<OUTPUT>>;
+  /** Stop watching the thread and cleanup any attached run streams. */
+  cleanup: () => void;
+}
+
+type DurableAgentThreadRunStartedEvent = {
+  type: 'run-started';
+  runId: string;
+  data: {
+    runId: string;
+    threadId: string;
+    resourceId?: string;
+  };
+};
 
 /**
  * Configuration for DurableAgent - wraps an existing Agent with durable execution
@@ -424,6 +463,130 @@ export class DurableAgent<
   // Public API
   // ===========================================================================
 
+  #attachToRunStream(
+    runId: string,
+    options: DurableAgentSubscribeToThreadOptions<TOutput>,
+  ): Promise<DurableAgentStreamResult<TOutput> | undefined> {
+    const entry = this.#runRegistry.get(runId);
+    if (!entry) return Promise.resolve(undefined);
+
+    const {
+      output,
+      cleanup,
+      ready,
+    } = createDurableAgentStream<TOutput>({
+      pubsub: this.pubsub,
+      runId,
+      messageId: runId,
+      model: {
+        modelId: entry.model.modelId,
+        provider: entry.model.provider,
+        version: 'v3',
+      },
+      threadId: options.threadId,
+      resourceId: options.resourceId,
+      offset: options.offset,
+      onChunk: options.onChunk,
+      onStepFinish: options.onStepFinish,
+      onFinish: options.onFinish,
+      onError: options.onError,
+      onSuspended: options.onSuspended,
+    });
+
+    return ready.then(() => ({
+      output,
+      get fullStream() {
+        return output.fullStream as ReadableStream<any>;
+      },
+      runId,
+      threadId: options.threadId,
+      resourceId: options.resourceId,
+      cleanup,
+    }));
+  }
+
+  /**
+   * Subscribe to durable streams for a memory thread, including future run IDs.
+   */
+  async subscribeToThread(
+    options: DurableAgentSubscribeToThreadOptions<TOutput>,
+  ): Promise<DurableAgentThreadSubscription<TOutput>> {
+    const topic = AGENT_THREAD_STREAM_TOPIC(options.resourceId, options.threadId);
+    const seenRunIds = new Set<string>();
+    const pendingRuns: DurableAgentStreamResult<TOutput>[] = [];
+    const runCleanups: Array<() => void> = [];
+    const waiters: Array<() => void> = [];
+    let done = false;
+
+    const wake = () => {
+      while (waiters.length) waiters.shift()?.();
+    };
+
+    const enqueueRun = async (runId: string) => {
+      if (done || seenRunIds.has(runId)) return;
+      seenRunIds.add(runId);
+      const runStream = await this.#attachToRunStream(runId, options);
+      if (!runStream || done) {
+        runStream?.cleanup();
+        return;
+      }
+      runCleanups.push(runStream.cleanup);
+      pendingRuns.push(runStream);
+      wake();
+    };
+
+    const handleThreadEvent = (event: unknown) => {
+      const threadEvent = event as DurableAgentThreadRunStartedEvent;
+      const runId = threadEvent.data?.runId ?? threadEvent.runId;
+      if (threadEvent.type === 'run-started' && runId) {
+        void enqueueRun(runId);
+      }
+    };
+
+    await this.pubsub.subscribeWithReplay(topic, handleThreadEvent);
+
+    const activeRunId = this.#runRegistry.getRunIdByThread({ resourceId: options.resourceId, threadId: options.threadId });
+    if (activeRunId) {
+      void enqueueRun(activeRunId);
+    }
+
+    const cleanup = () => {
+      if (done) return;
+      done = true;
+      void this.pubsub.unsubscribe(topic, handleThreadEvent);
+      for (const runCleanup of runCleanups.splice(0)) {
+        runCleanup();
+      }
+      wake();
+    };
+
+    return {
+      cleanup,
+      runs: (async function* () {
+        try {
+          while (!done || pendingRuns.length > 0) {
+            if (pendingRuns.length === 0) {
+              await new Promise<void>(resolve => waiters.push(resolve));
+              continue;
+            }
+            yield pendingRuns.shift()!;
+          }
+        } finally {
+          cleanup();
+        }
+      })(),
+    };
+  }
+
+  async #publishThreadRunStarted(runId: string, threadId?: string, resourceId?: string): Promise<void> {
+    if (!threadId) return;
+    await this.pubsub.publish(AGENT_THREAD_STREAM_TOPIC(resourceId, threadId), {
+      type: 'run-started',
+      runId,
+      data: { runId, threadId, resourceId },
+    });
+  }
+
   /**
    * Stream a response from the agent using durable execution.
    */
@@ -497,7 +660,10 @@ export class DurableAgent<
     // 4. Wait for subscription to be ready, then execute workflow
     // This prevents race conditions where events are published before subscription
     ready
-      .then(() => this.executeWorkflow(runId, workflowInput))
+      .then(async () => {
+        await this.#publishThreadRunStarted(runId, threadId, resourceId);
+        await this.executeWorkflow(runId, workflowInput);
+      })
       .catch(error => {
         void this.emitError(runId, error);
       });

--- a/packages/core/src/agent/durable/index.ts
+++ b/packages/core/src/agent/durable/index.ts
@@ -77,8 +77,10 @@ export {
 export {
   DurableAgent,
   type DurableAgentConfig,
+  type DurableAgentSubscribeToThreadOptions,
   type DurableAgentStreamOptions,
   type DurableAgentStreamResult,
+  type DurableAgentThreadSubscription,
 } from './durable-agent';
 
 // EventedAgent class (extends DurableAgent with fire-and-forget execution)

--- a/packages/core/src/agent/durable/run-registry.ts
+++ b/packages/core/src/agent/durable/run-registry.ts
@@ -210,6 +210,19 @@ export class ExtendedRunRegistry extends RunRegistry {
   }
 
   /**
+   * Find the active run for a memory thread.
+   */
+  getRunIdByThread({ resourceId, threadId }: { resourceId?: string; threadId: string }): string | undefined {
+    for (const [runId, memoryInfo] of Array.from(this.#memoryInfo.entries()).reverse()) {
+      if (memoryInfo.threadId === threadId && memoryInfo.resourceId === resourceId) {
+        return runId;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
    * Override cleanup to also remove MessageList and memory info
    */
   override cleanup(runId: string): void {


### PR DESCRIPTION
This adds a core durable-agent API for subscribing to durable streams by memory thread, including future run IDs.

```ts
const subscription = await durableAgent.subscribeToThread({
  resourceId,
  threadId,
});

for await (const run of subscription.runs) {
  // `run` is a local stream consumer attached to the existing durable run.
  // It does not start a new agent run.
  await processRun(run);
}
```

`subscribeToThread()` watches a thread-level durable stream topic. When a run starts for that thread, it emits the active `runId` and returns a local stream consumer attached to that run's existing durable pubsub stream. The same subscription continues to yield future runs for the thread, so callers do not need to poll for active run IDs.

Each run stream uses the existing durable pubsub replay path, so late subscribers can receive cached events while continuing with live events.

This keeps coordinator/transport concerns out of Harness. MastraCode-specific thread attachment and unix socket coordination are handled in the next stacked PR.
