### PR TITLE
feat(ai-sdk): add harness UI stream adapter

### DIFF
--- a/.changeset/green-years-obey.md
+++ b/.changeset/green-years-obey.md
@@ -7,5 +7,3 @@ Added a Harness display-state adapter for AI SDK UI.
 Use harnessToUIMessageStream from @mastra/ai-sdk/harness to stream Harness snapshots, assistant text, reasoning, and native AI SDK tool lifecycle chunks into AI SDK UI routes. The adapter emits a stable data-mastra-harness-snapshot baseline for tools, human-in-the-loop state, tasks, observational memory progress, modified files, usage, and subagents.
 
 It also supports delta mode, which starts with a full snapshot and then emits append-only data-mastra-harness-delta parts for changed fields and domains. This gives apps one supported bridge from Harness display state to AI SDK UI instead of rebuilding the mapping in each route.
-
-Closes https://github.com/mastra-ai/mastra/issues/15975

--- a/.changeset/green-years-obey.md
+++ b/.changeset/green-years-obey.md
@@ -2,8 +2,8 @@
 '@mastra/ai-sdk': minor
 ---
 
-Added a Harness display-state adapter for AI SDK UI.
+Added a Harness display-state adapter for the AI SDK UI.
 
-Use harnessToUIMessageStream from @mastra/ai-sdk/harness to stream Harness snapshots, assistant text, reasoning, and native AI SDK tool lifecycle chunks into AI SDK UI routes. The adapter emits a stable data-mastra-harness-snapshot baseline for tools, human-in-the-loop state, tasks, observational memory progress, modified files, usage, and subagents.
+Use `harnessToUIMessageStream` from `@mastra/ai-sdk/harness` to stream Harness display state into AI SDK UI output, including assistant text, reasoning, tool updates, human-in-the-loop state, tasks, files, usage, and subagent progress.
 
-It also supports delta mode, which starts with a full snapshot and then emits append-only data-mastra-harness-delta parts for changed fields and domains. This gives apps one supported bridge from Harness display state to AI SDK UI instead of rebuilding the mapping in each route.
+It sends a full initial snapshot and can switch to delta mode for incremental updates, so apps can reuse one supported mapping instead of rebuilding it in every route.

--- a/.changeset/green-years-obey.md
+++ b/.changeset/green-years-obey.md
@@ -1,0 +1,11 @@
+---
+'@mastra/ai-sdk': minor
+---
+
+Added a Harness display-state adapter for AI SDK UI.
+
+Use harnessToUIMessageStream from @mastra/ai-sdk/harness to stream Harness snapshots, assistant text, reasoning, and native AI SDK tool lifecycle chunks into AI SDK UI routes. The adapter emits a stable data-mastra-harness-snapshot baseline for tools, human-in-the-loop state, tasks, observational memory progress, modified files, usage, and subagents.
+
+It also supports delta mode, which starts with a full snapshot and then emits append-only data-mastra-harness-delta parts for changed fields and domains. This gives apps one supported bridge from Harness display state to AI SDK UI instead of rebuilding the mapping in each route.
+
+Closes https://github.com/mastra-ai/mastra/issues/15975

