### PR TITLE
feat(mastracode): add durable stream pubsub

### DIFF
--- a/.changeset/slow-planes-listen.md
+++ b/.changeset/slow-planes-listen.md
@@ -1,0 +1,5 @@
+---
+"mastracode": patch
+---
+
+Add MastraCode unix-socket durable stream pubsub plumbing.

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -22,6 +22,10 @@ vi.mock('@mastra/core/agent', () => ({
   },
 }));
 
+vi.mock('@mastra/core/agent/durable', () => ({
+  createDurableAgent: vi.fn(({ agent }) => agent),
+}));
+
 const agentConstructorMock = vi.fn();
 
 const harnessConstructorMock = vi.fn();

--- a/mastracode/src/durable-streams/index.test.ts
+++ b/mastracode/src/durable-streams/index.test.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { UnixSocketPubSub } from './index.js';
+
+const clients: UnixSocketPubSub[] = [];
+
+function createClient(socketPath: string) {
+  const client = new UnixSocketPubSub({ socketPath, autoStartCoordinator: true });
+  clients.push(client);
+  return client;
+}
+
+afterEach(async () => {
+  await Promise.all(clients.splice(0).map(client => client.close().catch(() => undefined)));
+});
+
+describe('UnixSocketPubSub', () => {
+  it('publishes events between processes over the socket', async () => {
+    const socketPath = path.join(os.tmpdir(), `mastracode-pubsub-${randomUUID()}.sock`);
+    const publisher = createClient(socketPath);
+    const subscriber = createClient(socketPath);
+
+    const received = new Promise<any>(resolve => {
+      void subscriber.subscribe('durable:test', event => resolve(event));
+    });
+
+    await publisher.publish('durable:test', { type: 'message', runId: 'run-1', data: { value: 1 } });
+
+    await expect(received).resolves.toMatchObject({
+      type: 'message',
+      runId: 'run-1',
+      data: { value: 1 },
+    });
+  });
+
+  it('returns topic history for late subscribers', async () => {
+    const socketPath = path.join(os.tmpdir(), `mastracode-pubsub-${randomUUID()}.sock`);
+    const publisher = createClient(socketPath);
+    const subscriber = createClient(socketPath);
+
+    await publisher.publish('durable:history', { type: 'message', runId: 'run-1', data: { value: 1 } });
+    await publisher.publish('durable:history', { type: 'message', runId: 'run-2', data: { value: 2 } });
+
+    await expect(subscriber.getHistory('durable:history', 1)).resolves.toMatchObject([
+      { type: 'message', runId: 'run-2', data: { value: 2 } },
+    ]);
+  });
+});

--- a/mastracode/src/durable-streams/index.ts
+++ b/mastracode/src/durable-streams/index.ts
@@ -1,0 +1,41 @@
+import { PubSub } from '@mastra/core/events';
+import type { Event, EventCallback, SubscribeOptions } from '@mastra/core/events';
+
+import { UnixSocketDurableRunClient } from './unix-socket-client.js';
+
+export { UnixSocketDurableRunClient } from './unix-socket-client.js';
+export { UnixSocketDurableRunCoordinator } from './unix-socket-coordinator.js';
+
+export class UnixSocketPubSub extends PubSub {
+  readonly client: UnixSocketDurableRunClient;
+
+  constructor(options: { socketPath: string; clientId?: string; autoStartCoordinator?: boolean }) {
+    super();
+    this.client = new UnixSocketDurableRunClient(options);
+  }
+
+  async publish(topic: string, event: Omit<Event, 'id' | 'createdAt'>): Promise<void> {
+    await this.client.connect();
+    await this.client.publishTopic(topic, event);
+  }
+
+  async subscribe(topic: string, cb: EventCallback, _options?: SubscribeOptions): Promise<void> {
+    await this.client.connect();
+    await this.client.subscribeTopic(topic, cb);
+  }
+
+  async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
+    await this.client.unsubscribeTopic(topic, cb);
+  }
+
+  async flush(): Promise<void> {}
+
+  async getHistory(topic: string, offset?: number): Promise<Event[]> {
+    await this.client.connect();
+    return this.client.getTopicHistory(topic, offset);
+  }
+
+  async close(): Promise<void> {
+    await this.client.close();
+  }
+}

