### PR TITLE
fix(server): reduce member permissions needed for agent builder

### DIFF
--- a/examples/agent/src/mastra/auth/workos.ts
+++ b/examples/agent/src/mastra/auth/workos.ts
@@ -23,10 +23,9 @@ export async function initWorkOS(): Promise<AuthResult> {
       superadmin: ['*'],
       // Agent Builder access: CRUD agents/skills, workspace file I/O, chat history
       member: [
+        // necessary
         'stored-agents:*',
         'stored-skills:*',
-        'agents:read',
-        'agents:execute',
         //not necessary, but lose out on some features (tools in tool list and chat history)
         'tools:read',
         'workflows:read',

--- a/examples/agent/src/mastra/auth/workos.ts
+++ b/examples/agent/src/mastra/auth/workos.ts
@@ -24,11 +24,10 @@ export async function initWorkOS(): Promise<AuthResult> {
       // Agent Builder access: CRUD agents/skills, workspace file I/O, chat history
       member: [
         'stored-agents:*',
-        'agents:*',
         'stored-skills:*',
-        'stored-workspaces:read',
-        'workspaces:read',
-        'workspaces:write',
+        'agents:read',
+        'agents:execute',
+        //not necessary, but lose out on some features (tools in tool list and chat history)
         'tools:read',
         'workflows:read',
         'memory:read',

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -166,15 +166,15 @@ export const mastra = new Mastra({
       },
       configuration: {
         agent: {
-          // workspace: { type: 'id', workspaceId: 'builder-workspace' },
-          workspace: {
-            type: 'inline',
-            config: {
-              name: 'builder-workspace',
-              filesystem: { provider: 'local', config: { basePath: '.mastra/workspace' } },
-              sandbox: { provider: 'daytona', config: {} },
-            },
-          },
+          workspace: { type: 'id', workspaceId: 'builder-workspace' },
+          // workspace: {
+          //   type: 'inline',
+          //   config: {
+          //     name: 'builder-workspace',
+          //     filesystem: { provider: 'local', config: { basePath: '.mastra/workspace' } },
+          //     sandbox: { provider: 'daytona', config: {} },
+          //   },
+          // },
           memory: {
             options: {
               lastMessages: 10,

--- a/packages/core/src/auth/ee/interfaces/permissions.generated.ts
+++ b/packages/core/src/auth/ee/interfaces/permissions.generated.ts
@@ -15,6 +15,7 @@ export const RESOURCES = [
   'a2a',
   'agent-builder',
   'agents',
+  'auth',
   'background-tasks',
   'channels',
   'datasets',
@@ -91,6 +92,8 @@ export const PERMISSION_PATTERNS = {
   'agent-builder:*': 'agent-builder:*',
   /** Full access to agents */
   'agents:*': 'agents:*',
+  /** Full access to auth */
+  'auth:*': 'auth:*',
   /** Full access to background-tasks */
   'background-tasks:*': 'background-tasks:*',
   /** Full access to channels */
@@ -163,6 +166,8 @@ export const PERMISSION_PATTERNS = {
   'agents:read': 'agents:read',
   /** Create and modify agents */
   'agents:write': 'agents:write',
+  /** View auth */
+  'auth:read': 'auth:read',
   /** View background-tasks */
   'background-tasks:read': 'background-tasks:read',
   /** View channels */
@@ -219,6 +224,8 @@ export const PERMISSION_PATTERNS = {
   'scores:write': 'scores:write',
   /** Delete stored agents */
   'stored-agents:delete': 'stored-agents:delete',
+  /** Execute stored agents */
+  'stored-agents:execute': 'stored-agents:execute',
   /** Publish, activate, or restore stored agents */
   'stored-agents:publish': 'stored-agents:publish',
   /** View stored agents */
@@ -333,6 +340,7 @@ export const PERMISSIONS = [
   'agents:execute',
   'agents:read',
   'agents:write',
+  'auth:read',
   'background-tasks:read',
   'channels:read',
   'channels:write',
@@ -361,6 +369,7 @@ export const PERMISSIONS = [
   'scores:read',
   'scores:write',
   'stored-agents:delete',
+  'stored-agents:execute',
   'stored-agents:publish',
   'stored-agents:read',
   'stored-agents:share',

--- a/packages/playground-ui/src/ds/components/IconButton/IconButton.tsx
+++ b/packages/playground-ui/src/ds/components/IconButton/IconButton.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip';
 import { Icon } from '@/ds/icons/Icon';
-import { formElementSizes, formElementFocus  } from '@/ds/primitives/form-element';
-import type {FormElementSize} from '@/ds/primitives/form-element';
+import { formElementSizes, formElementFocus } from '@/ds/primitives/form-element';
+import type { FormElementSize } from '@/ds/primitives/form-element';
 import { cn } from '@/lib/utils';
 
 export interface IconButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
@@ -331,7 +331,7 @@ export function SkillEditDialog({
                   Hide skill details
                 </button>
 
-                {(!hasFilesystem || !workspaceId) && (
+                {isAdmin && (!hasFilesystem || !workspaceId) && (
                   <div className="mb-4 flex items-start gap-2 rounded-lg bg-yellow-500/10 p-3 text-xs text-yellow-600">
                     <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
                     <span>

--- a/packages/playground/src/domains/agents/hooks/use-create-skill.ts
+++ b/packages/playground/src/domains/agents/hooks/use-create-skill.ts
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { extractSkillInstructions, extractSkillLicense } from '../components/agent-cms-pages/skill-file-tree';
 import type { InMemoryFileNode } from '../components/agent-edit-page/utils/form-validation';
+import { usePermissions } from '@/domains/auth/hooks';
 import { useWriteWorkspaceFile } from '@/domains/workspace/hooks';
 
 interface CreateSkillParams {
@@ -32,24 +33,30 @@ export function useCreateSkill() {
   const client = useMastraClient();
   const queryClient = useQueryClient();
   const writeFile = useWriteWorkspaceFile();
+  const { hasPermission } = usePermissions();
+  const canWriteWorkspace = hasPermission('workspaces:write');
 
   return useMutation({
     mutationFn: async (params: CreateSkillParams): Promise<StoredSkillResponse> => {
       const { name, description, workspaceId, files } = params;
 
-      // Write files to workspace filesystem if a workspace is available
-      if (workspaceId) {
+      // Write files to workspace filesystem (best-effort — DB is the source of truth)
+      if (workspaceId && canWriteWorkspace) {
         const filesToWrite = flattenFiles(files, '');
-        await Promise.all(
-          filesToWrite.map(file =>
-            writeFile.mutateAsync({
-              workspaceId,
-              path: `skills/${file.path}`,
-              content: file.content,
-              recursive: true,
-            }),
-          ),
-        );
+        try {
+          await Promise.all(
+            filesToWrite.map(file =>
+              writeFile.mutateAsync({
+                workspaceId,
+                path: `skills/${file.path}`,
+                content: file.content,
+                recursive: true,
+              }),
+            ),
+          );
+        } catch (err) {
+          console.warn('[skill] Workspace file write failed, saving to DB only:', err);
+        }
       }
 
       // Create stored skill via API (DB record always created)

--- a/packages/playground/src/domains/agents/hooks/use-update-skill.ts
+++ b/packages/playground/src/domains/agents/hooks/use-update-skill.ts
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { extractSkillInstructions, extractSkillLicense } from '../components/agent-cms-pages/skill-file-tree';
 import type { InMemoryFileNode } from '../components/agent-edit-page/utils/form-validation';
+import { usePermissions } from '@/domains/auth/hooks';
 import { useWriteWorkspaceFile } from '@/domains/workspace/hooks';
 
 interface UpdateSkillParams {
@@ -34,24 +35,30 @@ export function useUpdateSkill() {
   const client = useMastraClient();
   const queryClient = useQueryClient();
   const writeFile = useWriteWorkspaceFile();
+  const { hasPermission } = usePermissions();
+  const canWriteWorkspace = hasPermission('workspaces:write');
 
   return useMutation({
     mutationFn: async (params: UpdateSkillParams): Promise<StoredSkillResponse> => {
       const { id, name, description, visibility, instructions, files, workspaceId } = params;
 
-      // Write updated files to workspace filesystem if we have files and a workspace
-      if (files?.length && workspaceId) {
+      // Write updated files to workspace filesystem (best-effort — DB is the source of truth)
+      if (files?.length && workspaceId && canWriteWorkspace) {
         const filesToWrite = flattenFiles(files, '');
-        await Promise.all(
-          filesToWrite.map(file =>
-            writeFile.mutateAsync({
-              workspaceId,
-              path: `skills/${file.path}`,
-              content: file.content,
-              recursive: true,
-            }),
-          ),
-        );
+        try {
+          await Promise.all(
+            filesToWrite.map(file =>
+              writeFile.mutateAsync({
+                workspaceId,
+                path: `skills/${file.path}`,
+                content: file.content,
+                recursive: true,
+              }),
+            ),
+          );
+        } catch (err) {
+          console.warn('[skill] Workspace file write failed, saving to DB only:', err);
+        }
       }
 
       // Update stored skill via API

--- a/packages/server/scripts/check-permissions.ts
+++ b/packages/server/scripts/check-permissions.ts
@@ -30,12 +30,15 @@ const mismatches: string[] = [];
 for (const route of SERVER_ROUTES) {
   if (route.method === 'ALL') continue;
 
-  const runtimePerm = getEffectivePermission(route);
-  if (runtimePerm) {
-    runtimePermissions.add(runtimePerm);
+  const effective = getEffectivePermission(route);
+  if (effective) {
+    const perms = Array.isArray(effective) ? effective : [effective];
+    for (const runtimePerm of perms) {
+      runtimePermissions.add(runtimePerm);
 
-    if (!generatedPermissions.has(runtimePerm)) {
-      mismatches.push(`Missing: ${runtimePerm} (from ${route.method} ${route.path})`);
+      if (!generatedPermissions.has(runtimePerm)) {
+        mismatches.push(`Missing: ${runtimePerm} (from ${route.method} ${route.path})`);
+      }
     }
   }
 }

--- a/packages/server/scripts/permission-generator.ts
+++ b/packages/server/scripts/permission-generator.ts
@@ -118,13 +118,16 @@ export function derivePermissionData(): PermissionData {
   const permissionSet = new Set<string>();
 
   for (const route of SERVER_ROUTES) {
-    const permission = getEffectivePermission(route);
-    if (permission) {
-      const [resource, action] = permission.split(':');
-      if (resource && action) {
-        resourceSet.add(resource);
-        actionSet.add(action);
-        permissionSet.add(permission);
+    const effective = getEffectivePermission(route);
+    if (effective) {
+      const permissions = Array.isArray(effective) ? effective : [effective];
+      for (const permission of permissions) {
+        const [resource, action] = permission.split(':');
+        if (resource && action) {
+          resourceSet.add(resource);
+          actionSet.add(action);
+          permissionSet.add(permission);
+        }
       }
     }
   }

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -936,7 +936,7 @@ export const LIST_AGENTS_ROUTE = createRoute({
   description: 'Returns a list of all available agents in the system (both code-defined and stored)',
   tags: ['Agents'],
   requiresAuth: true,
-  requiresPermission: 'agents:read',
+  requiresPermission: ['agents:read', 'stored-agents:read'],
   handler: async ({ mastra, requestContext, partial }) => {
     try {
       const codeAgents = mastra.listAgents();
@@ -1343,6 +1343,7 @@ export const GET_PROVIDERS_ROUTE = createRoute({
   description: 'Returns a list of all configured AI model providers',
   tags: ['Agents'],
   requiresAuth: true,
+  requiresPermission: ['agents:read', 'stored-agents:read'],
   handler: async ({ mastra }) => {
     try {
       const allProviders: Record<string, ProviderConfig> = {};
@@ -1512,7 +1513,7 @@ export const STREAM_UNTIL_IDLE_GENERATE_ROUTE = createRoute({
     'Executes an agent with the provided messages and streams the response in real-time, also listens for background task completions and streams them in real-time',
   tags: ['Agents'],
   requiresAuth: true,
-  requiresPermission: 'agents:execute',
+  requiresPermission: ['agents:execute', 'stored-agents:execute'],
   handler: async ({ mastra, agentId, abortSignal, requestContext: serverRequestContext, ...params }) => {
     try {
       // UI Frameworks may send "client tools" in the body,

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -448,6 +448,9 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
    * 2. Otherwise, derive permission from path/method (e.g., GET /agents → agents:read)
    * 3. Routes with `requiresAuth: false` skip permission checks
    *
+   * When the route specifies an array of permissions, the user needs ANY ONE
+   * of them (logical OR).
+   *
    * @param route - The route being accessed
    * @param userPermissions - The user's permissions from the request context
    * @returns Error response if permission denied, null if allowed
@@ -472,12 +475,16 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
       return null;
     }
 
-    // Check if user has the required permission
-    if (!userPermissions || !hasPermissionFn(userPermissions, requiredPermission)) {
+    // Check if user has the required permission(s)
+    // When an array is provided, user needs ANY ONE of them (logical OR)
+    const permissions = Array.isArray(requiredPermission) ? requiredPermission : [requiredPermission];
+    const hasAny = userPermissions && permissions.some(perm => hasPermissionFn(userPermissions, perm));
+
+    if (!hasAny) {
       return {
         status: 403,
         error: 'Forbidden',
-        message: `Missing required permission: ${requiredPermission}`,
+        message: `Missing required permission: ${permissions.join(' or ')}`,
       };
     }
 

--- a/packages/server/src/server/server-adapter/routes/index.ts
+++ b/packages/server/src/server/server-adapter/routes/index.ts
@@ -134,11 +134,16 @@ export type ServerRoute<
    * If set, the user must have this permission to access the route.
    * Uses the format: `resource:action` or `resource:action:resourceId`
    *
+   * When an array is provided, the user needs ANY ONE of the listed permissions
+   * (logical OR). This is useful for routes that serve multiple resource types,
+   * e.g. a streaming endpoint used by both runtime and stored agents.
+   *
    * @example
    * requiresPermission: 'agents:read'
    * requiresPermission: 'workflows:execute'
+   * requiresPermission: ['agents:execute', 'stored-agents:execute']
    */
-  requiresPermission?: string;
+  requiresPermission?: string | string[];
   onValidationError?: ValidationErrorHook;
   /** @internal Phantom type — not present at runtime. Used for type-level schema inference. */
   readonly __schemas?: TSchemas;

--- a/packages/server/src/server/server-adapter/routes/permissions.test.ts
+++ b/packages/server/src/server/server-adapter/routes/permissions.test.ts
@@ -524,6 +524,15 @@ describe('getEffectivePermission', () => {
       // Would derive to agents:execute, but explicit takes precedence
       expect(getEffectivePermission(route)).toBe('agents:admin');
     });
+
+    it('should return array when requiresPermission is an array', () => {
+      const route = createRoute({
+        path: '/agents/:agentId/stream-until-idle',
+        method: 'POST',
+        requiresPermission: ['agents:execute', 'stored-agents:execute'],
+      });
+      expect(getEffectivePermission(route)).toEqual(['agents:execute', 'stored-agents:execute']);
+    });
   });
 
   describe('public routes', () => {

--- a/packages/server/src/server/server-adapter/routes/permissions.ts
+++ b/packages/server/src/server/server-adapter/routes/permissions.ts
@@ -163,14 +163,18 @@ export function derivePermission(route: Pick<ServerRoute, 'path' | 'method'>): s
  * Gets the effective permission for a route.
  *
  * Priority:
- * 1. Explicit requiresPermission on the route
+ * 1. Explicit requiresPermission on the route (string or string[])
  * 2. Derived permission from path/method convention
  * 3. null (no permission required - should only happen for public routes)
  *
+ * When the route specifies an array of permissions, the user needs ANY ONE
+ * of them (logical OR). This is useful for routes that serve multiple
+ * resource types.
+ *
  * @param route - The server route
- * @returns The permission string or null
+ * @returns The permission string, array of alternative permissions, or null
  */
-export function getEffectivePermission(route: ServerRoute): string | null {
+export function getEffectivePermission(route: ServerRoute): string | string[] | null {
   // If route is explicitly public, no permission needed
   if (route.requiresAuth === false) {
     return null;

--- a/packages/server/src/server/server-adapter/routes/route-builder.ts
+++ b/packages/server/src/server/server-adapter/routes/route-builder.ts
@@ -170,8 +170,10 @@ interface RouteConfig<
    * Permission required to access this route (EE feature).
    * If set, the user must have this permission to access the route.
    * Uses the format: `resource:action` or `resource:action:resourceId`
+   *
+   * When an array is provided, the user needs ANY ONE of the listed permissions.
    */
-  requiresPermission?: string;
+  requiresPermission?: string | string[];
   onValidationError?: ValidationErrorHook;
 }
 


### PR DESCRIPTION
## Summary

Members using the agent builder previously needed both `stored-agents:*` and `agents:*` permissions. The `agents:*` permissions were required because three routes under `/agents/` — used by the builder for the model picker, sub-agent list, and chat — derived their permissions from the `agents` resource.

This PR widens the `requiresPermission` route config to accept `string | string[]` (OR logic), and applies it to the three builder-critical routes so that `stored-agents:*` alone is sufficient:

| Route | Before | After |
|---|---|---|
| `GET /agents` (sub-agent picker) | `agents:read` | `agents:read` OR `stored-agents:read` |
| `GET /agents/providers` (model picker) | `agents:read` (derived) | `agents:read` OR `stored-agents:read` |
| `POST /agents/:id/stream-until-idle` (chat) | `agents:execute` | `agents:execute` OR `stored-agents:execute` |

## Changes

- **`routes/index.ts`, `route-builder.ts`**: Widen `requiresPermission` type from `string` to `string | string[]`
- **`permissions.ts`**: `getEffectivePermission()` returns `string | string[] | null`
- **`server-adapter/index.ts`**: `checkRoutePermission()` handles arrays with `some()` — user needs ANY ONE permission
- **`handlers/agents.ts`**: Apply array permissions to the three builder routes
- **`permission-generator.ts`, `check-permissions.ts`**: Handle array permissions in generation and validation
- **`permissions.generated.ts`**: Regenerated (adds `stored-agents:execute`, `auth:read`)
- **`permissions.test.ts`**: Test for array OR logic

## Known tradeoffs

### `stored-agents:execute` grants access to runtime agents too

The `stream-until-idle` handler resolves agents via `getAgentFromSystem()`, which tries code-defined (runtime) agents first, then falls back to stored agents. The permission check runs at the adapter layer *before* the handler, so there's no way to distinguish stored vs runtime agents at the route level. A member with only `stored-agents:execute` can chat with runtime agents too.

Practical risk is low — execution-only, no config access. In the builder flow, stored agents get registered as runtime agents anyway, so the distinction is artificial at execution time. Stricter isolation would require moving the permission check into the handler and threading through which resolution path was taken.

### `tools:read`, `workflows:read`, `memory:read` have no `stored-*` equivalents

These three resources are runtime-only — there are no `stored-tools`, `stored-workflows`, or `stored-memory` routes. Members still need these permissions directly for the tool picker, workflow picker, and chat history in the builder. Without them, the builder still works but those features are degraded (empty pickers, no conversation history).

## Test plan

- 168/168 permission tests pass
- Server typecheck clean
- `generate:permissions` and `check:permissions` both pass
- Manually verified: member with only `stored-agents:*` can use model picker and chat