--- a/client-sdks/ai-sdk/README.md
+++ b/client-sdks/ai-sdk/README.md
@@ -243,3 +243,25 @@ import { toAISdkMessages } from '@mastra/ai-sdk/ui';
 const v5Messages = toAISdkMessages(storedMessages);
 const v6Messages = toAISdkMessages(storedMessages, { version: 'v6' });
 ```
+
+## Harness display state streams
+
+Use `harnessToUIMessageStream` from `@mastra/ai-sdk/harness` to stream canonical Harness display-state snapshots to AI SDK UI.
+
+```typescript
+import { harnessToUIMessageStream } from '@mastra/ai-sdk/harness';
+import { createUIMessageStreamResponse } from 'ai';
+
+export async function GET() {
+  const stream = harnessToUIMessageStream(harness, {
+    windowMs: 250,
+    maxWaitMs: 500,
+    mode: 'delta',
+    include: ['tools', 'hitl', 'tasks', 'om', 'files', 'subagents'],
+  });
+
+  return createUIMessageStreamResponse({ stream });
+}
+```
+
+The adapter reads the initial state from `harness.getDisplayState()` and then subscribes with `harness.subscribeDisplayState()`. It emits assistant text, reasoning, and native AI SDK tool lifecycle chunks when available, plus a stable `data-mastra-harness-snapshot` baseline. In `delta` mode, later display-state changes are emitted as append-only `data-mastra-harness-delta` parts that replace changed fields or domains.

--- a/client-sdks/ai-sdk/package.json
+++ b/client-sdks/ai-sdk/package.json
@@ -25,6 +25,16 @@
         "default": "./dist/ui.cjs"
       }
     },
+    "./harness": {
+      "import": {
+        "types": "./dist/harness.d.ts",
+        "default": "./dist/harness.js"
+      },
+      "require": {
+        "types": "./dist/harness.d.ts",
+        "default": "./dist/harness.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/client-sdks/ai-sdk/src/__tests__/harness.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/harness.test.ts
@@ -1,0 +1,675 @@
+import { defaultDisplayState } from '@mastra/core/harness';
+import type { HarnessDisplayState, HarnessDisplayStateListener, HarnessMessage } from '@mastra/core/harness';
+import { describe, expect, it } from 'vitest';
+
+import { harnessToUIMessageStream } from '../harness';
+import type { HarnessUIMessageStreamChunk, HarnessUISnapshotDataPart } from '../harness';
+
+class FakeHarness {
+  state: HarnessDisplayState;
+  listeners = new Set<HarnessDisplayStateListener>();
+  options: { windowMs?: number; maxWaitMs?: number } | undefined;
+  unsubscribed = false;
+  subscribeCalls = 0;
+
+  constructor(state: HarnessDisplayState) {
+    this.state = state;
+  }
+
+  getDisplayState(): Readonly<HarnessDisplayState> {
+    return this.state;
+  }
+
+  subscribeDisplayState(
+    listener: HarnessDisplayStateListener,
+    options?: { windowMs?: number; maxWaitMs?: number },
+  ): () => void {
+    this.options = options;
+    this.subscribeCalls += 1;
+    this.listeners.add(listener);
+    return () => {
+      this.unsubscribed = true;
+      this.listeners.delete(listener);
+    };
+  }
+
+  emit(state: HarnessDisplayState): void {
+    this.state = state;
+    for (const listener of this.listeners) {
+      void listener(state);
+    }
+  }
+}
+
+function createState(
+  overrides: Partial<HarnessDisplayState> & {
+    message?: {
+      id?: string;
+      text?: string;
+      reasoning?: string;
+    };
+  } = {},
+): HarnessDisplayState {
+  const { message, ...stateOverrides } = overrides;
+  const state = defaultDisplayState();
+
+  Object.assign(state, stateOverrides);
+
+  if (message) {
+    const content: HarnessMessage['content'] = [];
+    if (message.reasoning !== undefined) {
+      content.push({ type: 'thinking', thinking: message.reasoning });
+    }
+    if (message.text !== undefined) {
+      content.push({ type: 'text', text: message.text });
+    }
+    state.currentMessage = {
+      id: message.id ?? 'message-1',
+      role: 'assistant',
+      content,
+      createdAt: new Date('2026-05-01T12:00:00.000Z'),
+    };
+  }
+
+  return state;
+}
+
+async function readChunk(
+  reader: ReadableStreamDefaultReader<HarnessUIMessageStreamChunk>,
+): Promise<HarnessUIMessageStreamChunk> {
+  const result = await reader.read();
+  expect(result.done).toBe(false);
+  return result.value;
+}
+
+async function readChunks(
+  reader: ReadableStreamDefaultReader<HarnessUIMessageStreamChunk>,
+  count: number,
+): Promise<HarnessUIMessageStreamChunk[]> {
+  const chunks: HarnessUIMessageStreamChunk[] = [];
+  for (let i = 0; i < count; i++) {
+    chunks.push(await readChunk(reader));
+  }
+  return chunks;
+}
+
+function expectSnapshot(chunk: HarnessUIMessageStreamChunk): HarnessUISnapshotDataPart {
+  expect(chunk.type).toBe('data-mastra-harness-snapshot');
+  return chunk as HarnessUISnapshotDataPart;
+}
+
+async function expectNoImmediateChunk(reader: ReadableStreamDefaultReader<HarnessUIMessageStreamChunk>): Promise<void> {
+  const result = await Promise.race([
+    reader.read().then(() => 'chunk' as const),
+    new Promise<'none'>(resolve => setTimeout(() => resolve('none'), 10)),
+  ]);
+  expect(result).toBe('none');
+}
+
+describe('harnessToUIMessageStream', () => {
+  it('emits the initial getDisplayState snapshot before subscription updates', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true, message: { id: 'm1', text: 'Hello' } }));
+    const stream = harnessToUIMessageStream(harness);
+    const reader = stream.getReader();
+
+    const initial = await readChunks(reader, 4);
+    expect(initial).toMatchObject([
+      { type: 'start', messageId: 'm1' },
+      { type: 'text-start', id: 'm1:text' },
+      { type: 'text-delta', id: 'm1:text', delta: 'Hello' },
+      {
+        type: 'data-mastra-harness-snapshot',
+        id: 'mastra-harness:snapshot',
+        data: { sequence: 1, messageId: 'm1' },
+      },
+    ]);
+
+    harness.emit(createState({ isRunning: true, message: { id: 'm1', text: 'Hello world' } }));
+
+    const update = await readChunks(reader, 2);
+    expect(update).toMatchObject([
+      { type: 'text-delta', id: 'm1:text', delta: ' world' },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 2, currentMessage: { text: 'Hello world' } } },
+    ]);
+
+    await reader.cancel();
+  });
+
+  it('passes coalescing options through and emits one snapshot for each harness callback', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true }));
+    const stream = harnessToUIMessageStream(harness, {
+      include: ['usage'],
+      windowMs: 123,
+      maxWaitMs: 456,
+    });
+    const reader = stream.getReader();
+
+    expect(harness.options).toEqual({ windowMs: 123, maxWaitMs: 456 });
+
+    await readChunks(reader, 2);
+
+    harness.emit(
+      createState({ isRunning: true, tokenUsage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 } }),
+    );
+    harness.emit(
+      createState({ isRunning: true, tokenUsage: { promptTokens: 2, completionTokens: 4, totalTokens: 6 } }),
+    );
+
+    const first = expectSnapshot(await readChunk(reader));
+    const second = expectSnapshot(await readChunk(reader));
+    expect(first.data.sequence).toBe(2);
+    expect(second.data.sequence).toBe(3);
+    expect(second.data.domains.usage).toEqual({ promptTokens: 2, completionTokens: 4, totalTokens: 6 });
+
+    await reader.cancel();
+  });
+
+  it('filters domains and message content with include', async () => {
+    const state = createState({
+      isRunning: false,
+      message: { id: 'm1', text: 'Hidden text' },
+      pendingApproval: { toolCallId: 'call-1', toolName: 'write_file', args: { path: 'a.ts' } },
+    });
+    const harness = new FakeHarness(state);
+    const reader = harnessToUIMessageStream(harness, { include: ['hitl'] }).getReader();
+
+    const chunks = await readChunks(reader, 3);
+    expect(chunks[0]).toEqual({ type: 'start', messageId: 'm1' });
+    const snapshot = expectSnapshot(chunks[1]);
+    expect(snapshot.data.domains).toEqual({
+      hitl: {
+        approval: { toolCallId: 'call-1', toolName: 'write_file', args: { path: 'a.ts' } },
+        suspension: null,
+        question: null,
+        planApproval: null,
+      },
+    });
+    expect(snapshot.data.currentMessage?.text).toBeUndefined();
+    expect(snapshot.data.currentMessage?.content).toEqual([]);
+    expect(chunks[2]).toEqual({ type: 'finish' });
+  });
+
+  it('represents HITL state appearing and clearing in replacing snapshots', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true }));
+    const reader = harnessToUIMessageStream(harness, { include: ['hitl'], sendStart: false }).getReader();
+
+    expectSnapshot(await readChunk(reader));
+
+    harness.emit(
+      createState({
+        isRunning: true,
+        pendingQuestion: {
+          questionId: 'q1',
+          question: 'Proceed?',
+          options: [{ label: 'Yes' }],
+          selectionMode: 'single_select',
+        },
+      }),
+    );
+    const pending = expectSnapshot(await readChunk(reader));
+    expect(pending.data.domains.hitl).toMatchObject({
+      question: { questionId: 'q1', question: 'Proceed?' },
+    });
+
+    harness.emit(createState({ isRunning: true }));
+    const cleared = expectSnapshot(await readChunk(reader));
+    expect(cleared.data.domains.hitl).toMatchObject({
+      approval: null,
+      suspension: null,
+      question: null,
+      planApproval: null,
+    });
+
+    await reader.cancel();
+  });
+
+  it('emits native AI SDK tool lifecycle chunks from display-state snapshots', async () => {
+    const initial = createState({ isRunning: true });
+    initial.activeTools.set('tool-1', { name: 'write_file', args: {}, status: 'streaming_input' });
+    initial.toolInputBuffers.set('tool-1', { toolName: 'write_file', text: '{"path"' });
+
+    const harness = new FakeHarness(initial);
+    const reader = harnessToUIMessageStream(harness, { include: ['tools'], sendStart: false }).getReader();
+
+    expect(await readChunks(reader, 3)).toMatchObject([
+      { type: 'tool-input-start', toolCallId: 'tool-1', toolName: 'write_file' },
+      { type: 'tool-input-delta', toolCallId: 'tool-1', inputTextDelta: '{"path"' },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 1 } },
+    ]);
+
+    const running = createState({ isRunning: true });
+    running.activeTools.set('tool-1', {
+      name: 'write_file',
+      args: { path: 'src/app.ts', content: 'hello' },
+      status: 'running',
+    });
+    harness.emit(running);
+
+    expect(await readChunks(reader, 2)).toMatchObject([
+      {
+        type: 'tool-input-available',
+        toolCallId: 'tool-1',
+        toolName: 'write_file',
+        input: { path: 'src/app.ts', content: 'hello' },
+      },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 2 } },
+    ]);
+
+    const completed = createState({ isRunning: true });
+    completed.activeTools.set('tool-1', {
+      name: 'write_file',
+      args: { path: 'src/app.ts', content: 'hello' },
+      status: 'completed',
+      result: { ok: true },
+      isError: false,
+    });
+    harness.emit(completed);
+
+    expect(await readChunks(reader, 2)).toMatchObject([
+      { type: 'tool-output-available', toolCallId: 'tool-1', output: { ok: true } },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 3 } },
+    ]);
+
+    await reader.cancel();
+  });
+
+  it('emits native AI SDK tool error chunks once', async () => {
+    const state = createState({ isRunning: true });
+    state.activeTools.set('tool-1', {
+      name: 'read_file',
+      args: { path: 'missing.ts' },
+      status: 'error',
+      result: new Error('not found'),
+      isError: true,
+    });
+
+    const reader = harnessToUIMessageStream(new FakeHarness(state), {
+      include: ['tools'],
+      sendStart: false,
+    }).getReader();
+
+    expect(await readChunks(reader, 3)).toMatchObject([
+      {
+        type: 'tool-input-available',
+        toolCallId: 'tool-1',
+        toolName: 'read_file',
+        input: { path: 'missing.ts' },
+      },
+      { type: 'tool-output-error', toolCallId: 'tool-1', errorText: 'not found' },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 1 } },
+    ]);
+  });
+
+  it('supports delta mode with an initial snapshot and append-only changed-domain parts', async () => {
+    const harness = new FakeHarness(
+      createState({ isRunning: true, tokenUsage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } }),
+    );
+    const reader = harnessToUIMessageStream(harness, {
+      mode: 'delta',
+      include: ['usage'],
+      sendStart: false,
+    }).getReader();
+
+    const initial = expectSnapshot(await readChunk(reader));
+    expect(initial.data).toMatchObject({
+      mode: 'snapshot',
+      sequence: 1,
+      domains: { usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } },
+    });
+
+    harness.emit(
+      createState({ isRunning: true, tokenUsage: { promptTokens: 2, completionTokens: 3, totalTokens: 5 } }),
+    );
+    const delta = await readChunk(reader);
+    expect(delta).toEqual({
+      type: 'data-mastra-harness-delta',
+      id: 'mastra-harness:delta:2',
+      data: {
+        version: 1,
+        sequence: 2,
+        emittedAt: expect.any(String),
+        mode: 'delta',
+        messageId: 'mastra-harness',
+        domains: { usage: { promptTokens: 2, completionTokens: 3, totalTokens: 5 } },
+      },
+    });
+
+    await reader.cancel();
+  });
+
+  it('emits null clears in delta mode', async () => {
+    const harness = new FakeHarness(
+      createState({
+        isRunning: true,
+        pendingQuestion: {
+          questionId: 'q1',
+          question: 'Proceed?',
+        },
+      }),
+    );
+    const reader = harnessToUIMessageStream(harness, {
+      mode: 'delta',
+      include: ['hitl'],
+      sendStart: false,
+    }).getReader();
+
+    expectSnapshot(await readChunk(reader));
+
+    harness.emit(createState({ isRunning: true }));
+    const delta = await readChunk(reader);
+
+    expect(delta).toMatchObject({
+      type: 'data-mastra-harness-delta',
+      data: {
+        domains: {
+          hitl: {
+            approval: null,
+            suspension: null,
+            question: null,
+            planApproval: null,
+          },
+        },
+      },
+    });
+
+    await reader.cancel();
+  });
+
+  it('suppresses no-op display-state deltas', async () => {
+    const state = createState({
+      isRunning: true,
+      tokenUsage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    });
+    const harness = new FakeHarness(state);
+    const reader = harnessToUIMessageStream(harness, {
+      mode: 'delta',
+      include: ['usage'],
+      sendStart: false,
+    }).getReader();
+
+    expectSnapshot(await readChunk(reader));
+    harness.emit(
+      createState({ isRunning: true, tokenUsage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } }),
+    );
+
+    await expectNoImmediateChunk(reader);
+    await reader.cancel();
+  });
+
+  it('does not emit invalid text replacement chunks for same-message shrink in delta mode', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true, message: { id: 'm1', text: 'abcdef' } }));
+    const reader = harnessToUIMessageStream(harness, {
+      mode: 'delta',
+      include: ['text'],
+      sendStart: false,
+    }).getReader();
+
+    expect(await readChunks(reader, 3)).toMatchObject([
+      { type: 'text-start', id: 'm1:text' },
+      { type: 'text-delta', id: 'm1:text', delta: 'abcdef' },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 1 } },
+    ]);
+
+    harness.emit(createState({ isRunning: true, message: { id: 'm1', text: 'abc' } }));
+
+    expect(await readChunk(reader)).toMatchObject({
+      type: 'data-mastra-harness-delta',
+      data: {
+        sequence: 2,
+        currentMessage: { text: 'abc' },
+      },
+    });
+
+    await reader.cancel();
+  });
+
+  it('closes old text and starts new text when message id changes in delta mode', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true, message: { id: 'm1', text: 'First' } }));
+    const reader = harnessToUIMessageStream(harness, {
+      mode: 'delta',
+      include: ['text'],
+      sendStart: false,
+    }).getReader();
+
+    await readChunks(reader, 3);
+    harness.emit(createState({ isRunning: true, message: { id: 'm2', text: 'Second' } }));
+
+    expect(await readChunks(reader, 4)).toMatchObject([
+      { type: 'text-end', id: 'm1:text' },
+      { type: 'text-start', id: 'm2:text' },
+      { type: 'text-delta', id: 'm2:text', delta: 'Second' },
+      {
+        type: 'data-mastra-harness-delta',
+        data: { sequence: 2, messageId: 'm2', currentMessage: { text: 'Second' } },
+      },
+    ]);
+
+    await reader.cancel();
+  });
+
+  it('serializes maps, sets, dates, errors, bigints, shared objects, and circular values safely', async () => {
+    const circular: Record<string, unknown> = { ok: true };
+    circular.self = circular;
+    const shared = { id: 'shared' };
+    const state = createState({ isRunning: false });
+    state.activeTools.set('tool-1', {
+      name: 'inspect',
+      args: {
+        circular,
+        sharedA: shared,
+        sharedB: shared,
+        createdAt: new Date('2026-05-01T12:34:56.000Z'),
+        ids: new Set(['a', 'b']),
+        count: 1n,
+        error: new Error('boom'),
+      },
+      status: 'running',
+    });
+    state.modifiedFiles.set('src/app.ts', {
+      operations: ['write_file'],
+      firstModified: new Date('2026-05-01T00:00:00.000Z'),
+    });
+
+    const reader = harnessToUIMessageStream(new FakeHarness(state), {
+      include: ['tools', 'files'],
+      sendStart: false,
+      sendFinish: false,
+    }).getReader();
+    const [, snapshotChunk] = await readChunks(reader, 2);
+    const snapshot = expectSnapshot(snapshotChunk);
+
+    expect(snapshot.data.domains.tools).toMatchObject({
+      active: {
+        'tool-1': {
+          args: {
+            circular: { ok: true, self: '[Circular]' },
+            sharedA: { id: 'shared' },
+            sharedB: { id: 'shared' },
+            createdAt: '2026-05-01T12:34:56.000Z',
+            ids: ['a', 'b'],
+            count: '1',
+            error: { name: 'Error', message: 'boom' },
+          },
+        },
+      },
+    });
+    expect(snapshot.data.domains.files).toEqual({
+      'src/app.ts': {
+        operations: ['write_file'],
+        firstModified: '2026-05-01T00:00:00.000Z',
+      },
+    });
+  });
+
+  it('closes text and reasoning parts, unsubscribes, and finishes on terminal state', async () => {
+    const harness = new FakeHarness(
+      createState({ isRunning: true, message: { id: 'm1', text: 'Hello', reasoning: 'Thinking' } }),
+    );
+    const reader = harnessToUIMessageStream(harness).getReader();
+
+    await readChunks(reader, 6);
+    harness.emit(createState({ isRunning: false, message: { id: 'm1', text: 'Hello', reasoning: 'Thinking done' } }));
+
+    const terminal = await readChunks(reader, 5);
+    expect(terminal).toMatchObject([
+      { type: 'reasoning-delta', id: 'm1:reasoning', delta: ' done' },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 2, isRunning: false } },
+      { type: 'text-end', id: 'm1:text' },
+      { type: 'reasoning-end', id: 'm1:reasoning' },
+      { type: 'finish' },
+    ]);
+
+    const done = await reader.read();
+    expect(done.done).toBe(true);
+    expect(harness.unsubscribed).toBe(true);
+  });
+
+  it('rehydrates reconnects from the latest display state with stable replacing snapshot identity', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true, message: { id: 'm1', text: 'Initial' } }));
+
+    const firstReader = harnessToUIMessageStream(harness, { include: ['text'] }).getReader();
+    await readChunks(firstReader, 4);
+    await firstReader.cancel();
+
+    harness.state = createState({ isRunning: true, message: { id: 'm1', text: 'Recovered text' } });
+    const secondReader = harnessToUIMessageStream(harness, { include: ['text'] }).getReader();
+    const chunks = await readChunks(secondReader, 4);
+
+    expect(chunks).toMatchObject([
+      { type: 'start', messageId: 'm1' },
+      { type: 'text-start', id: 'm1:text' },
+      { type: 'text-delta', id: 'm1:text', delta: 'Recovered text' },
+      {
+        type: 'data-mastra-harness-snapshot',
+        id: 'mastra-harness:snapshot',
+        data: { sequence: 1, currentMessage: { text: 'Recovered text' } },
+      },
+    ]);
+
+    await secondReader.cancel();
+  });
+
+  it('does not let late updates reach a canceled superseded stream', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true, message: { id: 'old', text: 'Old run' } }));
+    const oldReader = harnessToUIMessageStream(harness, { include: ['text'] }).getReader();
+
+    await readChunks(oldReader, 4);
+    await oldReader.cancel();
+
+    harness.state = createState({ isRunning: true, message: { id: 'new', text: 'New run' } });
+    const newReader = harnessToUIMessageStream(harness, { include: ['text'] }).getReader();
+    await readChunks(newReader, 4);
+
+    harness.emit(createState({ isRunning: false, message: { id: 'old', text: 'Old terminal' } }));
+
+    await expect(oldReader.read()).resolves.toEqual({ done: true, value: undefined });
+
+    await newReader.cancel();
+  });
+
+  it('restarts text chunks when text shrinks or the message id changes', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true, message: { id: 'm1', text: 'abcdef' } }));
+    const reader = harnessToUIMessageStream(harness).getReader();
+
+    await readChunks(reader, 4);
+    harness.emit(createState({ isRunning: true, message: { id: 'm1', text: 'abc' } }));
+
+    const reset = await readChunks(reader, 4);
+    expect(reset).toMatchObject([
+      { type: 'text-end', id: 'm1:text' },
+      { type: 'text-start', id: 'm1:text' },
+      { type: 'text-delta', id: 'm1:text', delta: 'abc' },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 2 } },
+    ]);
+
+    harness.emit(createState({ isRunning: true, message: { id: 'm2', text: 'abc' } }));
+    const newMessage = await readChunks(reader, 4);
+    expect(newMessage).toMatchObject([
+      { type: 'text-end', id: 'm1:text' },
+      { type: 'text-start', id: 'm2:text' },
+      { type: 'text-delta', id: 'm2:text', delta: 'abc' },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 3, messageId: 'm2' } },
+    ]);
+
+    await reader.cancel();
+  });
+
+  it('unsubscribes when the consumer cancels the stream', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true }));
+    const reader = harnessToUIMessageStream(harness, { include: ['usage'] }).getReader();
+
+    await readChunks(reader, 2);
+    await reader.cancel();
+
+    expect(harness.unsubscribed).toBe(true);
+  });
+
+  it('includes terminal subagent history when the Harness display state provides it', async () => {
+    const state = createState({ isRunning: false }) as HarnessDisplayState & {
+      subagentHistory: Array<{
+        toolCallId: string;
+        agentType: string;
+        task: string;
+        toolCalls: Array<{ name: string; isError: boolean }>;
+        textDelta: string;
+        status: 'completed' | 'error' | 'aborted';
+        endedAt: Date;
+        order: number;
+      }>;
+    };
+    state.subagentHistory = [
+      {
+        toolCallId: 'subagent-1',
+        agentType: 'research',
+        task: 'Find papers',
+        toolCalls: [{ name: 'search', isError: false }],
+        textDelta: 'done',
+        status: 'completed',
+        endedAt: new Date('2026-05-01T13:00:00.000Z'),
+        order: 0,
+      },
+    ];
+
+    const reader = harnessToUIMessageStream(new FakeHarness(state), {
+      include: ['subagents'],
+      sendStart: false,
+      sendFinish: false,
+    }).getReader();
+
+    const snapshot = expectSnapshot(await readChunk(reader));
+    expect(snapshot.data.domains.subagents).toEqual({
+      active: {},
+      history: [
+        {
+          toolCallId: 'subagent-1',
+          agentType: 'research',
+          task: 'Find papers',
+          toolCalls: [{ name: 'search', isError: false }],
+          textDelta: 'done',
+          status: 'completed',
+          endedAt: '2026-05-01T13:00:00.000Z',
+          order: 0,
+        },
+      ],
+    });
+  });
+
+  it('errors the stream and unsubscribes when mapping fails after subscription', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true }));
+    const reader = harnessToUIMessageStream(harness, {
+      include: ['usage'],
+      messageId: state => {
+        if (state.currentMessage?.id === 'boom') {
+          throw new Error('message id failed');
+        }
+        return 'ok';
+      },
+    }).getReader();
+
+    await readChunks(reader, 2);
+    harness.emit(createState({ isRunning: true, message: { id: 'boom', text: 'bad' } }));
+
+    await expect(reader.read()).rejects.toThrow('message id failed');
+    expect(harness.unsubscribed).toBe(true);
+  });
+});

--- a/client-sdks/ai-sdk/src/harness.test.ts
+++ b/client-sdks/ai-sdk/src/harness.test.ts
@@ -2,8 +2,8 @@ import { defaultDisplayState } from '@mastra/core/harness';
 import type { HarnessDisplayState, HarnessDisplayStateListener, HarnessMessage } from '@mastra/core/harness';
 import { describe, expect, it } from 'vitest';
 
-import { harnessToUIMessageStream } from '../harness';
-import type { HarnessUIMessageStreamChunk, HarnessUISnapshotDataPart } from '../harness';
+import { harnessToUIMessageStream } from './harness';
+import type { HarnessUIMessageStreamChunk, HarnessUISnapshotDataPart } from './harness';
 
 class FakeHarness {
   state: HarnessDisplayState;

--- a/client-sdks/ai-sdk/src/harness.test.ts
+++ b/client-sdks/ai-sdk/src/harness.test.ts
@@ -270,6 +270,13 @@ describe('harnessToUIMessageStream', () => {
       { type: 'data-mastra-harness-snapshot', data: { sequence: 3 } },
     ]);
 
+    harness.emit(completed);
+
+    expect(await readChunk(reader)).toMatchObject({
+      type: 'data-mastra-harness-snapshot',
+      data: { sequence: 4 },
+    });
+
     await reader.cancel();
   });
 
@@ -283,7 +290,8 @@ describe('harnessToUIMessageStream', () => {
       isError: true,
     });
 
-    const reader = harnessToUIMessageStream(new FakeHarness(state), {
+    const harness = new FakeHarness(state);
+    const reader = harnessToUIMessageStream(harness, {
       include: ['tools'],
       sendStart: false,
     }).getReader();
@@ -298,6 +306,21 @@ describe('harnessToUIMessageStream', () => {
       { type: 'tool-output-error', toolCallId: 'tool-1', errorText: 'not found' },
       { type: 'data-mastra-harness-snapshot', data: { sequence: 1 } },
     ]);
+
+    const repeated = createState({ isRunning: true });
+    repeated.activeTools.set('tool-1', {
+      name: 'read_file',
+      args: { path: 'missing.ts' },
+      status: 'error',
+      result: new Error('not found'),
+      isError: true,
+    });
+    harness.emit(repeated);
+
+    expect(await readChunk(reader)).toMatchObject({
+      type: 'data-mastra-harness-snapshot',
+      data: { sequence: 2 },
+    });
   });
 
   it('supports delta mode with an initial snapshot and append-only changed-domain parts', async () => {

--- a/client-sdks/ai-sdk/src/harness.ts
+++ b/client-sdks/ai-sdk/src/harness.ts
@@ -29,7 +29,6 @@ export interface HarnessToUIMessageStreamOptions {
   messageId?: string | ((state: HarnessDisplayState) => string);
   sendStart?: boolean;
   sendFinish?: boolean;
-  version?: 'v5' | 'v6';
 }
 
 export interface HarnessLike {
@@ -547,7 +546,7 @@ function createDeltaData(previous: HarnessUISnapshotData, current: HarnessUISnap
     delta.isRunning = current.isRunning;
   }
 
-  if (stableStringify(previous.currentMessage) !== stableStringify(current.currentMessage)) {
+  if (stringifyForComparison(previous.currentMessage) !== stringifyForComparison(current.currentMessage)) {
     delta.currentMessage = current.currentMessage;
   }
 
@@ -557,7 +556,7 @@ function createDeltaData(previous: HarnessUISnapshotData, current: HarnessUISnap
   >);
 
   for (const key of domainKeys) {
-    if (stableStringify(previous.domains[key]) !== stableStringify(current.domains[key])) {
+    if (stringifyForComparison(previous.domains[key]) !== stringifyForComparison(current.domains[key])) {
       domains[key] = current.domains[key] ?? null;
     }
   }
@@ -641,7 +640,7 @@ function stringifyToolError(error: unknown): string {
   return typeof json === 'string' ? json : (JSON.stringify(json) ?? 'Tool execution failed');
 }
 
-function stableStringify(value: unknown): string {
+function stringifyForComparison(value: unknown): string {
   return JSON.stringify(value);
 }
 

--- a/client-sdks/ai-sdk/src/harness.ts
+++ b/client-sdks/ai-sdk/src/harness.ts
@@ -1,0 +1,729 @@
+import type {
+  HarnessDisplayState,
+  HarnessDisplayStateListener,
+  HarnessDisplayStateSubscriptionOptions,
+  HarnessMessageContent,
+} from '@mastra/core/harness';
+
+type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export type HarnessUIStreamDomain =
+  | 'text'
+  | 'reasoning'
+  | 'usage'
+  | 'tools'
+  | 'hitl'
+  | 'tasks'
+  | 'om'
+  | 'files'
+  | 'subagents';
+
+export type HarnessUIStreamMode = 'snapshot' | 'delta';
+
+export interface HarnessToUIMessageStreamOptions {
+  mode?: HarnessUIStreamMode;
+  include?: readonly HarnessUIStreamDomain[];
+  windowMs?: number;
+  maxWaitMs?: number;
+  messageId?: string | ((state: HarnessDisplayState) => string);
+  sendStart?: boolean;
+  sendFinish?: boolean;
+  version?: 'v5' | 'v6';
+}
+
+export interface HarnessLike {
+  getDisplayState(): Readonly<HarnessDisplayState>;
+  subscribeDisplayState(
+    listener: HarnessDisplayStateListener,
+    options?: HarnessDisplayStateSubscriptionOptions,
+  ): () => void;
+}
+
+export interface HarnessUIMessageSnapshot {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  createdAt: string;
+  stopReason?: 'complete' | 'tool_use' | 'aborted' | 'error';
+  errorMessage?: string;
+  text?: string;
+  reasoning?: string;
+  content: JsonValue[];
+}
+
+export interface HarnessUISnapshotData {
+  version: 1;
+  sequence: number;
+  emittedAt: string;
+  mode: 'snapshot';
+  messageId: string;
+  isRunning: boolean;
+  currentMessage: HarnessUIMessageSnapshot | null;
+  domains: {
+    usage?: JsonValue;
+    tools?: JsonValue;
+    hitl?: JsonValue;
+    tasks?: JsonValue;
+    om?: JsonValue;
+    files?: JsonValue;
+    subagents?: JsonValue;
+  };
+}
+
+export interface HarnessUIDeltaData {
+  version: 1;
+  sequence: number;
+  emittedAt: string;
+  mode: 'delta';
+  messageId: string;
+  isRunning?: boolean;
+  currentMessage?: HarnessUIMessageSnapshot | null;
+  domains?: HarnessUISnapshotData['domains'];
+}
+
+export type HarnessUISnapshotDataPart = {
+  type: 'data-mastra-harness-snapshot';
+  id: 'mastra-harness:snapshot';
+  data: HarnessUISnapshotData;
+};
+
+export type HarnessUIDeltaDataPart = {
+  type: 'data-mastra-harness-delta';
+  id: string;
+  data: HarnessUIDeltaData;
+};
+
+export type HarnessUIErrorDataPart = {
+  type: 'data-mastra-harness-error';
+  id: 'mastra-harness:error';
+  data: {
+    message: string;
+    errorType?: string;
+  };
+};
+
+export type HarnessUIDataPart = HarnessUISnapshotDataPart | HarnessUIDeltaDataPart | HarnessUIErrorDataPart;
+
+type HarnessUITextChunk =
+  | { type: 'start'; messageId?: string }
+  | { type: 'finish' }
+  | { type: 'text-start'; id: string }
+  | { type: 'text-delta'; id: string; delta: string }
+  | { type: 'text-end'; id: string }
+  | { type: 'reasoning-start'; id: string }
+  | { type: 'reasoning-delta'; id: string; delta: string }
+  | { type: 'reasoning-end'; id: string }
+  | { type: 'tool-input-start'; toolCallId: string; toolName: string }
+  | { type: 'tool-input-delta'; toolCallId: string; inputTextDelta: string }
+  | { type: 'tool-input-available'; toolCallId: string; toolName: string; input: unknown }
+  | { type: 'tool-output-available'; toolCallId: string; output: unknown }
+  | { type: 'tool-output-error'; toolCallId: string; errorText: string };
+
+export type HarnessUIMessageStreamChunk = HarnessUITextChunk | HarnessUIDataPart;
+
+const DEFAULT_DOMAINS: readonly HarnessUIStreamDomain[] = [
+  'text',
+  'reasoning',
+  'usage',
+  'tools',
+  'hitl',
+  'tasks',
+  'om',
+  'files',
+  'subagents',
+];
+
+const SNAPSHOT_PART_ID = 'mastra-harness:snapshot';
+const DEFAULT_MESSAGE_ID = 'mastra-harness';
+
+type StreamTextState = {
+  id: string | null;
+  value: string;
+  open: boolean;
+};
+
+type NativeToolStreamState = {
+  inputStarted: boolean;
+  inputBuffer: string;
+  inputAvailable: boolean;
+  outputEmitted: boolean;
+};
+
+type EmitContext = {
+  controller: ReadableStreamDefaultController<HarnessUIMessageStreamChunk>;
+  include: ReadonlySet<HarnessUIStreamDomain>;
+  mode: HarnessUIStreamMode;
+  resolveMessageId: (state: HarnessDisplayState) => string;
+  text: StreamTextState;
+  reasoning: StreamTextState;
+  tools: Map<string, NativeToolStreamState>;
+  lastSnapshot: HarnessUISnapshotData | null;
+  sequence: number;
+  sendStart: boolean;
+  sendFinish: boolean;
+  started: boolean;
+};
+
+export function harnessToUIMessageStream(
+  harness: HarnessLike,
+  options: HarnessToUIMessageStreamOptions = {},
+): ReadableStream<HarnessUIMessageStreamChunk> {
+  const mode = options.mode ?? 'snapshot';
+  const include = new Set(options.include ?? DEFAULT_DOMAINS);
+  const windowMs = options.windowMs ?? 250;
+  const maxWaitMs = options.maxWaitMs ?? 500;
+  const sendStart = options.sendStart ?? true;
+  const sendFinish = options.sendFinish ?? true;
+  const resolveMessageId = createMessageIdResolver(options.messageId);
+
+  let unsubscribe: (() => void) | undefined;
+  let closed = false;
+
+  return new ReadableStream<HarnessUIMessageStreamChunk>({
+    start(controller) {
+      const context: EmitContext = {
+        controller,
+        include,
+        mode,
+        resolveMessageId,
+        text: { id: null, value: '', open: false },
+        reasoning: { id: null, value: '', open: false },
+        tools: new Map(),
+        lastSnapshot: null,
+        sequence: 0,
+        sendStart,
+        sendFinish,
+        started: false,
+      };
+
+      const closeStream = () => {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        unsubscribe?.();
+        controller.close();
+      };
+
+      const failStream = (error: unknown) => {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        unsubscribe?.();
+        controller.error(error);
+      };
+
+      const emit = (state: HarnessDisplayState) => {
+        if (closed) {
+          return;
+        }
+
+        try {
+          emitDisplayState(state, context);
+
+          if (!state.isRunning) {
+            closeOpenTextPart(context.text, controller, 'text-end');
+            closeOpenTextPart(context.reasoning, controller, 'reasoning-end');
+            if (sendFinish) {
+              controller.enqueue({ type: 'finish' });
+            }
+            closeStream();
+          }
+        } catch (error) {
+          failStream(error);
+        }
+      };
+
+      emit(harness.getDisplayState() as HarnessDisplayState);
+
+      if (!closed) {
+        unsubscribe = harness.subscribeDisplayState(emit, { windowMs, maxWaitMs });
+      }
+    },
+
+    cancel() {
+      closed = true;
+      unsubscribe?.();
+    },
+  });
+}
+
+function emitDisplayState(state: HarnessDisplayState, context: EmitContext): void {
+  const messageId = context.resolveMessageId(state);
+
+  if (!context.started) {
+    context.started = true;
+    if (context.sendStart) {
+      context.controller.enqueue({ type: 'start', messageId });
+    }
+  }
+
+  if (context.include.has('text')) {
+    emitGrowingTextPart({
+      controller: context.controller,
+      streamState: context.text,
+      emitReplacementForSameId: context.mode === 'snapshot',
+      id: `${messageId}:text`,
+      value: getMessageText(state),
+      startType: 'text-start',
+      deltaType: 'text-delta',
+      endType: 'text-end',
+    });
+  }
+
+  if (context.include.has('reasoning')) {
+    emitGrowingTextPart({
+      controller: context.controller,
+      streamState: context.reasoning,
+      emitReplacementForSameId: context.mode === 'snapshot',
+      id: `${messageId}:reasoning`,
+      value: getMessageReasoning(state),
+      startType: 'reasoning-start',
+      deltaType: 'reasoning-delta',
+      endType: 'reasoning-end',
+    });
+  }
+
+  if (context.include.has('tools')) {
+    emitNativeToolChunks(state, context);
+  }
+
+  context.sequence += 1;
+  const snapshot = createSnapshotData(state, {
+    include: context.include,
+    messageId,
+    sequence: context.sequence,
+  });
+
+  if (context.mode === 'snapshot' || !context.lastSnapshot) {
+    context.controller.enqueue({
+      type: 'data-mastra-harness-snapshot',
+      id: SNAPSHOT_PART_ID,
+      data: snapshot,
+    });
+  } else {
+    const delta = createDeltaData(context.lastSnapshot, snapshot);
+    if (delta) {
+      context.controller.enqueue({
+        type: 'data-mastra-harness-delta',
+        id: `mastra-harness:delta:${snapshot.sequence}`,
+        data: delta,
+      });
+    }
+  }
+
+  context.lastSnapshot = snapshot;
+}
+
+function emitGrowingTextPart(args: {
+  controller: ReadableStreamDefaultController<HarnessUIMessageStreamChunk>;
+  streamState: StreamTextState;
+  emitReplacementForSameId: boolean;
+  id: string;
+  value: string;
+  startType: 'text-start' | 'reasoning-start';
+  deltaType: 'text-delta' | 'reasoning-delta';
+  endType: 'text-end' | 'reasoning-end';
+}): void {
+  const { controller, streamState, emitReplacementForSameId, id, value, startType, deltaType, endType } = args;
+
+  if (!value) {
+    closeOpenTextPart(streamState, controller, endType);
+    return;
+  }
+
+  const sameId = streamState.id === id;
+  const isAppend = value.startsWith(streamState.value);
+  const shouldRestart = !streamState.open || !sameId || (emitReplacementForSameId && !isAppend);
+
+  if (shouldRestart) {
+    closeOpenTextPart(streamState, controller, endType);
+    controller.enqueue({ type: startType, id } as HarnessUIMessageStreamChunk);
+    controller.enqueue({ type: deltaType, id, delta: value } as HarnessUIMessageStreamChunk);
+  } else if (isAppend && value.length > streamState.value.length) {
+    controller.enqueue({
+      type: deltaType,
+      id,
+      delta: value.slice(streamState.value.length),
+    } as HarnessUIMessageStreamChunk);
+  }
+
+  streamState.id = id;
+  streamState.value = value;
+  streamState.open = true;
+}
+
+function closeOpenTextPart(
+  streamState: StreamTextState,
+  controller: ReadableStreamDefaultController<HarnessUIMessageStreamChunk>,
+  type: 'text-end' | 'reasoning-end',
+): void {
+  if (!streamState.open || !streamState.id) {
+    return;
+  }
+
+  controller.enqueue({ type, id: streamState.id } as HarnessUIMessageStreamChunk);
+  streamState.id = null;
+  streamState.value = '';
+  streamState.open = false;
+}
+
+function emitNativeToolChunks(state: HarnessDisplayState, context: EmitContext): void {
+  for (const [toolCallId, tool] of state.activeTools) {
+    const toolState = context.tools.get(toolCallId) ?? {
+      inputStarted: false,
+      inputBuffer: '',
+      inputAvailable: false,
+      outputEmitted: false,
+    };
+    context.tools.set(toolCallId, toolState);
+
+    const inputBuffer = state.toolInputBuffers.get(toolCallId);
+    if (inputBuffer) {
+      if (!toolState.inputStarted) {
+        context.controller.enqueue({
+          type: 'tool-input-start',
+          toolCallId,
+          toolName: inputBuffer.toolName || tool.name,
+        });
+        toolState.inputStarted = true;
+      }
+
+      if (
+        inputBuffer.text.startsWith(toolState.inputBuffer) &&
+        inputBuffer.text.length > toolState.inputBuffer.length
+      ) {
+        context.controller.enqueue({
+          type: 'tool-input-delta',
+          toolCallId,
+          inputTextDelta: inputBuffer.text.slice(toolState.inputBuffer.length),
+        });
+      }
+
+      toolState.inputBuffer = inputBuffer.text;
+    }
+
+    if (!toolState.inputAvailable && tool.status !== 'streaming_input') {
+      context.controller.enqueue({
+        type: 'tool-input-available',
+        toolCallId,
+        toolName: tool.name,
+        input: tool.args,
+      });
+      toolState.inputAvailable = true;
+    }
+
+    if (!toolState.outputEmitted && tool.status === 'completed') {
+      context.controller.enqueue({
+        type: 'tool-output-available',
+        toolCallId,
+        output: tool.result,
+      });
+      toolState.outputEmitted = true;
+    }
+
+    if (!toolState.outputEmitted && tool.status === 'error') {
+      context.controller.enqueue({
+        type: 'tool-output-error',
+        toolCallId,
+        errorText: stringifyToolError(tool.result ?? tool.partialResult ?? 'Tool execution failed'),
+      });
+      toolState.outputEmitted = true;
+    }
+  }
+}
+
+function createSnapshotData(
+  state: HarnessDisplayState,
+  args: {
+    include: ReadonlySet<HarnessUIStreamDomain>;
+    messageId: string;
+    sequence: number;
+  },
+): HarnessUISnapshotData {
+  const { include, messageId, sequence } = args;
+  const domains: HarnessUISnapshotData['domains'] = {};
+
+  if (include.has('usage')) {
+    domains.usage = toJsonValue(state.tokenUsage) ?? null;
+  }
+
+  if (include.has('tools')) {
+    domains.tools = {
+      active: mapToRecord(state.activeTools),
+      inputBuffers: mapToRecord(state.toolInputBuffers),
+    };
+  }
+
+  if (include.has('hitl')) {
+    domains.hitl = {
+      approval: toJsonValue(state.pendingApproval) ?? null,
+      suspension: toJsonValue(state.pendingSuspension) ?? null,
+      question: toJsonValue(state.pendingQuestion) ?? null,
+      planApproval: toJsonValue(state.pendingPlanApproval) ?? null,
+    };
+  }
+
+  if (include.has('tasks')) {
+    domains.tasks = {
+      current: toJsonValue(state.tasks) ?? [],
+      previous: toJsonValue(state.previousTasks) ?? [],
+    };
+  }
+
+  if (include.has('om')) {
+    domains.om = {
+      progress: toJsonValue(state.omProgress) ?? null,
+      bufferingMessages: state.bufferingMessages,
+      bufferingObservations: state.bufferingObservations,
+    };
+  }
+
+  if (include.has('files')) {
+    domains.files = mapToRecord(state.modifiedFiles);
+  }
+
+  if (include.has('subagents')) {
+    const stateWithHistory = state as HarnessDisplayState & { subagentHistory?: unknown };
+    domains.subagents = {
+      active: mapToRecord(state.activeSubagents),
+      history: toJsonValue(stateWithHistory.subagentHistory) ?? [],
+    };
+  }
+
+  return {
+    version: 1,
+    sequence,
+    emittedAt: new Date().toISOString(),
+    mode: 'snapshot',
+    messageId,
+    isRunning: state.isRunning,
+    currentMessage: createMessageSnapshot(state, include),
+    domains,
+  };
+}
+
+function createMessageSnapshot(
+  state: HarnessDisplayState,
+  include: ReadonlySet<HarnessUIStreamDomain>,
+): HarnessUIMessageSnapshot | null {
+  const message = state.currentMessage;
+
+  if (!message) {
+    return null;
+  }
+
+  const content = message.content.flatMap(part => {
+    if (!shouldIncludeMessageContent(part, include)) {
+      return [];
+    }
+    const value = toJsonValue(part);
+    return value === undefined ? [] : [value];
+  });
+
+  return {
+    id: message.id,
+    role: message.role,
+    createdAt: message.createdAt.toISOString(),
+    ...(message.stopReason ? { stopReason: message.stopReason } : {}),
+    ...(message.errorMessage ? { errorMessage: message.errorMessage } : {}),
+    ...(include.has('text') ? { text: getMessageText(state) } : {}),
+    ...(include.has('reasoning') ? { reasoning: getMessageReasoning(state) } : {}),
+    content,
+  };
+}
+
+function createDeltaData(previous: HarnessUISnapshotData, current: HarnessUISnapshotData): HarnessUIDeltaData | null {
+  const delta: HarnessUIDeltaData = {
+    version: 1,
+    sequence: current.sequence,
+    emittedAt: current.emittedAt,
+    mode: 'delta',
+    messageId: current.messageId,
+  };
+
+  if (previous.isRunning !== current.isRunning) {
+    delta.isRunning = current.isRunning;
+  }
+
+  if (stableStringify(previous.currentMessage) !== stableStringify(current.currentMessage)) {
+    delta.currentMessage = current.currentMessage;
+  }
+
+  const domains: HarnessUISnapshotData['domains'] = {};
+  const domainKeys = new Set([...Object.keys(previous.domains), ...Object.keys(current.domains)] as Array<
+    keyof HarnessUISnapshotData['domains']
+  >);
+
+  for (const key of domainKeys) {
+    if (stableStringify(previous.domains[key]) !== stableStringify(current.domains[key])) {
+      domains[key] = current.domains[key] ?? null;
+    }
+  }
+
+  if (Object.keys(domains).length > 0) {
+    delta.domains = domains;
+  }
+
+  if (delta.isRunning === undefined && delta.currentMessage === undefined && delta.domains === undefined) {
+    return null;
+  }
+
+  return delta;
+}
+
+function shouldIncludeMessageContent(
+  part: HarnessMessageContent,
+  include: ReadonlySet<HarnessUIStreamDomain>,
+): boolean {
+  if (part.type === 'text') {
+    return include.has('text');
+  }
+
+  if (part.type === 'thinking') {
+    return include.has('reasoning');
+  }
+
+  if (part.type === 'tool_call' || part.type === 'tool_result') {
+    return include.has('tools');
+  }
+
+  if (part.type.startsWith('om_')) {
+    return include.has('om');
+  }
+
+  return true;
+}
+
+function getMessageText(state: HarnessDisplayState): string {
+  return (
+    state.currentMessage?.content
+      .filter((part): part is Extract<HarnessMessageContent, { type: 'text' }> => part.type === 'text')
+      .map(part => part.text)
+      .join('') ?? ''
+  );
+}
+
+function getMessageReasoning(state: HarnessDisplayState): string {
+  return (
+    state.currentMessage?.content
+      .filter((part): part is Extract<HarnessMessageContent, { type: 'thinking' }> => part.type === 'thinking')
+      .map(part => part.thinking)
+      .join('') ?? ''
+  );
+}
+
+function createMessageIdResolver(
+  messageId: HarnessToUIMessageStreamOptions['messageId'],
+): (state: HarnessDisplayState) => string {
+  if (typeof messageId === 'function') {
+    return state => messageId(state) || state.currentMessage?.id || DEFAULT_MESSAGE_ID;
+  }
+
+  if (typeof messageId === 'string') {
+    return () => messageId;
+  }
+
+  return state => state.currentMessage?.id || DEFAULT_MESSAGE_ID;
+}
+
+function stringifyToolError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  const json = toJsonValue(error);
+  return typeof json === 'string' ? json : (JSON.stringify(json) ?? 'Tool execution failed');
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function mapToRecord(map: Map<string, unknown>): { [key: string]: JsonValue } {
+  const record: { [key: string]: JsonValue } = {};
+
+  for (const [key, value] of map) {
+    record[key] = toJsonValue(value) ?? null;
+  }
+
+  return record;
+}
+
+function toJsonValue(value: unknown, seen = new WeakSet<object>()): JsonValue | undefined {
+  if (value === null) {
+    return null;
+  }
+
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return value;
+    case 'number':
+      return Number.isFinite(value) ? value : null;
+    case 'bigint':
+      return value.toString();
+    case 'undefined':
+    case 'function':
+    case 'symbol':
+      return undefined;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      ...(value.stack ? { stack: value.stack } : {}),
+    };
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    const jsonValue = value.map(item => toJsonValue(item, seen) ?? null);
+    seen.delete(value);
+    return jsonValue;
+  }
+
+  if (value instanceof Map) {
+    const record: { [key: string]: JsonValue } = {};
+    for (const [key, mapValue] of value) {
+      const jsonValue = toJsonValue(mapValue, seen);
+      if (jsonValue !== undefined) {
+        record[String(key)] = jsonValue;
+      }
+    }
+    seen.delete(value);
+    return record;
+  }
+
+  if (value instanceof Set) {
+    const jsonValue = Array.from(value, item => toJsonValue(item, seen) ?? null);
+    seen.delete(value);
+    return jsonValue;
+  }
+
+  const record: { [key: string]: JsonValue } = {};
+  for (const [key, objectValue] of Object.entries(value)) {
+    const jsonValue = toJsonValue(objectValue, seen);
+    if (jsonValue !== undefined) {
+      record[key] = jsonValue;
+    }
+  }
+
+  seen.delete(value);
+  return record;
+}

--- a/client-sdks/ai-sdk/src/harness.ts
+++ b/client-sdks/ai-sdk/src/harness.ts
@@ -156,6 +156,7 @@ type EmitContext = {
   text: StreamTextState;
   reasoning: StreamTextState;
   tools: Map<string, NativeToolStreamState>;
+  finalizedTools: Set<string>;
   lastSnapshot: HarnessUISnapshotData | null;
   sequence: number;
   sendStart: boolean;
@@ -188,6 +189,7 @@ export function harnessToUIMessageStream(
         text: { id: null, value: '', open: false },
         reasoning: { id: null, value: '', open: false },
         tools: new Map(),
+        finalizedTools: new Set(),
         lastSnapshot: null,
         sequence: 0,
         sendStart,
@@ -370,6 +372,10 @@ function closeOpenTextPart(
 
 function emitNativeToolChunks(state: HarnessDisplayState, context: EmitContext): void {
   for (const [toolCallId, tool] of state.activeTools) {
+    if (context.finalizedTools.has(toolCallId)) {
+      continue;
+    }
+
     const toolState = context.tools.get(toolCallId) ?? {
       inputStarted: false,
       inputBuffer: '',
@@ -420,6 +426,8 @@ function emitNativeToolChunks(state: HarnessDisplayState, context: EmitContext):
         output: tool.result,
       });
       toolState.outputEmitted = true;
+      context.finalizedTools.add(toolCallId);
+      context.tools.delete(toolCallId);
     }
 
     if (!toolState.outputEmitted && tool.status === 'error') {
@@ -429,6 +437,20 @@ function emitNativeToolChunks(state: HarnessDisplayState, context: EmitContext):
         errorText: stringifyToolError(tool.result ?? tool.partialResult ?? 'Tool execution failed'),
       });
       toolState.outputEmitted = true;
+      context.finalizedTools.add(toolCallId);
+      context.tools.delete(toolCallId);
+    }
+  }
+
+  for (const toolCallId of context.tools.keys()) {
+    if (!state.activeTools.has(toolCallId)) {
+      context.tools.delete(toolCallId);
+    }
+  }
+
+  for (const toolCallId of context.finalizedTools) {
+    if (!state.activeTools.has(toolCallId)) {
+      context.finalizedTools.delete(toolCallId);
     }
   }
 }

--- a/client-sdks/ai-sdk/tsup.config.ts
+++ b/client-sdks/ai-sdk/tsup.config.ts
@@ -2,7 +2,7 @@ import { generateTypes } from '@internal/types-builder';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/ui.ts'],
+  entry: ['src/index.ts', 'src/ui.ts', 'src/harness.ts'],
   format: ['esm', 'cjs'],
   clean: true,
   dts: false,

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -409,6 +409,7 @@ Mastra streams data to the frontend as "parts" within messages. Each part has a 
 | `data-workflow` | `workflowRoute()` | Workflow execution state snapshots with step status and final outputs |
 | `data-workflow-step` | `workflowRoute()` | Workflow step delta with the full payload for the step that just changed |
 | `data-network` | `networkRoute()` | Agent network execution with ordered steps and outputs |
+| `data-mastra-harness-snapshot` / `data-mastra-harness-delta` | `harnessToUIMessageStream()` | Harness display-state snapshots and append-only deltas for tools, human-in-the-loop state, tasks, observational memory progress, file changes, and subagents |
 | `data-tool-agent` | Nested agent in tool | Agent output streamed from within a tool's `execute()` |
 | `data-tool-workflow` | Nested workflow in tool | Workflow output streamed from within a tool's `execute()` |
 | `data-tool-network` | Nested network in tool | Network output streamed from within a tool's `execute()` |

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -409,7 +409,7 @@ Mastra streams data to the frontend as "parts" within messages. Each part has a 
 | `data-workflow` | `workflowRoute()` | Workflow execution state snapshots with step status and final outputs |
 | `data-workflow-step` | `workflowRoute()` | Workflow step delta with the full payload for the step that just changed |
 | `data-network` | `networkRoute()` | Agent network execution with ordered steps and outputs |
-| `data-mastra-harness-snapshot` / `data-mastra-harness-delta` | `harnessToUIMessageStream()` | Harness display-state snapshots and append-only deltas for tools, human-in-the-loop state, tasks, observational memory progress, file changes, and subagents |
+| `data-mastra-harness-snapshot` / `data-mastra-harness-delta` | `harnessToUIMessageStream()` | Harness display-state snapshots and append-only deltas for usage, tools, human-in-the-loop state, tasks, observational memory progress, file changes, and subagents |
 | `data-tool-agent` | Nested agent in tool | Agent output streamed from within a tool's `execute()` |
 | `data-tool-workflow` | Nested workflow in tool | Workflow output streamed from within a tool's `execute()` |
 | `data-tool-network` | Nested network in tool | Network output streamed from within a tool's `execute()` |

--- a/docs/src/content/en/reference/ai-sdk/harness-to-ui-message-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/harness-to-ui-message-stream.mdx
@@ -1,0 +1,189 @@
+---
+title: "Reference: harnessToUIMessageStream() | AI SDK"
+description: API reference for harnessToUIMessageStream(), a function to stream Harness display state to AI SDK UI.
+packages:
+  - "@mastra/ai-sdk"
+  - "@mastra/core"
+---
+
+import PropertiesTable from "@site/src/components/PropertiesTable";
+
+# harnessToUIMessageStream()
+
+Converts a Harness display-state stream into AI SDK UI message stream parts. Use this function when a custom route needs to render a Harness session with AI SDK UI while preserving tools, human-in-the-loop state, tasks, observational memory progress, file changes, and subagent state.
+
+The adapter reads the first snapshot from [`harness.getDisplayState()`](/reference/harness/harness-class) and then listens with `harness.subscribeDisplayState()`. It does not subscribe to raw Harness events or add another coalescing layer.
+
+The stream can run in snapshot mode or delta mode. Delta mode still starts with a full snapshot baseline, then emits append-only replacement deltas for changed fields and domains.
+
+## Usage example
+
+The following example streams a Harness session from a custom route:
+
+```typescript title="app/api/harness/route.ts"
+import { harnessToUIMessageStream } from '@mastra/ai-sdk/harness'
+import { createUIMessageStreamResponse } from 'ai'
+
+export async function GET() {
+  const stream = harnessToUIMessageStream(harness, {
+    windowMs: 250,
+    maxWaitMs: 500,
+    mode: 'delta',
+    include: ['tools', 'hitl', 'tasks', 'om', 'files', 'subagents'],
+  })
+
+  return createUIMessageStreamResponse({ stream })
+}
+```
+
+## Parameters
+
+The first parameter is a Harness-like object with `getDisplayState()` and `subscribeDisplayState()`.
+
+The second parameter is an options object:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'mode',
+    type: "'snapshot' | 'delta'",
+    description:
+      'Selects the stream protocol. Snapshot mode emits a replacing snapshot on every display-state update. Delta mode emits one full snapshot baseline, then append-only replacement deltas for changed fields and domains.',
+    isOptional: true,
+    defaultValue: "'snapshot'",
+  },
+  {
+    name: 'include',
+    type: "Array<'text' | 'reasoning' | 'usage' | 'tools' | 'hitl' | 'tasks' | 'om' | 'files' | 'subagents'>",
+    description: 'Display-state domains to include in the emitted chunks.',
+    isOptional: true,
+    defaultValue: 'all domains',
+  },
+  {
+    name: 'windowMs',
+    type: 'number',
+    description: 'Minimum quiet window passed to `harness.subscribeDisplayState()` for non-critical display updates.',
+    isOptional: true,
+    defaultValue: '250',
+  },
+  {
+    name: 'maxWaitMs',
+    type: 'number',
+    description: 'Maximum wait passed to `harness.subscribeDisplayState()` while updates continue.',
+    isOptional: true,
+    defaultValue: '500',
+  },
+  {
+    name: 'messageId',
+    type: 'string | (state: HarnessDisplayState) => string',
+    description: 'Stable AI SDK message ID to use for start, text, reasoning, and snapshot chunks.',
+    isOptional: true,
+    defaultValue: "the current Harness message ID, then 'mastra-harness'",
+  },
+  {
+    name: 'sendStart',
+    type: 'boolean',
+    description: 'Whether to emit a `start` chunk before the first snapshot.',
+    isOptional: true,
+    defaultValue: 'true',
+  },
+  {
+    name: 'sendFinish',
+    type: 'boolean',
+    description: 'Whether to emit a `finish` chunk when the Harness display state becomes terminal.',
+    isOptional: true,
+    defaultValue: 'true',
+  },
+  {
+    name: 'version',
+    type: "'v5' | 'v6'",
+    description:
+      'Reserved for callers that want to mark the AI SDK stream contract they target. Snapshot data parts are the same for both versions.',
+    isOptional: true,
+    defaultValue: "'v5'",
+  },
+]}
+/>
+
+## Stream output
+
+The stream emits normal AI SDK UI chunks for assistant text and reasoning when those domains are included. When `tools` is included, the adapter also emits native AI SDK UI tool chunks for lifecycle state that can be safely derived from Harness display state:
+
+```json
+[
+  { "type": "tool-input-start", "toolCallId": "call-1", "toolName": "write_file" },
+  { "type": "tool-input-delta", "toolCallId": "call-1", "inputTextDelta": "{\"path\"" },
+  { "type": "tool-input-available", "toolCallId": "call-1", "toolName": "write_file", "input": {} },
+  { "type": "tool-output-available", "toolCallId": "call-1", "output": {} },
+  { "type": "tool-output-error", "toolCallId": "call-1", "errorText": "Tool execution failed" }
+]
+```
+
+Tool approvals, suspensions, questions, and plan approvals remain in the structured snapshot because those states need stable Harness identifiers and resume metadata.
+
+It also emits a durable custom data part with a stable ID:
+
+```json
+{
+  "type": "data-mastra-harness-snapshot",
+  "id": "mastra-harness:snapshot",
+  "data": {
+    "version": 1,
+    "sequence": 1,
+    "emittedAt": "2026-05-01T12:00:00.000Z",
+    "mode": "snapshot",
+    "messageId": "message-1",
+    "isRunning": true,
+    "currentMessage": null,
+    "domains": {}
+  }
+}
+```
+
+Use the latest `data-mastra-harness-snapshot` part to render replacing UI state. Missing or `null` fields clear stale state such as resolved approvals or completed prompts.
+
+In delta mode, later changes use unique IDs:
+
+```json
+{
+  "type": "data-mastra-harness-delta",
+  "id": "mastra-harness:delta:2",
+  "data": {
+    "version": 1,
+    "sequence": 2,
+    "emittedAt": "2026-05-01T12:00:01.000Z",
+    "mode": "delta",
+    "messageId": "message-1",
+    "domains": {
+      "hitl": {
+        "approval": null,
+        "suspension": null,
+        "question": null,
+        "planApproval": null
+      }
+    }
+  }
+}
+```
+
+Deltas are field and domain replacements, not JSON Patch operations.
+
+## Snapshot domains
+
+| Domain | Snapshot content |
+| - | - |
+| `usage` | Cumulative token usage from `displayState.tokenUsage` |
+| `tools` | Active tools and streaming tool input buffers |
+| `hitl` | Pending approval, suspension, question, and plan approval state |
+| `tasks` | Current and previous task lists |
+| `om` | Observational memory progress and buffering flags |
+| `files` | Modified files, operations, and first-modified timestamps |
+| `subagents` | Active subagents and terminal history when the Harness provides it |
+
+The snapshot data is JSON-safe. Maps become objects, sets become arrays, dates become ISO strings, errors keep their name and message, and circular references become `"[Circular]"`.
+
+## Terminal and cancellation behavior
+
+When `displayState.isRunning` becomes `false`, the adapter emits the final snapshot, closes any open text or reasoning part, emits `finish` when enabled, unsubscribes from the Harness, and closes the stream.
+
+When the consumer cancels the stream, the adapter unsubscribes from the Harness without emitting a synthetic final snapshot.

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -49,6 +49,7 @@ const sidebars = {
       collapsed: true,
       items: [
         { type: 'doc', id: 'ai-sdk/chat-route', label: 'chatRoute()' },
+        { type: 'doc', id: 'ai-sdk/harness-to-ui-message-stream', label: 'harnessToUIMessageStream()' },
         { type: 'doc', id: 'ai-sdk/handle-chat-stream', label: 'handleChatStream()' },
         { type: 'doc', id: 'ai-sdk/handle-network-stream', label: 'handleNetworkStream()' },
         { type: 'doc', id: 'ai-sdk/handle-workflow-stream', label: 'handleWorkflowStream()' },


### PR DESCRIPTION
Adds @mastra/ai-sdk/harness with harnessToUIMessageStream so Harness display state can be streamed directly to AI SDK UI.

The adapter emits assistant text and reasoning chunks, native AI SDK tool lifecycle chunks, a stable data-mastra-harness-snapshot baseline, and optional data-mastra-harness-delta replacement updates. It also serializes Harness display state safely for tools, HITL, tasks, observational memory progress, modified files, usage, active subagents, and optional terminal subagent history when the Harness provides it.

Example:

```ts
import { harnessToUIMessageStream } from '@mastra/ai-sdk/harness';