--- a/mastracode/src/durable-streams/types.ts
+++ b/mastracode/src/durable-streams/types.ts
@@ -1,0 +1,20 @@
+export type DurableAgentRunStatus = 'active' | 'suspended' | 'completed' | 'error';
+
+export interface DurableAgentActiveRun {
+  resourceId: string;
+  threadId: string;
+  runId: string;
+  ownerId?: string;
+  status: DurableAgentRunStatus;
+}
+
+export interface DurableAgentClaimThreadOptions {
+  resourceId: string;
+  threadId: string;
+  runId: string;
+  ownerId?: string;
+}
+
+export type DurableAgentClaimThreadResult =
+  | { claimed: true; activeRun: DurableAgentActiveRun }
+  | { claimed: false; activeRun: DurableAgentActiveRun };

--- a/mastracode/src/durable-streams/unix-socket-client.ts
+++ b/mastracode/src/durable-streams/unix-socket-client.ts
@@ -1,0 +1,333 @@
+import { randomUUID } from 'node:crypto';
+import { createConnection } from 'node:net';
+import type { Socket } from 'node:net';
+
+import type { DurableAgentActiveRun, DurableAgentClaimThreadOptions, DurableAgentClaimThreadResult } from './types.js';
+import { UnixSocketDurableRunCoordinator } from './unix-socket-coordinator.js';
+
+export interface UnixSocketDurableRunClientOptions {
+  socketPath: string;
+  clientId?: string;
+  autoStartCoordinator?: boolean;
+}
+
+type PendingRequest = {
+  resolve: (value: any) => void;
+  reject: (error: Error) => void;
+};
+
+type ClientResponse = {
+  id?: string | number;
+  ok?: boolean;
+  result?: any;
+  error?: string;
+};
+
+export class UnixSocketDurableRunClient {
+  readonly socketPath: string;
+  readonly clientId: string;
+  readonly autoStartCoordinator: boolean;
+
+  #socket?: Socket;
+  #hostedCoordinator?: UnixSocketDurableRunCoordinator;
+  #buffer = '';
+  #nextRequestId = 0;
+  #pending = new Map<number, PendingRequest>();
+  #signalHandlers = new Map<string, Set<(signal: unknown) => void>>();
+  #runEventHandlers = new Map<string, Set<(event: unknown) => void>>();
+  #threadEventHandlers = new Map<string, Set<(activeRun: DurableAgentActiveRun) => void>>();
+  #topicHandlers = new Map<string, Set<(event: any) => void>>();
+
+  constructor(options: UnixSocketDurableRunClientOptions) {
+    this.socketPath = options.socketPath;
+    this.clientId = options.clientId ?? randomUUID();
+    this.autoStartCoordinator = options.autoStartCoordinator ?? false;
+  }
+
+  async connect(): Promise<void> {
+    if (this.#socket) return;
+
+    try {
+      await this.#connectSocket();
+    } catch (error) {
+      if (!this.autoStartCoordinator) throw error;
+      await this.#startCoordinator();
+      await this.#connectSocket();
+    }
+
+    await this.#request('ping');
+  }
+
+  async reconnect(): Promise<void> {
+    const socket = this.#socket;
+    this.#socket = undefined;
+    socket?.destroy();
+    this.#rejectPending(new Error('Unix socket durable run client reconnecting'));
+    await this.connect();
+    await this.#restoreRegistrations();
+  }
+
+  async #connectSocket(): Promise<void> {
+    const socket = createConnection(this.socketPath);
+    this.#socket = socket;
+
+    socket.on('data', chunk => this.#handleData(chunk));
+    socket.on('close', () => {
+      if (this.#socket === socket) {
+        this.#socket = undefined;
+      }
+      this.#rejectPending(new Error('Unix socket durable run client disconnected'));
+    });
+    socket.on('error', error => this.#rejectPending(error));
+
+    await new Promise<void>((resolve, reject) => {
+      const onConnect = () => {
+        socket.off('error', onError);
+        resolve();
+      };
+      const onError = (error: Error) => {
+        socket.off('connect', onConnect);
+        if (this.#socket === socket) {
+          this.#socket = undefined;
+        }
+        reject(error);
+      };
+      socket.once('connect', onConnect);
+      socket.once('error', onError);
+    });
+  }
+
+  async #startCoordinator(): Promise<void> {
+    if (this.#hostedCoordinator) return;
+    const coordinator = new UnixSocketDurableRunCoordinator({ socketPath: this.socketPath });
+    try {
+      await coordinator.start();
+      this.#hostedCoordinator = coordinator;
+    } catch (error: any) {
+      await coordinator.close().catch(() => undefined);
+      if (error?.code !== 'EADDRINUSE') throw error;
+    }
+  }
+
+  async #restoreRegistrations(): Promise<void> {
+    for (const runId of this.#runEventHandlers.keys()) {
+      await this.#request('subscribeRun', { runId });
+    }
+    for (const key of this.#threadEventHandlers.keys()) {
+      const [resourceId, threadId] = key.split('\0');
+      if (resourceId && threadId) {
+        await this.#request('subscribeThread', { resourceId, threadId });
+      }
+    }
+    for (const runId of this.#signalHandlers.keys()) {
+      await this.#request('registerSignalHandler', { runId });
+    }
+    for (const topic of this.#topicHandlers.keys()) {
+      await this.#request('subscribeTopic', { topic });
+    }
+  }
+
+  async close(): Promise<void> {
+    const socket = this.#socket;
+    this.#socket = undefined;
+    if (socket) {
+      await new Promise<void>(resolve => {
+        socket.end(() => resolve());
+      });
+    }
+    const hostedCoordinator = this.#hostedCoordinator;
+    this.#hostedCoordinator = undefined;
+    await hostedCoordinator?.close();
+  }
+
+  claimThread(
+    options: Omit<DurableAgentClaimThreadOptions, 'ownerId'> & { ownerId?: string },
+  ): Promise<DurableAgentClaimThreadResult> {
+    return this.#request('claimThread', { ...options, ownerId: options.ownerId ?? this.clientId });
+  }
+
+  getActiveRun(options: { resourceId: string; threadId: string }): Promise<DurableAgentActiveRun | undefined> {
+    return this.#request('getActiveRun', options);
+  }
+
+  completeRun(runId: string): Promise<{ ok: true }> {
+    return this.#request('completeRun', { runId });
+  }
+
+  failRun(runId: string): Promise<{ ok: true }> {
+    return this.#request('failRun', { runId });
+  }
+
+  suspendRun(runId: string): Promise<{ ok: true }> {
+    return this.#request('suspendRun', { runId });
+  }
+
+  resumeRun(runId: string): Promise<{ ok: true }> {
+    return this.#request('resumeRun', { runId });
+  }
+
+  async subscribeRun(runId: string, handler: (event: unknown) => void): Promise<() => void> {
+    let handlers = this.#runEventHandlers.get(runId);
+    const needsRegistration = !handlers;
+    if (!handlers) {
+      handlers = new Set();
+      this.#runEventHandlers.set(runId, handlers);
+    }
+    handlers.add(handler);
+    if (needsRegistration) {
+      await this.#request('subscribeRun', { runId }).catch(error => {
+        handlers?.delete(handler);
+        if (handlers?.size === 0) {
+          this.#runEventHandlers.delete(runId);
+        }
+        throw error;
+      });
+    }
+    return () => {
+      handlers?.delete(handler);
+    };
+  }
+
+  async publishRunEvent(runId: string, event: unknown): Promise<{ ok: true }> {
+    return this.#request('publishRunEvent', { runId, event });
+  }
+
+  async subscribeThread(
+    options: { resourceId: string; threadId: string },
+    handler: (activeRun: DurableAgentActiveRun) => void,
+  ): Promise<() => void> {
+    const key = `${options.resourceId}\0${options.threadId}`;
+    let handlers = this.#threadEventHandlers.get(key);
+    if (!handlers) {
+      handlers = new Set();
+      this.#threadEventHandlers.set(key, handlers);
+      await this.#request('subscribeThread', options);
+    }
+    handlers.add(handler);
+    return () => {
+      handlers?.delete(handler);
+    };
+  }
+
+  async sendSignal(signal: unknown, target: { runId: string }): Promise<{ accepted: true; runId: string }> {
+    return this.#request('sendSignal', { signal, target });
+  }
+
+  async publishTopic(topic: string, event: unknown): Promise<{ ok: true }> {
+    return this.#request('publishTopic', { topic, event });
+  }
+
+  async subscribeTopic(topic: string, handler: (event: any) => void): Promise<() => void> {
+    let handlers = this.#topicHandlers.get(topic);
+    if (!handlers) {
+      handlers = new Set();
+      this.#topicHandlers.set(topic, handlers);
+      await this.#request('subscribeTopic', { topic });
+    }
+    handlers.add(handler);
+    return () => {
+      handlers?.delete(handler);
+    };
+  }
+
+  async unsubscribeTopic(topic: string, handler: (event: any) => void): Promise<void> {
+    const handlers = this.#topicHandlers.get(topic);
+    handlers?.delete(handler);
+    if (handlers?.size === 0) {
+      this.#topicHandlers.delete(topic);
+    }
+  }
+
+  async getTopicHistory(topic: string, offset?: number): Promise<any[]> {
+    return this.#request('getTopicHistory', { topic, offset });
+  }
+
+  async onSignal(runId: string, handler: (signal: unknown) => void): Promise<() => void> {
+    let handlers = this.#signalHandlers.get(runId);
+    if (!handlers) {
+      handlers = new Set();
+      this.#signalHandlers.set(runId, handlers);
+      await this.#request('registerSignalHandler', { runId });
+    }
+    handlers.add(handler);
+    return () => {
+      handlers?.delete(handler);
+    };
+  }
+
+  #request<T = unknown>(action: string, payload?: unknown): Promise<T> {
+    const socket = this.#socket;
+    if (!socket) {
+      return Promise.reject(new Error('Unix socket durable run client is not connected'));
+    }
+
+    const id = ++this.#nextRequestId;
+    return new Promise<T>((resolve, reject) => {
+      this.#pending.set(id, { resolve, reject });
+      socket.write(JSON.stringify({ id, action, clientId: this.clientId, payload }) + '\n');
+    });
+  }
+
+  #handleData(chunk: Buffer): void {
+    this.#buffer += chunk.toString();
+    const lines = this.#buffer.split('\n');
+    this.#buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const message = JSON.parse(line) as ClientResponse & {
+        type?: string;
+        runId?: string;
+        signal?: unknown;
+        event?: unknown;
+      };
+      if (message.type === 'signal' && message.runId) {
+        for (const handler of this.#signalHandlers.get(message.runId) ?? []) {
+          handler(message.signal);
+        }
+        continue;
+      }
+      if (message.type === 'runEvent' && message.runId) {
+        for (const handler of this.#runEventHandlers.get(message.runId) ?? []) {
+          handler(message.event);
+        }
+        continue;
+      }
+      if (message.type === 'threadActiveRun') {
+        const activeRun = (message as any).activeRun as DurableAgentActiveRun | undefined;
+        if (activeRun) {
+          const key = `${activeRun.resourceId}\0${activeRun.threadId}`;
+          for (const handler of this.#threadEventHandlers.get(key) ?? []) {
+            handler(activeRun);
+          }
+        }
+        continue;
+      }
+      if (message.type === 'topicEvent') {
+        const topic = (message as any).topic as string | undefined;
+        if (topic) {
+          for (const handler of this.#topicHandlers.get(topic) ?? []) {
+            handler(message.event);
+          }
+        }
+        continue;
+      }
+      if (message.id === undefined) continue;
+      const requestId = Number(message.id);
+      const pending = this.#pending.get(requestId);
+      if (!pending) continue;
+      this.#pending.delete(requestId);
+      if (message.ok === false) {
+        pending.reject(new Error(message.error ?? 'Unix socket durable run request failed'));
+      } else {
+        pending.resolve(message.result);
+      }
+    }
+  }
+
+  #rejectPending(error: Error): void {
+    for (const pending of this.#pending.values()) {
+      pending.reject(error);
+    }
+    this.#pending.clear();
+  }
+}

