### PR TITLE
fix(slack): Truncate manifest description to prevent app creation failure

### DIFF
--- a/.changeset/ten-paths-itch.md
+++ b/.changeset/ten-paths-itch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/slack': patch
+---
+
+Fixed Slack app creation failing when agent description exceeds 139 characters. The manifest description is now automatically truncated to prevent the Slack API from rejecting the request.

--- a/channels/slack/src/manifest.test.ts
+++ b/channels/slack/src/manifest.test.ts
@@ -28,6 +28,20 @@ describe('buildManifest', () => {
     expect(manifest.display_information.description).toBe('My custom bot');
   });
 
+  it('truncates description to 139 characters with ellipsis when too long', () => {
+    const longDesc = 'A'.repeat(200);
+    const manifest = buildManifest({ ...baseOptions, description: longDesc });
+    expect(manifest.display_information.description).toHaveLength(139);
+    expect(manifest.display_information.description).toBe('A'.repeat(136) + '...');
+  });
+
+  it('does not truncate description at exactly 139 characters', () => {
+    const exact = 'E'.repeat(139);
+    const manifest = buildManifest({ ...baseOptions, description: exact });
+    expect(manifest.display_information.description).toBe(exact);
+    expect(manifest.display_information.description).toHaveLength(139);
+  });
+
   it('includes default bot scopes', () => {
     const manifest = buildManifest(baseOptions);
     const scopes = manifest.oauth_config?.scopes?.bot ?? [];

--- a/channels/slack/src/manifest.ts
+++ b/channels/slack/src/manifest.ts
@@ -83,10 +83,16 @@ export function buildManifest(options: BuildManifestOptions): SlackAppManifest {
     scopes.push('commands');
   }
 
+  // Slack docs say 140 but the API rejects at that length for short_desc.
+  const MAX_DESC = 139;
+  const rawDescription = description ?? `${name} - Powered by Mastra`;
+  const shortDescription =
+    rawDescription.length > MAX_DESC ? rawDescription.slice(0, MAX_DESC - 3) + '...' : rawDescription;
+
   const manifest: SlackAppManifest = {
     display_information: {
       name,
-      description: description ?? `${name} - Powered by Mastra`,
+      description: shortDescription,
     },
     features: {
       app_home: {


### PR DESCRIPTION
## Summary

Fixes Slack app creation failing with `invalid_manifest: /display_information/short_desc: The short description is too long` when the agent description exceeds 139 characters.

## Changes

- Truncate the Slack manifest `description` field to 139 characters (with `...` suffix) before sending to the API
- Slack's docs say 140 is the limit, but the API actually rejects at that length

## Test Plan

- Added unit tests for truncation behavior (19/19 passing)
- Manually verified Slack app creation succeeds with a 155-character description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When creating a Slack app, if you give it a long description (more than 139 characters), Slack would reject it and the app creation would fail. This PR automatically fixes that by cutting off the description at 139 characters and adding "..." so it fits Slack's rules.

## Changes

This PR fixes Slack app creation failures that occurred when an agent description exceeded Slack's character limit for the app manifest's `display_information.short_desc` field. The fix implements automatic truncation of the manifest description to 139 characters (with an ellipsis appended) when necessary, preventing the Slack API from rejecting the request.

### Modified files:
- **channels/slack/src/manifest.ts**: Added logic to enforce a maximum description length of 139 characters, truncating the effective description (either the provided description or the default "{name} - Powered by Mastra") when it exceeds the limit.
- **channels/slack/src/manifest.test.ts**: Added two unit tests to verify the truncation behavior—one confirming that descriptions exceeding 139 characters are truncated with an ellipsis, and another confirming that descriptions of exactly 139 characters are preserved unchanged.
- **.changeset/ten-paths-itch.md**: Added a changeset entry documenting the `@mastra/slack` patch release.

### Testing
19 unit tests pass, including the new truncation tests. Manual verification confirmed that Slack app creation succeeds with descriptions up to 155 characters through the automatic truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->