const stream = harnessToUIMessageStream(harness, {
  mode: 'delta',
  windowMs: 250,
  maxWaitMs: 500,
});
```

Closes https://github.com/mastra-ai/mastra/issues/15975

Validated with pnpm --filter ./client-sdks/ai-sdk test src/__tests__/harness.test.ts, pnpm --filter ./client-sdks/ai-sdk lint, pnpm --filter ./client-sdks/ai-sdk build:lib, git diff --check, and ESM/CJS import smoke checks for @mastra/ai-sdk/harness. The broader pnpm --filter ./client-sdks/ai-sdk test run had 130 passing tests but still has unrelated existing environment/import failures around ai/test plus one LibSQL observational-memory assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a reusable adapter that converts a Harness's current UI state and live updates into the AI SDK UI message stream format. It sends one full snapshot of state and then streams incremental updates so UIs can rehydrate and stay in sync without reimplementing mapping logic.

## Overview

Adds @mastra/ai-sdk/harness exporting harnessToUIMessageStream(), a streaming adapter that consumes a Harness-like getDisplayState()/subscribeDisplayState() source and emits AI SDK UI–compatible message stream chunks: assistant text/reasoning lifecycle, tool lifecycle/input/output/error chunks, human-in-the-loop state, tasks, observational-memory progress, modified files, usage, subagents (including optional terminal subagent history), and durable harness snapshot/delta data parts. Supports snapshot and delta/replace modes, configurable coalescing/windowing, stable snapshot identity for safe reconnect/rehydration, and safe JSON-safe serialization of complex values.

## Changes

### Core Implementation
- New file: client-sdks/ai-sdk/src/harness.ts (~750 LOC)
  - Exported function: harnessToUIMessageStream(harness: HarnessLike, options?: HarnessToUIMessageStreamOptions): ReadableStream<HarnessUIMessageStreamChunk>
  - Exports types: JsonValue, HarnessUIStreamDomain, HarnessUIStreamMode, HarnessLike, HarnessToUIMessageStreamOptions, HarnessUIMessageSnapshot / HarnessUISnapshotData / HarnessUIDeltaData and related data-part types
  - Subscribes to harness.getDisplayState() (initial snapshot) and harness.subscribeDisplayState() (updates)
  - Emits text/reasoning start/delta/end parts with per-stream cursor handling; restarts/close semantics when message id changes or on shrink in snapshot mode
  - Tracks per-tool-call streaming state and emits tool-input-start/delta/available, tool-output-available, and tool-output-error; cleans up finalized tool state
  - Emits either data-mastra-harness-snapshot (snapshot mode or initial) or data-mastra-harness-delta (delta mode) parts; delta mode emits append-only replacement updates for changed domains and suppresses no-op deltas
  - Config options: mode ('snapshot'|'delta'), include domain list, windowMs, maxWaitMs, messageId, sendStart, sendFinish, version
  - Serializes values via toJsonValue: handles Date, Error, Map, Set, arrays, bigint, non-finite numbers, circular refs, and omits unsupported types

### Tests
- New tests: client-sdks/ai-sdk/src/harness.test.ts (~700 LOC)
  - Comprehensive Vitest suite validating snapshot/delta semantics, text/reasoning lifecycle/coalescing, tool lifecycle and error emission (one-time), include filtering, HITL handling, subagent history, safe serialization of complex values, unsubscribe/cleanup on consumer cancel, terminal finish sequencing, and stream error handling
  - Focused test runs used: pnpm --filter ./client-sdks/ai-sdk test src/__tests__/harness.test.ts

### Package / Build
- client-sdks/ai-sdk/package.json: added ./harness export with ESM (dist/harness.js), CJS (dist/harness.cjs), and types (dist/harness.d.ts)
- client-sdks/ai-sdk/tsup.config.ts: added src/harness.ts to build entries to produce harness outputs

### Documentation
- README: added "Harness display state streams" section with example GET handler using createUIMessageStreamResponse and options explanation
- Reference: docs/src/content/en/reference/ai-sdk/harness-to-ui-message-stream.mdx — full API/semantics/usage example and domain enumeration
- Guides: docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx — updated data part types table to include data-mastra-harness-snapshot/delta
- Sidebar: docs/src/content/en/reference/sidebars.js updated to include harnessToUIMessageStream() doc

### Release / Misc
- .changeset/green-years-obey.md: changeset documenting minor bump and adapter release
- Commit note: fix(ai-sdk): cleanup finalized harness tool state — adjusts cleanup of finalized tool state handling in the adapter
- Validation performed: focused tests, lint, build:lib, git diff --check, and ESM/CJS import smoke checks for @mastra/ai-sdk/harness; broader ai-sdk test run largely passed with unrelated environment/import failures and one LibSQL observational-memory assertion noted.

## Design highlights

- Keeps AI SDK protocol mapping colocated in ai-sdk package to centralize evolution/versioning of HarnessDisplayState domains.
- Supports both full-snapshot rehydration and append-only delta updates with stable snapshot identity for safe reconnects without duplication/stale state.
- Configurable coalescing (windowMs/maxWaitMs) to preserve Harness-level coalescing while offering client tuning.
- Robust serialization for complex and circular structures to ensure safe JSON-part payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->