--- a/mastracode/src/durable-streams/unix-socket-coordinator.ts
+++ b/mastracode/src/durable-streams/unix-socket-coordinator.ts
@@ -1,0 +1,384 @@
+import { existsSync, unlinkSync } from 'node:fs';
+import { createServer } from 'node:net';
+import type { Server, Socket } from 'node:net';
+
+import type {
+  DurableAgentActiveRun,
+  DurableAgentClaimThreadOptions,
+  DurableAgentClaimThreadResult,
+  DurableAgentRunStatus,
+} from './types.js';
+
+export interface UnixSocketDurableRunCoordinatorOptions {
+  socketPath: string;
+}
+
+type CoordinatorConnection = {
+  socket: Socket;
+  id?: string;
+  buffer: string;
+};
+
+type CoordinatorRequest = {
+  id?: string | number;
+  action: string;
+  clientId?: string;
+  payload?: any;
+};
+
+function threadKey(resourceId: string, threadId: string): string {
+  return `${resourceId}\0${threadId}`;
+}
+
+function writeJson(socket: Socket, message: unknown): void {
+  socket.write(`${JSON.stringify(message)}\n`);
+}
+
+export class UnixSocketDurableRunCoordinator {
+  readonly socketPath: string;
+
+  #server?: Server;
+  #connections = new Set<CoordinatorConnection>();
+  #connectionsById = new Map<string, CoordinatorConnection>();
+  #runsByThread = new Map<string, DurableAgentActiveRun>();
+  #threadKeyByRunId = new Map<string, string>();
+  #signalHandlersByRunId = new Map<string, CoordinatorConnection>();
+  #subscribersByRunId = new Map<string, Set<CoordinatorConnection>>();
+  #subscribersByThread = new Map<string, Set<CoordinatorConnection>>();
+  #eventsByRunId = new Map<string, unknown[]>();
+  #subscribersByTopic = new Map<string, Set<CoordinatorConnection>>();
+  #eventsByTopic = new Map<string, any[]>();
+
+  constructor(options: UnixSocketDurableRunCoordinatorOptions) {
+    this.socketPath = options.socketPath;
+  }
+
+  async start(): Promise<void> {
+    if (this.#server) return;
+
+    if (existsSync(this.socketPath)) {
+      unlinkSync(this.socketPath);
+    }
+
+    this.#server = createServer(socket => this.#handleConnection(socket));
+
+    await new Promise<void>((resolve, reject) => {
+      const server = this.#server!;
+      const onError = (error: Error) => {
+        server.off('listening', onListening);
+        reject(error);
+      };
+      const onListening = () => {
+        server.off('error', onError);
+        resolve();
+      };
+      server.once('error', onError);
+      server.once('listening', onListening);
+      server.listen(this.socketPath);
+    });
+  }
+
+  async close(): Promise<void> {
+    for (const connection of this.#connections) {
+      connection.socket.destroy();
+    }
+    this.#connections.clear();
+
+    const server = this.#server;
+    this.#server = undefined;
+    if (server) {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+
+    if (existsSync(this.socketPath)) {
+      unlinkSync(this.socketPath);
+    }
+  }
+
+  #handleConnection(socket: Socket): void {
+    const connection: CoordinatorConnection = { socket, buffer: '' };
+    this.#connections.add(connection);
+
+    socket.on('data', chunk => {
+      connection.buffer += chunk.toString();
+      const lines = connection.buffer.split('\n');
+      connection.buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        void this.#handleLine(connection, line);
+      }
+    });
+
+    socket.on('close', () => {
+      this.#connections.delete(connection);
+      if (connection.id) {
+        this.#connectionsById.delete(connection.id);
+      }
+      for (const [runId, handler] of this.#signalHandlersByRunId) {
+        if (handler === connection) {
+          this.#signalHandlersByRunId.delete(runId);
+        }
+      }
+      for (const [runId, subscribers] of this.#subscribersByRunId) {
+        subscribers.delete(connection);
+        if (subscribers.size === 0) {
+          this.#subscribersByRunId.delete(runId);
+        }
+      }
+      for (const [key, subscribers] of this.#subscribersByThread) {
+        subscribers.delete(connection);
+        if (subscribers.size === 0) {
+          this.#subscribersByThread.delete(key);
+        }
+      }
+      for (const [topic, subscribers] of this.#subscribersByTopic) {
+        subscribers.delete(connection);
+        if (subscribers.size === 0) {
+          this.#subscribersByTopic.delete(topic);
+        }
+      }
+      if (connection.id) {
+        this.#cleanupRunsForOwner(connection.id);
+      }
+    });
+  }
+
+  async #handleLine(connection: CoordinatorConnection, line: string): Promise<void> {
+    let request: CoordinatorRequest;
+    try {
+      request = JSON.parse(line) as CoordinatorRequest;
+    } catch (error) {
+      writeJson(connection.socket, { ok: false, error: error instanceof Error ? error.message : String(error) });
+      return;
+    }
+
+    if (request.clientId) {
+      connection.id = request.clientId;
+      this.#connectionsById.set(request.clientId, connection);
+    }
+
+    try {
+      const result = this.#dispatch(connection, request);
+      writeJson(connection.socket, { id: request.id, ok: true, result });
+    } catch (error) {
+      writeJson(connection.socket, {
+        id: request.id,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  #dispatch(connection: CoordinatorConnection, request: CoordinatorRequest): unknown {
+    switch (request.action) {
+      case 'claimThread':
+        return this.claimThread({
+          ...request.payload,
+          ownerId: request.payload?.ownerId ?? connection.id ?? request.clientId,
+        });
+      case 'getActiveRun':
+        return this.getActiveRun(request.payload);
+      case 'completeRun':
+        return this.completeRun(request.payload?.runId ?? request.payload);
+      case 'failRun':
+        return this.failRun(request.payload?.runId ?? request.payload);
+      case 'suspendRun':
+        return this.setRunStatus(request.payload?.runId ?? request.payload, 'suspended');
+      case 'resumeRun':
+        return this.setRunStatus(request.payload?.runId ?? request.payload, 'active');
+      case 'registerSignalHandler':
+        return this.registerSignalHandler(connection, request.payload?.runId ?? request.payload);
+      case 'sendSignal':
+        return this.sendSignal(request.payload?.signal, request.payload?.target);
+      case 'subscribeRun':
+        return this.subscribeRun(connection, request.payload?.runId ?? request.payload);
+      case 'subscribeThread':
+        return this.subscribeThread(connection, request.payload);
+      case 'publishRunEvent':
+        return this.publishRunEvent(request.payload?.runId, request.payload?.event);
+      case 'publishTopic':
+        return this.publishTopic(request.payload?.topic, request.payload?.event);
+      case 'subscribeTopic':
+        return this.subscribeTopic(connection, request.payload?.topic ?? request.payload);
+      case 'getTopicHistory':
+        return this.getTopicHistory(request.payload?.topic, request.payload?.offset);
+      case 'ping':
+        return { ok: true };
+      default:
+        throw new Error(`Unknown coordinator action: ${request.action}`);
+    }
+  }
+
+  claimThread(options: DurableAgentClaimThreadOptions): DurableAgentClaimThreadResult {
+    const key = threadKey(options.resourceId, options.threadId);
+    const activeRun = this.#runsByThread.get(key);
+    if (activeRun && !this.#isRunOwnerConnected(activeRun)) {
+      this.#cleanupRun(key, activeRun);
+    } else if (activeRun && (activeRun.status === 'active' || activeRun.status === 'suspended')) {
+      return { claimed: false, activeRun };
+    }
+
+    const claimedRun: DurableAgentActiveRun = {
+      resourceId: options.resourceId,
+      threadId: options.threadId,
+      runId: options.runId,
+      ownerId: options.ownerId ?? 'unknown',
+      status: 'active',
+    };
+    this.#runsByThread.set(key, claimedRun);
+    this.#threadKeyByRunId.set(options.runId, key);
+    this.#publishThreadActiveRun(key, claimedRun);
+    return { claimed: true, activeRun: claimedRun };
+  }
+
+  getActiveRun(options: { resourceId: string; threadId: string }): DurableAgentActiveRun | undefined {
+    const key = threadKey(options.resourceId, options.threadId);
+    const activeRun = this.#runsByThread.get(key);
+    if (!activeRun || activeRun.status === 'completed' || activeRun.status === 'error') return undefined;
+    if (!this.#isRunOwnerConnected(activeRun)) {
+      this.#cleanupRun(key, activeRun);
+      return undefined;
+    }
+    return activeRun;
+  }
+
+  completeRun(runId: string): { ok: true } {
+    return this.#finishRun(runId, 'completed');
+  }
+
+  failRun(runId: string): { ok: true } {
+    return this.#finishRun(runId, 'error');
+  }
+
+  subscribeRun(connection: CoordinatorConnection, runId: string): { ok: true } {
+    let subscribers = this.#subscribersByRunId.get(runId);
+    if (!subscribers) {
+      subscribers = new Set();
+      this.#subscribersByRunId.set(runId, subscribers);
+    }
+    subscribers.add(connection);
+    for (const event of this.#eventsByRunId.get(runId) ?? []) {
+      writeJson(connection.socket, { type: 'runEvent', runId, event });
+    }
+    return { ok: true };
+  }
+
+  subscribeThread(connection: CoordinatorConnection, options: { resourceId: string; threadId: string }): { ok: true } {
+    const key = threadKey(options.resourceId, options.threadId);
+    let subscribers = this.#subscribersByThread.get(key);
+    if (!subscribers) {
+      subscribers = new Set();
+      this.#subscribersByThread.set(key, subscribers);
+    }
+    subscribers.add(connection);
+    return { ok: true };
+  }
+
+  publishRunEvent(runId: string, event: unknown): { ok: true } {
+    const events = this.#eventsByRunId.get(runId) ?? [];
+    events.push(event);
+    this.#eventsByRunId.set(runId, events);
+    for (const subscriber of this.#subscribersByRunId.get(runId) ?? []) {
+      writeJson(subscriber.socket, { type: 'runEvent', runId, event });
+    }
+    return { ok: true };
+  }
+
+  publishTopic(topic: string, event: any): { ok: true } {
+    const fullEvent = {
+      ...event,
+      id: event?.id ?? crypto.randomUUID(),
+      createdAt: event?.createdAt ?? new Date(),
+    };
+    const events = this.#eventsByTopic.get(topic) ?? [];
+    events.push(fullEvent);
+    this.#eventsByTopic.set(topic, events);
+    for (const subscriber of this.#subscribersByTopic.get(topic) ?? []) {
+      writeJson(subscriber.socket, { type: 'topicEvent', topic, event: fullEvent });
+    }
+    return { ok: true };
+  }
+
+  subscribeTopic(connection: CoordinatorConnection, topic: string): { ok: true } {
+    let subscribers = this.#subscribersByTopic.get(topic);
+    if (!subscribers) {
+      subscribers = new Set();
+      this.#subscribersByTopic.set(topic, subscribers);
+    }
+    subscribers.add(connection);
+    return { ok: true };
+  }
+
+  getTopicHistory(topic: string, offset = 0): any[] {
+    return (this.#eventsByTopic.get(topic) ?? []).slice(offset);
+  }
+
+  #cleanupRunsForOwner(ownerId: string): void {
+    for (const [key, activeRun] of this.#runsByThread) {
+      if (activeRun.ownerId !== ownerId) continue;
+      this.#cleanupRun(key, activeRun);
+    }
+  }
+
+  #isRunOwnerConnected(activeRun: DurableAgentActiveRun): boolean {
+    return !activeRun.ownerId || activeRun.ownerId === 'unknown' || this.#connectionsById.has(activeRun.ownerId);
+  }
+
+  #cleanupRun(key: string, activeRun: DurableAgentActiveRun): void {
+    this.publishRunEvent(activeRun.runId, {
+      type: 'error',
+      payload: { error: `Durable run owner ${activeRun.ownerId} disconnected` },
+    });
+    this.#runsByThread.delete(key);
+    this.#threadKeyByRunId.delete(activeRun.runId);
+    this.#signalHandlersByRunId.delete(activeRun.runId);
+    this.#subscribersByRunId.delete(activeRun.runId);
+    this.#eventsByRunId.delete(activeRun.runId);
+  }
+
+  #publishThreadActiveRun(key: string, activeRun: DurableAgentActiveRun): void {
+    for (const subscriber of this.#subscribersByThread.get(key) ?? []) {
+      writeJson(subscriber.socket, { type: 'threadActiveRun', activeRun });
+    }
+  }
+
+  registerSignalHandler(connection: CoordinatorConnection, runId: string): { ok: true } {
+    this.#signalHandlersByRunId.set(runId, connection);
+    return { ok: true };
+  }
+
+  sendSignal(signal: unknown, target: { runId?: string } | undefined): { accepted: true; runId: string } {
+    const runId = target?.runId;
+    if (!runId) {
+      throw new Error('sendSignal requires target.runId');
+    }
+
+    const handler = this.#signalHandlersByRunId.get(runId);
+    if (!handler) {
+      throw new Error(`No signal handler registered for run ${runId}`);
+    }
+
+    writeJson(handler.socket, { type: 'signal', runId, signal });
+    return { accepted: true, runId };
+  }
+
+  setRunStatus(runId: string, status: DurableAgentRunStatus): { ok: true } {
+    const key = this.#threadKeyByRunId.get(runId);
+    if (!key) return { ok: true };
+    const activeRun = this.#runsByThread.get(key);
+    if (!activeRun) return { ok: true };
+    activeRun.status = status;
+    if (status === 'completed' || status === 'error') {
+      this.#runsByThread.delete(key);
+      this.#threadKeyByRunId.delete(runId);
+      this.#signalHandlersByRunId.delete(runId);
+      this.#subscribersByRunId.delete(runId);
+      this.#eventsByRunId.delete(runId);
+    }
+    return { ok: true };
+  }
+
+  #finishRun(runId: string, status: 'completed' | 'error'): { ok: true } {
+    return this.setRunStatus(runId, status);
+  }
+}

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -1,6 +1,9 @@
+import { createHash } from 'node:crypto';
+import os from 'node:os';
 import path from 'node:path';
 
 import { Agent } from '@mastra/core/agent';
