### PR TITLE
chore: merge main into yj/magnificent-marquess

### DIFF
--- a/.changeset/ten-paths-itch.md
+++ b/.changeset/ten-paths-itch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/slack': patch
+---
+
+Fixed Slack app creation failing when agent description exceeds 139 characters. The manifest description is now automatically truncated to prevent the Slack API from rejecting the request.

--- a/channels/slack/src/manifest.test.ts
+++ b/channels/slack/src/manifest.test.ts
@@ -28,6 +28,20 @@ describe('buildManifest', () => {
     expect(manifest.display_information.description).toBe('My custom bot');
   });
 
+  it('truncates description to 139 characters with ellipsis when too long', () => {
+    const longDesc = 'A'.repeat(200);
+    const manifest = buildManifest({ ...baseOptions, description: longDesc });
+    expect(manifest.display_information.description).toHaveLength(139);
+    expect(manifest.display_information.description).toBe('A'.repeat(136) + '...');
+  });
+
+  it('does not truncate description at exactly 139 characters', () => {
+    const exact = 'E'.repeat(139);
+    const manifest = buildManifest({ ...baseOptions, description: exact });
+    expect(manifest.display_information.description).toBe(exact);
+    expect(manifest.display_information.description).toHaveLength(139);
+  });
+
   it('includes default bot scopes', () => {
     const manifest = buildManifest(baseOptions);
     const scopes = manifest.oauth_config?.scopes?.bot ?? [];

--- a/channels/slack/src/manifest.ts
+++ b/channels/slack/src/manifest.ts
@@ -83,10 +83,16 @@ export function buildManifest(options: BuildManifestOptions): SlackAppManifest {
     scopes.push('commands');
   }
 
+  // Slack docs say 140 but the API rejects at that length for short_desc.
+  const MAX_DESC = 139;
+  const rawDescription = description ?? `${name} - Powered by Mastra`;
+  const shortDescription =
+    rawDescription.length > MAX_DESC ? rawDescription.slice(0, MAX_DESC - 3) + '...' : rawDescription;
+
   const manifest: SlackAppManifest = {
     display_information: {
       name,
-      description: description ?? `${name} - Powered by Mastra`,
+      description: shortDescription,
     },
     features: {
       app_home: {


### PR DESCRIPTION
Brings in latest from main, including the Slack manifest description truncation fix (#16093).