+import { createDurableAgent } from '@mastra/core/agent/durable';
 import type { MastraBrowser } from '@mastra/core/browser';
 import { Harness } from '@mastra/core/harness';
 import type {
@@ -35,6 +38,7 @@ import { createDynamicTools } from './agents/tools.js';
 
 import { getDynamicWorkspace } from './agents/workspace.js';
 import { AuthStorage } from './auth/storage.js';
+import { UnixSocketPubSub } from './durable-streams/index.js';
 import { createOutcomeScorer, createEfficiencyScorer } from './evals/scorers/index.js';
 import { HookManager } from './hooks/index.js';
 import { createMcpManager } from './mcp/index.js';
@@ -54,7 +58,6 @@ import {
 import { getToolCategory } from './permissions.js';
 import { setAuthStorage } from './providers/claude-max.js';
 import { setAuthStorage as setOpenAIAuthStorage } from './providers/openai-codex.js';
-
 import { stateSchema } from './schema.js';
 
 import { mastra } from './tui/theme.js';
@@ -73,6 +76,14 @@ const PROVIDER_TO_OAUTH_ID: Record<string, string> = {
   anthropic: 'anthropic',
   openai: 'openai-codex',
 };
+
+function getDurableStreamsSocketPath(resourceId: string, rootPath: string): string {
+  const hash = createHash('sha256')
+    .update(`${resourceId}:${rootPath}:durable-streams-v2`)
+    .digest('hex')
+    .slice(0, 16);
+  return path.join(os.tmpdir(), `mastracode-${hash}.sock`);
+}
 
 export interface MastraCodeConfig {
   /** Working directory for project detection. Default: process.cwd() */
@@ -360,6 +371,16 @@ export async function createMastraCode(config?: MastraCodeConfig) {
 
   const defaultSubagents = [exploreSubagent, planSubagent, executeSubagent];
 
+  const durableStreamsSocketPath = getDurableStreamsSocketPath(project.resourceId, project.rootPath);
+  const durableStreamsPubSub = new UnixSocketPubSub({
+    socketPath: durableStreamsSocketPath,
+    autoStartCoordinator: true,
+  });
+  const durableCodeAgent = createDurableAgent({
+    agent: codeAgent,
+    pubsub: durableStreamsPubSub,
+  }) as unknown as Agent;
+
   const defaultModes: HarnessMode<Record<string, unknown>>[] = [
     {
       id: 'build',
@@ -367,21 +388,21 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       default: true,
       defaultModelId: 'anthropic/claude-opus-4-6',
       color: mastra.green,
-      agent: codeAgent,
+      agent: durableCodeAgent,
     },
     {
       id: 'plan',
       name: 'Plan',
       defaultModelId: 'openai/gpt-5.2-codex',
       color: mastra.purple,
-      agent: codeAgent,
+      agent: durableCodeAgent,
     },
     {
       id: 'fast',
       name: 'Fast',
       defaultModelId: 'cerebras/zai-glm-4.7',
       color: mastra.orange,
-      agent: codeAgent,
+      agent: durableCodeAgent,
     },
   ];
 
@@ -595,16 +616,14 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     },
   });
 
-  // Sync hookManager session ID on thread changes
-  if (hookManager) {
-    harness.subscribe(event => {
-      if (event.type === 'thread_changed') {
-        hookManager.setSessionId(event.threadId);
-      } else if (event.type === 'thread_created') {
-        hookManager.setSessionId(event.thread.id);
-      }
-    });
-  }
+  harness.subscribe(event => {
+    if (!hookManager) return;
+    if (event.type === 'thread_changed') {
+      hookManager.setSessionId(event.threadId);
+    } else if (event.type === 'thread_created') {
+      hookManager.setSessionId(event.thread.id);
+    }
+  });
 
   return {
     harness,


### PR DESCRIPTION
This adds a Unix-socket-backed PubSub for MastraCode durable stream events, then wraps the default code agent with `createDurableAgent` using that shared PubSub.

The important bit is that MastraCode now uses the core durable stream subscription path from the previous PR instead of adding durable coordinator concepts to Harness.

```ts
const durableCodeAgent = createDurableAgent({
  agent: codeAgent,
  pubsub: durableStreamsPubSub,
});
```

Verified with focused durable stream tests, MastraCode startup tests, typecheck, lint, and `build:lib`.
